### PR TITLE
"Alert" component - "Toast" variant

### DIFF
--- a/packages/components/addon/components/hds/alert/index.js
+++ b/packages/components/addon/components/hds/alert/index.js
@@ -99,6 +99,11 @@ export default class HdsAlertIndexComponent extends Component {
     // Add a class based on the @type argument
     classes.push(`hds-alert--type-${this.type}`);
 
+    // Add an elevation to the "toast" alert
+    if (this.type === 'toast') {
+      classes.push(`hds-elevation-higher`);
+    }
+
     // Add a class based on the @color argument
     classes.push(`hds-alert--color-${this.color}`);
 

--- a/packages/components/app/styles/components/alert.scss
+++ b/packages/components/app/styles/components/alert.scss
@@ -64,12 +64,17 @@
 .hds-alert--color-neutral {
   background-color: var(--token-color-surface-faint);
 
+  // notice: in the "neutral" color the "inline" has a slightly darker border color compared to the others to increase contrast (eg. could be used on a light gray background)
   &.hds-alert--type-page {
     box-shadow: 0px 1px 0px 0px var(--token-color-palette-alpha-300);
   }
 
-  &.hds-alert--type-inline { 
+  &.hds-alert--type-inline {
     border-color: var(--token-color-border-strong);
+  }
+
+  &.hds-alert--type-toast {
+    border-color: var(--token-color-border-primary);
   }
 
   .hds-alert__icon, .hds-alert__title {
@@ -84,7 +89,8 @@
     box-shadow: 0px 1px 0px 0px var(--token-color-border-highlight);
   }
 
-  &.hds-alert--type-inline { 
+  &.hds-alert--type-inline,
+  &.hds-alert--type-toast {
     border-color: var(--token-color-border-highlight);
   }
 
@@ -95,15 +101,16 @@
 
 .hds-alert--color-success {
   background-color: var(--token-color-surface-success);
-  
+
   &.hds-alert--type-page {
     box-shadow: 0px 1px 0px 0px var(--token-color-border-success);
   }
 
-  &.hds-alert--type-inline { 
+  &.hds-alert--type-inline,
+  &.hds-alert--type-toast {
     border-color: var(--token-color-border-success);
   }
-  
+
   .hds-alert__icon, .hds-alert__title {
     color: var(--token-color-foreground-success-on-surface);
   }
@@ -116,7 +123,8 @@
     box-shadow: 0px 1px 0px 0px var(--token-color-border-warning);
   }
 
-  &.hds-alert--type-inline { 
+  &.hds-alert--type-inline,
+  &.hds-alert--type-toast {
     border-color: var(--token-color-border-warning);
   }
 
@@ -132,16 +140,18 @@
     box-shadow: 0px 1px 0px 0px var(--token-color-border-critical);
   }
 
-  &.hds-alert--type-inline { 
+  &.hds-alert--type-inline,
+  &.hds-alert--type-toast {
     border-color: var(--token-color-border-critical);
   }
 
   .hds-alert__icon, .hds-alert__title {
     color: var(--token-color-foreground-critical-on-surface);
-  } 
+  }
 }
 
-.hds-alert--type-inline {
+.hds-alert--type-inline,
+.hds-alert--type-toast {
   border-width: 1px;
   border-style: solid;
   border-radius: 6px;


### PR DESCRIPTION
### :pushpin: Summary

Added the styling for the `toast` type of `Alert`.

Later we will decide how to extend the `Alert::Toast` if we need to handle its animations/transitions (there are chances this will be handled by a third party addon, probably [`ember-cli-flash`](https://github.com/poteto/ember-cli-flash))

### :hammer_and_wrench: Detailed description

In this PR I have:
- added styling for the “Toast” variant of the “Alert” component

### :camera_flash: Screenshots

<img width="1047" alt="screenshot_1222" src="https://user-images.githubusercontent.com/686239/160921675-af5ceb8e-9b26-428c-a9bc-60199ad41062.png">

***

### 👀 How to review
👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201994286157145