### PR TITLE
Dummy website - Layout follow-up

### DIFF
--- a/packages/components/tests/dummy/app/components/dummy-footer.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-footer.hbs
@@ -1,42 +1,39 @@
 <footer class="dummy-footer">
 
   <div class="dummy-row dummy-row--first">
-    <div class="dummy-content-width-wrapper">
-      <p class="dummy-title-small">Our Accessibility Statement</p>
-      <p class="dummy-paragraph">
-        Each of our components intends to conform to
+    <p class="dummy-title-small">Our Accessibility Statement</p>
+    <p class="dummy-paragraph">
+      Each of our components intends to conform to
+      <a
+        href="https://www.w3.org/WAI/standards-guidelines/wcag/"
+        class="dummy-link"
+        target="_blank"
+        rel="noopener noreferrer"
+      >WCAG 2.1 AA standards</a>
+      (at a minimum). If you find an issue with any component, you can let us know in any of the following ways:
+    </p>
+    <ol class="dummy-list">
+      <li>
+        Post a message in the
         <a
-          href="https://www.w3.org/WAI/standards-guidelines/wcag/"
+          href="https://app.slack.com/client/T024UT03C/C7KTUHNUS/thread/CPB8GS9QT-1638823666.137000"
           class="dummy-link"
           target="_blank"
           rel="noopener noreferrer"
-        >WCAG 2.1 AA standards</a>
-        (at a minimum). If you find an issue with any component, you can let us know in any of the following ways:
-      </p>
-      <ol class="dummy-list">
-        <li>
-          Post a message in the
-          <a
-            href="https://app.slack.com/client/T024UT03C/C7KTUHNUS/thread/CPB8GS9QT-1638823666.137000"
-            class="dummy-link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >#team-design-systems</a>
-          channel in our internal Slack
-        </li>
-        <li>
-          Email
-          <a href="mailto:design-systems@hashicorp.com">
-            design-systems@hashicorp.com
-          </a>
-        </li>
-        <li>
-          File an issue on this
-          <a href="https://github.com/hashicorp/design-system" target="_blank" rel="noopener noreferrer">GitHub
-            repository</a>
-        </li>
-      </ol>
-    </div>
+        >#team-design-systems</a>
+        channel in our internal Slack
+      </li>
+      <li>
+        Email
+        <a href="mailto:design-systems@hashicorp.com">
+          design-systems@hashicorp.com
+        </a>
+      </li>
+      <li>
+        File an issue on this
+        <a href="https://github.com/hashicorp/design-system" target="_blank" rel="noopener noreferrer">GitHub repository</a>
+      </li>
+    </ol>
   </div>
   <div class="dummy-row dummy-row--last">
     <p class="dummy-paragraph dummy-content-width-wrapper">

--- a/packages/components/tests/dummy/app/components/dummy-footer.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-footer.hbs
@@ -1,6 +1,6 @@
 <footer class="dummy-footer">
 
-  <div class="dummy-row dummy-row--first">
+  <div class="dummy-footer__accessibility">
     <p class="dummy-title-small">Our Accessibility Statement</p>
     <p class="dummy-paragraph">
       Each of our components intends to conform to
@@ -35,8 +35,8 @@
       </li>
     </ol>
   </div>
-  <div class="dummy-row dummy-row--last">
-    <p class="dummy-paragraph dummy-content-width-wrapper">
+  <div class="dummy-footer__github">
+    <p class="dummy-paragraph">
       <a
         href="https://github.com/hashicorp/design-system/tree/main/packages/components"
         class="dummy-link"

--- a/packages/components/tests/dummy/app/components/dummy-sidebar.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-sidebar.hbs
@@ -1,8 +1,5 @@
-<aside class="dummy-aside">
+<aside class="dummy-aside" {{did-insert this.didInsert}}>
   <ul class="dummy-aside__list dummy-list">
     <li><LinkTo @route="index"><FlightIcon @name="arrow-left" @isInlineBlock={{false}} /> Component list</LinkTo></li>
