### PR TITLE
Add missing CSS helpers in "components" Sass imports

### DIFF
--- a/.changeset/pink-terms-eat.md
+++ b/.changeset/pink-terms-eat.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+added missing helpers for “color” and “typography” in “components” package

--- a/packages/components/app/styles/@hashicorp/design-system-components.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-components.scss
@@ -1,7 +1,9 @@
 // these are files coming from the 'design-system-tokens' package
 @use "tokens";
+@use "helpers/color";
 @use "helpers/elevation";
 @use "helpers/focus-ring";
+@use "helpers/typography";
 
 @use "../components/badge";
 @use "../components/badge-count";


### PR DESCRIPTION
### :pushpin: Summary

@dizzyup has noticed that the helpers for “color” and “typography” were not included in the “components” package (we forgot to add them when we created these helpers).

### :hammer_and_wrench: Detailed description

In this PR I have:
- added missing helpers for “color” and “typography” the main Sass file for the `components` package

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
