### PR TITLE
copy-item icon size bugfix

### DIFF
--- a/.changeset/silver-peas-sparkle.md
+++ b/.changeset/silver-peas-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+bugfix for icon size in copy-item component

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -205,6 +205,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 .hds-dropdown-list-item__copy-item-icon {
   color: var(--token-color-foreground-action);
+  flex: none;
   margin-left: 8px;
 }
 

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -1079,7 +1079,7 @@
         <Hds::Dropdown::ListItem::CopyItem @text="{{state}}: 91ee1e8ef65b337f0e70d793f456c71d" @state={{state}} />
       {{/each}}
       <Hds::Dropdown::ListItem::CopyItem
-        @text="success: 91ee1e8ef65b337f0e70d793f456c71d"
+        @text="success: 91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d"
         @state="success"
         @isSuccess="true"
       />


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves the issue where very very very long content in the `copy-item` component was causing the icon to become smaller and smaller.


Reviewer's checklist:

- [ ] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
