### PR TITLE
"Button" component - Fix "elevation" treatment

### DIFF
--- a/.changeset/lazy-gifts-serve.md
+++ b/.changeset/lazy-gifts-serve.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Fixed the "elevation" treatment for the "Button" component

--- a/packages/components/addon/components/hds/button/index.js
+++ b/packages/components/addon/components/hds/button/index.js
@@ -185,9 +185,6 @@ export default class HdsButtonIndexComponent extends Component {
       classes.push('hds-button--width-full');
     }
 
-    // the button has a "low" elevation effect applied to it
-    classes.push('hds-elevation-low');
-
     return classes.join(' ');
   }
 }

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -59,6 +59,8 @@ $hds-button-focus-border-width: 3px;
 
   &:focus,
   &.is-focus {
+    box-shadow: none;
+
     &::before {
       // the position absolute of an element is computed from the inside of the border of the container
       // so we have to take in account the border width of the pseudo-element container itself
@@ -141,6 +143,7 @@ $size-props: (
 .hds-button--color-primary {
   background-color: var(--token-color-palette-blue-200);
   border-color: var(--token-color-palette-blue-300);
+  box-shadow: var(--token-elevation-low-box-shadow);
   color: var(--token-color-foreground-high-contrast);
 
   &:focus,
@@ -183,6 +186,7 @@ $size-props: (
 .hds-button--color-secondary {
   background-color: var(--token-color-surface-faint);
   border-color: var(--token-color-border-strong);
+  box-shadow: var(--token-elevation-low-box-shadow);
   color: var(--token-color-foreground-primary);
 
   &:focus,
@@ -217,8 +221,6 @@ $size-props: (
   background-color: transparent;
   border-color: transparent;
   color: var(--token-color-foreground-action);
-  // TODO! fix the shadows for the button (this will be done in a follow-up PR)
-  box-shadow: none;
 
   &:focus,
   &.is-focus {
@@ -267,6 +269,7 @@ $size-props: (
 .hds-button--color-critical {
   background-color: var(--token-color-surface-critical);
   border-color: var(--token-color-foreground-critical-on-surface);
+  box-shadow: var(--token-elevation-low-box-shadow);
   color: var(--token-color-foreground-critical-on-surface);
 
   &:focus,


### PR DESCRIPTION
## :pushpin: Summary

While working on #76 I noticed that the way we applied the "elevation" styles to the `Button" component was not in sync with the design specs in Figma.

In this PR I have update the code accordingly to the designs.

Preview of the documentation page: https://hds-components-git-fix-button-elevation-treatment-hashicorp.vercel.app/components/button

## :camera_flash: Screenshots

These are the Button's `color` and `state` variant that have a `elevation-low` style applied (I've emphasized the effect to make it more visible)
<img width="729" alt="screenshot_1099" src="https://user-images.githubusercontent.com/686239/158586855-4f3c52be-9e22-4b66-80dd-5d78179c3514.png">

***

##  👀 How to review

👉 Review by files changed

Reviewer's checklist:
- [ ] +1 Percy
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201977868744725