### PR TITLE
Form controls - Base elements (01)

### DIFF
--- a/packages/components/addon/components/hds/form/error/index.hbs
+++ b/packages/components/addon/components/hds/form/error/index.hbs
@@ -1,0 +1,6 @@
+<div class={{this.classNames}} id={{this.id}} {{did-insert this.onInsert}} ...attributes>
+  <FlightIcon class="hds-form-error__icon" @name="alert-diamond-fill" />
+  <div class="hds-form-error__content">
+    {{yield (hash Message=(component "hds/form/error/message"))}}
+  </div>
+</div>

--- a/packages/components/addon/components/hds/form/error/index.js
+++ b/packages/components/addon/components/hds/form/error/index.js
@@ -7,7 +7,7 @@ export default class HdsFormErrorIndexComponent extends Component {
   /**
    * Determines the unique ID to assign to the element
    * @method id
-   * @return {(string|null)} The "id" attribute to apply to the element or false, if no controlId is provided
+   * @return {(string|null)} The "id" attribute to apply to the element or null, if no controlId is provided
    */
   get id() {
     let { controlId } = this.args;

--- a/packages/components/addon/components/hds/form/error/index.js
+++ b/packages/components/addon/components/hds/form/error/index.js
@@ -7,14 +7,14 @@ export default class HdsFormErrorIndexComponent extends Component {
   /**
    * Determines the unique ID to assign to the element
    * @method id
-   * @return {(string|boolean)} The "id" attribute to apply to the element or false, if no controlId is provided
+   * @return {(string|null)} The "id" attribute to apply to the element or false, if no controlId is provided
    */
   get id() {
     let { controlId } = this.args;
     if (controlId) {
       return `${ID_PREFIX}${controlId}`;
     }
-    return false;
+    return null;
   }
 
   /**

--- a/packages/components/addon/components/hds/form/error/index.js
+++ b/packages/components/addon/components/hds/form/error/index.js
@@ -1,0 +1,56 @@
+import Component from '@glimmer/component';
+export const ID_PREFIX = 'error-';
+
+const NOOP = () => {};
+
+export default class HdsFormErrorIndexComponent extends Component {
+  /**
+   * Determines the unique ID to assign to the element
+   * @method id
+   * @return {(string|boolean)} The "id" attribute to apply to the element or false, if no controlId is provided
+   */
+  get id() {
+    let { controlId } = this.args;
+    if (controlId) {
+      return `${ID_PREFIX}${controlId}`;
+    }
+    return false;
+  }
+
+  /**
+   * @param onInsert
+   * @type {function}
+   * @default () => {}
+   */
+  get onInsert() {
+    let { onInsert } = this.args;
+
+    // notice: this is a guard used to prevent triggering an error when the component is used as standalone element
+    if (typeof onInsert === 'function') {
+      return onInsert;
+    } else {
+      return NOOP;
+    }
+  }
+
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-form-error'];
+
+    // add typographic classes
+    classes.push('hds-typography-body-100', 'hds-font-weight-medium');
+
+    // add a class based on the @contextualClass argument
+    // notice: this will *not* be documented for public use
+    // the reason for this is that the contextual component declarations don't pass attributes to the component
+    if (this.args.contextualClass) {
+      classes.push(this.args.contextualClass);
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/addon/components/hds/form/error/message.hbs
+++ b/packages/components/addon/components/hds/form/error/message.hbs
@@ -1,0 +1,3 @@
+<p class="hds-form-error__message" ...attributes>
+  {{yield}}
+</p>

--- a/packages/components/addon/components/hds/form/field/index.hbs
+++ b/packages/components/addon/components/hds/form/field/index.hbs
@@ -1,0 +1,21 @@
+<div class={{this.classNames}} ...attributes>
+  {{yield (hash Label=(component "hds/form/label" controlId=this.id contextualClass="hds-form-field__label"))}}
+  {{yield
+    (hash
+      HelperText=(component
+        "hds/form/helper-text"
+        controlId=this.id
+        onInsert=this.appendDescriptor
+        contextualClass="hds-form-field__helper-text"
+      )
+    )
+  }}
+  {{yield (hash Control=(component "hds/yield") id=this.id ariaDescribedBy=this.ariaDescribedBy)}}
+  {{yield
+    (hash
+      Error=(component
+        "hds/form/error" controlId=this.id onInsert=this.appendDescriptor contextualClass="hds-form-field__error"
+      )
+    )
+  }}
+</div>

--- a/packages/components/addon/components/hds/form/field/index.js
+++ b/packages/components/addon/components/hds/form/field/index.js
@@ -1,0 +1,66 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import { getElementId } from '../utils/getElementId';
+import { getAriaDescribedBy } from '../utils/getAriaDescribedBy';
+
+export const LAYOUT_TYPES = ['vertical', 'flag'];
+
+export default class HdsFormFieldIndexComponent extends Component {
+  @tracked ariaDescribedBy;
+  @tracked descriptors = [];
+
+  @action
+  appendDescriptor(element) {
+    this.descriptors.push(element.id);
+    this.ariaDescribedBy = getAriaDescribedBy(this);
+  }
+
+  /**
+   * Sets the layout of the field
+   *
+   * @param layout
+   * @type {string}
+   */
+  get layout() {
+    let { layout } = this.args;
+
+    assert(
+      `@type for "Hds::Form::Field" must be one of the following: ${LAYOUT_TYPES.join(
+        ', '
+      )}, received: ${layout}`,
+      LAYOUT_TYPES.includes(layout)
+    );
+
+    return layout;
+  }
+
+  /**
+   * Calculates the unique ID to assign to the form control
+   */
+  get id() {
+    return getElementId(this);
+  }
+
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = [];
+
+    if (this.args.layout) {
+      classes.push(`hds-form-field--layout-${this.layout}`);
+    }
+
+    // add a class based on the @contextualClass argument
+    // notice: this will *not* be documented for public use
+    if (this.args.contextualClass) {
+      classes.push(this.args.contextualClass);
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/addon/components/hds/form/fieldset/index.hbs
+++ b/packages/components/addon/components/hds/form/fieldset/index.hbs
@@ -1,0 +1,23 @@
+<fieldset class={{this.classNames}} id={{this.id}} ...attributes aria-describedby={{this.ariaDescribedBy}}>
+  {{yield (hash Legend=(component "hds/form/legend" contextualClass="hds-form-group__legend"))}}
+  {{yield
+    (hash
+      HelperText=(component
+        "hds/form/helper-text"
+        controlId=this.id
+        onInsert=this.appendDescriptor
+        contextualClass="hds-form-group__helper-text"
+      )
+    )
+  }}
+  <div class="hds-form-group__control-fields-wrapper">
+    {{yield (hash Control=(component "hds/yield"))}}
+  </div>
+  {{yield
+    (hash
+      Error=(component
+        "hds/form/error" controlId=this.id onInsert=this.appendDescriptor contextualClass="hds-form-group__error"
+      )
+    )
+  }}
+</fieldset>

--- a/packages/components/addon/components/hds/form/fieldset/index.js
+++ b/packages/components/addon/components/hds/form/fieldset/index.js
@@ -1,0 +1,49 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { getElementId } from '../utils/getElementId';
+import { getAriaDescribedBy } from '../utils/getAriaDescribedBy';
+
+export default class HdsFormFieldsetIndexComponent extends Component {
+  @tracked ariaDescribedBy;
+  @tracked descriptors = [];
+
+  @action
+  appendDescriptor(element) {
+    this.descriptors.push(element.id);
+    this.ariaDescribedBy = getAriaDescribedBy(this);
+  }
+
+  /**
+   * Sets the layout of the group
+   *
+   * @param layout
+   * @type {enum}
+   * @default 'vertical'
+   */
+  get layout() {
+    return this.args.layout ?? 'vertical';
+  }
+
+  /**
+   * Calculates the unique ID to assign to the fieldset
+   */
+  get id() {
+    return getElementId(this);
+  }
+
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    // we just need a class for the layout
+    let classes = ['hds-form-group'];
+
+    // add a class based on the @layout argument
+    classes.push(`hds-form-group--layout-${this.layout}`);
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/addon/components/hds/form/helper-text/index.hbs
+++ b/packages/components/addon/components/hds/form/helper-text/index.hbs
@@ -1,0 +1,3 @@
+<div class={{this.classNames}} id={{this.id}} {{did-insert this.onInsert}} ...attributes>
+  {{yield}}
+</div>

--- a/packages/components/addon/components/hds/form/helper-text/index.js
+++ b/packages/components/addon/components/hds/form/helper-text/index.js
@@ -1,0 +1,56 @@
+import Component from '@glimmer/component';
+export const ID_PREFIX = 'helper-text-';
+
+const NOOP = () => {};
+
+export default class HdsFormHelperTextIndexComponent extends Component {
+  /**
+   * Determines the unique ID to assign to the element
+   * @method id
+   * @return {(string|boolean)} The "id" attribute to apply to the element or false, if no controlId is provided
+   */
+  get id() {
+    let { controlId } = this.args;
+    if (controlId) {
+      return `${ID_PREFIX}${controlId}`;
+    }
+    return false;
+  }
+
+  /**
+   * @param onInsert
+   * @type {function}
+   * @default () => {}
+   */
+  get onInsert() {
+    let { onInsert } = this.args;
+
+    // notice: this is a guard used to prevent triggering an error when the component is used as standalone element
+    if (typeof onInsert === 'function') {
+      return onInsert;
+    } else {
+      return NOOP;
+    }
+  }
+
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-form-helper-text'];
+
+    // add typographic classes
+    classes.push('hds-typography-body-100', 'hds-font-weight-regular');
+
+    // add a class based on the @contextualClass argument
+    // notice: this will *not* be documented for public use
+    // the reason for this is that the contextual component declarations don't pass attributes to the component
+    if (this.args.contextualClass) {
+      classes.push(this.args.contextualClass);
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/addon/components/hds/form/helper-text/index.js
+++ b/packages/components/addon/components/hds/form/helper-text/index.js
@@ -7,14 +7,14 @@ export default class HdsFormHelperTextIndexComponent extends Component {
   /**
    * Determines the unique ID to assign to the element
    * @method id
-   * @return {(string|boolean)} The "id" attribute to apply to the element or false, if no controlId is provided
+   * @return {(string|boolean)} The "id" attribute to apply to the element or null, if no controlId is provided
    */
   get id() {
     let { controlId } = this.args;
     if (controlId) {
       return `${ID_PREFIX}${controlId}`;
     }
-    return false;
+    return null;
   }
 
   /**

--- a/packages/components/addon/components/hds/form/helper-text/index.js
+++ b/packages/components/addon/components/hds/form/helper-text/index.js
@@ -7,7 +7,7 @@ export default class HdsFormHelperTextIndexComponent extends Component {
   /**
    * Determines the unique ID to assign to the element
    * @method id
-   * @return {(string|boolean)} The "id" attribute to apply to the element or null, if no controlId is provided
+   * @return {(string|null)} The "id" attribute to apply to the element or null, if no controlId is provided
    */
   get id() {
     let { controlId } = this.args;

--- a/packages/components/addon/components/hds/form/label/index.hbs
+++ b/packages/components/addon/components/hds/form/label/index.hbs
@@ -1,0 +1,3 @@
+<label class={{this.classNames}} for={{@controlId}} ...attributes>
+  {{yield}}
+</label>

--- a/packages/components/addon/components/hds/form/label/index.js
+++ b/packages/components/addon/components/hds/form/label/index.js
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+
+export default class HdsFormLabelIndexComponent extends Component {
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-form-label'];
+
+    // add typographic classes
+    classes.push('hds-typography-body-200', 'hds-font-weight-semibold');
+
+    // add a class based on the @contextualClass argument
+    // notice: this will *not* be documented for public use
+    // the reason for this is that the contextual component declarations don't pass attributes to the component
+    if (this.args.contextualClass) {
+      classes.push(this.args.contextualClass);
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/addon/components/hds/form/legend/index.hbs
+++ b/packages/components/addon/components/hds/form/legend/index.hbs
@@ -1,0 +1,3 @@
+<legend class={{this.classNames}} ...attributes>
+  {{yield}}
+</legend>

--- a/packages/components/addon/components/hds/form/legend/index.js
+++ b/packages/components/addon/components/hds/form/legend/index.js
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+
+export default class HdsFormLegendIndexComponent extends Component {
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-form-legend'];
+
+    // add typographic classes
+    classes.push('hds-typography-body-200', 'hds-font-weight-semibold');
+
+    // add a class based on the @contextualClass argument
+    // notice: this will *not* be documented for public use
+    // the reason for this is that the contextual component declarations don't pass attributes to the component
+    if (this.args.contextualClass) {
+      classes.push(this.args.contextualClass);
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/addon/components/hds/form/utils/getAriaDescribedBy.js
+++ b/packages/components/addon/components/hds/form/utils/getAriaDescribedBy.js
@@ -1,0 +1,11 @@
+export function getAriaDescribedBy(element) {
+  // initialize the array using the descriptors' IDs, if they exist
+  let ariaDescribedBy = element.descriptors ?? [];
+
+  // append @extraAriaDescribedBy arg, if provided
+  if (element.args.extraAriaDescribedBy) {
+    ariaDescribedBy.push(element.args.extraAriaDescribedBy);
+  }
+
+  return ariaDescribedBy.join(' ');
+}

--- a/packages/components/addon/components/hds/form/utils/getElementId.js
+++ b/packages/components/addon/components/hds/form/utils/getElementId.js
@@ -1,0 +1,14 @@
+import { guidFor } from '@ember/object/internals';
+
+export function getElementId(element) {
+  // use @id arg, if provided
+  if (element.args.id) {
+    return element.args.id;
+  }
+
+  // otherwise, generate and memoize a guid
+  if (!element._id) {
+    element._id = guidFor(element);
+  }
+  return element._id;
+}

--- a/packages/components/app/components/hds/form/error/index.js
+++ b/packages/components/app/components/hds/form/error/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/error/index';

--- a/packages/components/app/components/hds/form/error/message.js
+++ b/packages/components/app/components/hds/form/error/message.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/error/message';

--- a/packages/components/app/components/hds/form/field/index.js
+++ b/packages/components/app/components/hds/form/field/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/field/index';

--- a/packages/components/app/components/hds/form/fieldset/index.js
+++ b/packages/components/app/components/hds/form/fieldset/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/fieldset/index';

--- a/packages/components/app/components/hds/form/helper-text/index.js
+++ b/packages/components/app/components/hds/form/helper-text/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/helper-text/index';

--- a/packages/components/app/components/hds/form/label/index.js
+++ b/packages/components/app/components/hds/form/label/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/label/index';

--- a/packages/components/app/components/hds/form/legend/index.js
+++ b/packages/components/app/components/hds/form/legend/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/legend/index';

--- a/packages/components/app/styles/@hashicorp/design-system-components.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-components.scss
@@ -15,6 +15,7 @@
 @use "../components/card";
 @use "../components/disclosure";
 @use "../components/dropdown";
+@use "../components/form"; // multiple components
 @use "../components/icon-tile";
 @use "../components/link/inline";
 @use "../components/link/standalone";

--- a/packages/components/app/styles/components/form/error.scss
+++ b/packages/components/app/styles/components/form/error.scss
@@ -1,0 +1,27 @@
+//
+// FORM > ERROR
+//
+// properties within each class are sorted alphabetically
+//
+
+.hds-form-error {
+  align-items: flex-start;
+  color: var(--token-color-foreground-critical-on-surface);
+  display: flex;
+}
+
+.hds-form-error__icon {
+  color: var(--token-color-foreground-critical-on-surface);
+  flex: none;
+  height: 14px;
+  margin: 2px 8px 2px 0;
+  width: 14px;
+}
+
+.hds-form-error__content {
+  flex: 1 1 auto;
+}
+
+.hds-form-error__message {
+  margin: 0;
+}

--- a/packages/components/app/styles/components/form/field.scss
+++ b/packages/components/app/styles/components/form/field.scss
@@ -17,15 +17,6 @@
     width: fit-content; // needed to avoid extra invisible space since the <label> is interactive
   }
 
-  .hds-form-field__control {
-    &:not(:first-child) {
-      margin-top: 8px;
-    }
-    &:not(:last-child) {
-      margin-bottom: 8px;
-    }
-  }
-
   .hds-form-field__helper-text {
     &:not(:first-child) {
       margin-top: 4px;
@@ -34,6 +25,15 @@
     // special case: if there are multiple helper text lines, we want to reduce the spacing between them
     & + .hds-form-helper-text {
       margin-top: 2px;
+    }
+  }
+
+  .hds-form-field__control {
+    &:not(:first-child) {
+      margin-top: 8px;
+    }
+    &:not(:last-child) {
+      margin-bottom: 8px;
     }
   }
 }
@@ -54,15 +54,6 @@
     "control error";
   justify-items: start;
 
-  .hds-form-field__control {
-    grid-area: control;
-
-    &:not(:only-child) {
-      margin-top: 2px; // the line height of the label is bigger than the control size
-      margin-right: 8px;
-    }
-  }
-
   .hds-form-field__label {
     grid-area: label;
     width: fit-content; // needed to avoid extra invisible space since the <label> is interactive
@@ -71,6 +62,15 @@
   .hds-form-field__helper-text {
     grid-area: helper-text;
     margin-top: 4px;
+  }
+
+  .hds-form-field__control {
+    grid-area: control;
+
+    &:not(:only-child) {
+      margin-top: 2px; // the line height of the label is bigger than the control size
+      margin-right: 8px;
+    }
   }
 
   .hds-form-field__error {

--- a/packages/components/app/styles/components/form/field.scss
+++ b/packages/components/app/styles/components/form/field.scss
@@ -1,0 +1,90 @@
+//
+// FORM > FIELD
+//
+// properties within each class are sorted alphabetically
+//
+
+
+// "VERTICAL" LAYOUT
+// used for text-input, textarea, select
+
+.hds-form-field--layout-vertical {
+  display: grid;
+  justify-items: start;
+  width: 100%; // we want the input element to fill the parent container
+
+  .hds-form-field__label {
+    width: fit-content; // needed to avoid extra invisible space since the <label> is interactive
+  }
+
+  .hds-form-field__control {
+    &:not(:first-child) {
+      margin-top: 8px;
+    }
+    &:not(:last-child) {
+      margin-bottom: 8px;
+    }
+  }
+
+  .hds-form-field__helper-text {
+    &:not(:first-child) {
+      margin-top: 4px;
+    }
+
+    // special case: if there are multiple helper text lines, we want to reduce the spacing between them
+    & + .hds-form-helper-text {
+      margin-top: 2px;
+    }
+  }
+}
+
+
+// "FLAG" LAYOUT
+// used for checkbox, radio, toggle
+// see https://codepen.io/didoo/pen/xxYPNeY
+
+.hds-form-field--layout-flag {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto auto;
+  grid-auto-flow: row;
+  grid-template-areas:
+    "control label"
+    "control helper-text"
+    "control error";
+  justify-items: start;
+
+  .hds-form-field__control {
+    grid-area: control;
+
+    &:not(:only-child) {
+      margin-top: 2px; // the line height of the label is bigger than the control size
+      margin-right: 8px;
+    }
+  }
+
+  .hds-form-field__label {
+    grid-area: label;
+    width: fit-content; // needed to avoid extra invisible space since the <label> is interactive
+  }
+
+  .hds-form-field__helper-text {
+    grid-area: helper-text;
+    margin-top: 4px;
+  }
+
+  .hds-form-field__error {
+    margin-top: 4px;
+    grid-area: error;
+  }
+}
+
+
+
+// Debug (please don't remove)
+//
+// .hds-form-field--layout-vertical,
+// .hds-form-field--layout-flag { outline: 2px dashed pink; }
+// .hds-form-field__label { background-color: #00ff00; }
+// .hds-form-field__helper-text { background-color: #0000ff; }
+// .hds-form-field__error { background-color: #ff0000; }

--- a/packages/components/app/styles/components/form/group.scss
+++ b/packages/components/app/styles/components/form/group.scss
@@ -17,6 +17,7 @@
 }
 
 .hds-form-group__control-fields-wrapper {
+  // when the group contains a "legend", we reduce the visual weight of the "label"
   .hds-form-group__legend + & {
     .hds-form-label {
       font-weight: var(--token-typography-font-weight-regular);

--- a/packages/components/app/styles/components/form/group.scss
+++ b/packages/components/app/styles/components/form/group.scss
@@ -1,0 +1,51 @@
+//
+// FORM > GROUP
+//
+// properties within each class are sorted alphabetically
+//
+
+.hds-form-group { // notice: this is a <fieldset> element
+  border: none;
+  display: block;
+  margin: 0;
+  padding: 0;
+}
+
+.hds-form-group__legend { // notice: this is a <legend> element
+  margin: 0 0 4px 0;
+  padding: 0;
+}
+
+.hds-form-group__control-fields-wrapper {
+  .hds-form-group__legend + & {
+    .hds-form-label {
+      font-weight: var(--token-typography-font-weight-regular);
+    }
+  }
+}
+
+.hds-form-group--layout-vertical {
+  .hds-form-group__control-field + .hds-form-group__control-field {
+    margin-top: 16px;
+  }
+}
+
+.hds-form-group--layout-horizontal {
+  .hds-form-group__control-fields-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    margin-bottom: -4px;
+  }
+  .hds-form-group__control-field {
+    margin-right: 16px;
+    margin-bottom: 4px;
+  }
+}
+
+.hds-form-group__helper-text {
+  margin-bottom: 8px;
+}
+
+.hds-form-group__error {
+  margin-top: 8px;
+}

--- a/packages/components/app/styles/components/form/helper-text.scss
+++ b/packages/components/app/styles/components/form/helper-text.scss
@@ -1,0 +1,10 @@
+//
+// FORM > HELPER-TEXT
+//
+// properties within each class are sorted alphabetically
+//
+
+.hds-form-helper-text {
+  color: var(--token-color-foreground-faint);
+  display: block;
+}

--- a/packages/components/app/styles/components/form/index.scss
+++ b/packages/components/app/styles/components/form/index.scss
@@ -1,0 +1,11 @@
+//
+// FORM > INDEX
+//
+
+
+@use "./label";
+@use "./helper-text";
+@use "./error";
+@use "./field";
+@use "./legend";
+@use "./group";

--- a/packages/components/app/styles/components/form/label.scss
+++ b/packages/components/app/styles/components/form/label.scss
@@ -1,0 +1,12 @@
+//
+// FORM > LABEL
+//
+// properties within each class are sorted alphabetically
+//
+
+.hds-form-label {
+  color: var(--token-color-foreground-strong);
+  display: block;
+  max-width: 100%;
+  width: max-content; // to avoid it extends the full width of the parent container, leading to invisible interactive area
+}

--- a/packages/components/app/styles/components/form/legend.scss
+++ b/packages/components/app/styles/components/form/legend.scss
@@ -1,0 +1,10 @@
+//
+// FORM > LEGEND
+//
+// properties within each class are sorted alphabetically
+//
+
+.hds-form-legend {
+  color: var(--token-color-foreground-strong);
+  display: block;
+}

--- a/packages/components/blueprints/hds-component-test/files/tests/dummy/app/templates/components/__name__.hbs
+++ b/packages/components/blueprints/hds-component-test/files/tests/dummy/app/templates/components/__name__.hbs
@@ -8,14 +8,14 @@
 {{! Once done, please remove these comments (they're created by the generator). }}
 
 <section>
-  <h3 class="dummy-h3" id="overview"><a href="#overview">§</a> Overview</h3>
+  <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
 
   {{! ADD YOUR CONTENT HERE }}
 
 </section>
 
 <section>
-  <h3 class="dummy-h3" id="component-api"><a href="#component-api">§</a> Component API</h3>
+  <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
   <p class="dummy-paragraph" id="component-api-<%= kebabizedModuleName %>">
     Here is the API for the component:
   </p>
@@ -34,7 +34,7 @@
 </section>
 
 <section>
-  <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>Design guidelines</h3>
+  <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a> Design guidelines</h3>
   {{! UNCOMMENT THIS BLOCK (once the link and/or the image are available) }}
   {{!
   <div class="dummy-design-guidelines">

--- a/packages/components/tests/acceptance/percy-test.js
+++ b/packages/components/tests/acceptance/percy-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import percySnapshot from '@percy/ember';
 import config from 'dummy/config/environment';
@@ -43,6 +43,10 @@ module('Acceptance | Percy test', function (hooks) {
 
     await visit('/components/dropdown');
     await percySnapshot('Dropdown');
+
+    await visit('/components/form/base-elements');
+    await click('button#dummy-toggle-highlight');
+    await percySnapshot('Form - Base elements');
 
     await visit('/components/icon-tile');
     await percySnapshot('IconTile');

--- a/packages/components/tests/dummy/app/controllers/components/form/base-elements.js
+++ b/packages/components/tests/dummy/app/controllers/components/form/base-elements.js
@@ -1,0 +1,12 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class BaseElementsController extends Controller {
+  @tracked showHighlight = false;
+
+  @action
+  toggleHighlight() {
+    this.showHighlight = !this.showHighlight;
+  }
+}

--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -21,6 +21,9 @@ Router.map(function () {
     this.route('button');
     this.route('card');
     this.route('dropdown');
+    this.route('form', function () {
+      this.route('base-elements');
+    });
     this.route('icon-tile');
     this.route('link', function () {
       this.route('inline');

--- a/packages/components/tests/dummy/app/routes/components/form/base-elements.js
+++ b/packages/components/tests/dummy/app/routes/components/form/base-elements.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+
+export default class ComponentsFormBaseElementsRoute extends Route {
+  model() {
+    // these are used only for presentation purpose in the showcase
+    const SAMPLE_ERROR_MESSAGES = [
+      'First error message',
+      'Second error message',
+    ];
+    return {
+      SAMPLE_ERROR_MESSAGES,
+    };
+  }
+}

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -22,6 +22,7 @@
 @import "./pages/db-toast";
 @import "./pages/db-tokens";
 @import "./pages/db-typography";
+@import "./pages/form/db-base-elements";
 // END COMPONENT PAGES IMPORTS
 
 @import "./components/dummy-component-props";
@@ -90,7 +91,7 @@ body.dummy-app {
 }
 
 .dummy-divider {
-  margin: 4rem 0;
+  margin: 2rem 0;
 }
 .dummy-demo-border {
   border: 1px solid red;
@@ -115,7 +116,7 @@ body.dummy-app {
 
 .dummy-banner {
   padding: 0.75rem 1.25rem;
-  margin-bottom: 1rem;
+  margin: 1rem auto;
   border: 1px solid #d6d8db;
   border-radius: 0.25rem;
   background-color: #e2e3e5;

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -130,6 +130,10 @@ body.dummy-app {
   color: #004085;
   background-color: #cce5ff;
   border-color: #b8daff;
+
+  .flight-icon {
+    margin-right: 6px;
+  }
 }
 
 .dummy-banner--alert {

--- a/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
@@ -1,64 +1,64 @@
 // DUMMY COMPONENT PROPS
 
 .dummy-component-props {
-    font-family: monaco, Consolas, "Lucida Console", monospace;
-    font-size: 0.9rem;
-    line-height: 1.2;
-    max-width: 64rem;
+  font-family: monaco, Consolas, 'Lucida Console', monospace;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  max-width: 64rem;
 
-    dt {
-        color: #1F69FF;
-        font-size: 1rem;
-        font-weight: 700;
-        margin: 1.25rem 0 0.5rem 0;
+  dt {
+    color: #1f69ff;
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 1.25rem 0 0.5rem 0;
 
-        code {
-            color: #666666;
-            font-weight: 500;
-        }
+    code {
+      color: #666666;
+      font-weight: 500;
+    }
+  }
+
+  dd {
+    border-left: 1px solid #ccc;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0 0 0 1rem;
+
+    p {
+      margin: 0;
     }
 
-    dd {
-        border-left: 1px solid #ccc;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        margin: 0;
-        padding: 0 0 0 1rem;
-
-        p {
-            margin: 0;
-        }
-
-        p + p {
-            margin-top: 0.125rem;
-        }
-
-        ol {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-            margin: 0;
-            padding: 0;
-            list-style: none;
-
-            li {
-                flex: 0 0 auto;
-                padding: 0.125rem 0.25rem;
-                border-radius: 4px;
-                background-color: #E4E4E4;
-            }
-        }
-
-        .default {
-            display: inline-block;
-            padding: 0.125rem 0.25rem;
-            border-radius: 4px;
-            font-weight: 700;
-            color: #0C56E9;
-            background-color: #CCE3FE;
-        }
+    p + p {
+      margin-top: 0.125rem;
     }
+
+    ol {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+
+      li {
+        flex: 0 0 auto;
+        padding: 0.125rem 0.25rem;
+        border-radius: 4px;
+        background-color: #e4e4e4;
+      }
+    }
+
+    .default {
+      display: inline-block;
+      padding: 0.125rem 0.25rem;
+      border-radius: 4px;
+      font-weight: 700;
+      color: #0c56e9;
+      background-color: #cce3fe;
+    }
+  }
 
   // nested props blocks
 

--- a/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
@@ -42,16 +42,18 @@
             padding: 0;
             list-style: none;
 
+            li {
+                // display: inline-block;
+                flex: 0 0 auto;
+                padding: 0.125rem 0.25rem;
+                border-radius: 4px;
+                background-color: #E4E4E4;
+    
+            }
         }
+        
 
-        li {
-            // display: inline-block;
-            flex: 0 0 auto;
-            padding: 0.125rem 0.25rem;
-            border-radius: 4px;
-            background-color: #E4E4E4;
-
-        }
+        
 
         .default {
             display: inline-block;

--- a/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
@@ -43,17 +43,12 @@
             list-style: none;
 
             li {
-                // display: inline-block;
                 flex: 0 0 auto;
                 padding: 0.125rem 0.25rem;
                 border-radius: 4px;
                 background-color: #E4E4E4;
-    
             }
         }
-        
-
-        
 
         .default {
             display: inline-block;

--- a/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-component-props.scss
@@ -59,4 +59,12 @@
             background-color: #CCE3FE;
         }
     }
+
+  // nested props blocks
+
+  .dummy-component-props {
+    dt:first-child {
+      margin-top: 0;
+    }
+  }
 }

--- a/packages/components/tests/dummy/app/styles/components/dummy-placeholder.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-placeholder.scss
@@ -10,7 +10,7 @@
 
 
 .dummy-placeholder__text {
-    color: #999;
+    color: #6B6B6B; // if background is #EEE then this has the appropriate color contrast (4.59:1)
     font-family: monaco, Consolas, "Lucida Console", monospace;
     font-size: 10px;
     font-weight: bold;

--- a/packages/components/tests/dummy/app/styles/pages/form/db-base-elements.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-base-elements.scss
@@ -1,0 +1,64 @@
+// FORM > BASE ELEMENTS
+
+.dummy-form-base-elements-base-sample {
+  display: flex;
+  gap: 2rem;
+}
+
+.dummy-form-base-elements-label-with-badge,
+.dummy-form-base-elements-legend-with-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dummy-form-base-elements-max-width-sample {
+  max-width: 250px;
+}
+
+.dummy-form-base-elements-grid-sample {
+  align-items: start;
+  display: grid;
+  grid-gap: 1rem 3rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dummy-form-base-elements-containers {
+  align-items: start;
+  display: grid;
+  grid-gap: 3rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dummy-form-base-elements-containers__block {
+  display: block;
+}
+
+.dummy-form-base-elements-containers__flex {
+  display: flex;
+}
+
+.dummy-form-base-elements-containers__grid {
+  display: grid;
+  justify-items: start;
+}
+
+.dummy-form-base-elements-fieldset-layout {
+  display: flex;
+  gap: 3rem;
+}
+
+.dummy-form-base-elements-layout-highlight {
+  .hds-form-field--layout-vertical,
+  .hds-form-field--layout-flag { outline: 2px dashed #e3f2fd; }
+  .hds-form-field__label { background-color: #e3f2fd; }
+  .hds-form-field__helper-text { background-color: #e8f5e9; }
+  .hds-form-field__error { background-color: #ffebee; }
+  .hds-form-group--layout-vertical,
+  .hds-form-group--layout-horizontal {
+    outline: 2px dashed #e3f2fd;
+    .hds-form-legend { background-color: #fff8e1; }
+    .hds-form-helper-text { background-color: #e8f5e9; }
+    .hds-form-error { background-color: #ffebee; }
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -525,7 +525,7 @@
     <code class="dummy-code">controlId</code>
     is provided, no ID is generated (but if needed it can be passed directly as HTML attribute).</p>
   <p class="dummy-paragraph">
-    There may be cases in which the error is made of multiple messages. In this case it's possible to iterate over an
+    There may be cases in which the error is made of multiple messages. In this case it's possible to iterate over a
     collection of error messages:
   </p>
   {{! prettier-ignore-start }}
@@ -710,7 +710,7 @@
     <F.Error>This is the error</F.Error>
   </Hds::Form::Fieldset>
   <p class="dummy-paragraph">Depending on the context/need, one may want to pass just the legend, just the helper text,
-    both or none, while he error message is likely conditional to the validation of the inputs provided by the user.</p>
+    both or none, while the error message is likely conditional to the validation of the inputs provided by the user.</p>
   <p class="dummy-paragraph"><em><strong>Important:</strong>
       in this case the layout/styling of the content inside the "control" container is left to the consumer.</em></p>
 

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -613,7 +613,7 @@
           <input
             type="email"
             id=\{{F.id}}
-            value="john.doe@email.com"
+            value="jane.doe@email.com"
             class="my-custom-class"
             aria-describedby=\{{F.ariaDescribedBy}}
           />
@@ -633,7 +633,7 @@
       <input
         type="email"
         id={{F.id}}
-        value="john.doe@email.com"
+        value="jane.doe@email.com"
         class="my-custom-class"
         aria-describedby={{F.ariaDescribedBy}}
       />

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -335,27 +335,27 @@
     </dd>
     <dt>&lt;[F].Error&gt; <code>yielded component</code></dt>
     <dd>
-      <dd>
-        <p>It is a container that yields its content inside the "error" block (at group level).</p>
-        <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
-          style).</p>
-        <dl class="dummy-component-props">
-          <dt>[E].Message <code>yielded component</code></dt>
-          <dd>
-            <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-              individual items using
-              <code class="dummy-code">Error.Message</code>.
-            </p>
-          </dd>
-        </dl>
-        <p>For details about its API check the <code class="dummy-code">Form::Error</code> component.</p>
-        <p><em>Notice: the
+      <p>It is a container that yields its content inside the "error" block (at group level).</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+
+      <dl class="dummy-component-props">
+        <dt>[E].Message <code>yielded component</code></dt>
+        <dd>
+          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+            individual items using
+            <code class="dummy-code">Error.Message</code>.</p>
+          <p>For details about its API check the <code class="dummy-code">Form::Error</code> component.</p>
+          <p><em>Note:</em>
+            the
             <code class="dummy-code">id</code>
             attribute of the
             <code class="dummy-code">Error</code>
-            element is automatically generated.</em></p>
-      </dd>
+            element is automatically generated.</p>
+        </dd>
+      </dl>
     </dd>
+
     <dt>[F].id <code>function</code></dt>
     <dd>
       <p>returns the unique "id" attribute for the control element (generated automatically, unless provided using the
@@ -430,15 +430,15 @@
     <strong>Important:</strong>
     in this case, while the correct text styling is applied to the component's container, the layout/organization of the
     content inside the component is left to the consumer.</p>
-  <p class="dummy-banner dummy-banner--info dummy-paragraph"><span aria-hidden="true">⚠️</span>
-    The
+  <p class="dummy-banner dummy-banner--info dummy-paragraph"><FlightIcon @name="info" />
+    Note: The
     <code class="dummy-code">&lt;label&gt;</code>
     element is linked via
     <code class="dummy-code">for</code>
     attribute to the
     <code class="dummy-code">&lt;input/select/textarea&gt;</code>
-    elements. This means it becomes an interactive element, and for this reasons it's not possible to have links inside
-    it (nested interactive elements are not accessible).
+    elements. This means it becomes an interactive element, and for this reason it's not possible to have links inside
+    it (nested interactive elements cannot be reached by a user with assistive technology).
   </p>
 
   <h4 class="dummy-h4">Form::HelperText</h4>
@@ -457,14 +457,15 @@
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Form::HelperText @controlId="control-ID">This is some helper text</Hds::Form::HelperText>
-  <p class="dummy-paragraph"><em>Notice: the
-      <code class="dummy-code">controlId</code>
-      value will be used to generate an ID, prefixed with
-      <code class="dummy-code">helper-text-</code>, so that this ID can be referenced in the
-      <code class="dummy-code">aria-describedby</code>
-      attribute of the form control. If no
-      <code class="dummy-code">controlId</code>
-      is provided, no ID is generated (but if needed it can be passed directly as HTML attribute).</em></p>
+  <p class="dummy-banner dummy-banner--info dummy-paragraph"><FlightIcon @name="info" />
+    Note: the
+    <code class="dummy-code">controlId</code>
+    value will be used to generate an ID, prefixed with
+    <code class="dummy-code">helper-text-</code>, so that this ID can be referenced in the
+    <code class="dummy-code">aria-describedby</code>
+    attribute of the form control. If no
+    <code class="dummy-code">controlId</code>
+    is provided, no ID is generated (but if needed it can be passed directly as HTML attribute).</p>
   <p class="dummy-paragraph">
     There may be some cases in which the helper text needs to contain more than just text. First, it is important to
     note that interactive elements in text (associated with the input through
@@ -514,14 +515,15 @@
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Form::Error @controlId="control-ID">This is a simple error message</Hds::Form::Error>
-  <p class="dummy-paragraph"><em>Notice: the
-      <code class="dummy-code">controlId</code>
-      value will be used to generate an ID, prefixed with
-      <code class="dummy-code">error-</code>, so that this ID can be referenced in the
-      <code class="dummy-code">aria-describedby</code>
-      attribute of the form control. If no
-      <code class="dummy-code">controlId</code>
-      is provided, no ID is generated (but if needed it can be passed directly as HTML attribute).</em></p>
+  <p class="dummy-banner dummy-banner--info dummy-paragraph"><FlightIcon @name="info" />
+    Note: the
+    <code class="dummy-code">controlId</code>
+    value will be used to generate an ID, prefixed with
+    <code class="dummy-code">error-</code>, so that this ID can be referenced in the
+    <code class="dummy-code">aria-describedby</code>
+    attribute of the form control. If no
+    <code class="dummy-code">controlId</code>
+    is provided, no ID is generated (but if needed it can be passed directly as HTML attribute).</p>
   <p class="dummy-paragraph">
     There may be cases in which the error is made of multiple messages. In this case it's possible to iterate over an
     collection of error messages:
@@ -587,12 +589,11 @@
     content inside the component is left to the consumer.</p>
 
   <h4 class="dummy-h4">Form::Field</h4>
-  <div class="dummy-banner dummy-banner--info">
-    <p class="dummy-paragraph"><strong>⚠️ Notice ⚠️</strong>: it's very unlikely that you will ever need to use this
-      component direcly (it's mainly intended to be used inside the "form" controls). If for any reasons you need to use
-      it in your codebase, please contact the HDS team so they can provide support and guidance. Below we provide in any
-      case an example of how it can be used, but there are many more possible variants to it.</p>
-  </div>
+  <p class="dummy-banner dummy-banner--info dummy-paragraph"><FlightIcon @name="info" />Note: it's very unlikely that
+    you will ever need to use this component direcly (it's mainly intended to be used inside the "form" controls). If
+    for any reasons you need to use it in your codebase, please contact the HDS team so they can provide support and
+    guidance. Below we provide in any case an example of how it can be used, but there are many more possible variants
+    to it.</p>
   <p class="dummy-paragraph">
     The more general invocation for this component sees a set of contextual components passed to it, a control (in this
     case a text input) and a
@@ -651,12 +652,11 @@
       in this case the layout/styling of the content inside the "control" container is left to the consumer.</em></p>
 
   <h4 class="dummy-h4">Form::Fieldset</h4>
-  <div class="dummy-banner dummy-banner--info">
-    <p class="dummy-paragraph"><strong>⚠️ Notice ⚠️</strong>: it's very unlikely that you will ever need to use this
-      component direcly (it's mainly intended to be used inside the "form" controls). If for any reasons you need to use
-      it in your codebase, please contact the HDS team so they can provide support and guidance. Below we provide in any
-      case an example of how it can be used, but there are many more possible variants to it.</p>
-  </div>
+  <p class="dummy-banner dummy-banner--info dummy-paragraph"><FlightIcon @name="info" />Note: it's very unlikely that
+    you will ever need to use this component direcly (it's mainly intended to be used inside the "form" controls). If
+    for any reasons you need to use it in your codebase, please contact the HDS team so they can provide support and
+    guidance. Below we provide in any case an example of how it can be used, but there are many more possible variants
+    to it.</p>
   <p class="dummy-paragraph">
     The more general invocation for this component sees a set of contextual components passed to it, one or more fields
     (in this case radio buttons within a label), a

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -173,8 +173,8 @@
     </dd>
   </dl>
   <h5 class="dummy-h5">Contextual components</h5>
-  <p class="dummy-paragraph" id="component-api-form-text-base-elements-field-contextual-components">Control, label,
-    helper text and error content are passed to the field as yielded components, using the
+  <p class="dummy-paragraph" id="component-api-form-base-elements-field-contextual-components">Control, label, helper
+    text and error content are passed to the field as yielded components, using the
     <code class="dummy-code">Label</code>,
     <code class="dummy-code">HelperText</code>,
     <code class="dummy-code">Control</code>,

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -466,15 +466,16 @@
       <code class="dummy-code">controlId</code>
       is provided, no ID is generated (but if needed it can be passed directly as HTML attribute).</em></p>
   <p class="dummy-paragraph">
-    There may be some cases in which the helper text needs to contain more than just text. Note that interactive
-    elements in text (associated with the input through
+    There may be some cases in which the helper text needs to contain more than just text. First, it is important to
+    note that interactive elements in text (associated with the input through
     <code class="dummy-code">aria-describedby</code>) will not be read out as interactive elements to users with screen
-    readers; only the text itself will be read. As such, it is recommended to have a screen-reader only message that
-    informs the user that some help text includes link, and extra keyboard exploration may be required.
+    readers; only the text itself will be read. As such, it is recommended to have a screen reader-only message that
+    informs the user that some help text includes link, and additional keyboard exploration may be required.
   </p>
   <p class="dummy-paragraph">
-    Use the block form of the component to nest additional components as desired. Note that the correct text styling
-    will be applied to the component itself, but the nested components will need to have styling applied. For example:
+    To implement additional nested components within the helper text, use the block form of the component. Note that the
+    correct text styling will be applied to the component itself, but the nested components may need additional styling.
+    For example:
   </p>
   {{! prettier-ignore-start }}
   <CodeBlock
@@ -733,7 +734,168 @@
 
 <section>
   <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
-  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  <p class="dummy-paragraph">Since these are the base elements, they are conditionally conformant; that is, they are not
+    conformant until used with the elements that will make them conformant.</p>
+  <h4 class="dummy-h4">
+    Applicable WCAG Success Criteria (Reference)
+  </h4>
+  <p class="dummy-paragraph">
+    This section is for reference only, some descriptions have been truncated for brevity. This component intends to
+    conform to the following WCAG success criteria:
+  </p>
+  <ul class="dummy-list">
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.3.1 Info and Relationships (A):</a>
+      Information, structure, and relationships conveyed through presentation can be programmatically determined or are
+      available in text.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.3.2 Meaningful Sequence (A):</a>
+      When the sequence in which content is presented affects its meaning, a correct reading sequence can be
+      programmatically determined.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/orientation"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.3.4 Orientation (AA):</a>
+      Content does not restrict its view and operation to a single display orientation, such as portrait or landscape.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.3.5 Identify Input Purpose(AA):</a>
+      The purpose of each input field collecting information about the user can be programmatically determined when the
+      input field serves a purpose identified in the Input Purposes for User Interface Components section; and the
+      content is implemented using technologies with support for identifying the expected meaning for form input data.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.1 Use of Color (A):</a>
+      Color is not used as the only visual means of conveying information, indicating an action, prompting a response,
+      or distinguishing a visual element.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.3 Contrast Minimum (AA):</a>
+      The visual presentation of text and images of text has a contrast ratio of at least 4.5:1</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.4 Resize Text (AA):</a>
+      Except for captions and images of text, text can be resized without assistive technology up to 200 percent without
+      loss of content or functionality.</li>
+    <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow" rel="noopener noreferrer" target="_blank">1.4.10
+        Reflow (AA):</a>
+      Content can be presented without loss of information or functionality, and without requiring scrolling in two
+      dimensions</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.11 Non-text Contrast (AA):</a>
+      The visual presentation of the following have a contrast ratio of at least 3:1 against adjacent color(s): user
+      interface components; graphical objects.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.12 Text Spacing (AA):</a>
+      no loss of content or functionality occurs by setting all of the following and by changing no other style
+      property: line height set to 1.5; spacing following paragraphs set to at least 2x the font size; letter-spacing
+      set at least 0.12x of the font size, word spacing set to at least 0.16 times the font size.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.13 Content on Hover or Focus (AA):</a>
+      Where receiving and then removing pointer hover or keyboard focus triggers additional content to become visible
+      and then hidden, the following are true: dismissible, hoverable, persistent (see link)</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable"
+        rel="noopener noreferrer"
+        target="_blank"
+      >2.2.1 Timing Adjustable (A):</a>
+      if there are time limitations set by the content, one of the following should be true: turn off, adjust, extend,
+      real-time exception, essential exception, 20 hour exception.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels"
+        rel="noopener noreferrer"
+        target="_blank"
+      >2.4.6 Headings and Labels (AA):</a>
+      Headings and labels describe topic or purpose.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible"
+        rel="noopener noreferrer"
+        target="_blank"
+      >2.4.7 Focus Visible (AA):</a>
+      Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible.</li>
+    <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/on-focus" rel="noopener noreferrer" target="_blank">3.2.1
+        On Focus (A):</a>
+      When any user interface component receives focus, it does not initiate a change of context.</li>
+    <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/on-input" rel="noopener noreferrer" target="_blank">3.2.2
+        On Input (A):</a>
+      Changing the setting of any user interface component does not automatically cause a change of context unless the
+      user has been advised of the behavior before using the component.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification"
+        rel="noopener noreferrer"
+        target="_blank"
+      >3.2.4 Consistent Identification (AA):</a>
+      Components that have the same functionality within a set of Web pages are identified consistently.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/error-identification"
+        rel="noopener noreferrer"
+        target="_blank"
+      >3.3.1 Error Identification (A):</a>
+      If an input error is automatically detected, the item that is in error is identified and the error is described to
+      the user in text.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions"
+        rel="noopener noreferrer"
+        target="_blank"
+      >3.3.2 Labels or Instructions (A):</a>
+      Labels or instructions are provided when content requires user input.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion"
+        rel="noopener noreferrer"
+        target="_blank"
+      >3.3.3 Error Suggestion (AA):</a>
+      If an input error is automatically detected and suggestions for correction are known, then the suggestions are
+      provided to the user, unless it would jeopardize the security or purpose of the content.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/error-prevention"
+        rel="noopener noreferrer"
+        target="_blank"
+      >3.3.4 Error Prevention (Legal, Financial, Data) (AA):</a>
+      For Web pages that cause legal commitments or financial transactions for the user to occur, that modify or delete
+      user-controllable data in data storage systems, or that submit user test responses, at least one of the following
+      is true: submissions are reversible, data is checked and user is provided an opportunity to correct them, a
+      mechanism is available for reviewing, confirming and correcting the information before finalizing the submission.</li>
+    <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/parsing" rel="noopener noreferrer" target="_blank">4.1.1
+        Parsing (A):</a>
+      In content implemented using markup languages, elements have complete start and end tags, elements are nested
+      according to their specifications, elements do not contain duplicate attributes, and any IDs are unique.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value"
+        rel="noopener noreferrer"
+        target="_blank"
+      >4.1.2 Name, Role, Value (A):</a>
+      For all user interface components, the name and role can be programmatically determined; states, properties, and
+      values that can be set by the user can be programmatically set; and notification of changes to these items is
+      available to user agents, including assistive technologies.</li>
+    <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/" rel="noopener noreferrer" target="_blank">4.1.3 Status
+        Messages (AA):</a>
+      In content implemented using markup languages, status messages can be programmatically determined through role or
+      properties such that they can be presented to the user by assistive technologies without receiving focus.</li>
+  </ul>
 </section>
 
 <section data-test-percy>

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -1,0 +1,1243 @@
+{{page-title "Form / Base elements"}}
+
+<h2 class="dummy-h2">Form / Base elements</h2>
+
+<section>
+  <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
+  <p class="dummy-paragraph">In this page we collect a few "base" elements that are used to build/compose the "form"
+    fields. They can also be used to build custom fields (in very specific cases).</p>
+  <ul>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::Label</code>
+      is the label associated with the form control
+    </li>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::HelperText</code>
+      is an optional extra text used to help the user understand what the field is intended for
+    </li>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::Error</code>
+      is the error message shown to the user in case of failed validation of the field
+    </li>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::Legend</code>
+      is the legend associated to the fieldset
+    </li>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::Field</code>
+      is the generic container for control, label, helper text and error messaging
+    </li>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::Fieldset</code>
+      is the generic container to group multiple fields with label, helper text and error messaging
+    </li>
+  </ul>
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
+
+  <h4 class="dummy-h4">Form::Label</h4>
+  <p class="dummy-paragraph" id="component-api-form-label">
+    Here is the API for the component:
+  </p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-label">
+    <dt>controlId <code>string</code></dt>
+    <dd>
+      <p>The ID of the form control associated with the label. This is used to populate the
+        <code class="dummy-code">for</code>
+        attribute of the
+        <code class="dummy-code">&lt;label&gt;</code>
+        element.</p>
+    </dd>
+    <dt>"yield"</dt>
+    <dd>
+      <p>Elements passed as children of this component are yielded inside the
+        <code class="dummy-code">&lt;label&gt;</code>
+        element.</p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+    </dd>
+  </dl>
+
+  <h4 class="dummy-h4">Form::HelperText</h4>
+  <p class="dummy-paragraph" id="component-api-form-helper-text">
+    Here is the API for the component:
+  </p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-helper-text">
+    <dt>controlId <code>string</code></dt>
+    <dd>
+      <p>The ID of the form control associated with the helper text. This is used to populate the
+        <code class="dummy-code">id</code>
+        HTML attribute (with a
+        <code class="dummy-code">helper-text-</code>
+        prefix) of the element. This HelperText ID can then be referenced in the
+        <code class="dummy-code">aria-describedby</code>
+        attribute of the form control.</p>
+    </dd>
+    <dt>"yield"</dt>
+    <dd>
+      <p>Elements passed as children of this component are yielded inside the element.</p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+    </dd>
+  </dl>
+
+  <h4 class="dummy-h4">Form::Error</h4>
+  <p class="dummy-paragraph" id="component-api-form-helper-error">
+    Here is the API for the component:
+  </p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-helper-error">
+    <dt>controlId <code>string</code></dt>
+    <dd>
+      <p>The ID of the form control associated with the error. This is used to populate the
+        <code class="dummy-code">id</code>
+        HTML attribute (with an
+        <code class="dummy-code">error-</code>
+        prefix) of the element. This Error ID can then be referenced in the
+        <code class="dummy-code">aria-describedby</code>
+        attribute of the form control.</p>
+    </dd>
+    <dt>"yield"</dt>
+    <dd>
+      <p>Elements passed as children of this component are yielded inside the element.</p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+    </dd>
+  </dl>
+
+  <h4 class="dummy-h4">Form::Legend</h4>
+  <p class="dummy-paragraph" id="component-api-form-legend">
+    Here is the API for the component:
+  </p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-label">
+    <dt>"yield"</dt>
+    <dd>
+      <p>Elements passed as children of this component are yielded inside the
+        <code class="dummy-code">&lt;legend&gt;</code>
+        element.</p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+    </dd>
+  </dl>
+
+  <h4 class="dummy-h4">Form::Field</h4>
+  <p class="dummy-paragraph" id="component-api-form-field">Here is the API for the component:</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-field">
+    <dt>layout <code>enum</code></dt>
+    <dd>
+      <p>
+        Sets the layout of the component. "Vertical" layout is used for
+        <code class="dummy-code">TextInput</code>,
+        <code class="dummy-code">Textarea</code>
+        and
+        <code class="dummy-code">Select</code>
+        fields. "Flag" layout is used for
+        <code class="dummy-code">Checkbox</code>,
+        <code class="dummy-code">Radio</code>
+        and
+        <code class="dummy-code">Toggle</code>
+        fields.
+      </p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li>vertical</li>
+        <li>flag</li>
+      </ol>
+    </dd>
+    <dt>id <code>string</code></dt>
+    <dd>
+      <p>The control's ID attribute</p>
+      <p><em>Notice: by default the ID is automatically generated by the component; use this argument if you need to
+          pass a custom ID for specific reasons you may have.</em></p>
+    </dd>
+    <dt>extraAriaDescribedBy <code>string</code></dt>
+    <dd>
+      <p>An extra ID attribute to be added to the <code class="dummy-code">aria-describedby</code> HTML attribute.</p>
+      <p><em>Notice: by default the
+          <code class="dummy-code">aria-describedby</code>
+          attribute is automatically generated by the component, using the IDs of the helper text and errors (if they're
+          present); use this argument if you need to pass extra IDs for specific reasons you may have.</em></p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+    </dd>
+  </dl>
+  <h5 class="dummy-h5">Contextual components</h5>
+  <p class="dummy-paragraph" id="component-api-form-text-base-elements-field-contextual-components">Control, label,
+    helper text and error content are passed to the field as yielded components, using the
+    <code class="dummy-code">Label</code>,
+    <code class="dummy-code">HelperText</code>,
+    <code class="dummy-code">Control</code>,
+    <code class="dummy-code">Error</code>
+    keys.</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-base-elements-field-contextual-components">
+    <dt>&lt;[F].Label&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the <code class="dummy-code">&lt;label&gt;</code> element.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <p>For details about its API check the
+        <code class="dummy-code">Form::Label</code>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">for</code>
+          attribute of the label is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[F].HelperText&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the "helper text" block.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <p>For details about its API check the
+        <code class="dummy-code">Form::HelperText</code>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">id</code>
+          attribute of the element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[F].Control&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a very simple container that yields its content. It is used to forward the "base" control inside the
+        "field" control wrapper.</p>
+      <p>The
+        <code class="dummy-code">Control</code>
+        yielded component exposes two hashed arguments:</p>
+      <dl class="dummy-component-props">
+        <dt>[C].id <code>string</code></dt>
+        <dd>
+          <p>returns the unique "id" attribute for the control element (generated automatically, unless provided using
+            the
+            <code class="dummy-code">@id</code>
+            argument described above).
+          </p>
+        </dd>
+        <dt>[C].ariaDescribedBy <code>string</code></dt>
+        <dd>
+          <p>returns the "aria-describedby" attribute for the control element (generated automatically, based on the
+            presence of the
+            <code class="dummy-code">HelperText</code>
+            an/or the
+            <code class="dummy-code">Error</code>
+            elements in the field, plus the optional
+            <code class="dummy-code">@extraAriaDescribedBy</code>
+            argument described above).</p>
+        </dd>
+      </dl>
+    </dd>
+    <dt>&lt;[F].Error&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the "error" block.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <dl class="dummy-component-props">
+        <dt>[E].Message <code>yielded component</code></dt>
+        <dd>
+          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+            individual items using
+            <code class="dummy-code">Error.Message</code>.
+          </p>
+        </dd>
+      </dl>
+      <p>For details about its API check the <code class="dummy-code">Form::Error</code> component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">id</code>
+          attribute of the
+          <code class="dummy-code">Error</code>
+          element is automatically generated.</em></p>
+    </dd>
+  </dl>
+
+  <h4 class="dummy-h4">Form::Fieldset</h4>
+  <p class="dummy-paragraph" id="component-api-form-fieldset">Here is the API for the component:</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-field">
+    <dt>layout <code>enum</code></dt>
+    <dd>
+      <p>
+        Sets the layout of the field controls in the component.</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li class="default">vertical</li>
+        <li>horizontal</li>
+      </ol>
+    </dd>
+    <dt>id <code>string</code></dt>
+    <dd>
+      <p>The fieldset's ID attribute</p>
+      <p><em>Notice: by default the ID is automatically generated by the component; use this argument if you need to
+          pass a custom ID for specific reasons you may have.</em></p>
+    </dd>
+    <dt>extraAriaDescribedBy <code>string</code></dt>
+    <dd>
+      <p>An extra ID attribute to be added to the <code class="dummy-code">aria-describedby</code> HTML attribute.</p>
+      <p><em>Notice: by default the
+          <code class="dummy-code">aria-describedby</code>
+          attribute is automatically generated by the component, using the IDs of the helper text and errors (if they're
+          present); use this argument if you need to pass extra IDs for specific reasons you may have.</em></p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+    </dd>
+  </dl>
+  <h5 class="dummy-h5">Contextual components</h5>
+  <p class="dummy-paragraph" id="component-api-form-base-elements-fieldset-contextual-components">Control, label, helper
+    text and error content are passed to the field as yielded components, using the
+    <code class="dummy-code">Label</code>,
+    <code class="dummy-code">HelperText</code>,
+    <code class="dummy-code">Control</code>,
+    <code class="dummy-code">Error</code>
+    keys. The component exposes also two hashed methods,
+    <code class="dummy-code">id</code>
+    and
+    <code class="dummy-code">ariaDescribedBy</code>
+  </p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-base-elements-fieldset-contextual-components">
+    <dt>&lt;[F].Legend&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the
+        <code class="dummy-code">&lt;legend&gt;</code>
+        element.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <p>For details about its API check the
+        <code class="dummy-code">Form::Legend</code>
+        component.</p>
+    </dd>
+    <dt>&lt;[F].HelperText&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the "helper text" block (at group level).</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <p>For details about its API check the
+        <code class="dummy-code">Form::HelperText</code>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">id</code>
+          attribute of the element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[F].Control&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a very simple container that yields its content. It is used to forward the "field" control inside the
+        fields' "group" control wrapper.</p>
+      <p><em>Notice: you can pass all the controls to a single
+          <code class="dummy-code">&lt;Control&gt;</code>
+          container, or you can have one control per container.</em></p>
+    </dd>
+    <dt>&lt;[F].Error&gt; <code>yielded component</code></dt>
+    <dd>
+      <dd>
+        <p>It is a container that yields its content inside the "error" block (at group level).</p>
+        <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+          style).</p>
+        <dl class="dummy-component-props">
+          <dt>[E].Message <code>yielded component</code></dt>
+          <dd>
+            <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+              individual items using
+              <code class="dummy-code">Error.Message</code>.
+            </p>
+          </dd>
+        </dl>
+        <p>For details about its API check the <code class="dummy-code">Form::Error</code> component.</p>
+        <p><em>Notice: the
+            <code class="dummy-code">id</code>
+            attribute of the
+            <code class="dummy-code">Error</code>
+            element is automatically generated.</em></p>
+      </dd>
+    </dd>
+    <dt>[F].id <code>function</code></dt>
+    <dd>
+      <p>returns the unique "id" attribute for the control element (generated automatically, unless provided using the
+        <code class="dummy-code">@id</code>
+        argument described above).
+      </p>
+    </dd>
+    <dt>[F].ariaDescribedBy <code>function</code></dt>
+    <dd>
+      <p>returns the "aria-describedby" attribute for the control element (generated automatically, based on the
+        presence of the
+        <code class="dummy-code">HelperText</code>
+        an/or the
+        <code class="dummy-code">Error</code>
+        elements in the field, plus the optional
+        <code class="dummy-code">@extraAriaDescribedBy</code>
+        argument described above).</p>
+    </dd>
+  </dl>
+
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="how-to-use"><a href="#how-to-use" class="dummy-link-section">§</a> How to use</h3>
+
+  <p class="dummy-paragraph">
+    The base form elements collected in this page are used internally as building blocks for the "field" and "group"
+    controls, but can also be used in special cases when you need to implement custom layouts or controls in forms.
+    Unless strictly needed, we
+    <strong>strongly</strong>
+    suggest to use the pre-defined "field" and "group" controls provided by the system (you can find them in the other
+    "form" documentation pages).
+  </p>
+
+  <h4 class="dummy-h4">Form::Label</h4>
+  <p class="dummy-paragraph">
+    The most basic invocation just needs a text passed to the component and a
+    <code class="dummy-code">controlId</code>
+    argument (the ID of the form control associated with the label):
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::Label @controlId="control-ID">My label</Hds::Form::Label>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Label @controlId="control-ID">My label</Hds::Form::Label>
+  <p class="dummy-paragraph">
+    There may be cases in which the label needs to contain more than just text. In this case it's possible to pass
+    structured content to it (it's just yielded in output):
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::Label @controlId="control-ID">
+        <span>Some text</span>
+        <Hds::Badge @size="small" @text="Some badge" />
+      </Hds::Form::Label>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Label @controlId="control-ID">
+    <span>Some text</span>
+    <Hds::Badge @size="small" @text="Some badge" />
+  </Hds::Form::Label>
+  <p class="dummy-paragraph">
+    <strong>Important:</strong>
+    in this case, while the correct text styling is applied to the component's container, the layout/organization of the
+    content inside the component is left to the consumer.</p>
+  <p class="dummy-banner dummy-banner--info dummy-paragraph"><span aria-hidden="true">⚠️</span>
+    The
+    <code class="dummy-code">&lt;label&gt;</code>
+    element is linked via
+    <code class="dummy-code">for</code>
+    attribute to the
+    <code class="dummy-code">&lt;input/select/textarea&gt;</code>
+    elements. This means it becomes an interactive element, and for this reasons it's not possible to have links inside
+    it (nested interactive elements are not accessible).
+  </p>
+
+  <h4 class="dummy-h4">Form::HelperText</h4>
+  <p class="dummy-paragraph">
+    The most basic invocation just needs a text passed to the component and a
+    <code class="dummy-code">controlId</code>
+    argument:
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::HelperText @controlId="control-ID">This is some helper text</Hds::Form::HelperText>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::HelperText @controlId="control-ID">This is some helper text</Hds::Form::HelperText>
+  <p class="dummy-paragraph"><em>Notice: the
+      <code class="dummy-code">controlId</code>
+      value will be used to generate an ID, prefixed with
+      <code class="dummy-code">helper-text-</code>, so that this ID can be referenced in the
+      <code class="dummy-code">aria-describedby</code>
+      attribute of the form control. If no
+      <code class="dummy-code">controlId</code>
+      is provided, no ID is generated (but if needed it can be passed directly as HTML attribute).</em></p>
+  <p class="dummy-paragraph">
+    There may be some cases in which the helper text needs to contain more than just text. Note that interactive
+    elements in text (associated with the input through
+    <code class="dummy-code">aria-describedby</code>) will not be read out as interactive elements to users with screen
+    readers; only the text itself will be read. As such, it is recommended to have a screen-reader only message that
+    informs the user that some help text includes link, and extra keyboard exploration may be required.
+  </p>
+  <p class="dummy-paragraph">
+    Use the block form of the component to nest additional components as desired. Note that the correct text styling
+    will be applied to the component itself, but the nested components will need to have styling applied. For example:
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::HelperText @controlId="control-ID">
+        Some text with a
+        <Hds::Link::Inline @route="components.link.inline">Hds::Link::Inline</Hds::Link::Inline>,
+        or <code>some formatted code</code> or a <strong>strong message</strong>.
+      </Hds::Form::HelperText>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::HelperText @controlId="control-ID">
+    Some text with a
+    <Hds::Link::Inline @route="components.link.inline">Hds::Link::Inline</Hds::Link::Inline>, or
+    <code>some formatted code</code>
+    or a
+    <strong>strong message</strong>.
+  </Hds::Form::HelperText>
+
+  <h4 class="dummy-h4">Form::Error</h4>
+  <p class="dummy-paragraph">
+    The most basic invocation just needs a text passed to the component and a
+    <code class="dummy-code">controlId</code>
+    argument:
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::Error @controlId="control-ID">This is a simple error message</Hds::Form::Error>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Error @controlId="control-ID">This is a simple error message</Hds::Form::Error>
+  <p class="dummy-paragraph"><em>Notice: the
+      <code class="dummy-code">controlId</code>
+      value will be used to generate an ID, prefixed with
+      <code class="dummy-code">error-</code>, so that this ID can be referenced in the
+      <code class="dummy-code">aria-describedby</code>
+      attribute of the form control. If no
+      <code class="dummy-code">controlId</code>
+      is provided, no ID is generated (but if needed it can be passed directly as HTML attribute).</em></p>
+  <p class="dummy-paragraph">
+    There may be cases in which the error is made of multiple messages. In this case it's possible to iterate over an
+    collection of error messages:
+  </p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::Error @controlId="control-ID" as |Error|>
+        \{{#each @model.SAMPLE_ERROR_MESSAGES as |message|}}
+          <Error.Message>\{{message}}</Error.Message>
+        \{{/each}}
+      </Hds::Form::Error>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Error @controlId="control-ID" as |Error|>
+    {{#each @model.SAMPLE_ERROR_MESSAGES as |message|}}
+      <Error.Message>{{message}}</Error.Message>
+    {{/each}}
+  </Hds::Form::Error>
+
+  <h4 class="dummy-h4">Form::Legend</h4>
+  <p class="dummy-paragraph">
+    The most basic invocation just needs a text passed to the component:
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code="
+      <Hds::Form::Legend>My legend</Hds::Form::Legend>
+    "
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Legend>My legend</Hds::Form::Legend>
+  <p class="dummy-paragraph">
+    There may be cases in which the legend needs to contain more than just text. In this case it's possible to pass
+    structured content to it (it's just yielded in output):
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::Legend>
+        <span>Some text</span>
+        <Hds::Badge @size="small" @text="Some badge" />
+      </Hds::Form::Legend>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Legend>
+    <span>Some text</span>
+    <Hds::Badge @size="small" @text="Some badge" />
+  </Hds::Form::Legend>
+  <p class="dummy-paragraph">
+    <strong>Important:</strong>
+    in this case, while the correct text styling is applied to the component's container, the layout/organization of the
+    content inside the component is left to the consumer.</p>
+
+  <h4 class="dummy-h4">Form::Field</h4>
+  <div class="dummy-banner dummy-banner--info">
+    <p class="dummy-paragraph"><strong>⚠️ Notice ⚠️</strong>: it's very unlikely that you will ever need to use this
+      component direcly (it's mainly intended to be used inside the "form" controls). If for any reasons you need to use
+      it in your codebase, please contact the HDS team so they can provide support and guidance. Below we provide in any
+      case an example of how it can be used, but there are many more possible variants to it.</p>
+  </div>
+  <p class="dummy-paragraph">
+    The more general invocation for this component sees a set of contextual components passed to it, a control (in this
+    case a text input) and a
+    <code class="dummy-code">@layout</code>
+    argument provided, and a few hashed values passed back to the control:
+  </p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::Field @layout="vertical" as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Control>
+          // add your control here
+          <input
+            type="email"
+            id=\{{F.id}}
+            value="john.doe@email.com"
+            class="my-custom-class"
+            aria-describedby=\{{F.ariaDescribedBy}}
+          />
+        </F.Control>
+        <F.Error>This is the error</F.Error>
+      </Hds::Form::Field>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Field @layout="vertical" as |F|>
+    <F.Label>This is the label</F.Label>
+    <F.HelperText>This is the helper text</F.HelperText>
+    <F.Control>
+      {{! add your control here }}
+      <input
+        type="email"
+        id={{F.id}}
+        value="john.doe@email.com"
+        class="my-custom-class"
+        aria-describedby={{F.ariaDescribedBy}}
+      />
+    </F.Control>
+    <F.Error>This is the error</F.Error>
+  </Hds::Form::Field>
+  <p class="dummy-paragraph">Depending on the context/need, one may want to pass just the label, or the label
+    <em>and</em>
+    the helper text, while the error message is likely conditional to the validation of the input provided by the user.</p>
+  <p class="dummy-paragraph">Note also how the arguments
+    <code class="dummy-code">id</code>
+    and
+    <code class="dummy-code">ariaDescribedBy</code>, automatically generated by the component, are passed back to the
+    control.</p>
+  <p class="dummy-paragraph"><em><strong>Important:</strong>
+      in this case the layout/styling of the content inside the "control" container is left to the consumer.</em></p>
+
+  <h4 class="dummy-h4">Form::Fieldset</h4>
+  <div class="dummy-banner dummy-banner--info">
+    <p class="dummy-paragraph"><strong>⚠️ Notice ⚠️</strong>: it's very unlikely that you will ever need to use this
+      component direcly (it's mainly intended to be used inside the "form" controls). If for any reasons you need to use
+      it in your codebase, please contact the HDS team so they can provide support and guidance. Below we provide in any
+      case an example of how it can be used, but there are many more possible variants to it.</p>
+  </div>
+  <p class="dummy-paragraph">
+    The more general invocation for this component sees a set of contextual components passed to it, one or more fields
+    (in this case radio buttons within a label), a
+    <code class="dummy-code">@layout</code>
+    argument:
+  </p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::Fieldset @layout="horizontal" as |F|>
+        <F.Legend>This is the legend</F.Legend>
+        <F.HelperText>This is the helper text</F.HelperText>
+        // add your fields here
+        <F.Control>
+          <label for="my-group-checkbox1" class="my-custom-class">
+            <input type="checkbox" id="my-group-checkbox1" checked="checked" />
+            selection #1
+          </label>
+        </F.Control>
+        <F.Control>
+          <label for="my-group-checkbox2" class="my-custom-class">
+            <input type="checkbox" id="my-group-checkbox2" />
+            selection #2
+          </label>
+        </F.Control>
+        <F.Error>This is the error</F.Error>
+      </Hds::Form::Fieldset>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Fieldset @layout="horizontal" as |F|>
+    <F.Legend>This is the legend</F.Legend>
+    <F.HelperText>This is the helper text</F.HelperText>
+    {{! add your control here }}
+    <F.Control>
+      <label for="my-group-checkbox1" class="my-custom-class">
+        <input type="checkbox" id="my-group-checkbox1" checked="checked" />
+        selection #1
+      </label>
+    </F.Control>
+    <F.Control>
+      <label for="my-group-checkbox2" class="my-custom-class">
+        <input type="checkbox" id="my-group-checkbox2" />
+        selection #2
+      </label>
+    </F.Control>
+    <F.Error>This is the error</F.Error>
+  </Hds::Form::Fieldset>
+  <p class="dummy-paragraph">Depending on the context/need, one may want to pass just the legend, just the helper text,
+    both or none, while he error message is likely conditional to the validation of the inputs provided by the user.</p>
+  <p class="dummy-paragraph"><em><strong>Important:</strong>
+      in this case the layout/styling of the content inside the "control" container is left to the consumer.</em></p>
+
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
+    Design guidelines</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  {{! UNCOMMENT THIS BLOCK (once the link and/or the image are available) }}
+  {{!
+  <div class="dummy-design-guidelines">
+    <p class="dummy-paragraph">
+      <a href="[ADD THE LINK TO THE FIGMA FILE/PAGE HERE!]" target="_blank" rel="noopener noreferrer">Figma UI Kit</a>
+    </p>
+    <br />
+    <img class="dummy-figma-docs" src="/assets/images/form-label-design-usage.png" alt="" role="none" />
+  </div>
+  }}
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+</section>
+
+<section data-test-percy>
+  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+
+  <h4 class="dummy-h4">Label</h4>
+  <span class="dummy-text-small">With simple text</span>
+  <Hds::Form::Label>This is a simple label</Hds::Form::Label>
+  <br />
+  <span class="dummy-text-small">With structured content (eg. a
+    <code>flex</code>
+    layout and a
+    <code>&lt;Badge&gt;</code>)</span>
+  <Hds::Form::Label>
+    <div class="dummy-form-base-elements-label-with-badge">This is the label
+      <Hds::Badge @size="small" @text="Some badge" /></div>
+  </Hds::Form::Label>
+  <br />
+  <span class="dummy-text-small">With text that spans multiple lines</span>
+  <div class="dummy-form-base-elements-max-width-sample">
+    <Hds::Form::Label>This is a very long label text that should go on multiple lines</Hds::Form::Label>
+  </div>
+
+  {{! ###################### }}
+
+  <hr class="dummy-divider" />
+
+  <h4 class="dummy-h4">Helper text</h4>
+  <span class="dummy-text-small">With simple text</span>
+  <Hds::Form::HelperText>This is the helper text, usually used jointly with the label.</Hds::Form::HelperText>
+  <br />
+  <span class="dummy-text-small">With <code>&lt;Link::Inline&gt;</code></span>
+  <Hds::Form::HelperText>This is a helper text
+    <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></Hds::Form::HelperText>
+  <br />
+  <span class="dummy-text-small">With <code>&lt;Link::Inline&gt;</code> and <code>secondary</code> color</span>
+  <Hds::Form::HelperText>This is a helper text
+    <Hds::Link::Inline @route="index" @color="secondary">with a secondary link</Hds::Link::Inline></Hds::Form::HelperText>
+  <br />
+  <span class="dummy-text-small">With structured content (eg. HTML tags)</span>
+  <Hds::Form::HelperText>
+    A helper text may contain some
+    <code>&lt;code&gt;</code>
+    for example, or a
+    <strong>&lt;strong&gt;</strong>.
+  </Hds::Form::HelperText>
+  <br />
+  <span class="dummy-text-small">With text that spans multiple lines</span>
+  <div class="dummy-form-base-elements-max-width-sample">
+    <Hds::Form::HelperText>This is a very long helper text that should go on multiple lines</Hds::Form::HelperText>
+  </div>
+
+  {{! ###################### }}
+
+  <hr class="dummy-divider" />
+
+  <h4 class="dummy-h4">Error</h4>
+  <span class="dummy-text-small">With simple text</span>
+  <Hds::Form::Error>This is a simple error message</Hds::Form::Error>
+  <br />
+  <span class="dummy-text-small">With text that spans multiple lines</span>
+  <div class="dummy-form-base-elements-max-width-sample">
+    <Hds::Form::Error>This is a very long error message that should span on multiple lines</Hds::Form::Error>
+  </div>
+  <br />
+  <span class="dummy-text-small">With multiple error messages</span>
+  <Hds::Form::Error as |Error|>
+    {{#each @model.SAMPLE_ERROR_MESSAGES as |message|}}
+      <Error.Message>{{message}}</Error.Message>
+    {{/each}}
+  </Hds::Form::Error>
+
+  {{! ###################### }}
+
+  <hr class="dummy-divider" />
+
+  <h4 class="dummy-h4">Legend</h4>
+  <span class="dummy-text-small">With simple text</span>
+  <Hds::Form::Legend>This is a simple legend</Hds::Form::Legend>
+  <br />
+  <span class="dummy-text-small">With <code>&lt;Link::Inline&gt;</code></span>
+  <Hds::Form::Legend>This is a legend
+    <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></Hds::Form::Legend>
+  <br />
+  <span class="dummy-text-small">With <code>&lt;Link::Inline&gt;</code> and <code>secondary</code> color</span>
+  <Hds::Form::Legend>This is a legend
+    <Hds::Link::Inline @route="index" @color="secondary">with a secondary link</Hds::Link::Inline></Hds::Form::Legend>
+  <br />
+  <span class="dummy-text-small">With structured content (eg. a
+    <code>flex</code>
+    layout and a
+    <code>&lt;Badge&gt;</code>)</span>
+  <Hds::Form::Legend>
+    <div class="dummy-form-base-elements-legend-with-badge">This is the legend
+      <Hds::Badge @size="small" @text="Some badge" /></div>
+  </Hds::Form::Legend>
+  <br />
+  <span class="dummy-text-small">With text that spans multiple lines</span>
+  <div class="dummy-form-base-elements-max-width-sample">
+    <Hds::Form::Legend>This is a very long legend text that should go on multiple lines</Hds::Form::Legend>
+  </div>
+
+  {{! ###################### }}
+
+  <hr class="dummy-divider" />
+
+  <h4 class="dummy-h4">Field</h4>
+  <button id="dummy-toggle-highlight" type="button" {{on "click" this.toggleHighlight}}>{{if
+      this.showHighlight
+      "Hide"
+      "Show"
+    }}
+    layout highlight</button>
+  <div class="{{if this.showHighlight 'dummy-form-base-elements-layout-highlight'}}">
+    <h5 class="dummy-h5">Layout</h5>
+    <div class="dummy-form-base-elements-grid-sample">
+      {{#let (array "vertical" "flag") as |layouts|}}
+        {{#each layouts as |layout|}}
+          <div>
+            <span class="dummy-text-small">"{{layout}}" layout</span>
+            <br />
+            <Hds::Form::Field @layout={{layout}} as |F|>
+              <F.Label>This is the label</F.Label>
+              <F.HelperText>This is the helper text</F.HelperText>
+              <F.Control>
+                {{#if (eq layout "vertical")}}
+                  <DummyPlaceholder
+                    @text="control"
+                    @width="100%"
+                    @height="32"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+                {{#if (eq layout "flag")}}
+                  <DummyPlaceholder
+                    @text="✔"
+                    @width="16"
+                    @height="16"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+              </F.Control>
+              <F.Error>This is the error</F.Error>
+            </Hds::Form::Field>
+          </div>
+        {{/each}}
+      {{/let}}
+    </div>
+    <br />
+    {{#let (array "vertical" "flag") as |layouts|}}
+      {{#each layouts as |layout|}}
+        <h5 class="dummy-h5">Content / "{{layout}}" layout</h5>
+        <div class="dummy-form-base-elements-grid-sample">
+          <div>
+            <span class="dummy-text-small">Only label</span>
+            <br />
+            <Hds::Form::Field @layout={{layout}} as |F|>
+              <F.Label>This is the label text</F.Label>
+              <F.Control>
+                {{#if (eq layout "vertical")}}
+                  <DummyPlaceholder
+                    @text="control"
+                    @width="100%"
+                    @height="32"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+                {{#if (eq layout "flag")}}
+                  <DummyPlaceholder
+                    @text="✔"
+                    @width="16"
+                    @height="16"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+              </F.Control>
+            </Hds::Form::Field>
+          </div>
+          <div>
+            <span class="dummy-text-small">Label + Helper text</span>
+            <br />
+            <Hds::Form::Field @layout={{layout}} as |F|>
+              <F.Label>This is the label text</F.Label>
+              <F.HelperText>This is the helper text</F.HelperText>
+              <F.Control>
+                {{#if (eq layout "vertical")}}
+                  <DummyPlaceholder
+                    @text="control"
+                    @width="100%"
+                    @height="32"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+                {{#if (eq layout "flag")}}
+                  <DummyPlaceholder
+                    @text="✔"
+                    @width="16"
+                    @height="16"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+              </F.Control>
+            </Hds::Form::Field>
+          </div>
+        </div>
+        <div class="dummy-form-base-elements-grid-sample">
+          <div>
+            <span class="dummy-text-small">Label + Error</span>
+            <br />
+            <Hds::Form::Field @layout={{layout}} as |F|>
+              <F.Label>This is the label</F.Label>
+              <F.Control>
+                {{#if (eq layout "vertical")}}
+                  <DummyPlaceholder
+                    @text="control"
+                    @width="100%"
+                    @height="32"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+                {{#if (eq layout "flag")}}
+                  <DummyPlaceholder
+                    @text="✔"
+                    @width="16"
+                    @height="16"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+              </F.Control>
+              <F.Error>This is the error</F.Error>
+            </Hds::Form::Field>
+          </div>
+          <div>
+            <span class="dummy-text-small">Label + Helper text + Error</span>
+            <br />
+            <Hds::Form::Field @layout={{layout}} as |F|>
+              <F.Label>This is the label</F.Label>
+              <F.HelperText>This is the helper text</F.HelperText>
+              <F.Control>
+                {{#if (eq layout "vertical")}}
+                  <DummyPlaceholder
+                    @text="control"
+                    @width="100%"
+                    @height="32"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+                {{#if (eq layout "flag")}}
+                  <DummyPlaceholder
+                    @text="✔"
+                    @width="16"
+                    @height="16"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+              </F.Control>
+              <F.Error>This is the error</F.Error>
+            </Hds::Form::Field>
+          </div>
+          <div>
+            <span class="dummy-text-small">Label + Helper text + Errors</span>
+            <br />
+            <Hds::Form::Field @layout={{layout}} as |F|>
+              <F.Label>This is the label</F.Label>
+              <F.HelperText>This is the helper text</F.HelperText>
+              <F.Control>
+                {{#if (eq layout "vertical")}}
+                  <DummyPlaceholder
+                    @text="control"
+                    @width="100%"
+                    @height="32"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+                {{#if (eq layout "flag")}}
+                  <DummyPlaceholder
+                    @text="✔"
+                    @width="16"
+                    @height="16"
+                    @background="#eee"
+                    class="hds-form-field__control"
+                  />
+                {{/if}}
+              </F.Control>
+              <F.Error as |E|>
+                <E.Message>First error message</E.Message>
+                <E.Message>Second error message</E.Message>
+              </F.Error>
+            </Hds::Form::Field>
+          </div>
+        </div>
+      {{/each}}
+    {{/let}}
+
+    {{#let (array "vertical" "flag") as |layouts|}}
+      {{#each layouts as |layout|}}
+        <h5 class="dummy-h5">Containers / "{{layout}}" layout</h5>
+        <div class="dummy-form-base-elements-containers">
+          {{#let (array "block" "flex" "grid") as |displays|}}
+            {{#each displays as |display|}}
+              <div>
+                <span class="dummy-text-small">Parent with <code class="dummy-code">display: {{display}}</code></span>
+                <br />
+                <div class="dummy-form-base-elements-containers__{{display}}">
+                  <Hds::Form::Field @layout={{layout}} as |F|>
+                    <F.Label>This is the label</F.Label>
+                    <F.HelperText>This is the helper text</F.HelperText>
+                    <F.Control>
+                      {{#if (eq layout "vertical")}}
+                        <DummyPlaceholder
+                          @text="control"
+                          @width="100%"
+                          @height="32"
+                          @background="#eee"
+                          class="hds-form-field__control"
+                        />
+                      {{/if}}
+                      {{#if (eq layout "flag")}}
+                        <DummyPlaceholder
+                          @text="✔"
+                          @width="16"
+                          @height="16"
+                          @background="#eee"
+                          class="hds-form-field__control"
+                        />
+                      {{/if}}
+                    </F.Control>
+                    <F.Error>This is the error</F.Error>
+                  </Hds::Form::Field>
+                </div>
+                <br />
+                <div class="dummy-form-base-elements-containers__{{display}}">
+                  <Hds::Form::Field @layout={{layout}} as |F|>
+                    <F.Label>This is the label text that should go on multiple lines</F.Label>
+                    <F.HelperText>This is the helper text that should go on multiple lines</F.HelperText>
+                    <F.Control>
+                      {{#if (eq layout "vertical")}}
+                        <DummyPlaceholder
+                          @text="control"
+                          @width="100%"
+                          @height="32"
+                          @background="#eee"
+                          class="hds-form-field__control"
+                        />
+                      {{/if}}
+                      {{#if (eq layout "flag")}}
+                        <DummyPlaceholder
+                          @text="✔"
+                          @width="16"
+                          @height="16"
+                          @background="#eee"
+                          class="hds-form-field__control"
+                        />
+                      {{/if}}
+                    </F.Control>
+                    <F.Error as |E|>
+                      <E.Message>This is the first error text</E.Message>
+                      <E.Message>This is the second error text that should go on multiple lines</E.Message>
+                    </F.Error>
+                  </Hds::Form::Field>
+                </div>
+              </div>
+            {{/each}}
+          {{/let}}
+        </div>
+      {{/each}}
+    {{/let}}
+  </div>
+
+  {{! ###################### }}
+
+  <hr class="dummy-divider" />
+
+  <h4 class="dummy-h4">Fieldset</h4>
+  <button id="dummy-toggle-highlight-2" type="button" {{on "click" this.toggleHighlight}}>{{if
+      this.showHighlight
+      "Hide"
+      "Show"
+    }}
+    layout highlight</button>
+  <div class="{{if this.showHighlight 'dummy-form-base-elements-layout-highlight'}}">
+    <h5 class="dummy-h5">Layout</h5>
+    <div class="dummy-form-base-elements-fieldset-layout">
+      {{#let (array "vertical" "horizontal") as |layouts|}}
+        {{#each layouts as |layout|}}
+          <div>
+            <span class="dummy-text-small">"{{layout}}" layout</span>
+            <br />
+            <Hds::Form::Fieldset @layout={{layout}} as |F|>
+              <F.Legend>This is the legend</F.Legend>
+              <F.HelperText>This is the helper text</F.HelperText>
+              <F.Control>
+                <DummyPlaceholder
+                  @text="field"
+                  @width="120"
+                  @height="32"
+                  @background="#eee"
+                  class="hds-form-group__control-field"
+                />
+              </F.Control>
+              <F.Control>
+                <DummyPlaceholder
+                  @text="field"
+                  @width="120"
+                  @height="32"
+                  @background="#eee"
+                  class="hds-form-group__control-field"
+                />
+              </F.Control>
+              <F.Control>
+                <DummyPlaceholder
+                  @text="field"
+                  @width="120"
+                  @height="32"
+                  @background="#eee"
+                  class="hds-form-group__control-field"
+                />
+              </F.Control>
+              <F.Error>This is the error</F.Error>
+            </Hds::Form::Fieldset>
+          </div>
+        {{/each}}
+      {{/let}}
+    </div>
+    {{#let (array "vertical" "horizontal") as |layouts|}}
+      {{#each layouts as |layout|}}
+        <h5 class="dummy-h5">Containers / "{{layout}}" layout</h5>
+        <div class="dummy-form-base-elements-containers">
+          {{#let (array "block" "flex" "grid") as |displays|}}
+            {{#each displays as |display|}}
+              <div>
+                <span class="dummy-text-small">Parent with <code class="dummy-code">display: {{display}}</code></span>
+                <br />
+                <div class="dummy-form-base-elements-containers__{{display}}">
+                  <Hds::Form::Fieldset @layout={{layout}} as |F|>
+                    <F.Legend>This is the legend</F.Legend>
+                    <F.HelperText>This is the helper text</F.HelperText>
+                    <F.Control>
+                      <DummyPlaceholder
+                        @text="field"
+                        @width="120"
+                        @height="32"
+                        @background="#eee"
+                        class="hds-form-group__control-field"
+                      />
+                    </F.Control>
+                    <F.Control>
+                      <DummyPlaceholder
+                        @text="field"
+                        @width="120"
+                        @height="32"
+                        @background="#eee"
+                        class="hds-form-group__control-field"
+                      />
+                    </F.Control>
+                    <F.Error>This is the error</F.Error>
+                  </Hds::Form::Fieldset>
+                </div>
+                <br />
+                <div class="dummy-form-base-elements-containers__{{display}}">
+                  <Hds::Form::Fieldset @layout={{layout}} as |F|>
+                    <F.Legend>This is the legend text that should go on multiple lines</F.Legend>
+                    <F.HelperText>This is the helper text that should go on multiple lines</F.HelperText>
+                    <F.Control>
+                      <DummyPlaceholder
+                        @text="field"
+                        @width="120"
+                        @height="32"
+                        @background="#eee"
+                        class="hds-form-group__control-field"
+                      />
+                    </F.Control>
+                    <F.Control>
+                      <DummyPlaceholder
+                        @text="field"
+                        @width="120"
+                        @height="32"
+                        @background="#eee"
+                        class="hds-form-group__control-field"
+                      />
+                    </F.Control>
+                    <F.Error as |E|>
+                      <E.Message>This is the first error text</E.Message>
+                      <E.Message>This is the second error text that should go on multiple lines</E.Message>
+                    </F.Error>
+                  </Hds::Form::Fieldset>
+                </div>
+              </div>
+            {{/each}}
+          {{/let}}
+        </div>
+      {{/each}}
+    {{/let}}
+  </div>
+
+</section>

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -1107,6 +1107,7 @@
             </Hds::Form::Field>
           </div>
         </div>
+        <br />
         <div class="dummy-form-base-elements-grid-sample">
           <div>
             <span class="dummy-text-small">Label + Error</span>

--- a/packages/components/tests/dummy/app/templates/components/link/inline.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/inline.hbs
@@ -23,7 +23,7 @@
 </section>
 
 <section>
-  <h3 class="dummy-h3" id="overview"><a href="#overview">§</a> Overview</h3>
+  <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
 
   <p class="dummy-paragraph">The
     <code class="dummy-code">Link::Inline</code>
@@ -64,7 +64,7 @@
 </section>
 
 <section>
-  <h3 class="dummy-h3" id="component-api"><a href="#component-api">§</a> Component API</h3>
+  <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
   <p class="dummy-paragraph">
     Here is the API for the component:
   </p>

--- a/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
@@ -5,7 +5,7 @@
 <DummyLinkCtaButtonBanner />
 
 <section>
-  <h3 class="dummy-h3" id="overview"><a href="#overview">§</a> Overview</h3>
+  <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
 
   <p class="dummy-paragraph">The
     <code class="dummy-code">Link::Standalone</code>
@@ -57,7 +57,7 @@
 </section>
 
 <section>
-  <h3 class="dummy-h3" id="component-api"><a href="#component-api">§</a> Component API</h3>
+  <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
   <p class="dummy-paragraph" id="component-api-link-standalone">
     Here is the API for the component:
   </p>

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -106,7 +106,7 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown #test-list-item-interactive').doesNotExist();
   });
 
-  // SPLATTRIBUTES
+  // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     assert.expect(3);

--- a/packages/components/tests/integration/components/hds/form/error/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/error/index-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/error/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Error id="test-form-error" />`);
+    assert.dom('#test-form-error').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Error id="test-form-error" />`);
+    assert.dom('#test-form-error').hasClass('hds-form-error');
+  });
+  test('it should render with a CSS class provided via the @contextualClass argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Error @contextualClass="my-class" id="test-form-error" />`
+    );
+    assert.dom('#test-form-error').hasClass('my-class');
+  });
+
+  // CONTENT
+
+  test('it renders an error with the defined text', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Error id="test-form-error">This is the error</Hds::Form::Error>`
+    );
+    assert.dom('#test-form-error').hasText('This is the error');
+  });
+  test('it renders an error with the yielded content', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Error id="test-form-error"><pre>This is an HTML element inside the error</pre></Hds::Form::Error>`
+    );
+    assert.dom('#test-form-error pre').exists();
+    assert
+      .dom('#test-form-error pre')
+      .hasText('This is an HTML element inside the error');
+  });
+  test('it renders multiple error messages as contextual components', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Error id="test-form-error" as |E|><E.Message>First error message</E.Message><E.Message>Second error message</E.Message></Hds::Form::Error>`
+    );
+    assert
+      .dom('#test-form-error .hds-form-error__message')
+      .exists({ count: 2 });
+    assert
+      .dom('#test-form-error .hds-form-error__message')
+      .hasText('First error message');
+  });
+
+  // ATTRIBUTES
+
+  test('it renders an error with the correct "id" attribute if the @controlId argument is provided', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Error @controlId="my-control-id">This is the error</Hds::Form::Error>`
+    );
+    assert.dom('#error-my-control-id').exists();
+  });
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Error id="test-form-error" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-error').hasClass('my-class');
+    assert.dom('#test-form-error').hasAttribute('data-test1');
+    assert.dom('#test-form-error').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/field/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/field/index-test.js
@@ -1,0 +1,118 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/field/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Field id="test-form-field" />`);
+    assert.dom('#test-form-field').exists();
+  });
+  test('it should render with a CSS class provided via the @contextualClass argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Field @contextualClass="my-class" id="test-form-field" />`
+    );
+    assert.dom('#test-form-field').hasClass('my-class');
+  });
+
+  // LAYOUT
+
+  test('it should render the correct CSS layout class depending on the @layout prop', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" />`
+    );
+    assert.dom('#test-form-field').hasClass('hds-form-field--layout-vertical');
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(8);
+    await render(
+      hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Control><pre class="hds-form-field__control">This is a mock control</pre></F.Control>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Field>`
+    );
+    assert.dom('#test-form-field .hds-form-field__label').exists();
+    assert.dom('.hds-form-field__label').hasText('This is the label');
+    assert.dom('#test-form-field .hds-form-field__helper-text').exists();
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasText('This is the helper text');
+    assert.dom('#test-form-field .hds-form-field__control').exists();
+    assert.dom('.hds-form-field__control').hasText('This is a mock control');
+    assert.dom('#test-form-field .hds-form-field__error').exists();
+    assert.dom('.hds-form-field__error').hasText('This is the error');
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Control><pre class="hds-form-field__control" id={{F.id}} aria-describedby={{F.ariaDescribedBy}}>This is a mock control</pre></F.Control>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Field>`
+    );
+    // the control ID is dynamically generated
+    let control = this.element.querySelector(
+      '#test-form-field .hds-form-field__control'
+    );
+    let controlId = control.id;
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+  test('it automatically provides all the ID relations between the elements with a custom @id', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" @id="my-custom-id" as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Control><pre class="hds-form-field__control" id={{F.id}} aria-describedby={{F.ariaDescribedBy}}>This is a mock control</pre></F.Control>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Field>`
+    );
+    let controlId = 'my-custom-id';
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Field id="test-form-field" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-field').hasClass('my-class');
+    assert.dom('#test-form-field').hasAttribute('data-test1');
+    assert.dom('#test-form-field').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/fieldset/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/fieldset/index-test.js
@@ -1,0 +1,92 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/fieldset/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Fieldset id="test-form-fieldset" />`);
+    assert.dom('#test-form-fieldset').exists();
+  });
+  test('it renders the element as <fieldset>', async function (assert) {
+    await render(hbs`<Hds::Form::Fieldset id="test-form-fieldset" />`);
+    assert.dom('#test-form-fieldset').hasTagName('fieldset');
+  });
+
+  // LAYOUT
+
+  test('it should render the correct CSS layout class depending on the @layout prop', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Fieldset @layout="vertical" id="test-form-fieldset" />`
+    );
+    assert
+      .dom('#test-form-fieldset')
+      .hasClass('hds-form-group--layout-vertical');
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(8);
+    await render(
+      hbs`<Hds::Form::Fieldset @layout="vertical" id="test-form-fieldset" as |F|>
+          <F.Legend>This is the legend</F.Legend>
+          <F.HelperText>This is the group helper text</F.HelperText>
+          <F.Control><pre class="hds-form-group__control-field">This is a mock control field</pre></F.Control>
+          <F.Error>This is the group error</F.Error>
+        </Hds::Form::Fieldset>`
+    );
+    assert.dom('#test-form-fieldset .hds-form-group__legend').exists();
+    assert.dom('.hds-form-group__legend').hasText('This is the legend');
+    assert.dom('#test-form-fieldset .hds-form-group__helper-text').exists();
+    assert
+      .dom('.hds-form-group__helper-text')
+      .hasText('This is the group helper text');
+    assert.dom('#test-form-fieldset .hds-form-group__control-field').exists();
+    assert
+      .dom('.hds-form-group__control-field')
+      .hasText('This is a mock control field');
+    assert.dom('#test-form-fieldset .hds-form-group__error').exists();
+    assert.dom('.hds-form-group__error').hasText('This is the group error');
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Fieldset @layout="vertical" as |F|>
+          <F.Legend>This is the legend</F.Legend>
+          <F.HelperText>This is the group helper text</F.HelperText>
+          <F.Control><pre class="hds-form-group__control" id={{F.id}} aria-describedby={{F.ariaDescribedBy}}>This is a mock control</pre></F.Control>
+          <F.Error>This is the group error</F.Error>
+        </Hds::Form::Fieldset>`
+    );
+    // the fieldset ID is dynamically generated
+    let fieldset = this.element.querySelector('fieldset');
+    let fieldsetId = fieldset.id;
+    assert
+      .dom('.hds-form-group__helper-text')
+      .hasAttribute('id', `helper-text-${fieldsetId}`);
+    assert
+      .dom('fieldset')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${fieldsetId} error-${fieldsetId}`
+      );
+    assert
+      .dom('.hds-form-group__error')
+      .hasAttribute('id', `error-${fieldsetId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Fieldset id="test-form-fieldset" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-fieldset').hasClass('my-class');
+    assert.dom('#test-form-fieldset').hasAttribute('data-test1');
+    assert.dom('#test-form-fieldset').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/helper-text/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/helper-text/index-test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | hds/form/helper-text/index',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders the component', async function (assert) {
+      await render(hbs`<Hds::Form::HelperText id="test-form-helper-text" />`);
+      assert.dom('#test-form-helper-text').exists();
+    });
+    test('it should render with a CSS class that matches the component name', async function (assert) {
+      await render(hbs`<Hds::Form::HelperText id="test-form-helper-text" />`);
+      assert.dom('#test-form-helper-text').hasClass('hds-form-helper-text');
+    });
+    test('it should render with a CSS class provided via the @contextualClass argument', async function (assert) {
+      await render(
+        hbs`<Hds::Form::HelperText @contextualClass="my-class" id="test-form-helper-text" />`
+      );
+      assert.dom('#test-form-helper-text').hasClass('my-class');
+    });
+
+    // CONTENT
+
+    test('it renders a helper text with the defined text', async function (assert) {
+      await render(
+        hbs`<Hds::Form::HelperText id="test-form-helper-text">This is the helper text</Hds::Form::HelperText>`
+      );
+      assert.dom('#test-form-helper-text').hasText('This is the helper text');
+    });
+    test('it renders a helper text with the yielded content', async function (assert) {
+      assert.expect(2);
+      await render(
+        hbs`<Hds::Form::HelperText id="test-form-helper-text"><pre>This is an HTML element inside the helper text</pre></Hds::Form::HelperText>`
+      );
+      assert.dom('#test-form-helper-text > pre').exists();
+      assert
+        .dom('#test-form-helper-text pre')
+        .hasText('This is an HTML element inside the helper text');
+    });
+
+    // ATTRIBUTES
+
+    test('it renders a helper text with the correct "id" attribute if the @controlId argument is provided', async function (assert) {
+      await render(
+        hbs`<Hds::Form::HelperText @controlId="my-control-id">This is the helper text</Hds::Form::HelperText>`
+      );
+      assert.dom('#helper-text-my-control-id').exists();
+    });
+    test('it should spread all the attributes passed to the component', async function (assert) {
+      assert.expect(3);
+      await render(
+        hbs`<Hds::Form::HelperText id="test-form-helper-text" class="my-class" data-test1 data-test2="test" />`
+      );
+      assert.dom('#test-form-helper-text').hasClass('my-class');
+      assert.dom('#test-form-helper-text').hasAttribute('data-test1');
+      assert.dom('#test-form-helper-text').hasAttribute('data-test2', 'test');
+    });
+  }
+);

--- a/packages/components/tests/integration/components/hds/form/label/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/label/index-test.js
@@ -1,0 +1,60 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/label/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Label id="test-form-label" />`);
+    assert.dom('#test-form-label').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Label id="test-form-label" />`);
+    assert.dom('#test-form-label').hasClass('hds-form-label');
+  });
+  test('it should render with a CSS class provided via the @contextualClass argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Label @contextualClass="my-class" id="test-form-label" />`
+    );
+    assert.dom('#test-form-label').hasClass('my-class');
+  });
+
+  // CONTENT
+
+  test('it renders a label with the defined text', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Label id="test-form-label">This is the label</Hds::Form::Label>`
+    );
+    assert.dom('#test-form-label').hasText('This is the label');
+  });
+  test('it renders a label with the yielded content', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Label id="test-form-label"><pre>This is an HTML element inside the label</pre></Hds::Form::Label>`
+    );
+    assert.dom('#test-form-label > pre').exists();
+    assert
+      .dom('#test-form-label pre')
+      .hasText('This is an HTML element inside the label');
+  });
+
+  // ATTRIBUTES
+
+  test('it renders a label with the "for" attribute if the @controlId argument is provided', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Label @controlId="my-control-id" id="test-form-label">This is the label</Hds::Form::Label>`
+    );
+    assert.dom('#test-form-label').hasAttribute('for', 'my-control-id');
+  });
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Label id="test-form-label" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-label').hasClass('my-class');
+    assert.dom('#test-form-label').hasAttribute('data-test1');
+    assert.dom('#test-form-label').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/legend/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/legend/index-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/legend/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Legend id="test-form-legend" />`);
+    assert.dom('#test-form-legend').exists();
+  });
+  test('it renders the element as <legend>', async function (assert) {
+    await render(hbs`<Hds::Form::Legend id="test-form-legend" />`);
+    assert.dom('#test-form-legend').hasTagName('legend');
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Legend id="test-form-legend" />`);
+    assert.dom('#test-form-legend').hasClass('hds-form-legend');
+  });
+  test('it should render with a CSS class provided via the @contextualClass argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Legend @contextualClass="my-class" id="test-form-legend" />`
+    );
+    assert.dom('#test-form-legend').hasClass('my-class');
+  });
+
+  // CONTENT
+
+  test('it renders a legend with the defined text', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Legend id="test-form-legend">This is the legend</Hds::Form::Legend>`
+    );
+    assert.dom('#test-form-legend').hasText('This is the legend');
+  });
+  test('it renders a legend with the yielded content', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Legend id="test-form-legend"><pre>This is an HTML element inside the legend</pre></Hds::Form::Legend>`
+    );
+    assert.dom('#test-form-legend > pre').exists();
+    assert
+      .dom('#test-form-legend pre')
+      .hasText('This is an HTML element inside the legend');
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Legend id="test-form-legend" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-legend').hasClass('my-class');
+    assert.dom('#test-form-legend').hasAttribute('data-test1');
+    assert.dom('#test-form-legend').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/interactive/index-test.js
+++ b/packages/components/tests/integration/components/hds/interactive/index-test.js
@@ -61,7 +61,7 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
     assert.dom('#test-interactive').doesNotHaveAttribute('rel');
   });
 
-  // SPLATTRIBUTES
+  // ATTRIBUTES
 
   test('it should spread all the attributes passed to the <button> element', async function (assert) {
     assert.expect(3);


### PR DESCRIPTION
### :pushpin: Summary

This is the first PR for the `form controls` elements. It's about the low-level base components used to build the "field" and "group" controls:
- `label`
- `helper-text`
- `error`
- `legend`
- `field`
- `fieldset`

For the nomenclature see this illustration:
<img width="1055" alt="screenshot_1564" src="https://user-images.githubusercontent.com/686239/174313189-d9149463-3bb6-48bf-9efb-242f127caa98.png">

_Notice: the branch has been extracted from `form-controls/spike-playground` in #285 via a diff with the `main` branch and then cherry-picked only the changes needed for this PR._

### :hammer_and_wrench: Detailed description

In this PR we (me and @alex-ju) have:
- added the `base elements` for  the `form controls` components
- added the documentation page for the `base elements`
- added integration tests and percy testing
- done some minor tweaks to other components/files for consistency 

Preview of the documentation page: https://hds-components-git-form-controls-01-base-elements-hashicorp.vercel.app/components/form/base-elements

Notice: the page is not linked in the index file of the dummy/scrappy website on purpose, so it's not visible to the public.

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
