### PR TITLE
Adds an about page

### DIFF
--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -36,4 +36,5 @@ Router.map(function () {
   this.route('utilities', function () {
     this.route('disclosure');
   });
+  this.route('about');
 });

--- a/packages/components/tests/dummy/app/routes/about.js
+++ b/packages/components/tests/dummy/app/routes/about.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class AboutRoute extends Route {}

--- a/packages/components/tests/dummy/app/templates/about.hbs
+++ b/packages/components/tests/dummy/app/templates/about.hbs
@@ -4,26 +4,43 @@
 
 <section aria-labelledby="ds-purpose">
   <h3 class="dummy-h3" id="ds-purpose">Purpose</h3>
-  <p class="dummy-paragraph">The purpose of the design system is to provide a single source of truth for the design vision needed to build accessible, differentiated experiences for HashiCorp's products.</p>
-  <p class="dummy-paragraph">The Design System Team designs, creates and supports the design system, with input from our partners in product design and the engineers that we support.</p>
+  <p class="dummy-paragraph">The purpose of the design system is to provide a single source of truth for the design
+    vision needed to build accessible, differentiated experiences for HashiCorp's products.</p>
+  <p class="dummy-paragraph">The Design System Team designs, creates and supports the design system, with input from our
+    partners in product design and the engineers that we support.</p>
 </section>
 
 <section aria-labelledby="ds-purpose">
   <h3 class="dummy-h3" id="ds-usage">Usage</h3>
-  <p class="dummy-paragraph">While the technical usage instructions are available in the <a href="">components' repository</a>, this section intends to clarify the (other/philosophical/strategic) usage details.</p>
-  <p class="dummy-paragraph">First, it should be make explicitly clear that the design system does not intend to be a 1:1 replacement for existing styles, components, or code that may exist, not only because it seeks to unify design, provide accessibility conformance and code consistency, but also because previous implementations across products have proven to be inconsistent in all of these areas.</p>
+  <p class="dummy-paragraph">While the technical usage instructions are available in the
+    <a href="https://github.com/hashicorp/design-system/blob/main/README.md">design-system repository</a>, this section
+    intends to clarify the (other/philosophical/strategic) usage details.</p>
+  <p class="dummy-paragraph">First, it should be make explicitly clear that the design system does not intend to be a
+    1:1 replacement for existing styles, components, or code that may exist, not only because it seeks to unify design,
+    provide accessibility conformance and code consistency, but also because previous implementations across products
+    have proven to be inconsistent in all of these areas.</p>
 </section>
 
 <section aria-labelledby="ds-features">
   <h3 class="dummy-h3" id="ds-features">Documentation Features</h3>
   <p class="dummy-paragraph">The documentation for each component contains a few distinct features:</p>
   <ul class="dummy-list">
-    <li>Component definition: the first few sentences on the component page provide the definition of the component in a glossary-type way. This is important because there is no standard dictionary of UI components and a single component could be called many different things. By including this definition, we intend to reduce the number of assumptions about what we intend for the component to be.</li>
-    <li>API documentation: this documents the component's API, its intended type, acceptable values, and any defaults. Note: We recognize that <span class="dummy-code">enum</span> does not exist in JavaScript (natively), but it best describes the intention of the property defined. </li>
-    <li>Usage Instructions: The "how to use" section includes copyable code and in some cases outlines the different types of usage examples for that component. While these instructions may not include everything you can do with the component, they show the intended use of the component.</li>
-    <li>Design Guidelines: these are currently in an image form and should also have a link to the relevant (internal) Figma file.</li>
-    <li>Accessibility: This section outlines the purpose of the component, lists any known accessibility issues, and links to the relevant WCAG success criteria for that component.</li>
+    <li>Component definition: the first few sentences on the component page provide the definition of the component in a
+      glossary-type way. This is important because there is no standard dictionary of UI components and a single
+      component could be called many different things. By including this definition, we intend to reduce the number of
+      assumptions about what we intend for the component to be.</li>
+    <li>API documentation: this documents the component's API, its intended type, acceptable values, and any defaults.
+      Note: We recognize that
+      <span class="dummy-code">enum</span>
+      does not exist in JavaScript (natively), but it best describes the intention of the property defined.
+    </li>
+    <li>Usage Instructions: The "how to use" section includes copyable code and in some cases outlines the different
+      types of usage examples for that component. While these instructions may not include everything you can do with
+      the component, they show the intended use of the component.</li>
+    <li>Design Guidelines: these are currently in an image form and should also have a link to the relevant (internal)
+      Figma file.</li>
+    <li>Accessibility: This section outlines the purpose of the component, lists any known accessibility issues, and
+      links to the relevant WCAG success criteria for that component.</li>
     <li>Showcase: This section is mostly for the use of our visual regression testing tool, Percy.</li>
   </ul>
 </section>
