### PR TITLE
Add Ember blueprint for the creation of new HDS components

### DIFF
--- a/packages/components/.template-lintrc.js
+++ b/packages/components/.template-lintrc.js
@@ -7,4 +7,7 @@ module.exports = {
     'no-html-comments': false,
     'no-trailing-spaces': true,
   },
+  ignore: [
+    'blueprints/**'
+  ]
 };

--- a/packages/components/.template-lintrc.js
+++ b/packages/components/.template-lintrc.js
@@ -7,7 +7,5 @@ module.exports = {
     'no-html-comments': false,
     'no-trailing-spaces': true,
   },
-  ignore: [
-    'blueprints/**'
-  ]
+  ignore: ['blueprints/**'],
 };

--- a/packages/components/blueprints/hds-component-test/files/tests/dummy/app/routes/components/__name__.js
+++ b/packages/components/blueprints/hds-component-test/files/tests/dummy/app/routes/components/__name__.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class Components<%= classifiedModuleName %>Route extends Route {}

--- a/packages/components/blueprints/hds-component-test/files/tests/dummy/app/styles/pages/__dummyCSSFileName__.scss
+++ b/packages/components/blueprints/hds-component-test/files/tests/dummy/app/styles/pages/__dummyCSSFileName__.scss
@@ -1,0 +1,1 @@
+// <%= folderizedModuleName %>

--- a/packages/components/blueprints/hds-component-test/files/tests/dummy/app/templates/components/__name__.hbs
+++ b/packages/components/blueprints/hds-component-test/files/tests/dummy/app/templates/components/__name__.hbs
@@ -59,4 +59,7 @@
 
   {{! ADD YOUR CONTENT HERE }}
 
+  {{!-- This below is just an example of invocation, to get started --}}
+  <Hds::<%= columnizedModuleName %>>This is the Hds::<%= columnizedModuleName %> component </Hds::<%= columnizedModuleName %>>
+
 </section>

--- a/packages/components/blueprints/hds-component-test/files/tests/dummy/app/templates/components/__name__.hbs
+++ b/packages/components/blueprints/hds-component-test/files/tests/dummy/app/templates/components/__name__.hbs
@@ -59,7 +59,7 @@
 
   {{! ADD YOUR CONTENT HERE }}
 
-  {{!-- This below is just an example of invocation, to get started --}}
+  {{! This below is just an example of invocation, to get started }}
   <Hds::<%= columnizedModuleName %>>This is the Hds::<%= columnizedModuleName %> component </Hds::<%= columnizedModuleName %>>
 
 </section>

--- a/packages/components/blueprints/hds-component-test/files/tests/dummy/app/templates/components/__name__.hbs
+++ b/packages/components/blueprints/hds-component-test/files/tests/dummy/app/templates/components/__name__.hbs
@@ -1,0 +1,62 @@
+{{page-title "<%= columnizedModuleName %> Component"}}
+
+<h2 class="dummy-h2"><%= columnizedModuleName %></h2>
+
+{{! ADD YOUR CONTENT BELOW }}
+{{! Please follow as much as possible what it's already done in other components. }}
+{{! You can start by copy&pasting it, if you want, and then adapt it according to your needs. }}
+{{! Once done, please remove these comments (they're created by the generator). }}
+
+<section>
+  <h3 class="dummy-h3" id="overview"><a href="#overview">§</a> Overview</h3>
+
+  {{! ADD YOUR CONTENT HERE }}
+
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="component-api"><a href="#component-api">§</a> Component API</h3>
+  <p class="dummy-paragraph" id="component-api-<%= kebabizedModuleName %>">
+    Here is the API for the component:
+  </p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-<%= kebabizedModuleName %>">
+
+    {{! ADD YOUR CONTENT HERE }}
+
+  </dl>
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="how-to-use"><a href="#how-to-use" class="dummy-link-section">§</a> How to use</h3>
+
+  {{! ADD YOUR CONTENT HERE }}
+
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>Design guidelines</h3>
+  {{! UNCOMMENT THIS BLOCK (once the link and/or the image are available) }}
+  {{!
+  <div class="dummy-design-guidelines">
+    <p class="dummy-paragraph">
+      <a href="[ADD THE LINK TO THE FIGMA FILE/PAGE HERE!]" target="_blank" rel="noopener noreferrer">Figma UI Kit</a>
+    </p>
+    <br />
+    <img class="dummy-figma-docs" src="/assets/images/<%= kebabizedModuleName %>-design-usage.png" alt="" role="none" />
+  </div>
+  }}
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
+
+  {{! ADD YOUR CONTENT HERE }}
+
+</section>
+
+<section data-test-percy>
+  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+
+  {{! ADD YOUR CONTENT HERE }}
+
+</section>

--- a/packages/components/blueprints/hds-component-test/files/tests/integration/components/hds/__name__/index-test.js
+++ b/packages/components/blueprints/hds-component-test/files/tests/integration/components/hds/__name__/index-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/<%= dasherizedModuleName %>/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::<%= columnizedModuleName %> />`);
+    assert.dom(this.element).exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::<%= columnizedModuleName %> id="test-<%= kebabizedModuleName %>" />`);
+    assert.dom('#test-<%= kebabizedModuleName %>').hasClass('hds-<%= kebabizedModuleName %>');
+  });
+});

