### PR TITLE
Remove “component” text from items in index page

### DIFF
--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -34,32 +34,32 @@
 <ol>
   <li class="dummy-paragraph">
     <LinkTo @route="components.badge">
-      Badge component
+      Badge
     </LinkTo>
   </li>
   <li class="dummy-paragraph">
     <LinkTo @route="components.button">
-      Button component
+      Button
     </LinkTo>
   </li>
   <li class="dummy-paragraph">
     <LinkTo @route="components.card">
-      Card component
+      Card
     </LinkTo>
   </li>
   <li class="dummy-paragraph">
     <LinkTo @route="components.icon-tile">
-      IconTile component
+      IconTile
     </LinkTo>
   </li>
   <li class="dummy-paragraph">
     <LinkTo @route="components.link">
-      Link (Standalone) component
+      Link (Standalone)
     </LinkTo>
   </li>
   <li class="dummy-paragraph">
     <LinkTo @route="components.link-to">
-      LinkTo (Standalone) component
+      LinkTo (Standalone)
     </LinkTo>
   </li>
 </ol>
@@ -69,7 +69,7 @@
 <ol>
   <li class="dummy-paragraph">
     <LinkTo @route="utilities.disclosure">
-      Disclosure component
+      Disclosure
     </LinkTo>
   </li>
 </ol>


### PR DESCRIPTION
### :pushpin: Summary

Now that we have multiple components, the "component" text in the list of components in the home/index page becomes redundant, and makes the list harder to read/visually scan.

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed the “component” text from the items in index page of scrappy website

### :camera_flash: Screenshots

Before:
<img width="1283" alt="screenshot_1116" src="https://user-images.githubusercontent.com/686239/158807931-63b6ebd0-5fd4-41ba-8546-c1e5714f674a.png">

After:
<img width="1282" alt="screenshot_1115" src="https://user-images.githubusercontent.com/686239/158807923-233864cb-5711-4e7f-a1e3-0e5b71ce7003.png">
