### PR TITLE
automate releases to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,5 +27,10 @@ jobs:
 
       - name: Create Release Pull Request
         uses: changesets/action@v1
+        with:
+          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Token setup in Dhaulagiri's account
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.3",
     "@changesets/cli": "^2.21.0"
+  },
+  "scripts": {
+    "release": "yarn changeset publish"
   }
 }


### PR DESCRIPTION
## :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

Automatically publishes packages to NPM upon merge of release PRs

## :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

This PR follows [the instructions](https://github.com/changesets/action#with-publishing) for setting up auto publishing to NPM with the changeset github action. I think this is worth doing because it removes multiple manual steps which ensures the process is done correctly each time. As a bonus, it'll also create a release in the GitHub UI [like these](https://github.com/hashicorp/react-components/releases).

It's worth calling out that this is currently setup to use an NPM token generated by me, however I'll make followup tasks to improve this but that will likely take a couple of weeks to get setup.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