-    {{#each this.sections as |section|}}
-      <li><a href="{{section.fragment}}">{{section.title}}</a></li>
-    {{/each}}
   </ul>
 </aside>

--- a/packages/components/tests/dummy/app/components/dummy-sidebar.js
+++ b/packages/components/tests/dummy/app/components/dummy-sidebar.js
@@ -1,36 +1,19 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class DummySidebarComponent extends Component {
-  sections = [
-    {
-      title: 'Overview',
-      fragment: '',
-      icon: 'collections',
-    },
-    {
-      title: 'Component API',
-      fragment: '#component-api',
-      icon: 'hammer',
-    },
-    {
-      title: 'How to use',
-      fragment: '#how-to-use',
-      icon: 'wrench',
-    },
-    {
-      title: 'Design guidelines',
-      fragment: '#design-guidelines',
-      icon: 'monitor',
-    },
-    {
-      title: 'Accessibility',
-      fragment: '#accessibility',
-      icon: 'globe',
-    },
-    {
-      title: 'Showcase',
-      fragment: '#showcase',
-      icon: 'camera',
-    },
-  ];
+  @action
+  didInsert(element) {
+    this.element = element;
+    const asideList = this.element.querySelector('ul');
+    document
+      .querySelectorAll('a.dummy-link-section')
+      .forEach(function (anchor) {
+        const item = document.createElement('li');
+        const href = anchor.attributes.href.value;
+        const text = anchor.parentNode.innerText.replace(/^§\s+/, '');
+        item.innerHTML = `<a href="${href}"> ${text}</a>`;
+        asideList.appendChild(item);
+      });
+  }
 }

--- a/packages/components/tests/dummy/app/styles/_layout.scss
+++ b/packages/components/tests/dummy/app/styles/_layout.scss
@@ -5,17 +5,8 @@
 }
 
 .dummy-app {
-  display: grid;
-  grid-template-areas:
-    'header header'
-    'nav nav'
-    'aside  aside'
-    'main main'
-    'footer footer';
-  grid-template-columns: 1fr;
-  grid-template-rows: auto auto auto 1fr auto;
-
   @media screen and (min-width: 40em) {
+    display: grid;
     grid-template-areas:
       'header header header header'
       '. aside main .'

--- a/packages/components/tests/dummy/app/styles/_layout.scss
+++ b/packages/components/tests/dummy/app/styles/_layout.scss
@@ -52,8 +52,3 @@
   margin: 0;
   padding: 0;
 }
-
-.dummy-content-width-wrapper {
-  max-width: 100%;
-  width: var(--content-width);
-}

--- a/packages/components/tests/dummy/app/styles/_layout.scss
+++ b/packages/components/tests/dummy/app/styles/_layout.scss
@@ -42,13 +42,3 @@
 .dummy-footer {
   grid-area: footer;
 }
-
-.dummy-header,
-.dummy-footer {
-  align-content: center;
-  display: flex;
-  justify-content: center;
-  max-width: 100%;
-  margin: 0;
-  padding: 0;
-}

--- a/packages/components/tests/dummy/app/styles/_layout.scss
+++ b/packages/components/tests/dummy/app/styles/_layout.scss
@@ -1,5 +1,7 @@
 :root {
-  --content-width: calc(1024px + 2 * 8rem);
+  --aside-width: calc(200px + 1 * 2rem);
+  --main-width: calc(1024px + 2 * 2rem);
+  --content-width: calc(var(--aside-width) + var(--main-width));
 }
 
 .dummy-app {
@@ -21,8 +23,8 @@
     grid-template-rows: auto 1fr auto;
     grid-template-columns:
       1fr
-      minmax(12em, calc(var(--content-width) * 0.15))
-      minmax(30em, calc(var(--content-width) * 0.85))
+      minmax(12em, var(--aside-width))
+      minmax(30em, var(--main-width))
       1fr;
   }
 }

--- a/packages/components/tests/dummy/app/styles/_layout.scss
+++ b/packages/components/tests/dummy/app/styles/_layout.scss
@@ -1,39 +1,34 @@
 :root {
-	--content-width: calc(1024px + 2 * 8rem);
+  --content-width: calc(1024px + 2 * 8rem);
 }
 
 .dummy-app {
   display: grid;
-	grid-template-areas:
-		"header header"
-		"nav nav"
-		"aside  aside"
-		"main main"
-		"footer footer";
-	grid-template-columns: 1fr;
-	grid-template-rows: auto auto auto 1fr auto;
+  grid-template-areas:
+    'header header'
+    'nav nav'
+    'aside  aside'
+    'main main'
+    'footer footer';
+  grid-template-columns: 1fr;
+  grid-template-rows: auto auto auto 1fr auto;
 
-	@media screen and (min-width: 40em) {
-		grid-template-areas:
-			"header header header header"
-			"nav nav nav nav"
-			". aside main ."
-			"footer footer footer footer";
-		grid-template-rows: auto auto 1fr auto;
-		grid-template-columns:
-			1fr
-			minmax(12em, calc(var(--content-width) * 0.15))
-			minmax(30em, calc(var(--content-width) * 0.85))
-			1fr;
-	}
-
+  @media screen and (min-width: 40em) {
+    grid-template-areas:
+      'header header header header'
+      '. aside main .'
+      'footer footer footer footer';
+    grid-template-rows: auto 1fr auto;
+    grid-template-columns:
+      1fr
+      minmax(12em, calc(var(--content-width) * 0.15))
+      minmax(30em, calc(var(--content-width) * 0.85))
+      1fr;
+  }
 }
 
 .dummy-header {
   grid-area: header;
-}
-.dummy-nav {
-  grid-area: nav;
 }
 .dummy-aside {
   grid-area: aside;
@@ -49,17 +44,16 @@
 }
 
 .dummy-header,
-.dummy-nav,
 .dummy-footer {
-	align-content: center;
-	display: flex;
-	justify-content: center;
-	max-width: 100%;
+  align-content: center;
+  display: flex;
+  justify-content: center;
+  max-width: 100%;
   margin: 0;
   padding: 0;
 }
 
 .dummy-content-width-wrapper {
-	max-width: 100%;
-	width: var(--content-width);
+  max-width: 100%;
+  width: var(--content-width);
 }

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -57,40 +57,11 @@ body.dummy-app {
       padding: 0.5rem 1rem;
     }
   }
