### PR TITLE
Remove the “isDisabled“ prop from the “Button“ component in favour of the native “disabled” attribute

### DIFF
--- a/.changeset/proud-houses-glow.md
+++ b/.changeset/proud-houses-glow.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+removed the “isDisabled“ prop from the “Button” component in favour of the native “disabled“ attribute

--- a/packages/components/addon/components/hds/button/index.hbs
+++ b/packages/components/addon/components/hds/button/index.hbs
@@ -1,10 +1,4 @@
-<button
-  class={{this.classNames}}
-  ...attributes
-  aria-label={{if this.isIconOnly this.text null}}
-  type={{this.type}}
-  disabled={{if this.isDisabled "disabled" null}}
->
+<button class={{this.classNames}} ...attributes aria-label={{if this.isIconOnly this.text null}} type={{this.type}}>
   {{#if this.isIconOnly}}
     <div class="hds-button__icon">
       <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} />

--- a/packages/components/addon/components/hds/button/index.js
+++ b/packages/components/addon/components/hds/button/index.js
@@ -156,16 +156,6 @@ export default class HdsButtonIndexComponent extends Component {
   }
 
   /**
-   * @param isDisabled
-   * @type {boolean}
-   * @default null
-   * @description Sets the native HTML attribute `disabled` on the button element. Default is null (doesn't render the attribute).
-   */
-  get isDisabled() {
-    return this.args.isDisabled ?? null;
-  }
-
-  /**
    * Get the class names to apply to the component.
    * @method Button#classNames
    * @return {string} The "class" attribute to apply to the component.

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -64,12 +64,6 @@
     <dd>
       <p>This indicates that a button should take up the full width of the parent container. The default is false.</p>
     </dd>
-    <dt>isDisabled <code>boolean</code></dt>
-    <dd>
-      <p>Sets the native HTML attribute
-        <em>disabled</em>
-        on the button element. Default is null (doesn't render the attribute).</p>
-    </dd>
     <dt>“splattributes”</dt>
     <dd>
       <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
@@ -227,23 +221,20 @@
   {{! prettier-ignore-end }}
 
   <h4 class="dummy-h4">Disabled buttons</h4>
-  <p class="dummy-paragraph">This is the native button attribute,
-    <code class="dummy-code">disabled</code>. To use this attribute, set
-    <code class="dummy-code">@isDisabled</code>
-    to
-    <code class="dummy-code">true</code>. The default is
-    <code class="dummy-code">null</code>, which means that the attribute will not render at all in the DOM.
+  <p class="dummy-paragraph">To disable a button just use the native
+    <code class="dummy-code">disabled</code>
+    attribute:
   </p>
   {{! prettier-ignore-start }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Button @text="Copy to clipboard" @isDisabled=true />
+      <Hds::Button @text="Copy to clipboard" disabled />
     '
   />
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Button @text="Copy to clipboard" @isDisabled={{true}} />
+  <Hds::Button @text="Copy to clipboard" disabled />
 
   <h4 class="dummy-h4">Full-width buttons</h4>
   <p class="dummy-paragraph">

--- a/packages/components/tests/integration/components/hds/button/index-test.js
+++ b/packages/components/tests/integration/components/hds/button/index-test.js
@@ -108,11 +108,11 @@ module('Integration | Component | hds/button/index', function (hooks) {
     );
     assert.dom('.hds-button__text').doesNotExist();
   });
-  test('it should add the `disabled` attribute to the button if `@isDisabled` is set to true', async function (assert) {
+  test('it should disable to the button if the `disabled` attribute is passed', async function (assert) {
     await render(
-      hbs`<Hds::Button @text="copy to clipboard" @isDisabled={{true}} id="test-button" />`
+      hbs`<Hds::Button @text="copy to clipboard" disabled id="test-button" />`
     );
-    assert.dom('#test-button').hasAttribute('disabled');
+    assert.dom('#test-button').isDisabled();
   });
   test('it should have the correct CSS class to support full-width button size if @isFullWidth prop is true', async function (assert) {
     await render(


### PR DESCRIPTION
### :pushpin: Summary

This PR follows a conversation that happened in the RFC about migration to the `Hds::Button` component in Cloud UI ([see thread here](https://docs.google.com/document/d/1DwnPClfIMdHuGppDIkWJkDCBOJQqgLplHXnh1eI6sVo/edit?disco=AAAATd3VfeI)), in which multiple people raised the question why we were using a custom `isDisabled` prop instead of just relying on the native `disabled` attribute.

I don't remember why we went for the `isDisabled` prop (maybe we wanted to do some stuff with it using a CSS class?) After some thought, I decided it makes perfectly sense to just use the `disabled` attribute (which gets "splatted" via the `...attributes` on the `<button>` element).

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed the “isDisabled” parameter from the “Button” component
- updated accordingly the documentation and the integration tests for the “Button” component

### :camera_flash: Screenshots

<img width="1065" alt="screenshot_1193" src="https://user-images.githubusercontent.com/686239/160398064-aba54869-e566-478f-af1f-448763bd94dc.png">

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
