### PR TITLE
"Dropdown" component / Add splattributes to index

### DIFF
--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -1,4 +1,4 @@
-<Hds::Disclosure class="hds-dropdown">
+<Hds::Disclosure class="hds-dropdown" ...attributes>
   <:toggle as |t|>
     {{yield
       (hash

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -15,4 +15,16 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
   // - test @toggle prop or yielded toggles?
   // - test yielded list items? (use single render with multiple assertions)
   // - test @listPosition
+
+  // SPLATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Dropdown @text="dropdown toggle" id="test-dropdown" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-dropdown').hasClass('my-class');
+    assert.dom('#test-dropdown').hasAttribute('data-test1');
+    assert.dom('#test-dropdown').hasAttribute('data-test2', 'test');
+  });
 });


### PR DESCRIPTION
### :pushpin: Summary

We have found a few cases in the Cloud UI codebase (see https://github.com/hashicorp/cloud-ui/pull/2362) where the dropdown had some extra attributes (eg. `data-test` attributes) applied to it. We need to support this spread as well to be compatible with the existing code.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added the `splattributes` to the Dropdown `index` main element

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202122650634731