### PR TITLE
Add npm version to the page header for the dummy website

### DIFF
--- a/packages/components/tests/dummy/app/components/dummy-npm-version.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-npm-version.hbs
@@ -1,0 +1,8 @@
+<div class="dummy-npm-version">
+  current version
+  <a href="https://badge.fury.io/js/@hashicorp%2Fdesign-system-components"><img
+      src="https://badge.fury.io/js/@hashicorp%2Fdesign-system-components.svg"
+      alt="npm version"
+      height="18"
+    /></a>
+</div>

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -141,6 +141,15 @@ body.dummy-app {
   text-decoration: none;
 }
 
+.dummy-npm-version {
+  @include dummyFontFamily();
+  color: #ccc;
+  display: inline-flex;
+  font-size: 1rem;
+  gap: 1rem;
+  line-height: 1.2;
+}
+
 // Percy (percySnapshot) doesn't allow to target specific DOM elements, so we have to "blacklist" the elements
 // that we want to exclude from the snapshots using their own "Percy-specific CSS".
 // see: https://docs.percy.io/docs/percy-specific-css#section-hiding-regions-with-percy-specific-css

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -4,6 +4,7 @@
   <h1 class="dummy-h1">
     HashiCorp Design System (HDS)
   </h1>
+  <DummyNpmVersion />
 </header>
 
 {{outlet}}


### PR DESCRIPTION
### :pushpin: Summary

Sometimes people get confused about which version of the design system the documentation refers to.
This is not a perfect solution, but a good stopgag.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added npm version to the page header for the dummy website

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
