### PR TITLE
publish token's package files from root

### DIFF
--- a/packages/tokens/.npmignore
+++ b/packages/tokens/.npmignore
@@ -1,0 +1,8 @@
+/dist/
+/src
+/scripts
+
+/tsconfig.json
+
+/RELEASE.md
+/CONTRIBUTING.md

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -15,11 +15,6 @@
   },
   "license": "MPL-2.0",
   "author": "HashiCorp Design Systems <design-systems@hashicorp.com>",
-  "files": [
-    "devdot",
-    "docs",
-    "products"
-  ],
   "scripts": {
     "typecheck": "yarn tsc --noEmit",
     "lint": "yarn eslint --quiet --ext .js,.ts",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -15,10 +15,17 @@
   },
   "license": "MPL-2.0",
   "author": "HashiCorp Design Systems <design-systems@hashicorp.com>",
+  "files": [
+    "devdot",
+    "docs",
+    "products"
+  ],
   "scripts": {
     "typecheck": "yarn tsc --noEmit",
     "lint": "yarn eslint --quiet --ext .js,.ts",
-    "build": "ts-node --transpile-only ./scripts/build"
+    "build": "ts-node --transpile-only ./scripts/build",
+    "prepublishOnly": "cp -r ./dist/* .",
+    "postpublish": "git clean -fd"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",


### PR DESCRIPTION
## :pushpin: Summary

* On prepublish -> move files we want to publish to the root
* After publish -> restore things to their previous state

## :hammer_and_wrench: Detailed Description

For context the [changeset docs](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#publish), under the hood it runs the `npm publish` command for a package if there are changes to release. 

Previous to changesets, this package was released through [a series of scripts](https://github.com/hashicorp/design-system/blob/75336ae9d5be0f78dc272d62d0d1a6b2ceb39ac8/packages/tokens/package.json#L23-L25) that ultimately ran `npm publish` from _inside_ the `dist/` folder which seems incompatible with how changesets expects things to work. This PR introduces a method whereby the package can be released from the root (how changesets expects things) while maintaining parity with how the tokens package has been getting published to npm with the various assets in the package root, not in `dist/` as they exist on disk

### Before (in https://github.com/hashicorp/design-system/pull/38)
```bash
~/c/w/d/p/tokens (br-token-publish|✔) $ npm publish --dry-run
npm notice 
npm notice 📦  @hashicorp/design-system-tokens@0.5.1
npm notice === Tarball Contents === 
npm notice 3.1kB   CONTRIBUTING.md                                          
npm notice 16.7kB  LICENSE.md                                               
npm notice 1.3kB   README.md                                                
npm notice 2.5kB   RELEASE.md                                               
npm notice 3.7kB   dist/devdot/css/helpers/color.css                        
npm notice 1.1kB   dist/devdot/css/helpers/elevation.css                    
npm notice 158B    dist/devdot/css/helpers/focus-ring.css                   
npm notice 2.6kB   dist/devdot/css/helpers/typography.css                   
npm notice 21.0kB  dist/devdot/css/tokens.css                               
npm notice 133.1kB dist/docs/devdot/tokens.json                             
npm notice 132.3kB dist/docs/products/tokens.json                           
npm notice 3.6kB   dist/products/css/helpers/color.css                      
npm notice 1.1kB   dist/products/css/helpers/elevation.css                  
npm notice 158B    dist/products/css/helpers/focus-ring.css                 
npm notice 2.6kB   dist/products/css/helpers/typography.css                 
npm notice 20.8kB  dist/products/css/tokens.css                             
npm notice 1.1kB   package.json                                             
npm notice 264B    scripts/@types/Config.d.ts                               
npm notice 2.2kB   scripts/build-parts/generateColorHelpers.ts              
npm notice 2.0kB   scripts/build-parts/generateCssHelpers.ts                
npm notice 1.3kB   scripts/build-parts/generateElevationHelpers.ts          
npm notice 699B    scripts/build-parts/generateFocusRingHelpers.ts          
npm notice 2.1kB   scripts/build-parts/generateTypographyHelpers.ts         
npm notice 6.7kB   scripts/build.ts                                         
npm notice 400B    src/devdot/color/semantic-foreground.json                
npm notice 4.4kB   src/global/color/palette-accents.json                    
npm notice 2.0kB   src/global/color/palette-neutrals.json                   
npm notice 12.1kB  src/global/color/palette-products.json                   
npm notice 17.1kB  src/global/color/semantic-accents.json                   
npm notice 1.4kB   src/global/color/semantic-border.json                    
npm notice 1.1kB   src/global/color/semantic-focus.json                     
npm notice 3.6kB   src/global/color/semantic-foreground.json                
npm notice 2.7kB   src/global/color/semantic-neutrals.json                  
npm notice 389B    src/global/color/semantic-page.json                      
npm notice 2.1kB   src/global/color/semantic-surface.json                   
npm notice 1.0kB   src/global/elevation/elevation.json                      
npm notice 1.2kB   src/global/elevation/surface.json                        
npm notice 650B    src/global/elevation/values/base-level.json              
npm notice 386B    src/global/elevation/values/colors.json                  
npm notice 3.0kB   src/global/elevation/values/high-level.json              
npm notice 3.0kB   src/global/elevation/values/higher-level.json            
npm notice 1.8kB   src/global/elevation/values/inset-level.json             
npm notice 2.9kB   src/global/elevation/values/low-level.json               
npm notice 2.9kB   src/global/elevation/values/mid-level.json               
npm notice 3.0kB   src/global/elevation/values/overlay-level.json           
npm notice 1.2kB   src/global/focus-ring.json                               
npm notice 229B    src/products/shared/color/semantic-company.json          
npm notice 1.8kB   src/products/shared/color/semantic-product-boundary.json 
npm notice 1.8kB   src/products/shared/color/semantic-product-consul.json   
npm notice 217B    src/products/shared/color/semantic-product-hcp.json      
npm notice 1.8kB   src/products/shared/color/semantic-product-nomad.json    
npm notice 1.8kB   src/products/shared/color/semantic-product-packer.json   
npm notice 1.8kB   src/products/shared/color/semantic-product-terraform.json
npm notice 1.8kB   src/products/shared/color/semantic-product-vagrant.json  
npm notice 2.1kB   src/products/shared/color/semantic-product-vault.json    
npm notice 1.8kB   src/products/shared/color/semantic-product-waypoint.json 
npm notice 6.5kB   src/products/shared/typography.json                      
npm notice 10.9kB  tsconfig.json                                            
npm notice === Tarball Details === 
npm notice name:          @hashicorp/design-system-tokens          
npm notice version:       0.5.1                                    
npm notice filename:      @hashicorp/design-system-tokens-0.5.1.tgz
npm notice package size:  40.7 kB                                  
npm notice unpacked size: 462.7 kB                                 
npm notice shasum:        affbf244682298334b34d7ced2e10c047b26c8eb 
npm notice integrity:     sha512-ZYfXRnHtf5+5/[...]/pF3V+TelO8RQ== 
npm notice total files:   58                                       
npm notice 
+ @hashicorp/design-system-tokens@0.5.1
```

### After (matches [production](https://www.npmjs.com/package/@hashicorp/design-system-tokens)]

```bash
~/c/w/d/p/tokens (br-token-publish|…) [1] $ npm publish --dry-run

> @hashicorp/design-system-tokens@0.5.1 prepack
> cp -r ./dist/* .

npm notice 
npm notice 📦  @hashicorp/design-system-tokens@0.5.1
npm notice === Tarball Contents === 
npm notice 16.7kB  LICENSE.md                         
npm notice 1.3kB   README.md                          
npm notice 3.7kB   devdot/css/helpers/color.css       
npm notice 1.1kB   devdot/css/helpers/elevation.css   
npm notice 158B    devdot/css/helpers/focus-ring.css  
npm notice 2.6kB   devdot/css/helpers/typography.css  
npm notice 21.0kB  devdot/css/tokens.css              
npm notice 133.1kB docs/devdot/tokens.json            
npm notice 132.3kB docs/products/tokens.json          
npm notice 1.2kB   package.json                       
npm notice 3.6kB   products/css/helpers/color.css     
npm notice 1.1kB   products/css/helpers/elevation.css 
npm notice 158B    products/css/helpers/focus-ring.css
npm notice 2.6kB   products/css/helpers/typography.css
npm notice 20.8kB  products/css/tokens.css            
npm notice === Tarball Details === 
npm notice name:          @hashicorp/design-system-tokens          
npm notice version:       0.5.1                                    
npm notice filename:      @hashicorp/design-system-tokens-0.5.1.tgz
npm notice package size:  26.0 kB                                  
npm notice unpacked size: 341.3 kB                                 
npm notice shasum:        cb3e6ca49504adaf275d09623b6fd8e6ce69222e 
npm notice integrity:     sha512-Z66qr+H3pRlAv[...]L1tHwWMgzzUqQ== 
npm notice total files:   15                                       
npm notice 

> @hashicorp/design-system-tokens@0.5.1 postpublish
> git clean -fd

Removing devdot/⠂⠂⠂⸩ ⠧ : notice
Removing docs/
Removing products/
+ @hashicorp/design-system-tokens@0.5.1
```


## :link: External Links
* https://docs.npmjs.com/cli/v8/using-npm/scripts#npm-pack
* [StackOverflow inspiration](https://stackoverflow.com/a/55602875/763395)
<!-- Issues, RFC, etc. -->

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
