### PR TITLE
Form controls/input width fix

### DIFF
--- a/packages/components/app/styles/components/form/common.scss
+++ b/packages/components/app/styles/components/form/common.scss
@@ -13,6 +13,7 @@
 .hds-form-field--vertical-layout {
   display: grid;
   gap: 4px;
+  width: 100%; // we want the input element to fill the parent container
 
   .hds-form-field__label {
     width: fit-content; // needed to avoid extra invisible space since the <label> is interactive

--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -11,6 +11,7 @@
   border-radius: 5px;
   box-shadow: var(--hds-elevation-inset-box-shadow);
   padding: 4px;
+  width: 100%;
 
   // STATUS
 

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -11,6 +11,12 @@
   border-radius: 5px;
   box-shadow: var(--hds-elevation-inset-box-shadow);
   padding: 4px;
+  width: 100%;
+
+  &[type="date"],
+  &[type="time"] {
+    width: initial;
+  }
 
   // STATUS
 

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -11,6 +11,7 @@
   border-radius: 5px;
   box-shadow: var(--hds-elevation-inset-box-shadow);
   padding: 4px 8px;
+  width: 100%;
 
   // STATUS
 

--- a/packages/components/tests/dummy/app/styles/pages/form/db-select.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-select.scss
@@ -38,18 +38,17 @@
 }
 
 .dummy-form-select-custom-layout {
-  width: 500px;
+  align-items: center;
+  display: flex;
+  font-family: Verdana, sans-serif;
+  font-size: 0.8em;
+  gap: 10px;
 
-  .dummy-form-select-custom-layout__heading {
-    background-color: #E4E4E4;
-    border: 1px solid #999;
-    display: flex;
-    justify-content: space-between;
-    padding: 10px;
+  select {
+    flex: 1 1 0; // is a direct child of a flexbox and has a width of 100% so it blows up
   }
-  .dummy-form-select-custom-layout__control {
-    width: 100%;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
+
+  button {
+    align-self: stretch;
   }
 }

--- a/packages/components/tests/dummy/app/styles/pages/form/db-text-input.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-text-input.scss
@@ -46,13 +46,19 @@
 
 .dummy-form-text-input-custom-layout {
   display: flex;
+  font-family: Verdana, sans-serif;
+  font-size: 0.8em;
   align-items: center;
 
   label {
     margin-right: 10px;
   }
 
-  .dummy-form-text-input-custom-layout__prepend-text {
+  input {
+    flex: 1 1 0; // is a direct child of a flexbox and has a width of 100% so it blows up
+  }
+
+  .dummy-form-text-input-custom-layout__append-text {
     background-color: #E4E4E4;
     border: 1px solid #999;
     border-radius: 0 5px 5px 0;

--- a/packages/components/tests/dummy/app/styles/pages/form/db-textarea.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-textarea.scss
@@ -38,15 +38,20 @@
 }
 
 .dummy-form-textarea-custom-layout {
+  font-family: Verdana, sans-serif;
+  font-size: 0.8em;
   width: 500px;
 
   .dummy-form-textarea-custom-layout__heading {
     background-color: #E4E4E4;
     border: 1px solid #999;
+    border-bottom: none;
+    border-radius: 5px 5px 0 0;
     display: flex;
     justify-content: space-between;
     padding: 10px;
   }
+
   .dummy-form-textarea-custom-layout__control {
     width: 100%;
     border-top-left-radius: 0;

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -90,14 +90,14 @@
       <span class="dummy-text-small">With custom layout</span>
       <br />
       <div class="dummy-form-select-custom-layout">
-        <span>Some content</span>
+        <label for="my-custom-select-example">Custom label</label>
         <Hds::Form::Select::Base id="my-custom-select-example" as |C|>
           <C.Options>
             <option>Lorem ipsum dolor</option>
             <option>Sine qua non est</option>
           </C.Options>
         </Hds::Form::Select::Base>
-        <label for="my-custom-select-example">Custom label</label>
+        <button type="button">Apply</button>
       </div>
     </div>
   </div>

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -210,7 +210,7 @@
       <div class="dummy-form-text-input-custom-layout">
         <label for="my-custom-text-input-example">Custom label</label>
         <Hds::Form::TextInput::Base id="my-custom-text-input-example" @value="Lorem ipsum dolor" />
-        <span class="dummy-form-text-input-custom-layout__prepend-text">Some content</span>
+        <span class="dummy-form-text-input-custom-layout__append-text">Some content</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### :pushpin: Summary

Quick PR on top of #285 so @alex-ju can review the changes

Previews: 
- [TextInput](https://hds-components-git-form-controls-groups-hashicorp.vercel.app/components/form/text-input#showcase)
- [Textarea](https://hds-components-git-form-controls-groups-hashicorp.vercel.app/components/form/textarea#showcase)
- [Select](https://hds-components-git-form-controls-groups-hashicorp.vercel.app/components/form/select#showcase)

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202406670481197