### PR TITLE
"Dropdown" component - Fix issues with focus - Part 1

### DIFF
--- a/.changeset/famous-singers-admire.md
+++ b/.changeset/famous-singers-admire.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+- removed autofocus on first item for `Disclosure` component (and as a result also for `Breadcrum` and `Dropdown` components)
+- updated focus state treatment for `Dropdown` component

--- a/.changeset/famous-singers-admire.md
+++ b/.changeset/famous-singers-admire.md
@@ -2,5 +2,5 @@
 "@hashicorp/design-system-components": patch
 ---
 
-- removed autofocus on first item for `Disclosure` component (and as a result also for `Breadcrum` and `Dropdown` components)
+- removed autofocus on first item for `Disclosure` component (and as a result also for `Breadcrumb` and `Dropdown` components)
 - updated focus state treatment for `Dropdown` component

--- a/packages/components/addon/components/hds/disclosure/index.hbs
+++ b/packages/components/addon/components/hds/disclosure/index.hbs
@@ -7,7 +7,7 @@
       class="hds-disclosure__content"
       {{focus-trap
         isActive=this.isActive
-        shouldSelfFocus=false
+        shouldSelfFocus=true
         focusTrapOptions=(hash clickOutsideDeactivates=this.clickOutsideDeactivates onDeactivate=this.onDeactivate)
       }}
     >

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -285,6 +285,7 @@ $hds-dropdown-toggle-border-radius: 5px;
     // default focus for browsers that still rely on ":focus"
     &:focus,
     &.is-focus {
+      color: var(--current-color-focus);
       &::after {
         background-color: var(--current-background-color);
         box-shadow: var(--current-focus-ring-box-shadow);
@@ -300,6 +301,7 @@ $hds-dropdown-toggle-border-radius: 5px;
     }
     // set focus for browsers that support ":focus-visible"
     &:focus-visible {
+      color: var(--current-color-focus);
       &::after {
         background-color: var(--current-background-color);
         box-shadow: var(--current-focus-ring-box-shadow);
@@ -345,6 +347,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 
     // assign the values to the local CSS variables used above
     --current-color-hover: var(--token-color-foreground-action-hover);
+    --current-color-focus: var(--token-color-foreground-action-active);
     --current-color-active: var(--token-color-foreground-action-active);
     &::after {
       --current-background-color: var(--token-color-surface-action);
@@ -359,6 +362,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 
     // assign the values to the local CSS variables used above
     --current-color-hover: var(--token-color-palette-red-300);
+    --current-color-focus: var(--token-color-palette-red-400);
     --current-color-active: var(--token-color-palette-red-400);
     &::after {
       --current-background-color: var(--token-color-surface-critical);

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -274,6 +274,14 @@ $hds-dropdown-toggle-border-radius: 5px;
     // Notice: to avoid too much duplication we define two local CSS variables
     // and define their values in the color variants below
 
+    &:hover,
+    &.is-hover {
+      color: var(--current-color-hover);
+      &::before {
+        background-color: currentColor;
+      }
+    }
+
     // default focus for browsers that still rely on ":focus"
     &:focus,
     &.is-focus {
@@ -286,6 +294,7 @@ $hds-dropdown-toggle-border-radius: 5px;
     // undo the previous declaration for browsers that support ":focus-visible" but wouldn't normally show default focus styles
     &:focus:not(:focus-visible) {
       &::after {
+        background-color: transparent;
         box-shadow: none;
       }
     }
@@ -297,11 +306,26 @@ $hds-dropdown-toggle-border-radius: 5px;
         left: 4px;
       }
     }
+
     // remove the focus ring on "active + focused" state (by design)
     &:focus:active,
+    &:focus-visible:active,
     &.is-focus.is-active {
       &::after {
+        background-color: var(--current-background-color);
         box-shadow: none;
+        left: 10px;
+      }
+    }
+
+    &:active,
+    &.is-active {
+      color: var(--current-color-active);
+      &::before {
+        background-color: currentColor;
+      }
+      &::after {
+        background-color: var(--current-background-color);
       }
     }
   }
@@ -320,30 +344,11 @@ $hds-dropdown-toggle-border-radius: 5px;
     color: var(--token-color-foreground-primary);
 
     // assign the values to the local CSS variables used above
+    --current-color-hover: var(--token-color-foreground-action-hover);
+    --current-color-active: var(--token-color-foreground-action-active);
     &::after {
       --current-background-color: var(--token-color-surface-action);
-      --current-focus-ring-box-shadow: var(
-        --token-focus-ring-action-box-shadow
-      );
-    }
-
-    &:hover,
-    &.is-hover {
-      color: var(--token-color-foreground-action-hover);
-      &::before {
-        background-color: currentColor;
-      }
-    }
-
-    &:active,
-    &.is-active {
-      color: var(--token-color-foreground-action-active);
-      &::before {
-        background-color: currentColor;
-      }
-      &::after {
-        background-color: var(--token-color-surface-action);
-      }
+      --current-focus-ring-box-shadow: var(--token-focus-ring-action-box-shadow);
     }
   }
 }
@@ -353,27 +358,11 @@ $hds-dropdown-toggle-border-radius: 5px;
     color: var(--token-color-foreground-critical);
 
     // assign the values to the local CSS variables used above
+    --current-color-hover: var(--token-color-palette-red-300);
+    --current-color-active: var(--token-color-palette-red-400);
     &::after {
       --current-background-color: var(--token-color-surface-critical);
       --current-focus-ring-box-shadow: var(--token-focus-ring-critical-box-shadow);
-    }
-
-    &:hover,
-    &.is-hover {
-      color: var(--token-color-palette-red-300);
-      &::before {
-        background-color: currentColor;
-      }
-    }
-    &:active,
-    &.is-active {
-      color: var(--token-color-palette-red-400);
-      &::before {
-        background-color: currentColor;
-      }
-      &::after {
-        background-color: var(--token-color-surface-critical);
-      }
     }
   }
 }

