### PR TITLE
Fix missed semantic token update

### DIFF
--- a/packages/components/app/styles/components/link/standalone.scss
+++ b/packages/components/app/styles/components/link/standalone.scss
@@ -102,7 +102,7 @@ $size-props: (
     }
 
     &::before {
-      background-color: var(--token-color-action-background-faint);
+      background-color: var(--token-color-surface-action);
     }
   }
 }


### PR DESCRIPTION
## :pushpin: Summary

Not sure how, but I missed one semantic token replacement (likely due to some merged branch that contained this update).

## :white_check_mark: Reviewer's checklist

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
