### PR TITLE
Update "Button" documentation

### DIFF
--- a/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
@@ -29,6 +29,10 @@
             margin: 0;
         }
 
+        p + p {
+            margin-top: 0.125rem;
+        }
+
         ol {
             display: flex;
             flex-wrap: wrap;

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -33,6 +33,10 @@
     <dt>icon <code>string</code></dt>
     <dd>
       <p>Use this parameter to show an icon. Acceptable value: any Flight icon name.</p>
+      <p><strong>🚨 IMPORTANT:</strong>
+        <code class="dummy-code">tertiary</code>
+        buttons are required to have either a leading or trailing icon to be accessible.</p>
+
     </dd>
     <dt>iconPosition <code>enum</code></dt>
     <dd>
@@ -112,9 +116,6 @@
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" />
-  <p class="dummy-paragraph"><strong>🚨 IMPORTANT:</strong>
-    <code class="dummy-code">tertiary</code>
-    buttons are required to have either a leading or trailing icon to be accessible.</p>
 
   <h4 class="dummy-h4">Icon position</h4>
   <p class="dummy-paragraph">By default, if you define an icon, it is placed before the text. If you would like to


### PR DESCRIPTION
### :pushpin: Summary

The information that the `tertiary` button needs always an icon was buried in the examples and some people missed this critical information. Better to move it to the context of the `icon` prop.

### :hammer_and_wrench: Detailed description

In this PR I have:
- moved the information in a more prominent/contextual position.

### :camera_flash: Screenshots

How it looks now:
<img width="1054" alt="screenshot_1125" src="https://user-images.githubusercontent.com/686239/159054845-80cb24b2-7a27-41bc-8bfb-b07c0ce7cad1.png">

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
