### PR TITLE
Rename item type "link" to "interactive" 

### DIFF
--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -10,10 +10,11 @@
   </:toggle>
   <:content>
     <ul class="hds-dropdown-list hds-dropdown-list--absolute-right">
-      {{yield (hash 
-        ListItem=(component "hds/dropdown/list-item")
-        Separator=(component "hds/dropdown/list-item" item="separator")
-      )}}
+      {{yield
+        (hash
+          ListItem=(component "hds/dropdown/list-item") Separator=(component "hds/dropdown/list-item" item="separator")
+        )
+      }}
     </ul>
   </:content>
 </Hds::Disclosure>

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -10,7 +10,10 @@
   </:toggle>
   <:content>
     <ul class="hds-dropdown-list hds-dropdown-list--absolute-right">
-      {{yield (hash ListItem=(component "hds/dropdown/list-item"))}}
+      {{yield (hash 
+        ListItem=(component "hds/dropdown/list-item")
+        Separator=(component "hds/dropdown/list-item" item="separator")
+      )}}
     </ul>
   </:content>
 </Hds::Disclosure>

--- a/packages/components/addon/components/hds/dropdown/list-item.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item.hbs
@@ -17,7 +17,7 @@
     copy item will go here
   </li>
 
-{{else if (eq this.item "link")}}
+{{else if (eq this.item "interactive")}}
   <li class={{this.classNames}}>
     {{#if @route}}
       {{! // TODO consider approach }}

--- a/packages/components/addon/components/hds/dropdown/list-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item.js
@@ -2,9 +2,15 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
 export const DEFAULT_COLOR = 'action';
-export const DEFAULT_ITEM = 'link';
+export const DEFAULT_ITEM = 'interactive';
 export const COLORS = ['action', 'critical'];
-export const ITEMS = ['heading', 'help-text', 'separator', 'copy-item', 'link'];
+export const ITEMS = [
+  'heading',
+  'help-text',
+  'separator',
+  'copy-item',
+  'interactive',
+];
 
 export default class HdsDropdownListItemComponent extends Component {
   /**
@@ -49,7 +55,7 @@ export default class HdsDropdownListItemComponent extends Component {
   /**
    * @param item
    * @type {string}
-   * @default link
+   * @default interactive
    * @description Determines the type of item to show
    */
   get item() {
@@ -79,7 +85,7 @@ export default class HdsDropdownListItemComponent extends Component {
     }
 
     // add a class based on the @color argument
-    if (this.item === 'link' && this.color) {
+    if (this.item === 'interactive' && this.color) {
       classes.push(`hds-dropdown-list-item--color-${this.color}`);
     }
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -215,7 +215,7 @@ $size-props: (
   }
 }
 
-.hds-dropdown-list-item--link {
+.hds-dropdown-list-item--interactive {
   position: relative;
   isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
   min-height: 36px;
@@ -296,6 +296,7 @@ $size-props: (
   line-height: var(--token-typography-body-200-line-height);
 }
 
+// TODO (MS) re-add flex column here to vertically center icon with text
 .hds-dropdown-list-item__link-icon {
   margin-right: 8px;
 }

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -215,14 +215,14 @@
       @code='
         &lt;Hds::Dropdown
           @toggle="text"
-          @toggleText="Toggle"
+          @toggleText="Text Toggle"
           as |dd| &gt;
 
           &lt;dd.ListItem @route="components.dropdown" @text="Hover" /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Focus" /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Dropdown Component" /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Active (+ Hover)" /&gt;
-          &lt;dd.ListItem @item="separator" /&gt;
+          &lt;dd.Separator /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" /&gt;
         &lt;/Hds::Dropdown&gt;
       '
@@ -234,13 +234,13 @@
     <nav class="dummy-nav-dropdown" aria-label="example positioned right">
       <ul class="dummy-nav-dropdown__list">
         <li class="dummy-nav-dropdown__list-item">
-          <Hds::Dropdown @toggle="text" @toggleText="Toggle" as |dd|>
+          <Hds::Dropdown @toggle="text" @toggleText="Text Toggle" as |dd|>
 
             <dd.ListItem @route="components.dropdown" @text="Hover" />
             <dd.ListItem @route="components.dropdown" @text="Focus" />
             <dd.ListItem @route="components.dropdown" @text="Dropdown Component" />
             <dd.ListItem @route="components.dropdown" @text="Active (+ Hover)" />
-            <dd.ListItem @item="separator" />
+            <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" />
           </Hds::Dropdown>
         </li>
@@ -256,7 +256,7 @@
             <dd.ListItem @route="components.dropdown" @text="Focus" />
             <dd.ListItem @route="components.dropdown" @text="Dropdown Component" />
             <dd.ListItem @route="components.dropdown" @text="Active (+ Hover)" />
-            <dd.ListItem @item="separator" />
+            <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" />
           </Hds::Dropdown>
         </li>
@@ -355,7 +355,7 @@
 
           &lt;dd.ListItem @item="heading" @text="Signed In" /&gt;
           &lt;dd.ListItem @item="help-text" @text="design-systems@hashicorp.com" /&gt;
-          &lt;dd.ListItem @item="separator" /&gt;
+          &lt;dd.Separator /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Settings and Preferences" /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" /&gt;
         &lt;/Hds::Dropdown&gt;
@@ -370,7 +370,7 @@
           <Hds::Dropdown @toggle="user" @toggleText="user menu" as |dd|>
             <dd.ListItem @item="heading" @text="Signed In" />
             <dd.ListItem @item="help-text" @text="design-systems@hashicorp.com" />
-            <dd.ListItem @item="separator" />
+            <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Settings and Preferences" />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" />
           </Hds::Dropdown>
@@ -385,7 +385,7 @@
 
             <dd.ListItem @item="heading" @text="Signed In" />
             <dd.ListItem @item="help-text" @text="design-systems@hashicorp.com" />
-            <dd.ListItem @item="separator" />
+            <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Settings and Preferences" />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @leadingIcon="trash" />
           </Hds::Dropdown>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -131,7 +131,7 @@
         <li>help-text</li>
         <li>separator</li>
         <li>copy-item</li>
-        <li class="default">link</li>
+        <li class="default">interactive</li>
       </ol>
     </dd>
     <dt>text
@@ -156,7 +156,7 @@
     </dt>
     <dd>
       <p>
-        If the link is internal, define a
+        If the interactive item is an internal link, define a
         <span class="dummy-code">route</span>; Ember's
         <span class="dummy-code">LinkTo</span>
         component will be rendered.
@@ -170,7 +170,7 @@
     </dt>
     <dd>
       <p>
-        If the link is internal, define a
+        If the interactive item is an external link, define a
         <span class="dummy-code">href</span>; an
         <span class="dummy-code">&lt;a&gt;</span>
         element with the appropriate attributes will be rendered.


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR renames the default list-item item type from "link" to "interactive". This is to make room for a future change to add support for button elements in list items, with a single style. 

This PR only covers the minimal changes required, as some further changes may require some discussion first. Therefore, some child block CSS classes were not changed (but still function in context and as expected).


## 👀 How to review

👉  Review commit [cc40386](https://github.com/hashicorp/design-system/commit/cc403862c108336157f9822dabce3af69c08b92a)

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202045371056991