### PR TITLE
Docs: Expand on the tertiary button icon requirement

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -35,9 +35,19 @@
     <dt>icon <code>string</code></dt>
     <dd>
       <p>Use this parameter to show an icon. Acceptable value: any Flight icon name.</p>
-      <p><strong>🚨 IMPORTANT:</strong>
+      <p><strong>🚨 IMPORTANT a11y note:</strong>
         <code class="dummy-code">tertiary</code>
-        buttons are required to have either a leading or trailing icon to be accessible.</p>
+        buttons have transparent backgrounds, and interactive elements must communicate interactivity with more than
+        just color. Therefore, a leading or trailing icon is required when using the
+        <code class="dummy-code">tertiary</code>
+        color.
+        <Hds::Link::Standalone
+          href="https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=141#use-of-color"
+          @text="WCAG 2.1 Criterion 1.4.1: Use of Color (Level A)"
+          @icon="external-link"
+          @iconPosition="trailing"
+        />
+      </p>
     </dd>
     <dt>iconPosition <code>enum</code></dt>
     <dd>

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -41,12 +41,13 @@
         just color. Therefore, a leading or trailing icon is required when using the
         <code class="dummy-code">tertiary</code>
         color.
-        <Hds::Link::Standalone
+        <a
           href="https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=141#use-of-color"
-          @text="WCAG 2.1 Criterion 1.4.1: Use of Color (Level A)"
-          @icon="external-link"
-          @iconPosition="trailing"
-        />
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          WCAG 2.1 Criterion 1.4.1: Use of Color (Level A)
+        </a>
       </p>
     </dd>
     <dt>iconPosition <code>enum</code></dt>


### PR DESCRIPTION
### :pushpin: Summary

This describes why tertiary buttons without an icon are deemed inaccessible and links to the WCAG 2.1 techniques for the criterion.

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

### :hammer_and_wrench: Detailed description

I still have reservations on whether or not this should actually be a restriction on the component.  The applicability section for the [use of color criterion techniques](https://www.w3.org/WAI/WCAG21/Techniques/general/G182.html) states:

> Colored text when the color is used to convey information such as:
> - Words that are links in a paragraph
> - Items in a list where some are different than others and are presented in colored text

Since buttons should never be buried in paragraphs of text like an inline link would be, the criterion shouldn't be applicable--or at the very least so rarely applicable that is shouldn't be a hard restriction encoded in the `Hds::Button` component.

And from the description of the technique on the same page:

> The intent of this technique is to provide a redundant visual cue for users who may not be able to discern a difference in text color.

Interpreting this intent, the position of a button outside the flow of prose is itself a way to discern the difference between text and the button.

Nonetheless, if this restriction is going to be in place on the component, I doubt I'll be the last person to wonder why, so having docs link to the official source should be valuable!

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
