### PR TITLE
copy-item icon size

### DIFF
--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -169,6 +169,7 @@
     border: 1px solid var(--token-color-border-primary);
     color: var(--token-color-foreground-primary);  
     display: flex;
+    flex: 1 0 0;
     font-family: var(--token-typography-font-stack-code);
     justify-content: space-between;
     padding: 12px 8px;
@@ -217,6 +218,7 @@
     .hds-dropdown-list-item__copy-item-icon {
       color: var(--token-color-foreground-action);
       margin-left: 0.5rem;
+      min-width: 16px;
     }
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -768,14 +768,14 @@
         <Hds::Dropdown::ListItem
           @copyItemTitle="Optional copyItemTitle"
           @item="copy-item"
-          @text="{{state}}: 91ee1e8ef65b337f0e70d793f456c71d"
+          @text="{{state}}: 91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d"
           @state={{state}}
         />
       {{/each}}
       <Hds::Dropdown::ListItem
         @copyItemTitle="Optional copyItemTitle"
         @item="copy-item"
-        @text="success: 91ee1e8ef65b337f0e70d793f456c71d"
+        @text="success: 91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d"
         @isSuccess="true"
         @state="success"
       />


### PR DESCRIPTION
Resolves issue where the `copy-item` icon was too small when text was super long. 

(I wonder if it would make more sense for @didoo to pull the relevant code lines into his most recent PR set? Leaving this in draft state for that reason)

Screenshot showing that the icon no longer shrinks:
![CleanShot 2022-04-26 at 10 38 12](https://user-images.githubusercontent.com/4587451/165339272-59bf165a-8351-4c89-91fe-b1c04169b445.png)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202167094155066