### PR TITLE
tell prettier to ignore tests folder

### DIFF
--- a/packages/components/.prettierignore
+++ b/packages/components/.prettierignore
@@ -14,6 +14,7 @@
 /coverage/
 !.*
 .eslintcache
+/tests/
 
 # ember-try
 /.node_modules.ember-try/


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR turns off prettier for the `/tests/` folder (so, tests and dummy app). It's driving me batty, hampering my productivity (rather than helping) and adds extra whitespace in my HTML that makes the documentation appear off for inline code blocks. I endorse using it for our templates in general, but I think it's safe enough to turn off in tests and dummy app.

WDYT?

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
