### PR TITLE
refactored heading and help text

### DIFF
--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -17,8 +17,8 @@
     <ul class="hds-dropdown-list {{if (eq @listPosition "left") "hds-dropdown-list--position-left" "hds-dropdown-list--position-right"}}">
       {{yield
         (hash
-          Heading=(component "hds/dropdown/list-item" item="heading")
-          HelpText=(component "hds/dropdown/list-item" item="help-text")
+          Title=(component "hds/dropdown/list-item" item="title")
+          Description=(component "hds/dropdown/list-item" item="description")
           ListItem=(component "hds/dropdown/list-item")
           Separator=(component "hds/dropdown/list-item" item="separator")
         )

--- a/packages/components/addon/components/hds/dropdown/list-item.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item.hbs
@@ -1,9 +1,9 @@
-{{#if (eq this.item "heading")}}
+{{#if (eq this.item "title")}}
   <li class={{this.classNames}}>
     {{@text}}
   </li>
 
-{{else if (eq this.item "help-text")}}
+{{else if (eq this.item "description")}}
   <li class={{this.classNames}}>
     {{@text}}
   </li>

--- a/packages/components/addon/components/hds/dropdown/list-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item.js
@@ -4,7 +4,7 @@ import { assert } from '@ember/debug';
 export const DEFAULT_COLOR = 'action';
 export const DEFAULT_ITEM = 'interactive';
 export const COLORS = ['action', 'critical'];
-export const ITEMS = ['heading', 'help-text', 'separator', 'interactive'];
+export const ITEMS = ['title', 'description', 'separator', 'interactive'];
 
 export default class HdsDropdownListItemComponent extends Component {
   /**

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -132,7 +132,7 @@ $hds-dropdown-toggle-border-width: 1px;
   // LIST > LIST-ITEM
   // HDS::DROPDOWN::LIST-ITEM
 
-  .hds-dropdown-list-item--heading {
+  .hds-dropdown-list-item--title {
     color: var(--token-color-foreground-strong);
     font-family: var(--token-typography-body-100-font-family);
     font-size: var(--token-typography-body-100-font-size);
@@ -141,7 +141,7 @@ $hds-dropdown-toggle-border-width: 1px;
     padding: 10px 16px 4px;
   }
 
-  .hds-dropdown-list-item--help-text {
+  .hds-dropdown-list-item--description {
     color: var(--token-color-foreground-faint);
     font-family: var(--token-typography-body-100-font-family);
     font-size: var(--token-typography-body-100-font-size);

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -117,8 +117,8 @@
         Acceptable values:
       </p>
       <ol>
-        <li>heading</li>
-        <li>help-text</li>
+        <li>title</li>
+        <li>description</li>
         <li>separator</li>
         <li class="default">interactive</li>
       </ol>
@@ -316,7 +316,7 @@
   <div>
     <h4 class="dummy-h4">Toggle/Icon: User Icon</h4>
     <p class="dummy-paragraph">
-      In this example, we have a user icon with a header, help-text, separator, and links.
+      In this example, we have a user icon with a title, description, separator, and links.
       <br />Note that
       <span class="dummy-code">toggleText</span>
       is still required, because it supplies the value for the
@@ -333,8 +333,8 @@
           @isOpen=&lbrace;&lbrace;false&rbrace;&rbrace;
           as |dd| &gt;
 
-          &lt;dd.Heading @text="Signed In" /&gt;
-          &lt;dd.HelpText @text="design-systems@hashicorp.com" /&gt;
+          &lt;dd.Title @text="Signed In" /&gt;
+          &lt;dd.Description @text="design-systems@hashicorp.com" /&gt;
           &lt;dd.Separator /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Settings and Preferences" /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @icon="trash" /&gt;
@@ -348,8 +348,8 @@
       <ul class="dummy-nav-dropdown__list">
         <li class="dummy-nav-dropdown__list-item">
           <Hds::Dropdown @toggleText="user menu" @isOpen={{false}} as |dd|>
-            <dd.Heading @text="Signed In" />
-            <dd.HelpText @text="design-systems@hashicorp.com" />
+            <dd.Title @text="Signed In" />
+            <dd.Description @text="design-systems@hashicorp.com" />
             <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Settings and Preferences" />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @icon="trash" />
@@ -364,8 +364,8 @@
         <li class="dummy-nav-dropdown__list-item">
           <Hds::Dropdown @toggleText="user menu" @isOpen={{false}} as |dd|>
 
-            <dd.Heading @text="Signed In" />
-            <dd.HelpText @text="design-systems@hashicorp.com" />
+            <dd.Title @text="Signed In" />
+            <dd.Description @text="design-systems@hashicorp.com" />
             <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Settings and Preferences" />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @icon="trash" />
@@ -378,7 +378,7 @@
   <div>
     <h4 class="dummy-h4">Toggle/Icon: Other Icons</h4>
     <p class="dummy-paragraph">
-      In this example, we have a settings icon with a header, help-text, separator, and links.
+      In this example, we have a settings icon with a title, description, separator, and links.
       <br />Note that
       <span class="dummy-code">toggleText</span>
       is still required, because it supplies the value for the
@@ -396,8 +396,8 @@
           @isOpen=&lbrace;&lbrace;false&rbrace;&rbrace;
           as |dd| &gt;
 
-          &lt;dd.Heading @text="Signed In" /&gt;
-          &lt;dd.HelpText @text="design-systems@hashicorp.com" /&gt;
+          &lt;dd.Title @text="Signed In" /&gt;
+          &lt;dd.Description @text="design-systems@hashicorp.com" /&gt;
           &lt;dd.Separator /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Settings and Preferences" /&gt;
           &lt;dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @icon="trash" /&gt;
@@ -411,8 +411,8 @@
       <ul class="dummy-nav-dropdown__list">
         <li class="dummy-nav-dropdown__list-item">
           <Hds::Dropdown @toggleText="settings menu" @iconName="settings" @isOpen={{false}} as |dd|>
-            <dd.Heading @text="Signed In" />
-            <dd.HelpText @text="design-systems@hashicorp.com" />
+            <dd.Title @text="Signed In" />
+            <dd.Description @text="design-systems@hashicorp.com" />
             <dd.Separator />
             <dd.ListItem @route="components.dropdown" @text="Settings and Preferences" />
             <dd.ListItem @route="components.dropdown" @text="Delete" @color="critical" @icon="trash" />
@@ -641,17 +641,17 @@
 
   <h3 class="dummy-h3" id="section-showcase-listitem">Showcase: List Items</h3>
 
-  <h4 class="dummy-h4">Heading, Help Text, Separator</h4>
+  <h4 class="dummy-h4">Title, Description, Separator</h4>
   <div class="dummy-dropdown-list-items-base-sample hds-dropdown">
     <ul class="hds-dropdown-list">
-      <Hds::Dropdown::ListItem @item="heading" @text="A simple heading" />
-      <Hds::Dropdown::ListItem @item="help-text" @text="Some help text." />
+      <Hds::Dropdown::ListItem @item="title" @text="A simple Title" />
+      <Hds::Dropdown::ListItem @item="description" @text="A description." />
       <Hds::Dropdown::ListItem @item="separator" />
       <Hds::Dropdown::ListItem @route="index" @text="Item" />
     </ul>
     <ul class="hds-dropdown-list">
-      <Hds::Dropdown::ListItem @item="heading" @text="A longer heading that goes on multiple lines" />
-      <Hds::Dropdown::ListItem @item="help-text" @text="A longer help text that can span on multiple lines." />
+      <Hds::Dropdown::ListItem @item="title" @text="A longer title that could span multiple lines if the characters surpass a certain length" />
+      <Hds::Dropdown::ListItem @item="description" @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default." />
       <Hds::Dropdown::ListItem @item="separator" />
       <Hds::Dropdown::ListItem @route="index" @text="Item" />
     </ul>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR changes `heading` to `title` and `help-text` to `description`. 


Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
