### PR TITLE
Fix the order of declarations in the Ember components backing classes

### DIFF
--- a/packages/components/addon/components/hds/link-to/cta.js
+++ b/packages/components/addon/components/hds/link-to/cta.js
@@ -127,19 +127,6 @@ export default class HdsLinkToCtaComponent extends Component {
     return route;
   }
 
-  @action
-  didInsert(el) {
-    // we need to register the element to compare it with the one that triggered the "key/space" event
-    this.el = el;
-  }
-
-  @action
-  onKeySpace(event) {
-    if (event.target === this.el) {
-      event.target.click();
-    }
-  }
-
   /**
    * Get the class names to apply to the component.
    * @method classNames
@@ -161,5 +148,18 @@ export default class HdsLinkToCtaComponent extends Component {
     }
 
     return classes.join(' ');
+  }
+
+  @action
+  didInsert(el) {
+    // we need to register the element to compare it with the one that triggered the "key/space" event
+    this.el = el;
+  }
+
+  @action
+  onKeySpace(event) {
+    if (event.target === this.el) {
+      event.target.click();
+    }
   }
 }

--- a/packages/components/addon/components/hds/link/cta.js
+++ b/packages/components/addon/components/hds/link/cta.js
@@ -112,19 +112,6 @@ export default class HdsLinkCtaComponent extends Component {
     return this.args.isFullWidth ?? false;
   }
 
-  @action
-  didInsert(el) {
-    // we need to register the element to compare it with the one that triggered the "key/space" event
-    this.el = el;
-  }
-
-  @action
-  onKeySpace(event) {
-    if (event.target === this.el) {
-      event.target.click();
-    }
-  }
-
   /**
    * Get the class names to apply to the component.
    * @method classNames
@@ -146,5 +133,18 @@ export default class HdsLinkCtaComponent extends Component {
     }
 
     return classes.join(' ');
+  }
+
+  @action
+  didInsert(el) {
+    // we need to register the element to compare it with the one that triggered the "key/space" event
+    this.el = el;
+  }
+
+  @action
+  onKeySpace(event) {
+    if (event.target === this.el) {
+      event.target.click();
+    }
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

This resolves #197

### :hammer_and_wrench: Detailed description

In this PR I have:
- moved the `@action` declarations to the bottom of the backing classes for the `link(to)/cta` files

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
