### PR TITLE
"Dropdown" component -  Order of "list-item" sub-elements in code (03)

### DIFF
--- a/packages/components/addon/components/hds/dropdown/list-item.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item.hbs
@@ -1,14 +1,4 @@
-{{#if (eq this.item "title")}}
-  <li class={{this.classNames}}>
-    {{this.text}}
-  </li>
-
-{{else if (eq this.item "generic")}}
-  <li class={{this.classNames}}>
-    {{yield}}
-  </li>
-
-{{else if (eq this.item "copy-item")}}
+{{#if (eq this.item "copy-item")}}
   <li class={{this.classNames}}>
     {{#if @copyItemTitle}}
       <div
@@ -35,8 +25,10 @@
     {{this.text}}
   </li>
 
-{{else if (eq this.item "separator")}}
-  <li class={{this.classNames}} role="separator"></li>
+{{else if (eq this.item "generic")}}
+  <li class={{this.classNames}}>
+    {{yield}}
+  </li>
 
 {{else if (eq this.item "interactive")}}
   <li class={{this.classNames}}>
@@ -83,4 +75,13 @@
       </button>
     {{/if}}
   </li>
+
+{{else if (eq this.item "separator")}}
+  <li class={{this.classNames}} role="separator"></li>
+
+{{else if (eq this.item "title")}}
+  <li class={{this.classNames}}>
+    {{this.text}}
+  </li>
+
 {{/if}}

--- a/packages/components/addon/components/hds/dropdown/list-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item.js
@@ -97,13 +97,14 @@ export default class HdsDropdownListItemComponent extends Component {
 
     // add a class based on the @item argument
     classes.push(`hds-dropdown-list-item--${this.item}`);
-    if (this.item === 'title') {
-      classes.push('hds-typography-body-100');
-      classes.push('hds-font-weight-semibold');
-    }
     if (this.item === 'description') {
       classes.push('hds-typography-body-100');
       classes.push('hds-font-weight-regular');
+    }
+
+    if (this.item === 'title') {
+      classes.push('hds-typography-body-100');
+      classes.push('hds-font-weight-semibold');
     }
 
     // add a class based on the @color argument

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -141,36 +141,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 // LIST > LIST-ITEM
 // HDS::DROPDOWN::LIST-ITEM
 
-.hds-dropdown-list-item--title {
-  color: var(--token-color-foreground-strong);
-  padding: 10px 16px 4px;
-}
-
-.hds-dropdown-list-item--generic {
-  padding-left: 16px;
-  padding-right: 16px;
-}
-
-.hds-dropdown-list-item--description {
-  color: var(--token-color-foreground-faint);
-  padding: 2px 16px 4px;
-}
-
-.hds-dropdown-list-item--separator {
-  height: 4px;
-  position: relative;
-  width: 100%;
-
-  &::before {
-    border-bottom: 1px solid var(--token-color-border-primary);
-    bottom: 0;
-    content: '';
-    left: 6px;
-    position: absolute;
-    right: 6px;
-  }
-}
-
 .hds-dropdown-list-item__copy-item-title {
   color: var(--token-color-foreground-faint);
   padding: 2px 0 4px;
@@ -232,6 +202,17 @@ $hds-dropdown-toggle-border-radius: 5px;
   color: var(--token-color-foreground-action);
   margin-left: 8px;
 }
+
+.hds-dropdown-list-item--description {
+  color: var(--token-color-foreground-faint);
+  padding: 2px 16px 4px;
+}
+
+.hds-dropdown-list-item--generic {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
 
 .hds-dropdown-list-item--interactive {
   isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
@@ -391,3 +372,24 @@ $hds-dropdown-toggle-border-radius: 5px;
     }
   }
 }
+
+.hds-dropdown-list-item--separator {
+  height: 4px;
+  position: relative;
+  width: 100%;
+
+  &::before {
+    border-bottom: 1px solid var(--token-color-border-primary);
+    bottom: 0;
+    content: '';
+    left: 6px;
+    position: absolute;
+    right: 6px;
+  }
+}
+
+.hds-dropdown-list-item--title {
+  color: var(--token-color-foreground-strong);
+  padding: 10px 16px 4px;
+}
+

--- a/packages/components/tests/integration/components/hds/dropdown/list-item-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item-test.js
@@ -59,7 +59,7 @@ module('Integration | Component | hds/dropdown/list-item', function (hooks) {
   });
   test('it should render the "list-item/interactive" with a CSS class that matches the component name and the type of item', async function (assert) {
     assert.expect(2);
-    await render(hbs`<Hds::Dropdown::ListItem @item="generic" />`);
+    await render(hbs`<Hds::Dropdown::ListItem @item="interactive" />`);
     assert.dom('.hds-dropdown-list-item').hasClass('hds-dropdown-list-item');
     assert
       .dom('.hds-dropdown-list-item')

--- a/packages/components/tests/integration/components/hds/dropdown/list-item-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item-test.js
@@ -59,7 +59,9 @@ module('Integration | Component | hds/dropdown/list-item', function (hooks) {
   });
   test('it should render the "list-item/interactive" with a CSS class that matches the component name and the type of item', async function (assert) {
     assert.expect(2);
-    await render(hbs`<Hds::Dropdown::ListItem @item="interactive" />`);
+    await render(
+      hbs`<Hds::Dropdown::ListItem @item="interactive" @text="interactive" />`
+    );
     assert.dom('.hds-dropdown-list-item').hasClass('hds-dropdown-list-item');
     assert
       .dom('.hds-dropdown-list-item')

--- a/packages/components/tests/integration/components/hds/dropdown/list-item-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item-test.js
@@ -29,13 +29,15 @@ module('Integration | Component | hds/dropdown/list-item', function (hooks) {
       .dom('.hds-dropdown-list-item')
       .hasClass('hds-dropdown-list-item--interactive');
   });
-  test('it should render the "list-item/title" with a CSS class that matches the component name and the type of item', async function (assert) {
+  test('it should render the "list-item/copy-item" with a CSS class that matches the component name and the type of item', async function (assert) {
     assert.expect(2);
-    await render(hbs`<Hds::Dropdown::ListItem @item="title" @text="title" />`);
+    await render(
+      hbs`<Hds::Dropdown::ListItem @item="copy-item" @text="copy-item" />`
+    );
     assert.dom('.hds-dropdown-list-item').hasClass('hds-dropdown-list-item');
     assert
       .dom('.hds-dropdown-list-item')
-      .hasClass('hds-dropdown-list-item--title');
+      .hasClass('hds-dropdown-list-item--copy-item');
   });
   test('it should render the "list-item/description" with a CSS class that matches the component name and the type of item', async function (assert) {
     assert.expect(2);
@@ -47,24 +49,6 @@ module('Integration | Component | hds/dropdown/list-item', function (hooks) {
       .dom('.hds-dropdown-list-item')
       .hasClass('hds-dropdown-list-item--description');
   });
-  test('it should render the "list-item/separator" with a CSS class that matches the component name and the type of item', async function (assert) {
-    assert.expect(2);
-    await render(hbs`<Hds::Dropdown::ListItem @item="separator" />`);
-    assert.dom('.hds-dropdown-list-item').hasClass('hds-dropdown-list-item');
-    assert
-      .dom('.hds-dropdown-list-item')
-      .hasClass('hds-dropdown-list-item--separator');
-  });
-  test('it should render the "list-item/copy-item" with a CSS class that matches the component name and the type of item', async function (assert) {
-    assert.expect(2);
-    await render(
-      hbs`<Hds::Dropdown::ListItem @item="copy-item" @text="copy-item" />`
-    );
-    assert.dom('.hds-dropdown-list-item').hasClass('hds-dropdown-list-item');
-    assert
-      .dom('.hds-dropdown-list-item')
-      .hasClass('hds-dropdown-list-item--copy-item');
-  });
   test('it should render the "list-item/generic" with a CSS class that matches the component name and the type of item', async function (assert) {
     assert.expect(2);
     await render(hbs`<Hds::Dropdown::ListItem @item="generic" />`);
@@ -73,14 +57,29 @@ module('Integration | Component | hds/dropdown/list-item', function (hooks) {
       .dom('.hds-dropdown-list-item')
       .hasClass('hds-dropdown-list-item--generic');
   });
-
-  // ITEM: TEXT
-
-  test('it should render the "list-item/title" with a title text', async function (assert) {
-    await render(
-      hbs`<Hds::Dropdown::ListItem @item="title" @text="This is the title" />`
-    );
-    assert.dom('.hds-dropdown-list-item').hasText('This is the title');
+  test('it should render the "list-item/interactive" with a CSS class that matches the component name and the type of item', async function (assert) {
+    assert.expect(2);
+    await render(hbs`<Hds::Dropdown::ListItem @item="generic" />`);
+    assert.dom('.hds-dropdown-list-item').hasClass('hds-dropdown-list-item');
+    assert
+      .dom('.hds-dropdown-list-item')
+      .hasClass('hds-dropdown-list-item--interactive');
+  });
+  test('it should render the "list-item/separator" with a CSS class that matches the component name and the type of item', async function (assert) {
+    assert.expect(2);
+    await render(hbs`<Hds::Dropdown::ListItem @item="separator" />`);
+    assert.dom('.hds-dropdown-list-item').hasClass('hds-dropdown-list-item');
+    assert
+      .dom('.hds-dropdown-list-item')
+      .hasClass('hds-dropdown-list-item--separator');
+  });
+  test('it should render the "list-item/title" with a CSS class that matches the component name and the type of item', async function (assert) {
+    assert.expect(2);
+    await render(hbs`<Hds::Dropdown::ListItem @item="title" @text="title" />`);
+    assert.dom('.hds-dropdown-list-item').hasClass('hds-dropdown-list-item');
+    assert
+      .dom('.hds-dropdown-list-item')
+      .hasClass('hds-dropdown-list-item--title');
   });
 
   // ITEM: DESCRIPTION
@@ -133,6 +132,15 @@ module('Integration | Component | hds/dropdown/list-item', function (hooks) {
   test('it should render the text passed as @text prop', async function (assert) {
     await render(hbs`<Hds::Dropdown::ListItem @text="interactive text" />`);
     assert.dom('.hds-dropdown-list-item').hasText('interactive text');
+  });
+
+  // ITEM: TITLE
+
+  test('it should render the "list-item/title" with a title text', async function (assert) {
+    await render(
+      hbs`<Hds::Dropdown::ListItem @item="title" @text="This is the title" />`
+    );
+    assert.dom('.hds-dropdown-list-item').hasText('This is the title');
   });
 
   // A11Y


### PR DESCRIPTION
### :pushpin: Summary

We want to keep  consistent order of the sub-elements of the `list-item` element in the `Dropdown` code so that it's easier to find what one is looking for, it's easier to do code reviews, and it's easier to spot differences or missing cases (eg. we missed one in the integration tests).

This is a follow-up of these comments:
- https://github.com/hashicorp/design-system/pull/66/files#r845396773
- https://github.com/hashicorp/design-system/pull/66#discussion_r845396773

### :hammer_and_wrench: Detailed description

In this PR I have:
- sorted alphabetically the “list-item” sub-elements 
  - in JS
  - in HBS
  - in CSS
  - in integration tests

**Notice:**  if we decide to split the sub-elements in independent sub-components (there will be a follow-up PR) then this order will become relevant only in the `index` of the Dropdown and in the CSS file.

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202108023378530