### PR TITLE
use PAT to bypass github security change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Token setup in Dhaulagiri's account
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           # Token setup in Dhaulagiri's account
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

A recent security change at GitHub has made it so our previous behavior will no longer work. This PR is a temporary step using a personal access token from my account (Release PRs will be opened "by me") until we can more permanently fix this (I have a plan). 

I've already set the token so this _should_ work but we can't test it until a new release PR is _created_.


### :link: External links

* [GitHub Changelog](https://github.blog/changelog/2022-05-03-github-actions-prevent-github-actions-from-creating-and-approving-pull-requests/)

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed



:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
