### PR TITLE
Improve readability of the documentation website

### DIFF
--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -19,6 +19,7 @@
 @import "./components/dummy-placeholder";
 
 body.dummy-app {
+    background-color: #d9d9d9;
     padding: 0;
     max-width: 100%;
     margin: 0 auto;
@@ -76,8 +77,12 @@ body.dummy-app {
         }
 
         .dummy-main {
+            background-color: #fff;
             padding: 2rem;
+            margin: 0 auto;
+            max-width: 100%;
             min-height: 84.75vh;
+            width: 1024px;
         }
         .dummy-footer {
             padding: 0 2rem;


### PR DESCRIPTION
### :pushpin: Summary

Currently the content in the "scrappy" documentation website is full width, so with large screens it's really hard to read long paragraphs and to scan visually the content. Is better to apply a max-width to it. 

### :hammer_and_wrench: Detailed description

In this PR I have
- applied specific width to the main content
- applied a background to the body (to differentiate the two)

### :camera_flash: Screenshots

**Before:**
![before](https://user-images.githubusercontent.com/686239/158978969-75df6995-468d-4635-8b23-29e1c3864b40.png)

**After:**
![after](https://user-images.githubusercontent.com/686239/158978988-748ad9b5-e36d-4225-a321-61abf27feaff.png)

***

### 👀 How to review

Reviewer's checklist:

- [ ] +1 Percy (all the screenshots will be udpated)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
