### PR TITLE
Fix order of the states declarations in the CSS files

### DIFF
--- a/.changeset/gold-terms-clap.md
+++ b/.changeset/gold-terms-clap.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Re-ordered declarations of CSS states

--- a/packages/components/app/styles/components/breadcrumb.scss
+++ b/packages/components/app/styles/components/breadcrumb.scss
@@ -2,6 +2,7 @@
 // BREADCRUMB
 //
 // properties within each class are sorted alphabetically
+// notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
 //
 //
 
@@ -75,9 +76,6 @@ $hds-breadcrumb-item-visual-horizontal-padding: 4px;
     // notice: the text decoration is applied directly to the "text" container because of a bug in Safari (see https://github.com/hashicorp/design-system-components/issues/159)
     text-decoration-color: transparent;
 
-    // we apply the focus directly to the element, without using a pseudo-element
-    @include hds-focus-ring-basic();
-
     &:hover,
     &.is-hover {
         color: var(--token-color-palette-neutral-600);
@@ -86,6 +84,9 @@ $hds-breadcrumb-item-visual-horizontal-padding: 4px;
             text-decoration-color: currentColor;
         }
     }
+
+    // we apply the focus directly to the element, without using a pseudo-element
+    @include hds-focus-ring-basic();
 
     &:active,
     &.is-active {
@@ -153,24 +154,26 @@ $hds-breadcrumb-item-visual-horizontal-padding: 4px;
     padding: 0;
     width: $hds-breadcrumb-item-height;
 
-    // we apply the focus directly to the element, without using a pseudo-element
-    @include hds-focus-ring-basic();
-
     &:hover,
     &.is-hover {
         border-color: var(--token-color-border-strong);
         color: var(--token-color-foreground-faint);
     }
+
+    // we apply the focus directly to the element, without using a pseudo-element
+    @include hds-focus-ring-basic();
+
+    &:focus,
+    &.is-focus {
+        background-color: transparent;
+        border: none; // important: we need to completely remove the border, of the inner box-shadow of the focus ring will be drawn inside the border
+    }
+
     &:active,
     &.is-active {
         background-color: var(--token-color-surface-interactive-active);
         border-color: var(--token-color-border-strong);
         color: var(--token-color-foreground-primary);
-    }
-    &:focus,
-    &.is-focus {
-        background-color: transparent;
-        border: none; // important: we need to completely remove the border, of the inner box-shadow of the focus ring will be drawn inside the border
     }
 }
 

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -2,8 +2,7 @@
 // BUTTON COMPONENT
 //
 // properties within each class are sorted alphabetically
-// notice: pseudo-classes for the states *must* follow the order link > visited > focus > hover > active
-// see https://github.com/hashicorp/design-system-components/issues/132
+// notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
 //
 //
 
