### PR TITLE
Illusions of dist-ribution

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -56,34 +56,34 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_COMPONENTS }}
 
-  # try-scenarios:
-  #   name: ${{ matrix.try-scenario }}
-  #   runs-on: ubuntu-latest
-  #   needs: 'test'
+  try-scenarios:
+    name: ${{ matrix.try-scenario }}
+    runs-on: ubuntu-latest
+    needs: 'test'
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       try-scenario:
-  #         - ember-lts-3.24
-  #         - ember-lts-3.28
-  #         - ember-release
-  #         - ember-beta
-  #        # - ember-canary
-  #         - ember-classic
-  #        # - embroider-safe
-  #        # - embroider-optimized
+    strategy:
+      fail-fast: false
+      matrix:
+        try-scenario:
+          - ember-lts-3.24
+          - ember-lts-3.28
+          - ember-release
+          - ember-beta
+         # - ember-canary
+          - ember-classic
+         # - embroider-safe
+         # - embroider-optimized
 
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install Node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: ${{ env.NODE_VERSION }}
-  #         cache: yarn
-  #         cache-dependency-path: yarn.lock
-  #     - name: Install Dependencies
-  #       run: yarn install --frozen-lockfile
-  #     - name: Run Tests
-  #       working-directory: packages/components
-  #       run: yarn run test:ember-compatibility:ci ${{ matrix.try-scenario }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+          cache-dependency-path: yarn.lock
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run Tests
+        working-directory: packages/components
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}

