### PR TITLE
"Alert" component - Actions as named blocks

### DIFF
--- a/packages/components/addon/components/hds/alert/index.hbs
+++ b/packages/components/addon/components/hds/alert/index.hbs
@@ -6,13 +6,29 @@
     </div>
   {{/unless}}
 
-  <div class="hds-alert__text">
-    {{#if @title}}
-      <div class="hds-alert__title">{{@title}}</div>
-    {{/if}}
+  <div class="hds-alert__content">
+    <div class="hds-alert__text">
 
-    {{#if @description}}
-      <div class="hds-alert__description">{{html-safe @description}}</div>
-    {{/if}}
+      {{#if @title}}
+        <div class="hds-alert__title">{{@title}}</div>
+      {{/if}}
+
+      {{#if @description}}
+        <div class="hds-alert__description">{{html-safe @description}}</div>
+      {{/if}}
+
+      {{#if (has-block "actions")}}
+        {{! IMPORTANT: don't change the formatting or it will add empty space inside the element (we're using ":empty" in CSS to hide it when it's empty!) }}
+        <div class="hds-alert__actions">{{yield
+            (hash
+              Button=(component "hds/button")
+              Link::Standalone=(component "hds/link/standalone")
+              LinkTo::Standalone=(component "hds/link-to/standalone")
+            )
+            to="actions"
+          }}</div>
+      {{/if}}
+    </div>
+
   </div>
 </div>

--- a/packages/components/addon/components/hds/alert/index.hbs
+++ b/packages/components/addon/components/hds/alert/index.hbs
@@ -8,27 +8,24 @@
 
   <div class="hds-alert__content">
     <div class="hds-alert__text">
-
       {{#if @title}}
         <div class="hds-alert__title">{{@title}}</div>
       {{/if}}
-
       {{#if @description}}
         <div class="hds-alert__description">{{html-safe @description}}</div>
       {{/if}}
-
-      {{#if (has-block "actions")}}
-        {{! IMPORTANT: don't change the formatting or it will add empty space inside the element (we're using ":empty" in CSS to hide it when it's empty!) }}
-        <div class="hds-alert__actions">{{yield
-            (hash
-              Button=(component "hds/button")
-              Link::Standalone=(component "hds/link/standalone")
-              LinkTo::Standalone=(component "hds/link-to/standalone")
-            )
-            to="actions"
-          }}</div>
-      {{/if}}
     </div>
 
+    {{#if (has-block "actions")}}
+      {{! IMPORTANT: don't change the formatting or it will add empty space inside the element (we're using ":empty" in CSS to hide it when it's empty!) }}
+      <div class="hds-alert__actions">{{yield
+          (hash
+            Button=(component "hds/button")
+            Link::Standalone=(component "hds/link/standalone")
+            LinkTo::Standalone=(component "hds/link-to/standalone")
+          )
+          to="actions"
+        }}</div>
+    {{/if}}
   </div>
 </div>

--- a/packages/components/app/styles/components/alert.scss
+++ b/packages/components/app/styles/components/alert.scss
@@ -105,3 +105,17 @@
     color: var(--token-color-foreground-success-on-surface);
   }
 }
+
+.hds-alert__actions {
+  align-items: center;
+  display: flex;
+  margin-top: 1rem; // 16px
+
+  > * + * {
+    margin-left: 1rem; // 16px
+  }
+
+  &:empty {
+    display: none;
+  }
+}

--- a/packages/components/tests/dummy/app/components/dummy-placeholder/index.js
+++ b/packages/components/tests/dummy/app/components/dummy-placeholder/index.js
@@ -11,7 +11,7 @@ export default class DummyPlaceholderIndexComponent extends Component {
   get width() {
     let { width = '100%' } = this.args;
 
-    if (typeof width === 'string' && width.match(/[\d]+/)) {
+    if (typeof width === 'string' && width.match(/^[\d]+$/)) {
       width = `${parseInt(width, 10)}px`;
     }
 
@@ -28,7 +28,7 @@ export default class DummyPlaceholderIndexComponent extends Component {
   get height() {
     let { height = '100%' } = this.args;
 
-    if (typeof height === 'string' && height.match(/[\d]+/)) {
+    if (typeof height === 'string' && height.match(/^[\d]+$/)) {
       height = `${parseInt(height, 10)}px`;
     }
 

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -3,6 +3,7 @@
 
 @import "./_typography";
 
+@import "./pages/db-alert";
 @import "./pages/db-badge";
 @import "./pages/db-breadcrumb";
 @import "./pages/db-button";

--- a/packages/components/tests/dummy/app/styles/pages/db-alert.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-alert.scss
@@ -1,0 +1,15 @@
+// ALERT
+
+.dummy-alert-sample-custom-actions__actions {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+}
+
+.dummy-alert-sample-custom-actions__text {
+    @include dummyFontFamily();
+    @include dummyFontSize(0.8rem);
+    display: block;
+    color: #999;
+    margin-top: 1rem;
+}

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -268,6 +268,49 @@
       view to be useful."
   />
   <br />
+
+  <h4 class="dummy-h4">Actions</h4>
+  <span class="dummy-text-small">with actions passed as yielded components</span>
+  <Hds::Alert
+    @icon="alert-triangle"
+    @title="This is the title"
+    @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  >
+    <:actions as |A|>
+      <A.Button @text="Button" @size="small" @color="secondary" />
+      <A.Button @icon="plus" @text="Button" @size="small" @color="tertiary" />
+      <A.Link::Standalone @icon="plus" @text="Link" href="#" @size="small" @color="secondary" />
+    </:actions>
+  </Hds::Alert>
+  <br />
+  <span class="dummy-text-small">with content yielded in the "actions" named block</span>
+  <Hds::Alert
+    @icon="alert-triangle"
+    @title="This is the title"
+    @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  >
+    <:actions>
+      <DummyPlaceholder @text="generic content" @height="80" @background="#e1f5fe" />
+    </:actions>
+  </Hds::Alert>
+  <br />
+  <span class="dummy-text-small">with custom content yielded in the "actions" named block</span>
+  <Hds::Alert
+    @icon="alert-triangle"
+    @title="This is the title"
+    @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  >
+    <:actions>
+      <div>
+        <div class="dummy-alert-sample-custom-actions__actions">
+          <Hds::Button @text="Button" @size="small" @color="secondary" />
+          <Hds::Link::Standalone @icon="plus" @text="Link text" href="#" @size="small" @color="secondary" />
+        </div>
+        <span class="dummy-alert-sample-custom-actions__text">This for example could be extra text, specific only for
+          one special use case.</span>
+      </div>
+    </:actions>
+  </Hds::Alert>
 </section>
 
 <section>

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -100,21 +100,9 @@
       </ol>
     </dd>
 
-    <dt>🚧 hasActions <code>boolean</code></dt>
+    <dt>&lt;:actions&gt; <code>named block</code></dt>
     <dd>
-      <p>The alert has content below the
-        <code class="dummy-code">title</code>
-        and
-        <code class="dummy-code">description</code>, such as an
-        <code class="dummy-code">Hds::Button</code>
-        and an
-        <code class="dummy-code">Hds::LinkTo::Standalone</code>.
-      </p>
-      <p>Acceptable values:</p>
-      <ol>
-        <li>true</li>
-        <li class="default">false</li>
-      </ol>
+      <p>TODO</p>
     </dd>
 
     <dt>“splattributes”</dt>


### PR DESCRIPTION
### :pushpin: Summary

As a follow-up of https://github.com/hashicorp/design-system/pull/104 this PR brings in only the relevant changes to the `Alert` component.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added the `actions` for the `Alert` component as named block with yielded components
- added showcase for `actions`
- fixed regex used in the “DummyPlaceholder” (extra)

Notice: the documentation about the `actions` (API, how to use, etc) will be done in final part of the component implementation, when things are more stable.

***

### 👀 How to review

👉 Review by files changed (take in account the code has already been reviewed in #104)

Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
