### PR TITLE
Ignore prettier / ember-template-lint in tests

### DIFF
--- a/packages/components/.prettierignore
+++ b/packages/components/.prettierignore
@@ -19,3 +19,6 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# tests
+/tests/*


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

Without this change, when you open an existing test file, there will often be Prettier / ember-template-lint errors.

I don't think that we want Prettier in tests, it seems like overkill and will be very tedious.

TBH I'm not sure why this wasn't happening before. May have come with the monorepo change. I believe the best path forward is to fix it vs investigating the root cause beyond what I timeboxed.

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

WAS:
Existing button/index-test file:
![image](https://user-images.githubusercontent.com/1372946/159143300-5302d9a9-bc8c-406a-92d7-297e79ed5437.png)

Would get Prettier errors in CI, on any new test file: https://github.com/hashicorp/design-system/runs/5595891309?check_suite_focus=true

IS:
No Prettier test errors in /tests/:

<img width="1377" alt="image" src="https://user-images.githubusercontent.com/1372946/159143369-e90584ac-586a-4403-9262-be3273795355.png">


### :link: External links

<!-- Issues, RFC, etc. -->

https://app.asana.com/0/1201630204387510/1201988425660720/f

***

### 👀 How to review

Reviewer's checklist:

- [N/A] +1 Percy if applicable
- [N/A] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