-

--- a/packages/components/tests/dummy/app/templates/about.hbs
+++ b/packages/components/tests/dummy/app/templates/about.hbs
@@ -1,0 +1,29 @@
+{{page-title "About this Design System"}}
+
+<h2 class="dummy-h2">🚧 About This Design System </h2>
+
+<section aria-labelledby="ds-purpose">
+  <h3 class="dummy-h3" id="ds-purpose">Purpose</h3>
+  <p class="dummy-paragraph">The purpose of the design system is to provide a single source of truth for the design vision needed to build accessible, differentiated experiences for HashiCorp's products.</p>
+  <p class="dummy-paragraph">The Design System Team designs, creates and supports the design system, with input from our partners in product design and the engineers that we support.</p>
+</section>
+
+<section aria-labelledby="ds-purpose">
+  <h3 class="dummy-h3" id="ds-usage">Usage</h3>
+  <p class="dummy-paragraph">While the technical usage instructions are available in the <a href="">components' repository</a>, this section intends to clarify the (other/philosophical/strategic) usage details.</p>
+  <p class="dummy-paragraph">First, it should be make explicitly clear that the design system does not intend to be a 1:1 replacement for existing styles, components, or code that may exist, not only because it seeks to unify design, provide accessibility conformance and code consistency, but also because previous implementations across products have proven to be inconsistent in all of these areas.</p>
+</section>
+
+<section aria-labelledby="ds-features">
+  <h3 class="dummy-h3" id="ds-features">Documentation Features</h3>
+  <p class="dummy-paragraph">The documentation for each component contains a few distinct features:</p>
+  <ul class="dummy-list">
+    <li>Component definition: the first few sentences on the component page provide the definition of the component in a glossary-type way. This is important because there is no standard dictionary of UI components and a single component could be called many different things. By including this definition, we intend to reduce the number of assumptions about what we intend for the component to be.</li>
+    <li>API documentation: this documents the component's API, its intended type, acceptable values, and any defaults. Note: We recognize that <span class="dummy-code">enum</span> does not exist in JavaScript (natively), but it best describes the intention of the property defined. </li>
+    <li>Usage Instructions: The "how to use" section includes copyable code and in some cases outlines the different types of usage examples for that component. While these instructions may not include everything you can do with the component, they show the intended use of the component.</li>
+    <li>Design Guidelines: these are currently in an image form and should also have a link to the relevant (internal) Figma file.</li>
+    <li>Accessibility: This section outlines the purpose of the component, lists any known accessibility issues, and links to the relevant WCAG success criteria for that component.</li>
+    <li>Showcase: This section is mostly for the use of our visual regression testing tool, Percy.</li>
+  </ul>
+</section>
+

--- a/packages/components/tests/dummy/app/templates/about.hbs
+++ b/packages/components/tests/dummy/app/templates/about.hbs
@@ -1,6 +1,6 @@
 {{page-title "About this Design System"}}
 
-<h2 class="dummy-h2">🚧 About This Design System </h2>
+<h2 class="dummy-h2">🚧 About the HashiCorp Design System </h2>
 
 <section aria-labelledby="ds-purpose">
   <h3 class="dummy-h3" id="ds-purpose">Purpose</h3>

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -14,6 +14,12 @@
           Home
         </LinkTo>
       </li>
+      <li class="dummy-paragraph">
+        <LinkTo @route="about">
+          <FlightIcon @name="info" />
+          About this Design System
+        </LinkTo>
+      </li>
     </ul>
   </nav>
   <main id="main" class="dummy-main">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds an "about this design system" page.

### :hammer_and_wrench: Detailed description

We are discovering knowledge gaps where we think that providing additional context for the design system will be valuable for our users (and valuable to us to refer users to as we provide support). 

While some of this information is available in RFCs, it is always useful to have a condensed version in the same place as the components themselves for additional context. We believe that users will explore "about this design system" if they are new to the design system in general, and this will help them understand the context better than if they had to intuit it alone. In this way, we are supporting designers and developers at all stages of their career and reducing the risk of loss of time due to assumptions. 

For reviewers: I've added the information I think would be the most useful, but if other information would be useful here, please comment and/or PR to add. 

Screenshot:
![CleanShot 2022-04-25 at 10 07 30](https://user-images.githubusercontent.com/4587451/165117863-6c6ff12e-59d1-4801-8714-a9218a2acb7e.png)


Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
