### PR TITLE
"Dropdown" component - Expose an "onClose" event (09)

### DIFF
--- a/packages/components/addon/components/hds/disclosure/index.js
+++ b/packages/components/addon/components/hds/disclosure/index.js
@@ -38,6 +38,10 @@ export default class HdsDisclosureComponent extends Component {
       this.isActive = false;
       // we need to reset this check
       this.isToggleClicked = false;
+      // we call the "onClose" callback if it exists (and is a function)
+      if (this.args.onClose && typeof this.args.onClose === 'function') {
+        this.args.onClose();
+      }
     }
   }
 }

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -1,4 +1,4 @@
-<Hds::Disclosure class="hds-dropdown" ...attributes>
+<Hds::Disclosure class="hds-dropdown" @onClose={{@onClose}} ...attributes>
   <:toggle as |t|>
     {{yield
       (hash

--- a/packages/components/tests/dummy/app/controllers/dropdown.js
+++ b/packages/components/tests/dummy/app/controllers/dropdown.js
@@ -1,3 +1,0 @@
-import Controller from '@ember/controller';
-
-export default class DropdownController extends Controller {}

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -24,6 +24,10 @@
         <span class="dummy-code">listPostion</span>
         is defined, it will automatically be positioned to the right.</p>
     </dd>
+    <dt>onClose <code>function</code></dt>
+    <dd>
+      <p>Callback function invoked when the dropdown is closed (if provided).</p>
+    </dd>
   </dl>
   <hr />
   <p class="dummy-paragraph" id="toggle-button-api">

--- a/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
@@ -25,6 +25,10 @@
     <dd>
       <p>This is a named block where to pass the actual content that is shown/hidden upon toggling.</p>
     </dd>
+    <dt>onClose <code>function</code></dt>
+    <dd>
+      <p>Callback function invoked when the dropdown is closed (if provided).</p>
+    </dd>
     <dt>“splattributes”</dt>
     <dd>
       <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>


### PR DESCRIPTION
### :pushpin: Summary

While working on the test of the integration of the `Dropdown` component in Cloud UI (see https://github.com/hashicorp/cloud-ui/pull/2362) I realized we need to expose a `onClose` action/hook because in some cases is called directly by the consumer (see comments [here](https://github.com/hashicorp/cloud-ui/pull/2362#issuecomment-1097865469) and [here](https://github.com/hashicorp/cloud-ui/pull/2362#issuecomment-1097884555)).

### :hammer_and_wrench: Detailed description

In this PR I have:
- added the `onClose` callback to the `Disclosure` component
- added the `onClose` callback to the `Dropdown` component
  - while doing this, I found a leftover file related to the dropdown and removed it

_Notice: I didn't add integration tests because I don't even know if it's possible to test such functionality._

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202122650634744