### PR TITLE
Add missing Percy test for `Dropdown` component

### DIFF
--- a/packages/components/tests/acceptance/percy-test.js
+++ b/packages/components/tests/acceptance/percy-test.js
@@ -14,14 +14,14 @@ module('Acceptance | Percy test', function (hooks) {
   }
 
   test('Take percy snapshots', async function (assert) {
-    await visit('/foundations/elevation');
-    await percySnapshot('Elevation');
-
     await visit('/foundations/colors');
     await percySnapshot('Colors');
 
     await visit('/foundations/typography');
     await percySnapshot('Typography');
+
+    await visit('/foundations/elevation');
+    await percySnapshot('Elevation');
 
     await visit('/foundations/focus-ring');
     await percySnapshot('FocusRing');
@@ -32,14 +32,17 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/components/badge');
     await percySnapshot('Badge');
 
-    await visit('/components/button');
-    await percySnapshot('Button');
-
     await visit('/components/breadcrumb');
     await percySnapshot('Breadcrumb');
 
+    await visit('/components/button');
+    await percySnapshot('Button');
+
     await visit('/components/card');
     await percySnapshot('Card');
+
+    await visit('/components/dropdown');
+    await percySnapshot('Dropdown');
 
     await visit('/components/icon-tile');
     await percySnapshot('IconTile');


### PR DESCRIPTION
### :pushpin: Summary

I noticed there was no Percy testing for the `Dropdown` component and so I opened this PR to fix this oversight.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added the missing Percy test for the `Dropdown` component
  - in the process I have also re-ordered the code to follow same order as in the index page

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
