### PR TITLE
Form controls - error block

### DIFF
--- a/packages/components/addon/components/hds/form/error/index.hbs
+++ b/packages/components/addon/components/hds/form/error/index.hbs
@@ -1,3 +1,11 @@
 <div class={{this.classNames}} id={{this.id}} ...attributes>
-  {{yield}}
+  <FlightIcon
+    class="hds-form-error__icon"
+    @name="alert-diamond-fill"
+    @size="16"
+    @color="var(--token-color-foreground-critical-on-surface)"
+  />
+  <div class="hds-form-error__content">
+    {{yield (hash message=(component "hds/form/error/message"))}}
+  </div>
 </div>

--- a/packages/components/addon/components/hds/form/error/message.hbs
+++ b/packages/components/addon/components/hds/form/error/message.hbs
@@ -1,0 +1,3 @@
+<p class="hds-form-error__message" ...attributes>
+  {{yield}}
+</p>

--- a/packages/components/app/components/hds/form/error/message.js
+++ b/packages/components/app/components/hds/form/error/message.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/error/message';

--- a/packages/components/app/styles/components/form/error.scss
+++ b/packages/components/app/styles/components/form/error.scss
@@ -5,6 +5,22 @@
 //
 
 .hds-form-error {
-    color: var(--token-color-foreground-critical-on-surface);
-    display: block;
+  align-items: flex-start;
+  color: var(--token-color-foreground-critical-on-surface);
+  display: flex;
+}
+
+.hds-form-error__icon {
+  flex: none;
+  height: 14px;
+  margin: 2px 8px 2px 0;
+  width: 14px;
+}
+
+.hds-form-error__content {
+  flex: 1 1 auto;
+}
+
+.hds-form-error__message {
+  margin: 0;
 }

--- a/packages/components/tests/dummy/app/routes/components/form/base-elements.js
+++ b/packages/components/tests/dummy/app/routes/components/form/base-elements.js
@@ -1,3 +1,14 @@
 import Route from '@ember/routing/route';
 
-export default class ComponentsFormBaseElementsRoute extends Route {}
+export default class ComponentsFormBaseElementsRoute extends Route {
+  model() {
+    // these are used only for presentation purpose in the showcase
+    const SAMPLE_ERROR_MESSAGES = [
+      'First error message',
+      'Second error message',
+    ];
+    return {
+      SAMPLE_ERROR_MESSAGES,
+    };
+  }
+}

--- a/packages/components/tests/dummy/app/routes/components/form/text-input.js
+++ b/packages/components/tests/dummy/app/routes/components/form/text-input.js
@@ -6,9 +6,14 @@ export default class ComponentsFormTextInputRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
     const STATES = ['default', 'hover', 'active', 'focus'];
+    const SAMPLE_ERROR_MESSAGES = [
+      'First error message',
+      'Second error message',
+    ];
     return {
       TYPES,
       STATES,
+      SAMPLE_ERROR_MESSAGES,
     };
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -183,7 +183,53 @@
     content inside the component is left to the consumer.</p>
 
   <h4 class="dummy-h4">Form::Error</h4>
-  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  <p class="dummy-paragraph">
+    The most basic invocation just needs a text passed to the component and a
+    <code class="dummy-code">fieldId</code>
+    argument:
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::Error @fieldId="control-ID">This is a simple error message</Hds::Form::Error>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Error @fieldId="control-ID">This is a simple error message</Hds::Form::Error>
+  <p class="dummy-paragraph"><em>Notice: the
+      <code class="dummy-code">fieldId</code>
+      value will be used to generate an ID, prefixed with
+      <code class="dummy-code">error-</code>, so that this ID can be referenced in the
+      <code class="dummy-code">aria-describedby</code>
+      attribute of the form control. If no
+      <code class="dummy-code">fieldId</code>
+      is provided, no ID is generated (but if needed it can be passed directly as HTML attribute).</em></p>
+  <p class="dummy-paragraph">
+    There may be cases in which the error is made of multiple messages. In this case it's possible to iterate over an
+    collection of error messages:
+  </p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::Error @fieldId="control-ID" as |error|>
+        \{{#each @model.SAMPLE_ERROR_MESSAGES as |message|}}
+          <error.message>\{{message}}</error.message>
+        \{{/each}}
+      </Hds::Form::Error>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Error @fieldId="control-ID" as |error|>
+    {{#each @model.SAMPLE_ERROR_MESSAGES as |message|}}
+      <error.message>{{message}}</error.message>
+    {{/each}}
+  </Hds::Form::Error>
 
 </section>
 
@@ -260,6 +306,19 @@
   </div>
 
   <h4 class="dummy-h4">Error</h4>
-  <Hds::Form::Error>This is the Hds::Form::Error component (TODO)</Hds::Form::Error>
+  <span class="dummy-text-small">With simple text</span>
+  <Hds::Form::Error>This is a simple error message</Hds::Form::Error>
+  <br />
+  <span class="dummy-text-small">With text that spans multiple lines</span>
+  <div class="dummy-form-base-elements-max-width-sample">
+    <Hds::Form::Error>This is a very long error message that should span on multiple lines</Hds::Form::Error>
+  </div>
+  <br />
+  <span class="dummy-text-small">With multiple error messages</span>
+  <Hds::Form::Error as |error|>
+    {{#each @model.SAMPLE_ERROR_MESSAGES as |message|}}
+      <error.message>{{message}}</error.message>
+    {{/each}}
+  </Hds::Form::Error>
 
 </section>

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -212,6 +212,19 @@
         <C.Error>This is the error</C.Error>
       </Hds::Form::TextInput>
     </div>
+    <div>
+      <span class="dummy-text-small">Label + Helper text + Errors</span>
+      <br />
+      <Hds::Form::TextInput @id="custom-id" @ariaDescribedBy="custom-describedby" as |C|>
+        <C.Label>This is the label</C.Label>
+        <C.HelperText>This is the helper text</C.HelperText>
+        <C.Error as |error|>
+          {{#each @model.SAMPLE_ERROR_MESSAGES as |message|}}
+            <error.message>{{message}}</error.message>
+          {{/each}}
+        </C.Error>
+      </Hds::Form::TextInput>
+    </div>
   </div>
 
   <h4 class="dummy-h4">States</h4>


### PR DESCRIPTION
### :pushpin: Summary

PR branched off of #285 to avoid conflicts with changes coming with #340.

### :hammer_and_wrench: Detailed description

This PR adds rudimentary styling (based on the currently work in progress designs) to the `error` utility form element and enables one or multiple error messages to be passed in to the main block (design for multiple errors to be confirmed).

### :link: External links

[Asana task](https://app.asana.com/0/1202168297424991/1202346498517522)

***

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
