### PR TITLE
disable embroider test for ember-flight-icons

### DIFF
--- a/.github/workflows/ci-ember-flight-icons.yml
+++ b/.github/workflows/ci-ember-flight-icons.yml
@@ -72,7 +72,7 @@ jobs:
          # - ember-canary
           - ember-classic
           - embroider-safe
-          - embroider-optimized
+        # - embroider-optimized
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

These tests are not that useful for us and [an upstream change broke them](https://github.com/emberjs/ember-test-helpers/issues/1220)
