### PR TITLE
"Dropdown" component - Fix "list-item/interactive" height (04)

### DIFF
--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -219,11 +219,9 @@ $hds-dropdown-toggle-border-radius: 5px;
   min-height: 36px;
   position: relative;
 
-  // need to reset a few extra things to make the button visually appear the same as the links
-  // TODO this is 2px taller than the link...
+  // need to reset a few extra things to make the button visually appear the same as the link
   button {
     background-color: transparent;
-    border: 1px inset transparent; // cause of the extra height
     width: 100%;
 
     &:hover {
@@ -235,10 +233,11 @@ $hds-dropdown-toggle-border-radius: 5px;
   // shared styles for links and buttons
   a, button {
     align-items: center;
+    border: 1px solid transparent; // because a border for the button is needed for a11y, we apply it to both the button and the link so they have the same height
     display: flex;
     outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
     outline-color: transparent;
-    padding: 8px 10px 8px 16px;
+    padding: 7px 9px 7px 15px; // notice: we're subtracting 1px because of the transparent border
     text-decoration: none;
 
     // this is used for the left "hover" indicator


### PR DESCRIPTION
### :pushpin: Summary

Per comment in https://github.com/hashicorp/design-system/pull/66/files#r846173376 we need to fix the height of the `list-item/interactive` when it's a button.

### :hammer_and_wrench: Detailed description

In this PR I have:
- moved the transparent border declaration so it's applied to both the `button` and `a` elements, and updated the `list-item/interactive` internal padding accordingly

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202108023378535