### PR TITLE
Fix "noop" guard for "Breadcrumb" component

### DIFF
--- a/.changeset/spicy-sheep-camp.md
+++ b/.changeset/spicy-sheep-camp.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+small change to the “noop“ guard in the “@didInsert“ method of the “Disclosure“ component

--- a/packages/components/addon/components/hds/breadcrumb/index.js
+++ b/packages/components/addon/components/hds/breadcrumb/index.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
-const noop = () => {};
+const NOOP = () => {};
 
 export default class HdsBreadcrumbComponent extends Component {
   /**
@@ -9,8 +9,13 @@ export default class HdsBreadcrumbComponent extends Component {
    * @default () => {}
    */
   get didInsert() {
-    // TODO discuss with Matthew if this is the right way to create a guard for this method
-    return this.args.didInsert ?? noop;
+    let { didInsert } = this.args;
+
+    if (typeof didInsert === 'function') {
+      return didInsert;
+    } else {
+      return NOOP;
+    }
   }
 
   /**


### PR DESCRIPTION
### :pushpin: Summary

While working on the `Breadcrumb` component I left a TODO comment to check with @meirish if my implementation of the guard for the `didInsert` method was correct. Today I found the exact same pattern in the Structure codebase, with a better/safer implementation (checks the `type` of the parameter too, makes sense) so I decided to change our implementation to follow the Structure one.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the “noop” guard for the `@didInsert` method in the `Breadcrumb` component to follow a better pattern found in Structure

### :camera_flash: Screenshots

The pattern in Structure:
<img width="599" alt="screenshot_1204" src="https://user-images.githubusercontent.com/686239/160625761-7bf65971-dc12-47a4-82e1-e02c8206fe51.png">
([source](https://github.com/hashicorp/structure/blob/dffbb0e0ae5246d3b832586ab25bcb981a052b30/packages/pds-ember/addon/components/pds/popup/index.js#L23-L31))

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
