### PR TITLE
Form controls - Add integration tests

### DIFF
--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -91,7 +91,7 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown ul').hasStyle({ width: '248px' });
   });
 
-  // SPLATTRIBUTES
+  // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     assert.expect(3);

--- a/packages/components/tests/integration/components/hds/form/checkbox/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/base-test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/checkbox/base', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" />`);
+    assert.dom('#test-form-checkbox').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" />`);
+    assert.dom('#test-form-checkbox').hasClass('hds-form-checkbox');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" @isInvalid={{true}} />`
+    );
+    assert.dom('#test-form-checkbox').hasClass('hds-form-checkbox--is-invalid');
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-checkbox').hasClass('my-class');
+    assert.dom('#test-form-checkbox').hasAttribute('data-test1');
+    assert.dom('#test-form-checkbox').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
@@ -1,0 +1,98 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/checkbox/field', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Checkbox::Field />`);
+    assert.dom('input').exists();
+  });
+  test('it should render the input with a specific CSS class', async function (assert) {
+    await render(hbs`<Hds::Form::Checkbox::Field />`);
+    assert.dom('input').hasClass('hds-form-field__control');
+  });
+
+  // VALUE
+
+  test('it should render the input with the value provided via @value argument', async function (assert) {
+    await render(hbs`<Hds::Form::Checkbox::Field @value="abc123" />`);
+    assert.dom('input').hasValue('abc123');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(hbs`<Hds::Form::Checkbox::Field @isInvalid={{true}} />`);
+    assert.dom('input').hasClass('hds-form-checkbox--is-invalid');
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(5);
+    await render(
+      hbs`<Hds::Form::Checkbox::Field checked="checked" as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Checkbox::Field>`
+    );
+    assert.dom('.hds-form-field__label').exists();
+    assert.dom('.hds-form-field__helper-text').exists();
+    assert.dom('.hds-form-field__control').exists();
+    assert.dom('.hds-form-field__control').isChecked();
+    assert.dom('.hds-form-field__error').exists();
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::Checkbox::Field />`);
+    assert.dom('.hds-form-field__label').doesNotExist();
+    assert.dom('.hds-form-field__helper-text').doesNotExist();
+    assert.dom('.hds-form-field__error').doesNotExist();
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Checkbox::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Checkbox::Field>`
+    );
+    // the control ID is dynamically generated
+    let control = this.element.querySelector('.hds-form-field__control');
+    let controlId = control.id;
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the input', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('input').hasClass('my-class');
+    assert.dom('input').hasAttribute('data-test1');
+    assert.dom('input').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/checkbox/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/group-test.js
@@ -1,0 +1,80 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/checkbox/group', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Checkbox::Group id="test-form-checkbox" />`);
+    assert.dom('#test-form-checkbox').exists();
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components and subcomponents', async function (assert) {
+    assert.expect(12);
+    await render(
+      hbs`<Hds::Form::Checkbox::Group as |G|>
+            <G.Legend>This is the legend</G.Legend>
+            <G.HelperText>This is the group helper text</G.HelperText>
+            <G.Checkbox::Field checked="checked" @value="abc123" as |F|>
+              <F.Label>This is the control label</F.Label>
+              <F.HelperText>This is the control helper text</F.HelperText>
+              <F.Error>This is the control error</F.Error>
+            </G.Checkbox::Field>
+            <G.Error>This is the group error</G.Error>
+        </Hds::Form::Checkbox::Group>`
+    );
+    assert.dom('.hds-form-group__legend').exists();
+    assert.dom('.hds-form-group__legend').hasText('This is the legend');
+    assert.dom('.hds-form-group__helper-text').exists();
+    assert
+      .dom('.hds-form-group__helper-text')
+      .hasText('This is the group helper text');
+    assert
+      .dom('.hds-form-group__control-fields-wrapper .hds-form-field__label')
+      .exists();
+    assert
+      .dom(
+        '.hds-form-group__control-fields-wrapper .hds-form-field__helper-text'
+      )
+      .exists();
+    assert
+      .dom('.hds-form-group__control-fields-wrapper .hds-form-field__control')
+      .exists();
+    assert.dom('.hds-form-group__control-fields-wrapper input').isChecked();
+    assert
+      .dom('.hds-form-group__control-fields-wrapper input')
+      .hasValue('abc123');
+    assert
+      .dom('.hds-form-group__control-fields-wrapper .hds-form-field__error')
+      .exists();
+    assert.dom('.hds-form-group__error').exists();
+    assert.dom('.hds-form-group__error').hasText('This is the group error');
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::Checkbox::Group />`);
+    assert.dom('.hds-form-group__legend').doesNotExist();
+    assert.dom('.hds-form-group__helper-text').doesNotExist();
+    assert.dom('.hds-form-group__error').doesNotExist();
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the element', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Checkbox::Group id="test-form-checkbox" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-checkbox').hasClass('my-class');
+    assert.dom('#test-form-checkbox').hasAttribute('data-test1');
+    assert.dom('#test-form-checkbox').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/error/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/error/index-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/error/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Error id="test-form-error" />`);
+    assert.dom('#test-form-error').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Error id="test-form-error" />`);
+    assert.dom('#test-form-error').hasClass('hds-form-error');
+  });
+  test('it should render with a CSS class provided via the @contextualClass argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Error @contextualClass="my-class" id="test-form-error" />`
+    );
+    assert.dom('#test-form-error').hasClass('my-class');
+  });
+
+  // CONTENT
+
+  test('it renders an error with the defined text', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Error id="test-form-error">This is the error</Hds::Form::Error>`
+    );
+    assert.dom('#test-form-error').hasText('This is the error');
+  });
+  test('it renders an error with the yielded content', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Error id="test-form-error"><pre>This is an HTML element inside the error</pre></Hds::Form::Error>`
+    );
+    assert.dom('#test-form-error pre').exists();
+    assert
+      .dom('#test-form-error pre')
+      .hasText('This is an HTML element inside the error');
+  });
+  test('it renders multiple error messages as contextual components', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Error id="test-form-error" as |E|><E.Message>First error message</E.Message><E.Message>Second error message</E.Message></Hds::Form::Error>`
+    );
+    assert
+      .dom('#test-form-error .hds-form-error__message')
+      .exists({ count: 2 });
+    assert
+      .dom('#test-form-error .hds-form-error__message')
+      .hasText('First error message');
+  });
+
+  // ATTRIBUTES
+
+  test('it renders an error with the correct "id" attribute if the @controlId argument is provided', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Error @controlId="my-control-id">This is the error</Hds::Form::Error>`
+    );
+    assert.dom('#error-my-control-id').exists();
+  });
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Error id="test-form-error" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-error').hasClass('my-class');
+    assert.dom('#test-form-error').hasAttribute('data-test1');
+    assert.dom('#test-form-error').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/field/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/field/index-test.js
@@ -1,0 +1,118 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/field/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Field id="test-form-field" />`);
+    assert.dom('#test-form-field').exists();
+  });
+  test('it should render with a CSS class provided via the @contextualClass argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Field @contextualClass="my-class" id="test-form-field" />`
+    );
+    assert.dom('#test-form-field').hasClass('my-class');
+  });
+
+  // LAYOUT
+
+  test('it should render the correct CSS layout class depending on the @layout prop', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" />`
+    );
+    assert.dom('#test-form-field').hasClass('hds-form-field--layout-vertical');
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(8);
+    await render(
+      hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Control><pre class="hds-form-field__control">This is a mock control</pre></F.Control>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Field>`
+    );
+    assert.dom('#test-form-field .hds-form-field__label').exists();
+    assert.dom('.hds-form-field__label').hasText('This is the label');
+    assert.dom('#test-form-field .hds-form-field__helper-text').exists();
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasText('This is the helper text');
+    assert.dom('#test-form-field .hds-form-field__control').exists();
+    assert.dom('.hds-form-field__control').hasText('This is a mock control');
+    assert.dom('#test-form-field .hds-form-field__error').exists();
+    assert.dom('.hds-form-field__error').hasText('This is the error');
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Control><pre class="hds-form-field__control" id={{F.id}} aria-describedby={{F.ariaDescribedBy}}>This is a mock control</pre></F.Control>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Field>`
+    );
+    // the control ID is dynamically generated
+    let control = this.element.querySelector(
+      '#test-form-field .hds-form-field__control'
+    );
+    let controlId = control.id;
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+  test('it automatically provides all the ID relations between the elements with a custom @id', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" @id="my-custom-id" as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Control><pre class="hds-form-field__control" id={{F.id}} aria-describedby={{F.ariaDescribedBy}}>This is a mock control</pre></F.Control>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Field>`
+    );
+    let controlId = 'my-custom-id';
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Field id="test-form-field" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-field').hasClass('my-class');
+    assert.dom('#test-form-field').hasAttribute('data-test1');
+    assert.dom('#test-form-field').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/fieldset/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/fieldset/index-test.js
@@ -1,0 +1,92 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/fieldset/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Fieldset id="test-form-fieldset" />`);
+    assert.dom('#test-form-fieldset').exists();
+  });
+  test('it renders the element as <fieldset>', async function (assert) {
+    await render(hbs`<Hds::Form::Fieldset id="test-form-fieldset" />`);
+    assert.dom('#test-form-fieldset').hasTagName('fieldset');
+  });
+
+  // LAYOUT
+
+  test('it should render the correct CSS layout class depending on the @layout prop', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Fieldset @layout="vertical" id="test-form-fieldset" />`
+    );
+    assert
+      .dom('#test-form-fieldset')
+      .hasClass('hds-form-group--layout-vertical');
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(8);
+    await render(
+      hbs`<Hds::Form::Fieldset @layout="vertical" id="test-form-fieldset" as |F|>
+          <F.Legend>This is the legend</F.Legend>
+          <F.HelperText>This is the group helper text</F.HelperText>
+          <F.Control><pre class="hds-form-group__control-field">This is a mock control field</pre></F.Control>
+          <F.Error>This is the group error</F.Error>
+        </Hds::Form::Fieldset>`
+    );
+    assert.dom('#test-form-fieldset .hds-form-group__legend').exists();
+    assert.dom('.hds-form-group__legend').hasText('This is the legend');
+    assert.dom('#test-form-fieldset .hds-form-group__helper-text').exists();
+    assert
+      .dom('.hds-form-group__helper-text')
+      .hasText('This is the group helper text');
+    assert.dom('#test-form-fieldset .hds-form-group__control-field').exists();
+    assert
+      .dom('.hds-form-group__control-field')
+      .hasText('This is a mock control field');
+    assert.dom('#test-form-fieldset .hds-form-group__error').exists();
+    assert.dom('.hds-form-group__error').hasText('This is the group error');
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Fieldset @layout="vertical" as |F|>
+          <F.Legend>This is the legend</F.Legend>
+          <F.HelperText>This is the group helper text</F.HelperText>
+          <F.Control><pre class="hds-form-group__control" id={{F.id}} aria-describedby={{F.ariaDescribedBy}}>This is a mock control</pre></F.Control>
+          <F.Error>This is the group error</F.Error>
+        </Hds::Form::Fieldset>`
+    );
+    // the fieldset ID is dynamically generated
+    let fieldset = this.element.querySelector('fieldset');
+    let fieldsetId = fieldset.id;
+    assert
+      .dom('.hds-form-group__helper-text')
+      .hasAttribute('id', `helper-text-${fieldsetId}`);
+    assert
+      .dom('fieldset')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${fieldsetId} error-${fieldsetId}`
+      );
+    assert
+      .dom('.hds-form-group__error')
+      .hasAttribute('id', `error-${fieldsetId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Fieldset id="test-form-fieldset" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-fieldset').hasClass('my-class');
+    assert.dom('#test-form-fieldset').hasAttribute('data-test1');
+    assert.dom('#test-form-fieldset').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/helper-text/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/helper-text/index-test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | hds/form/helper-text/index',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders the component', async function (assert) {
+      await render(hbs`<Hds::Form::HelperText id="test-form-helper-text" />`);
+      assert.dom('#test-form-helper-text').exists();
+    });
+    test('it should render with a CSS class that matches the component name', async function (assert) {
+      await render(hbs`<Hds::Form::HelperText id="test-form-helper-text" />`);
+      assert.dom('#test-form-helper-text').hasClass('hds-form-helper-text');
+    });
+    test('it should render with a CSS class provided via the @contextualClass argument', async function (assert) {
+      await render(
+        hbs`<Hds::Form::HelperText @contextualClass="my-class" id="test-form-helper-text" />`
+      );
+      assert.dom('#test-form-helper-text').hasClass('my-class');
+    });
+
+    // CONTENT
+
+    test('it renders a helper text with the defined text', async function (assert) {
+      await render(
+        hbs`<Hds::Form::HelperText id="test-form-helper-text">This is the helper text</Hds::Form::HelperText>`
+      );
+      assert.dom('#test-form-helper-text').hasText('This is the helper text');
+    });
+    test('it renders a helper text with the yielded content', async function (assert) {
+      assert.expect(2);
+      await render(
+        hbs`<Hds::Form::HelperText id="test-form-helper-text"><pre>This is an HTML element inside the helper text</pre></Hds::Form::HelperText>`
+      );
+      assert.dom('#test-form-helper-text > pre').exists();
+      assert
+        .dom('#test-form-helper-text pre')
+        .hasText('This is an HTML element inside the helper text');
+    });
+
+    // ATTRIBUTES
+
+    test('it renders a helper text with the correct "id" attribute if the @controlId argument is provided', async function (assert) {
+      await render(
+        hbs`<Hds::Form::HelperText @controlId="my-control-id">This is the helper text</Hds::Form::HelperText>`
+      );
+      assert.dom('#helper-text-my-control-id').exists();
+    });
+    test('it should spread all the attributes passed to the component', async function (assert) {
+      assert.expect(3);
+      await render(
+        hbs`<Hds::Form::HelperText id="test-form-helper-text" class="my-class" data-test1 data-test2="test" />`
+      );
+      assert.dom('#test-form-helper-text').hasClass('my-class');
+      assert.dom('#test-form-helper-text').hasAttribute('data-test1');
+      assert.dom('#test-form-helper-text').hasAttribute('data-test2', 'test');
+    });
+  }
+);

--- a/packages/components/tests/integration/components/hds/form/label/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/label/index-test.js
@@ -1,0 +1,60 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/label/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Label id="test-form-label" />`);
+    assert.dom('#test-form-label').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Label id="test-form-label" />`);
+    assert.dom('#test-form-label').hasClass('hds-form-label');
+  });
+  test('it should render with a CSS class provided via the @contextualClass argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Label @contextualClass="my-class" id="test-form-label" />`
+    );
+    assert.dom('#test-form-label').hasClass('my-class');
+  });
+
+  // CONTENT
+
+  test('it renders a label with the defined text', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Label id="test-form-label">This is the label</Hds::Form::Label>`
+    );
+    assert.dom('#test-form-label').hasText('This is the label');
+  });
+  test('it renders a label with the yielded content', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Label id="test-form-label"><pre>This is an HTML element inside the label</pre></Hds::Form::Label>`
+    );
+    assert.dom('#test-form-label > pre').exists();
+    assert
+      .dom('#test-form-label pre')
+      .hasText('This is an HTML element inside the label');
+  });
+
+  // ATTRIBUTES
+
+  test('it renders a label with the "for" attribute if the @controlId argument is provided', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Label @controlId="my-control-id" id="test-form-label">This is the label</Hds::Form::Label>`
+    );
+    assert.dom('#test-form-label').hasAttribute('for', 'my-control-id');
+  });
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Label id="test-form-label" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-label').hasClass('my-class');
+    assert.dom('#test-form-label').hasAttribute('data-test1');
+    assert.dom('#test-form-label').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/legend/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/legend/index-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/legend/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Legend id="test-form-legend" />`);
+    assert.dom('#test-form-legend').exists();
+  });
+  test('it renders the element as <legend>', async function (assert) {
+    await render(hbs`<Hds::Form::Legend id="test-form-legend" />`);
+    assert.dom('#test-form-legend').hasTagName('legend');
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Legend id="test-form-legend" />`);
+    assert.dom('#test-form-legend').hasClass('hds-form-legend');
+  });
+  test('it should render with a CSS class provided via the @contextualClass argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Legend @contextualClass="my-class" id="test-form-legend" />`
+    );
+    assert.dom('#test-form-legend').hasClass('my-class');
+  });
+
+  // CONTENT
+
+  test('it renders a legend with the defined text', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Legend id="test-form-legend">This is the legend</Hds::Form::Legend>`
+    );
+    assert.dom('#test-form-legend').hasText('This is the legend');
+  });
+  test('it renders a legend with the yielded content', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Legend id="test-form-legend"><pre>This is an HTML element inside the legend</pre></Hds::Form::Legend>`
+    );
+    assert.dom('#test-form-legend > pre').exists();
+    assert
+      .dom('#test-form-legend pre')
+      .hasText('This is an HTML element inside the legend');
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Legend id="test-form-legend" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-legend').hasClass('my-class');
+    assert.dom('#test-form-legend').hasAttribute('data-test1');
+    assert.dom('#test-form-legend').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/radio/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/base-test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/radio/base', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Radio::Base id="test-form-radio" />`);
+    assert.dom('#test-form-radio').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Radio::Base id="test-form-radio" />`);
+    assert.dom('#test-form-radio').hasClass('hds-form-radio');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Radio::Base id="test-form-radio" @isInvalid={{true}} />`
+    );
+    assert.dom('#test-form-radio').hasClass('hds-form-radio--is-invalid');
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Radio::Base id="test-form-radio" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-radio').hasClass('my-class');
+    assert.dom('#test-form-radio').hasAttribute('data-test1');
+    assert.dom('#test-form-radio').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/radio/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/field-test.js
@@ -1,0 +1,97 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/radio/field', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Radio::Field />`);
+    assert.dom('input').exists();
+  });
+  test('it should render the input with a specific CSS class', async function (assert) {
+    await render(hbs`<Hds::Form::Radio::Field />`);
+    assert.dom('input').hasClass('hds-form-field__control');
+  });
+
+  // VALUE
+
+  test('it should render the input with the value provided via @value argument', async function (assert) {
+    await render(hbs`<Hds::Form::Radio::Field @value="abc123" />`);
+    assert.dom('input').hasValue('abc123');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(hbs`<Hds::Form::Radio::Field @isInvalid={{true}} />`);
+    assert.dom('input').hasClass('hds-form-radio--is-invalid');
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Radio::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Radio::Field>`
+    );
+    assert.dom('.hds-form-field__label').exists();
+    assert.dom('.hds-form-field__helper-text').exists();
+    assert.dom('.hds-form-field__control').exists();
+    assert.dom('.hds-form-field__error').exists();
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::Radio::Field />`);
+    assert.dom('.hds-form-field__label').doesNotExist();
+    assert.dom('.hds-form-field__helper-text').doesNotExist();
+    assert.dom('.hds-form-field__error').doesNotExist();
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Radio::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Radio::Field>`
+    );
+    // the control ID is dynamically generated
+    let control = this.element.querySelector('.hds-form-field__control');
+    let controlId = control.id;
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the input', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('input').hasClass('my-class');
+    assert.dom('input').hasAttribute('data-test1');
+    assert.dom('input').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/radio/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/group-test.js
@@ -1,0 +1,80 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/radio/group', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Radio::Group id="test-form-radio" />`);
+    assert.dom('#test-form-radio').exists();
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components and subcomponents', async function (assert) {
+    assert.expect(12);
+    await render(
+      hbs`<Hds::Form::Radio::Group as |G|>
+            <G.Legend>This is the legend</G.Legend>
+            <G.HelperText>This is the group helper text</G.HelperText>
+            <G.Radio::Field checked="checked" @value="abc123" as |F|>
+              <F.Label>This is the control label</F.Label>
+              <F.HelperText>This is the control helper text</F.HelperText>
+              <F.Error>This is the control error</F.Error>
+            </G.Radio::Field>
+            <G.Error>This is the group error</G.Error>
+        </Hds::Form::Radio::Group>`
+    );
+    assert.dom('.hds-form-group__legend').exists();
+    assert.dom('.hds-form-group__legend').hasText('This is the legend');
+    assert.dom('.hds-form-group__helper-text').exists();
+    assert
+      .dom('.hds-form-group__helper-text')
+      .hasText('This is the group helper text');
+    assert
+      .dom('.hds-form-group__control-fields-wrapper .hds-form-field__label')
+      .exists();
+    assert
+      .dom(
+        '.hds-form-group__control-fields-wrapper .hds-form-field__helper-text'
+      )
+      .exists();
+    assert
+      .dom('.hds-form-group__control-fields-wrapper .hds-form-field__control')
+      .exists();
+    assert.dom('.hds-form-group__control-fields-wrapper input').isChecked();
+    assert
+      .dom('.hds-form-group__control-fields-wrapper input')
+      .hasValue('abc123');
+    assert
+      .dom('.hds-form-group__control-fields-wrapper .hds-form-field__error')
+      .exists();
+    assert.dom('.hds-form-group__error').exists();
+    assert.dom('.hds-form-group__error').hasText('This is the group error');
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::Radio::Group />`);
+    assert.dom('.hds-form-group__legend').doesNotExist();
+    assert.dom('.hds-form-group__helper-text').doesNotExist();
+    assert.dom('.hds-form-group__error').doesNotExist();
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the element', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Radio::Group id="test-form-radio" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-radio').hasClass('my-class');
+    assert.dom('#test-form-radio').hasAttribute('data-test1');
+    assert.dom('#test-form-radio').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/select/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/base-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/select/base', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Base id="test-form-select" />`);
+    assert.dom('#test-form-select').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Base id="test-form-select" />`);
+    assert.dom('#test-form-select').hasClass('hds-form-select');
+  });
+
+  // OPTIONS
+
+  test('it should render the options passed via contextual component', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Select::Base id="test-form-select" as |C|><C.Options><option value="abc123">This is the option</option></C.Options></Hds::Form::Select::Base>`
+    );
+    assert.dom('#test-form-select option').exists();
+    assert.dom('#test-form-select option').hasText('This is the option');
+    assert.dom('#test-form-select option').hasValue('abc123');
+  });
+
+  // WIDTH
+
+  test('it should render the select with a fixed width if a @width value is passed', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Select::Base @width="248px" id="test-form-select" />`
+    );
+    assert.dom('#test-form-select').hasStyle({ width: '248px' });
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Select::Base id="test-form-select" @isInvalid={{true}} />`
+    );
+    assert.dom('#test-form-select').hasClass('hds-form-select--is-invalid');
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Select::Base id="test-form-select" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-select').hasClass('my-class');
+    assert.dom('#test-form-select').hasAttribute('data-test1');
+    assert.dom('#test-form-select').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/select/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/field-test.js
@@ -1,0 +1,108 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/select/field', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Field />`);
+    assert.dom('select').exists();
+  });
+  test('it should render the input with a specific CSS class', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Field />`);
+    assert.dom('select').hasClass('hds-form-field__control');
+  });
+
+  // OPTIONS
+
+  test('it should render the options passed via contextual component', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Select::Field id="test-form-select" as |F|><F.Options><option value="abc123">This is the option</option></F.Options></Hds::Form::Select::Field>`
+    );
+    assert.dom('select option').exists();
+    assert.dom('select option').hasText('This is the option');
+    assert.dom('select option').hasValue('abc123');
+  });
+
+  // WIDTH
+
+  test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Field @width="248px" />`);
+    assert.dom('select').hasStyle({ width: '248px' });
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Field @isInvalid={{true}} />`);
+    assert.dom('select').hasClass('hds-form-select--is-invalid');
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Select::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Select::Field>`
+    );
+    assert.dom('.hds-form-field__label').exists();
+    assert.dom('.hds-form-field__helper-text').exists();
+    assert.dom('.hds-form-field__control').exists();
+    assert.dom('.hds-form-field__error').exists();
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::Select::Field />`);
+    assert.dom('.hds-form-field__label').doesNotExist();
+    assert.dom('.hds-form-field__helper-text').doesNotExist();
+    assert.dom('.hds-form-field__error').doesNotExist();
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Select::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Select::Field>`
+    );
+    // the control ID is dynamically generated
+    let control = this.element.querySelector('.hds-form-field__control');
+    let controlId = control.id;
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the input', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Select::Field class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('select').hasClass('my-class');
+    assert.dom('select').hasAttribute('data-test1');
+    assert.dom('select').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/text-input/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/base-test.js
@@ -1,0 +1,90 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/text-input/base', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Base id="test-form-text-input" />`);
+    assert.dom('#test-form-text-input').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Base id="test-form-text-input" />`);
+    assert.dom('#test-form-text-input').hasClass('hds-form-text-input');
+  });
+
+  // TYPE
+
+  test('it should render the "text" type if no type is declared', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Base id="test-form-text-input" />`);
+    assert.dom('#test-form-text-input').hasAttribute('type', 'text');
+  });
+  test('it should render the correct type depending on the @type prop', async function (assert) {
+    await render(
+      hbs`<Hds::Form::TextInput::Base @type="email" id="test-form-text-input" />`
+    );
+    assert.dom('#test-form-text-input').hasAttribute('type', 'email');
+  });
+
+  // VALUE
+
+  test('it should render the input with the value provided via @value argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::TextInput::Base @value="abc123" id="test-form-text-input" />`
+    );
+    assert.dom('#test-form-text-input').hasValue('abc123');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @isInvalid={{true}} />`
+    );
+    assert
+      .dom('#test-form-text-input')
+      .hasClass('hds-form-text-input--is-invalid');
+  });
+
+  // WIDTH
+
+  test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
+    await render(
+      hbs`<Hds::Form::TextInput::Base @width="248px" id="test-form-text-input" />`
+    );
+    assert.dom('#test-form-text-input').hasStyle({ width: '248px' });
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-text-input').hasClass('my-class');
+    assert.dom('#test-form-text-input').hasAttribute('data-test1');
+    assert.dom('#test-form-text-input').hasAttribute('data-test2', 'test');
+  });
+
+  // ASSERTIONS
+
+  test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {
+    const errorMessage =
+      '@type for "Hds::Form::TextInput" must be one of the following: text, email, password, url, search, date, time, received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Form::TextInput::Base @type="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/text-input/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/field-test.js
@@ -1,0 +1,115 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/text-input/field', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field />`);
+    assert.dom('input').exists();
+  });
+  test('it should render the input with a specific CSS class', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field />`);
+    assert.dom('input').hasClass('hds-form-field__control');
+  });
+
+  // TYPE
+
+  test('it should render the "text" type if no type is declared', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field />`);
+    assert.dom('input').hasAttribute('type', 'text');
+  });
+  test('it should render the correct type depending on the @type prop', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field @type="email" />`);
+    assert.dom('input').hasAttribute('type', 'email');
+  });
+
+  // VALUE
+
+  test('it should render the input with the value provided via @value argument', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field @value="abc123" />`);
+    assert.dom('input').hasValue('abc123');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field @isInvalid={{true}} />`);
+    assert.dom('input').hasClass('hds-form-text-input--is-invalid');
+  });
+
+  // WIDTH
+
+  test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field @width="248px" />`);
+    assert.dom('input').hasStyle({ width: '248px' });
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::TextInput::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::TextInput::Field>`
+    );
+    assert.dom('.hds-form-field__label').exists();
+    assert.dom('.hds-form-field__helper-text').exists();
+    assert.dom('.hds-form-field__control').exists();
+    assert.dom('.hds-form-field__error').exists();
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::TextInput::Field />`);
+    assert.dom('.hds-form-field__label').doesNotExist();
+    assert.dom('.hds-form-field__helper-text').doesNotExist();
+    assert.dom('.hds-form-field__error').doesNotExist();
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::TextInput::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::TextInput::Field>`
+    );
+    // the control ID is dynamically generated
+    let control = this.element.querySelector('.hds-form-field__control');
+    let controlId = control.id;
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the input', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::TextInput::Field class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('input').hasClass('my-class');
+    assert.dom('input').hasAttribute('data-test1');
+    assert.dom('input').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/textarea/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/base-test.js
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/textarea/base', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Textarea::Base id="test-form-textarea" />`);
+    assert.dom('#test-form-textarea').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Textarea::Base id="test-form-textarea" />`);
+    assert.dom('#test-form-textarea').hasClass('hds-form-textarea');
+  });
+
+  // VALUE
+
+  test('it should render the input with the value provided via @value argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Textarea::Base @value="abc123" id="test-form-textarea" />`
+    );
+    assert.dom('#test-form-textarea').hasValue('abc123');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" @isInvalid={{true}} />`
+    );
+    assert.dom('#test-form-textarea').hasClass('hds-form-textarea--is-invalid');
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-textarea').hasClass('my-class');
+    assert.dom('#test-form-textarea').hasAttribute('data-test1');
+    assert.dom('#test-form-textarea').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/textarea/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/field-test.js
@@ -1,0 +1,96 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/textarea/field', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Textarea::Field />`);
+    assert.dom('textarea').exists();
+  });
+  test('it should render the input with a specific CSS class', async function (assert) {
+    await render(hbs`<Hds::Form::Textarea::Field />`);
+    assert.dom('textarea').hasClass('hds-form-field__control');
+  });
+
+  // VALUE
+
+  test('it should render the input with the value provided via @value argument', async function (assert) {
+    await render(hbs`<Hds::Form::Textarea::Field @value="abc123" />`);
+    assert.dom('textarea').hasValue('abc123');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(hbs`<Hds::Form::Textarea::Field @isInvalid={{true}} />`);
+    assert.dom('textarea').hasClass('hds-form-textarea--is-invalid');
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Textarea::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Textarea::Field>`
+    );
+    assert.dom('.hds-form-field__label').exists();
+    assert.dom('.hds-form-field__helper-text').exists();
+    assert.dom('.hds-form-field__control').exists();
+    assert.dom('.hds-form-field__error').exists();
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::Textarea::Field />`);
+    assert.dom('.hds-form-field__label').doesNotExist();
+    assert.dom('.hds-form-field__helper-text').doesNotExist();
+    assert.dom('.hds-form-field__error').doesNotExist();
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Textarea::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Textarea::Field>`
+    );
+    // the control ID is dynamically generated
+    let control = this.element.querySelector('.hds-form-field__control');
+    let controlId = control.id;
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the input', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Textarea::Field class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('textarea').hasClass('my-class');
+    assert.dom('textarea').hasAttribute('data-test1');
+    assert.dom('textarea').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/toggle/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/base-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/toggle/base', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Toggle::Base id="test-form-toggle" />`);
+    assert.dom('#test-form-toggle').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::Toggle::Base id="test-form-toggle" />`);
+    // Notice: the "toggle" component has a slightly different DOM structure than the other form controls
+    assert.dom('.hds-form-toggle').exists();
+    assert.dom('.hds-form-toggle > #test-form-toggle').exists();
+    assert.dom('#test-form-toggle').hasClass('hds-form-toggle__control');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" @isInvalid={{true}} />`
+    );
+    assert.dom('.hds-form-toggle').hasClass('hds-form-toggle--is-invalid');
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-toggle').hasClass('my-class');
+    assert.dom('#test-form-toggle').hasAttribute('data-test1');
+    assert.dom('#test-form-toggle').hasAttribute('data-test2', 'test');
+  });
+
+  // ACCESSIBILITY
+
+  test('it should render with the correct role', async function (assert) {
+    await render(hbs`<Hds::Form::Toggle::Base id="test-form-toggle" />`);
+    assert.dom('#test-form-toggle').hasAttribute('role', 'switch');
+  });
+  // role="switch"
+});

