### PR TITLE
resolves issue with focus on dropdown

### DIFF
--- a/packages/components/addon/components/hds/disclosure/index.hbs
+++ b/packages/components/addon/components/hds/disclosure/index.hbs
@@ -7,7 +7,7 @@
       class="hds-disclosure__content"
       {{focus-trap
         isActive=this.isActive
-        shouldSelfFocus=false
+        shouldSelfFocus=true
         focusTrapOptions=(hash clickOutsideDeactivates=this.clickOutsideDeactivates onDeactivate=this.onDeactivate)
       }}
     >


### PR DESCRIPTION
Potential resolution for the half-active focus for the dropdown. Changing a setting in the discloser component resolved the issue but it should be checked to see if it's the solution you want, so leaving it in draft mode. Feel free to close if this is not the approach you want to take.