### PR TITLE
Add a banner on top of the "Button" and "Link" pages to explain difference between Link/CTA/Button

### DIFF
--- a/packages/components/tests/dummy/app/components/dummy-link-cta-button-banner/index.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-link-cta-button-banner/index.hbs
@@ -1,0 +1,30 @@
+<div class="dummy-link-cta-button-banner">
+  <h3>Links, Buttons, CTAs...oh my!</h3>
+  <h4>When to use a Link</h4>
+  <p>A link navigates the user to a new destination via a URL or route. Use
+    <code class="dummy-code">Link::Inline</code>
+    [soon available] within a body of text and
+    <LinkTo @route="components.link"><code class="dummy-code">Link::Standalone</code></LinkTo>
+    or
+    <LinkTo @route="components.link-to"><code class="dummy-code">LinkTo::Standalone</code></LinkTo>
+    outside of a body of text, ie. on its own or in a list.</p>
+  <h4>When to use a CTA</h4>
+  <p>A CTA is a link that looks like a button. It navigates the user to a new destination via a URL or route, but has
+    more visual weight than a standard link. Use a
+    <code class="dummy-code">Link::CTA</code>
+    [soon available] to guide the user and encourage interaction. Use sparingly as overuse dilutes its importance.</p>
+  <h4>When to use a Button</h4>
+  <p>A button triggers an action within the page, ie. opening a dropdown or submitting a form.
+    <LinkTo @route="components.button"><code class="dummy-code">Button</code></LinkTo>
+    is offered in a variety of visual weights to provide flexibility in use. Please refer to the Design Guidelines to
+    learn more about the different variants.
+  </p>
+  <h4>Want to learn more?</h4>
+  <p><a href="https://medium.com/@h_locke/links-vs-buttons-e8b523660fb3" target="_blank" rel="noopener noreferrer">Links
+      vs Buttons</a>
+    by Hannah Locke</p>
+  <p>
+    <a href="https://css-tricks.com/use-button-element/" target="_blank" rel="noopener noreferrer">When to use the
+      Button element</a>
+    by Chris Coyier</p>
+</div>

--- a/packages/components/tests/dummy/app/components/dummy-link-cta-button-banner/index.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-link-cta-button-banner/index.hbs
@@ -2,20 +2,20 @@
   <h3>Links, Buttons, CTAs...oh my!</h3>
   <h4>When to use a Link</h4>
   <p>A link navigates the user to a new destination via a URL or route. Use
-    <code class="dummy-code">Link::Inline</code>
+    <code>Link::Inline</code>
     [soon available] within a body of text and
-    <LinkTo @route="components.link"><code class="dummy-code">Link::Standalone</code></LinkTo>
+    <LinkTo @route="components.link"><code>Link::Standalone</code></LinkTo>
     or
-    <LinkTo @route="components.link-to"><code class="dummy-code">LinkTo::Standalone</code></LinkTo>
+    <LinkTo @route="components.link-to"><code>LinkTo::Standalone</code></LinkTo>
     outside of a body of text, ie. on its own or in a list.</p>
   <h4>When to use a CTA</h4>
   <p>A CTA is a link that looks like a button. It navigates the user to a new destination via a URL or route, but has
     more visual weight than a standard link. Use a
-    <code class="dummy-code">Link::CTA</code>
+    <code>Link::CTA</code>
     [soon available] to guide the user and encourage interaction. Use sparingly as overuse dilutes its importance.</p>
   <h4>When to use a Button</h4>
   <p>A button triggers an action within the page, ie. opening a dropdown or submitting a form.
-    <LinkTo @route="components.button"><code class="dummy-code">Button</code></LinkTo>
+    <LinkTo @route="components.button"><code>Button</code></LinkTo>
     is offered in a variety of visual weights to provide flexibility in use. Please refer to the Design Guidelines to
     learn more about the different variants.
   </p>

