### PR TITLE
Revert "Update @hashicorp/flight-icons requirement from ^2.1.1 to ^2.2.0 in /packages/ember-flight-icons"

### DIFF
--- a/packages/ember-flight-icons/package.json
+++ b/packages/ember-flight-icons/package.json
@@ -35,7 +35,7 @@
     "test:ember:percy": "percy exec ember test"
   },
   "dependencies": {
-    "@hashicorp/flight-icons": "^2.2.0",
+    "@hashicorp/flight-icons": "^2.1.1",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.0.1"
   },


### PR DESCRIPTION
Reverts hashicorp/design-system#149

Had briefly synced with Brian. After doing a bit more digging "how to create a changeset from nothing", as I want to create a changeset for this PR, with no additional changes
-  Let's revert this
- Make the change again in a new PR, with a changeset for ember-flight-icons (bumping flight-icons), as well as design-system-components (bumping ember-flight-icons)