### PR TITLE
Change focus management in disclosure utility component

### DIFF
--- a/.changeset/olive-parrots-work.md
+++ b/.changeset/olive-parrots-work.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Change focus management in disclosure utility component

--- a/packages/components/addon/components/hds/disclosure/index.hbs
+++ b/packages/components/addon/components/hds/disclosure/index.hbs
@@ -3,6 +3,7 @@
   ...attributes
   {{did-insert this.didInsert}}
   {{on "focusout" this.onFocusOut}}
+  {{on "keyup" this.onKeyUp}}
 >
   <div class="hds-disclosure__toggle">
     {{yield (hash onClickToggle=this.onClickToggle isActive=this.isActive) to="toggle"}}

--- a/packages/components/addon/components/hds/disclosure/index.hbs
+++ b/packages/components/addon/components/hds/disclosure/index.hbs
@@ -1,3 +1,4 @@
+{{! template-lint-disable no-invalid-interactive }}
 <div
   class="hds-disclosure"
   ...attributes

--- a/packages/components/addon/components/hds/disclosure/index.hbs
+++ b/packages/components/addon/components/hds/disclosure/index.hbs
@@ -6,7 +6,7 @@
   {{on "focusout" this.onFocusOut}}
   {{on "keyup" this.onKeyUp}}
 >
