### PR TITLE
added note in the CONTRIBUTING markdown file for Flight icons

### DIFF
--- a/packages/flight-icons/CONTRIBUTING.md
+++ b/packages/flight-icons/CONTRIBUTING.md
@@ -48,6 +48,8 @@ This action will:
 * Export the assets as `.svg` files into `./svg-original/`
 * Generate the `catalog.json` file
 
+*🚨 **Notice**: it's not uncommon that when doing a `sync` you will find that some SVGs of the icons appear as "modified" in the codebase even if they have not been really changed by the designers. The reasons can be different: Figma has slighly changed the algorithm that generates the SVGs in output, or the designer changed the order of the icons in the frame, or maybe just Figma changing by a sub-pixel the internal path of an SVG element. In that case it's hard to detect if this change is OK or not, you have to try to understand if it's expected or not, and if you want to be 100% sure you have to compare the SVGs (old and new) importing them in Figma and overlaying one on top of the other and eyeball if there are differences.*
+
 ## Build
 
 The "build" step takes the assets exported from Figma, optimize and process them, and saves the final SVG files in the bundles that will be published as npm package.

--- a/packages/flight-icons/CONTRIBUTING.md
+++ b/packages/flight-icons/CONTRIBUTING.md
@@ -48,7 +48,7 @@ This action will:
 * Export the assets as `.svg` files into `./svg-original/`
 * Generate the `catalog.json` file
 
-*🚨 **Notice**: it's not uncommon that when doing a `sync` you will find that some SVGs of the icons appear as "modified" in the codebase even if they have not been really changed by the designers. The reasons can be different: Figma has slighly changed the algorithm that generates the SVGs in output, or the designer changed the order of the icons in the frame, or maybe just Figma changing by a sub-pixel the internal path of an SVG element. In that case it's hard to detect if this change is OK or not, you have to try to understand if it's expected or not, and if you want to be 100% sure you have to compare the SVGs (old and new) importing them in Figma and overlaying one on top of the other and eyeball if there are differences.*
+*🚨 **Notice**: it's not uncommon that when doing a `sync` you will find that some SVGs of the icons appear as "modified" in the codebase even if they have not been really changed by the designers. The reasons can be different: Figma has slightly changed the algorithm that generates the SVGs in output, or the designer changed the order of the icons in the frame, or maybe just Figma changing by a sub-pixel the internal path of an SVG element. In these cases it's hard to detect if this change is OK or not. You have to try to understand if it's expected or not, and if you want to be 100% sure you have to compare the SVGs (old and new) importing them in Figma and overlaying one on top of the other and eyeball if there are differences.*
 
 ## Build
 


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of this comment by @Dhaulagiri: https://github.com/hashicorp/design-system/pull/131#discussion_r838548364

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a note in the CONTRIBUTING markdown file for Flight icons explaining what to do if there are unexpected diffs when re-syncing the Flight icons.

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
