### PR TITLE
Added “foreground-action-visited-hover” color to DevDot

### DIFF
--- a/.changeset/blue-clouds-marry.md
+++ b/.changeset/blue-clouds-marry.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-tokens": patch
+---
+
+Added “foreground-action-visited-hover” color token to DevDot

--- a/packages/tokens/dist/devdot/css/helpers/color.css
+++ b/packages/tokens/dist/devdot/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 04 Mar 2022 17:16:48 GMT
+ * Generated on Thu, 17 Mar 2022 08:19:13 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }
@@ -32,6 +32,7 @@
 .hds-foreground-critical-on-surface { color: var(--token-color-foreground-critical-on-surface); }
 .hds-foreground-critical-high-contrast { color: var(--token-color-foreground-critical-high-contrast); }
 .hds-foreground-action-visited { color: var(--token-color-foreground-action-visited); }
+.hds-foreground-action-visited-hover { color: var(--token-color-foreground-action-visited-hover); }
 .hds-page-primary { background-color: var(--token-color-page-primary); }
 .hds-page-faint { background-color: var(--token-color-page-faint); }
 .hds-surface-primary { background-color: var(--token-color-surface-primary); }

--- a/packages/tokens/dist/devdot/css/tokens.css
+++ b/packages/tokens/dist/devdot/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 07 Mar 2022 11:14:41 GMT
+ * Generated on Thu, 17 Mar 2022 08:19:13 GMT
  */
 
 :root {
@@ -134,6 +134,7 @@
   --token-color-foreground-critical-on-surface: #c00005;
   --token-color-foreground-critical-high-contrast: #51130a;
   --token-color-foreground-action-visited: #a737ff; /* This extra color is unique for the DevDot platform (the 'visited' state of a link is not differentiated in the products applications). */
+  --token-color-foreground-action-visited-hover: #7b00db; /* This extra color is unique for the DevDot platform (the 'visited+hover' state of a link is not differentiated in the products applications). */
   --token-color-neutral-foreground-primary: #0c0c0e; /* deprecated: replace with 'token-color-foreground-strong' */
   --token-color-neutral-foreground-secondary: #3b3d45; /* deprecated: replace with 'token-color-foreground-primary' */
   --token-color-neutral-foreground-faint: #656a76; /* deprecated: replace with 'token-color-foreground-faint' */

--- a/packages/tokens/dist/docs/devdot/tokens.json
+++ b/packages/tokens/dist/docs/devdot/tokens.json
@@ -2970,6 +2970,29 @@
     ]
   },
   {
+    "value": "#7b00db",
+    "type": "color",
+    "group": "semantic",
+    "comment": "This extra color is unique for the DevDot platform (the 'visited+hover' state of a link is not differentiated in the products applications).",
+    "original": {
+      "value": "{color.palette.purple-400.value}",
+      "type": "color",
+      "group": "semantic",
+      "comment": "This extra color is unique for the DevDot platform (the 'visited+hover' state of a link is not differentiated in the products applications)."
+    },
+    "name": "token-color-foreground-action-visited-hover",
+    "attributes": {
+      "category": "color",
+      "type": "foreground",
+      "item": "action-visited-hover"
+    },
+    "path": [
+      "color",
+      "foreground",
+      "action-visited-hover"
+    ]
+  },
+  {
     "value": "#0c0c0e",
     "type": "color",
     "deprecated": true,

--- a/packages/tokens/src/devdot/color/semantic-foreground.json
+++ b/packages/tokens/src/devdot/color/semantic-foreground.json
@@ -6,6 +6,12 @@
                 "type": "color",
                 "group": "semantic",
                 "comment": "This extra color is unique for the DevDot platform (the 'visited' state of a link is not differentiated in the products applications)."
+            },
+            "action-visited-hover": {
+                "value": "{color.palette.purple-400.value}",
+                "type": "color",
+                "group": "semantic",
+                "comment": "This extra color is unique for the DevDot platform (the 'visited+hover' state of a link is not differentiated in the products applications)."
             }
         }
     }


### PR DESCRIPTION
### :pushpin: Summary

In https://github.com/hashicorp/dev-portal/pull/187 the DevDot team has used `purple-400` as color to differentiate the `:visited+:hover`  state of an inline link. During review we agreed is better to have a specific "semantic" design token for it.

In this PR I have
- added the `foreground-action-visited-hover` color (only for DevDot)
- regenerated the design tokens in output

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
