### PR TITLE
Updated the yield hash for the dropdown/list-item component

### DIFF
--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -10,10 +10,11 @@
   </:toggle>
   <:content>
     <ul class="hds-dropdown-list hds-dropdown-list--absolute-right">
-      {{yield (hash 
-        ListItem=(component "hds/dropdown/list-item")
-        Separator=(component "hds/dropdown/list-item" item="separator")
-      )}}
+      {{yield
+        (hash
+          ListItem=(component "hds/dropdown/list-item") Separator=(component "hds/dropdown/list-item" item="separator")
+        )
+      }}
     </ul>
   </:content>
 </Hds::Disclosure>

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -10,7 +10,10 @@
   </:toggle>
   <:content>
     <ul class="hds-dropdown-list hds-dropdown-list--absolute-right">
-      {{yield (hash ListItem=(component "hds/dropdown/list-item"))}}
+      {{yield (hash 
+        ListItem=(component "hds/dropdown/list-item")
+        Separator=(component "hds/dropdown/list-item" item="separator")
+      )}}
     </ul>
   </:content>
 </Hds::Disclosure>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -215,14 +215,14 @@
       @code='
         &lt;Hds::Dropdown
           @toggle="text"
-          @toggleText="Toggle"
+          @toggleText="Text Toggle"
           as |dd| &gt;
 
           &lt;dd.ListItem @route="components.dropdown" @text="Hover" /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Focus" /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Dropdown Component" /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Active (+ Hover)" /&gt;
-          &lt;dd.ListItem @item="separator" /&gt;
+          &lt;dd.Separator /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" /&gt;
         &lt;/Hds::Dropdown&gt;
       '
@@ -234,13 +234,13 @@
     <nav class="dummy-nav-dropdown" aria-label="example positioned right">
       <ul class="dummy-nav-dropdown__list">
         <li class="dummy-nav-dropdown__list-item">
-          <Hds::Dropdown @toggle="text" @toggleText="Toggle" as |dd|>
+          <Hds::Dropdown @toggle="text" @toggleText="Text Toggle" as |dd|>
 
             <dd.ListItem @route="components.dropdown" @text="Hover" />
             <dd.ListItem @route="components.dropdown" @text="Focus" />
             <dd.ListItem @route="components.dropdown" @text="Dropdown Component" />
             <dd.ListItem @route="components.dropdown" @text="Active (+ Hover)" />
-            <dd.ListItem @item="separator" />
+            <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" />
           </Hds::Dropdown>
         </li>
@@ -256,7 +256,7 @@
             <dd.ListItem @route="components.dropdown" @text="Focus" />
             <dd.ListItem @route="components.dropdown" @text="Dropdown Component" />
             <dd.ListItem @route="components.dropdown" @text="Active (+ Hover)" />
-            <dd.ListItem @item="separator" />
+            <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" />
           </Hds::Dropdown>
         </li>
@@ -355,7 +355,7 @@
 
           &lt;dd.ListItem @item="heading" @text="Signed In" /&gt;
           &lt;dd.ListItem @item="help-text" @text="design-systems@hashicorp.com" /&gt;
-          &lt;dd.ListItem @item="separator" /&gt;
+          &lt;dd.Separator /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Settings and Preferences" /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" /&gt;
         &lt;/Hds::Dropdown&gt;
@@ -370,7 +370,7 @@
           <Hds::Dropdown @toggle="user" @toggleText="user menu" as |dd|>
             <dd.ListItem @item="heading" @text="Signed In" />
             <dd.ListItem @item="help-text" @text="design-systems@hashicorp.com" />
-            <dd.ListItem @item="separator" />
+            <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Settings and Preferences" />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" />
           </Hds::Dropdown>
@@ -385,7 +385,7 @@
 
             <dd.ListItem @item="heading" @text="Signed In" />
             <dd.ListItem @item="help-text" @text="design-systems@hashicorp.com" />
-            <dd.ListItem @item="separator" />
+            <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Settings and Preferences" />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" />
           </Hds::Dropdown>


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR updates the yield hash for the dropdown content block to enable terse invocation for the separator.

### Before 

```hbs
{{yield (hash ListItem=(component "hds/dropdown/list-item")) }}
```

### After 

```hbs
{{yield (hash 
  ListItem=(component "hds/dropdown/list-item")
  Separator=(component "hds/dropdown/list-item" item="separator")
)}}
  ```
 
 ### Screenshot

Updated invocation: 

![CleanShot 2022-03-30 at 09 46 13](https://user-images.githubusercontent.com/4587451/160863112-468f6f55-dabf-4dc3-9000-ef6a3039e7bb.png)
 
  

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202025538866560