### PR TITLE
Fix tokens css reference in `package/components`

### DIFF
--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Installation
 
 * `git clone <repository-url>`
-* `cd packages/design-system-components`
+* `cd packages/components`
 * `yarn install`
 
 ## Linting

--- a/packages/components/ember-cli-build.js
+++ b/packages/components/ember-cli-build.js
@@ -8,7 +8,7 @@ module.exports = function (defaults) {
     sassOptions: {
       precision: 4,
       includePaths: [
-        '../../node_modules/@hashicorp/design-system-tokens/dist/products/css',
+        'node_modules/@hashicorp/design-system-tokens/dist/products/css',
       ],
     },
     'ember-prism': {

--- a/packages/tokens/CONTRIBUTING.md
+++ b/packages/tokens/CONTRIBUTING.md
@@ -5,8 +5,8 @@
 *Notice: [Node.js](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/getting-started/install) needs to be installed on your local machine.*
 
 * `git clone <repository-url>`
-* `yarn install`
 * `cd packages/tokens`
+* `yarn install`
 
 ## Linting
 


### PR DESCRIPTION
### :pushpin: Summary

Fix `design-system-tokens/dist/products/css` reference in `package/components/ember-cli-build.js` and two tweaks to contribution docs.

### :hammer_and_wrench: Detailed description

Currently, running `ember test` in `packages/components` fails with 'Directory not found' because `node_modules` are currently under `packages/components` as a sibling of `ember-cli-build.js` script – so we update the reference accordingly

### Note
Do I need to be added to a team in Vercel? 😬 