### PR TITLE
Docs: adds a sidebar to component pages

### DIFF
--- a/packages/components/tests/dummy/app/components/dummy-toc.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-toc.hbs
@@ -1,0 +1,8 @@
+<ul class="dummy-aside-list dummy-list">
+  <li class="dummy-aside-list-item"><a href="{{this.dummyRouteUrl}}">The Component</a></li>
+  <li class="dummy-aside-list-item"><a href="{{this.dummyRouteUrl}}#component-api">Component API</a></li>
+  <li class="dummy-aside-list-item"><a href="{{this.dummyRouteUrl}}#how-to-use">How To Use</a></li>
+  <li class="dummy-aside-list-item"><a href="{{this.dummyRouteUrl}}#design-guidelines">Design Guidelines</a></li>
+  <li class="dummy-aside-list-item"><a href="{{this.dummyRouteUrl}}#accessibility">Accessibility</a></li>
+  <li class="dummy-aside-list-item"><a href="{{this.dummyRouteUrl}}#showcase">Showcase</a></li>
+</ul>

--- a/packages/components/tests/dummy/app/components/dummy-toc.js
+++ b/packages/components/tests/dummy/app/components/dummy-toc.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+
+export default class DummyTocComponent extends Component {
+  @service router;
+
+  get dummyRouteUrl() {
+    let dummyPathUrl = this.router.currentURL;
+    return dummyPathUrl;
+  }
+}

--- a/packages/components/tests/dummy/app/styles/_layout.scss
+++ b/packages/components/tests/dummy/app/styles/_layout.scss
@@ -1,0 +1,16 @@
+.dummy-with-sidebar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.dummy-with-sidebar > :first-child {
+  flex-basis: 12rem;
+  flex-grow: 1;
+}
+
+.dummy-with-sidebar > :last-child {
+  flex-basis: 0;
+  flex-grow: 999;
+  min-inline-size: 70%;
+}

--- a/packages/components/tests/dummy/app/styles/_typography.scss
+++ b/packages/components/tests/dummy/app/styles/_typography.scss
@@ -27,6 +27,10 @@
     @include dummyFontSize(2.5rem);
     font-weight: 600;
     line-height: 1.2;
+    // the first one shouldn't have a top margin else it looks weird next to the sidebar
+    &:first-of-type {
+        margin-top: 0;
+    }
 }
 
 .dummy-h3 {

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -1,5 +1,6 @@
 @import '@hashicorp/design-system-components';
 
+@import "./layout";
 @import "./_typography";
 
 @import "./pages/db-badge";
@@ -20,6 +21,7 @@
 @import "./components/dummy-component-props";
 @import "./components/dummy-placeholder";
 @import "./components/dummy-link-cta-button-banner";
+@import "./components/dummy-toc";
 
 html {
     box-sizing: border-box;

--- a/packages/components/tests/dummy/app/styles/components/dummy-toc.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-toc.scss
@@ -1,0 +1,22 @@
+.dummy-aside-list {
+  box-sizing: border-box;
+  list-style: none;
+  padding: 0;
+  margin: auto;
+}
+
+.dummy-aside-list-item {
+  box-sizing: border-box;
+  width: 100%;
+  a {
+    border: 2px solid transparent;
+    box-sizing: border-box;
+    padding: 0.5rem;
+    width: 100%;
+    display: flex;
+    &:hover {
+      background-color: aliceblue;
+      border-left-color: blue;
+    }
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components.hbs
+++ b/packages/components/tests/dummy/app/templates/components.hbs
@@ -1,0 +1,8 @@
+<div class="dummy-with-sidebar">
+  <aside class="dummy-aside">
+    <DummyToc />
+  </aside>
+  <div class="dummy-main-content">
+    {{outlet}}
+  </div>
+</div>


### PR DESCRIPTION
### :pushpin: Summary

Some consistent feedback is that our docs are good but a lot. In this PR, I've added a sidebar to the component's page, with the sections in the sidebar for hopefully easier navigation.

If this is useful to our ambassadors, we can tidy up the styling a bit and ship it. 

### :camera_flash: Screenshots

This screenshot shows the focused state, the default state, and the hover state. I've mainly stuck to defaults so that if @heatherlarsen and @cveigt have styling opinions there wouldn't be too much to undo.

![CleanShot 2022-05-09 at 19 03 42](https://user-images.githubusercontent.com/4587451/167517646-e0dfb95a-425f-4fb3-9f66-3bb3d28fdcbb.png)

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
