### PR TITLE
Small fix on component contribution doc

### DIFF
--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 ## Installation
 
 * `git clone <repository-url>`
-* `cd packages/design-system-components`
 * `yarn install`
+* `cd packages/components`
 
 ## Linting
 


### PR DESCRIPTION
### :pushpin: Summary

Update contribution docs to fix folder name and promote `yarn install` at the root level instead of package level.

### :hammer_and_wrench: Detailed description

The order of commands in the initial setup made me think `yarn install` is required at the package level.