### PR TITLE
"Dropdown" component - Remove icon requirement from "critical" list item (13)

### DIFF
--- a/packages/components/addon/components/hds/dropdown/list-item/interactive.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/interactive.hbs
@@ -11,7 +11,7 @@
     >
       {{#if @icon}}
         <div class="hds-dropdown-list-item__interactive-icon">
-          <FlightIcon @name={{this.icon}} @isInlineBlock={{false}} />
+          <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
         </div>
       {{/if}}
       <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
@@ -20,9 +20,9 @@
     </LinkTo>
   {{else if @href}}
     <a target="_blank" rel="noopener noreferrer" href={{@href}} class="{{if @state (concat 'is-' @state)}}">
-      {{#if this.icon}}
+      {{#if @icon}}
         <div class="hds-dropdown-list-item__interactive-icon">
-          <FlightIcon @name={{this.icon}} @isInlineBlock={{false}} />
+          <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
         </div>
       {{/if}}
       <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
@@ -31,9 +31,9 @@
     </a>
   {{else}}
     <button class="{{if @state (concat 'is-' @state)}}" type="button" ...attributes>
-      {{#if this.icon}}
+      {{#if @icon}}
         <div class="hds-dropdown-list-item__interactive-icon">
-          <FlightIcon @name={{this.icon}} @isInlineBlock={{false}} />
+          <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
         </div>
       {{/if}}
       <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">

--- a/packages/components/addon/components/hds/dropdown/list-item/interactive.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/interactive.js
@@ -41,21 +41,6 @@ export default class HdsDropdownListItemInteractiveComponent extends Component {
   }
 
   /**
-   * @param icon
-   * @type {string}
-   * @default null
-   * @description The name of the icon to be used.
-   */
-  get icon() {
-    assert(
-      `when the "Hds::ListItem::Interactive" @color is "critical" an @icon is required`,
-      !(this.color === 'critical' && !this.args.icon)
-    );
-
-    return this.args.icon ?? null;
-  }
-
-  /**
    * Get the class names to apply to the component.
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.


### PR DESCRIPTION
### :pushpin: Summary

After discussion with @MelSumner @cveigt @heatherlarsen we have come to agreement that we will not force the existence of an icon for the `critical` list item _in code_, but we will add specific guidance about it in the form of documentation.

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed the “icon” logic from backing class of `list-item/interactive`
  - this also removed the assertion thrown if an icon was not added to a `critical` list item

_Notice: the documentation will be updated in #235_ 

### :link: External links

- [Evaluation: destructive icon use](https://docs.google.com/document/d/17QBAykTNEMseyfCnHY_HpQH2-d3Hgw7urIiN5PXly_E/edit#heading=h.25d6lx259sym)

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202156353993851