### PR TITLE
remove design system deps from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,3 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" 
-    directory: "packages/ember-flight-icons/" 
-    versioning-strategy: increase
-    schedule:
-      interval: "daily"
-    allow: 
-      - dependency-name: "@hashicorp/*"
-  - package-ecosystem: "npm" 
-    directory: "packages/website/" 
-    versioning-strategy: increase
-    schedule:
-      interval: "daily"
-    allow: 
-      - dependency-name: "@hashicorp/*"
-


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

with the monorepo + changesets setup this is no longer needed (hasn't run at all in quite some time). the package updates happen as part of changeset releases.

Leaving the file here as https://github.com/hashicorp/design-system/pull/304 will add a new check
