### PR TITLE
add dummy-sidebar component

### DIFF
--- a/packages/components/tests/dummy/app/components/dummy-sidebar.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-sidebar.hbs
@@ -3,8 +3,11 @@
 <aside class="dummy-aside">
   <ul class="dummy-aside__ul">
     <li><LinkTo @route="index"><FlightIcon @name="arrow-left" @isInlineBlock={{false}} /> Back</LinkTo></li>
-    {{#each this.sections as | section | }}
-      <li><a href="{{this.dummyRouteUrl}}{{section.fragment}}"><FlightIcon @name="{{section.icon}}" @isInlineBlock={{false}} />{{section.title}}</a></li>
+    {{#each this.sections as |section|}}
+      <li><a href="{{this.dummyRouteUrl}}{{section.fragment}}"><FlightIcon
+            @name="{{section.icon}}"
+            @isInlineBlock={{false}}
+          />{{section.title}}</a></li>
     {{/each}}
   </ul>
 </aside>

--- a/packages/components/tests/dummy/app/components/dummy-sidebar.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-sidebar.hbs
@@ -1,0 +1,10 @@
+{{yield}}
+
+<aside class="dummy-aside">
+  <ul class="dummy-aside__ul">
+    <li><LinkTo @route="index"><FlightIcon @name="arrow-left" @isInlineBlock={{false}} /> Back</LinkTo></li>
+    {{#each this.sections as | section | }}
+      <li><a href="{{this.dummyRouteUrl}}{{section.fragment}}"><FlightIcon @name="{{section.icon}}" @isInlineBlock={{false}} />{{section.title}}</a></li>
+    {{/each}}
+  </ul>
+</aside>

--- a/packages/components/tests/dummy/app/components/dummy-sidebar.js
+++ b/packages/components/tests/dummy/app/components/dummy-sidebar.js
@@ -1,0 +1,43 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+export default class DummySidebarComponent extends Component {
+  @service router;
+
+  sections = [
+    {
+      title: 'Overview',
+      fragment: '#',
+      icon: 'collections',
+    },
+    {
+      title: 'Component API',
+      fragment: '#component-api',
+      icon: 'hammer',
+    },
+    {
+      title: 'How to use',
+      fragment: '#how-to-use',
+      icon: 'wrench',
+    },
+    {
+      title: 'Design Guidelines',
+      fragment: '#design-guidelines',
+      icon: 'monitor',
+    },
+    {
+      title: 'Accessibility',
+      fragment: '#accessibility',
+      icon: 'globe',
+    },
+    {
+      title: 'Showcase',
+      fragment: '#showcase',
+      icon: 'camera',
+    },
+  ];
+  get dummyRouteUrl() {
+    let dummyPathUrl = this.router.currentURL;
+    return dummyPathUrl;
+  }
+}

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -25,6 +25,7 @@
 @import "./components/dummy-component-props";
 @import "./components/dummy-placeholder";
 @import "./components/dummy-link-cta-button-banner";
+@import "./components/dummy-sidebar";
 
 html {
     box-sizing: border-box;

--- a/packages/components/tests/dummy/app/styles/components/dummy-sidebar.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-sidebar.scss
@@ -1,0 +1,61 @@
+.dummy-aside {
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  max-width: 100%;
+  width: 100%;
+}
+
+@media screen and (min-width: 40em) {
+  .dummy-aside {
+    height: 100vh;
+    padding: 0.5rem;
+    position: sticky;
+    top: 0;
+    width: 12em;
+  }
+}
+
+.dummy-aside__ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.dummy-aside__ul li {
+  // "back" is the first item, we want to separate it visually from the rest of the links
+  // to give it some breathing room, but still have it be part of the ul element from a AT perspective.
+  &:first-of-type {
+    padding: 1rem 0;
+    margin-bottom: 1rem;
+  }
+}
+.dummy-aside__ul li a {
+  align-items: center;
+  border-radius: 5px;
+  border: 2px solid transparent;
+  color: black;
+  display: flex;
+  flex-direction: row;
+  font-size: 0.9rem;
+  gap: 5px;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+  &:focus {
+    border-color: blue;
+    text-decoration: underline;
+  }
+  &:focus-visible {
+    outline-offset: 4px;
+    outline-color: blue;
+  }
+
+  .flight-icon {
+    color: blue;
+  }
+}

--- a/packages/components/tests/dummy/app/styles/components/dummy-sidebar.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-sidebar.scss
@@ -54,6 +54,11 @@
     outline-offset: 4px;
     outline-color: blue;
   }
+  &:active {
+    background-color: aliceblue;
+    border-color: blue;
+    text-decoration: underline;
+  }
 
   .flight-icon {
     color: blue;

--- a/packages/components/tests/dummy/app/templates/components.hbs
+++ b/packages/components/tests/dummy/app/templates/components.hbs
@@ -1,5 +1,7 @@
 {{page-title "Components"}}
 
+<DummySidebar />
+
 <main id="main" class="dummy-main">
   {{outlet}}
 </main>


### PR DESCRIPTION
### :pushpin: Summary

 If merged, this PR adds the `dummy-sidebar` component to the `melsumner/sidebar` branch.

### :hammer_and_wrench: Detailed description

Note: this is proposing a static sidebar that is very purposeful. It won't capture any section that is not in the standard list of sections, but after trying a few different ways to do this, this one felt the best to use across the board so I hope we will consider it. 

I was also able to assign icons to each of the sections because it was a static list, which allowed me to remove the link underlines since we'd have the icon support. 

- adds a "back" button that returns the user to the list of components
- adds the common sections as the content for the sidebar
- adds a `dummy-sidebar` component
- adds a keyboard-navigation specific focus state (`focus-visible`)
- adds "sticky" positioning to the sidebar so it's always at the top of the viewport

Important: I'm still working on the layout, so right now it's not aligned correctly, but I'll address that in a subsequent PR.

### :camera_flash: Screenshots

Not pictured here: an active state that adds a light blue background but otherwise matches the focus state. 

**Default state:**
<img width="196" alt="sidebar-prototype@2x" src="https://user-images.githubusercontent.com/4587451/169185842-02c88464-6aaf-4e93-a26d-6121e841c1a9.png">

**Focus state:** 
<img width="193" alt="sidebar-proto-focus@2x" src="https://user-images.githubusercontent.com/4587451/169185790-d0647e0e-95b9-4ac7-9551-9078806829a8.png">

**Hover ("design guidelines") and keyboard-focus ("overview") state:** 
<img width="199" alt="sidebar-proto-focus-hover@2x" src="https://user-images.githubusercontent.com/4587451/169185903-8ea49968-88f1-4dd0-97e9-0dc04559ad99.png">


### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
