### PR TITLE
prep dummy app to add sidebar

### DIFF
--- a/packages/components/tests/dummy/app/routes/components.js
+++ b/packages/components/tests/dummy/app/routes/components.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ComponentsRoute extends Route {}

--- a/packages/components/tests/dummy/app/routes/content.js
+++ b/packages/components/tests/dummy/app/routes/content.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ContentRoute extends Route {}

--- a/packages/components/tests/dummy/app/routes/foundations.js
+++ b/packages/components/tests/dummy/app/routes/foundations.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class FoundationsRoute extends Route {}

--- a/packages/components/tests/dummy/app/routes/utilities.js
+++ b/packages/components/tests/dummy/app/routes/utilities.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class UtilitiesRoute extends Route {}

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -16,9 +16,9 @@
       </li>
     </ul>
   </nav>
-  <main id="main" class="dummy-main">
-    {{outlet}}
-  </main>
+
+  {{outlet}}
+
   <footer class="dummy-footer">
     <div class="dummy-row-wrapper">
       <div class="dummy-row">

--- a/packages/components/tests/dummy/app/templates/components.hbs
+++ b/packages/components/tests/dummy/app/templates/components.hbs
@@ -1,0 +1,5 @@
+{{page-title "Components"}}
+
+<main id="main" class="dummy-main">
+  {{outlet}}
+</main>

--- a/packages/components/tests/dummy/app/templates/content.hbs
+++ b/packages/components/tests/dummy/app/templates/content.hbs
@@ -1,0 +1,5 @@
+{{page-title "Content"}}
+
+<main id="main" class="dummy-main">
+  {{outlet}}
+</main>

--- a/packages/components/tests/dummy/app/templates/foundations.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations.hbs
@@ -1,0 +1,5 @@
+{{page-title "Foundations"}}
+
+<main id="main" class="dummy-main">
+  {{outlet}}
+</main>

--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -1,115 +1,117 @@
-<h2 class="dummy-h2">
-  Foundations:
-</h2>
-<ol>
-  <li class="dummy-paragraph">
-    <LinkTo @route="foundations.tokens">
-      Design tokens
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="foundations.colors">
-      Colors
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="foundations.typography">
-      Typography
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="foundations.elevation">
-      Elevation
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="foundations.focus-ring">
-      Focus ring
-    </LinkTo>
-  </li>
-</ol>
-<h2 class="dummy-h2">
-  Components:
-</h2>
-<ol>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.alert">
-      Alert
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.badge">
-      Badge
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.breadcrumb">
-      Breadcrumb
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.button">
-      Button
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.card">
-      Card
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.dropdown">
-      Dropdown
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.icon-tile">
-      IconTile
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.link.cta">
-      Link::CTA (Call To Action)
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.link-to.cta">
-      LinkTo::CTA (Call To Action)
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.link.standalone">
-      Link::Standalone
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.link-to.standalone">
-      LinkTo::Standalone
-    </LinkTo>
-  </li>
-  <li class="dummy-paragraph">
-    <LinkTo @route="components.toast">
-      Toast
-    </LinkTo>
-  </li>
-</ol>
-<h2 class="dummy-h2">
-  Utilities:
-</h2>
-<ol>
-  <li class="dummy-paragraph">
-    <LinkTo @route="utilities.disclosure">
-      Disclosure
-    </LinkTo>
-  </li>
-</ol>
-<h2 class="dummy-h2">
-  Content:
-</h2>
-<ol>
-  <li class="dummy-paragraph">
-    <LinkTo @route="content.writing-guidelines">
-      🚧 Writing guidelines
-    </LinkTo>
-  </li>
-</ol>
+<main id="main" class="dummy-main">
+  <h2 class="dummy-h2">
+    Foundations:
+  </h2>
+  <ol>
+    <li class="dummy-paragraph">
+      <LinkTo @route="foundations.tokens">
+        Design tokens
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="foundations.colors">
+        Colors
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="foundations.typography">
+        Typography
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="foundations.elevation">
+        Elevation
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="foundations.focus-ring">
+        Focus ring
+      </LinkTo>
+    </li>
+  </ol>
+  <h2 class="dummy-h2">
+    Components:
+  </h2>
+  <ol>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.alert">
+        Alert
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.badge">
+        Badge
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.breadcrumb">
+        Breadcrumb
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.button">
+        Button
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.card">
+        Card
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.dropdown">
+        Dropdown
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.icon-tile">
+        IconTile
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.link.cta">
+        Link::CTA (Call To Action)
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.link-to.cta">
+        LinkTo::CTA (Call To Action)
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.link.standalone">
+        Link::Standalone
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.link-to.standalone">
+        LinkTo::Standalone
+      </LinkTo>
+    </li>
+    <li class="dummy-paragraph">
+      <LinkTo @route="components.toast">
+        Toast
+      </LinkTo>
+    </li>
+  </ol>
+  <h2 class="dummy-h2">
+    Utilities:
+  </h2>
+  <ol>
+    <li class="dummy-paragraph">
+      <LinkTo @route="utilities.disclosure">
+        Disclosure
+      </LinkTo>
+    </li>
+  </ol>
+  <h2 class="dummy-h2">
+    Content:
+  </h2>
+  <ol>
+    <li class="dummy-paragraph">
+      <LinkTo @route="content.writing-guidelines">
+        🚧 Writing guidelines
+      </LinkTo>
+    </li>
+  </ol>
+</main>

--- a/packages/components/tests/dummy/app/templates/utilities.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities.hbs
@@ -1,0 +1,5 @@
+{{page-title "Utilities"}}
+
+<main id="main" class="dummy-main">
+  {{outlet}}
+</main>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adjusts our dummy app routes and templates so it will more easily support layout updates, specifically the sidebar addition. It should make no visible changes to the website.

### :hammer_and_wrench: Detailed description

- removes the `main` element wrapping the outlet in application.hbs
- adds the `main` element wrapper to the other top-level route templates

I was fighting with the dummy app for a while today before I realized that we have accidental complexity in here which is why it felt like a battle. So I've adjusted things to be more correct (for Ember apps). This change will allow addition of a `dummy-sidebar` component that will be rendered for the sections we wish. Subsequent PR to follow. 

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
