### PR TITLE
Form controls: Determine `aria-describedby` more accurately

### DIFF
--- a/packages/components/addon/components/hds/form/error/index.hbs
+++ b/packages/components/addon/components/hds/form/error/index.hbs
@@ -1,4 +1,4 @@
-<div class={{this.classNames}} id={{this.id}} ...attributes>
+<div class={{this.classNames}} id={{this.id}} {{did-insert @onInsert}} ...attributes>
   <FlightIcon class="hds-form-error__icon" @name="alert-diamond-fill" />
   <div class="hds-form-error__content">
     {{yield (hash Message=(component "hds/form/error/message"))}}

--- a/packages/components/addon/components/hds/form/field/index.hbs
+++ b/packages/components/addon/components/hds/form/field/index.hbs
@@ -5,7 +5,7 @@
       HelperText=(component
         "hds/form/helper-text"
         controlId=this.id
-        onInsert=this.appendDescriptors
+        onInsert=this.appendDescriptor
         contextualClass="hds-form-field__helper-text"
       )
     )
@@ -14,7 +14,7 @@
   {{yield
     (hash
       Error=(component
-        "hds/form/error" controlId=this.id onInsert=this.appendDescriptors contextualClass="hds-form-field__error"
+        "hds/form/error" controlId=this.id onInsert=this.appendDescriptor contextualClass="hds-form-field__error"
       )
     )
   }}

--- a/packages/components/addon/components/hds/form/field/index.hbs
+++ b/packages/components/addon/components/hds/form/field/index.hbs
@@ -1,8 +1,21 @@
-<div class={{this.classNames}} ...attributes {{did-insert this.didInsert}}>
+<div class={{this.classNames}} ...attributes>
   {{yield (hash Label=(component "hds/form/label" controlId=this.id contextualClass="hds-form-field__label"))}}
   {{yield
-    (hash HelperText=(component "hds/form/helper-text" controlId=this.id contextualClass="hds-form-field__helper-text"))
+    (hash
+      HelperText=(component
+        "hds/form/helper-text"
+        controlId=this.id
+        onInsert=this.appendDescriptors
+        contextualClass="hds-form-field__helper-text"
+      )
+    )
   }}
   {{yield (hash Control=(component "hds/yield") id=this.id ariaDescribedBy=this.ariaDescribedBy)}}
-  {{yield (hash Error=(component "hds/form/error" controlId=this.id contextualClass="hds-form-field__error"))}}
+  {{yield
+    (hash
+      Error=(component
+        "hds/form/error" controlId=this.id onInsert=this.appendDescriptors contextualClass="hds-form-field__error"
+      )
+    )
+  }}
 </div>

