### PR TITLE
"Dropdown" component - Remove default icon from "toggle/icon" (12)

### DIFF
--- a/packages/components/addon/components/hds/dropdown/toggle/icon.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/icon.hbs
@@ -2,8 +2,8 @@
   <div class="hds-dropdown-toggle-icon__wrapper">
     {{#if @imageSrc}}
       <img src={{@imageSrc}} alt="" role="presentation" height="32" width="32" />
-    {{else}}
-      <FlightIcon @name={{this.icon}} @size="24" />
+    {{else if @icon}}
+      <FlightIcon @name={{@icon}} @size="24" />
     {{/if}}
   </div>
   {{#if this.hasChevron}}

--- a/packages/components/addon/components/hds/dropdown/toggle/icon.js
+++ b/packages/components/addon/components/hds/dropdown/toggle/icon.js
@@ -3,6 +3,15 @@ import { assert } from '@ember/debug';
 
 const NOOP = () => {};
 export default class HdsDropdownToggleIconComponent extends Component {
+  constructor() {
+    super(...arguments);
+    if (!(this.args.icon || this.args.imageSrc)) {
+      assert(
+        '@icon or @imageSrc must be defined for "Hds::Dropdown::Toggle::Icon"'
+      );
+    }
+  }
+
   /**
    * @param text
    * @type {string}

--- a/packages/components/addon/components/hds/dropdown/toggle/icon.js
+++ b/packages/components/addon/components/hds/dropdown/toggle/icon.js
@@ -31,17 +31,6 @@ export default class HdsDropdownToggleIconComponent extends Component {
   }
 
   /**
-   * Sets the icon name
-   *
-   * @param icon
-   * @type {string}
-   * @default user
-   */
-  get icon() {
-    return this.args.icon ?? 'user';
-  }
-
-  /**
    * @param onClick
    * @type {function}
    * @default () => {}

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -392,7 +392,7 @@
       @language="markup"
       @code='
         &lt;Hds::Dropdown as |dd|&gt;
-          &lt;dd.ToggleIcon @text="user menu" /&gt;
+          &lt;dd.ToggleIcon @icon="user" @text="user menu" /&gt;
           &lt;dd.Title @text="Signed In" /&gt;
           &lt;dd.Description @text="design-systems@hashicorp.com" /&gt;
           &lt;dd.Separator /&gt;
@@ -407,7 +407,7 @@
       <ul class="dummy-nav-dropdown__list">
         <li class="dummy-nav-dropdown__list-item">
           <Hds::Dropdown as |dd|>
-            <dd.ToggleIcon @text="user menu" />
+            <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="design-systems@hashicorp.com" />
             <dd.Separator />
@@ -423,7 +423,7 @@
       <ul class="dummy-nav-dropdown__list">
         <li class="dummy-nav-dropdown__list-item">
           <Hds::Dropdown as |dd|>
-            <dd.ToggleIcon @text="user menu" />
+            <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="design-systems@hashicorp.com" />
             <dd.Separator />
@@ -442,7 +442,7 @@
       <ul class="dummy-nav-dropdown__list">
         <li class="dummy-nav-dropdown__list-item dummy-nav-dropdown__list-item-customized">
           <Hds::Dropdown @width="248px" as |dd|>
-            <dd.ToggleIcon @text="user menu" />
+            <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="design-systems@hashicorp.com" />
             <dd.Separator />
@@ -656,9 +656,9 @@
   <div class="dummy-dropdown-toggle-states-grid">
     <div class="hds-dropdown">
       <span class="dummy-text-small">State: closed (default)</span>
-      <Hds::Dropdown::Toggle::Icon @text="user menu" />
+      <Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" />
       <span class="dummy-text-small">State: opened</span>
-      <Hds::Dropdown::Toggle::Icon @isOpen={{true}} @text="user menu" />
+      <Hds::Dropdown::Toggle::Icon @isOpen={{true}} @icon="user" @text="user menu" />
     </div>
   </div>
   <h4 class="dummy-h4">ToggleIcon (Overflow)</h4>
@@ -714,7 +714,7 @@
       <div class="hds-dropdown">
         <span class="dummy-text-small">{{state}}:</span>
         <br />
-        <Hds::Dropdown::Toggle::Icon @text={{state}} class="is-{{state}}" />
+        <Hds::Dropdown::Toggle::Icon @icon="user" @text={{state}} class="is-{{state}}" />
       </div>
     {{/each}}
     {{#each @model.TOGGLE_STATES as |state|}}

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -22,7 +22,7 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     await render(hbs`
       <Hds::Dropdown id="test-dropdown" as |dd|>
         <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.ToggleIcon @text="toggle icon" id="test-toggle-icon" />
+        <dd.ToggleIcon @icon="user" @text="toggle icon" id="test-toggle-icon" />
       </Hds::Dropdown>
     `);
     assert.dom('#test-dropdown #test-toggle-button').exists();

--- a/packages/components/tests/integration/components/hds/dropdown/toggle/icon-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle/icon-test.js
@@ -13,19 +13,15 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
   // notice: by default the "toggle-icon" has "user" icon, "chevron-down", and an aria-label
 
   test('it renders the "toggle-icon"', async function (assert) {
-    await render(hbs`<Hds::Dropdown::Toggle::Icon @text="toggle text" />`);
+    await render(
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="toggle text" />`
+    );
     assert.dom(this.element).exists();
   });
 
   // ICON
 
-  test('it should render with the "user" icon by default', async function (assert) {
-    await render(
-      hbs`<Hds::Dropdown::Toggle::Icon @text="user menu" id="test-toggle-icon" />`
-    );
-    assert.dom('.flight-icon.flight-icon-user').exists();
-  });
-  test('if an icon is declared the flight icon should render in the component', async function (assert) {
+  test('if an @icon is declared the flight icon should render in the component', async function (assert) {
     await render(
       hbs`<Hds::Dropdown::Toggle::Icon @icon="settings" @text="settings menu" id="test-toggle-icon" />`
     );
@@ -36,7 +32,7 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
 
   test('if an @imageSrc is declared the image should render in the component', async function (assert) {
     await render(
-      hbs`<Hds::Dropdown::Toggle::Icon @text="user menu" @imageSrc="/assets/images/avatar.png" id="test-toggle-icon" />`
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" @imageSrc="/assets/images/avatar.png" id="test-toggle-icon" />`
     );
     assert.dom('img').exists();
   });
@@ -45,13 +41,13 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
 
   test('it should render the chevron "down" by default', async function (assert) {
     await render(
-      hbs`<Hds::Dropdown::Toggle::Icon @text="user menu" id="test-toggle-icon" />`
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" id="test-toggle-icon" />`
     );
     assert.dom('.flight-icon.flight-icon-chevron-down').exists();
   });
   test('toggle-icon renders no chevron when hasChevron is set to false', async function (assert) {
     await render(
-      hbs`<Hds::Dropdown::Toggle::Icon @text="user menu" id="test-toggle-icon" @hasChevron={{false}} />`
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" id="test-toggle-icon" @hasChevron={{false}} />`
     );
     assert.dom('.flight-icon.flight-icon-chevron-down').doesNotExist();
   });
@@ -60,13 +56,13 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
 
   test('it should render with the correct aria attribute declared using the @text prop', async function (assert) {
     await render(
-      hbs`<Hds::Dropdown::Toggle::Icon @text="user menu" id="test-toggle-icon" />`
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" id="test-toggle-icon" />`
     );
     assert.dom('#test-toggle-icon').hasAria('label', 'user menu');
   });
   test('it should render the user "avatar" image with the correct role', async function (assert) {
     await render(
-      hbs`<Hds::Dropdown::Toggle::Icon @text="user menu" @imageSrc="/assets/images/avatar.png" id="test-toggle-icon" />`
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" @imageSrc="/assets/images/avatar.png" id="test-toggle-icon" />`
     );
     assert.dom('#test-toggle-icon img').hasAttribute('role', 'presentation');
   });
@@ -79,7 +75,21 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Dropdown::Toggle::Icon id="test-toggle-icon" />`);
+    await render(
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" id="test-toggle-icon" />`
+    );
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+  test('it should throw an assertion if both @icon and @imageSrc are not defined', async function (assert) {
+    const errorMessage =
+      '@icon or @imageSrc must be defined for "Hds::Dropdown::Toggle::Icon"';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Dropdown::Toggle::Icon @text="user menu" />`);
     assert.throws(function () {
       throw new Error(errorMessage);
     });


### PR DESCRIPTION
### :pushpin: Summary

While working on the documentation of the dropdown, I noticed that the default icon for the Toggle::Icon is the user one. afaik there’s only one use case in the entire application where this icon in the dropdown is used, which is the user menu, so why have we promoted it to default? for me there should not be a default for this parameter, doesn’t make sense (in which way is helping me, consumer of the component?)

We had a discussion with @MelSumner @heatherlarsen @cveigt, there was no unanimous consensus on this but I decided to  move on with this change for the reasons above.

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed “icon” logic from backing class of `toggle/icon`
  - also added assertion to make sure one of `@icon` or `@imageSrc` is passed to the component 
- updated the documentation 
  - to make sure it compiles, the full update will be in #235
- updated integration tests

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202166650438500