### PR TITLE
"Breadcrumb" component - Remove comment and update documentation for "aria-label"

### DIFF
--- a/packages/components/addon/components/hds/breadcrumb/index.hbs
+++ b/packages/components/addon/components/hds/breadcrumb/index.hbs
@@ -1,12 +1,4 @@
-<nav
-  class={{this.classNames}}
-  {{!
-    TODO: should this string be localized, like in Structure? https://github.com/hashicorp/structure/blob/dffbb0e0ae5246d3b832586ab25bcb981a052b30/packages/pds-ember/addon/components/pds/breadcrumbs/index.hbs#L3
-    (in which case, we need to expose a prop? or start to have localization in the HDS system?)
-  }}
-  aria-label="breadcrumbs"
-  ...attributes
->
+<nav class={{this.classNames}} aria-label="breadcrumbs" ...attributes>
   <ol class="hds-breadcrumb__list" {{did-insert this.didInsert}}>
     {{yield}}
   </ol>

--- a/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
+++ b/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
@@ -44,6 +44,11 @@
     <dt>“splattributes”</dt>
     <dd>
       <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+      <p><em>Notice: by default an attribute
+          <code class="dummy-code">aria-label="breadcrumbs"</code>
+          is assigned to the component. If you want to localize it you can override it passing the same attribute with a
+          different value.
+        </em></p>
     </dd>
   </dl>
   <h4 class="dummy-h4">Breadcrumb::Item</h4>


### PR DESCRIPTION
### :pushpin: Summary

After [this clarification in Slack](https://hashicorp.slack.com/archives/C7KTUHNUS/p1647861127049559) we can remove the comment left in the `Breadcrumb` index template. 

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed comment in “breadcrumb” main component
- updated the “Breadcrumb” documentation to explain how users can override the default `aria-label` value

***

### 👀 How to review

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
