### PR TITLE
"Alert" and "Toast" components - Convert "Title" and "Description" to be yielded contextual components

### DIFF
--- a/.changeset/violet-masks-sparkle.md
+++ b/.changeset/violet-masks-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+added "description" as contextual component to the "Alert" and "Toast" components

--- a/.changeset/violet-masks-sparkle.md
+++ b/.changeset/violet-masks-sparkle.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-added "description" as contextual component to the "Alert" and "Toast" components
+"Alert" and "Toast" components - converted "title" and "description" arguments to be contextual components

--- a/packages/components/addon/components/hds/alert/description.hbs
+++ b/packages/components/addon/components/hds/alert/description.hbs
@@ -1,0 +1,1 @@
+<div class="hds-alert__description">{{yield}}</div>

--- a/packages/components/addon/components/hds/alert/description.hbs
+++ b/packages/components/addon/components/hds/alert/description.hbs
@@ -1,1 +1,1 @@
-<div class="hds-alert__description">{{yield}}</div>
+<div class="hds-alert__description" ...attributes>{{yield}}</div>

--- a/packages/components/addon/components/hds/alert/index.hbs
+++ b/packages/components/addon/components/hds/alert/index.hbs
@@ -13,6 +13,7 @@
       {{#if @description}}
         <div class="hds-alert__description">{{html-safe @description}}</div>
       {{/if}}
+      {{yield (hash Description=(component "hds/alert/description"))}}
     </div>
 
     <div class="hds-alert__actions">

--- a/packages/components/addon/components/hds/alert/index.hbs
+++ b/packages/components/addon/components/hds/alert/index.hbs
@@ -7,12 +7,7 @@
 
   <div class="hds-alert__content">
     <div class="hds-alert__text">
-      {{#if @title}}
-        <div class="hds-alert__title">{{@title}}</div>
-      {{/if}}
-      {{#if @description}}
-        <div class="hds-alert__description">{{html-safe @description}}</div>
-      {{/if}}
+      {{yield (hash Title=(component "hds/alert/title"))}}
       {{yield (hash Description=(component "hds/alert/description"))}}
     </div>
 

--- a/packages/components/addon/components/hds/alert/title.hbs
+++ b/packages/components/addon/components/hds/alert/title.hbs
@@ -1,0 +1,1 @@
+<div class="hds-alert__title" ...attributes>{{yield}}</div>

--- a/packages/components/addon/components/hds/toast/index.hbs
+++ b/packages/components/addon/components/hds/toast/index.hbs
@@ -10,6 +10,12 @@
   as |A|
 >
   {{yield
-    (hash Button=A.Button Link::Standalone=A.Link::Standalone LinkTo::Standalone=A.LinkTo::Standalone Generic=A.Generic)
+    (hash
+      Description=A.Description
+      Button=A.Button
+      Link::Standalone=A.Link::Standalone
+      LinkTo::Standalone=A.LinkTo::Standalone
+      Generic=A.Generic
+    )
   }}
 </Hds::Alert>

--- a/packages/components/addon/components/hds/toast/index.hbs
+++ b/packages/components/addon/components/hds/toast/index.hbs
@@ -3,14 +3,13 @@
   @type="inline"
   @color={{@color}}
   @icon={{@icon}}
-  @title={{@title}}
-  @description={{@description}}
   @onDismiss={{@onDismiss}}
   ...attributes
   as |A|
 >
   {{yield
     (hash
+      Title=A.Title
       Description=A.Description
       Button=A.Button
       Link::Standalone=A.Link::Standalone

--- a/packages/components/app/components/hds/alert/description.js
+++ b/packages/components/app/components/hds/alert/description.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/alert/description';

--- a/packages/components/app/components/hds/alert/title.js
+++ b/packages/components/app/components/hds/alert/title.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/alert/title';

--- a/packages/components/app/styles/components/alert.scss
+++ b/packages/components/app/styles/components/alert.scss
@@ -74,13 +74,12 @@
     border-radius: 5px;
     display: inline;
     font-family: var(--token-typography-code-100-font-family);
-    // font-size: var(--token-typography-code-100-font-size);
-    font-size: 0.9em; // TODO discuss with CVeight
+    font-size: 0.9em; // as discussed with designers, we reduce the size for optical/visual balance
     line-height: 1em;
     padding: 1px 5px;
   }
 
-  // Notice: in the future this may become a "Link::Inline" component (for now we declare the exact same styles directly here)
+  // Notice: in the future this may become a "Link::Inline" component (for now we declare directly the same styles here)
   a {
     color: var(--token-color-foreground-action);
 

--- a/packages/components/app/styles/components/alert.scss
+++ b/packages/components/app/styles/components/alert.scss
@@ -70,7 +70,7 @@
 
   code, pre {
     background-color: var(--token-color-surface-primary);
-    border: 1px solid var(--token-color-palette-neutral-300);
+    border: 1px solid var(--token-color-palette-neutral-200);
     border-radius: 5px;
     display: inline;
     font-family: var(--token-typography-code-100-font-family);

--- a/packages/components/app/styles/components/alert.scss
+++ b/packages/components/app/styles/components/alert.scss
@@ -69,14 +69,28 @@
   }
 
   code, pre {
-    font-family: var(--token-typography-font-stack-code);
+    background-color: var(--token-color-surface-primary);
+    border: 1px solid var(--token-color-palette-neutral-300);
+    border-radius: 5px;
+    display: inline;
+    font-family: var(--token-typography-code-100-font-family);
+    // font-size: var(--token-typography-code-100-font-size);
+    font-size: 0.9em; // TODO discuss with CVeight
+    line-height: 1em;
+    padding: 1px 5px;
   }
 
-  // Notice: in the future this may become a "Link::Inline" component (for now we declare the styles directly here)
+  // Notice: in the future this may become a "Link::Inline" component (for now we declare the exact same styles directly here)
   a {
     color: var(--token-color-foreground-action);
-    // At the moment the "focus" state is not well defined in design (the one that is in Figma does not work) so we just apply a simple color to the default outline
-    outline-color: var(--token-color-focus-action-external);
+
+    &:focus,
+    &.is-focus,
+    &:focus-visible {
+      outline: 2px solid var(--token-color-focus-action-internal);
+      outline-offset: 1px;
+      text-decoration: none;
+    }
 
     &:hover {
       color: var(--token-color-foreground-action-hover);

--- a/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
@@ -19,11 +19,12 @@
     }
 
     dd {
+        border-left: 1px solid #ccc;
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
         margin: 0;
-        padding: 0;
+        padding: 0 0 0 1rem;
 
         p {
             margin: 0;

--- a/packages/components/tests/dummy/app/styles/pages/db-alert.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-alert.scss
@@ -10,6 +10,12 @@
         grid-column: 1 / 4;
     }
 
+    .dummy-alert-sample-grid__column {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
     &.dummy-alert-sample-grid--wide-content {
         grid-template-columns: repeat(2, 1fr);
     }

--- a/packages/components/tests/dummy/app/styles/pages/db-toast.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-toast.scss
@@ -1,33 +1,39 @@
 // TOAST
 
 .dummy-toast-base-sample {
-    display: flex;
-    gap: 16px;
-    align-items: center;
-    flex-wrap: wrap;
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .dummy-toast-sample-grid {
-    align-items: start;
-    display: grid;
-    grid-gap: 1rem;
-    grid-template-columns: repeat(4, 1fr);
+  align-items: start;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: repeat(4, 1fr);
 
-    &.dummy-toast-sample-grid--wide-content {
-        grid-template-columns: repeat(2, 1fr);
-    }
+  .dummy-toast-sample-grid__column {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &.dummy-toast-sample-grid--wide-content {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .dummy-toast-sample-custom-actions__actions {
-    display: flex;
-    gap: 16px;
-    align-items: center;
+  display: flex;
+  gap: 16px;
+  align-items: center;
 }
 
 .dummy-toast-sample-custom-actions__text {
-    @include dummyFontFamily();
-    @include dummyFontSize(0.8rem);
-    display: block;
-    color: #999;
-    margin-top: 1rem;
+  @include dummyFontFamily();
+  @include dummyFontSize(0.8rem);
+  display: block;
+  color: #999;
+  margin-top: 1rem;
 }

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -537,7 +537,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert @type="inline" @color="success" @title="Title here" as |A|>
+  <Hds::Alert @type="inline" @color="success" as |A|>
     <A.Title>Title here</A.Title>
     <A.Description>First line of description.</A.Description>
     <A.Description>Second line of description.</A.Description>
@@ -568,7 +568,9 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert @type="inline" @title="Title here" @description="Description here" as |A|>
+  <Hds::Alert @type="inline" as |A|>
+    <A.Title>Title here</A.Title>
+    <A.Description>Description here</A.Description>
     <A.Generic>
       [your content here]
     </A.Generic>

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -12,7 +12,7 @@
     are not required to receive focus, it should not be required that the user close the alert.</p>
   <p class="dummy-paragraph">For messages that are the result of a user's actions see the
     <LinkTo @route="components.toast">Toast</LinkTo>
-    component.)
+    component.
   </p>
 
   <p class="dummy-paragraph">
@@ -148,8 +148,8 @@
   </dl>
 
   <h4 class="dummy-h4">Contextual components</h4>
-  <p class="dummy-paragraph" id="contextual-components-alert">Title, description, actions and generic content are passed into
-    the alert as yielded components, using the
+  <p class="dummy-paragraph" id="contextual-components-alert">Title, description, actions and generic content are passed
+    into the alert as yielded components, using the
     <code class="dummy-code">Title</code>,
     <code class="dummy-code">Description</code>,
     <code class="dummy-code">Button</code>,
@@ -255,11 +255,12 @@
   <h4 class="dummy-h4">Basic use</h4>
   <p class="dummy-paragraph">
     The most basic invocation requires the
-    <code class="dummy-code">type</code>,
+    <code class="dummy-code">type</code>
+    argument to be passed, along with the
     <code class="dummy-code">title</code>
     and/or
-    <code class="dummy-code">text</code>
-    arguments to be passed. By default a
+    <code class="dummy-code">description</code>
+    content. By default a
     <code class="dummy-code">neutral</code>
     alert is generated (with a neutral color applied and a specific icon visible).
   </p>

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -135,27 +135,12 @@
         <code class="dummy-code">false</code>
         for no icon.</p>
     </dd>
-
-    <dt>title <code>string</code></dt>
-    <dd>
-      <p>The title text in the alert.</p>
-    </dd>
-
-    <dt>description <code>string</code></dt>
-    <dd>
-      <p>The description text in the alert.</p>
-      <p><em>Notice: this is intended for simple textual descriptions; if you need to put logic, rich HTML or structured
-          content inside the description, you can use the
-          <code class="dummy-code">A.Description</code>
-          contextual component (see below).</em></p>
-    </dd>
     <dt>onDismiss <code>function</code></dt>
     <dd>
       <p>
         The alert can be dismissed by the user. When a function is passed, the "dismiss" button is displayed.
       </p>
     </dd>
-
     <dt>...attributes</dt>
     <dd>
       <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
@@ -163,14 +148,24 @@
   </dl>
 
   <h4 class="dummy-h4">Contextual components</h4>
-  <p class="dummy-paragraph" id="contextual-components-alert">Actions and generic content can optionally be passed into
+  <p class="dummy-paragraph" id="contextual-components-alert">Title, description, actions and generic content are passed into
     the alert as yielded components, using the
+    <code class="dummy-code">Title</code>,
+    <code class="dummy-code">Description</code>,
     <code class="dummy-code">Button</code>,
     <code class="dummy-code">Link::Standalone</code>,
     <code class="dummy-code">LinkTo::Standalone</code>,
     <code class="dummy-code">Generic</code>
     keys.</p>
   <dl class="dummy-component-props" aria-labelledby="contextual-components-alert">
+    <dt>&lt;[A].Title&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the
+        <code class="dummy-code">"title"</code>
+        block (the content inherits its style). It accepts
+        <code class="dummy-code">...attributes</code>
+        spreading.</p>
+    </dd>
     <dt>&lt;[A].Description&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the
@@ -186,10 +181,6 @@
           <code class="dummy-code">a</code>,
           <code class="dummy-code">code/pre</code>) we apply styling. If you use other elements you will need to take
           care of styling them accordingly.</em></p>
-      <p>🚨
-        <em><strong>Important</strong>: this is not intended to be a generic container for any possible type of content,
-          but a way to allow Ember logic inside the "description" block (and to retrofit existing alert elements in the
-          product codebase).</em></p>
     </dd>
     <dt>&lt;[A].Button&gt; <code>yielded component</code></dt>
     <dd>
@@ -276,37 +267,50 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert @type="inline" @title="Title here" @description="Description here" />
+      <Hds::Alert @type="inline" as |A|>
+        <A.Title>Title here</A.Title>
+        <A.Description>Description here</A.Description>
+      </Hds::Alert>
     '
   />
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert @type="inline" @title="Title here" @description="Description here" />
+  <Hds::Alert @type="inline" as |A|>
+    <A.Title>Title here</A.Title>
+    <A.Description>Description here</A.Description>
+  </Hds::Alert>
   <p class="dummy-paragraph">
     If needed, you can pass only
     <code class="dummy-code">title</code>
     or only
-    <code class="dummy-code">text</code>
-    as argument.
+    <code class="dummy-code">text</code>.
   </p>
   {{! prettier-ignore-start }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert @type="inline" @title="Title here" />
+      <Hds::Alert @type="inline" as |A|>
+        <A.Title>Title here</A.Title>
+      </Hds::Alert>
     '
   />
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert @type="inline" @description="Description here" />
+      <Hds::Alert @type="inline" as |A|>
+        <A.Title>Title here</A.Title>
+      </Hds::Alert>
     '
   />
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert @type="inline" @title="Title here" />
+  <Hds::Alert @type="inline" as |A|>
+    <A.Title>Title here</A.Title>
+  </Hds::Alert>
   <br />
-  <Hds::Alert @type="inline" @description="Description here" />
+  <Hds::Alert @type="inline" as |A|>
+    <A.Description>Description here</A.Description>
+  </Hds::Alert>
 
   <h4 class="dummy-h4">Type</h4>
   <p class="dummy-paragraph">
@@ -318,12 +322,18 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert @type="page" @title="Title here" @description="Description here" />
+      <Hds::Alert @type="page" as |A|>
+        <A.Title>Title here</A.Title>
+        <A.Description>Description here</A.Description>
+      </Hds::Alert>
     '
   />
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert @type="page" @title="Title here" @description="Description here" />
+  <Hds::Alert @type="page" as |A|>
+    <A.Title>Title here</A.Title>
+    <A.Description>Description here</A.Description>
+  </Hds::Alert>
 
   <h4 class="dummy-h4">Color</h4>
   <p class="dummy-paragraph">
@@ -335,12 +345,18 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert @type="inline" @color="success" @title="Title here" @description="Description here" />
+      <Hds::Alert @type="inline" @color="success" as |A|>
+        <A.Title>Title here</A.Title>
+        <A.Description>Description here</A.Description>
+      </Hds::Alert>
     '
   />
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert @type="inline" @color="success" @title="Title here" @description="Description here" />
+  <Hds::Alert @type="inline" @color="success" as |A|>
+    <A.Title>Title here</A.Title>
+    <A.Description>Description here</A.Description>
+  </Hds::Alert>
 
   <h4 class="dummy-h4">Icon</h4>
   <p class="dummy-paragraph">
@@ -352,12 +368,18 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert @type="inline" @color="success" @icon="bulb" @title="Title here" @description="Description here" />
+      <Hds::Alert @type="inline" @color="success" @icon="bulb" as |A|>
+        <A.Title>Title here</A.Title>
+        <A.Description>Description here</A.Description>
+      </Hds::Alert>
     '
   />
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert @type="inline" @color="success" @icon="bulb" @title="Title here" @description="Description here" />
+  <Hds::Alert @type="inline" @color="success" @icon="bulb" as |A|>
+    <A.Title>Title here</A.Title>
+    <A.Description>Description here</A.Description>
+  </Hds::Alert>
   <p class="dummy-paragraph">
     If instead you want to completely hide the icon you have to pass a
     <code class="dummy-code">false</code>
@@ -370,13 +392,19 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert @type="inline" @color="success" @icon=\{{false}} @title="Title here" @description="Description here" />
+      <Hds::Alert @type="inline" @color="success" @icon=\{{false}} as |A|>
+        <A.Title>Title here</A.Title>
+        <A.Description>Description here</A.Description>
+      </Hds::Alert>
     '
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert @type="inline" @color="success" @icon={{false}} @title="Title here" @description="Description here" />
+  <Hds::Alert @type="inline" @color="success" @icon={{false}} as |A|>
+    <A.Title>Title here</A.Title>
+    <A.Description>Description here</A.Description>
+  </Hds::Alert>
 
   <h4 class="dummy-h4">Dismiss</h4>
   <p class="dummy-paragraph">
@@ -396,38 +424,64 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert
-        @type="inline"
-        @color="warning"
-        @title="Title here"
-        @description="Description here"
-        @onDismiss=\{{ your function here }}
-      />
+      <Hds::Alert @type="inline" @color="warning" @onDismiss=\{{ your function here }} as |A|>
+        <A.Title>Title here</A.Title>
+        <A.Description>Description here</A.Description>
+      </Hds::Alert>
     '
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert
-    @type="inline"
-    @color="warning"
-    @title="Title here"
-    @description="Description here"
-    @onDismiss={{this.noop}}
-  />
+  <Hds::Alert @type="inline" @color="warning" @onDismiss={{this.noop}} as |A|>
+    <A.Title>Title here</A.Title>
+    <A.Description>Description here</A.Description>
+  </Hds::Alert>
 
-  <h4 class="dummy-h4" id="how-to-use-description">Description with structured content</h4>
-  <p class="dummy-paragraph">If the "description" block needs to contain logic, rich HTML or structured content it's
-    necessary to use the
+  <h4 class="dummy-h4" id="how-to-use-actions">Actions</h4>
+  <p class="dummy-paragraph">Actions can optionally be passed to component using one of the suggested
+    <code class="dummy-code">Button</code>,
+    <code class="dummy-code">Link::Standalone</code>
+    or
+    <code class="dummy-code">LinkTo::Standalone</code>
+    contextual components.</p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Alert @type="inline" as |A|>
+        <A.Title>Title here</A.Title>
+        <A.Description>Description here</A.Description>
+        <A.Button @text="Your action" @color="secondary" @onClick=\{{ your function here }} />
+        <A.LinkTo::Standalone @color="secondary" @icon="plus" @text="Another action" @route="..." @color="secondary" />
+        <A.Link::Standalone @icon="arrow-right" @iconPosition="leading" @text="Another action" href="#" />
+      </Hds::Alert>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Alert @type="inline" as |A|>
+    <A.Title>Title here</A.Title>
+    <A.Description>Description here</A.Description>
+    <A.Button @text="Your action" @color="secondary" />
+    <A.LinkTo::Standalone @color="secondary" @icon="plus" @text="Another action" @route="index" />
+    <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @text="Another action" href="#" />
+  </Hds::Alert>
+
+  <h4 class="dummy-h4" id="how-to-use-description">Structured content</h4>
+  <p class="dummy-paragraph">When needed the
     <code class="dummy-code">Description</code>
-    contextual component.
+    contextual component can contain logic, rich HTML or structured content.
   </p>
   {{! prettier-ignore-start }}
   {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert @type="inline" @color="success" @title="Title here" as |A|>
+      <Hds::Alert @type="inline" @color="success" as |A|>
+        <A.Title>Title here</A.Title>
         <A.Description>
           The description can contain
           \{{#if true}}conditional logic\{{/if}}, Ember components, and HTML tags, like
@@ -444,7 +498,8 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert @type="inline" @color="success" @title="Title here" as |A|>
+  <Hds::Alert @type="inline" @color="success" as |A|>
+    <A.Title>Title here</A.Title>
     <A.Description>
       The description can contain
       {{#if true}}conditional logic{{/if}}, Ember components, and HTML tags, like
@@ -472,7 +527,8 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert @type="inline" @color="success" @title="Title here" as |A|>
+      <Hds::Alert @type="inline" @color="success" as |A|>
+        <A.Title>Title here</A.Title>
         <A.Description>First line of description.</A.Description>
         <A.Description>Second line of description.</A.Description>
       </Hds::Alert>
@@ -482,36 +538,9 @@
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Alert @type="inline" @color="success" @title="Title here" as |A|>
+    <A.Title>Title here</A.Title>
     <A.Description>First line of description.</A.Description>
     <A.Description>Second line of description.</A.Description>
-  </Hds::Alert>
-
-  <h4 class="dummy-h4" id="how-to-use-actions">Actions</h4>
-  <p class="dummy-paragraph">Actions can optionally be passed to component using one of the suggested
-    <code class="dummy-code">Button</code>,
-    <code class="dummy-code">Link::Standalone</code>
-    or
-    <code class="dummy-code">LinkTo::Standalone</code>
-    contextual components.</p>
-  {{! prettier-ignore-start }}
-  {{! template-lint-disable no-unbalanced-curlies }}
-  <CodeBlock
-    @language="markup"
-    @code='
-      <Hds::Alert @type="inline" @title="Title here" @description="Description here" as |A|>
-        <A.Button @text="Your action" @color="secondary" @onClick=\{{ your function here }} />
-        <A.LinkTo::Standalone @color="secondary" @icon="plus" @text="Another action" @route="..." @color="secondary" />
-        <A.Link::Standalone @icon="arrow-right" @iconPosition="leading" @text="Another action" href="#" />
-      </Hds::Alert>
-    '
-  />
-  {{! template-lint-enable no-unbalanced-curlies }}
-  {{! prettier-ignore-end }}
-  <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Alert @type="inline" @title="Title here" @description="Description here" as |A|>
-    <A.Button @text="Your action" @color="secondary" />
-    <A.LinkTo::Standalone @color="secondary" @icon="plus" @text="Another action" @route="index" />
-    <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @text="Another action" href="#" />
   </Hds::Alert>
 
   <h4 class="dummy-h4" id="how-to-use-generic">Generic content</h4>
@@ -527,7 +556,9 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Alert @type="inline" @title="Title here" @description="Description here" as |A|>
+      <Hds::Alert @type="inline" as |A|>
+        <A.Title>Title here</A.Title>
+        <A.Description>Description here</A.Description>
         <A.Generic>
           [your content here]
         </A.Generic>
@@ -677,7 +708,10 @@
     <p class="dummy-paragraph">{{capitalize type}}</p>
     <br />
     <div class="dummy-alert-sample-item--type-{{type}}">
-      <Hds::Alert @type={{type}} @title={{capitalize type}} @description="Lorem ipsum dolor sit amet." />
+      <Hds::Alert @type={{type}} as |A|>
+        <A.Title>{{capitalize type}}</A.Title>
+        <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+      </Hds::Alert>
     </div>
   {{/each}}
 
@@ -687,12 +721,10 @@
       <p class="dummy-paragraph dummy-alert-sample-grid__title">{{capitalize color}}</p>
       {{#each @model.TYPES as |type|}}
         <div class="dummy-alert-sample-item--type-{{type}}">
-          <Hds::Alert
-            @type={{type}}
-            @color={{color}}
-            @title="{{capitalize type}} title"
-            @description="This is the <em>{{type}}</em> alert with <em>{{color}}</em> color."
-          />
+          <Hds::Alert @type={{type}} @color={{color}} as |A|>
+            <A.Title>{{capitalize type}} title</A.Title>
+            <A.Description>This is the <em>{{type}}</em> alert with <em>{{color}}</em> color.</A.Description>
+          </Hds::Alert>
         </div>
       {{/each}}
     {{/each}}
@@ -700,45 +732,46 @@
 
   <h4 class="dummy-h4">Icon</h4>
   <div class="dummy-alert-sample-grid">
-    <Hds::Alert @type="inline" @color="highlight" @title="Default icon" @description="Lorem ipsum dolor sit amet." />
-    <Hds::Alert
-      @type="inline"
-      @color="highlight"
-      @icon="meh"
-      @title="With icon override"
-      @description="Lorem ipsum dolor sit amet."
-    />
-    <Hds::Alert
-      @type="inline"
-      @color="highlight"
-      @icon="running"
-      @title="With animated icon"
-      @description="Lorem ipsum dolor sit amet."
-    />
-    <Hds::Alert
-      @type="inline"
-      @color="highlight"
-      @icon=""
-      @title="Without icon"
-      @description="Lorem ipsum dolor sit amet."
-    />
+    <Hds::Alert @type="inline" @color="highlight" as |A|>
+      <A.Title>Default icon</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    </Hds::Alert>
+    <Hds::Alert @type="inline" @color="highlight" @icon="meh" as |A|>
+      <A.Title>With icon override</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    </Hds::Alert>
+    <Hds::Alert @type="inline" @color="highlight" @icon="running" as |A|>
+      <A.Title>With animated icon</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    </Hds::Alert>
+    <Hds::Alert @type="inline" @color="highlight" @icon="" as |A|>
+      <A.Title>Without icon</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    </Hds::Alert>
   </div>
 
   <h4 class="dummy-h4">Content</h4>
   <div class="dummy-alert-sample-grid dummy-alert-sample-grid--wide-content">
     <div class="dummy-alert-sample-grid__column">
-      <Hds::Alert @type="inline" @color="success" @title="A simple title" @description="A simple description text" />
-      <Hds::Alert @type="inline" @color="success" @title="An alert with just a title and no description text." />
-      <Hds::Alert @type="inline" @color="success" @description="An alert with no title and just a description text" />
-      <Hds::Alert
-        @type="inline"
-        @color="success"
-        @title="An alert with a very long title and a long description text that should go on multiple lines"
-        @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla."
-      />
+      <Hds::Alert @type="inline" @color="success" as |A|>
+        <A.Title>A simple title</A.Title>
+        <A.Description>A simple description text</A.Description>
+      </Hds::Alert>
+      <Hds::Alert @type="inline" @color="success" as |A|>
+        <A.Title>An alert with just a title and no description text.</A.Title>
+      </Hds::Alert>
+      <Hds::Alert @type="inline" @color="success" as |A|>
+        <A.Description>An alert with no title and just a description text</A.Description>
+      </Hds::Alert>
+      <Hds::Alert @type="inline" @color="success" as |A|>
+        <A.Title>An alert with a very long title and a long description text that should go on multiple lines</A.Title>
+        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna
+          eget, porttitor lobortis nulla.</A.Description>
+      </Hds::Alert>
     </div>
     <div class="dummy-alert-sample-grid__column">
-      <Hds::Alert @type="inline" @color="success" @title="An alert with a rich description (HTML)" as |A|>
+      <Hds::Alert @type="inline" @color="success" as |A|>
+        <A.Title>An alert with a rich description (HTML)</A.Title>
         <A.Description>Using the
           <code>A.Description</code>
           contextual component it's possible to have content that contains HTML tags, like
@@ -751,12 +784,8 @@
           and
           <a href="#">inline links</a>.</A.Description>
       </Hds::Alert>
-      <Hds::Alert
-        @type="inline"
-        @color="success"
-        @title="Multiple lines of description using more than one 'description' contextual component"
-        as |A|
-      >
+      <Hds::Alert @type="inline" @color="success" as |A|>
+        <A.Title>Multiple lines of description using more than one 'description' contextual component</A.Title>
         <A.Description>This is the first line of description, yielded to a
           <code>A.Description</code>
           contextual component.</A.Description>
@@ -764,13 +793,11 @@
           <code>A.Description</code>
           contextual component.</A.Description>
       </Hds::Alert>
-      <Hds::Alert
-        @type="inline"
-        @color="success"
-        @title="An alert with extra/custom content"
-        @description="In special cases, you can pass extra content to the alert using the <code>A.Generic</code> contextual component."
-        as |A|
-      >
+      <Hds::Alert @type="inline" @color="success" as |A|>
+        <A.Title>An alert with extra/custom content</A.Title>
+        <A.Description>In special cases, you can pass extra content to the alert using the
+          <code>A.Generic</code>
+          contextual component.</A.Description>
         <A.Generic>
           <DummyPlaceholder @text="some generic content" @height="50" @background="#eee" />
         </A.Generic>
@@ -780,33 +807,22 @@
 
   <h4 class="dummy-h4">Actions</h4>
   <div class="dummy-alert-sample-grid dummy-alert-sample-grid--wide-content">
-    <Hds::Alert
-      @type="inline"
-      @color="warning"
-      @title="Action passed as yielded component"
-      @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      as |A|
-    >
+    <Hds::Alert @type="inline" @color="warning" as |A|>
+      <A.Title>Action passed as yielded component</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
       <A.Button @text="Action" @color="secondary" />
     </Hds::Alert>
-    <Hds::Alert
-      @type="inline"
-      @color="warning"
-      @title="With multiple actions passed as yielded components"
-      @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      as |A|
-    >
+    <Hds::Alert @type="inline" @color="warning" as |A|>
+      <A.Title>With multiple actions passed as yielded components</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
       <A.Button @text="Secondary" @color="secondary" />
       <A.Button @icon="plus" @text="Tertiary" @color="tertiary" />
       <A.Link::Standalone @icon="plus" @text="Standalone" href="#" @color="secondary" />
     </Hds::Alert>
-    <Hds::Alert
-      @type="inline"
-      @color="warning"
-      @title="With actions and custom content"
-      @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-      as |A|
-    >
+    <Hds::Alert @type="inline" @color="warning" as |A|>
+      <A.Title>With actions and custom content</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+        et dolore magna aliqua.</A.Description>
       <A.Button @text="Action" @color="secondary" />
       <A.Link::Standalone @icon="plus" @text="Action" href="#" @color="secondary" />
       <A.Generic>
@@ -818,34 +834,27 @@
 
   <h4 class="dummy-h4">Dismiss</h4>
   <div class="dummy-alert-sample-grid dummy-alert-sample-grid--wide-content">
+    <Hds::Alert @type="inline" @color="neutral" as |A|>
+      <A.Title>Without the dismiss button (default)</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
+    </Hds::Alert>
     <Hds::Alert
       @type="inline"
       @color="neutral"
-      @title="Without the dismiss button (default)"
-      @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-    />
-    <Hds::Alert
-      @type="inline"
-      @color="neutral"
-      @title="With the dismiss button"
-      @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       {{! TODO: understand if we can use a generic helper - see https://hashicorp.slack.com/archives/C11JCBJTW/p1648751235987409 }}
       @onDismiss={{this.noop}}
-    />
-    <Hds::Alert
-      @type="inline"
-      @color="neutral"
-      @icon=""
-      @title="With the dismiss button and no icon"
-      @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @onDismiss={{this.noop}}
-    />
-    <Hds::Alert
-      @type="inline"
-      @color="neutral"
-      @description="With the dismiss button and no title"
-      @onDismiss={{this.noop}}
-    />
+      as |A|
+    >
+      <A.Title>With the dismiss button</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
+    </Hds::Alert>
+    <Hds::Alert @type="inline" @color="neutral" @icon="" @onDismiss={{this.noop}} as |A|>
+      <A.Title>With the dismiss button and no icon</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
+    </Hds::Alert>
+    <Hds::Alert @type="inline" @color="neutral" @onDismiss={{this.noop}} as |A|>
+      <A.Description>With the dismiss button and no title</A.Description>
+    </Hds::Alert>
   </div>
 
 </section>

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -433,7 +433,7 @@
           \{{#if true}}conditional logic\{{/if}}, Ember components, and HTML tags, like
           <strong>strong text</strong>,
           <em>emphasized text</em>,
-          <code>HTML</code>,
+          <code>code</code>,
           <pre>pre</pre>,
           <a href="#">inline</a>
           <LinkTo @route="index">links</LinkTo>.
@@ -450,7 +450,7 @@
       {{#if true}}conditional logic{{/if}}, Ember components, and HTML tags, like
       <strong>strong text</strong>,
       <em>emphasized text</em>,
-      <code>HTML</code>,
+      <code>code</code>,
       <pre>pre</pre>,
       <a href="#">inline</a>
       <LinkTo @route="index">links</LinkTo>.

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -144,6 +144,10 @@
     <dt>description <code>string</code></dt>
     <dd>
       <p>The description text in the alert.</p>
+      <p><em>Notice: this is intended for simple textual descriptions; if you need to put logic, rich HTML or structured
+          content inside the description, you can use the
+          <code class="dummy-code">A.Description</code>
+          contextual component (see below).</em></p>
     </dd>
     <dt>onDismiss <code>function</code></dt>
     <dd>
@@ -167,6 +171,26 @@
     <code class="dummy-code">Generic</code>
     keys.</p>
   <dl class="dummy-component-props" aria-labelledby="contextual-components-alert">
+    <dt>&lt;[A].Description&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the
+        <code class="dummy-code">"description"</code>
+        block (the content inherits its style). It accepts
+        <code class="dummy-code">...attributes</code>
+        spreading.</p>
+      <p>It can be used to pass content more complex than a simple string (eg. logic/conditionals, HTML elements, other
+        Ember components, etc.) inside the "description" block.</p>
+      <p><em>Notice: for a few simple HTML elements (like
+          <code class="dummy-code">strong</code>,
+          <code class="dummy-code">em</code>,
+          <code class="dummy-code">a</code>,
+          <code class="dummy-code">code/pre</code>) we apply styling. If you use other elements you will need to take
+          care of styling them accordingly.</em></p>
+      <p>🚨
+        <em><strong>Important</strong>: this is not intended to be a generic container for any possible type of content,
+          but a way to allow Ember logic inside the "description" block (and to retrofit existing alert elements in the
+          product codebase).</em></p>
+    </dd>
     <dt>&lt;[A].Button&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a yielded
@@ -226,6 +250,7 @@
 
   <p class="dummy-paragraph">
     For more details about how to invoke these contextual components see the sections
+    <a href="#how-to-use-description">"How to use > Description"</a>,
     <a href="#how-to-use-actions">"How to use > Actions"</a>
     and
     <a href="#how-to-use-generic">"How to use > Generic content"</a>
@@ -390,6 +415,76 @@
     @description="Description here"
     @onDismiss={{this.noop}}
   />
+
+  <h4 class="dummy-h4" id="how-to-use-description">Description with structured content</h4>
+  <p class="dummy-paragraph">If the "description" block needs to contain logic, rich HTML or structured content it's
+    necessary to use the
+    <code class="dummy-code">Description</code>
+    contextual component.
+  </p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Alert @type="inline" @color="success" @title="Title here" as |A|>
+        <A.Description>
+          The description can contain
+          \{{#if true}}conditional logic\{{/if}}, Ember components, and HTML tags, like
+          <strong>strong text</strong>,
+          <em>emphasized text</em>,
+          <code>HTML</code>,
+          <pre>pre</pre>,
+          <a href="#">inline</a>
+          <LinkTo @route="index">links</LinkTo>.
+        </A.Description>
+      </Hds::Alert>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Alert @type="inline" @color="success" @title="Title here" as |A|>
+    <A.Description>
+      The description can contain
+      {{#if true}}conditional logic{{/if}}, Ember components, and HTML tags, like
+      <strong>strong text</strong>,
+      <em>emphasized text</em>,
+      <code>HTML</code>,
+      <pre>pre</pre>,
+      <a href="#">inline</a>
+      <LinkTo @route="index">links</LinkTo>.
+    </A.Description>
+  </Hds::Alert>
+  <p class="dummy-paragraph"><em>Notice: for a few simple HTML elements (like
+      <code class="dummy-code">strong</code>,
+      <code class="dummy-code">em</code>,
+      <code class="dummy-code">a</code>,
+      <code class="dummy-code">code/pre</code>) we apply styling. If you use other elements you will need to take care
+      of styling them accordingly.</em>
+  </p>
+  <p class="dummy-paragraph">You can pass more than one
+    <code class="dummy-code">D.Description</code>
+    contextual components to have multiple description lines.
+  </p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Alert @type="inline" @color="success" @title="Title here" as |A|>
+        <A.Description>First line of description.</A.Description>
+        <A.Description>Second line of description.</A.Description>
+      </Hds::Alert>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Alert @type="inline" @color="success" @title="Title here" as |A|>
+    <A.Description>First line of description.</A.Description>
+    <A.Description>Second line of description.</A.Description>
+  </Hds::Alert>
 
   <h4 class="dummy-h4" id="how-to-use-actions">Actions</h4>
   <p class="dummy-paragraph">Actions can optionally be passed to component using one of the suggested
@@ -631,32 +726,56 @@
 
   <h4 class="dummy-h4">Content</h4>
   <div class="dummy-alert-sample-grid dummy-alert-sample-grid--wide-content">
-    <Hds::Alert @type="inline" @color="success" @title="A simple title" @description="A simple description text" />
-    <Hds::Alert
-      @type="inline"
-      @color="success"
-      @title="An alert with a very long title and a long description text that should go on multiple lines"
-      @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla."
-    />
-    <Hds::Alert @type="inline" @color="success" @title="An alert with just a title and no description text." />
-    <Hds::Alert @type="inline" @color="success" @description="An alert with no title and just a description text" />
-    <Hds::Alert
-      @type="inline"
-      @color="success"
-      @title="An alert with rich text description (HTML)"
-      @description="The description text can support HTML tags embedded in the string value, like <strong>strong</strong> and <em>em</em> as well as <code>code</code> and <a href='#'>links</a>."
-    />
-    <Hds::Alert
-      @type="inline"
-      @color="success"
-      @title="An alert with extra/custom content"
-      @description="In special cases, you can pass extra content to the alert using the <code>Generic</code> contextual component."
-      as |A|
-    >
-      <A.Generic>
-        <DummyPlaceholder @text="some generic content" @height="50" @background="#eee" />
-      </A.Generic>
-    </Hds::Alert>
+    <div class="dummy-alert-sample-grid__column">
+      <Hds::Alert @type="inline" @color="success" @title="A simple title" @description="A simple description text" />
+      <Hds::Alert @type="inline" @color="success" @title="An alert with just a title and no description text." />
+      <Hds::Alert @type="inline" @color="success" @description="An alert with no title and just a description text" />
+      <Hds::Alert
+        @type="inline"
+        @color="success"
+        @title="An alert with a very long title and a long description text that should go on multiple lines"
+        @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla."
+      />
+    </div>
+    <div class="dummy-alert-sample-grid__column">
+      <Hds::Alert @type="inline" @color="success" @title="An alert with a rich description (HTML)" as |A|>
+        <A.Description>Using the
+          <code>A.Description</code>
+          contextual component it's possible to have content that contains HTML tags, like
+          <strong>strong text</strong>
+          and
+          <em>emphasized text</em>
+          as well as
+          <code>code</code>,
+          <pre>pre</pre>
+          and
+          <a href="#">inline links</a>.</A.Description>
+      </Hds::Alert>
+      <Hds::Alert
+        @type="inline"
+        @color="success"
+        @title="Multiple lines of description using more than one 'description' contextual component"
+        as |A|
+      >
+        <A.Description>This is the first line of description, yielded to a
+          <code>A.Description</code>
+          contextual component.</A.Description>
+        <A.Description>And this is the second line of description, yielded to another
+          <code>A.Description</code>
+          contextual component.</A.Description>
+      </Hds::Alert>
+      <Hds::Alert
+        @type="inline"
+        @color="success"
+        @title="An alert with extra/custom content"
+        @description="In special cases, you can pass extra content to the alert using the <code>A.Generic</code> contextual component."
+        as |A|
+      >
+        <A.Generic>
+          <DummyPlaceholder @text="some generic content" @height="50" @background="#eee" />
+        </A.Generic>
+      </Hds::Alert>
+    </div>
   </div>
 
   <h4 class="dummy-h4">Actions</h4>

--- a/packages/components/tests/dummy/app/templates/components/toast.hbs
+++ b/packages/components/tests/dummy/app/templates/components/toast.hbs
@@ -201,7 +201,7 @@
           \{{#if true}}conditional logic\{{/if}}, Ember components, and HTML tags, like
           <strong>strong text</strong>,
           <em>emphasized text</em>,
-          <code>HTML</code>,
+          <code>code</code>,
           <pre>pre</pre>,
           <a href="#">inline</a>
           <LinkTo @route="index">links</LinkTo>.
@@ -218,7 +218,7 @@
       {{#if true}}conditional logic{{/if}}, Ember components, and HTML tags, like
       <strong>strong text</strong>,
       <em>emphasized text</em>,
-      <code>HTML</code>,
+      <code>code</code>,
       <pre>pre</pre>,
       <a href="#">inline</a>
       <LinkTo @route="index">links</LinkTo>.

--- a/packages/components/tests/dummy/app/templates/components/toast.hbs
+++ b/packages/components/tests/dummy/app/templates/components/toast.hbs
@@ -436,70 +436,55 @@
   <h4 class="dummy-h4">Color</h4>
   <div class="dummy-toast-base-sample">
     {{#each @model.COLORS as |color|}}
-      <Hds::Toast
-        @color={{color}}
-        @title={{capitalize color}}
-        @description="This is the toast with <em>{{color}}</em> color."
-        @onDismiss={{this.noop}}
-      />
+      <Hds::Toast @color={{color}} @onDismiss={{this.noop}} as |A|>
+        <A.Title>{{capitalize color}}</A.Title>
+        <A.Description>This is the toast with <em>{{color}}</em> color.</A.Description>
+      </Hds::Toast>
     {{/each}}
   </div>
 
   <h4 class="dummy-h4">Icon</h4>
   <div class="dummy-toast-base-sample">
-    <Hds::Toast
-      @color="highlight"
-      @title="Default icon"
-      @description="Lorem ipsum dolor sit amet."
-      @onDismiss={{this.noop}}
-    />
-    <Hds::Toast
-      @color="highlight"
-      @icon="meh"
-      @title="With icon override"
-      @description="Lorem ipsum dolor sit amet."
-      @onDismiss={{this.noop}}
-    />
-    <Hds::Toast
-      @color="highlight"
-      @icon="running"
-      @title="With animated icon"
-      @description="Lorem ipsum dolor sit amet."
-      @onDismiss={{this.noop}}
-    />
-    <Hds::Toast
-      @color="highlight"
-      @icon=""
-      @title="Without icon"
-      @description="Lorem ipsum dolor sit amet."
-      @onDismiss={{this.noop}}
-    />
+    <Hds::Toast @color="highlight" @onDismiss={{this.noop}} as |A|>
+      <A.Title>Default icon</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    </Hds::Toast>
+    <Hds::Toast @color="highlight" @icon="meh" @onDismiss={{this.noop}} as |A|>
+      <A.Title>With icon override</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    </Hds::Toast>
+    <Hds::Toast @color="highlight" @icon="running" @onDismiss={{this.noop}} as |A|>
+      <A.Title>With animated icon</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    </Hds::Toast>
+    <Hds::Toast @color="highlight" @icon="" @onDismiss={{this.noop}} as |A|>
+      <A.Title>Without icon</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    </Hds::Toast>
   </div>
 
   <h4 class="dummy-h4">Content</h4>
   <div class="dummy-toast-sample-grid dummy-toast-sample-grid--wide-content">
     <div class="dummy-toast-sample-grid__column">
-      <Hds::Toast
-        @color="success"
-        @title="A simple title"
-        @description="A simple description text"
-        @onDismiss={{this.noop}}
-      />
-      <Hds::Toast @color="success" @title="A toast with a title and no description text." @onDismiss={{this.noop}} />
-      <Hds::Toast
-        @color="success"
-        @description="A toast with no title and just a description text"
-        @onDismiss={{this.noop}}
-      />
-      <Hds::Toast
-        @color="success"
-        @title="A toast with a very long title and a long description text that should go on multiple lines"
-        @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla."
-        @onDismiss={{this.noop}}
-      />
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
+        <A.Title>A simple title</A.Title>
+        <A.Description>A simple description text</A.Description>
+      </Hds::Toast>
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
+        <A.Title>A toast with a title and no description text.</A.Title>
+      </Hds::Toast>
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
+        <A.Description>A toast with no title and just a description text</A.Description>
+      </Hds::Toast>
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
+        <A.Title>A toast with a very long title and a long description text that should go on multiple lines</A.Title>
+        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna
+          eget, porttitor lobortis nulla.</A.Description>
+      </Hds::Toast>
     </div>
     <div class="dummy-toast-sample-grid__column">
-      <Hds::Toast @color="success" @title="A toast with a rich description (HTML)" @onDismiss={{this.noop}} as |A|>
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
+        <A.Title>A toast with a rich description (HTML)</A.Title>
         <A.Description>Using the
           <code>A.Description</code>
           contextual component it's possible to have content that contains HTML tags, like
@@ -512,12 +497,8 @@
           and
           <a href="#">inline links</a>.</A.Description>
       </Hds::Toast>
-      <Hds::Toast
-        @onDismiss={{this.noop}}
-        @color="success"
-        @title="Multiple lines of description using more than one 'description' contextual component"
-        as |A|
-      >
+      <Hds::Toast @onDismiss={{this.noop}} @color="success" as |A|>
+        <A.Title>Multiple lines of description using more than one 'description' contextual component</A.Title>
         <A.Description>This is the first line of description, yielded to a
           <code>A.Description</code>
           contextual component.</A.Description>
@@ -525,13 +506,11 @@
           <code>A.Description</code>
           contextual component.</A.Description>
       </Hds::Toast>
-      <Hds::Toast
-        @color="success"
-        @title="A toast with extra/custom content"
-        @description="In special cases, you can pass extra content to the toast using the <code>A.Generic</code> contextual component."
-        @onDismiss={{this.noop}}
-        as |A|
-      >
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
+        <A.Title>A toast with extra/custom content</A.Title>
+        <A.Description>In special cases, you can pass extra content to the toast using the
+          <code>A.Generic</code>
+          contextual component.</A.Description>
         <A.Generic>
           <DummyPlaceholder @text="some generic content" @height="50" @background="#eee" />
         </A.Generic>
@@ -541,22 +520,14 @@
 
   <h4 class="dummy-h4">Actions</h4>
   <div class="dummy-toast-sample-grid dummy-toast-sample-grid--wide-content">
-    <Hds::Toast
-      @color="warning"
-      @title="Action passed as yielded component"
-      @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @onDismiss={{this.noop}}
-      as |A|
-    >
+    <Hds::Toast @color="warning" @onDismiss={{this.noop}} as |A|>
+      <A.Title>Action passed as yielded component</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
       <A.Button @text="Action" @color="secondary" />
     </Hds::Toast>
-    <Hds::Toast
-      @color="warning"
-      @title="With multiple actions passed as yielded components"
-      @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @onDismiss={{this.noop}}
-      as |A|
-    >
+    <Hds::Toast @color="warning" @onDismiss={{this.noop}} as |A|>
+      <A.Title>With multiple actions passed as yielded components</A.Title>
+      <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
       <A.Button @text="Secondary" @color="secondary" />
       <A.Button @icon="plus" @text="Tertiary" @color="tertiary" />
       <A.Link::Standalone @icon="plus" @text="Standalone" href="#" @color="secondary" />

--- a/packages/components/tests/dummy/app/templates/components/toast.hbs
+++ b/packages/components/tests/dummy/app/templates/components/toast.hbs
@@ -7,10 +7,12 @@
 
   <p class="dummy-paragraph">
     A Toast is an element intended for
-    <strong>messages that are the result of a user's actions</strong>
-    (for system-generated messages see the
+    <strong>messages that are the result of a user's actions</strong>.
+  </p>
+  <p class="dummy-paragraph">
+    For system-generated messages see the
     <LinkTo @route="components.alert">Alert</LinkTo>
-    component.).
+    component.
   </p>
 
   <p class="dummy-paragraph">Typically it displays a brief, temporary notification and it disappears on its own (after a
@@ -58,13 +60,14 @@
   <h4 class="dummy-h4">Basic use</h4>
   <p class="dummy-paragraph">
     The most basic invocation requires the
-    <code class="dummy-code">type</code>,
-    <code class="dummy-code">title</code>
-    and/or
-    <code class="dummy-code">text</code>
+    <code class="dummy-code">type</code>
     arguments to be passed, and an
     <code class="dummy-code">onDismiss</code>
-    callback function. By default a
+    callback function, along with the
+    <code class="dummy-code">title</code>
+    and/or
+    <code class="dummy-code">description</code>
+    content. By default a
     <code class="dummy-code">neutral</code>
     toast is generated (with a neutral color applied and a specific icon visible).
   </p>
@@ -72,14 +75,21 @@
   {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
-    @code='
-      <Hds::Toast @title="Title here" @description="Description here" @onDismiss=\{{ your function here }} />
-    '
+    @code="
+      <Hds::Toast @onDismiss=\{{ your function here }} as |T|>
+        <T.Title>Title here</T.Title>
+        <T.Description>Description here</T.Description>
+      </Hds::Toast>
+    "
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast @title="Title here" @description="Description here" @onDismiss={{this.noop}} />
+  <Hds::Toast @onDismiss={{this.noop}} as |T|>
+    <T.Title>Title here</T.Title>
+    <T.Description>Description here</T.Description>
+  </Hds::Toast>
+
   <p class="dummy-paragraph">
     🚨
     <em><strong>Important</strong>: the actual implementation of what happens to the alert when the
@@ -98,22 +108,30 @@
   {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
-    @code='
-      <Hds::Toast @title="Title here" @onDismiss=\{{...}} />
-    '
+    @code="
+      <Hds::Toast @onDismiss=\{{...}} as |T|>
+        <T.Title>Title here</T.Title>
+      </Hds::Toast>
+    "
   />
   <CodeBlock
     @language="markup"
-    @code='
-      <Hds::Toast @description="Description here" @onDismiss=\{{...}} />
-    '
+    @code="
+      <Hds::Toast @onDismiss=\{{...}} as |T|>
+        <T.Description>Description here</T.Description>
+      </Hds::Toast>
+    "
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast @title="Title here" @onDismiss={{this.noop}} />
+  <Hds::Toast @onDismiss={{this.noop}} as |T|>
+    <T.Title>Title here</T.Title>
+  </Hds::Toast>
   <br />
-  <Hds::Toast @description="Description here" @onDismiss={{this.noop}} />
+  <Hds::Toast @onDismiss={{this.noop}} as |T|>
+    <T.Description>Description here</T.Description>
+  </Hds::Toast>
 
   <h4 class="dummy-h4">Color</h4>
   <p class="dummy-paragraph">
@@ -126,13 +144,19 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Toast @color="success" @title="Title here" @description="Description here" @onDismiss=\{{...}} />
+      <Hds::Toast @color="success" @onDismiss=\{{...}} as |T|>
+        <T.Title>Title here</T.Title>
+        <T.Description>Description here</T.Description>
+      </Hds::Toast>
     '
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast @color="success" @title="Title here" @description="Description here" @onDismiss={{this.noop}} />
+  <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
+    <T.Title>Title here</T.Title>
+    <T.Description>Description here</T.Description>
+  </Hds::Toast>
 
   <h4 class="dummy-h4">Icon</h4>
   <p class="dummy-paragraph">
@@ -145,19 +169,20 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Toast @color="success" @icon="bulb" @title="Title here" @description="Description here" @onDismiss=\{{...}} />
+      <Hds::Toast @color="success" @icon="bulb" @onDismiss=\{{...}} as |T|>
+        <T.Title>Title here</T.Title>
+        <T.Description>Description here</T.Description>
+      </Hds::Toast>
+
     '
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast
-    @color="success"
-    @icon="bulb"
-    @title="Title here"
-    @description="Description here"
-    @onDismiss={{this.noop}}
-  />
+  <Hds::Toast @color="success" @icon="bulb" @onDismiss={{this.noop}} as |T|>
+    <T.Title>Title here</T.Title>
+    <T.Description>Description here</T.Description>
+  </Hds::Toast>
   <p class="dummy-paragraph">
     If instead you want to completely hide the icon you have to pass a
     <code class="dummy-code">false</code>
@@ -170,33 +195,63 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Toast @color="success" @icon=\{{false}} @title="Title here" @description="Description here" @onDismiss=\{{...}} />
+      <Hds::Toast @color="success" @icon=\{{false}} @onDismiss=\{{...}} as |T|>
+        <T.Title>Title here</T.Title>
+        <T.Description>Description here</T.Description>
+      </Hds::Toast>
     '
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast
-    @color="success"
-    @icon={{false}}
-    @title="Title here"
-    @description="Description here"
-    @onDismiss={{this.noop}}
-  />
+  <Hds::Toast @color="success" @icon={{false}} @onDismiss={{this.noop}} as |T|>
+    <T.Title>Title here</T.Title>
+    <T.Description>Description here</T.Description>
+  </Hds::Toast>
 
-  <h4 class="dummy-h4" id="how-to-use-description">Description with structured content</h4>
-  <p class="dummy-paragraph">If the "description" block needs to contain logic, rich HTML or structured content it's
-    necessary to use the
+  <h4 class="dummy-h4">Actions</h4>
+  <p class="dummy-paragraph">Actions can optionally be passed into the component using one of the suggested
+    <code class="dummy-code">Button</code>,
+    <code class="dummy-code">Link::Standalone</code>
+    or
+    <code class="dummy-code">LinkTo::Standalone</code>
+    yielded components.</p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Toast @color="critical" @onDismiss=\{{...}} as |T|>
+        <T.Title>Title here</T.Title>
+        <T.Description>Description here</T.Description>
+        <T.Button @text="Your action" @color="secondary" @onClick=\{{ your function here }} />
+        <T.LinkTo::Standalone @color="secondary" @icon="plus" @text="Another action" @route="..." @color="secondary" />
+      </Hds::Toast>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Toast @color="critical" @onDismiss={{this.noop}} as |T|>
+    <T.Title>Title here</T.Title>
+    <T.Description>Description here</T.Description>
+    <T.Button @text="Your action" @color="secondary" />
+    <T.LinkTo::Standalone @color="secondary" @icon="plus" @text="Another action" @route="index" />
+  </Hds::Toast>
+
+  <h4 class="dummy-h4" id="how-to-use-description">Structured content</h4>
+  <p class="dummy-paragraph">When needed the
     <code class="dummy-code">Description</code>
-    contextual component.
+    contextual component can contain logic, rich HTML or structured content.
   </p>
   {{! prettier-ignore-start }}
   {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Toast @color="success" @title="Title here" onDismiss=\{{...}} as |A|>
-        <A.Description>
+      <Hds::Toast @color="success" onDismiss=\{{...}} as |T|>
+        <T.Title>Title here</T.Title>
+        <T.Description>
           The description can contain
           \{{#if true}}conditional logic\{{/if}}, Ember components, and HTML tags, like
           <strong>strong text</strong>,
@@ -205,15 +260,16 @@
           <pre>pre</pre>,
           <a href="#">inline</a>
           <LinkTo @route="index">links</LinkTo>.
-        </A.Description>
+        </T.Description>
       </Hds::Toast>
     '
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast @color="success" @title="Title here" onDismiss={{this.noop}} as |A|>
-    <A.Description>
+  <Hds::Toast @color="success" onDismiss={{this.noop}} as |T|>
+    <T.Title>Title here</T.Title>
+    <T.Description>
       The description can contain
       {{#if true}}conditional logic{{/if}}, Ember components, and HTML tags, like
       <strong>strong text</strong>,
@@ -222,7 +278,7 @@
       <pre>pre</pre>,
       <a href="#">inline</a>
       <LinkTo @route="index">links</LinkTo>.
-    </A.Description>
+    </T.Description>
   </Hds::Toast>
   <p class="dummy-paragraph"><em>Notice: for a few simple HTML elements (like
       <code class="dummy-code">strong</code>,
@@ -240,44 +296,20 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Toast @color="success" @title="Title here" onDismiss=\{{...}} as |A|>
-        <A.Description>First line of description.</A.Description>
-        <A.Description>Second line of description.</A.Description>
+      <Hds::Toast @color="success" onDismiss=\{{...}} as |T|>
+        <T.Title>Title here</T.Title>
+        <T.Description>First line of description.</T.Description>
+        <T.Description>Second line of description.</T.Description>
       </Hds::Toast>
     '
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast @color="success" @title="Title here" onDismiss={{this.noop}} as |A|>
-    <A.Description>First line of description.</A.Description>
-    <A.Description>Second line of description.</A.Description>
-  </Hds::Toast>
-
-  <h4 class="dummy-h4">Actions</h4>
-  <p class="dummy-paragraph">Actions can optionally be passed into the component using one of the suggested
-    <code class="dummy-code">Button</code>,
-    <code class="dummy-code">Link::Standalone</code>
-    or
-    <code class="dummy-code">LinkTo::Standalone</code>
-    yielded components.</p>
-  {{! prettier-ignore-start }}
-  {{! template-lint-disable no-unbalanced-curlies }}
-  <CodeBlock
-    @language="markup"
-    @code='
-      <Hds::Toast @color="critical" @title="Title here" @description="Description here" @onDismiss=\{{...}} as |A|>
-        <A.Button @text="Your action" @color="secondary" @onClick=\{{ your function here }} />
-        <A.LinkTo::Standalone @color="secondary" @icon="plus" @text="Another action" @route="..." @color="secondary" />
-      </Hds::Toast>
-    '
-  />
-  {{! template-lint-enable no-unbalanced-curlies }}
-  {{! prettier-ignore-end }}
-  <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast @color="critical" @title="Title here" @description="Description here" @onDismiss={{this.noop}} as |A|>
-    <A.Button @text="Your action" @color="secondary" />
-    <A.LinkTo::Standalone @color="secondary" @icon="plus" @text="Another action" @route="index" />
+  <Hds::Toast @color="success" onDismiss={{this.noop}} as |T|>
+    <T.Title>Title here</T.Title>
+    <T.Description>First line of description.</T.Description>
+    <T.Description>Second line of description.</T.Description>
   </Hds::Toast>
 
   <h4 class="dummy-h4">Generic content</h4>
@@ -292,21 +324,25 @@
   {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
-    @code='
-      <Hds::Toast @title="Title here" @description="Description here" @onDismiss=\{{...}} as |A|>
-        <A.Generic>
+    @code="
+      <Hds::Toast @onDismiss=\{{...}} as |T|>
+        <T.Title>Title here</T.Title>
+        <T.Description>Description here</T.Description>
+        <T.Generic>
           [your content here]
-        </A.generic>
+        </T.generic>
       </Hds::Toast>
-    '
+    "
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast @title="Title here" @description="Description here" @onDismiss={{this.noop}} as |A|>
-    <A.Generic>
+  <Hds::Toast @onDismiss={{this.noop}} as |T|>
+    <T.Title>Title here</T.Title>
+    <T.Description>Description here</T.Description>
+    <T.Generic>
       [your content here]
-    </A.Generic>
+    </T.Generic>
   </Hds::Toast>
   <p class="dummy-paragraph">🚨
     <em><strong>Important</strong>: this method should be used only in special cases and as an escape hatch. If you find
@@ -436,56 +472,56 @@
   <h4 class="dummy-h4">Color</h4>
   <div class="dummy-toast-base-sample">
     {{#each @model.COLORS as |color|}}
-      <Hds::Toast @color={{color}} @onDismiss={{this.noop}} as |A|>
-        <A.Title>{{capitalize color}}</A.Title>
-        <A.Description>This is the toast with <em>{{color}}</em> color.</A.Description>
+      <Hds::Toast @color={{color}} @onDismiss={{this.noop}} as |T|>
+        <T.Title>{{capitalize color}}</T.Title>
+        <T.Description>This is the toast with <em>{{color}}</em> color.</T.Description>
       </Hds::Toast>
     {{/each}}
   </div>
 
   <h4 class="dummy-h4">Icon</h4>
   <div class="dummy-toast-base-sample">
-    <Hds::Toast @color="highlight" @onDismiss={{this.noop}} as |A|>
-      <A.Title>Default icon</A.Title>
-      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    <Hds::Toast @color="highlight" @onDismiss={{this.noop}} as |T|>
+      <T.Title>Default icon</T.Title>
+      <T.Description>Lorem ipsum dolor sit amet.</T.Description>
     </Hds::Toast>
-    <Hds::Toast @color="highlight" @icon="meh" @onDismiss={{this.noop}} as |A|>
-      <A.Title>With icon override</A.Title>
-      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    <Hds::Toast @color="highlight" @icon="meh" @onDismiss={{this.noop}} as |T|>
+      <T.Title>With icon override</T.Title>
+      <T.Description>Lorem ipsum dolor sit amet.</T.Description>
     </Hds::Toast>
-    <Hds::Toast @color="highlight" @icon="running" @onDismiss={{this.noop}} as |A|>
-      <A.Title>With animated icon</A.Title>
-      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    <Hds::Toast @color="highlight" @icon="running" @onDismiss={{this.noop}} as |T|>
+      <T.Title>With animated icon</T.Title>
+      <T.Description>Lorem ipsum dolor sit amet.</T.Description>
     </Hds::Toast>
-    <Hds::Toast @color="highlight" @icon="" @onDismiss={{this.noop}} as |A|>
-      <A.Title>Without icon</A.Title>
-      <A.Description>Lorem ipsum dolor sit amet.</A.Description>
+    <Hds::Toast @color="highlight" @icon="" @onDismiss={{this.noop}} as |T|>
+      <T.Title>Without icon</T.Title>
+      <T.Description>Lorem ipsum dolor sit amet.</T.Description>
     </Hds::Toast>
   </div>
 
   <h4 class="dummy-h4">Content</h4>
   <div class="dummy-toast-sample-grid dummy-toast-sample-grid--wide-content">
     <div class="dummy-toast-sample-grid__column">
-      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
-        <A.Title>A simple title</A.Title>
-        <A.Description>A simple description text</A.Description>
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
+        <T.Title>A simple title</T.Title>
+        <T.Description>A simple description text</T.Description>
       </Hds::Toast>
-      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
-        <A.Title>A toast with a title and no description text.</A.Title>
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
+        <T.Title>A toast with a title and no description text.</T.Title>
       </Hds::Toast>
-      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
-        <A.Description>A toast with no title and just a description text</A.Description>
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
+        <T.Description>A toast with no title and just a description text</T.Description>
       </Hds::Toast>
-      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
-        <A.Title>A toast with a very long title and a long description text that should go on multiple lines</A.Title>
-        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna
-          eget, porttitor lobortis nulla.</A.Description>
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
+        <T.Title>A toast with a very long title and a long description text that should go on multiple lines</T.Title>
+        <T.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna
+          eget, porttitor lobortis nulla.</T.Description>
       </Hds::Toast>
     </div>
     <div class="dummy-toast-sample-grid__column">
-      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
-        <A.Title>A toast with a rich description (HTML)</A.Title>
-        <A.Description>Using the
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
+        <T.Title>A toast with a rich description (HTML)</T.Title>
+        <T.Description>Using the
           <code>A.Description</code>
           contextual component it's possible to have content that contains HTML tags, like
           <strong>strong text</strong>
@@ -495,42 +531,42 @@
           <code>code</code>,
           <pre>pre</pre>
           and
-          <a href="#">inline links</a>.</A.Description>
+          <a href="#">inline links</a>.</T.Description>
       </Hds::Toast>
-      <Hds::Toast @onDismiss={{this.noop}} @color="success" as |A|>
-        <A.Title>Multiple lines of description using more than one 'description' contextual component</A.Title>
-        <A.Description>This is the first line of description, yielded to a
+      <Hds::Toast @onDismiss={{this.noop}} @color="success" as |T|>
+        <T.Title>Multiple lines of description using more than one 'description' contextual component</T.Title>
+        <T.Description>This is the first line of description, yielded to a
           <code>A.Description</code>
-          contextual component.</A.Description>
-        <A.Description>And this is the second line of description, yielded to another
+          contextual component.</T.Description>
+        <T.Description>And this is the second line of description, yielded to another
           <code>A.Description</code>
-          contextual component.</A.Description>
+          contextual component.</T.Description>
       </Hds::Toast>
-      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |A|>
-        <A.Title>A toast with extra/custom content</A.Title>
-        <A.Description>In special cases, you can pass extra content to the toast using the
+      <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
+        <T.Title>A toast with extra/custom content</T.Title>
+        <T.Description>In special cases, you can pass extra content to the toast using the
           <code>A.Generic</code>
-          contextual component.</A.Description>
-        <A.Generic>
+          contextual component.</T.Description>
+        <T.Generic>
           <DummyPlaceholder @text="some generic content" @height="50" @background="#eee" />
-        </A.Generic>
+        </T.Generic>
       </Hds::Toast>
     </div>
   </div>
 
   <h4 class="dummy-h4">Actions</h4>
   <div class="dummy-toast-sample-grid dummy-toast-sample-grid--wide-content">
-    <Hds::Toast @color="warning" @onDismiss={{this.noop}} as |A|>
-      <A.Title>Action passed as yielded component</A.Title>
-      <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
-      <A.Button @text="Action" @color="secondary" />
+    <Hds::Toast @color="warning" @onDismiss={{this.noop}} as |T|>
+      <T.Title>Action passed as yielded component</T.Title>
+      <T.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</T.Description>
+      <T.Button @text="Action" @color="secondary" />
     </Hds::Toast>
-    <Hds::Toast @color="warning" @onDismiss={{this.noop}} as |A|>
-      <A.Title>With multiple actions passed as yielded components</A.Title>
-      <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
-      <A.Button @text="Secondary" @color="secondary" />
-      <A.Button @icon="plus" @text="Tertiary" @color="tertiary" />
-      <A.Link::Standalone @icon="plus" @text="Standalone" href="#" @color="secondary" />
+    <Hds::Toast @color="warning" @onDismiss={{this.noop}} as |T|>
+      <T.Title>With multiple actions passed as yielded components</T.Title>
+      <T.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</T.Description>
+      <T.Button @text="Secondary" @color="secondary" />
+      <T.Button @icon="plus" @text="Tertiary" @color="tertiary" />
+      <T.Link::Standalone @icon="plus" @text="Standalone" href="#" @color="secondary" />
     </Hds::Toast>
   </div>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/toast.hbs
+++ b/packages/components/tests/dummy/app/templates/components/toast.hbs
@@ -184,6 +184,76 @@
     @onDismiss={{this.noop}}
   />
 
+  <h4 class="dummy-h4" id="how-to-use-description">Description with structured content</h4>
+  <p class="dummy-paragraph">If the "description" block needs to contain logic, rich HTML or structured content it's
+    necessary to use the
+    <code class="dummy-code">Description</code>
+    contextual component.
+  </p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Toast @color="success" @title="Title here" onDismiss=\{{...}} as |A|>
+        <A.Description>
+          The description can contain
+          \{{#if true}}conditional logic\{{/if}}, Ember components, and HTML tags, like
+          <strong>strong text</strong>,
+          <em>emphasized text</em>,
+          <code>HTML</code>,
+          <pre>pre</pre>,
+          <a href="#">inline</a>
+          <LinkTo @route="index">links</LinkTo>.
+        </A.Description>
+      </Hds::Toast>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Toast @color="success" @title="Title here" onDismiss={{this.noop}} as |A|>
+    <A.Description>
+      The description can contain
+      {{#if true}}conditional logic{{/if}}, Ember components, and HTML tags, like
+      <strong>strong text</strong>,
+      <em>emphasized text</em>,
+      <code>HTML</code>,
+      <pre>pre</pre>,
+      <a href="#">inline</a>
+      <LinkTo @route="index">links</LinkTo>.
+    </A.Description>
+  </Hds::Toast>
+  <p class="dummy-paragraph"><em>Notice: for a few simple HTML elements (like
+      <code class="dummy-code">strong</code>,
+      <code class="dummy-code">em</code>,
+      <code class="dummy-code">a</code>,
+      <code class="dummy-code">code/pre</code>) we apply styling. If you use other elements you will need to take care
+      of styling them accordingly.</em>
+  </p>
+  <p class="dummy-paragraph">You can pass more than one
+    <code class="dummy-code">D.Description</code>
+    contextual components to have multiple description lines.
+  </p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Toast @color="success" @title="Title here" onDismiss=\{{...}} as |A|>
+        <A.Description>First line of description.</A.Description>
+        <A.Description>Second line of description.</A.Description>
+      </Hds::Toast>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Toast @color="success" @title="Title here" onDismiss={{this.noop}} as |A|>
+    <A.Description>First line of description.</A.Description>
+    <A.Description>Second line of description.</A.Description>
+  </Hds::Toast>
+
   <h4 class="dummy-h4">Actions</h4>
   <p class="dummy-paragraph">Actions can optionally be passed into the component using one of the suggested
     <code class="dummy-code">Button</code>,
@@ -408,41 +478,65 @@
 
   <h4 class="dummy-h4">Content</h4>
   <div class="dummy-toast-sample-grid dummy-toast-sample-grid--wide-content">
-    <Hds::Toast
-      @color="success"
-      @title="A simple title"
-      @description="A simple description text"
-      @onDismiss={{this.noop}}
-    />
-    <Hds::Toast
-      @color="success"
-      @title="A toast with a very long title and a long description text that should go on multiple lines"
-      @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla."
-      @onDismiss={{this.noop}}
-    />
-    <Hds::Toast @color="success" @title="A toast with a title and no description text." @onDismiss={{this.noop}} />
-    <Hds::Toast
-      @color="success"
-      @description="A toast with no title and just a description text"
-      @onDismiss={{this.noop}}
-    />
-    <Hds::Toast
-      @color="success"
-      @title="A toast with rich text description (HTML)"
-      @description="The description text can support HTML tags embedded in the string value, like <strong>strong</strong> and <em>em</em> as well as <code>code</code> and <a href='#'>links</a>."
-      @onDismiss={{this.noop}}
-    />
-    <Hds::Toast
-      @color="success"
-      @title="A toast with extra/custom content"
-      @description="In special cases, you can pass extra content to the toast using the <code>Generic</code> contextual component."
-      @onDismiss={{this.noop}}
-      as |A|
-    >
-      <A.Generic>
-        <DummyPlaceholder @text="some generic content" @height="50" @background="#eee" />
-      </A.Generic>
-    </Hds::Toast>
+    <div class="dummy-toast-sample-grid__column">
+      <Hds::Toast
+        @color="success"
+        @title="A simple title"
+        @description="A simple description text"
+        @onDismiss={{this.noop}}
+      />
+      <Hds::Toast @color="success" @title="A toast with a title and no description text." @onDismiss={{this.noop}} />
+      <Hds::Toast
+        @color="success"
+        @description="A toast with no title and just a description text"
+        @onDismiss={{this.noop}}
+      />
+      <Hds::Toast
+        @color="success"
+        @title="A toast with a very long title and a long description text that should go on multiple lines"
+        @description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla."
+        @onDismiss={{this.noop}}
+      />
+    </div>
+    <div class="dummy-toast-sample-grid__column">
+      <Hds::Toast @color="success" @title="A toast with a rich description (HTML)" @onDismiss={{this.noop}} as |A|>
+        <A.Description>Using the
+          <code>A.Description</code>
+          contextual component it's possible to have content that contains HTML tags, like
+          <strong>strong text</strong>
+          and
+          <em>emphasized text</em>
+          as well as
+          <code>code</code>,
+          <pre>pre</pre>
+          and
+          <a href="#">inline links</a>.</A.Description>
+      </Hds::Toast>
+      <Hds::Toast
+        @onDismiss={{this.noop}}
+        @color="success"
+        @title="Multiple lines of description using more than one 'description' contextual component"
+        as |A|
+      >
+        <A.Description>This is the first line of description, yielded to a
+          <code>A.Description</code>
+          contextual component.</A.Description>
+        <A.Description>And this is the second line of description, yielded to another
+          <code>A.Description</code>
+          contextual component.</A.Description>
+      </Hds::Toast>
+      <Hds::Toast
+        @color="success"
+        @title="A toast with extra/custom content"
+        @description="In special cases, you can pass extra content to the toast using the <code>A.Generic</code> contextual component."
+        @onDismiss={{this.noop}}
+        as |A|
+      >
+        <A.Generic>
+          <DummyPlaceholder @text="some generic content" @height="50" @background="#eee" />
+        </A.Generic>
+      </Hds::Toast>
+    </div>
   </div>
 
   <h4 class="dummy-h4">Actions</h4>

--- a/packages/components/tests/integration/components/hds/alert/index-test.js
+++ b/packages/components/tests/integration/components/hds/alert/index-test.js
@@ -11,23 +11,19 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   });
 
   test('it renders the alert container', async function (assert) {
-    await render(hbs`<Hds::Alert @type="inline" @title="I'm a cool alert!" />`);
+    await render(hbs`<Hds::Alert @type="inline" />`);
     assert.dom(this.element).exists();
   });
   test('it should render with a CSS class that matches the component name', async function (assert) {
-    await render(
-      hbs`<Hds::Alert @type="inline" @title="I'm a cool alert!" id="test-alert" />`
-    );
+    await render(hbs`<Hds::Alert @type="inline" id="test-alert" />`);
     assert.dom('#test-alert').hasClass('hds-alert');
   });
 
   // TYPE
 
-  test('it should render the correct CSS type class if @type prop is declared', async function (assert) {
-    await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" id="test-alert" />`
-    );
-    assert.dom('#test-alert').hasClass('hds-alert--type-inline');
+  test('it should render the correct CSS type class depending on the @type prop', async function (assert) {
+    await render(hbs`<Hds::Alert @type="page" id="test-alert" />`);
+    assert.dom('#test-alert').hasClass('hds-alert--type-page');
   });
 
   // ICON
@@ -35,73 +31,51 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   test('it should render an icon by default depending on the type and color', async function (assert) {
     // here we don't test all the possible combinations, only some of them as precaution
     assert.expect(6);
-    await render(hbs`<Hds::Alert @type="inline" @description="yo" />`);
+    await render(hbs`<Hds::Alert @type="inline" />`);
     assert.dom('.flight-icon-info').exists();
-    await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" @type="compact" />`
-    );
+    await render(hbs`<Hds::Alert @type="compact" />`);
     assert.dom('.flight-icon-info-fill').exists();
-    await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" @color="highlight" />`
-    );
+    await render(hbs`<Hds::Alert @type="inline" @color="highlight" />`);
     assert.dom('.flight-icon-info').exists();
-    await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" @color="success" />`
-    );
+    await render(hbs`<Hds::Alert @type="inline" @color="success" />`);
     assert.dom('.flight-icon-check-circle').exists();
-    await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" @color="warning" />`
-    );
+    await render(hbs`<Hds::Alert @type="inline" @color="warning" />`);
     assert.dom('.flight-icon-alert-triangle').exists();
-    await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" @color="critical" />`
-    );
+    await render(hbs`<Hds::Alert @type="inline" @color="critical" />`);
     assert.dom('.flight-icon-alert-diamond').exists();
   });
 
   test('if an icon is declared, the icon should render in the component and override the default one', async function (assert) {
     assert.expect(2);
-    await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" @icon="clipboard-copy" />`
-    );
+    await render(hbs`<Hds::Alert @type="inline" @icon="clipboard-copy" />`);
     assert.dom('.flight-icon-clipboard-copy').exists();
-    await render(
-      hbs`<Hds::Alert @description="yo" @type="compact" @icon="clipboard-copy" />`
-    );
+    await render(hbs`<Hds::Alert @type="compact" @icon="clipboard-copy" />`);
     assert.dom('.flight-icon-clipboard-copy').exists();
   });
 
   test('it should display no icon when @icon is set to false', async function (assert) {
-    await render(
-      hbs`<Hds::Alert @type="inline" @title="yo" @icon={{false}} />`
-    );
+    await render(hbs`<Hds::Alert @type="inline" @icon={{false}} />`);
     assert.dom('.flight-icon').doesNotExist();
   });
 
   // TEXT (TITLE + DESCRIPTION)
 
-  test('it should render the title when the @title argument is provided', async function (assert) {
-    await render(hbs`<Hds::Alert @type="inline" @title="This is the title" />`);
+  test('it should render the title when the "title" contextual component is provided', async function (assert) {
+    await render(
+      hbs`<Hds::Alert @type="inline" as |A|><A.Title>This is the title</A.Title></Hds::Alert>`
+    );
     assert.dom(this.element).hasText('This is the title');
   });
-  test('it should render the description when the @description argument is provided', async function (assert) {
+  test('it should render the description when the "description" contextual component is provided', async function (assert) {
     await render(
-      hbs`<Hds::Alert @type="inline" @description="This is the description" />`
+      hbs`<Hds::Alert @type="inline" as |A|><A.Description>This is the description</A.Description></Hds::Alert>`
     );
     assert.dom(this.element).hasText('This is the description');
   });
-  test('it should render both the title and the description when both the @title and @description arguments are provided', async function (assert) {
-    assert.expect(2);
-    await render(
-      hbs`<Hds::Alert @type="inline" @title="This is the title" @description="This is the description" />`
-    );
-    assert.dom('.hds-alert__title').hasText('This is the title');
-    assert.dom('.hds-alert__description').hasText('This is the description');
-  });
-  test('it should render rich HTML when the @description argument contains HTML tags', async function (assert) {
+  test('it should render rich HTML when the "description" contextual component contains HTML tags', async function (assert) {
     assert.expect(8);
     await render(
-      hbs`<Hds::Alert @type="inline" @description="Hello <strong>strong</strong> and <em>em</em> and <code>code</code> and <a href='#'>link</a>" />`
+      hbs`<Hds::Alert @type="inline" as |A|><A.Description>Hello <strong>strong</strong> and <em>em</em> and <code>code</code> and <a href='#'>link</a></A.Description></Hds::Alert>`
     );
     assert.dom('.hds-alert__description strong').exists().hasText('strong');
     assert.dom('.hds-alert__description em').exists().hasText('em');
@@ -114,7 +88,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   test('it should render an Hds::Button component yielded to the "actions" container', async function (assert) {
     assert.expect(5);
     await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" id="test-alert" as |A|><A.Button @text="I am a button" @size="small" @color="secondary" /></Hds::Alert>`
+      hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Button @text="I am a button" @size="small" @color="secondary" /></Hds::Alert>`
     );
     assert
       .dom('#test-alert .hds-alert__actions button')
@@ -127,7 +101,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   test('it should render an Hds::Link::Standalone component yielded to the "actions" container', async function (assert) {
     assert.expect(5);
     await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" id="test-alert" as |A|><A.Link::Standalone @icon="plus" @text="I am a link" href="#" @size="small" @color="secondary" /></Hds::Alert>`
+      hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Link::Standalone @icon="plus" @text="I am a link" href="#" @size="small" @color="secondary" /></Hds::Alert>`
     );
     assert
       .dom('#test-alert .hds-alert__actions a')
@@ -143,7 +117,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   test('it should render any content passed to the "generic" contextual component', async function (assert) {
     assert.expect(2);
     await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" id="test-alert" as |A|><A.Generic><pre>test</pre></A.Generic></Hds::Alert>`
+      hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Generic><pre>test</pre></A.Generic></Hds::Alert>`
     );
     assert.dom('#test-alert .hds-alert__content pre').exists().hasText('test');
   });
@@ -151,23 +125,19 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   // DISMISS
 
   test('it should not render the "dismiss" button by default', async function (assert) {
-    await render(hbs`<Hds::Alert @type="inline" @title="yo" />`);
+    await render(hbs`<Hds::Alert @type="inline" />`);
     assert.dom('button.hds-alert__dismiss').doesNotExist();
   });
   test('it should render the "dismiss" button if a callback function is passed to the @onDismiss argument', async function (assert) {
     this.set('NOOP', () => {});
-    await render(
-      hbs`<Hds::Alert @type="inline" @description="yo" @onDismiss={{this.NOOP}} />`
-    );
+    await render(hbs`<Hds::Alert @type="inline" @onDismiss={{this.NOOP}} />`);
     assert.dom('button.hds-alert__dismiss').exists();
   });
 
   // A11Y
 
   test('it should render with the correct semantic tags and aria attributes', async function (assert) {
-    await render(
-      hbs`<Hds::Alert @type="inline" @title="This is the title" @description="This is the description" id="test-alert" />`
-    );
+    await render(hbs`<Hds::Alert @type="inline" id="test-alert" />`);
     assert.dom('#test-alert').hasAttribute('role', 'alert');
   });
 
@@ -180,7 +150,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Alert @type="foo" @description="yo" />`);
+    await render(hbs`<Hds::Alert @type="foo" />`);
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -192,9 +162,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(
-      hbs`<Hds::Alert @type="compact" @description="yo" @icon={{false}} />`
-    );
+    await render(hbs`<Hds::Alert @type="compact" @icon={{false}} />`);
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -206,9 +174,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(
-      hbs`<Hds::Alert @type="inline" @color="foo" @description="yo" />`
-    );
+    await render(hbs`<Hds::Alert @type="inline" @color="foo" />`);
     assert.throws(function () {
       throw new Error(errorMessage);
     });

--- a/packages/components/tests/integration/components/hds/toast/index-test.js
+++ b/packages/components/tests/integration/components/hds/toast/index-test.js
@@ -9,12 +9,12 @@ module('Integration | Component | hds/toast/index', function (hooks) {
   // notice: "toast" is a wrapper around the "hds::alert" so we test only very specific things
 
   test('it renders the "toast"', async function (assert) {
-    await render(hbs`<Hds::Toast @text="alert text" />`);
+    await render(hbs`<Hds::Toast />`);
     assert.dom(this.element).exists();
   });
 
   test('it should render with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Toast @title="alert text" id="test-toast" />`);
+    await render(hbs`<Hds::Toast id="test-toast" />`);
     assert.dom('#test-toast').hasClass('hds-toast');
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

While doing a demo of the `Alert` and `Toast` components to the HDS Engineering Ambassadors, we have found a few use cases where the content of the `description` field was more structured than simple text (it could contain conditional logic, HTML elements, Ember components).

See for example here:
- https://github.com/hashicorp/cloud-ui/blob/c3161a6a5ff5b9cd0007601a4cad68555f4300f2/engines/monitoring/addon/components/audit-logs/archives-unavailable-banner/index.hbs#L6-L12
- https://github.com/hashicorp/atlas/blob/c77e9c1ccd481f199811b80a53f20a8a7f2162c5/frontend/atlas/app/components/subscription-plan-viewer.hbs#L4-L30
- https://github.com/hashicorp/atlas/blob/f35acb239b90211ab1c4905162b814219e6028c7/frontend/atlas/app/components/vcs-repo-select.hbs#L3-L28
- https://github.com/hashicorp/atlas/blob/ccd7d558038ba143c3237f9cfebc6db2e94b0aec/frontend/atlas/app/components/v2/runs-blank-slate.hbs#L5-L31

We have agreed that the best option in this case was to introduce an alternative way to pass the content of the `description` using an ad-hoc contextual component.

While working on the PR, we have realized (see comments below) that at this point it was better/more consistent to have also the `title` as contextual component, and remove them as arguments.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added `Title` and `Description` as yielded children to the `Alert` component
  - removed `@title` and `@description` as arguments
- updated documentation for the `Alert` component
- improved styling of the HTML basic tags inside the `description` field (to be discussed with @cveigt before release)
- updated the `Toast` component to yield also the new `Title` and `Description` contextual components
- updated documentation for the `Toast` component
- updated integration tests for the `Alert` and `Toast` components

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
