### PR TITLE
"Breadcrumb" component - Remove "extra" container

### DIFF
--- a/packages/components/addon/components/hds/breadcrumb/item.hbs
+++ b/packages/components/addon/components/hds/breadcrumb/item.hbs
@@ -7,12 +7,6 @@
         </div>
       {{/if}}
       <span class="hds-breadcrumb__text">{{@text}}</span>
-      {{! TODO: this should work but it doesn't (for me) - see also https://youtu.be/RD8a2SrjieM?t=4936 }}
-      {{#if (has-block "extra")}}
-        <div class="hds-breadcrumb__extra">
-          {{yield to="extra"}}
-        </div>
-      {{/if}}
     </div>
   {{else}}
     <LinkTo
@@ -29,12 +23,6 @@
         </div>
       {{/if}}
       <span class="hds-breadcrumb__text">{{@text}}</span>
-      {{! TODO: this should work but it doesn't (for me) - see also https://youtu.be/RD8a2SrjieM?t=4936 }}
-      {{#if (has-block "extra")}}
-        <div class="hds-breadcrumb__extra">
-          {{yield to="extra"}}
-        </div>
-      {{/if}}
     </LinkTo>
   {{/if}}
 </li>

--- a/packages/components/app/styles/components/breadcrumb.scss
+++ b/packages/components/app/styles/components/breadcrumb.scss
@@ -133,21 +133,6 @@ $hds-breadcrumb-item-visual-horizontal-padding: 4px;
     white-space: nowrap;
 }
 
-.hds-breadcrumb__extra {
-    align-items: center;
-    display: flex;
-    flex: none;
-    height: $hds-breadcrumb-item-height;
-    margin-left: 4px;
-    overflow: visible;
-
-    // TODO necessary until we figure out if we can do a conditional in the HBS file
-    // UPDATE: doesn't work because Ember adds an empty comment ¯\_(ツ)_/¯
-    &:empty{
-        display: none;
-    }
-}
-
 // TRUNCATION
 
 .hds-breadcrumb__truncation-toggle {

--- a/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
+++ b/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
@@ -27,20 +27,6 @@
     <Hds::Breadcrumb::Item @text="Current" @current={{true}} />
   </Hds::Breadcrumb>
 
-  <p class="dummy-paragraph">with extra</p>
-  <Hds::Breadcrumb>
-    <Hds::Breadcrumb::Item @text="Level one" />
-    <Hds::Breadcrumb::Item @text="Level two" />
-    <Hds::Breadcrumb::Item @text="Level three" />
-    <Hds::Breadcrumb::Item @text="Level four" />
-    <Hds::Breadcrumb::Item @text="Level five">
-      <:extra>
-        <Hds::Badge @text="Badge" @color="neutral" />
-      </:extra>
-    </Hds::Breadcrumb::Item>
-    <Hds::Breadcrumb::Item @text="Current" @current={{true}} />
-  </Hds::Breadcrumb>
-
   <p class="dummy-paragraph">with truncation</p>
   <Hds::Breadcrumb>
     <Hds::Breadcrumb::Item @text="Level one" />
@@ -69,11 +55,7 @@
       <Hds::Breadcrumb::Item @text="Another sub-level with icon" @icon="folder" />
     </Hds::Breadcrumb::Truncation>
     <Hds::Breadcrumb::Item @text="Level four" />
-    <Hds::Breadcrumb::Item @text="Level five">
-      <:extra>
-        <Hds::Badge @text="Badge" @color="neutral" />
-      </:extra>
-    </Hds::Breadcrumb::Item>
+    <Hds::Breadcrumb::Item @text="Level five" />
     <Hds::Breadcrumb::Item @text="Current" @current={{true}} />
   </Hds::Breadcrumb>
 
@@ -88,11 +70,7 @@
       <Hds::Breadcrumb::Item @text="Another sub-level with icon" @icon="folder" />
     </Hds::Breadcrumb::Truncation>
     <Hds::Breadcrumb::Item @text="Level four" @hover={{true}} />
-    <Hds::Breadcrumb::Item @text="Level five" @hover={{true}}>
-      <:extra>
-        <Hds::Badge @text="Badge" @color="neutral" @hover={{true}} />
-      </:extra>
-    </Hds::Breadcrumb::Item>
+    <Hds::Breadcrumb::Item @text="Level five" @hover={{true}} />
     <Hds::Breadcrumb::Item @text="Current" @current={{true}} @hover={{true}} />
   </Hds::Breadcrumb>
 
@@ -107,11 +85,7 @@
       <Hds::Breadcrumb::Item @text="Another sub-level with icon" @icon="folder" />
     </Hds::Breadcrumb::Truncation>
     <Hds::Breadcrumb::Item @text="Level four" @active={{true}} />
-    <Hds::Breadcrumb::Item @text="Level five" @active={{true}}>
-      <:extra>
-        <Hds::Badge @text="Badge" @color="neutral" @active={{true}} />
-      </:extra>
-    </Hds::Breadcrumb::Item>
+    <Hds::Breadcrumb::Item @text="Level five" @active={{true}} />
     <Hds::Breadcrumb::Item @text="Current" @current={{true}} @active={{true}} />
   </Hds::Breadcrumb>
 
@@ -126,11 +100,7 @@
       <Hds::Breadcrumb::Item @text="Another sub-level with icon" @icon="folder" />
     </Hds::Breadcrumb::Truncation>
     <Hds::Breadcrumb::Item @text="Level four" @focus={{true}} />
-    <Hds::Breadcrumb::Item @text="Level five" @focus={{true}}>
-      <:extra>
-        <Hds::Badge @text="Badge" @color="neutral" @focus={{true}} />
-      </:extra>
-    </Hds::Breadcrumb::Item>
+    <Hds::Breadcrumb::Item @text="Level five" @focus={{true}} />
     <Hds::Breadcrumb::Item @text="Current" @current={{true}} @focus={{true}} />
   </Hds::Breadcrumb>
 
@@ -148,18 +118,13 @@
         <Hds::Breadcrumb::Item @text="Another sub-level with icon" @icon="folder" />
       </Hds::Breadcrumb::Truncation>
       <Hds::Breadcrumb::Item @text="Level four" />
-      <Hds::Breadcrumb::Item @text="Level five">
-        <:extra>
-          <Hds::Badge @text="Badge" @color="neutral" />
-        </:extra>
-      </Hds::Breadcrumb::Item>
+      <Hds::Breadcrumb::Item @text="Level five" />
       <Hds::Breadcrumb::Item @text="Current" @current={{true}} />
     </Hds::Breadcrumb>
   </div>
 
   <p class="dummy-paragraph">with long strings / items can wrap (default)</p>
   <div class="dummy-breadcrumb-max-width-container-large">
-    <Hds::Breadcrumb @icons={{true}} @longStrings={{true}} @extra={{true}} @truncation={{true}} />
     <Hds::Breadcrumb>
       <Hds::Breadcrumb::Item @text="Level one with a very long string" @icon="org" />
       <Hds::Breadcrumb::Item @text="Level two with a very long string" @icon="folder" />
@@ -170,11 +135,7 @@
         <Hds::Breadcrumb::Item @text="Another sub-level with icon" @icon="folder" />
       </Hds::Breadcrumb::Truncation>
       <Hds::Breadcrumb::Item @text="Level four with a very long string" />
-      <Hds::Breadcrumb::Item @text="Level five with a very long string">
-        <:extra>
-          <Hds::Badge @text="Badge" @color="neutral" />
-        </:extra>
-      </Hds::Breadcrumb::Item>
+      <Hds::Breadcrumb::Item @text="Level five with a very long string" />
       <Hds::Breadcrumb::Item @text="Current with a very long string" @current={{true}} />
     </Hds::Breadcrumb>
 
@@ -192,11 +153,7 @@
         <Hds::Breadcrumb::Item @text="Another sub-level with icon" @icon="folder" />
       </Hds::Breadcrumb::Truncation>
       <Hds::Breadcrumb::Item @text="Level four with a very long string" />
-      <Hds::Breadcrumb::Item @text="Level five with a very long string">
-        <:extra>
-          <Hds::Badge @text="Badge" @color="neutral" />
-        </:extra>
-      </Hds::Breadcrumb::Item>
+      <Hds::Breadcrumb::Item @text="Level five with a very long string" />
       <Hds::Breadcrumb::Item @text="Current with a very long string" @current={{true}} />
     </Hds::Breadcrumb>
   </div>
@@ -208,11 +165,7 @@
       <Hds::Breadcrumb::Item @text="Level two" @icon="folder" />
       <Hds::Breadcrumb::Item @text="Level three" />
       <Hds::Breadcrumb::Item @text="Level four with a very long string" @maxWidth="180px" />
-      <Hds::Breadcrumb::Item @text="Level five">
-        <:extra>
-          <Hds::Badge @text="Badge" @color="neutral" />
-        </:extra>
-      </Hds::Breadcrumb::Item>
+      <Hds::Breadcrumb::Item @text="Level five" />
       <Hds::Breadcrumb::Item @text="Current" @current={{true}} />
     </Hds::Breadcrumb>
   </div>


### PR DESCRIPTION
⚠️ Notice: preview of the branch does not work yet, please review only the code as is.

## :pushpin: Summary

After considerations, the designers have decided to limit what a breadcrumb `item` can have as elements only an `icon` (optional) and `text`. See [thread here](https://hashicorp.slack.com/archives/C02PRETTF24/p1646953039737739).

## :hammer_and_wrench: Detailed description

In this PR I have:
- removed the `extra` named block from the `Hds::Breadcrumb` item (and its styling)
- updated the showcase in the documentation page accordingly

## :white_check_mark: Reviewer's checklist

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
