### PR TITLE
Update `font-weight` for `HDs::Link::Standalone` component

### DIFF
--- a/.changeset/three-pears-glow.md
+++ b/.changeset/three-pears-glow.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+updated `font-weight` to `medium` for `Link::Standalone` component (to be in sync with design specs)

--- a/packages/components/app/styles/components/link/standalone.scss
+++ b/packages/components/app/styles/components/link/standalone.scss
@@ -19,6 +19,7 @@ $hds-link-standalone-border-width: 1px;
   border: $hds-link-standalone-border-width solid transparent; // needs to exist AND be transparent for a11y
   display: flex;
   font-family: var(--token-typography-font-stack-text);
+  font-weight: var(--token-typography-font-weight-medium);
   justify-content: center;
   // notice: the text decoration is applied directly to the "text" container because of a bug in Safari (see https://github.com/hashicorp/design-system-components/issues/159)
   text-decoration-color: transparent;


### PR DESCRIPTION
### :pushpin: Summary

While working on the codebase I noticed that in the codebase the `font-weight` of the `Hds::Link::Standalone` is _regular_, while in design is **medium**. Likely is an error in code, and we have to fix it.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added “medium” `font-weight` to `Link::Standalone` component

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202363319565659