-  .dummy-nav {
-    background-color: #f1f2f3;
 
-    ul {
-      display: flex;
-      justify-content: flex-start;
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      width: 100%;
-      li {
-        padding: 0;
-        margin: 0;
-        a {
-          border: 2px solid transparent;
-          display: flex;
-          gap: 0.5rem;
-          justify-content: space-evenly;
-          line-height: 1;
-          min-width: fit-content;
-          padding: 0.75rem;
-          &:visited {
-            color: blue;
-          }
-          &:hover {
-            border: 2px dashed blue;
-          }
-        }
-      }
-    }
-  }
   .dummy-aside {
-    background-color: #ffffff;
+    background-color: #e5e6e7;
   }
+
   .dummy-main {
     background-color: #fff;
     padding: 0 2rem 2rem;
@@ -177,7 +148,6 @@ body.dummy-app {
 
 @media only percy {
   header,
-  nav,
   aside,
   footer,
   main section:not([data-test-percy]) {

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -50,9 +50,10 @@ body.dummy-app {
     background-color: black;
     color: white;
     text-align: center;
+    padding: 0.75rem;
 
     .dummy-h1 {
-      margin: 0.75rem auto;
+      margin: 0 auto;
       padding: 0.5rem 1rem;
     }
   }

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -45,6 +45,7 @@ body.dummy-app {
   color: black;
   padding: 0;
   margin: 0;
+  min-height: 100vh;
 
   .dummy-header {
     background-color: black;
@@ -67,6 +68,13 @@ body.dummy-app {
     background-color: #fff;
     padding: 2rem;
   }
+}
+
+.dummy-index {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  gap: 2rem;
 }
 
 .dummy-design-guidelines {

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -49,11 +49,10 @@ body.dummy-app {
   .dummy-header {
     background-color: black;
     color: white;
+    text-align: center;
 
     .dummy-h1 {
-      display: flex;
-      justify-content: center;
-      margin-top: 0.75rem;
+      margin: 0.75rem auto;
       padding: 0.5rem 1rem;
     }
   }
@@ -65,14 +64,6 @@ body.dummy-app {
   .dummy-main {
     background-color: #fff;
     padding: 0 2rem 2rem;
-  }
-
-  .dummy-footer {
-    background-color: #f1f2f3;
-    flex-flow: row wrap;
-    margin: auto;
-    padding: 0;
-    width: 100%;
   }
 }
 

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -176,8 +176,8 @@ body.dummy-app {
 // so we had to rely on this specific custom media query
 
 @media only percy {
-  header.dummy-header,
-  nav.dummy-nav,
+  header,
+  nav,
   aside,
   footer,
   main section:not([data-test-percy]) {

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -58,12 +58,13 @@ body.dummy-app {
   }
 
   .dummy-aside {
-    background-color: #e5e6e7;
+    background-color: #fff;
+    padding: 2rem 1rem;
   }
 
   .dummy-main {
     background-color: #fff;
-    padding: 0 2rem 2rem;
+    padding: 2rem;
   }
 }
 

--- a/packages/components/tests/dummy/app/styles/components/dummy-footer.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-footer.scss
@@ -21,7 +21,7 @@
   background-color: black;
   color: white;
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
 
   .dummy-paragraph {
     margin: 0;

--- a/packages/components/tests/dummy/app/styles/components/dummy-footer.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-footer.scss
@@ -1,44 +1,48 @@
 .dummy-footer {
-  .dummy-row {
-    &.dummy-row--first {
-      .dummy-title-small,
-      .dummy-paragraph,
-      .dummy-list {
-        padding: 0 2rem;
-      }
-      .dummy-title-small {
-        padding-top: 2rem;
-      }
-      .dummy-list {
-        list-style-position: inside;
-        padding-bottom: 2rem;
-      }
-    }
-    &.dummy-row--last {
-      background-color: black;
-      color: white;
-      width: 100%;
-      .dummy-paragraph {
-        margin: 0 auto;
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-end;
-        .dummy-link {
-          border: 1px solid transparent;
-          align-content: center;
-          color: white;
-          display: flex;
-          gap: 6px;
-          margin: 0;
-          padding: 1rem;
-          text-decoration: none;
-          width: fit-content;
+  background-color: #f1f2f3;
+}
 
-          &:hover,
-          &:focus {
-            text-decoration: underline;
-          }
-        }
+.dummy-footer__accessibility {
+  margin: auto;
+  max-width: var(--content-width);
+
+  .dummy-title-small,
+  .dummy-paragraph,
+  .dummy-list {
+    padding: 0 2rem;
+  }
+  .dummy-title-small {
+    padding-top: 2rem;
+  }
+  .dummy-list {
+    list-style-position: inside;
+    padding-bottom: 2rem;
+  }
+}
+
+.dummy-footer__github {
+  background-color: black;
+  color: white;
+  display: flex;
+  justify-content: flex-end;
+
+  .dummy-paragraph {
+    margin: 0;
+
+    .dummy-link {
+      border: 1px solid transparent;
+      align-content: center;
+      color: white;
+      display: flex;
+      gap: 6px;
+      margin: 0;
+      padding: 1rem;
+      text-decoration: none;
+      width: fit-content;
+
+      &:hover,
+      &:focus {
+        text-decoration: underline;
       }
     }
   }

--- a/packages/components/tests/dummy/app/styles/components/dummy-footer.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-footer.scss
@@ -5,14 +5,11 @@
 .dummy-footer__accessibility {
   margin: auto;
   max-width: var(--content-width);
+  padding: 0 2rem;
 
-  .dummy-title-small,
-  .dummy-paragraph,
-  .dummy-list {
-    padding: 0 2rem;
-  }
   .dummy-title-small {
     padding-top: 2rem;
+    margin-top: 0;
   }
   .dummy-list {
     list-style-position: inside;

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -1,11 +1,9 @@
 {{page-title "HDS Design System"}}
 <header class="dummy-header">
-  <div class="dummy-content-width-wrapper">
-    <NavigationNarrator />
-    <h1 class="dummy-h1">
-      HashiCorp Design System (HDS)
-    </h1>
-  </div>
+  <NavigationNarrator />
+  <h1 class="dummy-h1">
+    HashiCorp Design System (HDS)
+  </h1>
 </header>
 
 {{outlet}}

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -7,18 +7,6 @@
     </h1>
   </div>
 </header>
-<nav aria-label="primary nav" class="dummy-nav">
-  <div class="dummy-content-width-wrapper">
-    <ul>
-      <li class="dummy-paragraph">
-        <LinkTo @route="index">
-          <FlightIcon @name="home" />
-          Home
-        </LinkTo>
-      </li>
-    </ul>
-  </div>
-</nav>
 
 {{outlet}}
 

--- a/packages/components/tests/dummy/app/templates/foundations.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations.hbs
@@ -1,5 +1,7 @@
 {{page-title "Foundations"}}
 
+<DummySidebar />
+
 <main id="main" class="dummy-main">
   {{outlet}}
 </main>

--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -1,112 +1,122 @@
 <main id="main" class="dummy-main">
-  <h2 class="dummy-h2">
-    Foundations:
-  </h2>
-  <ol>
-    <li class="dummy-paragraph">
-      <LinkTo @route="foundations.tokens">
-        Design tokens
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="foundations.colors">
-        Colors
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="foundations.typography">
-        Typography
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="foundations.elevation">
-        Elevation
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="foundations.focus-ring">
-        Focus ring
-      </LinkTo>
-    </li>
-  </ol>
-  <h2 class="dummy-h2">
-    Components:
-  </h2>
-  <ol>
-    <li class="dummy-paragraph">
-      <LinkTo @route="components.alert">
-        Alert
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="components.badge">
-        Badge
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="components.breadcrumb">
-        Breadcrumb
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="components.button">
-        Button
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="components.card">
-        Card
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="components.dropdown">
-        Dropdown
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="components.icon-tile">
-        IconTile
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="components.link.inline">
-        Link::Inline
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="components.link.standalone">
-        Link::Standalone
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="components.toast">
-        Toast
-      </LinkTo>
-    </li>
-  </ol>
-  <h2 class="dummy-h2">
-    Utilities:
-  </h2>
-  <ol>
-    <li class="dummy-paragraph">
-      <LinkTo @route="utilities.disclosure">
-        Disclosure
-      </LinkTo>
-    </li>
-    <li class="dummy-paragraph">
-      <LinkTo @route="utilities.interactive">
-        Interactive
-      </LinkTo>
-    </li>
-  </ol>
-  <h2 class="dummy-h2">
-    Content:
-  </h2>
-  <ol>
-    <li class="dummy-paragraph">
-      <LinkTo @route="content.writing-guidelines">
-        🚧 Writing guidelines
-      </LinkTo>
-    </li>
-  </ol>
+  <div class="dummy-index">
+    <div>
+      <h2 class="dummy-h2">
+        Foundations:
+      </h2>
+      <ol>
+        <li class="dummy-paragraph">
+          <LinkTo @route="foundations.tokens">
+            Design tokens
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="foundations.colors">
+            Colors
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="foundations.typography">
+            Typography
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="foundations.elevation">
+            Elevation
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="foundations.focus-ring">
+            Focus ring
+          </LinkTo>
+        </li>
+      </ol>
+    </div>
+    <div>
+      <h2 class="dummy-h2">
+        Components:
+      </h2>
+      <ol>
+        <li class="dummy-paragraph">
+          <LinkTo @route="components.alert">
+            Alert
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="components.badge">
+            Badge
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="components.breadcrumb">
+            Breadcrumb
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="components.button">
+            Button
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="components.card">
+            Card
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="components.dropdown">
+            Dropdown
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="components.icon-tile">
+            IconTile
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="components.link.inline">
+            Link::Inline
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="components.link.standalone">
+            Link::Standalone
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="components.toast">
+            Toast
+          </LinkTo>
+        </li>
+      </ol>
+    </div>
+    <div>
+      <h2 class="dummy-h2">
+        Utilities:
+      </h2>
+      <ol>
+        <li class="dummy-paragraph">
+          <LinkTo @route="utilities.disclosure">
+            Disclosure
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <LinkTo @route="utilities.interactive">
+            Interactive
+          </LinkTo>
+        </li>
+      </ol>
+    </div>
+    <div>
+      <h2 class="dummy-h2">
+        Content:
+      </h2>
+      <ol>
+        <li class="dummy-paragraph">
+          <LinkTo @route="content.writing-guidelines">
+            🚧 Writing guidelines
+          </LinkTo>
+        </li>
+      </ol>
+    </div>
+  </div>
 </main>

--- a/packages/components/tests/dummy/app/templates/utilities.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities.hbs
@@ -1,5 +1,7 @@
 {{page-title "Utilities"}}
 
+<DummySidebar />
+
 <main id="main" class="dummy-main">
   {{outlet}}
 </main>


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of #306.

### :hammer_and_wrench: Detailed description

In this PR I have:
- done some layout + CSS refactoring to remove unnecessary code
   - remove unnecessary CSS qualifiers
   - removed “dummy-content-width-wrapper” (not needed)
   - simplified `header` and `footer`
   - removed grid layout declaration for mobile viewport (not needed)
- removed the top nav element (not needed anymore, now that we have the `components list` in the sidebar)
- restored the width of `(1024px + 2 * 2rem)` for the `main` block (previous width, used for showcase and percy testing)
- re-organized the `index` page layout (expecially with new components in the pipeline, list will become extremely long)
  - notice: this is a stopgag solution, while we wait for proper design for the website
- modified `DummySidebar` component to generate dynamically the list of internal links

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
