### PR TITLE
Refactor `yield` helper component

### DIFF
--- a/.changeset/rotten-sloths-sort.md
+++ b/.changeset/rotten-sloths-sort.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+small update to the `yield` helper component - this is used in `Alert` and `Toast` but the changes should have no impact

--- a/packages/components/addon/components/hds/yield/index.hbs
+++ b/packages/components/addon/components/hds/yield/index.hbs
@@ -1,3 +1,2 @@
-<div ...attributes>
-  {{yield}}
-</div>
+{{!-- template-lint-disable no-yield-only --}}
+{{yield}}

--- a/packages/components/addon/components/hds/yield/index.hbs
+++ b/packages/components/addon/components/hds/yield/index.hbs
@@ -1,2 +1,2 @@
-{{!-- template-lint-disable no-yield-only --}}
+{{! template-lint-disable no-yield-only }}
 {{yield}}

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -212,10 +212,7 @@
     </dd>
     <dt>&lt;[A].Generic&gt; <code>yielded component</code></dt>
     <dd>
-      <p>It is a very simple component that yields its content (inside a
-        <code class="dummy-code">&lt;div&gt;</code>) and accepts
-        <code class="dummy-code">...attributes</code>
-        spreading.</p>
+      <p>It is a very simple component that yields its content.</p>
       <p><em>Notice: generic the content will appear at the bottom, after title, description and actions, and the
           developer will need to take care of spacing, layout and styling of the custom content in this case.</em></p>
       <p>🚨

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -34,7 +34,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
       <Hds::Dropdown id="test-dropdown" as |dd|>
         <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
         <dd.Description @text="description" id="test-list-item-description" />
-        <dd.Generic id="test-list-item-generic" />
+        <dd.Generic>
+          <div id="test-list-item-generic" />
+        </dd.Generic>
         <dd.Interactive @route="components.dropdown" @text="interactive" id="test-list-item-interactive" />
         <dd.Separator id="test-list-item-separator" />
         <dd.Title @text="title" id="test-list-item-title" />


### PR DESCRIPTION
### :pushpin: Summary

While working on #285 we realized that the `yield` helper component actually wraps the content in a `<div>` element, de-facto changing the expected DOM structure of the content. Checking at the codebase this is not necessary, and it's more semantic and less misleading to have this component to just yield the content (it's used as placeholder for contextual components).

### :hammer_and_wrench: Detailed description

In this PR I have:
- refactored `yield` helper component to be a “pure” yield
- updated the integration tests
- updated the documentation for `Alert`

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
