### PR TITLE
[WIP] Add icon support to "Link::Inline" component

### DIFF
--- a/packages/components/addon/components/hds/link/inline.hbs
+++ b/packages/components/addon/components/hds/link/inline.hbs
@@ -11,5 +11,16 @@
   rel="noopener noreferrer"
   ...attributes
 >
+  {{! IMPORTANT: we need to add "squishies" here (~) because otherwise the whitespace added by Ember becomes visible in the link (being an inline element) - See https://handlebarsjs.com/guide/expressions.html#whitespace-control }}
+  {{~#if (and @icon (eq this.iconPosition "leading"))~}}
+    <span class="hds-link-inline__icon">
+      <FlightIcon @name={{@icon}} @size="16" @stretched={{true}} />
+    </span>
+  {{~/if~}}
   {{yield}}
+  {{~#if (and @icon (eq this.iconPosition "trailing"))~}}
+    <span class="hds-link-inline__icon">
+      <FlightIcon @name={{@icon}} @size="16" @stretched={{true}} />
+    </span>
+  {{~/if~}}
 </Hds::Interactive>

--- a/packages/components/addon/components/hds/link/inline.js
+++ b/packages/components/addon/components/hds/link/inline.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
-export const DEFAULT_ICONPOSITION = 'leading';
+export const DEFAULT_ICONPOSITION = 'trailing';
 export const DEFAULT_COLOR = 'primary';
 export const ICONPOSITIONS = ['leading', 'trailing'];
 export const COLORS = ['primary', 'secondary'];

--- a/packages/components/addon/components/hds/link/inline.js
+++ b/packages/components/addon/components/hds/link/inline.js
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
+export const DEFAULT_ICONPOSITION = 'leading';
 export const DEFAULT_COLOR = 'primary';
+export const ICONPOSITIONS = ['leading', 'trailing'];
 export const COLORS = ['primary', 'secondary'];
 
 export default class HdsLinkInlineComponent extends Component {
@@ -29,6 +31,25 @@ export default class HdsLinkInlineComponent extends Component {
     );
 
     return color;
+  }
+
+  /**
+   * @param iconPosition
+   * @type {string}
+   * @default leading
+   * @description Positions the icon before or after the text; allowed values are `leading` or `trailing`
+   */
+  get iconPosition() {
+    let { iconPosition = DEFAULT_ICONPOSITION } = this.args;
+
+    assert(
+      `@iconPosition for "Hds::Link::Inline" must be one of the following: ${ICONPOSITIONS.join(
+        ', '
+      )}; received: ${iconPosition}`,
+      ICONPOSITIONS.includes(iconPosition)
+    );
+
+    return iconPosition;
   }
 
   /**

--- a/packages/components/app/styles/components/link/inline.scss
+++ b/packages/components/app/styles/components/link/inline.scss
@@ -19,6 +19,21 @@
   }
 }
 
+.hds-link-inline__icon {
+  display: inline-block;
+  height: 1em;
+  vertical-align: middle;
+  width: 1em;
+
+  &:first-child {
+    margin-right: 0.25em;
+  }
+
+  &:last-child {
+    margin-left: 0.25em;
+  }
+}
+
 
 // COLORS & STATES
 

--- a/packages/components/app/styles/components/link/inline.scss
+++ b/packages/components/app/styles/components/link/inline.scss
@@ -22,7 +22,7 @@
 .hds-link-inline__icon {
   display: inline-block;
   height: 1em;
-  vertical-align: middle;
+  vertical-align: text-bottom; // don't use "middle" here or it will extend beyond the
   width: 1em;
 
   &:first-child {

--- a/packages/components/tests/dummy/app/templates/components/link/inline.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/inline.hbs
@@ -44,7 +44,8 @@
     <p class="dummy-paragraph">Here's a
       <Hds::Link::Inline @href="#">Link (Inline)</Hds::Link::Inline>
       that is inline with adjacent text. And this is
-      <Hds::Link::Inline @href="#">another Link (Inline)</Hds::Link::Inline></p>
+      <Hds::Link::Inline @href="#" @icon="external-link" @iconPosition="trailing">another Link (Inline)</Hds::Link::Inline>
+      with an icon too.</p>
   </div>
 </section>
 
@@ -69,6 +70,18 @@
       <p>Elements passed as children are yielded to the content of the
         <code>&lt;a&gt;</code>
         HTML element.</p>
+    </dd>
+    <dt> icon <code>string</code></dt>
+    <dd>
+      <p>Use this parameter to show an icon. Acceptable value: any Flight icon name.</p>
+    </dd>
+    <dt>iconPosition <code>enum</code></dt>
+    <dd>
+      <p>Positions the icon before or after the text. Acceptable values:</p>
+      <ol>
+        <li>leading</li>
+        <li class="default">trailing</li>
+      </ol>
     </dd>
     <dt>href</dt>
     <dd>
@@ -151,6 +164,46 @@
     container, mimicking the default behaviour of the
     <code class="dummy-code">&lt;a&gt;</code>
     HTML element.</p>
+
+  <h4 class="dummy-h4">Add an icon</h4>
+  <p class="dummy-paragraph">To add an icon to your inline link, give the
+    <code class="dummy-code">@icon</code>
+    a
+    <a href="https://flight-hashicorp.vercel.app/">Flight icon</a>
+    name:
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Link::Inline @href="..." @icon="external-link">Watch tutorial video</Hds::Link::Inline>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Link::Inline @href="#" @icon="external-link">Watch tutorial video</Hds::Link::Inline>
+
+  <p class="dummy-paragraph"><em>Notice: since the
+      <code class="dummy-code">Hds::Link::Inline</code>
+      doesn't have an intrinsic size, the size of the icon is calculated proportionally (via
+      <code class="dummy-code">em</code>) in relation to the font-size of the text
+    </em>.</p>
+
+  <h4 class="dummy-h4">Icon position</h4>
+  <p class="dummy-paragraph">By default, if you define an icon, it is placed after the text. If you would like to
+    position the icon before the text, define
+    <code class="dummy-code">@iconPosition</code>:
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Link::Inline @href="..." @icon="video" @iconPosition="leading">Watch tutorial video</Hds::Link::Inline>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Link::Inline @href="#" @icon="video" @iconPosition="leading">Watch tutorial video</Hds::Link::Inline>
 
   <h4 class="dummy-h4">Color</h4>
   <p class="dummy-paragraph">
@@ -267,9 +320,9 @@
 
 <section data-test-percy>
   <h3 class="dummy-h3">Showcase</h3>
-  <p class="dummy-paragraph"><em>Notice: in the following examples we apply a
-      <code class="dummy-code">.hds-typography-body-300</code>
-      style to the text for presentation purpose.</em></p>
+  <p class="dummy-paragraph"><em>Notice: in the following examples we apply
+      <code class="dummy-code">.hds-typography</code>
+      styles to the text for presentation purpose.</em></p>
 
   <h4 class="dummy-h4">Generated element</h4>
 
@@ -305,7 +358,7 @@
       <Hds::Link::Inline @color="primary" @href="#">Only text</Hds::Link::Inline>
     </div>
     <div class="hds-typography-body-300">
-      <Hds::Link::Inline @color="primary" @icon="globe" @href="#">Text + leading icon</Hds::Link::Inline>
+      <Hds::Link::Inline @color="primary" @icon="globe" @iconPosition="leading" @href="#">Text + leading icon</Hds::Link::Inline>
     </div>
     <div class="hds-typography-body-300">
       <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#">Text + trailing
@@ -315,7 +368,7 @@
   <br />
   <div class="hds-typography-body-100">
     Lorem
-    <Hds::Link::Inline @color="primary" @icon="globe" @href="#">ipsum dolor</Hds::Link::Inline>
+    <Hds::Link::Inline @color="primary" @icon="globe" @iconPosition="leading" @href="#">ipsum dolor</Hds::Link::Inline>
     sit amet
     <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#">consectetur
       adipiscing</Hds::Link::Inline>
@@ -323,7 +376,7 @@
   </div>
   <div class="hds-typography-body-200">
     Lorem
-    <Hds::Link::Inline @color="primary" @icon="globe" @href="#">ipsum dolor</Hds::Link::Inline>
+    <Hds::Link::Inline @color="primary" @icon="globe" @iconPosition="leading" @href="#">ipsum dolor</Hds::Link::Inline>
     sit amet
     <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#">consectetur
       adipiscing</Hds::Link::Inline>
@@ -331,7 +384,7 @@
   </div>
   <div class="hds-typography-body-300">
     Lorem
-    <Hds::Link::Inline @color="primary" @icon="globe" @href="#">ipsum dolor</Hds::Link::Inline>
+    <Hds::Link::Inline @color="primary" @icon="globe" @iconPosition="leading" @href="#">ipsum dolor</Hds::Link::Inline>
     sit amet
     <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#">consectetur
       adipiscing</Hds::Link::Inline>

--- a/packages/components/tests/dummy/app/templates/components/link/inline.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/inline.hbs
@@ -198,12 +198,12 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Link::Inline @href="..." @icon="video" @iconPosition="leading">Watch tutorial video</Hds::Link::Inline>
+      <Hds::Link::Inline @href="..." @icon="film" @iconPosition="leading">Watch tutorial video</Hds::Link::Inline>
     '
   />
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Link::Inline @href="#" @icon="video" @iconPosition="leading">Watch tutorial video</Hds::Link::Inline>
+  <Hds::Link::Inline @href="#" @icon="film" @iconPosition="leading">Watch tutorial video</Hds::Link::Inline>
 
   <h4 class="dummy-h4">Color</h4>
   <p class="dummy-paragraph">

--- a/packages/components/tests/dummy/app/templates/components/link/inline.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/inline.hbs
@@ -301,6 +301,44 @@
   <h4 class="dummy-h4">Content</h4>
 
   <div class="dummy-link-inline-content-list">
+    <div class="hds-typography-body-300">
+      <Hds::Link::Inline @color="primary" @href="#">Only text</Hds::Link::Inline>
+    </div>
+    <div class="hds-typography-body-300">
+      <Hds::Link::Inline @color="primary" @icon="globe" @href="#">Text + leading icon</Hds::Link::Inline>
+    </div>
+    <div class="hds-typography-body-300">
+      <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#">Text + trailing
+        icon</Hds::Link::Inline>
+    </div>
+  </div>
+  <br />
+  <div class="hds-typography-body-100">
+    Lorem
+    <Hds::Link::Inline @color="primary" @icon="globe" @href="#">ipsum dolor</Hds::Link::Inline>
+    sit amet
+    <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#">consectetur
+      adipiscing</Hds::Link::Inline>
+    elit.
+  </div>
+  <div class="hds-typography-body-200">
+    Lorem
+    <Hds::Link::Inline @color="primary" @icon="globe" @href="#">ipsum dolor</Hds::Link::Inline>
+    sit amet
+    <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#">consectetur
+      adipiscing</Hds::Link::Inline>
+    elit.
+  </div>
+  <div class="hds-typography-body-300">
+    Lorem
+    <Hds::Link::Inline @color="primary" @icon="globe" @href="#">ipsum dolor</Hds::Link::Inline>
+    sit amet
+    <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#">consectetur
+      adipiscing</Hds::Link::Inline>
+    elit.
+  </div>
+  <br />
+  <div class="dummy-link-inline-content-list">
     <div class="dummy-link-inline-content-list__item">
       <span class="dummy-text-small">within text block</span>
       <br />
@@ -336,13 +374,26 @@
     {{#each @model.COLORS as |color|}}
       <h5 class="dummy-h5 dummy-link-inline-states-grid__title">{{capitalize color}}</h5>
       {{#each @model.STATES as |state|}}
-        <div class="hds-typography-body-300">This is the
-          <Hds::Link::Inline
-            @color={{color}}
-            class="is-{{state}}"
-            @href="../components/link"
-          >{{state}}</Hds::Link::Inline>
-          state
+        <div>
+          <div class="hds-typography-body-300">This is the
+            <Hds::Link::Inline
+              @color={{color}}
+              class="is-{{state}}"
+              @href="../components/link"
+            >{{state}}</Hds::Link::Inline>
+            state
+          </div>
+          <br />
+          <div class="hds-typography-body-300">This is the
+            <Hds::Link::Inline
+              @color={{color}}
+              class="is-{{state}}"
+              @href="../components/link"
+              @icon="external-link"
+              @iconPosition="trailing"
+            >{{state}}</Hds::Link::Inline>
+            state
+          </div>
         </div>
       {{/each}}
     {{/each}}

--- a/packages/components/tests/integration/components/hds/link/inline-test.js
+++ b/packages/components/tests/integration/components/hds/link/inline-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | hds/link/inline', function (hooks) {
     resetOnerror();
   });
 
-  test('it renders the link(inline)', async function (assert) {
+  test('it renders the component', async function (assert) {
     await render(hbs`<Hds::Link::Inline @href="/" />`);
     assert.dom(this.element).exists();
   });
@@ -20,9 +20,26 @@ module('Integration | Component | hds/link/inline', function (hooks) {
     assert.dom('#test-link').hasClass('hds-link-inline');
   });
 
+  // ICON
+
+  test('it should render the icon in the trailing position by default', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Link::Inline @href="/" @icon="film" id="test-link">watch video</Hds::Link::Inline>`
+    );
+    assert.dom('#test-link .hds-link-inline__icon').exists();
+    assert.dom('#test-link ').hasClass('hds-link-inline--icon-trailing');
+  });
+  test('it should render the icon in the leading position if @iconPosition is set to leading', async function (assert) {
+    await render(
+      hbs`<Hds::Link::Inline @href="/" @icon="film" @iconPosition="leading" id="test-link">watch video</Hds::Link::Inline>`
+    );
+    assert.dom('#test-link ').hasClass('hds-link-inline--icon-leading');
+  });
+
   // COLOR
 
-  test('it should render the primary color as the default if no color is declared', async function (assert) {
+  test('it should render the primary color as the default if no @color prop is declared', async function (assert) {
     await render(
       hbs`<Hds::Link::Inline @href="/" id="test-link">watch video</Hds::Link::Inline>`
     );


### PR DESCRIPTION
### :pushpin: Summary

This is a spike to understand if it's possible to add support for `icon` to the `Link::Inline` component.

Now, while the results show that it's technically possible, I am a bit wary of implementing it, because is likely not used that much (and can be achieved independently, because the content is `yielded` so the consumer can add generic content (`icon + text` included) and organize its layout how the see fit. 

Another reason for this, is that achieving this in Figma is not possible, because is not a "block" component, so it's more of a style than a component (and you can't apply icons to styles). I can expand on this if it's not obvious what I mean.

Personally I would prefer to document how to do it in the "How to use" section, with a real example, than doing it as done in this PR (likely this will solve only a sub-set of all the possible cases).