### PR TITLE
[WIP] toggle-icon

### DIFF
--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -1,7 +1,7 @@
 <Hds::Disclosure>
   <:toggle as |t|>
     {{#if (eq @toggle "overflow")}}
-      <Hds::Dropdown::ToggleOverflow @text={{@toggleText}} @size={{@size}} {{on "click" t.onClickToggle}} />
+      <Hds::Dropdown::ToggleOverflow @text={{@toggleText}} {{on "click" t.onClickToggle}} />
     {{else if (eq @toggle "user")}}
       <Hds::Dropdown::ToggleUser @text={{@toggleText}} @avatarUrl={{@avatarUrl}} {{on "click" t.onClickToggle}} />
     {{else}}

--- a/packages/components/addon/components/hds/dropdown/toggle-icon.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle-icon.hbs
@@ -1,0 +1,44 @@
+<button class="hds-dropdown-toggle-icon" aria-label={{@text}} type="button" ...attributes>
+  
+    {{#if (eq @iconType "overflow")}}
+      <div class="hds-dropdown-toggle-icon__wrapper">
+        <FlightIcon @name="more-horizontal" @size="24" />
+      </div>  
+    {{else if (eq @iconType "user")}}
+      <div class="hds-dropdown-toggle-icon__wrapper hds-dropdown-toggle-icon--hasChevron">
+        {{#if @avatarUrl}}
+            <img src={{@avatarUrl}} alt="" role="presentation" height="32" width="32" />
+        {{else}}
+          <FlightIcon @name="user" @size="24" />
+        {{/if}}
+      </div>
+      <FlightIcon @name="chevron-{{if @isOpen "up" "down"}}" />
+    {{else}}
+      <div class="hds-dropdown-toggle-icon__wrapper hds-dropdown-toggle-icon--hasChevron">      
+        <FlightIcon @name={{@iconName}} @size="24" />
+      </div>
+      <FlightIcon @name="chevron-{{if @isOpen "up" "down"}}" />
+    {{/if}}
+</button>
+
+{{!-- another approach: it is more DRY but it also uses an "unless" --}}
+<button class="hds-dropdown-toggle-icon" aria-label={{@text}} type="button" ...attributes> 
+  <div class="hds-dropdown-toggle-icon__wrapper">
+    {{#if (eq @iconType "overflow")}}
+      <FlightIcon @name="more-horizontal" @size="24" />
+    {{else if (eq @iconType "user")}}
+      {{#if @avatarUrl}}
+          <img src={{@avatarUrl}} alt="" role="presentation" height="32" width="32" />
+      {{else}}
+        <FlightIcon @name="user" @size="24" />
+      {{/if}}
+    {{else}}
+      <FlightIcon @name={{@iconName}} @size="24" />
+    {{/if}}
+  </div>
+  {{#unless (eq @iconType "overflow")}}
+    <div class="hds-dropdown-toggle-icon__chevron">
+      <FlightIcon @name="chevron-{{if @isOpen "up" "down"}}" />
+    </div>
+  {{/unless}}
+</button>

--- a/packages/components/addon/components/hds/dropdown/toggle-icon.js
+++ b/packages/components/addon/components/hds/dropdown/toggle-icon.js
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class HdsDropdownToggleIconComponent extends Component {}

--- a/packages/components/addon/components/hds/dropdown/toggle-overflow.js
+++ b/packages/components/addon/components/hds/dropdown/toggle-overflow.js
@@ -25,10 +25,6 @@ export default class HdsDropdownToggleOverflowComponent extends Component {
    */
   get classNames() {
     let classes = ['hds-dropdown-toggle-overflow'];
-
-    // add a class based on the @size argument
-    classes.push(`hds-dropdown-toggle-overflow--size-${this.size}`);
-
     return classes.join(' ');
   }
 }

--- a/packages/components/app/components/hds/dropdown/toggle-icon.js
+++ b/packages/components/app/components/hds/dropdown/toggle-icon.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/dropdown/toggle-icon';

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -29,7 +29,8 @@ $hds-dropdown-toggle-border-width: 1px;
 // TOGGLE/BASE (for "OVERFLOW" and "USER")
 
 .hds-dropdown-toggle-overflow,
-.hds-dropdown-toggle-user {
+.hds-dropdown-toggle-user,
+.hds-dropdown-toggle-icon {
   align-items: center;
   background-color: transparent;
   border: $hds-dropdown-toggle-border-width solid transparent; // We need this to be transparent for a11y
@@ -44,7 +45,7 @@ $hds-dropdown-toggle-border-width: 1px;
   outline-color: transparent; // We need this to be transparent for a11y
   padding: 0;
   position: relative;
-  width: auto;
+  min-width: $hds-dropdown-toggle-base-height;
 
   &:hover,
   &.is-hover {
@@ -106,6 +107,34 @@ $hds-dropdown-toggle-border-width: 1px;
       border-radius: inherit;
     }
   }
+}
+
+.hds-dropdown-toggle-icon {
+  border-color: lightgray;
+  padding: 1px;
+}
+.hds-dropdown-toggle-icon__wrapper {
+  align-items: center;
+  border-radius: 3px; // $hds-dropdown-toggle-border-radius- 1px padding - 1px border
+  display: flex;
+  justify-content: center;
+  height: 32px;
+  width: 32px;
+
+  > * {
+    border-radius: inherit;
+  }
+}
+
+.hds-dropdown-toggle-icon--hasChevron {
+  margin-right: 0.25rem;
+}
+.hds-dropdown-toggle-icon__chevron {
+  display: flex;
+  flex-flow: column;
+  align-content: center;
+  justify-content: center;
+  margin-left: 0.25rem;
 }
 
 

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -1,6 +1,16 @@
 {{page-title "Dropdown Component"}}
 
 <h2 class="dummy-h2">Dropdown Component</h2>
+<Hds::Dropdown::ToggleIcon @text="toggle icon, type overflow" @iconType="overflow" @isOpen={{false}} />
+<br/>
+<Hds::Dropdown::ToggleIcon @text="toggle icon, type user" @iconType="user" @isOpen={{false}} />
+<br/>
+<Hds::Dropdown::ToggleIcon @text="toggle icon, type user with avatar" @iconType="user" @isOpen={{false}} @avatarUrl="/assets/images/avatar.png" />
+<br/>
+<Hds::Dropdown::ToggleIcon @text="toggle icon, no type" @iconName="settings" @isOpen={{false}} />
+<br/>
+<Hds::Dropdown::ToggleIcon @text="toggle icon, no type" @iconName="more-horizontal" @isOpen={{false}} />
+
 
 <section>
   <p class="dummy-paragraph">

--- a/packages/components/tests/integration/components/hds/dropdown/toggle-icon-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle-icon-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/dropdown/toggle-icon', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Hds::Dropdown::ToggleIcon />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Hds::Dropdown::ToggleIcon>
+        template block text
+      </Hds::Dropdown::ToggleIcon>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR condenses `toggle-overflow` and `toggle-user` into `toggle-icon` in order to offer a little more flexibility for the icon-only dropdown.

Current status: 
1. there are two approaches in the `toggle-icon` component, see comments in .hbs file
2. once we decide on an approach, I will remove the `toggle-overflow` and `toggle-user` components
3. once the other components are removed, will clean up the CSS and add a toggle-icon.js file and make this component more consistent with the other components
 
Screenshot: (border only exists for easier development; will remove before shipping)
![CleanShot 2022-03-30 at 17 18 11](https://user-images.githubusercontent.com/4587451/160941042-b83d6f30-1342-4f85-98f4-1d34454eeca8.png)



### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