--- a/packages/components/ember-cli-build.js
+++ b/packages/components/ember-cli-build.js
@@ -8,7 +8,7 @@ module.exports = function (defaults) {
     sassOptions: {
       precision: 4,
       includePaths: [
-        '../../node_modules/@hashicorp/design-system-tokens/dist/products/css',
+        '../../node_modules/@hashicorp/design-system-tokens/products/css',
       ],
     },
     'ember-prism': {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,7 +31,6 @@
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each",
-    "test:ember-compatibility:ci": "ember try:one",
     "test:ember:percy": "percy exec ember test"
   },
   "dependencies": {

--- a/packages/components/tests/dummy/app/routes/foundations/colors.js
+++ b/packages/components/tests/dummy/app/routes/foundations/colors.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 
-import TOKENS_RAW from '@hashicorp/design-system-tokens/dist/docs/products/tokens.json';
+import TOKENS_RAW from '@hashicorp/design-system-tokens/docs/products/tokens.json';
 
 export default class FoundationsColorsRoute extends Route {
   model() {

--- a/packages/components/tests/dummy/app/routes/foundations/tokens.js
+++ b/packages/components/tests/dummy/app/routes/foundations/tokens.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 
-import TOKENS_RAW from '@hashicorp/design-system-tokens/dist/docs/products/tokens.json';
+import TOKENS_RAW from '@hashicorp/design-system-tokens/docs/products/tokens.json';
 
 export default class FoundationsTokensRoute extends Route {
   model() {

--- a/packages/tokens/devdot
+++ b/packages/tokens/devdot
@@ -1,0 +1,1 @@
+dist/devdot

--- a/packages/tokens/docs
+++ b/packages/tokens/docs
@@ -1,0 +1,1 @@
+dist/docs

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -19,8 +19,8 @@
     "typecheck": "yarn tsc --noEmit",
     "lint": "yarn eslint --quiet --ext .js,.ts",
     "build": "ts-node --transpile-only ./scripts/build",
-    "prepublishOnly": "cp -r ./dist/* .",
-    "postpublish": "git clean -fd"
+    "prepublishOnly": "./scripts/publish.sh",
+    "postpublish": "./scripts/postPublish.sh"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",

--- a/packages/tokens/products
+++ b/packages/tokens/products
@@ -1,0 +1,1 @@
+dist/products

--- a/packages/tokens/scripts/postPublish.sh
+++ b/packages/tokens/scripts/postPublish.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# now that we have published, remove the folders that were copied over from `dist`
+rm -rf devdot
+rm -rf docs
+rm -rf products
+
+# manually recreate the symlinks so it looks like the folders in `dist` exist at the root
+ln -s dist/devdot devdot
+ln -s dist/docs docs
+ln -s dist/products products

--- a/packages/tokens/scripts/publish.sh
+++ b/packages/tokens/scripts/publish.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# remove the symlinks pointing to folders in `dist`
+rm devdot
+rm docs
+rm products
+
+# copy folders from dist to root for packing/publishing
+cp -r ./dist/* .


### PR DESCRIPTION
## :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

Make all component tests work while maintaining the illusion that the published version of tokens is the same as what we are working with on disk.

## :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

I'm not convinced this is "good", but it does work. This PR does two main things.

First, it creates symlinks in the root of the `packages/tokens` folder pointing to the corresponding folder in `dist`. This allows us to reference assets in that folder similar to how they are in the published version of the package which is from the root *not* `dist/`. This effectively restores the code to what it was before the monorepo migration.

Second, when it comes time to publish we remove these symlinks so we can actually copy the folders to root for publishing. This is necessary because `npm publish` [does not follow symlinks](https://github.com/npm/npm/issues/3310). Once we are done publishing, the symlinks are manually restored via a separate script.

So, this does work but it feels a bit overcomplicated when we could publish these files from `dist/` and avoid the need for all of this.

```bash
~/c/w/d/p/tokens (br-hoist|✚2) $ ls -l
total 96
-rw-r--r--  1 runnells  staff   3060 Mar 11 09:54 CONTRIBUTING.md
-rw-r--r--  1 runnells  staff  16725 Mar 11 09:54 LICENSE.md
-rw-r--r--  1 runnells  staff   1381 Mar 11 09:54 README.md
-rw-r--r--  1 runnells  staff   2499 Mar 11 09:54 RELEASE.md
lrwxr-xr-x  1 runnells  staff     11 Mar 15 08:31 devdot@ -> dist/devdot
drwxr-xr-x  5 runnells  staff    160 Mar 11 15:27 dist/
lrwxr-xr-x  1 runnells  staff      9 Mar 15 08:31 docs@ -> dist/docs
drwxr-xr-x  7 runnells  staff    224 Mar 15 08:23 node_modules/
-rw-r--r--  1 runnells  staff   1190 Mar 15 08:24 package.json
lrwxr-xr-x  1 runnells  staff     13 Mar 15 08:31 products@ -> dist/products
drwxr-xr-x  7 runnells  staff    224 Mar 15 08:24 scripts/
drwxr-xr-x  5 runnells  staff    160 Mar 11 09:54 src/
-rw-r--r--  1 runnells  staff  10885 Mar 11 09:54 tsconfig.json
~/c/w/d/p/tokens (br-hoist|✚2) $ npm publish --dry-run

> @hashicorp/design-system-tokens@0.5.1 prepublishOnly
> ./scripts/publish.sh

npm notice 
npm notice 📦  @hashicorp/design-system-tokens@0.5.1
npm notice === Tarball Contents === 
npm notice 16.7kB  LICENSE.md                         
npm notice 1.4kB   README.md                          
npm notice 3.7kB   devdot/css/helpers/color.css       
npm notice 1.1kB   devdot/css/helpers/elevation.css   
npm notice 158B    devdot/css/helpers/focus-ring.css  
npm notice 2.6kB   devdot/css/helpers/typography.css  
npm notice 21.0kB  devdot/css/tokens.css              
npm notice 133.1kB docs/devdot/tokens.json            
npm notice 132.3kB docs/products/tokens.json          
npm notice 1.2kB   package.json                       
npm notice 3.6kB   products/css/helpers/color.css     
npm notice 1.1kB   products/css/helpers/elevation.css 
npm notice 158B    products/css/helpers/focus-ring.css
npm notice 2.6kB   products/css/helpers/typography.css
npm notice 20.8kB  products/css/tokens.css            
npm notice === Tarball Details === 
npm notice name:          @hashicorp/design-system-tokens          
npm notice version:       0.5.1                                    
npm notice filename:      @hashicorp/design-system-tokens-0.5.1.tgz
npm notice package size:  26.0 kB                                  
npm notice unpacked size: 341.3 kB                                 
npm notice shasum:        cd984b038be77bc3784ec08080243c9b98cfe3f4 
npm notice integrity:     sha512-glSqbJXPWC8Nk[...]oyB52Wg/A59TA== 
npm notice total files:   15                                       
npm notice 

> @hashicorp/design-system-tokens@0.5.1 postpublish
> ./scripts/postPublish.sh

+ @hashicorp/design-system-tokens@0.5.1
~/c/w/d/p/tokens (br-hoist|✔) $ ls -l
total 96
-rw-r--r--  1 runnells  staff   3060 Mar 11 09:54 CONTRIBUTING.md
-rw-r--r--  1 runnells  staff  16725 Mar 11 09:54 LICENSE.md
-rw-r--r--  1 runnells  staff   1381 Mar 11 09:54 README.md
-rw-r--r--  1 runnells  staff   2499 Mar 11 09:54 RELEASE.md
lrwxr-xr-x  1 runnells  staff     11 Mar 15 08:37 devdot@ -> dist/devdot
drwxr-xr-x  5 runnells  staff    160 Mar 11 15:27 dist/
lrwxr-xr-x  1 runnells  staff      9 Mar 15 08:37 docs@ -> dist/docs
drwxr-xr-x  7 runnells  staff    224 Mar 15 08:23 node_modules/
-rw-r--r--  1 runnells  staff   1190 Mar 15 08:24 package.json
lrwxr-xr-x  1 runnells  staff     13 Mar 15 08:37 products@ -> dist/products
drwxr-xr-x  7 runnells  staff    224 Mar 15 08:24 scripts/
drwxr-xr-x  5 runnells  staff    160 Mar 11 09:54 src/
-rw-r--r--  1 runnells  staff  10885 Mar 11 09:54 tsconfig.json
```

## :white_check_mark: Reviewer's checklist

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