--- a/packages/components/blueprints/hds-component-test/index.js
+++ b/packages/components/blueprints/hds-component-test/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-string-prototype-extensions */
+/* eslint-disable node/no-extraneous-require */
 'use strict';
 
 const stringUtil = require('ember-cli-string-utils');

--- a/packages/components/blueprints/hds-component-test/index.js
+++ b/packages/components/blueprints/hds-component-test/index.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const stringUtil = require('ember-cli-string-utils');
+const EmberRouterGenerator = require('ember-router-generator');
+const fs = require('fs');
 
 module.exports = {
   description: 'Generates tests for an HDS component',
 
   locals(options) {
-    // Return custom template variables here.
     return {
       columnizedModuleName: options.entity.name
         .split('/')
@@ -23,8 +24,7 @@ module.exports = {
     };
   },
 
-  fileMapTokens(options) {
-    // Return custom tokens to be replaced in your files paths
+  fileMapTokens() {
     return {
       // prepend `db-` to the file name
       __dummyCSSFileName__(options) {
@@ -34,4 +34,17 @@ module.exports = {
       },
     };
   },
+
+  afterInstall(options) {
+    updateRouter.call(this, options);
+  },
 };
+
+function updateRouter(options) {
+  const newRouteToAdd = `components/${options.entity.name}`; // we prefix all the component routes with "components"
+  const routerFilePath = `${options.project.root}/tests/dummy/app/router.js`;
+  let source = fs.readFileSync(routerFilePath, 'utf-8');
+  let oldRoutes = new EmberRouterGenerator(source);
+  let newRoutes = oldRoutes['add'](newRouteToAdd, options);
+  fs.writeFileSync(routerFilePath, newRoutes.code());
+}

--- a/packages/components/blueprints/hds-component-test/index.js
+++ b/packages/components/blueprints/hds-component-test/index.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const stringUtil = require('ember-cli-string-utils');
+
+module.exports = {
+  description: 'Generates tests for an HDS component',
+
+  locals(options) {
+    // Return custom template variables here.
+    return {
+      columnizedModuleName: options.entity.name
+        .split('/')
+        .map((part) => stringUtil.classify(part))
+        .join('::'),
+      kebabizedModuleName: options.entity.name
+        .split('/')
+        .map((part) => stringUtil.dasherize(part))
+        .join('-'),
+      folderizedModuleName: options.entity.name
+        .split('/')
+        .map((part) => stringUtil.dasherize(part).toUpperCase())
+        .join(' > '),
+    };
+  },
+
+  fileMapTokens(options) {
+    // Return custom tokens to be replaced in your files paths
+    return {
+      // prepend `db-` to the file name
+      __dummyCSSFileName__(options) {
+        const parts = options.dasherizedModuleName.split('/');
+        const fileName = parts.pop();
+        return `${parts.join('/')}/db-${fileName}`;
+      },
+    };
+  },
+};

--- a/packages/components/blueprints/hds-component-test/index.js
+++ b/packages/components/blueprints/hds-component-test/index.js
@@ -36,15 +36,48 @@ module.exports = {
   },
 
   afterInstall(options) {
-    updateRouter.call(this, options);
+    updateDummyAppRouter.call(this, options);
+    updateDummyAppCSS.call(this, options);
   },
 };
 
-function updateRouter(options) {
+function updateDummyAppRouter(options) {
   const newRouteToAdd = `components/${options.entity.name}`; // we prefix all the component routes with "components"
   const routerFilePath = `${options.project.root}/tests/dummy/app/router.js`;
-  let source = fs.readFileSync(routerFilePath, 'utf-8');
+  const source = fs.readFileSync(routerFilePath, 'utf-8');
   let oldRoutes = new EmberRouterGenerator(source);
   let newRoutes = oldRoutes['add'](newRouteToAdd, options);
   fs.writeFileSync(routerFilePath, newRoutes.code());
+}
+
+function updateDummyAppCSS(options) {
+  const parts = options.entity.name.split('/');
+  const fileName = `db-${parts.pop()}`;
+  const cssFilePath = `${options.project.root}/tests/dummy/app/styles/app.scss`;
+  const source = fs.readFileSync(cssFilePath, 'utf-8');
+  const oldLinesArray = source.split(/\r?\n/);
+  const firstComponentImportIndex =
+    oldLinesArray.findIndex((line) =>
+      line.match(/^\/\/ START COMPONENT PAGES IMPORTS/)
+    ) + 1;
+  const lastComponentImportIndex =
+    oldLinesArray.findIndex((line) =>
+      line.match(/^\/\/ END COMPONENT PAGES IMPORTS/)
+    ) - 1;
+  const importLinesArray = oldLinesArray.slice(
+    firstComponentImportIndex,
+    lastComponentImportIndex + 1
+  );
+  importLinesArray.push(
+    `@import "./pages/${parts.concat([fileName]).join('/')}";`
+  );
+  const newImportLinesArray = importLinesArray
+    .filter((line, index, self) => self.indexOf(line) === index)
+    .sort();
+  const newLinesArray = [].concat(
+    oldLinesArray.slice(0, firstComponentImportIndex),
+    newImportLinesArray,
+    oldLinesArray.slice(lastComponentImportIndex + 1)
+  );
+  fs.writeFileSync(cssFilePath, newLinesArray.join('\n'));
 }

--- a/packages/components/blueprints/hds-component/files/addon/components/hds/__name__/index.hbs
+++ b/packages/components/blueprints/hds-component/files/addon/components/hds/__name__/index.hbs
@@ -1,0 +1,4 @@
+{{! ADD YOUR TEMPLATE CONTENT HERE }}
+<div className={{this.classNames}} ...attributes>
+  {{yield}}
+</div>

--- a/packages/components/blueprints/hds-component/files/addon/components/hds/__name__/index.js
+++ b/packages/components/blueprints/hds-component/files/addon/components/hds/__name__/index.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+
+export default class Hds<%= classifiedModuleName %>IndexComponent extends Component {
+  // UNCOMMENT THIS IF YOU NEED A CONSTRUCTOR
+  // constructor() {
+  //   super(...arguments);
+  //   // ADD YOUR ASSERTIONS HERE
+  // }
+
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-<%= kebabizedModuleName %>'];
+
+    // add a class based on the @xxx argument
+    // classes.push(`hds-<%= kebabizedModuleName %>--[variant]-${this.xxx}`);
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/blueprints/hds-component/files/app/components/hds/__name__/index.js
+++ b/packages/components/blueprints/hds-component/files/app/components/hds/__name__/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/<%= dasherizedModuleName %>/index';

--- a/packages/components/blueprints/hds-component/files/app/styles/components/__name__.scss
+++ b/packages/components/blueprints/hds-component/files/app/styles/components/__name__.scss
@@ -1,0 +1,6 @@
+//
+// <%= folderizedModuleName %>
+//
+// properties within each class are sorted alphabetically
+//
+

--- a/packages/components/blueprints/hds-component/index.js
+++ b/packages/components/blueprints/hds-component/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-string-prototype-extensions */
+/* eslint-disable node/no-extraneous-require */
 'use strict';
 
 const stringUtil = require('ember-cli-string-utils');

--- a/packages/components/blueprints/hds-component/index.js
+++ b/packages/components/blueprints/hds-component/index.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const stringUtil = require('ember-cli-string-utils');
+
+module.exports = {
+  description: 'Generates all files for an HDS component',
+
+  locals(options) {
+    // Return custom template variables here.
+    return {
+      columnizedModuleName: options.entity.name
+        .split('/')
+        .map((part) => stringUtil.classify(part))
+        .join('::'),
+      kebabizedModuleName: options.entity.name
+        .split('/')
+        .map((part) => stringUtil.dasherize(part))
+        .join('-'),
+      folderizedModuleName: options.entity.name
+        .split('/')
+        .map((part) => stringUtil.dasherize(part).toUpperCase())
+        .join(' > '),
+    };
+  },
+
+  afterInstall(options) {
+    // console.log('AAAAA', options);
+  },
+};

--- a/packages/components/blueprints/hds-component/index.js
+++ b/packages/components/blueprints/hds-component/index.js
@@ -6,7 +6,6 @@ module.exports = {
   description: 'Generates all files for an HDS component',
 
   locals(options) {
-    // Return custom template variables here.
     return {
       columnizedModuleName: options.entity.name
         .split('/')
@@ -21,9 +20,5 @@ module.exports = {
         .map((part) => stringUtil.dasherize(part).toUpperCase())
         .join(' > '),
     };
-  },
-
-  afterInstall(options) {
-    // console.log('AAAAA', options);
   },
 };

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -2,6 +2,8 @@
 
 @import "./_typography";
 
+// Notice: this list can be automatically edited by the Ember blueprint, please don't remove the start/end comments
+// START COMPONENT PAGES IMPORTS
 @import "./pages/db-alert";
 @import "./pages/db-badge";
 @import "./pages/db-breadcrumb";
@@ -18,6 +20,7 @@
 @import "./pages/db-toast";
 @import "./pages/db-tokens";
 @import "./pages/db-typography";
+// END COMPONENT PAGES IMPORTS
 
 @import "./components/dummy-component-props";
 @import "./components/dummy-placeholder";


### PR DESCRIPTION
### :pushpin: Summary

Now that we know what needs to happen when create a component, we can use a custom blueprint to generate some the docs boilerplate. 

Documentation: https://cli.emberjs.com/release/advanced-use/blueprints/ 

_Notice: I impemented the blueprint because I needed to generate six new components for the `form controls` development, and it was more efficient to automate the process (also for the future) than create them manually._

### :hammer_and_wrench: Detailed description

In this PR I have:
- implemented a blueprint for the creation of a new component that
  - adds the HBS + JS + CSS files for the component in the right folders
  - adds a skeleton of documentation page for the component (with routing and styling already set up)
  - adds a basic integration test file for the component

#### How to test it

- check out the branch 
- create a new component with the command `ember generate hds-component [my-component-name] ` where `[my-component-name]` is the name of your component (eg. `navbar` or `form/input`)
- go to your localhost and check the new component page

### TODOs

If approved I'll:
- [ ] update the NEW-COMPONENT-CHECKLIST.md before merging the branch
- [ ] fix the linting issues reported (it may need to disable linting for that folders or specific files)

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202002491095025