### PR TITLE
add link to accessible tooltip pattern for icon-only buttons

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -187,7 +187,7 @@
   <Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" @isIconOnly={{true}} />
   <p class="dummy-banner dummy-banner--info dummy-paragraph"><span aria-hidden="true">✍️</span>
     If you need to add a tooltip to an icon-only button, here is an example of how to do it in an accessible way:
-    <a href="https://codepen.io/melsumner/pen/bGGdmMV">Accessible Button Tooltip Pattern</a>.</p>
+    <a href="https://codepen.io/melsumner/pen/bGGdmMV" target="_blank" rel="noopener noreferrer">Accessible Button Tooltip Pattern</a>.</p>
 
   <h4 class="dummy-h4">Color</h4>
   <p class="dummy-paragraph">

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -185,6 +185,9 @@
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" @isIconOnly={{true}} />
+  <p class="dummy-banner dummy-banner--info dummy-paragraph"><span aria-hidden="true">✍️</span>
+    If you need to add a tooltip to an icon-only button, here is an example of how to do it in an accessible way:
+    <a href="https://codepen.io/melsumner/pen/bGGdmMV">Accessible Button Tooltip Pattern</a>.</p>
 
   <h4 class="dummy-h4">Color</h4>
   <p class="dummy-paragraph">

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -187,7 +187,8 @@
   <Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" @isIconOnly={{true}} />
   <p class="dummy-banner dummy-banner--info dummy-paragraph"><span aria-hidden="true">✍️</span>
     If you need to add a tooltip to an icon-only button, here is an example of how to do it in an accessible way:
-    <a href="https://codepen.io/melsumner/pen/bGGdmMV" target="_blank" rel="noopener noreferrer">Accessible Button Tooltip Pattern</a>.</p>
+    <a href="https://codepen.io/melsumner/pen/bGGdmMV" target="_blank" rel="noopener noreferrer">Accessible Button
+      Tooltip Pattern</a>.</p>
 
   <h4 class="dummy-h4">Color</h4>
   <p class="dummy-paragraph">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a link to an accessible tooltip pattern for an icon-only button.


### :camera_flash: Screenshots

![CleanShot 2022-06-07 at 11 28 36](https://user-images.githubusercontent.com/4587451/172434865-9204904c-e41e-4d0b-b1aa-37793bde3cfa.png)

### :link: External links

[Internal Asana issue](https://app.asana.com/0/1202008719910219/1202406951269641/f)

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
