### PR TITLE
pin @percy/cli to 1.0.0-beta.70

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   },
   "scripts": {
     "release": "yarn changeset publish"
+  },
+  "resolutions": {
+    "@percy/ember/@percy/sdk-utils": "1.0.0-beta.76"
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,9 +44,6 @@
     "ember-named-blocks-polyfill": "^0.2.5",
     "sass": "^1.43.4"
   },
-  "resolutions": {
-    "@percy/sdk-utils": "1.0.0-beta.76"
-  },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.4.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
     "@embroider/test-setup": "^0.43.5",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@percy/cli": "^1.0.0-beta.70",
+    "@percy/cli": "1.0.0-beta.76",
     "@percy/ember": "^3.0.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -51,6 +51,7 @@
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@percy/cli": "1.0.0-beta.76",
+    "@percy/sdk-utils": "1.0.0-beta.76",
     "@percy/ember": "^3.0.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,6 +44,9 @@
     "ember-named-blocks-polyfill": "^0.2.5",
     "sass": "^1.43.4"
   },
+  "resolutions": {
+    "@percy/sdk-utils": "1.0.0-beta.76"
+  },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.4.2",

--- a/packages/ember-flight-icons/package.json
+++ b/packages/ember-flight-icons/package.json
@@ -45,7 +45,7 @@
     "@embroider/test-setup": "^1.0.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@percy/cli": "^1.0.0-beta.68",
+    "@percy/cli": "1.0.0-beta.76",
     "@percy/ember": "^3.0.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/flight-website/package.json
+++ b/packages/flight-website/package.json
@@ -34,7 +34,7 @@
     "@glimmer/tracking": "^1.0.4",
     "@hashicorp/ember-flight-icons": "^2.0.2",
     "@hashicorp/flight-icons": "^2.1.1",
-    "@percy/cli": "^1.0.0-beta.68",
+    "@percy/cli": "1.0.0-beta.76",
     "@percy/ember": "^3.0.0",
     "@tailwindcss/forms": "^0.3.4",
     "@tailwindcss/typography": "^0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1873,17 +1873,29 @@
   resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.0.0-beta.76.tgz#079f3a1174717d8da15e7e0575ff821fdf035aa5"
   integrity sha512-+Mx9K3wjFriMT0cMD5l+VRo6mhQ/XssKy77SUeWrOaGIk7Xs/FsnDUpLOCXAGUeJr1AznZM76ng99IOBM6pY4w==
 
+"@percy/logger@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.0.0.tgz#d500729480c067efe552ede119b3915eaca14b41"
+  integrity sha512-rr5QxZ0LzYrgrTlkbGW61Fre/Fb7VQh82Y+gIUf2rf+vrKvVgMJrlmhhRsE2EZ0KpX/S9POEHt1Z+p0OaYQd9Q==
+
 "@percy/logger@1.0.0-beta.76":
   version "1.0.0-beta.76"
   resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.0.0-beta.76.tgz#1a75c583670acc078389a43d8b7410fd655c0b92"
   integrity sha512-v5zIMNv1xqdcWBAOK5A6ZEO99ZBwzWS3phLEfkKbIlGIUxvjkJHSfZv/k1dnt2RRfpDNkM6X5pMg2yI8j1+d+g==
 
-"@percy/sdk-utils@^1.0.0-beta.46":
+"@percy/sdk-utils@1.0.0-beta.76":
   version "1.0.0-beta.76"
   resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.0.0-beta.76.tgz#71b4d7a7664b7029761aea5850295defeb134f98"
   integrity sha512-5B070+VlTiCjxmwHU5Q8+ow1dGdmOkukY8TkSBkkbSs2OE4IPcYBlb+t/hGhpw7D34znPXc2dmUrZrbXwkRd2A==
   dependencies:
     "@percy/logger" "1.0.0-beta.76"
+
+"@percy/sdk-utils@^1.0.0-beta.46":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.0.0.tgz#8ce7b06619c93081ef5a73c1df4c01ffad79e99a"
+  integrity sha512-2gA64hhLwR7Wc0WuTmzsrvMGXtaxkOmvEydnDEUXAxweIIRZJNUzDpPPxKpM6bM5xqpIleQHC7QV7lpmGoP4Hg==
+  dependencies:
+    "@percy/logger" "1.0.0"
 
 "@simple-dom/interface@^1.4.0":
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,7 +1806,7 @@
     globby "^11.0.4"
     image-size "^1.0.0"
 
-"@percy/cli@^1.0.0-beta.68", "@percy/cli@^1.0.0-beta.70":
+"@percy/cli@1.0.0-beta.76":
   version "1.0.0-beta.76"
   resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.0.0-beta.76.tgz#2c5ab442b7cfa00f49a8a6fd009c2335b3319a9d"
   integrity sha512-X3I+28KNedv2vlitVnhu751QdxC0JMmFN51gOBNHkh4gy5rU372oQk1Y6XUQHYjq69BvZMHJnv4Pxhh2RFDZgg==
@@ -10869,7 +10869,7 @@ mime-db@1.51.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
-"mime-db@>= 1.43.0 < 2":
+mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
@@ -10886,12 +10886,19 @@ mime-types@2.1.18:
   dependencies:
     mime-db "~1.33.0"
 
-mime-types@^2.1.18, mime-types@^2.1.26, mime-types@^2.1.27, mime-types@^2.1.34, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.18, mime-types@^2.1.26, mime-types@^2.1.27, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
   dependencies:
     mime-db "1.51.0"
+
+mime-types@^2.1.34:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime@1.6.0:
   version "1.6.0"


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
`@percy/cli` released a `1.0.0` today that is breaking our test suite for unknown reasons ([example](https://github.com/hashicorp/design-system/runs/5794494619?check_suite_focus=true#step:5:42)). To avoid that blocking our work we can, for now, pin to the last know working version.
