### PR TITLE
Cleanup the "box-sizing: border-box" declarations from the codebase

### DIFF
--- a/.changeset/curly-emus-begin.md
+++ b/.changeset/curly-emus-begin.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+removed “box-sizing“ declarations from the components (we assume the consumers codebase already have set it to “border-box“ by default

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -47,6 +47,8 @@ Finally, add this line to the top of your app's style file (`app.scss` or simila
 @import '@hashicorp/design-system-components';
 ```
 
+⚠️ **Notice**: our component library assumes that a `*, *::before, *::after { box-sizing: border-box; }` reset is applied globally in the CSS of the application. If in your use case this is not true, please speak with the design system team (we can try to find a workaround).
+
 Usage
 ------------------------------------------------------------------------------
 

--- a/packages/components/app/styles/components/badge-count.scss
+++ b/packages/components/app/styles/components/badge-count.scss
@@ -15,7 +15,6 @@ $hds-badge-count-border-width: 1px;
 .hds-badge-count {
   align-items: center;
   border: $hds-badge-count-border-width solid transparent;
-  box-sizing: border-box;
   display: inline-flex;
   font-family: var(--token-typography-font-stack-text);
   max-width: 100%;

--- a/packages/components/app/styles/components/badge.scss
+++ b/packages/components/app/styles/components/badge.scss
@@ -16,7 +16,6 @@
   align-items: center;
   border-radius: 5px;
   border: $hds-badge-border-width solid transparent;
-  box-sizing: border-box;
   display: inline-flex;
   max-width: 100%;
 }

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -18,7 +18,6 @@ $hds-button-focus-border-width: 3px;
   align-items: center;
   border: $hds-button-border-width solid transparent; // We need this to be transparent for a11y
   border-radius: $hds-button-border-radius;
-  box-sizing: border-box; // TODO https://github.com/hashicorp/design-system-components/issues/46
   display: flex;
   font-family: var(--token-typography-font-stack-text);
   isolation: isolate;
@@ -69,7 +68,6 @@ $hds-button-focus-border-width: 3px;
       border-radius: $hds-button-border-radius + $hds-button-focus-border-width;
       border: $hds-button-focus-border-width solid transparent;
       bottom: -$shift;
-      box-sizing: border-box;
       content: '';
       left: -$shift;
       position: absolute;

--- a/packages/components/app/styles/components/icon-tile.scss
+++ b/packages/components/app/styles/components/icon-tile.scss
@@ -17,7 +17,6 @@
   border-radius: 4px;
   border: $hds-icon-tile-border-width solid transparent;
   box-shadow: $hds-icon-tile-box-shadow;
-  box-sizing: border-box;
   display: flex;
   position: relative;
 }

--- a/packages/components/app/styles/mixins/_focus-ring.scss
+++ b/packages/components/app/styles/mixins/_focus-ring.scss
@@ -35,7 +35,6 @@
   &::before {
     border-radius: $radius;
     bottom: $bottom;
-    box-sizing: border-box;
     content: '';
     left: $left;
     position: absolute;

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -92,7 +92,7 @@ body.dummy-app {
             margin: 0 auto;
             max-width: 100%;
             min-height: 84.75vh;
-            width: 1024px;
+            width: calc(1024px + 2 * 2rem);
         }
 
         .dummy-footer {

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -19,6 +19,14 @@
 @import "./components/dummy-component-props";
 @import "./components/dummy-placeholder";
 
+html {
+    box-sizing: border-box;
+}
+
+*, *::before, *::after {
+    box-sizing: inherit;
+}
+
 body.dummy-app {
     background-color: #d9d9d9;
     padding: 0;

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -53,7 +53,6 @@ body.dummy-app {
         }
         .dummy-nav {
             background-color: #f1f2f3;
-            box-sizing: border-box;
             display: flex;
             margin: 0;
             padding: 0 0 0 0.5rem;
@@ -97,7 +96,6 @@ body.dummy-app {
 
         .dummy-footer {
             background-color: #f1f2f3;
-            box-sizing: border-box;
             display: flex;
             flex-flow: row wrap;
             margin: auto;
@@ -128,7 +126,6 @@ body.dummy-app {
                         min-height: fit-content;
                         .dummy-link {
                             border: 1px solid transparent;
-                            box-sizing: border-box;
                             align-content: center;
                             color: white;
                             display: flex;
@@ -137,9 +134,6 @@ body.dummy-app {
                             padding: 1rem;
                             text-decoration: none;
                             width: fit-content;
-                            &::before, &::after {
-                                box-sizing: border-box;
-                            }
                             &:hover, &:focus {
                                 text-decoration: underline;
                             }

--- a/packages/components/tests/dummy/app/styles/pages/db-colors.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-colors.scss
@@ -5,7 +5,7 @@
 }
 
 .dummy-color-card {
-    max-width: 600px;
+    max-width: 740px;
     padding: 20px 20px 20px 160px;
     position: relative;
     width: 100%;

--- a/packages/flight-website/app/styles/components/ds-icon-grid.css
+++ b/packages/flight-website/app/styles/components/ds-icon-grid.css
@@ -73,7 +73,6 @@ button.ds-toggle-button {
   bg-brand
   border-2 
   border-transparent 
-  box-border
   cursor-pointer 
   duration-200 
   ease-in-out 
@@ -93,7 +92,6 @@ button.ds-toggle-button {
 .ds-toggle-button-slider {
   @apply
   bg-transparent
-  box-border
   flex
   h-9
   justify-evenly
@@ -108,7 +106,6 @@ button.ds-toggle-button {
 
 .ds-toggle-16 {
   @apply 
-  box-border
   text-white
   ease-in 
   duration-200 
@@ -132,7 +129,6 @@ button.ds-toggle-button {
 .ds-toggle-24 {
   @apply
   bg-transparent
-  box-border
   duration-100
   ease-out
   flex
@@ -156,7 +152,6 @@ button.ds-toggle-button {
 
 /* Icon Grid */
 ul.ds-ul-grid {
-  box-sizing: border-box;
   display: grid;
   font-family: var(--font-body);
   gap: 16px;
@@ -172,7 +167,6 @@ ul.ds-ul-grid li.ds-li {
   background: var(--gray-7);
   border-radius: 3px;
   box-shadow: 0 0 0 1px var(--gray-5);
-  box-sizing: border-box;
   display: flex;
   flex-direction: row;
   gap: 1em;
@@ -180,7 +174,6 @@ ul.ds-ul-grid li.ds-li {
 }
 ul.ds-ul-grid li.ds-li .ds-icon-frame {
   align-items: center;
-  box-sizing: border-box;
   background: #fff;
   border-radius: 3px;
   box-shadow: 0 0 0 1px var(--gray-5);


### PR DESCRIPTION
### :pushpin: Summary

While developing the Ember components, in many cases we had to add a `box-sizing: border-box` declaration in the styling of a UI element to make sure that the this was the box model used by the browser to render that element. 
We have discussed many times with @MelSumner of how to solve this problem once for all (see for example https://github.com/hashicorp/design-system-components/issues/46) but we never made a decision.

In this PR I make this proposal: we assume that every consumer of the Ember components has a "standard" box-sizing reset/normalize global declaration in their CSS:
```
*, *::before, *::after {
  box-sizing: border-box;
}
```
so that we don't have to add it every time in our components. The reason is that this has become a standard de facto, and to make sure this assumption was correct I asked to the front-end developers if all the applications were using this reset.
Their answer was positive (see [this thread in Slack](https://hashicorp.slack.com/archives/C11JCBJTW/p1648639657008599)) so can safely make this assumption and remove all the box-sizing declarations from our codebase (we will also need to make sure that our websites, the "dummy" app and the Flight website, contain this reset).

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a global `box-sizing: border-box` reset in the CSS of the dummy app + updated the size of main “documentation” page container
   - this was to check that the payout of the pages remained the same, so any diff in Percy would have meant a diff in the components, not in the layout of the containing page
- removed any redundant `box-sizing` declaration from the CSS of dummy app
- removed any redundant `box-sizing` declaration from the CSS of components
- removed any redundant `box-sizing` declaration from the CSS of Flight website
  - notice: the `box-sizing` declaration in this case is already contained in the existing resets (see #151)
- updated the documentation to highlight that we assume the `box-sizing` reset for our components

_Notice: we don't expect any difference in the consuming codebases, once this release is adopted, but for precaution we declare this as a _minor_ version change (which in the current semver strategy is a breaking change)_

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy
    - 🚨 Notice: there a couple of failing test, but only on very small screens (375px) and are due to some strange reflow in the previous version in a specific page (colors) on a specific dummy component used to visualize these colors, they're not about the HDS components (also, the correct ones are the new screenshots)
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

/cc @hashicorp/design-systems 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202055821223298