### PR TITLE
Add banner to CTA

### DIFF
--- a/packages/components/tests/dummy/app/components/dummy-link-cta-button-banner/index.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-link-cta-button-banner/index.hbs
@@ -4,15 +4,17 @@
   <p>A link navigates the user to a new destination via a URL or route. Use
     <code>Link::Inline</code>
     [soon available] within a body of text and
-    <LinkTo @route="components.link"><code>Link::Standalone</code></LinkTo>
+    <LinkTo @route="components.link.standalone"><code>Link::Standalone</code></LinkTo>
     or
-    <LinkTo @route="components.link-to"><code>LinkTo::Standalone</code></LinkTo>
+    <LinkTo @route="components.link-to.standalone"><code>LinkTo::Standalone</code></LinkTo>
     outside of a body of text, ie. on its own or in a list.</p>
   <h4>When to use a CTA</h4>
   <p>A CTA is a link that looks like a button. It navigates the user to a new destination via a URL or route, but has
     more visual weight than a standard link. Use a
-    <code>Link::CTA</code>
-    [soon available] to guide the user and encourage interaction. Use sparingly as overuse dilutes its importance.</p>
+    <LinkTo @route="components.link.cta"><code>Link::CTA</code></LinkTo>
+    or
+    <LinkTo @route="components.link-to.cta"><code>LinkTo::CTA</code></LinkTo>
+    to guide the user and encourage interaction. Use sparingly as overuse dilutes its importance.</p>
   <h4>When to use a Button</h4>
   <p>A button triggers an action within the page, ie. opening a dropdown or submitting a form.
     <LinkTo @route="components.button"><code>Button</code></LinkTo>

--- a/packages/components/tests/dummy/app/templates/components/link-to/cta.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link-to/cta.hbs
@@ -2,6 +2,8 @@
 
 <h2 class="dummy-h2">LinkTo::CTA (Call To Action)</h2>
 
+<DummyLinkCtaButtonBanner />
+
 <section>
   <h3 class="dummy-h3">
     Overview

--- a/packages/components/tests/dummy/app/templates/components/link/cta.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/cta.hbs
@@ -2,6 +2,8 @@
 
 <h2 class="dummy-h2">Link::CTA (Call To Action)</h2>
 
+<DummyLinkCtaButtonBanner />
+
 <section>
   <h3 class="dummy-h3">
     Overview


### PR DESCRIPTION
### :pushpin: Summary

Now that we have added the banner in #187 and the CTA component is released in #115 we need to add the same banner to the CTA doc pages as well.

### :hammer_and_wrench: Detailed description

In this PR I have: 
- added the banner to the `Link/LinkTo::CTA` documentation pages
- updated the internal links in banner

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