--- a/packages/components/tests/dummy/app/components/dummy-link-cta-button-banner/index.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-link-cta-button-banner/index.hbs
@@ -1,4 +1,4 @@
-<div class="dummy-link-cta-button-banner">
+<section class="dummy-link-cta-button-banner">
   <h3>Links, Buttons, CTAs...oh my!</h3>
   <h4>When to use a Link</h4>
   <p>A link navigates the user to a new destination via a URL or route. Use
@@ -27,4 +27,4 @@
     <a href="https://css-tricks.com/use-button-element/" target="_blank" rel="noopener noreferrer">When to use the
       Button element</a>
     by Chris Coyier</p>
-</div>
+</section>

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -18,6 +18,7 @@
 
 @import "./components/dummy-component-props";
 @import "./components/dummy-placeholder";
+@import "./components/dummy-link-cta-button-banner";
 
 html {
     box-sizing: border-box;

--- a/packages/components/tests/dummy/app/styles/components/dummy-link-cta-button-banner.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-link-cta-button-banner.scss
@@ -1,0 +1,32 @@
+// notice: here we use custom typography to make the banner more compact
+
+.dummy-link-cta-button-banner {
+    @include dummyFontFamily();
+    border-radius: 0.25rem;
+    background-color: #f9f2ff;
+    margin: 1rem auto;
+    padding: 1.25rem;
+
+    h3 {
+        font-size: 1.1rem;
+        color: #911ced;
+        font-weight: 600;
+        margin: 0;
+    }
+
+    h4 {
+        font-size: 0.95rem;
+        font-weight: 500;
+        margin: 1rem 0 0 0;
+    }
+
+    p {
+        font-size: 0.9rem;
+        margin: 0.5rem 0 0 0;
+    }
+
+    a {
+        color: inherit;
+    }
+}
+

--- a/packages/components/tests/dummy/app/styles/components/dummy-link-cta-button-banner.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-link-cta-button-banner.scss
@@ -28,5 +28,9 @@
     a {
         color: inherit;
     }
+
+    code {
+        font-weight: bold;
+    }
 }
 

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -2,6 +2,8 @@
 
 <h2 class="dummy-h2">Button component</h2>
 
+<DummyLinkCtaButtonBanner />
+
 <section>
   <h3 class="dummy-h3">Component API</h3>
   <p class="dummy-paragraph">Here is the API for the component:</p>

--- a/packages/components/tests/dummy/app/templates/components/link-to/standalone.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link-to/standalone.hbs
@@ -4,6 +4,8 @@
   LinkTo (Standalone)
 </h2>
 
+<DummyLinkCtaButtonBanner />
+
 <section>
   <h3 class="dummy-h3">
     Overview

--- a/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
@@ -4,6 +4,8 @@
   Link (Standalone)
 </h2>
 
+<DummyLinkCtaButtonBanner />
+
 <section>
   <h3 class="dummy-h3">
     Overview


### PR DESCRIPTION
### :pushpin: Summary

@heatherlarsen has added a banner on top of the "Button" and "Link" Figma pages to explain the difference between Link/CTA/Button. We want to do the same in the web documentation pages.

![banner](https://user-images.githubusercontent.com/686239/161935785-07550499-22e8-46f8-9f11-20e0df074461.png)

### :hammer_and_wrench: Detailed description

In this PR I have:
- created a `dummy-link-cta-button-banner` component (so that it can be used in multiple places and easily changed across them)
- added this banner on top of the `button`, `link` and `link-to` component pages
   - _notice: once merged in `main` this banner will be added to the `Link::CTA` page too (see #115)_

### :camera_flash: Screenshots

<img width="1184" alt="screenshot_1272" src="https://user-images.githubusercontent.com/686239/161935735-bf35b00c-a6f6-4cc7-bfc3-dc828c3512dc.png">

Preview: https://hds-components-git-add-link-cta-button-banner-hashicorp.vercel.app/components/button

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202085974735471