### PR TITLE
Add Flight icons to index page of HDS dummy website

### DIFF
--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -31,6 +31,16 @@
           </LinkTo>
         </li>
       </ol>
+      <h2 class="dummy-h2">
+        Icons:
+      </h2>
+      <ol>
+        <li class="dummy-paragraph">
+          <a href="https://flight-hashicorp.vercel.app/" rel="noopener noreferrer">
+            ✈️ Flight icons
+          </a>
+        </li>
+      </ol>
     </div>
     <div>
       <h2 class="dummy-h2">


### PR DESCRIPTION
### :pushpin: Summary

As [suggested](https://hashicorp.slack.com/archives/C03A0N1QK8S/p1654705203890569) by @evankerrigan:
> _would it be possible to add a link to [the Flight icons site](https://flight-hashicorp.vercel.app/) somewhere on the home page (maybe under Foundations?)? It would help make viewing guidance and assets into more of a one-stop shop._

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a "Icons" section (and a link to the Flight website) to the index page of the docs website.

Preview: https://hds-components-git-add-flight-link-hashicorp.vercel.app/

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
