### PR TITLE
add anchor link to alert showcase

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -701,7 +701,7 @@
 </section>
 
 <section data-test-percy>
-  <h3 class="dummy-h3">Showcase</h3>
+  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
 
   <p class="dummy-paragraph">👀 Note: the compact alert is borderless, but shown with a dotted border throughout the
     "Showcase" for clarity.</p>


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

Adds a missing anchor link to the showcase section of the alert docs

### :camera_flash: Screenshots

#### Before
<img width="930" alt="Screen Shot 2022-05-24 at 08 59 09" src="https://user-images.githubusercontent.com/1672302/170053943-32bca348-85ea-409e-a264-b117427af59b.png">


#### After
<img width="874" alt="Screen Shot 2022-05-24 at 08 59 19" src="https://user-images.githubusercontent.com/1672302/170053899-9dee235b-e3d1-4099-8e32-26c70298cbb0.png">
 :link: External links


### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