--- a/packages/components/tests/integration/components/hds/form/toggle/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/field-test.js
@@ -1,0 +1,99 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/toggle/field', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Toggle::Field />`);
+    assert.dom('input').exists();
+  });
+  test('it should render the input with a specific CSS class', async function (assert) {
+    await render(hbs`<Hds::Form::Toggle::Field />`);
+    // Notice: the "toggle" component has a slightly different DOM structure than the other form controls
+    assert.dom('input').hasClass('hds-form-toggle__control');
+  });
+
+  // VALUE
+
+  test('it should render the input with the value provided via @value argument', async function (assert) {
+    await render(hbs`<Hds::Form::Toggle::Field @value="abc123" />`);
+    assert.dom('input').hasValue('abc123');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(hbs`<Hds::Form::Toggle::Field @isInvalid={{true}} />`);
+    assert.dom('.hds-form-toggle').hasClass('hds-form-toggle--is-invalid');
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Toggle::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Toggle::Field>`
+    );
+    assert.dom('.hds-form-field__label').exists();
+    assert.dom('.hds-form-field__helper-text').exists();
+    assert.dom('.hds-form-field__control').exists();
+    assert.dom('.hds-form-field__error').exists();
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::Toggle::Field />`);
+    assert.dom('.hds-form-field__label').doesNotExist();
+    assert.dom('.hds-form-field__helper-text').doesNotExist();
+    assert.dom('.hds-form-field__error').doesNotExist();
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Toggle::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Toggle::Field>`
+    );
+    // the control ID is dynamically generated
+    // Notice: the "toggle" component has a slightly different DOM structure than the other form controls
+    let control = this.element.querySelector('.hds-form-field__control input');
+    let controlId = control.id;
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control input')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the input', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Toggle::Field checked="checked" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('input').hasClass('my-class');
+    assert.dom('input').hasAttribute('data-test1');
+    assert.dom('input').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/interactive/index-test.js
+++ b/packages/components/tests/integration/components/hds/interactive/index-test.js
@@ -62,7 +62,7 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
     assert.dom('#test-interactive').doesNotHaveAttribute('rel');
   });
 
-  // SPLATTRIBUTES
+  // ATTRIBUTES
 
   test('it should spread all the attributes passed to the <button> element', async function (assert) {
     assert.expect(3);


### PR DESCRIPTION
### :pushpin: Summary

Now that the `form controls` components start to be pretty stable, it's time to add integration tests for them.

### :hammer_and_wrench: Detailed description

In this PR I have: 
- added integration tests for:
  - `form/label`
  - `form/helper-text`
  - `form/error`
  - `form/legend`
  - `form/field`
  - `form/fieldset`
  - `form/text-input (base + field)`
  - `form/textarea (base + field)`
  - `form/select (base + field)`
  - `form/checkbox (base + field + group)`
  - `form/radio (base + field + group)`
  - `form/toggle (base + field)`



***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202426961675273