--- a/packages/components/tests/integration/components/hds/disclosure/index-test.js
+++ b/packages/components/tests/integration/components/hds/disclosure/index-test.js
@@ -81,23 +81,6 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
 
   // FOCUS
 
-  test('it should focus the first item in the "content" when the "toggle" is clicked', async function (assert) {
-    await render(hbs`
-      <Hds::Disclosure>
-        <:toggle as |t|>
-          <button type="button" id="test-disclosure-button" {{on "click" t.onClickToggle}} />
-        </:toggle>
-        <:content>
-          <a id="test-disclosure-link-1" href="#">test1</a>
-          <a id="test-disclosure-link-2" href="#">test2</a>
-        </:content>
-      </Hds::Disclosure>
-    `);
-    await click('button#test-disclosure-button');
-    await waitNextExecutionFrame();
-    assert.dom('a#test-disclosure-link-1').isFocused();
-  });
-
   // TODO this doesn't work
   // see https://github.com/emberjs/ember-test-helpers/issues/738
   // https://discord.com/channels/480462759797063690/480523424121356298/842578755633545276


### PR DESCRIPTION
### :pushpin: Summary

This is a possible fix for part of the problems related to focus states in `Dropdown::ListItem::Interactive` (see #258).

There will be a second round of fix, in which we want to review all the focus management for the components that rely on the `Disclosure` component (with the intent to fix also the bug seen in https://github.com/hashicorp/cloud-ui/pull/2362#issuecomment-1097909966).

### :hammer_and_wrench: Detailed description

In this PR I have:
- fixed the issues with the color of text + combination of `active+focus` states
  - in doing so, did a small refactoring to simplify even more the definition of the colors, and centralize the "logic" of the interactive states in a single place
- ported the changes from https://github.com/hashicorp/design-system/pull/261 into this branch.
- removed integration test

### 🔗 Links
- codepen that can be used/forked to do some tests: https://codepen.io/didoo/pen/OJzeVjG?editors=1100

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202198964307759