### PR TITLE
Add custom search cancel icon

### DIFF
--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -107,5 +107,14 @@
     background-position: 7px 50%;
     background-size: 16px;
     background-repeat: no-repeat;
+
+    &::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+      background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3e%3c/svg%3e");
+      background-position: center center;
+      background-size: 16px;
+      height: 16px;
+      width: 16px;
+    }
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

Use 'x' Flight icon as custom icon for search cancel button on inputs.

### :hammer_and_wrench: Detailed description

In line with design, we want to provide a Flight icon for this scenario, somehow similarly to how we provide Flight icons for the date/time picker indicators. The icon replaces the native one, which is shown on hover in Chrome, Edge and Opera, always in Safari, and never in Firefox.

👉 [Preview text-input](https://hds-components-git-form-controls-custom-search-4e7b4b-hashicorp.vercel.app/components/form/text-input#showcase)

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="218" alt="before" src="https://user-images.githubusercontent.com/788096/173120895-ad9d0550-b87c-45da-9bcc-c6a018f2f57d.png">


</td><td>

<img width="218" alt="after" src="https://user-images.githubusercontent.com/788096/173120910-acdbebd6-39e2-4be7-8754-f3666796013d.png">


</td></tr>
</table>

### :link: External links

<!-- Issues, RFC, etc. -->

***

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
