### PR TITLE
Add back the top banner about “buttons vs links” in the `Button` doc page

### DIFF
--- a/packages/components/tests/dummy/app/components/dummy-link-cta-button-banner/index.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-link-cta-button-banner/index.hbs
@@ -1,25 +1,30 @@
 <section class="dummy-link-cta-button-banner">
-  <h3>Links, Buttons, CTAs...oh my!</h3>
+  <h3>Links, Buttons, Links that look like Buttons...oh my!</h3>
   <h4>When to use a Link</h4>
   <p>A link navigates the user to a new destination via a URL or route. Use
     <LinkTo @route="components.link.inline"><code>Link::Inline</code></LinkTo>
     within a body of text and
     <LinkTo @route="components.link.standalone"><code>Link::Standalone</code></LinkTo>
     outside of a body of text, ie. on its own or in a list.</p>
-  <h4>When to use a CTA</h4>
-  <p>A CTA is a link that looks like a button. It navigates the user to a new destination via a URL or route, but has
-    more visual weight than a standard link. Use a
-    <LinkTo @route="components.button"><code>Button</code></LinkTo>
-    as a link (with
-    <code>@href</code>
-    or
-    <code>@route</code>) to guide the user and encourage interaction. Use sparingly as overuse dilutes its importance.</p>
   <h4>When to use a Button</h4>
   <p>A button triggers an action within the page, ie. opening a dropdown or submitting a form.
     <LinkTo @route="components.button"><code>Button</code></LinkTo>
-    is offered in a variety of visual weights to provide flexibility in use. Please refer to the Design Guidelines to
-    learn more about the different variants.
+    is offered in a variety of visual weights to provide flexibility in use. Please refer to the
+    <LinkTo @route="components.button">Design Guidelines</LinkTo>
+    to learn more about the different variants.
   </p>
+  <h4>When to use a Link that looks like a Button</h4>
+  <p>Occasionally there is a need to display a link with more prominence (ie. a CTA or
+    <em>Cancel</em>
+    next to
+    <em>Submit</em>), so the
+    <LinkTo @route="components.button"><code>Button</code></LinkTo>
+    component offers support to be used as a link (with
+    <code>@href</code>
+    or
+    <code>@route</code>). Please refer to the
+    <LinkTo @route="components.button">How to use</LinkTo>
+    section to learn more.</p>
   <h4>Want to learn more?</h4>
   <p><a href="https://medium.com/@h_locke/links-vs-buttons-e8b523660fb3" target="_blank" rel="noopener noreferrer">Links
       vs Buttons</a>

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -2,7 +2,7 @@
 
 <h2 class="dummy-h2">Button component</h2>
 
-{{! <DummyLinkCtaButtonBanner /> }}
+<DummyLinkCtaButtonBanner />
 
 <section>
   <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>

--- a/packages/components/tests/dummy/app/templates/components/link/inline.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/inline.hbs
@@ -4,6 +4,8 @@
   Link::Inline
 </h2>
 
+<DummyLinkCtaButtonBanner />
+
 <section>
   <div class="dummy-banner dummy-banner--info">
     <p class="dummy-paragraph">👀 <strong>Notice</strong> 👀</p>

--- a/packages/components/tests/dummy/app/templates/components/link/inline.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/inline.hbs
@@ -4,8 +4,6 @@
   Link::Inline
 </h2>
 
-{{! <DummyLinkCtaButtonBanner /> }}
-
 <section>
   <div class="dummy-banner dummy-banner--info">
     <p class="dummy-paragraph">👀 <strong>Notice</strong> 👀</p>

--- a/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
@@ -2,8 +2,6 @@
 
 <h2 class="dummy-h2">Link::Standalone</h2>
 
-{{! <DummyLinkCtaButtonBanner /> }}
-
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview">§</a> Overview</h3>
 

--- a/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
@@ -2,6 +2,8 @@
 
 <h2 class="dummy-h2">Link::Standalone</h2>
 
+<DummyLinkCtaButtonBanner />
+
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview">§</a> Overview</h3>
 


### PR DESCRIPTION
### :pushpin: Summary

In #217 we commented the code for the top banner about _Button/Link/CTA_ in the docs pages, waiting for the designers to update the same banner in Figma. Now that it's updated, we can port the changes in code, and make it visible again.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added back the top banner about “buttons vs links” in the `Button` doc page

### :camera_flash: Screenshots

The same banner in Figma:
![banner](https://user-images.githubusercontent.com/686239/170695758-ea37849b-e696-4924-99b8-3dd0be57b390.png)

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
