### PR TITLE
Debug ember-cli-build in Yarn workspaces monorepo

### DIFF
--- a/packages/components/ember-cli-build.js
+++ b/packages/components/ember-cli-build.js
@@ -8,7 +8,7 @@ module.exports = function (defaults) {
     sassOptions: {
       precision: 4,
       includePaths: [
-        './node_modules/@hashicorp/design-system-tokens/products/css',
+        '../../node_modules/@hashicorp/design-system-tokens/dist/products/css',
       ],
     },
     'ember-prism': {


### PR DESCRIPTION
## :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

In previous setup of separate repos on GitHub, we were calling the file from https://www.npmjs.com/package/@hashicorp/design-system-tokens from the node_modules.

Since moving to the monorepo, you now run `yarn` at root. 

If I try to run `yarn start` from `packages/components`, I get this error:

```
design-system (main) 🌔 ~ pwd
/Users/amyrlam/src/hashicorp/design-system/packages/components
design-system (main) 🌔 ~ yarn start
yarn run v1.22.17
$ ember serve
assets by chunk 251 KiB (id hint: vendors)
  asset chunk.vendors-node_modules_qunit_qunit_qunit_js.eee25cc03640966de22f.js 191 KiB [emitted] [immutable] (id hint: vendors)
  asset chunk.vendors-node_modules_clipboard_dist_clipboard_js-node_modules_ember-focus-trap_dist_modifiers-7792e0.c22fe5d1b2b6b10ad945.js 59.9 KiB [emitted] [immutable] (id hint: vendors)
asset chunk.app.67844eb45a34e618854a.js 11.4 KiB [emitted] [immutable] (name: app)
asset chunk.tests.2b5f45b0af97f43756ac.js 9.31 KiB [emitted] [immutable] (name: tests)
Entrypoint app 71.3 KiB = chunk.vendors-node_modules_clipboard_dist_clipboard_js-node_modules_ember-focus-trap_dist_modifiers-7792e0.c22fe5d1b2b6b10ad945.js 59.9 KiB chunk.app.67844eb45a34e618854a.js 11.4 KiB
Entrypoint tests 200 KiB = chunk.vendors-node_modules_qunit_qunit_qunit_js.eee25cc03640966de22f.js 191 KiB chunk.tests.2b5f45b0af97f43756ac.js 9.31 KiB
runtime modules 5.96 KiB 10 modules
built modules 242 KiB [built]
  modules by path ../../node_modules/ 241 KiB
    ../../node_modules/clipboard/dist/clipboard.js 21.8 KiB [built] [code generated]
    ../../node_modules/ember-focus-trap/dist/modifiers/focus-trap.js 2.07 KiB [built] [code generated]
    ../../node_modules/prismjs-glimmer/dist/glimmer.esm.min.js 2.88 KiB [built] [code generated]
    ../../node_modules/qunit/qunit/qunit.js 186 KiB [built] [code generated]
    ../../node_modules/focus-trap/dist/focus-trap.esm.js 20.3 KiB [built] [code generated]
    ../../node_modules/tabbable/dist/index.esm.js 7.13 KiB [built] [code generated]
  modules by path ../../../../../../../private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/*.js 1.42 KiB
    ../../../../../../../private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/l.js 50 bytes [built] [code generated]
    ../../../../../../../private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/app.js 896 bytes [built] [code generated]
    ../../../../../../../private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/tests.js 511 bytes [built] [code generated]
  external "@ember/modifier" 42 bytes [built] [code generated]

ERROR in ../../../../../../../private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/app.js 15:91-159
Module not found: Error: Can't resolve '@hashicorp/design-system-tokens/docs/products/tokens.json' in '/private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack'
resolve '@hashicorp/design-system-tokens/docs/products/tokens.json' in '/private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack'
  Parsed request is a module
  No description file found in /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack or above
  resolve as module
    looking for modules in /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/node_modules
      existing directory /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/node_modules/@hashicorp/design-system-tokens
        using description file: /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/node_modules/@hashicorp/design-system-tokens/package.json (relative path: .)
          using description file: /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/node_modules/@hashicorp/design-system-tokens/package.json (relative path: ./docs/products/tokens.json)
            no extension
              Field 'browser' doesn't contain a valid alias configuration
              /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/node_modules/@hashicorp/design-system-tokens/docs/products/tokens.json doesn't exist
            .js
              Field 'browser' doesn't contain a valid alias configuration
              /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/node_modules/@hashicorp/design-system-tokens/docs/products/tokens.json.js doesn't exist
            .ts
              Field 'browser' doesn't contain a valid alias configuration
              /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/node_modules/@hashicorp/design-system-tokens/docs/products/tokens.json.ts doesn't exist
            .json
              Field 'browser' doesn't contain a valid alias configuration
              /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/node_modules/@hashicorp/design-system-tokens/docs/products/tokens.json.json doesn't exist
            as directory
              /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/cache-256-webpack_bundler_ember_auto_import_webpack/node_modules/@hashicorp/design-system-tokens/docs/products/tokens.json doesn't exist
    /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/broccoli-49626T75N700O2eXz/node_modules doesn't exist or is not a directory
    /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/node_modules doesn't exist or is not a directory
    /private/var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/node_modules doesn't exist or is not a directory
    /private/var/folders/4h/node_modules doesn't exist or is not a directory
    /private/var/folders/node_modules doesn't exist or is not a directory
    /private/var/node_modules doesn't exist or is not a directory
    /private/node_modules doesn't exist or is not a directory
    /node_modules doesn't exist or is not a directory

webpack 5.70.0 compiled with 1 error in 
Build Error (WebpackBundler)

webpack returned errors to ember-auto-import


Stack Trace and Error Report: /var/folders/4h/xdzhnlzn31d3ts77p18y5qhm0000gq/T/error.dump.1e9a48070997a4dd311d91ce83120671.log
```

We are doing some moving around of the files for publish to npm, meaning that the file structure of the local `node_modules` at root != that of npm explore https://www.npmjs.com/package/@hashicorp/design-system-tokens

![image](https://user-images.githubusercontent.com/1372946/157925935-3069d4c3-0f26-4749-8e0a-96f1b77a88c7.png)

My hunch is to have the file structure be the same, but I can't really test this without publishing to npm. I am new to yarn workspaces, but that's my best guess. Let me know if you have any ideas
