### PR TITLE
Fix Percy screenshot for "Breadcrumb" page

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
+++ b/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
@@ -2,14 +2,16 @@
 
 <h2 class="dummy-h2">Breadcrumb</h2>
 
-<div class="dummy-banner dummy-banner--alert">
-  <p class="dummy-paragraph"><strong>🚨 ATTENTION 🚨</strong></p>
-  <p class="dummy-paragraph">Despite being ready this component can't be used in production code yet. The reason is
-    that, in order to be fully adopted in the Cloud UI codebase, it requires some refactoring on the way breadcrumbs are
-    implemented in Cloud UI.</p>
-  <p class="dummy-paragraph">If you need to adopt it in your codebase please speak with the HDS team first so they can
-    help you.</p>
-</div>
+<section>
+  <div class="dummy-banner dummy-banner--alert">
+    <p class="dummy-paragraph"><strong>🚨 ATTENTION 🚨</strong></p>
+    <p class="dummy-paragraph">Despite being ready this component can't be used in production code yet. The reason is
+      that, in order to be fully adopted in the Cloud UI codebase, it requires some refactoring on the way breadcrumbs
+      are implemented in Cloud UI.</p>
+    <p class="dummy-paragraph">If you need to adopt it in your codebase please speak with the HDS team first so they can
+      help you.</p>
+  </div>
+</section>
 
 <section>
   <h3 class="dummy-h3">Component API</h3>


### PR DESCRIPTION
### :pushpin: Summary

I noticed that the Percy tests for the "Breadcrumb" page includes the top banner, and it shouldn't.

<img width="1787" alt="screenshot_1240" src="https://user-images.githubusercontent.com/686239/161233439-5964bfbd-4afc-43cb-8355-9dda760001de.png">


### :hammer_and_wrench: Detailed description

In this PR I have:
- moved the top banner in the “Breadcrumb” page inside a `<section>` so it's picked up by the CSS rule that hides elements without the `data-test-percy` attribute.

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
