### PR TITLE
Fix issue with "click outside" in Safari for "Disclosure/Breadcrumb/Dropdown"

### DIFF
--- a/.changeset/happy-peaches-type.md
+++ b/.changeset/happy-peaches-type.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fixed issue with "click outside" in Safari for "Disclosure/Breadcrumb/Dropdown"

--- a/packages/components/addon/components/hds/disclosure/index.js
+++ b/packages/components/addon/components/hds/disclosure/index.js
@@ -20,7 +20,9 @@ export default class HdsDisclosureComponent extends Component {
   clickOutsideDeactivates(event) {
     // we check if the toggle reference belongs to the tree of parent DOM nodes
     // of the element that was clicked and triggered the "click outside" event handling
-    this.isToggleClicked = event.path.includes(this.toggleRef);
+    // notice: we use "event.composedPath" here because is now fully supported (see https://caniuse.com/?search=event%20path)
+    const path = event.composedPath();
+    this.isToggleClicked = path.includes(this.toggleRef);
     // here we need to return `true` to make sure that the focus trap will be deactivated (and allow the click event to do its thing (i.e. to pass-through to the element that was clicked).
     // see: https://github.com/focus-trap/focus-trap#createoptions
     return true;


### PR DESCRIPTION
### :pushpin: Summary

While working on #66 I noticed that in Safari the "click outside" triggered an error (`undefined is not an object (evaluating 'e.path.includes')` because I was using `event.path` which is not supported in Safari.

This error was impacting the `Disclosure`, the `Breadcrumb` and the `Dropdown` component.

### :hammer_and_wrench: Detailed description

In this PR I have:
- replaced `event.path` with `event.composedPath` in the “Disclosure” component (it's [widely supported now](https://caniuse.com/?search=event%20path))

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202083137907265