### PR TITLE
"Dropdown" component - CSS cleanup (02)

### DIFF
--- a/packages/components/addon/components/hds/dropdown/list-item.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item.hbs
@@ -11,14 +11,16 @@
 {{else if (eq this.item "copy-item")}}
   <li class={{this.classNames}}>
     {{#if @copyItemTitle}}
-      <div class="hds-dropdown-list-item__copy-item-title">{{@copyItemTitle}}</div>
+      <div
+        class="hds-dropdown-list-item__copy-item-title hds-typography-body-100 hds-font-weight-semibold"
+      >{{@copyItemTitle}}</div>
     {{/if}}
     <button
       type="button"
       class="{{if @state (concat 'is-' @state)}} {{if this.isSuccess 'is-success'}}"
       {{on "click" this.copyCode}}
     >
-      <div class="hds-dropdown-list-item__copy-item-text">
+      <div class="hds-dropdown-list-item__copy-item-text hds-typography-code-100">
         {{this.text}}
       </div>
       <FlightIcon
@@ -53,7 +55,7 @@
             <FlightIcon @name={{this.icon}} @isInlineBlock={{false}} />
           </div>
         {{/if}}
-        <div class="hds-dropdown-list-item__interactive-text">
+        <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
           {{this.text}}
         </div>
       </LinkTo>
@@ -64,7 +66,7 @@
             <FlightIcon @name={{this.icon}} @isInlineBlock={{false}} />
           </div>
         {{/if}}
-        <div class="hds-dropdown-list-item__interactive-text">
+        <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
           {{this.text}}
         </div>
       </a>
@@ -75,7 +77,7 @@
             <FlightIcon @name={{this.icon}} @isInlineBlock={{false}} />
           </div>
         {{/if}}
-        <div class="hds-dropdown-list-item__interactive-text">
+        <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
           {{this.text}}
         </div>
       </button>

--- a/packages/components/addon/components/hds/dropdown/list-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item.js
@@ -96,8 +96,14 @@ export default class HdsDropdownListItemComponent extends Component {
     let classes = ['hds-dropdown-list-item'];
 
     // add a class based on the @item argument
-    if (this.item) {
-      classes.push(`hds-dropdown-list-item--${this.item}`);
+    classes.push(`hds-dropdown-list-item--${this.item}`);
+    if (this.item === 'title') {
+      classes.push('hds-typography-body-100');
+      classes.push('hds-font-weight-semibold');
+    }
+    if (this.item === 'description') {
+      classes.push('hds-typography-body-100');
+      classes.push('hds-font-weight-regular');
     }
 
     // add a class based on the @color argument

--- a/packages/components/addon/components/hds/dropdown/toggle-icon.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle-icon.hbs
@@ -1,7 +1,7 @@
 <button class={{this.classNames}} aria-label={{this.text}} ...attributes {{on "click" this.onClick}} type="button">
   <div class="hds-dropdown-toggle-icon__wrapper">
     {{#if @imageSrc}}
-      <img src={{@imageSrc}} alt="" role="presentation" height="32" width="32" />
+      <img src={{@imageSrc}} alt="" role="presentation" />
     {{else}}
       <FlightIcon @name={{this.icon}} @size="24" />
     {{/if}}

--- a/packages/components/addon/components/hds/dropdown/toggle-icon.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle-icon.hbs
@@ -1,7 +1,7 @@
 <button class={{this.classNames}} aria-label={{this.text}} ...attributes {{on "click" this.onClick}} type="button">
   <div class="hds-dropdown-toggle-icon__wrapper">
     {{#if @imageSrc}}
-      <img src={{@imageSrc}} alt="" role="presentation" />
+      <img src={{@imageSrc}} alt="" role="presentation" height="32" width="32" />
     {{else}}
       <FlightIcon @name={{this.icon}} @size="24" />
     {{/if}}

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -21,6 +21,9 @@
 
 @use '../mixins/focus-ring' as *;
 
+$hds-dropdown-toggle-base-height: 36px;
+$hds-dropdown-toggle-border-radius: 5px;
+
 
 // TOGGLE/ICON
 
@@ -28,14 +31,14 @@
   align-items: center;
   background-color: transparent;
   border: 1px solid transparent; // We need this to be transparent for a11y
-  border-radius: 5px;
+  border-radius: $hds-dropdown-toggle-border-radius;
   display: flex;
-  height: 36px;
+  height: $hds-dropdown-toggle-base-height;
   justify-content: center;
   outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
   outline-color: transparent; // We need this to be transparent for a11y
   padding: 1px;
-  min-width: 36px;
+  min-width: $hds-dropdown-toggle-base-height;
 
   &:hover,
   &.is-hover {
@@ -44,7 +47,7 @@
     cursor: pointer;
   }
 
-  @include hds-focus-ring-with-pseudo-element($top: -1px, $right: -1px, $bottom: -1px, $left: -1px, $radius: 5px);
+  @include hds-focus-ring-with-pseudo-element($top: -1px, $right: -1px, $bottom: -1px, $left: -1px, $radius: $hds-dropdown-toggle-border-radius);
 
   &:active,
   &.is-active {
@@ -55,7 +58,7 @@
 
 .hds-dropdown-toggle-icon__wrapper {
   align-items: center;
-  border-radius: 3px; // 5px- 1px padding - 1px border
+  border-radius: 3px; // $hds-dropdown-toggle-border-radius - 1px padding - 1px border
   display: flex;
   justify-content: center;
   height: 32px;

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -35,10 +35,10 @@ $hds-dropdown-toggle-border-radius: 5px;
   display: flex;
   height: $hds-dropdown-toggle-base-height;
   justify-content: center;
+  min-width: $hds-dropdown-toggle-base-height;
   outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
   outline-color: transparent; // We need this to be transparent for a11y
   padding: 1px;
-  min-width: $hds-dropdown-toggle-base-height;
 
   &:hover,
   &.is-hover {
@@ -91,8 +91,8 @@ $hds-dropdown-toggle-border-radius: 5px;
   box-shadow: none; // we override this to remove the elevation style
 
   .hds-button__icon {
-    margin-right: -6px; // we apply a negative margin to counter the padding-right of the button and reduce the visual space between the icon and the right border
     margin-left: 8px; // this overrides the rule `.hds-button__text + .hds-button__icon`
+    margin-right: -6px; // we apply a negative margin to counter the padding-right of the button and reduce the visual space between the icon and the right border
 
     @media (prefers-reduced-motion: no-preference) {
       transition: transform .3s;
@@ -121,7 +121,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   max-width: 400px;
   min-width: 200px;
   padding: 4px 0;
-  width: max-content;
+  width: max-content; // notice: this is important because being in a position absolute means the layout algorithm assigns a width of 0 and this impacts on the flex algorithm of the children (in some cases they don't use the full width)
 
   &.hds-dropdown-list--position-right {
     position: absolute;
@@ -131,8 +131,8 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 
   &.hds-dropdown-list--position-left {
-    position: absolute;
     left: 0;
+    position: absolute;
     top: calc(100% + 4px);
     z-index: 2; // https://github.com/hashicorp/design-system/issues/114
   }
@@ -157,17 +157,17 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown-list-item--separator {
-  position: relative;
   height: 4px;
+  position: relative;
   width: 100%;
 
   &::before {
+    border-bottom: 1px solid var(--token-color-border-primary);
+    bottom: 0;
+    content: '';
+    left: 6px;
     position: absolute;
     right: 6px;
-    left: 6px;
-    bottom: 0;
-    border-bottom: 1px solid var(--token-color-border-primary);
-    content: '';
   }
 }
 
@@ -211,8 +211,8 @@ $hds-dropdown-toggle-border-radius: 5px;
     }
 
     &.is-success {
-      border-color: var(--token-color-border-success);
       background-color: var(--token-color-surface-success);
+      border-color: var(--token-color-border-success);
 
       .hds-dropdown-list-item__copy-item-icon {
         color: var(--token-color-foreground-success);
@@ -234,15 +234,15 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown-list-item--interactive {
-  position: relative;
   isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
   min-height: 36px;
+  position: relative;
 
   // need to reset a few extra things to make the button visually appear the same as the links
   // TODO this is 2px taller than the link...
   button {
-    border: 1px inset transparent; // cause of the extra height
     background-color: transparent;
+    border: 1px inset transparent; // cause of the extra height
     width: 100%;
 
     &:hover {
@@ -281,8 +281,8 @@ $hds-dropdown-toggle-border-radius: 5px;
       left: 10px;
       position: absolute;
       right: 4px;
-      z-index: -1;
       top: 0;
+      z-index: -1;
     }
 
     // Notice: to avoid too much duplication we define two local CSS variables
@@ -369,25 +369,19 @@ $hds-dropdown-toggle-border-radius: 5px;
     // assign the values to the local CSS variables used above
     &::after {
       --current-background-color: var(--token-color-surface-critical);
-      --current-focus-ring-box-shadow: var(
-        --token-focus-ring-critical-box-shadow
-      );
+      --current-focus-ring-box-shadow: var(--token-focus-ring-critical-box-shadow);
     }
 
     &:hover,
     &.is-hover {
-      color: var(
-        --token-color-palette-red-300
-      ); // TODO we need to add this token to the design system
+      color: var(--token-color-palette-red-300);
       &::before {
         background-color: currentColor;
       }
     }
     &:active,
     &.is-active {
-      color: var(
-        --token-color-palette-red-400
-      ); // TODO we need to add this token to the design system
+      color: var(--token-color-palette-red-400);
       &::before {
         background-color: currentColor;
       }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -119,6 +119,8 @@ $hds-dropdown-toggle-border-radius: 5px;
   max-width: 400px;
   min-width: 200px;
   padding: 4px 0;
+  width: max-content;
+
   &.hds-dropdown-list--position-right {
     position: absolute;
     right: 0;

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -67,7 +67,9 @@ $hds-dropdown-toggle-border-radius: 5px;
 
   img {
     border-radius: inherit;
+    height: 100%;
     object-fit: cover; // this will make sure it's correct even if the item isn't square
+    width: 100%;
   }
 }
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -72,7 +72,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown-toggle-icon__chevron {
-  margin-left: 0.25rem;
+  margin-left: 4px;
 
   @media (prefers-reduced-motion: no-preference) {
     transition: transform .3s;
@@ -90,7 +90,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 
   .hds-button__icon {
     margin-right: -6px; // we apply a negative margin to counter the padding-right of the button and reduce the visual space between the icon and the right border
-    margin-left: 0.5rem; // this overrides the rule `.hds-button__text + .hds-button__icon`
+    margin-left: 8px; // this overrides the rule `.hds-button__text + .hds-button__icon`
 
     @media (prefers-reduced-motion: no-preference) {
       transition: transform .3s;
@@ -116,20 +116,20 @@ $hds-dropdown-toggle-border-radius: 5px;
   box-shadow: var(--token-surface-high-box-shadow);
   list-style: none;
   margin: 0;
-  max-width: 25rem;
-  min-width: 12.5rem;
+  max-width: 400px;
+  min-width: 200px;
   padding: 4px 0;
   &.hds-dropdown-list--position-right {
     position: absolute;
     right: 0;
-    top: calc(100% + 0.25rem);
+    top: calc(100% + 4px);
     z-index: 2; // https://github.com/hashicorp/design-system/issues/114
   }
 
   &.hds-dropdown-list--position-left {
     position: absolute;
     left: 0;
-    top: calc(100% + 0.25rem);
+    top: calc(100% + 4px);
     z-index: 2; // https://github.com/hashicorp/design-system/issues/114
   }
 }
@@ -241,7 +241,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 
     .hds-dropdown-list-item__copy-item-icon {
       color: var(--token-color-foreground-action);
-      margin-left: 0.5rem;
+      margin-left: 8px;
     }
   }
 }
@@ -252,7 +252,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   min-height: 36px;
 
   // need to reset a few extra things to make the button visually appear the same as the links
-  // TODO this is 0.125rem taller than the link...
+  // TODO this is 2px taller than the link...
   button {
     border: 1px inset transparent; // cause of the extra height
     background-color: transparent;
@@ -278,7 +278,7 @@ $hds-dropdown-toggle-border-radius: 5px;
       border-radius: 1px;
       bottom: 6px;
       content: '';
-      left: 0.25rem;
+      left: 4px;
       position: absolute;
       top: 6px;
       width: 2px;
@@ -291,9 +291,9 @@ $hds-dropdown-toggle-border-radius: 5px;
       border-radius: 5px;
       bottom: 0px;
       content: '';
-      left: 0.625rem;
+      left: 10px;
       position: absolute;
-      right: 0.25rem;
+      right: 4px;
       z-index: -1;
       top: 0;
     }
@@ -307,7 +307,7 @@ $hds-dropdown-toggle-border-radius: 5px;
       &::after {
         background-color: var(--current-background-color);
         box-shadow: var(--current-focus-ring-box-shadow);
-        left: 0.25rem;
+        left: 4px;
       }
     }
     // undo the previous declaration for browsers that support ":focus-visible" but wouldn't normally show default focus styles
@@ -321,7 +321,7 @@ $hds-dropdown-toggle-border-radius: 5px;
       &::after {
         background-color: var(--current-background-color);
         box-shadow: var(--current-focus-ring-box-shadow);
-        left: 0.25rem;
+        left: 4px;
       }
     }
     // remove the focus ring on "active + focused" state (by design)
@@ -343,7 +343,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown-list-item__interactive-icon {
-  margin-right: 0.5rem;
+  margin-right: 8px;
 }
 
 .hds-dropdown-list-item--color-action {

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -122,21 +122,22 @@ $hds-dropdown-toggle-border-radius: 5px;
   min-width: 200px;
   padding: 4px 0;
   width: max-content; // notice: this is important because being in a position absolute means the layout algorithm assigns a width of 0 and this impacts on the flex algorithm of the children (in some cases they don't use the full width)
-
-  &.hds-dropdown-list--position-right {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 4px);
-    z-index: 2; // https://github.com/hashicorp/design-system/issues/114
-  }
-
-  &.hds-dropdown-list--position-left {
-    left: 0;
-    position: absolute;
-    top: calc(100% + 4px);
-    z-index: 2; // https://github.com/hashicorp/design-system/issues/114
-  }
 }
+
+.hds-dropdown-list--position-right {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 2; // https://github.com/hashicorp/design-system/issues/114
+}
+
+.hds-dropdown-list--position-left {
+  left: 0;
+  position: absolute;
+  top: calc(100% + 4px);
+  z-index: 2; // https://github.com/hashicorp/design-system/issues/114
+}
+
 
 // LIST > LIST-ITEM
 // HDS::DROPDOWN::LIST-ITEM

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -141,10 +141,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 .hds-dropdown-list-item--title {
   color: var(--token-color-foreground-strong);
-  font-family: var(--token-typography-body-100-font-family);
-  font-size: var(--token-typography-body-100-font-size);
-  font-weight: var(--token-typography-font-weight-semibold);
-  line-height: var(--token-typography-body-100-line-height);
   padding: 10px 16px 4px;
 }
 
@@ -155,10 +151,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 .hds-dropdown-list-item--description {
   color: var(--token-color-foreground-faint);
-  font-family: var(--token-typography-body-100-font-family);
-  font-size: var(--token-typography-body-100-font-size);
-  font-weight: var(--token-typography-font-weight-regular);
-  line-height: var(--token-typography-body-100-line-height);
   padding: 2px 16px 4px;
 }
 
@@ -179,10 +171,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 .hds-dropdown-list-item__copy-item-title {
   color: var(--token-color-foreground-faint);
-  font-family: var(--token-typography-body-100-font-family);
-  font-size: var(--token-typography-body-100-font-size); // 13
-  font-weight: var(--token-typography-font-weight-semibold);
-  line-height: var(--token-typography-body-100-line-height); // 18
   padding: 2px 0 4px;
 }
 
@@ -196,7 +184,6 @@ $hds-dropdown-toggle-border-radius: 5px;
     border: 1px solid var(--token-color-border-primary);
     color: var(--token-color-foreground-primary);
     display: flex;
-    font-family: var(--token-typography-font-stack-code);
     justify-content: space-between;
     padding: 12px 8px;
     width: 100%;
@@ -231,10 +218,6 @@ $hds-dropdown-toggle-border-radius: 5px;
     }
 
     .hds-dropdown-list-item__copy-item-text {
-      font-size: var(--token-typography-code-100-font-size);
-      font-weight: var(--token-typography-font-weight-regular);
-      line-height: var(--token-typography-code-100-line-height);
-      // max-width: 250px; // TODO we should be able to figure out the proportions here
       overflow: hidden;
       text-align: left;
       text-overflow: ellipsis;
@@ -337,10 +320,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown-list-item__interactive-text {
-  font-family: var(--token-typography-body-200-font-family);
-  font-size: var(--token-typography-body-200-font-size);
-  font-weight: var(--token-typography-font-weight-medium);
-  line-height: var(--token-typography-body-200-line-height);
   text-align: left; // the button element was centering text
 }
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -216,19 +216,19 @@ $hds-dropdown-toggle-border-radius: 5px;
         color: var(--token-color-foreground-success);
       }
     }
-
-    .hds-dropdown-list-item__copy-item-text {
-      overflow: hidden;
-      text-align: left;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .hds-dropdown-list-item__copy-item-icon {
-      color: var(--token-color-foreground-action);
-      margin-left: 8px;
-    }
   }
+}
+
+.hds-dropdown-list-item__copy-item-text {
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hds-dropdown-list-item__copy-item-icon {
+  color: var(--token-color-foreground-action);
+  margin-left: 8px;
 }
 
 .hds-dropdown-list-item--interactive {

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -1,5 +1,4 @@
 @import '@hashicorp/design-system-components';
-@import 'helpers/typography';
 
 @import "./_typography";
 


### PR DESCRIPTION
### :pushpin: Summary

Some minor cleanup/refactoring of the CSS for the `Dropdown` component.

### :hammer_and_wrench: Detailed description

- **re-added back Sass variables**
  - removed in 0a974bc3 / see https://github.com/hashicorp/design-system/pull/66#discussion_r846285980)
- **check that all sizes are in `px` and not in `rem`**
  - some leftovers of 06e556a + b02b0e8/ see https://github.com/hashicorp/design-system/pull/66#pullrequestreview-936446035)
- **added `width: max-content` to the list so that it doesn’t compress the text**
  - see https://github.com/hashicorp/design-system/pull/66#discussion_r846317623)
  - _notice: the reason is that the element has position absolute so no intrinsic width, so this impacts on the flex algorithm of the children (in some cases they don't use the full width, probably the layout algorithm has constrasting requirements)_
- **removed extra import (in the dummy app) of the typography CSS helper classes**
  - it was not only duplicating the import of CSS classes, but also coming after the components CSS, so resetting margin/padding applied to text elements
- **replaced typographic tokens with CSS helper classes in “list-item” text elements**
  - see https://github.com/hashicorp/design-system/pull/66#discussion_r846159125)
- **un-indented CSS classes where is not needed**
  - see https://github.com/hashicorp/design-system/pull/66#discussion_r846168092)
- **removed inline size for the image in the `toggle-icon`** 
  - this is to avoid having two distinct places where this size is declared (in CSS **and** in HTML)
- **re-ordered properties alphabetically**
- **some other small refactorings/cleanups**

### 👀 How to review

👉 Review commit-by-commit

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202108023378525