### PR TITLE
use ember-cli-deprecation-workflow in packages/components

### DIFF
--- a/.changeset/mean-sheep-rest.md
+++ b/.changeset/mean-sheep-rest.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+update to ember-keyboard@8.1.0 in packages/components

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,7 +41,7 @@
     "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-sass": "^10.0.1",
     "ember-focus-trap": "^1.0.1",
-    "ember-keyboard": "^8.0.0",
+    "ember-keyboard": "^8.1.0",
     "ember-named-blocks-polyfill": "^0.2.5",
     "sass": "^1.43.4"
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,6 +59,7 @@
     "ember-cli": "~3.28.4",
     "ember-cli-clipboard": "^0.15.0",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-deprecation-workflow": "^2.1.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-markdown-it-templates": "^0.0.3",
     "ember-cli-sri": "^2.1.1",

--- a/packages/components/tests/dummy/config/deprecation-workflow.js
+++ b/packages/components/tests/dummy/config/deprecation-workflow.js
@@ -3,9 +3,9 @@
 self.deprecationWorkflow = self.deprecationWorkflow || {};
 self.deprecationWorkflow.config = {
   workflow: [
-    { handler: "silence", matchId: "ember-modifier.use-destroyables" },
-    { handler: "silence", matchId: "ember-modifier.use-modify" },
-    { handler: "silence", matchId: "ember-modifier.no-args-property" },
-    { handler: "silence", matchId: "ember-modifier.no-element-property" }
+    { handler: "throw", matchId: "ember-modifier.use-destroyables" },
+    { handler: "throw", matchId: "ember-modifier.use-modify" },
+    { handler: "throw", matchId: "ember-modifier.no-args-property" },
+    { handler: "throw", matchId: "ember-modifier.no-element-property" }
   ]
 };

--- a/packages/components/tests/dummy/config/deprecation-workflow.js
+++ b/packages/components/tests/dummy/config/deprecation-workflow.js
@@ -1,0 +1,11 @@
+/* eslint-disable */
+
+self.deprecationWorkflow = self.deprecationWorkflow || {};
+self.deprecationWorkflow.config = {
+  workflow: [
+    { handler: "silence", matchId: "ember-modifier.use-destroyables" },
+    { handler: "silence", matchId: "ember-modifier.use-modify" },
+    { handler: "silence", matchId: "ember-modifier.no-args-property" },
+    { handler: "silence", matchId: "ember-modifier.no-element-property" }
+  ]
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,7 +4467,7 @@ broccoli-plugin@^3.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3, broccoli-plugin@^4.0.7:
+broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3, broccoli-plugin@^4.0.5, broccoli-plugin@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz#dd176a85efe915ed557d913744b181abe05047db"
   integrity sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==
@@ -6440,6 +6440,16 @@ ember-cli-dependency-checker@^3.2.0:
     resolve "^1.5.0"
     semver "^5.3.0"
 
+ember-cli-deprecation-workflow@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-2.1.0.tgz#f0d38ece7ac0ab7b3f83790a3a092e3472f58cff"
+  integrity sha512-Ay9P9iKMJdY4Gq5XPowh3HqqeAzLfwBRj1oB1ZKkDW1fryZQWBN4pZuRnjnB+3VWZjBnZif5e7Pacc7YNW9hWg==
+  dependencies:
+    broccoli-funnel "^3.0.3"
+    broccoli-merge-trees "^4.2.0"
+    broccoli-plugin "^4.0.5"
+    ember-cli-htmlbars "^5.3.2"
+
 ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
@@ -6465,7 +6475,7 @@ ember-cli-htmlbars@^4.2.3, ember-cli-htmlbars@^4.3.1:
     strip-bom "^4.0.0"
     walk-sync "^2.0.2"
 
-ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.7.1:
+ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.3.2, ember-cli-htmlbars@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz#e0cd2fb3c20d85fe4c3e228e6f0590ee1c645ba8"
   integrity sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7022,12 +7022,13 @@ ember-focus-trap@^1.0.1:
     "@embroider/addon-shim" "^1.0.0"
     focus-trap "^6.7.1"
 
-ember-keyboard@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-8.0.0.tgz#dd4a7253d277be9ed9d6878f073ea32406e29435"
-  integrity sha512-/9poW0DS8akMLvYsvn1scAMMCsyOPt22L4W7c4CLruFkUY7wdVrfFxb/qHwDmtWxyZDka0yc8aIZHqL6sSa9wQ==
+ember-keyboard@^8.1.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-8.1.1.tgz#b12844a0f87cbb091b7c21293afccbf5aedc2ea3"
+  integrity sha512-mgCV2LBeD3JrFCDqubY8GjHH7o1zysb4BbAogCStJIo/4HCvjHmw5UOO0ePXk4vjlpoVrDx7lxVsKLb604Y/Iw==
   dependencies:
     "@embroider/addon-shim" "^1.5.0"
+    ember-destroyable-polyfill "^2.0.3"
     ember-modifier "^2.1.2 || ^3.1.0"
     ember-modifier-manager-polyfill "^1.2.0"
 
@@ -7072,9 +7073,9 @@ ember-modifier@^2.1.1:
     ember-modifier-manager-polyfill "^1.2.0"
 
 "ember-modifier@^2.1.2 || ^3.1.0":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.4.tgz#dd05d8f93d5a6a93a8b08993c8fb66c4f2cad277"
-  integrity sha512-gWshNHgj4cF5FjIJnrU+RNZ6fg2UM024Pi0GGXM7sp30khe/t08s9ExJTlFUCyHJVeLpIH1cnML77lX1JFjubQ==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.7.tgz#f2d35b7c867cbfc549e1acd8d8903c5ecd02ea4b"
+  integrity sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==
   dependencies:
     ember-cli-babel "^7.26.6"
     ember-cli-normalize-entity-name "^1.0.0"


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

Adds [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) to manage our deprecation warnings

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

The main benefit of this tool is that it gives more control for us in managing these deprecations. Often times we can't actually fix them so by suppressing them in the console we reduce noise in our consoles during development and testing. Once we are ready to address them we can set the `handler` to `throw` and ensure we don't regress on the deprecation in the future.

As part of this PR I've upgraded `ember-keyboard` to remove deprecated code upstream and set those to `throw` so we won't regress on them in the future.

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
