### PR TITLE
add github action to automate flight icon build & sync

### DIFF
--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -1,0 +1,40 @@
+name: Sync & Build Icons
+
+on:
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: '16.x'
+
+jobs:
+  sync_iconset:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+          cache-dependency-path: yarn.lock
+  
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Sync icons
+        env:
+          # this is Brian's personal access token
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }} 
+        run: yarn sync
+        working-directory: packages/flight-icons
+
+      - name: Build icons
+        run: yarn build
+        working-directory: packages/flight-icons
+
+      - name: Open a PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: 'sync & build of flight icons'
+          title: 'Updated export of icons from Figma'
+          body: ''
+          token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

Creates a github action which we can use to sync and build icons without needing to run the commands locally.

### :hammer_and_wrench: Detailed description

Back in https://github.com/hashicorp/flight/pull/322 I created this action which "worked" but didn't fully work because it didn't trigger our other checks due to a [known limitation](https://github.com/hashicorp/flight/issues/346) with GitHub actions. Now that we have a bot account this can be unblocked for us to experiment with.

Unfortunately this can only be tested in `main` as the action doesn't technically exist yet for us to run it. 

If this works I'll update the docs, but I don't want to invest too much time in this if it doesn't actually work.