### PR TITLE
use correct package for changelog generation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.7.0/schema.json",
-  "changelog": ["@changesets/cli/changelog-github",
+  "changelog": ["@changesets/changelog-github",
     { "repo": "hashicorp/design-system" }
   ],
   "commit": false,

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ yarn changeset publish
 
 Note: You will need a company-approved 2FA-enabled account on npm to publish (see [npm 2FA docs](https://docs.npmjs.com/configuring-two-factor-authentication) for more info).
 
+### Local Testing of Versioning
+
+You can simulate the versioning experience locally with this command:
+
+```bash
+yarn changeset version
+```
+
+In order for this step to complete successfully you'll need to create a personal access token [in GitHub](https://github.com/settings/tokens). The name could be anything e.g. `design-system`, with `read:user` and `repo:status` scopes, and then add the token to a `.env` file in the project's root.
+
+```
+GITHUB_TOKEN=YOUR-TOKEN-HERE
+```
+
 ## Flight Icons
 
 | Package                                                                              | Version                                                                                                                         |


### PR DESCRIPTION
## :pushpin: Summary

I'm not sure how I messed this up, but the path here was not correct and it caused the release generation action to [fail](https://github.com/hashicorp/design-system/actions/runs/1989088450). I've verified locally that this works and once this PR is merged the action should succeed.