### PR TITLE
move .gitignore to packages/flight-icons

### DIFF
--- a/packages/flight-icons/.gitignore
+++ b/packages/flight-icons/.gitignore
@@ -1,10 +1,5 @@
 .env
-.DS_Store
-node_modules/
 flight-icons/temp
 
 # Output of `npm pack`, which is an (optional) test for `npm publish`
 *.tgz
-
-# For Percy command line testing
-snapshots.yml


### PR DESCRIPTION
## :pushpin: Summary

This feels like the best place to move this one for now