### PR TITLE
Form controls - `TextInput` component (02)

### DIFF
--- a/packages/components/addon/components/hds/form/text-input/base.hbs
+++ b/packages/components/addon/components/hds/form/text-input/base.hbs
@@ -1,0 +1,1 @@
+<input class={{this.classNames}} {{style width=@width}} ...attributes value={{@value}} type={{this.type}} />

--- a/packages/components/addon/components/hds/form/text-input/base.js
+++ b/packages/components/addon/components/hds/form/text-input/base.js
@@ -1,0 +1,56 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+// notice: we don't support all the possible HTML types, only a subset
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
+export const DEFAULT_TYPE = 'text';
+export const TYPES = [
+  'text',
+  'email',
+  'password',
+  'url',
+  'search',
+  'date',
+  'time',
+];
+
+export default class HdsFormTextInputBaseComponent extends Component {
+  /**
+   * Sets the type of input
+   *
+   * @param type
+   * @type {string}
+   * @default 'text'
+   */
+  get type() {
+    let { type = DEFAULT_TYPE } = this.args;
+
+    assert(
+      `@type for "Hds::Form::TextInput" must be one of the following: ${TYPES.join(
+        ', '
+      )}, received: ${type}`,
+      TYPES.includes(type)
+    );
+
+    return type;
+  }
+
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-form-text-input'];
+
+    // add typographic classes
+    classes.push('hds-typography-body-200', 'hds-font-weight-regular');
+
+    // add a class based on the @isInvalid argument
+    if (this.args.isInvalid) {
+      classes.push(`hds-form-text-input--is-invalid`);
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/addon/components/hds/form/text-input/field.hbs
+++ b/packages/components/addon/components/hds/form/text-input/field.hbs
@@ -1,0 +1,16 @@
+<Hds::Form::Field @layout="vertical" as |F|>
+  {{! Notice: the order of the elements is not relevant here, because is controlled at "Hds::Form::Field" component level }}
+  {{yield (hash Label=F.Label HelperText=F.HelperText Error=F.Error)}}
+  <F.Control>
+    <Hds::Form::TextInput::Base
+      class="hds-form-field__control"
+      @type={{@type}}
+      @value={{@value}}
+      @isInvalid={{@isInvalid}}
+      @width={{@width}}
+      ...attributes
+      id={{F.id}}
+      aria-describedby={{F.ariaDescribedBy}}
+    />
+  </F.Control>
+</Hds::Form::Field>

--- a/packages/components/app/components/hds/form/text-input/base.js
+++ b/packages/components/app/components/hds/form/text-input/base.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/text-input/base';

--- a/packages/components/app/components/hds/form/text-input/field.js
+++ b/packages/components/app/components/hds/form/text-input/field.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/text-input/field';

--- a/packages/components/app/styles/components/form/index.scss
+++ b/packages/components/app/styles/components/form/index.scss
@@ -9,3 +9,5 @@
 @use "./field";
 @use "./legend";
 @use "./group";
+
+@use "./text-input";

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -46,9 +46,18 @@
     border-color: var(--token-color-focus-action-internal);
   }
 
+  // READONLY
+
+  &:read-only,
+  &[readonly] {
+    background-color: var(--token-color-surface-strong);
+    border-color: var(--token-color-palette-neutral-400);
+  }
+
   // DISABLED
 
-  &:disabled {
+  &:disabled,
+  &[disabled] {
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
   }

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -1,0 +1,127 @@
+//
+// FORM > TEXT-INPUT
+//
+// properties within each class are sorted alphabetically
+//
+
+// "BASE" CONTROL
+
+.hds-form-text-input {
+  border: 1px solid var(--token-color-palette-neutral-400);
+  border-radius: 5px;
+  box-shadow: var(--hds-elevation-inset-box-shadow);
+  color: var(--token-color-foreground-primary);
+  font-family: var(--token-typography-body-200-font-family);
+  font-size: var(--token-typography-body-200-font-size);
+  line-height: var(--token-typography-body-200-line-height);
+  padding: 7px;
+  width: 100%;
+  max-width: 100%;
+
+  // PLACEHOLDER
+
+  ::placeholder {
+    color: var(--token-color-foreground-faint);
+  }
+
+  // STATUS
+
+  &:hover,
+  &.mock-hover {
+    border-color: var(--token-color-palette-neutral-500);
+  }
+
+  // focus (same for all the states)
+  // TODO add handling of focus-visible
+  &:focus,
+  &.mock-focus {
+    border-color: var(--token-color-focus-action-internal);
+    // TODO: Safari doesn't apply a rounded border
+    outline: 2px solid var(--token-color-focus-action-external);
+    outline-offset: 0px;
+  }
+
+  &:active,
+  &.mock-active {
+    border-color: var(--token-color-focus-action-internal);
+  }
+
+  // DISABLED
+
+  &:disabled {
+    background-color: var(--token-color-surface-interactive-disabled);
+    border-color: var(--token-color-border-primary);
+  }
+
+  // INVALID
+
+  &.hds-form-text-input--is-invalid {
+    border-color: var(--token-color-foreground-critical);
+  }
+}
+
+
+
+// "TYPE" CUSTOMIZATION
+
+.hds-form-text-input {
+
+  // DATE/TIME
+
+  &[type="date"],
+  &[type="time"] {
+
+    // browsers set a specific width for these controls, we want to keep it
+    width: initial;
+
+    // show the native icon dimmed if disabled (hidden in Chrome)
+    &[disabled]::-webkit-calendar-picker-indicator,
+    &:disabled::-webkit-calendar-picker-indicator {
+        visibility: visible;
+        opacity: 0.5;
+    }
+
+    // show the icon if readonly
+    &[readonly]::-webkit-calendar-picker-indicator {
+        visibility: visible;
+    }
+  }
+
+  // we override the default icon with the Flight corresponding one
+  // notice: the original in Chrome has two assets, one for light and one for dark mode, and uses a special syntax, but apparently it doesn't work if used in a stylesheet
+  &[type="date"] {
+    &::-webkit-calendar-picker-indicator {
+      // notice: the icon color is hardcoded here!
+      background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M11.5.75a.75.75 0 00-1.5 0V1H6V.75a.75.75 0 00-1.5 0V1H3.25A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1H11.5V.75zm-7 2.5V2.5H3.25a.75.75 0 00-.75.75V5h11V3.25a.75.75 0 00-.75-.75H11.5v.75a.75.75 0 01-1.5 0V2.5H6v.75a.75.75 0 01-1.5 0zm9 3.25h-11v6.25c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V6.5z' fill-rule='evenodd' clip-rule='evenodd' fill='%233B3D45'/%3e%3c/svg%3e");
+      background-position: center center;
+      background-size: 16px;
+    }
+  }
+  &[type="time"] {
+    &::-webkit-calendar-picker-indicator {
+      // notice: the icon color is hardcoded here!
+      background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%233B3D45'%3e%3cpath d='M8.5 3.75a.75.75 0 00-1.5 0V8c0 .284.16.544.415.67l2.5 1.25a.75.75 0 10.67-1.34L8.5 7.535V3.75z'/%3e%3cpath d='M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e");
+      background-position: center center;
+      background-size: 16px;
+    }
+  }
+
+  // SEARCH
+  &[type="search"] {
+    padding-left: 32px;
+    // notice: the icon color is hardcoded here!
+    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%23656A76'%3e%3cpath d='M7.25 2a5.25 5.25 0 103.144 9.455l2.326 2.325a.75.75 0 101.06-1.06l-2.325-2.326A5.25 5.25 0 007.25 2zM3.5 7.25a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e");
+    background-position: 7px 50%;
+    background-size: 16px;
+    background-repeat: no-repeat;
+
+    &::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+      background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3e%3c/svg%3e");
+      background-position: center center;
+      background-size: 16px;
+      height: 16px;
+      width: 16px;
+    }
+  }
+}

--- a/packages/components/tests/acceptance/percy-test.js
+++ b/packages/components/tests/acceptance/percy-test.js
@@ -48,6 +48,9 @@ module('Acceptance | Percy test', function (hooks) {
     await click('button#dummy-toggle-highlight');
     await percySnapshot('Form - Base elements');
 
+    await visit('/components/form/text-input');
+    await percySnapshot('Form - TextInput');
+
     await visit('/components/icon-tile');
     await percySnapshot('IconTile');
 

--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -23,6 +23,7 @@ Router.map(function () {
     this.route('dropdown');
     this.route('form', function () {
       this.route('base-elements');
+      this.route('text-input');
     });
     this.route('icon-tile');
     this.route('link', function () {

--- a/packages/components/tests/dummy/app/routes/components/form/text-input.js
+++ b/packages/components/tests/dummy/app/routes/components/form/text-input.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+
+import { TYPES } from '@hashicorp/design-system-components/components/hds/form/text-input/base';
+
+export default class ComponentsFormTextInputRoute extends Route {
+  model() {
+    // these are used only for presentation purpose in the showcase
+    const STATES = ['default', 'hover', 'active', 'focus'];
+    return {
+      TYPES,
+      STATES,
+    };
+  }
+}

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -23,6 +23,7 @@
 @import "./pages/db-tokens";
 @import "./pages/db-typography";
 @import "./pages/form/db-base-elements";
+@import "./pages/form/db-text-input";
 // END COMPONENT PAGES IMPORTS
 
 @import "./components/dummy-component-props";

--- a/packages/components/tests/dummy/app/styles/pages/form/db-text-input.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-text-input.scss
@@ -1,0 +1,72 @@
+// FORM > TEXT-INPUT
+
+.dummy-form-text-input-base-sample {
+  display: flex;
+  gap: 2rem;
+}
+
+.dummy-form-text-input-types-grid {
+  align-items: start;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: repeat(5, 1fr);
+}
+
+.dummy-form-text-input-grid-sample {
+  align-items: start;
+  display: grid;
+  grid-gap: 1rem 3rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.dummy-form-text-input-containers {
+  align-items: start;
+  display: grid;
+  grid-gap: 3rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dummy-form-text-input-containers__block {
+  display: block;
+}
+
+.dummy-form-text-input-containers__flex {
+  display: flex;
+}
+
+.dummy-form-text-input-containers__grid {
+  display: grid;
+  justify-items: start;
+}
+
+.dummy-form-text-input-sublist {
+  > * + * {
+    margin-top: 0.5rem;
+  }
+}
+
+.dummy-form-text-input-custom-layout {
+  display: flex;
+  font-family: Verdana, sans-serif;
+  font-size: 0.8em;
+  align-items: center;
+
+  label {
+    margin-right: 10px;
+  }
+
+  input {
+    flex: 1 1 0; // is a direct child of a flexbox and has a width of 100% so it blows up
+  }
+
+  .dummy-form-text-input-custom-layout__append-text {
+    background-color: #E4E4E4;
+    border: 1px solid #999;
+    border-radius: 0 5px 5px 0;
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    align-self: stretch;
+    margin-left: -10px;
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -1,0 +1,478 @@
+{{page-title "Form::TextInput Component"}}
+
+<h2 class="dummy-h2">Form::TextInput</h2>
+
+<section>
+  <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
+  <p class="dummy-paragraph">The
+    <code class="dummy-code">Form::TextInput</code>
+    component has different variants, with their own APIs:</p>
+  <ul>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::TextInput::Base</code>
+      - the "basic" component: just the
+      <code class="dummy-code">&lt;input&gt;</code>
+      control
+    </li>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::TextInput::Field</code>
+      - the "field" parent component: the
+      <code class="dummy-code">&lt;input&gt;</code>
+      control, with label, helper text and error messaging (in a wrapping container)
+    </li>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::TextInput::Group</code>
+      - the "group" parent component: a
+      <code class="dummy-code">&lt;legend&gt;</code>
+      (optional), a list of fields, and error messaging
+    </li>
+  </ul>
+  <h4 class="dummy-h4">Form::TextInput::Base</h4>
+  <p class="dummy-paragraph" id="component-api-form-text-input-base">Here is the API for the "base" component:</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-text-input-base">
+    <dt>type <code>enum</code></dt>
+    <dd>
+      <p>
+        Sets the native HTML
+        <code class="dummy-code">type</code>
+        of the
+        <code class="dummy-code">&lt;input&gt;</code>. This list covers all the official types (see
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input"
+          target="_blank"
+          rel="noopener noreferrer"
+        >MDN documentation</a>)
+      </p>
+      <p>Acceptable values:</p>
+      <ol>
+        {{#each @model.TYPES as |type|}}
+          <li class={{if (eq type "text") "default"}}>{{type}}</li>
+        {{/each}}
+      </ol>
+    </dd>
+    <dt>value <code>string|number|date</code></dt>
+    <dd>
+      <p>The input control's value.</p>
+    </dd>
+    <dt>isInvalid <code>boolean</code></dt>
+    <dd>
+      <p>It applies an "invalid" appearance to the control (<em>notice: this does _not_ modify its logical validity</em>).</p>
+      <p>Default: <span class="default">false</span></p>
+    </dd>
+    <dt>width <code>string</code></dt>
+    <dd>
+      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p><em>Notice: by default the
+          <code class="dummy-code">&lt;input&gt;</code>
+          has a
+          <code class="dummy-code">width</code>
+          of
+          <code class="dummy-code">100%</code>
+          applied to it, so it fills the parent container. If a
+          <code class="dummy-code">@width</code>
+          parameter is provided then the control will have a fixed width.</em></p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+      <p><em>Notice: the attributes will be applied to the
+          <code class="dummy-code">&lt;input&gt;</code>
+          element. This means you can use all the standard HTML attributes of the
+          <code class="dummy-code">&lt;input&gt;</code>
+          element and all the usual Ember techniques for event handling, validation, etc.</em></p>
+      <p><em>Some examples of HTML attributes that you will likely use:
+          <code class="dummy-code">id</code>,
+          <code class="dummy-code">name</code>,
+          <code class="dummy-code">value</code>,
+          <code class="dummy-code">placeholder</code>,
+          <code class="dummy-code">disabled</code>,
+          <code class="dummy-code">readonly</code>,
+          <code class="dummy-code">required</code>
+          (<a
+            href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attributes"
+            rel="noopener noreferrer"
+          >see whole list here</a>) and some examples of Ember modifiers:
+          <code class="dummy-code">&lcub;&lcub;on "input" [do something]&rcub;&rcub;</code>,
+          <code class="dummy-code">&lcub;&lcub;on "change" [do something]&rcub;&rcub;</code>,
+          <code class="dummy-code">&lcub;&lcub;on "blur" [do something]&rcub;&rcub;</code>.
+        </em></p>
+    </dd>
+  </dl>
+  <h4 class="dummy-h4">Form::TextInput::Field</h4>
+  <p class="dummy-paragraph" id="component-api-form-text-input-field">Here is the API for the "field" component:</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-text-input-field">
+    <dt>type <code>enum</code></dt>
+    <dd>
+      <p>
+        Sets the native HTML
+        <code class="dummy-code">type</code>
+        of the
+        <code class="dummy-code">&lt;input&gt;</code>. This list covers all the official types (see
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input"
+          target="_blank"
+          rel="noopener noreferrer"
+        >MDN documentation</a>)
+      </p>
+      <p>Acceptable values:</p>
+      <ol>
+        {{#each @model.TYPES as |type|}}
+          <li class={{if (eq type "text") "default"}}>{{type}}</li>
+        {{/each}}
+      </ol>
+    </dd>
+    <dt>value <code>string|number|date</code></dt>
+    <dd>
+      <p>The input control's value.</p>
+    </dd>
+    <dt>isInvalid <code>boolean</code></dt>
+    <dd>
+      <p>It applies an "invalid" appearance to the control (<em>notice: this does _not_ modify its logical validity</em>).</p>
+      <p>Default: <span class="default">false</span></p>
+    </dd>
+    <dt>width <code>string</code></dt>
+    <dd>
+      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p><em>Notice: by default the
+          <code class="dummy-code">&lt;input&gt;</code>
+          has a
+          <code class="dummy-code">width</code>
+          of
+          <code class="dummy-code">100%</code>
+          applied to it, so it fills the parent container. If a
+          <code class="dummy-code">@width</code>
+          parameter is provided then the control will have a fixed width. This width will be applied
+          <strong>only</strong>
+          to the control, not the other elements of the field.</em></p>
+    </dd>
+    <dt>id <code>string</code></dt>
+    <dd>
+      <p>The input control's ID attribute</p>
+      <p><em>Notice: by default the ID is automatically generated by the component; use this argument if you need to
+          pass a custom ID for specific reasons you may have.</em></p>
+    </dd>
+    <dt>ariaDescribedBy <code>string</code></dt>
+    <dd>
+      <p>An extra ID attribute to be added to the <code class="dummy-code">aria-describedby</code> HTML attribute.</p>
+      <p><em>Notice: by default the
+          <code class="dummy-code">aria-describedby</code>
+          attribute is automatically generated by the component, using the IDs of the helper text and errors (if they're
+          present); use this argument if you need to pass an extra ID for specific reasons you may have.</em></p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+      <p><em>Notice: the attributes will be applied to the
+          <code class="dummy-code">&lt;input&gt;</code>
+          element. This means you can use all the standard HTML attributes of the
+          <code class="dummy-code">&lt;input&gt;</code>
+          element and all the usual Ember techniques for event handling, validation, etc.</em></p>
+      <p><em>Some examples of HTML attributes that you will likely use:
+          <code class="dummy-code">id</code>,
+          <code class="dummy-code">name</code>,
+          <code class="dummy-code">value</code>,
+          <code class="dummy-code">placeholder</code>,
+          <code class="dummy-code">disabled</code>,
+          <code class="dummy-code">readonly</code>,
+          <code class="dummy-code">required</code>
+          (<a
+            href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attributes"
+            rel="noopener noreferrer"
+          >see whole list here</a>) and some examples of Ember modifiers:
+          <code class="dummy-code">&lcub;&lcub;on "input" [do something]&rcub;&rcub;</code>,
+          <code class="dummy-code">&lcub;&lcub;on "change" [do something]&rcub;&rcub;</code>,
+          <code class="dummy-code">&lcub;&lcub;on "blur" [do something]&rcub;&rcub;</code>.
+        </em></p>
+    </dd>
+  </dl>
+  <h5 class="dummy-h5">Contextual components</h5>
+  <p class="dummy-paragraph" id="component-api-form-text-input-field-contextual-components">Label, helper text and error
+    content are passed to the field as yielded components, using the
+    <code class="dummy-code">Label</code>,
+    <code class="dummy-code">HelperText</code>,
+    <code class="dummy-code">Error</code>
+    keys.</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-text-input-field-contextual-components">
+    <dt>&lt;[C].Label&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the <code class="dummy-code">&lt;label&gt;</code> element.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <p>For details about its API check the
+        <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Label</code></LinkTo>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">for</code>
+          attribute of the label is automatically generated, using the
+          <code class="dummy-code">controlId</code>
+          value of the control.</em></p>
+    </dd>
+    <dt>&lt;[C].HelperText&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the "helper text" block.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <p>For details about its API check the
+        <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::HelperText</code></LinkTo>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">id</code>
+          attribute of the element is automatically generated, using the
+          <code class="dummy-code">controlId</code>
+          value of the control.</em></p>
+    </dd>
+    <dt>&lt;[C].Error&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the "error" block.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <dl class="dummy-component-props">
+        <dt>[E].Message <code>yielded component</code></dt>
+        <dd>
+          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+            individual items using
+            <code class="dummy-code">Error.Message</code>.
+          </p>
+        </dd>
+      </dl>
+      <p>For details about its API check the
+        <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">id</code>
+          attribute of the
+          <code class="dummy-code">Error</code>
+          element is automatically generated.</em></p>
+    </dd>
+  </dl>
+
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="how-to-use"><a href="#how-to-use" class="dummy-link-section">§</a> How to use</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
+    Design guidelines</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  {{! UNCOMMENT THIS BLOCK (once the link and/or the image are available) }}
+  {{!
+  <div class="dummy-design-guidelines">
+    <p class="dummy-paragraph">
+      <a href="[ADD THE LINK TO THE FIGMA FILE/PAGE HERE!]" target="_blank" rel="noopener noreferrer">Figma UI Kit</a>
+    </p>
+    <br />
+    <img class="dummy-figma-docs" src="/assets/images/form-text-input-design-usage.png" alt="" role="none" />
+  </div>
+  }}
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+</section>
+
+<section data-test-percy>
+  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+
+  <h4 class="dummy-h4">"Base" control</h4>
+  <h5 class="dummy-h6">Interaction status</h5>
+  <div class="dummy-form-text-input-base-sample">
+    <div>
+      <span class="dummy-text-small">Default</span>
+      <br />
+      <Hds::Form::TextInput::Base />
+    </div>
+    <div>
+      <span class="dummy-text-small">With placeholder</span>
+      <br />
+      <Hds::Form::TextInput::Base placeholder="Lorem ipsum dolor" />
+    </div>
+    <div>
+      <span class="dummy-text-small">With value</span>
+      <br />
+      <Hds::Form::TextInput::Base @value="Lorem ipsum dolor" />
+    </div>
+  </div>
+  <h5 class="dummy-h5">Types (native)</h5>
+  <div class="dummy-form-text-input-types-grid">
+    {{#each @model.TYPES as |type|}}
+      <div>
+        <span class="dummy-text-small">{{capitalize type}}:</span>
+        <br />
+        <Hds::Form::TextInput::Base @type={{type}} @value={{type}} />
+      </div>
+    {{/each}}
+  </div>
+  <h5 class="dummy-h6">States</h5>
+  <div class="dummy-form-text-input-grid-sample">
+    {{#let (array "base" "disabled" "readonly" "invalid") as |variants|}}
+      {{#each variants as |variant|}}
+        {{#each @model.STATES as |state|}}
+          <div>
+            <span class="dummy-text-small">{{capitalize variant}} / {{capitalize state}}:</span>
+            <br />
+            <div class="dummy-form-text-input-sublist" mock-state-value={{state}} mock-state-selector="input">
+              <Hds::Form::TextInput::Base
+                disabled={{if (eq variant "disabled") "disabled"}}
+                readonly={{if (eq variant "readonly") "readonly"}}
+                @isInvalid={{if (eq variant "invalid") true}}
+              />
+              <Hds::Form::TextInput::Base
+                placeholder="Placeholder"
+                disabled={{if (eq variant "disabled") "disabled"}}
+                readonly={{if (eq variant "readonly") "readonly"}}
+                @isInvalid={{if (eq variant "invalid") true}}
+              />
+              <Hds::Form::TextInput::Base
+                @value="Lorem ipsum dolor"
+                disabled={{if (eq variant "disabled") "disabled"}}
+                readonly={{if (eq variant "readonly") "readonly"}}
+                @isInvalid={{if (eq variant "invalid") true}}
+              />
+              <Hds::Form::TextInput::Base
+                @type="date"
+                @value="Lorem ipsum dolor"
+                disabled={{if (eq variant "disabled") "disabled"}}
+                readonly={{if (eq variant "readonly") "readonly"}}
+                @isInvalid={{if (eq variant "invalid") true}}
+              />
+              <Hds::Form::TextInput::Base
+                @type="time"
+                @value="Lorem ipsum dolor"
+                disabled={{if (eq variant "disabled") "disabled"}}
+                readonly={{if (eq variant "readonly") "readonly"}}
+                @isInvalid={{if (eq variant "invalid") true}}
+              />
+            </div>
+          </div>
+        {{/each}}
+      {{/each}}
+    {{/let}}
+  </div>
+  <h5 class="dummy-h6">Custom layout</h5>
+  <div class="dummy-form-text-input-base-sample">
+    <div>
+      <span class="dummy-text-small">With custom layout</span>
+      <br />
+      <div class="dummy-form-text-input-custom-layout">
+        <label for="my-custom-text-input-example">Custom label</label>
+        <Hds::Form::TextInput::Base id="my-custom-text-input-example" @value="Lorem ipsum dolor" />
+        <span class="dummy-form-text-input-custom-layout__append-text">Some content</span>
+      </div>
+    </div>
+  </div>
+  <h5 class="dummy-h5">Containers</h5>
+  <div class="dummy-form-text-input-containers">
+    {{#let (array "block" "flex" "grid") as |displays|}}
+      {{#each displays as |display|}}
+        <div>
+          <span class="dummy-text-small">Parent with <code class="dummy-code">display: {{display}}</code></span>
+          <br />
+          <div class="dummy-form-text-input-sublist">
+            <div class="dummy-form-text-input-containers__{{display}}">
+              <Hds::Form::TextInput::Base @value="Default width" />
+            </div>
+            <div class="dummy-form-text-input-containers__{{display}}">
+              <Hds::Form::TextInput::Base @value="Custom width" @width="248px" />
+            </div>
+            <div class="dummy-form-text-input-containers__{{display}}">
+              <Hds::Form::TextInput::Base @type="date" />
+            </div>
+            <div class="dummy-form-text-input-containers__{{display}}">
+              <Hds::Form::TextInput::Base @type="time" />
+            </div>
+          </div>
+        </div>
+      {{/each}}
+    {{/let}}
+  </div>
+
+  <h4 class="dummy-h4">"Field" control</h4>
+  <h5 class="dummy-h5">Content</h5>
+  <div class="dummy-form-text-input-grid-sample">
+    <div>
+      <span class="dummy-text-small">Only label</span>
+      <br />
+      <Hds::Form::TextInput::Field @value="Lorem ipsum dolor" as |F|>
+        <F.Label>This is the label text</F.Label>
+      </Hds::Form::TextInput::Field>
+    </div>
+    <div>
+      <span class="dummy-text-small">Label + Helper text</span>
+      <br />
+      <Hds::Form::TextInput::Field @value="Lorem ipsum dolor" as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::TextInput::Field>
+    </div>
+  </div>
+  <br />
+  <div class="dummy-form-text-input-grid-sample">
+    <div>
+      <span class="dummy-text-small">Label + Error</span>
+      <br />
+      <Hds::Form::TextInput::Field @value="Lorem ipsum dolor" @isInvalid={{true}} as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.Error>This is the error</F.Error>
+      </Hds::Form::TextInput::Field>
+    </div>
+    <div>
+      <span class="dummy-text-small">Label + Helper text + Error</span>
+      <br />
+      <Hds::Form::TextInput::Field @value="Lorem ipsum dolor" @isInvalid={{true}} as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Error>This is the error</F.Error>
+      </Hds::Form::TextInput::Field>
+    </div>
+    <div>
+      <span class="dummy-text-small">Label + Helper text + Errors</span>
+      <br />
+      <Hds::Form::TextInput::Field @value="Lorem ipsum dolor" @isInvalid={{true}} as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Error as |E|>
+          <E.Message>First error message</E.Message>
+          <E.Message>Second error message</E.Message>
+        </F.Error>
+      </Hds::Form::TextInput::Field>
+    </div>
+  </div>
+  <h5 class="dummy-h5">Containers</h5>
+  <div class="dummy-form-text-input-containers">
+    {{#let (array "block" "flex" "grid") as |displays|}}
+      {{#each displays as |display|}}
+        <div>
+          <span class="dummy-text-small">Parent with <code class="dummy-code">display: {{display}}</code></span>
+          <br />
+          <div class="dummy-form-text-input-containers__{{display}}">
+            <Hds::Form::TextInput::Field @value="Default width" as |F|>
+              <F.Label>This is the label</F.Label>
+              <F.HelperText>This is the helper text</F.HelperText>
+            </Hds::Form::TextInput::Field>
+          </div>
+          <br />
+          <div class="dummy-form-text-input-containers__{{display}}">
+            <Hds::Form::TextInput::Field @value="Custom width" @width="120px" @isInvalid={{true}} as |F|>
+              <F.Label>This is the label text that should go on multiple lines</F.Label>
+              <F.HelperText>This is the helper text that should go on multiple lines</F.HelperText>
+              <F.Error as |E|>
+                <E.Message>This is the first error text</E.Message>
+                <E.Message>This is the second error text that should go on multiple lines</E.Message>
+              </F.Error>
+            </Hds::Form::TextInput::Field>
+          </div>
+        </div>
+      {{/each}}
+    {{/let}}
+  </div>
+
+</section>

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -276,7 +276,170 @@
 
 <section>
   <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
-  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  <p class="dummy-paragraph">This component was designed with WCAG conformance as a requirement. As such, the
+    <code class="dummy-code">Form::TextInput::Base</code>
+    is conditionally conformant; that is, it is not conformant until it has an accessible name. The other components are
+    conformant; please report any conformance issues that you find.</p>
+  <h4 class="dummy-h4">
+    Applicable WCAG Success Criteria (Reference)
+  </h4>
+  <p class="dummy-paragraph">
+    This section is for reference only, some descriptions have been truncated for brevity. This component intends to
+    conform to the following WCAG success criteria:
+  </p>
+  <ul class="dummy-list">
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.3.1 Info and Relationships (A):</a>
+      Information, structure, and relationships conveyed through presentation can be programmatically determined or are
+      available in text.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.3.2 Meaningful Sequence (A):</a>
+      When the sequence in which content is presented affects its meaning, a correct reading sequence can be
+      programmatically determined.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/orientation"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.3.4 Orientation (AA):</a>
+      Content does not restrict its view and operation to a single display orientation, such as portrait or landscape.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.3.5 Identify Input Purpose(AA):</a>
+      The purpose of each input field collecting information about the user can be programmatically determined when the
+      input field serves a purpose identified in the Input Purposes for User Interface Components section; and the
+      content is implemented using technologies with support for identifying the expected meaning for form input data.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.1 Use of Color (A):</a>
+      Color is not used as the only visual means of conveying information, indicating an action, prompting a response,
+      or distinguishing a visual element.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.3 Contrast Minimum (AA):</a>
+      The visual presentation of text and images of text has a contrast ratio of at least 4.5:1</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.4 Resize Text (AA):</a>
+      Except for captions and images of text, text can be resized without assistive technology up to 200 percent without
+      loss of content or functionality.</li>
+    <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow" rel="noopener noreferrer" target="_blank">1.4.10
+        Reflow (AA):</a>
+      Content can be presented without loss of information or functionality, and without requiring scrolling in two
+      dimensions</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.11 Non-text Contrast (AA):</a>
+      The visual presentation of the following have a contrast ratio of at least 3:1 against adjacent color(s): user
+      interface components; graphical objects.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.12 Text Spacing (AA):</a>
+      no loss of content or functionality occurs by setting all of the following and by changing no other style
+      property: line height set to 1.5; spacing following paragraphs set to at least 2x the font size; letter-spacing
+      set at least 0.12x of the font size, word spacing set to at least 0.16 times the font size.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus"
+        rel="noopener noreferrer"
+        target="_blank"
+      >1.4.13 Content on Hover or Focus (AA):</a>
+      Where receiving and then removing pointer hover or keyboard focus triggers additional content to become visible
+      and then hidden, the following are true: dismissible, hoverable, persistent (see link)</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable"
+        rel="noopener noreferrer"
+        target="_blank"
+      >2.2.1 Timing Adjustable (A):</a>
+      if there are time limitations set by the content, one of the following should be true: turn off, adjust, extend,
+      real-time exception, essential exception, 20 hour exception.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels"
+        rel="noopener noreferrer"
+        target="_blank"
+      >2.4.6 Headings and Labels (AA):</a>
+      Headings and labels describe topic or purpose.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible"
+        rel="noopener noreferrer"
+        target="_blank"
+      >2.4.7 Focus Visible (AA):</a>
+      Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible.</li>
+    <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/on-focus" rel="noopener noreferrer" target="_blank">3.2.1
+        On Focus (A):</a>
+      When any user interface component receives focus, it does not initiate a change of context.</li>
+    <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/on-input" rel="noopener noreferrer" target="_blank">3.2.2
+        On Input (A):</a>
+      Changing the setting of any user interface component does not automatically cause a change of context unless the
+      user has been advised of the behavior before using the component.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification"
+        rel="noopener noreferrer"
+        target="_blank"
+      >3.2.4 Consistent Identification (AA):</a>
+      Components that have the same functionality within a set of Web pages are identified consistently.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/error-identification"
+        rel="noopener noreferrer"
+        target="_blank"
+      >3.3.1 Error Identification (A):</a>
+      If an input error is automatically detected, the item that is in error is identified and the error is described to
+      the user in text.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions"
+        rel="noopener noreferrer"
+        target="_blank"
+      >3.3.2 Labels or Instructions (A):</a>
+      Labels or instructions are provided when content requires user input.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion"
+        rel="noopener noreferrer"
+        target="_blank"
+      >3.3.3 Error Suggestion (AA):</a>
+      If an input error is automatically detected and suggestions for correction are known, then the suggestions are
+      provided to the user, unless it would jeopardize the security or purpose of the content.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/error-prevention"
+        rel="noopener noreferrer"
+        target="_blank"
+      >3.3.4 Error Prevention (Legal, Financial, Data) (AA):</a>
+      For Web pages that cause legal commitments or financial transactions for the user to occur, that modify or delete
+      user-controllable data in data storage systems, or that submit user test responses, at least one of the following
+      is true: submissions are reversible, data is checked and user is provided an opportunity to correct them, a
+      mechanism is available for reviewing, confirming and correcting the information before finalizing the submission.</li>
+    <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/parsing" rel="noopener noreferrer" target="_blank">4.1.1
+        Parsing (A):</a>
+      In content implemented using markup languages, elements have complete start and end tags, elements are nested
+      according to their specifications, elements do not contain duplicate attributes, and any IDs are unique.</li>
+    <li><a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value"
+        rel="noopener noreferrer"
+        target="_blank"
+      >4.1.2 Name, Role, Value (A):</a>
+      For all user interface components, the name and role can be programmatically determined; states, properties, and
+      values that can be set by the user can be programmatically set; and notification of changes to these items is
+      available to user agents, including assistive technologies.</li>
+    <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/" rel="noopener noreferrer" target="_blank">4.1.3 Status
+        Messages (AA):</a>
+      In content implemented using markup languages, status messages can be programmatically determined through role or
+      properties such that they can be presented to the user by assistive technologies without receiving focus.</li>
+  </ul>
 </section>
 
 <section data-test-percy>

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -11,7 +11,7 @@
   <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
   <p class="dummy-paragraph">The
     <code class="dummy-code">Form::TextInput</code>
-    component has different variants, with their own APIs:</p>
+    component has two different variants, with their own APIs:</p>
   <ul>
     <li class="dummy-paragraph">
       <code class="dummy-code">Form::TextInput::Base</code>
@@ -24,12 +24,6 @@
       - the "field" parent component: the
       <code class="dummy-code">&lt;input&gt;</code>
       control, with label, helper text and error messaging (in a wrapping container)
-    </li>
-    <li class="dummy-paragraph">
-      <code class="dummy-code">Form::TextInput::Group</code>
-      - the "group" parent component: a
-      <code class="dummy-code">&lt;legend&gt;</code>
-      (optional), a list of fields, and error messaging
     </li>
   </ul>
   <h4 class="dummy-h4">Form::TextInput::Base</h4>
@@ -198,7 +192,7 @@
     <code class="dummy-code">Error</code>
     keys.</p>
   <dl class="dummy-component-props" aria-labelledby="component-api-form-text-input-field-contextual-components">
-    <dt>&lt;[C].Label&gt; <code>yielded component</code></dt>
+    <dt>&lt;[F].Label&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the <code class="dummy-code">&lt;label&gt;</code> element.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
@@ -212,7 +206,7 @@
           <code class="dummy-code">controlId</code>
           value of the control.</em></p>
     </dd>
-    <dt>&lt;[C].HelperText&gt; <code>yielded component</code></dt>
+    <dt>&lt;[F].HelperText&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the "helper text" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
@@ -226,7 +220,7 @@
           <code class="dummy-code">controlId</code>
           value of the control.</em></p>
     </dd>
-    <dt>&lt;[C].Error&gt; <code>yielded component</code></dt>
+    <dt>&lt;[F].Error&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the "error" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text

--- a/packages/components/tests/integration/components/hds/form/text-input/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/base-test.js
@@ -1,0 +1,90 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/text-input/base', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Base id="test-form-text-input" />`);
+    assert.dom('#test-form-text-input').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Base id="test-form-text-input" />`);
+    assert.dom('#test-form-text-input').hasClass('hds-form-text-input');
+  });
+
+  // TYPE
+
+  test('it should render the "text" type if no type is declared', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Base id="test-form-text-input" />`);
+    assert.dom('#test-form-text-input').hasAttribute('type', 'text');
+  });
+  test('it should render the correct type depending on the @type prop', async function (assert) {
+    await render(
+      hbs`<Hds::Form::TextInput::Base @type="email" id="test-form-text-input" />`
+    );
+    assert.dom('#test-form-text-input').hasAttribute('type', 'email');
+  });
+
+  // VALUE
+
+  test('it should render the input with the value provided via @value argument', async function (assert) {
+    await render(
+      hbs`<Hds::Form::TextInput::Base @value="abc123" id="test-form-text-input" />`
+    );
+    assert.dom('#test-form-text-input').hasValue('abc123');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @isInvalid={{true}} />`
+    );
+    assert
+      .dom('#test-form-text-input')
+      .hasClass('hds-form-text-input--is-invalid');
+  });
+
+  // WIDTH
+
+  test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
+    await render(
+      hbs`<Hds::Form::TextInput::Base @width="248px" id="test-form-text-input" />`
+    );
+    assert.dom('#test-form-text-input').hasStyle({ width: '248px' });
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-text-input').hasClass('my-class');
+    assert.dom('#test-form-text-input').hasAttribute('data-test1');
+    assert.dom('#test-form-text-input').hasAttribute('data-test2', 'test');
+  });
+
+  // ASSERTIONS
+
+  test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {
+    const errorMessage =
+      '@type for "Hds::Form::TextInput" must be one of the following: text, email, password, url, search, date, time, received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Form::TextInput::Base @type="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/text-input/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/field-test.js
@@ -1,0 +1,115 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/text-input/field', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field />`);
+    assert.dom('input').exists();
+  });
+  test('it should render the input with a specific CSS class', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field />`);
+    assert.dom('input').hasClass('hds-form-field__control');
+  });
+
+  // TYPE
+
+  test('it should render the "text" type if no type is declared', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field />`);
+    assert.dom('input').hasAttribute('type', 'text');
+  });
+  test('it should render the correct type depending on the @type prop', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field @type="email" />`);
+    assert.dom('input').hasAttribute('type', 'email');
+  });
+
+  // VALUE
+
+  test('it should render the input with the value provided via @value argument', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field @value="abc123" />`);
+    assert.dom('input').hasValue('abc123');
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field @isInvalid={{true}} />`);
+    assert.dom('input').hasClass('hds-form-text-input--is-invalid');
+  });
+
+  // WIDTH
+
+  test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
+    await render(hbs`<Hds::Form::TextInput::Field @width="248px" />`);
+    assert.dom('input').hasStyle({ width: '248px' });
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::TextInput::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::TextInput::Field>`
+    );
+    assert.dom('.hds-form-field__label').exists();
+    assert.dom('.hds-form-field__helper-text').exists();
+    assert.dom('.hds-form-field__control').exists();
+    assert.dom('.hds-form-field__error').exists();
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::TextInput::Field />`);
+    assert.dom('.hds-form-field__label').doesNotExist();
+    assert.dom('.hds-form-field__helper-text').doesNotExist();
+    assert.dom('.hds-form-field__error').doesNotExist();
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::TextInput::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::TextInput::Field>`
+    );
+    // the control ID is dynamically generated
+    let control = this.element.querySelector('.hds-form-field__control');
+    let controlId = control.id;
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the input', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::TextInput::Field class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('input').hasClass('my-class');
+    assert.dom('input').hasAttribute('data-test1');
+    assert.dom('input').hasAttribute('data-test2', 'test');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

> **Note**
> This is not the final version: we will complete the component (documentation included) when the design specs are finalized.

This PR adds the `TextInput` form control to the system in two variants:
- `base`
- `field`

---

For the nomenclature see this illustration:
<img width="1055" alt="screenshot_1564" src="https://user-images.githubusercontent.com/686239/174313189-d9149463-3bb6-48bf-9efb-242f127caa98.png">

_Notice: the branch has been extracted from `form-controls/spike-playground` in #285 via a diff with the `main` branch and then cherry-picked only the changes needed for this PR._

### :hammer_and_wrench: Detailed description

In this PR we (me and @alex-ju) have:
- added the "base" and "field" `TextInput` form controls as components
- added the documentation page for the `TextInput`
- added integration tests and percy testing

Preview of the documentation page: https://hds-components-git-form-controls-02-text-input-hashicorp.vercel.app/components/form/text-input

Notice: the page is not linked in the index file of the dummy/scrappy website on purpose, so it's not visible to the public.

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
