### PR TITLE
resolves FF bug related to `copy-item` component

### DIFF
--- a/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
@@ -39,12 +39,15 @@ export default class HdsDropdownListItemCopyItemComponent extends Component {
   @action
   async copyCode() {
     let copyText = await this.args.text;
+    // https://codepen.io/chrisdavidmills/full/gzYjag/
     // execCommand is supposedly deprecated but it's also what Firefox says to do in this situation so we'll try it
-    await document.execCommand('copy', false, copyText || '');
+    // also execCommand is synchronous so we can't await it
+    document.execCommand('copy', false, copyText || '');
 
     if (copyText === this.args.text) {
       this.isSuccess = true;
-      console.log(`success: ${this.isSuccess}; copied text: ${copyText}`);
+      // if you un-comment the next line you'll see what you expect in the browser when you visit the showcase for this component.
+      // console.log(`success: ${this.isSuccess}; copied text: ${copyText}`);
       // make it fade back to the default state
       setTimeout(() => {
         this.isSuccess = false;

--- a/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
@@ -38,7 +38,7 @@ export default class HdsDropdownListItemCopyItemComponent extends Component {
 
   @action
   async copyCode() {
-    let copyText = await this.args.text;
+    let copyText = this.args.text;
     // https://codepen.io/chrisdavidmills/full/gzYjag/
     // execCommand is supposedly deprecated but it's also what Firefox says to do in this situation so we'll try it
     // also execCommand is synchronous so we can't await it

--- a/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
@@ -38,14 +38,13 @@ export default class HdsDropdownListItemCopyItemComponent extends Component {
 
   @action
   async copyCode() {
-    // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
-    await navigator.clipboard.writeText(this.args.text);
-    const result = await navigator.clipboard.readText();
+    let copyText = await this.args.text;
+    // execCommand is supposedly deprecated but it's also what Firefox says to do in this situation so we'll try it
+    await document.execCommand('copy', false, copyText || '');
 
-    if (result === this.args.text) {
+    if (copyText === this.args.text) {
       this.isSuccess = true;
-      // console.log(`result is ${result}`);
-
+      console.log(`success: ${this.isSuccess}; copied text: ${copyText}`);
       // make it fade back to the default state
       setTimeout(() => {
         this.isSuccess = false;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR should resolve issue #290 


### :hammer_and_wrench: Detailed description

I can't quite get the conditional to activate correctly in Firefox, so I ended up taking out the clipboard API and just using Firefox's recommended approach. I tested it in Chrome, FF and Safari and it's working as expected, but I don't like the idea of only using execCommand (which has been deprecated). 

Here's what I wanted to do though, maybe someone can see what I am missing: 

```js
@action
  async copyCode() {
    // check to see if the browser even supports the clipboard-write permission
    if (navigator.permissions.query({ name: 'clipboard-write' })) {
      // query for the clipboard-write navigator permission
      const permResult = await navigator.permissions.query({
        name: 'clipboard-write',
      });

      // if the permission is granted, then we can copy the text
      if (permResult.state === 'granted' || permResult.state === 'prompt') {
        // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
        await navigator.clipboard.writeText(this.args.text);
        const result = await navigator.clipboard.readText();

        // if the copied text is equal to the text to be copied, then we have been successful
        if (result === this.args.text) {
          this.isSuccess = true;
          console.log(`result is ${result}`);

          // make it fade back to the default state
          setTimeout(() => {
            this.isSuccess = false;
          }, 1000);
        }
      } else {
        // if permission is denied, we want to know about it
        console.log(`Permission denied: ${permResult.state}`);
        alert(
          'you have not granted your browser permission to use the clipboard'
        );
      }
    } else {
      // if the clipboard-write permission doesn't exist for the browser, we want to try something else
      let copyText = await this.args.text;
      // https://codepen.io/chrisdavidmills/full/gzYjag/
      // execCommand is supposedly deprecated but it's also what Firefox says to do in this situation so we'll try it
      document.execCommand('copy', false, copyText || '');

      console.log(`Copied text: ${copyText}`);

      if (copyText === this.args.text) {
        this.isSuccess = true;
        console.log(`copied text is ${copyText}`);

        // make it fade back to the default state
        setTimeout(() => {
          this.isSuccess = false;
        }, 1000);
      }
    }
  }
  ```


### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