--- a/packages/components/addon/components/hds/form/field/index.hbs
+++ b/packages/components/addon/components/hds/form/field/index.hbs
@@ -1,4 +1,4 @@
-<div class={{this.classNames}} ...attributes>
+<div class={{this.classNames}} ...attributes {{did-insert this.didInsert}}>
   {{yield (hash Label=(component "hds/form/label" controlId=this.id contextualClass="hds-form-field__label"))}}
   {{yield
     (hash HelperText=(component "hds/form/helper-text" controlId=this.id contextualClass="hds-form-field__helper-text"))

--- a/packages/components/addon/components/hds/form/field/index.js
+++ b/packages/components/addon/components/hds/form/field/index.js
@@ -9,10 +9,11 @@ export const LAYOUT_TYPES = ['vertical', 'flag'];
 
 export default class HdsFormFieldIndexComponent extends Component {
   @tracked ariaDescribedBy;
+  @tracked descriptors = [];
 
   @action
-  didInsert(element) {
-    this.HTMLElement = element;
+  appendDescriptors(element) {
+    this.descriptors.push(element.id);
     this.ariaDescribedBy = getAriaDescribedBy(this);
   }
 

--- a/packages/components/addon/components/hds/form/field/index.js
+++ b/packages/components/addon/components/hds/form/field/index.js
@@ -12,7 +12,7 @@ export default class HdsFormFieldIndexComponent extends Component {
   @tracked descriptors = [];
 
   @action
-  appendDescriptors(element) {
+  appendDescriptor(element) {
     this.descriptors.push(element.id);
     this.ariaDescribedBy = getAriaDescribedBy(this);
   }

--- a/packages/components/addon/components/hds/form/field/index.js
+++ b/packages/components/addon/components/hds/form/field/index.js
@@ -1,12 +1,21 @@
 import Component from '@glimmer/component';
-
+import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
+import { action } from '@ember/object';
 import { getElementId } from '../utils/getElementId';
 import { getAriaDescribedBy } from '../utils/getAriaDescribedBy';
 
 export const LAYOUT_TYPES = ['vertical', 'flag'];
 
 export default class HdsFormFieldIndexComponent extends Component {
+  @tracked ariaDescribedBy;
+
+  @action
+  didInsert(element) {
+    this.HTMLElement = element;
+    this.ariaDescribedBy = getAriaDescribedBy(this);
+  }
+
   /**
    * Sets the layout of the field
    *
@@ -31,15 +40,6 @@ export default class HdsFormFieldIndexComponent extends Component {
    */
   get id() {
     return getElementId(this);
-  }
-
-  /**
-   * Get the array of IDs for elements that relate to this form control.
-   * @method ariaDescribedBy
-   * @return {string} The "aria-describedby" attribute to apply to the component.
-   */
-  get ariaDescribedBy() {
-    return getAriaDescribedBy(this);
   }
 
   /**

--- a/packages/components/addon/components/hds/form/fieldset/index.hbs
+++ b/packages/components/addon/components/hds/form/fieldset/index.hbs
@@ -5,7 +5,7 @@
       HelperText=(component
         "hds/form/helper-text"
         controlId=this.id
-        onInsert=this.appendDescriptors
+        onInsert=this.appendDescriptor
         contextualClass="hds-form-group__helper-text"
       )
     )
@@ -16,7 +16,7 @@
   {{yield
     (hash
       Error=(component
-        "hds/form/error" controlId=this.id onInsert=this.appendDescriptors contextualClass="hds-form-group__error"
+        "hds/form/error" controlId=this.id onInsert=this.appendDescriptor contextualClass="hds-form-group__error"
       )
     )
   }}

--- a/packages/components/addon/components/hds/form/fieldset/index.hbs
+++ b/packages/components/addon/components/hds/form/fieldset/index.hbs
@@ -1,16 +1,23 @@
-<fieldset
-  class={{this.classNames}}
-  id={{this.id}}
-  ...attributes
-  aria-describedby={{this.ariaDescribedBy}}
-  {{did-insert this.didInsert}}
->
+<fieldset class={{this.classNames}} id={{this.id}} ...attributes aria-describedby={{this.ariaDescribedBy}}>
   {{yield (hash Legend=(component "hds/form/legend" contextualClass="hds-form-group__legend"))}}
   {{yield
-    (hash HelperText=(component "hds/form/helper-text" controlId=this.id contextualClass="hds-form-group__helper-text"))
+    (hash
+      HelperText=(component
+        "hds/form/helper-text"
+        controlId=this.id
+        onInsert=this.appendDescriptors
+        contextualClass="hds-form-group__helper-text"
+      )
+    )
   }}
   <div class="hds-form-group__control-fields-wrapper">
     {{yield (hash Control=(component "hds/yield"))}}
   </div>
-  {{yield (hash Error=(component "hds/form/error" controlId=this.id contextualClass="hds-form-group__error"))}}
+  {{yield
+    (hash
+      Error=(component
+        "hds/form/error" controlId=this.id onInsert=this.appendDescriptors contextualClass="hds-form-group__error"
+      )
+    )
+  }}
 </fieldset>

--- a/packages/components/addon/components/hds/form/fieldset/index.hbs
+++ b/packages/components/addon/components/hds/form/fieldset/index.hbs
@@ -1,4 +1,10 @@
-<fieldset class={{this.classNames}} id={{this.id}} ...attributes aria-describedby={{this.ariaDescribedBy}}>
+<fieldset
+  class={{this.classNames}}
+  id={{this.id}}
+  ...attributes
+  aria-describedby={{this.ariaDescribedBy}}
+  {{did-insert this.didInsert}}
+>
   {{yield (hash Legend=(component "hds/form/legend" contextualClass="hds-form-group__legend"))}}
   {{yield
     (hash HelperText=(component "hds/form/helper-text" controlId=this.id contextualClass="hds-form-group__helper-text"))

--- a/packages/components/addon/components/hds/form/fieldset/index.js
+++ b/packages/components/addon/components/hds/form/fieldset/index.js
@@ -6,10 +6,11 @@ import { getAriaDescribedBy } from '../utils/getAriaDescribedBy';
 
 export default class HdsFormFieldsetIndexComponent extends Component {
   @tracked ariaDescribedBy;
+  @tracked descriptors = [];
 
   @action
-  didInsert(element) {
-    this.HTMLElement = element;
+  appendDescriptors(element) {
+    this.descriptors.push(element.id);
     this.ariaDescribedBy = getAriaDescribedBy(this);
   }
 

--- a/packages/components/addon/components/hds/form/fieldset/index.js
+++ b/packages/components/addon/components/hds/form/fieldset/index.js
@@ -9,7 +9,7 @@ export default class HdsFormFieldsetIndexComponent extends Component {
   @tracked descriptors = [];
 
   @action
-  appendDescriptors(element) {
+  appendDescriptor(element) {
     this.descriptors.push(element.id);
     this.ariaDescribedBy = getAriaDescribedBy(this);
   }

--- a/packages/components/addon/components/hds/form/fieldset/index.js
+++ b/packages/components/addon/components/hds/form/fieldset/index.js
@@ -1,9 +1,18 @@
 import Component from '@glimmer/component';
-
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { getElementId } from '../utils/getElementId';
 import { getAriaDescribedBy } from '../utils/getAriaDescribedBy';
 
 export default class HdsFormFieldsetIndexComponent extends Component {
+  @tracked ariaDescribedBy;
+
+  @action
+  didInsert(element) {
+    this.HTMLElement = element;
+    this.ariaDescribedBy = getAriaDescribedBy(this);
+  }
+
   /**
    * Sets the layout of the group
    *
@@ -20,15 +29,6 @@ export default class HdsFormFieldsetIndexComponent extends Component {
    */
   get id() {
     return getElementId(this);
-  }
-
-  /**
-   * Get the array of IDs for elements that relate to this fieldset.
-   * @method ariaDescribedBy
-   * @return {string} The "aria-describedby" attribute to apply to the component.
-   */
-  get ariaDescribedBy() {
-    return getAriaDescribedBy(this);
   }
 
   /**

--- a/packages/components/addon/components/hds/form/helper-text/index.hbs
+++ b/packages/components/addon/components/hds/form/helper-text/index.hbs
@@ -1,3 +1,3 @@
-<div class={{this.classNames}} id={{this.id}} ...attributes>
+<div class={{this.classNames}} id={{this.id}} {{did-insert @onInsert}} ...attributes>
   {{yield}}
 </div>

--- a/packages/components/addon/components/hds/form/utils/getAriaDescribedBy.js
+++ b/packages/components/addon/components/hds/form/utils/getAriaDescribedBy.js
@@ -3,9 +3,7 @@ export function getAriaDescribedBy(element) {
 
   // append descriptor's IDs, if provided
   if (element.descriptors) {
-    element.descriptors.forEach((descriptor) =>
-      ariaDescribedBy.push(descriptor)
-    );
+    ariaDescribedBy.concat(element.descriptors);
   }
 
   // append @extraAriaDescribedBy arg, if provided

--- a/packages/components/addon/components/hds/form/utils/getAriaDescribedBy.js
+++ b/packages/components/addon/components/hds/form/utils/getAriaDescribedBy.js
@@ -8,9 +8,9 @@ export function getAriaDescribedBy(element) {
     );
   }
 
-  // append @ariaDescribedBy arg, if provided
-  if (element.args.ariaDescribedBy) {
-    ariaDescribedBy.push(element.args.ariaDescribedBy);
+  // append @extraAriaDescribedBy arg, if provided
+  if (element.args.extraAriaDescribedBy) {
+    ariaDescribedBy.push(element.args.extraAriaDescribedBy);
   }
   return ariaDescribedBy.join(' ');
 }

--- a/packages/components/addon/components/hds/form/utils/getAriaDescribedBy.js
+++ b/packages/components/addon/components/hds/form/utils/getAriaDescribedBy.js
@@ -3,8 +3,23 @@ import { ID_PREFIX as HELPER_TEXT_ID_PREFIX } from '../helper-text';
 
 export function getAriaDescribedBy(element) {
   let ariaDescribedBy = [];
-  ariaDescribedBy.push(`${HELPER_TEXT_ID_PREFIX}${element.id}`);
-  ariaDescribedBy.push(`${ERROR_ID_PREFIX}${element.id}`);
+
+  if (element.HTMLElement) {
+    let helperText = element.HTMLElement.querySelector(
+      `#${HELPER_TEXT_ID_PREFIX}${element.id}`
+    );
+    let error = element.HTMLElement.querySelector(
+      `#${ERROR_ID_PREFIX}${element.id}`
+    );
+
+    if (helperText) {
+      ariaDescribedBy.push(`${HELPER_TEXT_ID_PREFIX}${element.id}`);
+    }
+    if (error) {
+      ariaDescribedBy.push(`${ERROR_ID_PREFIX}${element.id}`);
+    }
+  }
+
   // append @ariaDescribedBy arg, if provided
   if (element.args.ariaDescribedBy) {
     ariaDescribedBy.push(element.args.ariaDescribedBy);

--- a/packages/components/addon/components/hds/form/utils/getAriaDescribedBy.js
+++ b/packages/components/addon/components/hds/form/utils/getAriaDescribedBy.js
@@ -1,23 +1,11 @@
-import { ID_PREFIX as ERROR_ID_PREFIX } from '../error';
-import { ID_PREFIX as HELPER_TEXT_ID_PREFIX } from '../helper-text';
-
 export function getAriaDescribedBy(element) {
   let ariaDescribedBy = [];
 
-  if (element.HTMLElement) {
-    let helperText = element.HTMLElement.querySelector(
-      `#${HELPER_TEXT_ID_PREFIX}${element.id}`
+  // append descriptor's IDs, if provided
+  if (element.descriptors) {
+    element.descriptors.forEach((descriptor) =>
+      ariaDescribedBy.push(descriptor)
     );
-    let error = element.HTMLElement.querySelector(
-      `#${ERROR_ID_PREFIX}${element.id}`
-    );
-
-    if (helperText) {
-      ariaDescribedBy.push(`${HELPER_TEXT_ID_PREFIX}${element.id}`);
-    }
-    if (error) {
-      ariaDescribedBy.push(`${ERROR_ID_PREFIX}${element.id}`);
-    }
   }
 
   // append @ariaDescribedBy arg, if provided


### PR DESCRIPTION
### :pushpin: Summary

To overcome limitations of not being able to check if a certain contextual component (e.g. helper-text or error) has content, we turn to a client-side approach for an accurate `aria-describedby` value.

### :hammer_and_wrench: Detailed description

The current implementation of `aria-describedby` in our form components lists both the `id` of the helper text and the `id` of the error block regardless of which of these two block are being passed in. While assistive technologies fail gracefully in such scenario (if `aria-describedby` contains the `id` of an element that doesn't exist in the DOM) any automated test will pick up this anomaly and report it, so we'd like to be accurate.

### :link: External links

[Asana task](https://app.asana.com/0/1202168297424991/1202443172675747)

***

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
