### PR TITLE
publish design-system-tokens to dist and root

### DIFF
--- a/.changeset/lovely-candles-pull.md
+++ b/.changeset/lovely-candles-pull.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-tokens": patch
+---
+
+Publish assets also to dist/

--- a/packages/tokens/.npmignore
+++ b/packages/tokens/.npmignore
@@ -1,4 +1,3 @@
-/dist/
 /src
 /scripts
 


### PR DESCRIPTION
## :pushpin: Summary

This is a stopgap PR to temporarily publish tokens to both the root of the design-system-tokens package and to `dist/`.

## :hammer_and_wrench: Detailed description

We ultimately want to only publish these to `dist/`, but if we made the change all at once we'd have a situation where we're trying to access assets in a folder that hasn't been published to npm yet but exists locally in the monorepo. Confusing!

Once this PR is merged we can publish the package to NPM and then merge the follow-on PR to fully resolve this.

```bash
~/c/w/d/p/tokens (br-tokens-to-dist|✔) $ npm publish --dry-run

> @hashicorp/design-system-tokens@0.5.1 prepublishOnly
> ./scripts/publish.sh

npm notice 
npm notice 📦  @hashicorp/design-system-tokens@0.5.1
npm notice === Tarball Contents === 
npm notice 16.7kB  LICENSE.md                              
npm notice 1.4kB   README.md                               
npm notice 3.7kB   devdot/css/helpers/color.css            
npm notice 1.1kB   devdot/css/helpers/elevation.css        
npm notice 158B    devdot/css/helpers/focus-ring.css       
npm notice 2.6kB   devdot/css/helpers/typography.css       
npm notice 21.0kB  devdot/css/tokens.css                   
npm notice 3.7kB   dist/devdot/css/helpers/color.css       
npm notice 1.1kB   dist/devdot/css/helpers/elevation.css   
npm notice 158B    dist/devdot/css/helpers/focus-ring.css  
npm notice 2.6kB   dist/devdot/css/helpers/typography.css  
npm notice 21.0kB  dist/devdot/css/tokens.css              
npm notice 133.1kB dist/docs/devdot/tokens.json            
npm notice 132.3kB dist/docs/products/tokens.json          
npm notice 3.6kB   dist/products/css/helpers/color.css     
npm notice 1.1kB   dist/products/css/helpers/elevation.css 
npm notice 158B    dist/products/css/helpers/focus-ring.css
npm notice 2.6kB   dist/products/css/helpers/typography.css
npm notice 20.8kB  dist/products/css/tokens.css            
npm notice 133.1kB docs/devdot/tokens.json                 
npm notice 132.3kB docs/products/tokens.json               
npm notice 1.2kB   package.json                            
npm notice 3.6kB   products/css/helpers/color.css          
npm notice 1.1kB   products/css/helpers/elevation.css      
npm notice 158B    products/css/helpers/focus-ring.css     
npm notice 2.6kB   products/css/helpers/typography.css     
npm notice 20.8kB  products/css/tokens.css                 
npm notice === Tarball Details === 
npm notice name:          @hashicorp/design-system-tokens          
npm notice version:       0.5.1                                    
npm notice filename:      @hashicorp/design-system-tokens-0.5.1.tgz
npm notice package size:  41.3 kB                                  
npm notice unpacked size: 663.4 kB                                 
npm notice shasum:        f4483764783aeb3cc9fe46db8f645491a44d4e6b 
npm notice integrity:     sha512-7eIrHK7EuvA1Z[...]1nvDIQZ397Vow== 
npm notice total files:   27                                       
npm notice 

```

***

## :white_check_mark: Reviewer's checklist

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