-  <div class="hds-disclosure__toggle">
+  <div class="hds-disclosure__toggle" tabindex="-1">
     {{yield (hash onClickToggle=this.onClickToggle isActive=this.isActive) to="toggle"}}
   </div>
   {{#if this.isActive}}

--- a/packages/components/addon/components/hds/disclosure/index.hbs
+++ b/packages/components/addon/components/hds/disclosure/index.hbs
@@ -1,16 +1,14 @@
-<div class="hds-disclosure" ...attributes>
+<div
+  class="hds-disclosure"
+  ...attributes
+  {{did-insert this.didInsert}}
+  {{on "focusout" this.onFocusOut}}
+>
   <div class="hds-disclosure__toggle">
     {{yield (hash onClickToggle=this.onClickToggle isActive=this.isActive) to="toggle"}}
   </div>
   {{#if this.isActive}}
-    <div
-      class="hds-disclosure__content"
-      {{focus-trap
-        isActive=this.isActive
-        shouldSelfFocus=true
-        focusTrapOptions=(hash clickOutsideDeactivates=this.clickOutsideDeactivates onDeactivate=this.onDeactivate)
-      }}
-    >
+    <div class="hds-disclosure__content" tabindex="-1">
       {{yield to="content"}}
     </div>
   {{/if}}

--- a/packages/components/addon/components/hds/disclosure/index.js
+++ b/packages/components/addon/components/hds/disclosure/index.js
@@ -32,6 +32,14 @@ export default class HdsDisclosureComponent extends Component {
   }
 
   @action
+  onKeyUp(event) {
+    if (event.key === 'Escape') {
+      this.deactivate();
+      this.toggleRef.focus();
+    }
+  }
+
+  @action
   deactivate() {
     if (this.isActive) {
       this.isActive = false;

--- a/packages/components/addon/components/hds/disclosure/index.js
+++ b/packages/components/addon/components/hds/disclosure/index.js
@@ -19,6 +19,8 @@ export default class HdsDisclosureComponent extends Component {
       this.toggleRef = event.currentTarget;
     }
     this.isActive = !this.isActive;
+    // we explicitly apply a focus state to the toggle element to overcome a bug in WebKit (see b8abfcf)
+    this.toggleRef.focus();
   }
 
   @action

--- a/packages/components/addon/components/hds/disclosure/index.js
+++ b/packages/components/addon/components/hds/disclosure/index.js
@@ -8,6 +8,11 @@ export default class HdsDisclosureComponent extends Component {
   @tracked isToggleClicked;
 
   @action
+  didInsert(element) {
+    this.element = element;
+  }
+
+  @action
   onClickToggle(event) {
     // we store a reference to the DOM node that has the "onClickToggle" event associated with it
     if (!this.toggleRef) {
@@ -17,31 +22,23 @@ export default class HdsDisclosureComponent extends Component {
   }
 
   @action
-  clickOutsideDeactivates(event) {
-    // we check if the toggle reference belongs to the tree of parent DOM nodes
-    // of the element that was clicked and triggered the "click outside" event handling
-    // notice: we use "event.composedPath" here because is now fully supported (see https://caniuse.com/?search=event%20path)
-    const path = event.composedPath();
-    this.isToggleClicked = path.includes(this.toggleRef);
-    // here we need to return `true` to make sure that the focus trap will be deactivated (and allow the click event to do its thing (i.e. to pass-through to the element that was clicked).
-    // see: https://github.com/focus-trap/focus-trap#createoptions
-    return true;
+  onFocusOut(event) {
+    if (
+      !event.relatedTarget || // click or tap a non-related target (e.g. outside the element)
+      !this.element.contains(event.relatedTarget) // move focus to a target outside the element
+    ) {
+      this.deactivate();
+    }
   }
 
   @action
-  onDeactivate() {
-    // on deactivate we hide the content, except for the case when the button has been clicked
-    // the reason is that the "onClickToggle" is called in any case (there's no way to block the event)
-    // so when the user clicks the toggle to close the panel, we let the "onClickToggle" handle the closure
-    // otherwise we would have two changes of status, this and the toggle, and the panel would remain open
-    if (!this.isToggleClicked) {
+  deactivate() {
+    if (this.isActive) {
       this.isActive = false;
-      // we need to reset this check
-      this.isToggleClicked = false;
-      // we call the "onClose" callback if it exists (and is a function)
-      if (this.args.onClose && typeof this.args.onClose === 'function') {
-        this.args.onClose();
-      }
+    }
+    // we call the "onClose" callback if it exists (and is a function)
+    if (this.args.onClose && typeof this.args.onClose === 'function') {
+      this.args.onClose();
     }
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,6 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-sass": "^10.0.1",
-    "ember-focus-trap": "^1.0.1",
     "ember-keyboard": "^8.1.0",
     "ember-named-blocks-polyfill": "^0.2.5",
     "sass": "^1.43.4"

--- a/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
@@ -85,25 +85,14 @@
     <code class="dummy-code">enter/return</code>), clicking outside of the content, or via the
     <code class="dummy-code">esc</code>
     key.</p>
-  <p class="dummy-paragraph"><strong>Important:</strong></p>
-  <ul>
-    <li class="dummy-paragraph">
-      the
-      <code class="dummy-code">HDS::Disclosure</code>
-      component will trap the focus inside the "content" while it's open (we're using the
-      <a href="https://github.com/focus-trap/focus-trap" target="_blank" rel="noopener noreferrer">
-        <code class="dummy-code">
-          focus-trap</code>
-      </a>
-      library); at the moment we don't allow non-focusable content (it will trigger an error).
-    </li>
-    <li class="dummy-paragraph">the "content" is not positioned in any way in relation to the toggle: this
-      responsibility is left to the consumers (eg by applying a
-      <code class="dummy-code">position: absolute</code>
-      to a wrapper around the content that is passed to the
-      <code class="dummy-code">:content</code>
-      block).</li>
-  </ul>
+  <p class="dummy-paragraph">
+    <strong>Important:</strong>
+    The "content" is not positioned in any way in relation to the toggle: this responsibility is left to the consumers
+    (eg by applying a
+    <code class="dummy-code">position: absolute</code>
+    to a wrapper around the content that is passed to the
+    <code class="dummy-code">:content</code>
+    block).</p>
 </section>
 
 <section data-test-percy>
@@ -123,9 +112,7 @@
         </button>
       </:toggle>
       <:content>
-        <a href="#">
-          <DummyPlaceholder @text="some generic content here" @width="200" @height="90" @background="#FAFAFA" />
-        </a>
+        <DummyPlaceholder @text="some generic content here" @width="200" @height="90" @background="#FAFAFA" />
       </:content>
     </Hds::Disclosure>
   </div>

--- a/packages/components/tests/integration/components/hds/disclosure/index-test.js
+++ b/packages/components/tests/integration/components/hds/disclosure/index-test.js
@@ -9,13 +9,6 @@ import {
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-// we need to wait for the next event loop cycle after clicking the "toggle"
-// otherwise the test don't work (surely related to the focus-trap 'delayInitialFocus' parameter)
-// see https://github.com/focus-trap/focus-trap#createoptions
-// notice: you can use console.log(document.activeElement) to check which element has focus
-const waitNextExecutionFrame = () =>
-  new Promise((resolve) => setTimeout(resolve, 100));
-
 module('Integration | Component | hds/disclosure/index', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -73,7 +66,6 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
       </Hds::Disclosure>
     `);
     await triggerKeyEvent('button#test-disclosure-button', 'keydown', 'Enter');
-    // await waitNextExecutionFrame();
     // await waitFor('.hds-disclosure__content', { timeout: 2000 });
     assert.dom('.hds-disclosure__content').exists();
     assert.dom('a#test-disclosure-link').exists();
@@ -100,7 +92,6 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
       </Hds::Disclosure>
     `);
     await click('button#test-disclosure-button');
-    await waitNextExecutionFrame();
     // console.log('BBB', document.activeElement);
     assert.dom('a#test-disclosure-link-1').isFocused();
     await triggerKeyEvent('a#test-disclosure-link-1', 'keydown', 'Tab');

--- a/packages/components/tests/integration/components/hds/disclosure/index-test.js
+++ b/packages/components/tests/integration/components/hds/disclosure/index-test.js
@@ -1,9 +1,9 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
   click,
+  triggerEvent,
   triggerKeyEvent,
-  // waitFor,
   render,
   resetOnerror,
 } from '@ember/test-helpers';
@@ -52,11 +52,13 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
     assert.dom('.hds-disclosure__content').exists();
     assert.dom('a#test-disclosure-link').exists();
   });
-  // TODO this doesn't work
-  skip('it should render the "content" when the "toggle" is activated via "enter"', async function (assert) {
-    assert.expect(2);
+
+  // ESCAPE KEY
+
+  test('it should hide the "content" when the "toggle" is deactivated via "Escape"', async function (assert) {
+    assert.expect(4);
     await render(hbs`
-      <Hds::Disclosure>
+      <Hds::Disclosure id="test-disclosure">
         <:toggle as |t|>
           <button type="button" id="test-disclosure-button" {{on "click" t.onClickToggle}} />
         </:toggle>
@@ -65,40 +67,33 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
         </:content>
       </Hds::Disclosure>
     `);
-    await triggerKeyEvent('button#test-disclosure-button', 'keydown', 'Enter');
-    // await waitFor('.hds-disclosure__content', { timeout: 2000 });
+    await click('button#test-disclosure-button');
     assert.dom('.hds-disclosure__content').exists();
     assert.dom('a#test-disclosure-link').exists();
+    await triggerKeyEvent('#test-disclosure', 'keyup', 'Escape');
+    assert.dom('.hds-disclosure__content').doesNotExist();
+    assert.dom('a#test-disclosure-link').doesNotExist();
   });
 
-  // FOCUS
+  // FOCUS OUT
 
-  // TODO this doesn't work
-  // see https://github.com/emberjs/ember-test-helpers/issues/738
-  // https://discord.com/channels/480462759797063690/480523424121356298/842578755633545276
-  // https://github.com/emberjs/ember-test-helpers/issues/626
-  // https://discord.com/channels/480462759797063690/483601670685720591/831546103266148403
-  skip('it should trap the focus inside the "content" block', async function (assert) {
-    assert.expect(3);
+  test('it should hide the "content" when the focus is moved outside', async function (assert) {
+    assert.expect(4);
     await render(hbs`
-      <Hds::Disclosure>
+      <Hds::Disclosure id="test-disclosure">
         <:toggle as |t|>
           <button type="button" id="test-disclosure-button" {{on "click" t.onClickToggle}} />
         </:toggle>
         <:content>
-          <a id="test-disclosure-link-1" href="#">test1</a>
-          <a id="test-disclosure-link-2" href="#">test2</a>
+          <a id="test-disclosure-link" href="#">test</a>
         </:content>
       </Hds::Disclosure>
     `);
     await click('button#test-disclosure-button');
-    // console.log('BBB', document.activeElement);
-    assert.dom('a#test-disclosure-link-1').isFocused();
-    await triggerKeyEvent('a#test-disclosure-link-1', 'keydown', 'Tab');
-    // console.log('CCC', document.activeElement);
-    assert.dom('a#test-disclosure-link-2').isFocused();
-    await triggerKeyEvent('a#test-disclosure-link-2', 'keydown', 'Tab');
-    // console.log('DDD', document.activeElement);
-    assert.dom('a#test-disclosure-link-1').isFocused();
+    assert.dom('.hds-disclosure__content').exists();
+    assert.dom('a#test-disclosure-link').exists();
+    await triggerEvent('#test-disclosure', 'focusout');
+    assert.dom('.hds-disclosure__content').doesNotExist();
+    assert.dom('a#test-disclosure-link').doesNotExist();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,7 +1383,7 @@
     ember-cli-version-checker "^5.1.2"
     semver "^7.3.5"
 
-"@embroider/addon-shim@^1.0.0", "@embroider/addon-shim@^1.5.0":
+"@embroider/addon-shim@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@embroider/addon-shim/-/addon-shim-1.5.0.tgz#639b8b394336a5ae26dd3e24ffc3d34d864ac5ce"
   integrity sha512-5zgwA/wTYjgn2Oo6hKRQhF/5Gnwb+hGhj/WXhZQa5yA7fRRdBV1tVMS7b7SLawZcmOhuWkyPwFdgsYtGBvDB0w==
@@ -6568,14 +6568,6 @@ ember-fetch@^8.1.1:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.6.2"
 
-ember-focus-trap@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ember-focus-trap/-/ember-focus-trap-1.0.1.tgz#a99565f6ce55d500b92a0965e79e3ad04219f157"
-  integrity sha512-ZUyq5ZkIuXp+ng9rCMkqBh36/V95PltL7iljStkma4+651xlAy3Z84L9WOu/uOJyVpNUxii8RJBbAySHV6c+RQ==
-  dependencies:
-    "@embroider/addon-shim" "^1.0.0"
-    focus-trap "^6.7.1"
-
 ember-keyboard@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-8.1.1.tgz#b12844a0f87cbb091b7c21293afccbf5aedc2ea3"
@@ -7878,13 +7870,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-focus-trap@^6.7.1:
-  version "6.7.3"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.7.3.tgz#b5dc195b49c90001f08a63134471d1e6dd381ddd"
-  integrity sha512-8xCEKndV4KrseGhFKKKmczVA14yx1/hnmFICPOjcFjToxCJYj/NHH43tPc3YE/PLnLRNZoFug0EcWkGQde/miQ==
-  dependencies:
-    tabbable "^5.2.1"
 
 follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.14.9"
@@ -13259,11 +13244,6 @@ sync-disk-cache@^2.0.0:
     mkdirp "^0.5.0"
     rimraf "^3.0.0"
     username-sync "^1.0.2"
-
-tabbable@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
-  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
 
 table@^6.0.9:
   version "6.8.0"


### PR DESCRIPTION
### :pushpin: Summary

This PR is proposing an alternative approach to focus management in our disclosure utility component on the back of #280

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->
The main change is dropping the focus-trap mechanism and letting the focus flow through the component while preserving the rest of the requirements defined in [the associated CRD](https://docs.google.com/document/d/1PSIAdUypvGWCLBAkeOo4HSa3qd6qN-pWvlLrfuwYT4o/edit#). The solution is meant to avoid any change the API of the component.

I propose this change to fix the issues described in #280 (briefly: "fix focus-trap bug when the interactive opens a modal", and the "scrolling caused by focus returning to the previously active element"). It also addresses the WCAG 2.1 success criterion [2.1.2 No Keyboard Trap](https://www.w3.org/TR/WCAG21/#no-keyboard-trap) (Level A) by allowing the users to exit the disclosed content using the default keyboard shortcut (tab).

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![disclosure-focus-before](https://user-images.githubusercontent.com/788096/168081360-26c78968-aa97-4c52-b6d7-97bc07b529ec.gif)

</td><td>

![disclosure-focus-after](https://user-images.githubusercontent.com/788096/168081408-cd8ab2ae-80a1-4760-bb0b-0dc5c7dc620b.gif)

</td></tr></table>

Note: the colors went way off on the above compressed gifs 😱 

### :link: External links

[Review of focus management in Disclosure (+ Dropdown/Breadcrumb) components](https://github.com/hashicorp/design-system/issues/280)
Fixes https://github.com/hashicorp/design-system/issues/267 and https://github.com/hashicorp/cloud-ui/pull/2362#issuecomment-1097778784

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202253786016960