### PR TITLE
Convey disclosure state to assistive tech for dropdown and truncated breadcrumbs

### DIFF
--- a/packages/components/addon/components/hds/breadcrumb/truncation.hbs
+++ b/packages/components/addon/components/hds/breadcrumb/truncation.hbs
@@ -7,6 +7,7 @@
           {{if @hover 'is-hover'}}
           {{if @active 'is-active'}}
           {{if @focus 'is-focus'}}"
+        aria-expanded={{if t.isActive "true" "false"}}
         {{on "click" t.onClickToggle}}
       >
         <FlightIcon @name="more-horizontal" @size="16" @isInlineBlock={{false}} />

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -19,5 +19,6 @@
   @iconPosition="trailing"
   @color={{this.color}}
   ...attributes
+  aria-expanded={{this.expanded}}
   {{on "click" this.onClick}}
 />

--- a/packages/components/addon/components/hds/dropdown/toggle/button.js
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.js
@@ -74,4 +74,14 @@ export default class HdsDropdownToggleButtonComponent extends Component {
 
     return classes.join(' ');
   }
+
+  /**
+   * Get the state of the toggle based on the @isOpen argument
+   * @method ToggleButton#expanded
+   * @default "false"
+   * @return {string} "true" when expanded, "false" when collapsed
+   */
+  get expanded() {
+    return this.args.isOpen ? 'true' : 'false';
+  }
 }

--- a/packages/components/addon/components/hds/dropdown/toggle/icon.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/icon.hbs
@@ -1,4 +1,11 @@
-<button class={{this.classNames}} aria-label={{this.text}} ...attributes {{on "click" this.onClick}} type="button">
+<button
+  class={{this.classNames}}
+  aria-label={{this.text}}
+  ...attributes
+  aria-expanded={{this.expanded}}
+  {{on "click" this.onClick}}
+  type="button"
+>
   <div class="hds-dropdown-toggle-icon__wrapper">
     {{#if @imageSrc}}
       <img src={{@imageSrc}} alt="" role="presentation" height="32" width="32" />

--- a/packages/components/addon/components/hds/dropdown/toggle/icon.js
+++ b/packages/components/addon/components/hds/dropdown/toggle/icon.js
@@ -71,4 +71,14 @@ export default class HdsDropdownToggleIconComponent extends Component {
 
     return classes.join(' ');
   }
+
+  /**
+   * Get the state of the toggle based on the @isOpen argument
+   * @method ToggleButton#expanded
+   * @default "false"
+   * @return {string} "true" when expanded, "false" when collapsed
+   */
+  get expanded() {
+    return this.args.isOpen ? 'true' : 'false';
+  }
 }

--- a/packages/components/tests/integration/components/hds/breadcrumb/truncation-test.js
+++ b/packages/components/tests/integration/components/hds/breadcrumb/truncation-test.js
@@ -40,4 +40,20 @@ module('Integration | Component | hds/breadcrumb/truncation', function (hooks) {
     assert.dom('.hds-breadcrumb__truncation-content > ol').exists();
     assert.dom('a#test-breadcrumb-truncation-link').exists();
   });
+
+  // A11Y
+
+  test('it should render with the correct aria-expanded attribute on the toggle element', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" />`
+    );
+    assert
+      .dom('#test-breadcrumb-truncation button')
+      .hasAttribute('aria-expanded', 'false');
+    await click('#test-breadcrumb-truncation button');
+    assert
+      .dom('#test-breadcrumb-truncation button')
+      .hasAttribute('aria-expanded', 'true');
+  });
 });

--- a/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
@@ -52,6 +52,15 @@ module(
       assert.dom('#test-toggle-button').hasClass('hds-button--color-secondary');
     });
 
+    // A11Y
+
+    test('it should render with the correct aria-expanded attribute on the toggle element', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" @isOpen={{true}} id="test-toggle-button" />`
+      );
+      assert.dom('#test-toggle-button').hasAttribute('aria-expanded', 'true');
+    });
+
     // ASSERTIONS
 
     test('it should throw an assertion if @text is not defined', async function (assert) {

--- a/packages/components/tests/integration/components/hds/dropdown/toggle/icon-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle/icon-test.js
@@ -66,6 +66,12 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
     );
     assert.dom('#test-toggle-icon img').hasAttribute('role', 'presentation');
   });
+  test('it should render with the correct aria-expanded attribute on the toggle element', async function (assert) {
+    await render(
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" @isOpen={{true}} id="test-toggle-icon" />`
+    );
+    assert.dom('#test-toggle-icon').hasAttribute('aria-expanded', 'true');
+  });
 
   // ASSERTIONS
 


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
Convey the disclosure state to assistive tech for dropdown and truncated breadcrumbs.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->
**What**: I propose that we use `aria-expanded` on the toggle elements to convey to assistive tech whether the disclosed container is expanded or collapsed.

**Why**: When sighted users interact with the toggle element they see the expanded container and have a visual clue in the chevron icon changing its state. With this change we try to express the same clue to screen reader users so that when they reach a the toggle element, it will be read out as `collapsed` or `expanded`, depending on its state.

### :camera_flash: Screenshots

Exemplified on the first dropdown example in VoiceOver

Collapsed (default)
<img width="158" alt="Screenshot 2022-05-19 at 12 41 40" src="https://user-images.githubusercontent.com/788096/169285351-0f5693bf-24c7-4525-a631-5453e0c4c449.png">


Expanded
<img width="235" alt="Screenshot 2022-05-19 at 12 44 14" src="https://user-images.githubusercontent.com/788096/169285791-0a342de0-c088-4e32-b053-b8236945ac87.png">



<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

Collapsed (default)/expanded
<img width="646" alt="Screenshot 2022-05-19 at 12 38 27" src="https://user-images.githubusercontent.com/788096/169284964-4ccef244-b2f1-4bd9-95f2-6a288af6da1d.png">

</td><td>
Collapsed (default)
<img width="646" alt="Screenshot 2022-05-19 at 12 38 37" src="https://user-images.githubusercontent.com/788096/169285023-c177794f-b367-4bc3-8a7a-084385baf2fd.png">

Expanded
<img width="646" alt="Screenshot 2022-05-19 at 12 38 41" src="https://user-images.githubusercontent.com/788096/169285037-5d5ea34a-9f58-40f8-9d1d-84701f52a2c6.png">


</td></tr>
</table>

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