@@ -145,6 +144,14 @@ $size-props: (
   box-shadow: var(--token-elevation-low-box-shadow);
   color: var(--token-color-foreground-high-contrast);
 
+  &:hover,
+  &.is-hover {
+    background-color: var(--token-color-palette-blue-300);
+    border-color: var(--token-color-palette-blue-400);
+    color: var(--token-color-foreground-high-contrast);
+    cursor: pointer;
+  }
+
   &:focus,
   &.is-focus {
     background-color: var(--token-color-palette-blue-200);
@@ -163,13 +170,7 @@ $size-props: (
       top: -$shift;
     }
   }
-  &:hover,
-  &.is-hover {
-    background-color: var(--token-color-palette-blue-300);
-    border-color: var(--token-color-palette-blue-400);
-    color: var(--token-color-foreground-high-contrast);
-    cursor: pointer;
-  }
+
   &:active,
   &.is-active {
     background-color: var(--token-color-palette-blue-400);
@@ -188,6 +189,14 @@ $size-props: (
   box-shadow: var(--token-elevation-low-box-shadow);
   color: var(--token-color-foreground-primary);
 
+  &:hover,
+  &.is-hover {
+    background-color: var(--token-color-surface-primary);
+    border-color: var(--token-color-border-strong);
+    color: var(--token-color-foreground-primary);
+    cursor: pointer;
+  }
+
   &:focus,
   &.is-focus {
     background-color: var(--token-color-surface-faint);
@@ -197,13 +206,7 @@ $size-props: (
       border-color: var(--token-color-focus-action-external);
     }
   }
-  &:hover,
-  &.is-hover {
-    background-color: var(--token-color-surface-primary);
-    border-color: var(--token-color-border-strong);
-    color: var(--token-color-foreground-primary);
-    cursor: pointer;
-  }
+
   &:active,
   &.is-active {
     background-color: var(--token-color-surface-interactive-active);
@@ -221,6 +224,14 @@ $size-props: (
   border-color: transparent;
   color: var(--token-color-foreground-action);
 
+  &:hover,
+  &.is-hover {
+    background-color: var(--token-color-surface-primary);
+    border-color: var(--token-color-border-strong);
+    color: var(--token-color-foreground-action-hover);
+    cursor: pointer;
+  }
+
   &:focus,
   &.is-focus {
     border-color: var(--token-color-focus-action-internal);
@@ -229,13 +240,7 @@ $size-props: (
       border-color: var(--token-color-focus-action-external);
     }
   }
-  &:hover,
-  &.is-hover {
-    background-color: var(--token-color-surface-primary);
-    border-color: var(--token-color-border-strong);
-    color: var(--token-color-foreground-action-hover);
-    cursor: pointer;
-  }
+
   &:active,
   &.is-active {
     background-color: var(--token-color-surface-interactive-active);
@@ -271,6 +276,14 @@ $size-props: (
   box-shadow: var(--token-elevation-low-box-shadow);
   color: var(--token-color-foreground-critical-on-surface);
 
+  &:hover,
+  &.is-hover {
+    background-color: var(--token-color-palette-red-300);
+    border-color: var(--token-color-palette-red-400);
+    color: var(--token-color-foreground-high-contrast);
+    cursor: pointer;
+  }
+
   &:focus,
   &.is-focus {
     background-color: var(--token-color-surface-critical);
@@ -279,13 +292,6 @@ $size-props: (
     &::before {
       border-color: var(--token-color-focus-critical-external);
     }
-  }
-  &:hover,
-  &.is-hover {
-    background-color: var(--token-color-palette-red-300);
-    border-color: var(--token-color-palette-red-400);
-    color: var(--token-color-foreground-high-contrast);
-    cursor: pointer;
   }
 
   &:active,

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -15,7 +15,6 @@
 //
 // properties within each class are sorted alphabetically
 // notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
-// see https://github.com/hashicorp/design-system-components/issues/132
 //
 //
 

--- a/packages/components/app/styles/components/link/standalone.scss
+++ b/packages/components/app/styles/components/link/standalone.scss
@@ -2,8 +2,7 @@
 // LINK > STANDALONE COMPONENT
 //
 // properties within each class are sorted alphabetically
-// notice: pseudo-classes for the states *must* follow the order link > visited > focus > hover > active
-// see https://github.com/hashicorp/design-system-components/issues/132
+// notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
 //
 //
 


### PR DESCRIPTION
### :pushpin: Summary

As discussed with @MelSumner we have a bit of mix&match in the order of the declarations for the CSS states in our components. This PR intends to do a cleanup and sort the declarations according to this order:
- `link > visited > hover > focus > active` (“Lord Vader Hates Fluffy Animals”)

### :hammer_and_wrench: Detailed description

In this PR I have:
- re-ordered the “states” declarations
- done small cleanup of the comments

### :link: External links

- https://css-tricks.com/snippets/css/link-pseudo-classes-in-order/
- https://developer.mozilla.org/en-US/docs/Web/CSS/:active

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202112658196418