### PR TITLE
Add z-index isolation to the “Button” component

### DIFF
--- a/.changeset/gorgeous-singers-punch.md
+++ b/.changeset/gorgeous-singers-punch.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+added a stacking context for the “Button” component so that the focus z-index is isolated in the button

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -21,6 +21,7 @@ $hds-button-focus-border-width: 3px;
   box-sizing: border-box; // TODO https://github.com/hashicorp/design-system-components/issues/46
   display: flex;
   font-family: var(--token-typography-font-stack-text);
+  isolation: isolate;
   justify-content: center;
   outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
   outline-color: transparent; // We need this to be transparent for a11y


### PR DESCRIPTION
### :pushpin: Summary

In https://github.com/hashicorp/design-system/pull/94 we have changed the layout of the documentation pages. In particular we have applied a background color to the main container, to stand out against the light gray background.

This has surfaced an issue with the focus on the `Button` component, that went undetected until now (it was not noticed in Percy because all the pages were resized, so all tests were failing!).

This is how it looks like now the page:
<img width="800" alt="screenshot_1158" src="https://user-images.githubusercontent.com/686239/159808545-2a787153-9257-4511-9386-d16e11848805.png">
The reason for that is that the pseudo-element used to show the focus has a `z-index: -1` so it goes below the `main` content background (before it was transparent).

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a `z-index` isolation to the “Button” component

This is how it looks after the fix:
<img width="1043" alt="screenshot_1159" src="https://user-images.githubusercontent.com/686239/159809212-b2631d5b-07c7-4c89-91d3-6f9d65c2bba5.png">

Notice: I have bumped the package version anyway, for precaution (technically we're changing the behaviour of the button, so better to have a new release for this).

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [x] +1 Percy
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
