### PR TITLE
proposes additional yields for list-item types

### DIFF
--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -16,7 +16,10 @@
     <ul class="hds-dropdown-list hds-dropdown-list--absolute-right">
       {{yield
         (hash
-          ListItem=(component "hds/dropdown/list-item") Separator=(component "hds/dropdown/list-item" item="separator")
+          ListItem=(component "hds/dropdown/list-item")
+          Separator=(component "hds/dropdown/list-item" item="separator")
+          Heading=(component "hds/dropdown/list-item" item="heading")
+          HelpText=(component "hds/dropdown/list-item" item="help-text")
         )
       }}
     </ul>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR proposes some additional yield types for the content block


### :hammer_and_wrench: Detailed description

When looking at the Separator, I was curious if we were interested in doing this for the other item types too: 

```hbs
 {{yield
    (hash
      ListItem=(component "hds/dropdown/list-item") 
      Separator=(component "hds/dropdown/list-item" item="separator")
      Heading=(component "hds/dropdown/list-item" item="heading")
      HelpText=(component "hds/dropdown/list-item" item="help-text")
    )
  }}
```

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
