### PR TITLE
Form controls - `Select` component (04)

### DIFF
--- a/packages/components/addon/components/hds/form/select/base.hbs
+++ b/packages/components/addon/components/hds/form/select/base.hbs
@@ -1,0 +1,3 @@
+<select class={{this.classNames}} {{style width=@width}} ...attributes>
+  {{yield (hash Options=(component "hds/yield"))}}
+</select>

--- a/packages/components/addon/components/hds/form/select/base.js
+++ b/packages/components/addon/components/hds/form/select/base.js
@@ -1,0 +1,22 @@
+import Component from '@glimmer/component';
+
+export default class HdsFormSelectBaseComponent extends Component {
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-form-select'];
+
+    // add typographic classes
+    classes.push('hds-typography-body-200', 'hds-font-weight-regular');
+
+    // add a class based on the @isInvalid argument
+    if (this.args.isInvalid) {
+      classes.push(`hds-form-select--is-invalid`);
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/addon/components/hds/form/select/field.hbs
+++ b/packages/components/addon/components/hds/form/select/field.hbs
@@ -1,0 +1,18 @@
+<Hds::Form::Field @layout="vertical" as |F|>
+  {{! Notice: the order of the elements is not relevant here, because is controlled at "Hds::Form::Field" component level }}
+  {{yield (hash Label=F.Label HelperText=F.HelperText Error=F.Error)}}
+  <F.Control>
+    <Hds::Form::Select::Base
+      class="hds-form-field__control"
+      @value={{@value}}
+      @isInvalid={{@isInvalid}}
+      @width={{@width}}
+      ...attributes
+      id={{F.id}}
+      aria-describedby={{F.ariaDescribedBy}}
+      as |S|
+    >
+      {{yield (hash Options=S.Options)}}
+    </Hds::Form::Select::Base>
+  </F.Control>
+</Hds::Form::Field>

--- a/packages/components/app/components/hds/form/select/base.js
+++ b/packages/components/app/components/hds/form/select/base.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/select/base';

--- a/packages/components/app/components/hds/form/select/field.js
+++ b/packages/components/app/components/hds/form/select/field.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/select/field';

--- a/packages/components/app/styles/components/form/index.scss
+++ b/packages/components/app/styles/components/form/index.scss
@@ -12,3 +12,4 @@
 
 @use "./text-input";
 @use "./textarea";
+@use "./select";

--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -1,0 +1,55 @@
+//
+// FORM > SELECT
+//
+// properties within each class are sorted alphabetically
+//
+
+// "BASE" CONTROL
+
+.hds-form-select {
+  border: 1px solid var(--token-color-palette-neutral-400);
+  border-radius: 5px;
+  box-shadow: var(--hds-elevation-inset-box-shadow);
+  color: var(--token-color-foreground-primary);
+  font-family: var(--token-typography-body-200-font-family);
+  font-size: var(--token-typography-body-200-font-size);
+  line-height: var(--token-typography-body-200-line-height);
+  padding: 7px;
+  max-width: 100%;
+
+  // STATUS
+
+  &:hover,
+  &.mock-hover {
+    border-color: var(--token-color-palette-neutral-500);
+  }
+
+  // focus (same for all the states)
+  // TODO add handling of focus-visible
+  &:focus,
+  &.mock-focus {
+    border-color: var(--token-color-focus-action-internal);
+    // TODO: Safari doesn't apply a rounded border
+    outline: 2px solid var(--token-color-focus-action-external);
+    outline-offset: 0px;
+  }
+
+  &:active,
+  &.mock-active {
+    background-color: var(--token-color-surface-interactive-disabled);
+    border-color: var(--token-color-border-primary);
+  }
+
+  // DISABLED
+
+  &:disabled {
+    background-color: var(--token-color-surface-strong);
+    border-color: var(--token-color-border-primary);
+  }
+
+  // INVALID
+
+  &.hds-form-select--is-invalid {
+    border-color: var(--token-color-foreground-critical);
+  }
+}

--- a/packages/components/tests/acceptance/percy-test.js
+++ b/packages/components/tests/acceptance/percy-test.js
@@ -54,6 +54,9 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/components/form/textarea');
     await percySnapshot('Form - Textarea');
 
+    await visit('/components/form/select');
+    await percySnapshot('Form - Select');
+
     await visit('/components/icon-tile');
     await percySnapshot('IconTile');
 

--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -25,6 +25,7 @@ Router.map(function () {
       this.route('base-elements');
       this.route('text-input');
       this.route('textarea');
+      this.route('select');
     });
     this.route('icon-tile');
     this.route('link', function () {

--- a/packages/components/tests/dummy/app/routes/components/form/select.js
+++ b/packages/components/tests/dummy/app/routes/components/form/select.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+
+export default class ComponentsFormSelectRoute extends Route {
+  model() {
+    // these are used only for presentation purpose in the showcase
+    const STATES = ['default', 'hover', 'active', 'focus'];
+    return {
+      STATES,
+    };
+  }
+}

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -25,6 +25,7 @@
 @import "./pages/form/db-base-elements";
 @import "./pages/form/db-text-input";
 @import "./pages/form/db-textarea";
+@import "./pages/form/db-select";
 // END COMPONENT PAGES IMPORTS
 
 @import "./components/dummy-component-props";

--- a/packages/components/tests/dummy/app/styles/pages/form/db-select.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-select.scss
@@ -1,0 +1,62 @@
+// FORM > SELECT
+
+.dummy-form-select-base-sample {
+  display: flex;
+  gap: 2rem;
+}
+
+.dummy-form-select-grid-sample {
+  align-items: start;
+  display: grid;
+  grid-gap: 1rem 3rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.dummy-form-select-sublist {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dummy-form-select-containers {
+  align-items: start;
+  display: grid;
+  grid-gap: 3rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dummy-form-select-containers__block {
+  display: block;
+}
+
+.dummy-form-select-containers__flex {
+  display: flex;
+}
+
+.dummy-form-select-containers__grid {
+  display: grid;
+  justify-items: start;
+}
+
+.dummy-form-select-sublist {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dummy-form-select-custom-layout {
+  align-items: center;
+  display: flex;
+  font-family: Verdana, sans-serif;
+  font-size: 0.8em;
+  gap: 10px;
+
+  select {
+    flex: 1 1 0; // is a direct child of a flexbox and has a width of 100% so it blows up
+  }
+
+  button {
+    align-self: stretch;
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -85,7 +85,11 @@
       <p>It is a container that yields its content inside the
         <code class="dummy-code">&lt;select&gt;</code>
         element.</p>
-      <p>The content needs to be a set of native HTML <code class="dummy-code">&lt;option&gt;</code> elements.</p>
+      <p>The content needs to be a set of native HTML
+        <code class="dummy-code">&lt;option&gt;</code>
+        and
+        <code class="dummy-code">&lt;optgroup&gt;</code>
+        elements.</p>
     </dd>
   </dl>
   <h4 class="dummy-h4">Form::Select::Field</h4>
@@ -160,7 +164,11 @@
       <p>It is a container that yields its content inside the
         <code class="dummy-code">&lt;select&gt;</code>
         element.</p>
-      <p>The content needs to be a set of native HTML <code class="dummy-code">&lt;option&gt;</code> elements.</p>
+      <p>The content needs to be a set of native HTML
+        <code class="dummy-code">&lt;option&gt;</code>
+        and
+        <code class="dummy-code">&lt;optgroup&gt;</code>
+        elements.</p>
     </dd>
     <dt>&lt;[C].Label&gt; <code>yielded component</code></dt>
     <dd>

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -1,0 +1,431 @@
+{{page-title "Form::Select Component"}}
+
+<h2 class="dummy-h2">Form::Select</h2>
+
+<section>
+  <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
+  <p class="dummy-paragraph">The
+    <code class="dummy-code">Form::Select</code>
+    component has different variants, with their own APIs:</p>
+  <ul>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::Select::Base</code>
+      - the "basic" component: just the
+      <code class="dummy-code">&lt;select&gt;</code>
+      control
+    </li>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::Select::Field</code>
+      - the "field" parent component: the
+      <code class="dummy-code">&lt;select&gt;</code>
+      control, with label, helper text and error messaging (in a wrapping container)
+    </li>
+    <li class="dummy-paragraph">
+      <code class="dummy-code">Form::Select::Group</code>
+      - the "group" parent component: a
+      <code class="dummy-code">&lt;legend&gt;</code>
+      (optional), a list of fields, and error messaging
+    </li>
+  </ul>
+  <h4 class="dummy-h4">Form::Select::Base</h4>
+  <p class="dummy-paragraph" id="component-api-form-text-select-base">Here is the API for the "base" component:</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-text-select-base">
+    <dt>isInvalid <code>boolean</code></dt>
+    <dd>
+      <p>It applies an "invalid" appearance to the control (<em>notice: this does _not_ modify its logical validity</em>).</p>
+      <p>Default: <span class="default">false</span></p>
+    </dd>
+    <dt>width <code>string</code></dt>
+    <dd>
+      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p><em>Notice: by default the
+          <code class="dummy-code">&lt;select&gt;</code>
+          has an intrinsic width based on its content. If a
+          <code class="dummy-code">@width</code>
+          parameter is provided then the control will have a fixed width.</em></p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+      <p><em>Notice: the attributes will be applied to the
+          <code class="dummy-code">&lt;select&gt;</code>
+          element. This means you can use all the standard HTML attributes of the
+          <code class="dummy-code">&lt;select&gt;</code>
+          element and all the usual Ember techniques for event handling, validation, etc.</em></p>
+      <p><em>Some examples of HTML attributes that you will likely use:
+          <code class="dummy-code">id</code>,
+          <code class="dummy-code">name</code>,
+          <code class="dummy-code">value</code>,
+          <code class="dummy-code">placeholder</code>,
+          <code class="dummy-code">disabled</code>,
+          <code class="dummy-code">readonly</code>,
+          <code class="dummy-code">required</code>
+          (<a
+            href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attributes"
+            rel="noopener noreferrer"
+          >see whole list here</a>) and some examples of Ember modifiers:
+          <code class="dummy-code">&lcub;&lcub;on "change" [do something]&rcub;&rcub;</code>,
+          <code class="dummy-code">&lcub;&lcub;on "blur" [do something]&rcub;&rcub;</code>.
+        </em></p>
+    </dd>
+  </dl>
+  <h5 class="dummy-h5">Contextual components</h5>
+  <p class="dummy-paragraph" id="component-api-form-text-select-base-contextual-components">Select's options are passed
+    to the field as yielded components, using the
+    <code class="dummy-code">Options</code>
+    key.</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-text-select-base-contextual-components">
+    <dt>&lt;[C].Options&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the
+        <code class="dummy-code">&lt;select&gt;</code>
+        element.</p>
+      <p>The content needs to be a set of native HTML <code class="dummy-code">&lt;option&gt;</code> elements.</p>
+    </dd>
+  </dl>
+  <h4 class="dummy-h4">Form::Select::Field</h4>
+  <p class="dummy-paragraph" id="component-api-form-text-select-field">Here is the API for the "field" component:</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-text-select-field">
+    <dt>isInvalid <code>boolean</code></dt>
+    <dd>
+      <p>It applies an "invalid" appearance to the control (<em>notice: this does _not_ modify its logical validity</em>).</p>
+      <p>Default: <span class="default">false</span></p>
+    </dd>
+    <dt>width <code>string</code></dt>
+    <dd>
+      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p><em>Notice: by default the
+          <code class="dummy-code">&lt;select&gt;</code>
+          has an intrinsic width based on its content. If a
+          <code class="dummy-code">@width</code>
+          parameter is provided then the control will have a fixed width. This width will be applied
+          <strong>only</strong>
+          to the control, not the other elements of the field.</em></p>
+    </dd>
+    <dt>id <code>string</code></dt>
+    <dd>
+      <p>The select control's ID attribute</p>
+      <p><em>Notice: by default the ID is automatically generated by the component; use this argument if you need to
+          pass a custom ID for specific reasons you may have.</em></p>
+    </dd>
+    <dt>ariaDescribedBy <code>string</code></dt>
+    <dd>
+      <p>An extra ID attribute to be added to the <code class="dummy-code">aria-describedby</code> HTML attribute.</p>
+      <p><em>Notice: by default the
+          <code class="dummy-code">aria-describedby</code>
+          attribute is automatically generated by the component, using the IDs of the helper text and errors (if they're
+          present); use this argument if you need to pass an extra ID for specific reasons you may have.</em></p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+      <p><em>Notice: the attributes will be applied to the
+          <code class="dummy-code">&lt;select&gt;</code>
+          element. This means you can use all the standard HTML attributes of the
+          <code class="dummy-code">&lt;select&gt;</code>
+          element and all the usual Ember techniques for event handling, validation, etc.</em></p>
+      <p><em>Some examples of HTML attributes that you will likely use:
+          <code class="dummy-code">id</code>,
+          <code class="dummy-code">name</code>,
+          <code class="dummy-code">value</code>,
+          <code class="dummy-code">placeholder</code>,
+          <code class="dummy-code">disabled</code>,
+          <code class="dummy-code">readonly</code>,
+          <code class="dummy-code">required</code>
+          (<a
+            href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attributes"
+            rel="noopener noreferrer"
+          >see whole list here</a>) and some examples of Ember modifiers:
+          <code class="dummy-code">&lcub;&lcub;on "change" [do something]&rcub;&rcub;</code>,
+          <code class="dummy-code">&lcub;&lcub;on "blur" [do something]&rcub;&rcub;</code>.
+        </em></p>
+    </dd>
+  </dl>
+  <h5 class="dummy-h5">Contextual components</h5>
+  <p class="dummy-paragraph" id="component-api-form-text-select-field-contextual-components">Options, label, helper text
+    and error content are passed to the field as yielded components, using the
+    <code class="dummy-code">Options</code>,
+    <code class="dummy-code">Label</code>,
+    <code class="dummy-code">HelperText</code>,
+    <code class="dummy-code">Error</code>
+    keys.</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-text-select-field-contextual-components">
+    <dt>&lt;[C].Options&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the
+        <code class="dummy-code">&lt;select&gt;</code>
+        element.</p>
+      <p>The content needs to be a set of native HTML <code class="dummy-code">&lt;option&gt;</code> elements.</p>
+    </dd>
+    <dt>&lt;[C].Label&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the <code class="dummy-code">&lt;label&gt;</code> element.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <p>For details about its API check the
+        <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Label</code></LinkTo>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">for</code>
+          attribute of the label is automatically generated, using the
+          <code class="dummy-code">controlId</code>
+          value of the control.</em></p>
+    </dd>
+    <dt>&lt;[C].HelperText&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the "helper text" block.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <p>For details about its API check the
+        <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::HelperText</code></LinkTo>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">id</code>
+          attribute of the element is automatically generated, using the
+          <code class="dummy-code">controlId</code>
+          value of the control.</em></p>
+    </dd>
+    <dt>&lt;[C].Error&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the "error" block.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <dl class="dummy-component-props">
+        <dt>[E].Message <code>yielded component</code></dt>
+        <dd>
+          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+            individual items using
+            <code class="dummy-code">Error.Message</code>.
+          </p>
+        </dd>
+      </dl>
+      <p>For details about its API check the
+        <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">id</code>
+          attribute of the
+          <code class="dummy-code">Error</code>
+          element is automatically generated.</em></p>
+    </dd>
+  </dl>
+
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="how-to-use"><a href="#how-to-use" class="dummy-link-section">§</a> How to use</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
+    Design guidelines</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  {{! UNCOMMENT THIS BLOCK (once the link and/or the image are available) }}
+  {{!
+  <div class="dummy-design-guidelines">
+    <p class="dummy-paragraph">
+      <a href="[ADD THE LINK TO THE FIGMA FILE/PAGE HERE!]" target="_blank" rel="noopener noreferrer">Figma UI Kit</a>
+    </p>
+    <br />
+    <img class="dummy-figma-docs" src="/assets/images/form-select-design-usage.png" alt="" role="none" />
+  </div>
+  }}
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+</section>
+
+<section data-test-percy>
+  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+
+  <h4 class="dummy-h4">"Base" control</h4>
+  <h5 class="dummy-h6">Interaction status</h5>
+  <div class="dummy-form-select-base-sample">
+    <div>
+      <span class="dummy-text-small">Default</span>
+      <br />
+      <Hds::Form::Select::Base as |C|>
+        <C.Options>
+          <option>Lorem ipsum dolor</option>
+          <option>Sine qua non est</option>
+        </C.Options>
+      </Hds::Form::Select::Base>
+    </div>
+  </div>
+  <h5 class="dummy-h6">States</h5>
+  <div class="dummy-form-select-grid-sample">
+    {{#let (array "base" "disabled" "invalid") as |variants|}}
+      {{#each variants as |variant|}}
+        {{#each @model.STATES as |state|}}
+          <div>
+            <span class="dummy-text-small">{{capitalize variant}} / {{capitalize state}}:</span>
+            <br />
+            <div class="dummy-form-select-sublist" mock-state-value={{state}} mock-state-selector="select">
+              <Hds::Form::Select::Field
+                disabled={{if (eq variant "disabled") "disabled"}}
+                @isInvalid={{if (eq variant "invalid") true}}
+                as |F|
+              >
+                <F.Options>
+                  <option>Lorem ipsum dolor</option>
+                  <option>Sine qua non est</option>
+                </F.Options>
+              </Hds::Form::Select::Field>
+            </div>
+          </div>
+        {{/each}}
+      {{/each}}
+    {{/let}}
+  </div>
+  <h5 class="dummy-h6">Custom layout</h5>
+  <div class="dummy-form-select-base-sample">
+    <div>
+      <span class="dummy-text-small">With custom layout</span>
+      <br />
+      <div class="dummy-form-select-custom-layout">
+        <label for="my-custom-select-example">Custom label</label>
+        <Hds::Form::Select::Base id="my-custom-select-example" as |C|>
+          <C.Options>
+            <option>Lorem ipsum dolor</option>
+            <option>Sine qua non est</option>
+          </C.Options>
+        </Hds::Form::Select::Base>
+        <button type="button">Apply</button>
+      </div>
+    </div>
+  </div>
+  <h5 class="dummy-h5">Containers</h5>
+  <div class="dummy-form-select-containers">
+    {{#let (array "block" "flex" "grid") as |displays|}}
+      {{#each displays as |display|}}
+        <div>
+          <span class="dummy-text-small">Parent with <code class="dummy-code">display: {{display}}</code></span>
+          <br />
+          <div class="dummy-form-select-sublist">
+            <div class="dummy-form-select-containers__{{display}}">
+              <Hds::Form::Select::Base as |C|>
+                <C.Options>
+                  <option>Default width</option>
+                  <option>Lorem ipsum dolor</option>
+                  <option>Sine qua non est</option>
+                </C.Options>
+              </Hds::Form::Select::Base>
+            </div>
+            <div class="dummy-form-select-containers__{{display}}">
+              <Hds::Form::Select::Base @width="248px" as |C|>
+                <C.Options>
+                  <option>Custom width</option>
+                  <option>Lorem ipsum dolor</option>
+                  <option>Sine qua non est</option>
+                </C.Options>
+              </Hds::Form::Select::Base>
+            </div>
+          </div>
+        </div>
+      {{/each}}
+    {{/let}}
+  </div>
+
+  <h4 class="dummy-h4">"Field" control</h4>
+  <h5 class="dummy-h5">Content</h5>
+  <div class="dummy-form-select-grid-sample">
+    <div>
+      <span class="dummy-text-small">Only label</span>
+      <br />
+      <Hds::Form::Select::Field as |F|>
+        <F.Label>Lorem ipsum dolor</F.Label>
+        <F.Options>
+          <option>Lorem ipsum dolor</option>
+          <option>Sine qua non est</option>
+        </F.Options>
+      </Hds::Form::Select::Field>
+    </div>
+    <div>
+      <span class="dummy-text-small">Label + Helper text</span>
+      <br />
+      <Hds::Form::Select::Field as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Options>
+          <option>Lorem ipsum dolor</option>
+          <option>Sine qua non est</option>
+        </F.Options>
+      </Hds::Form::Select::Field>
+    </div>
+  </div>
+  <br />
+  <div class="dummy-form-select-grid-sample">
+    <div>
+      <span class="dummy-text-small">Label + Error</span>
+      <br />
+      <Hds::Form::Select::Field @isInvalid={{true}} as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.Options>
+          <option>Lorem ipsum dolor</option>
+          <option>Sine qua non est</option>
+        </F.Options>
+        <F.Error>This is the error</F.Error>
+      </Hds::Form::Select::Field>
+    </div>
+    <div>
+      <span class="dummy-text-small">Label + Helper text + Error</span>
+      <br />
+      <Hds::Form::Select::Field @isInvalid={{true}} as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Options>
+          <option>Lorem ipsum dolor</option>
+          <option>Sine qua non est</option>
+        </F.Options>
+        <F.Error>This is the error</F.Error>
+      </Hds::Form::Select::Field>
+    </div>
+    <div>
+      <span class="dummy-text-small">Label + Helper text + Errors</span>
+      <br />
+      <Hds::Form::Select::Field @isInvalid={{true}} as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Options>
+          <option>Lorem ipsum dolor</option>
+          <option>Sine qua non est</option>
+        </F.Options>
+        <F.Error as |E|>
+          <E.Message>First error message</E.Message>
+          <E.Message>Second error message</E.Message>
+        </F.Error>
+      </Hds::Form::Select::Field>
+    </div>
+  </div>
+  <h5 class="dummy-h5">Containers</h5>
+  <div class="dummy-form-select-containers">
+    {{#let (array "block" "flex" "grid") as |displays|}}
+      {{#each displays as |display|}}
+        <div>
+          <span class="dummy-text-small">Parent with <code class="dummy-code">display: {{display}}</code></span>
+          <br />
+          <div class="dummy-form-select-containers__{{display}}">
+            <Hds::Form::Select::Field @isInvalid={{true}} as |F|>
+              <F.Label>This is the label</F.Label>
+              <F.HelperText>This is the helper text</F.HelperText>
+              <F.Options>
+                <option>Lorem ipsum dolor</option>
+                <option>Sine qua non est</option>
+              </F.Options>
+              <F.Error>This is the error</F.Error>
+            </Hds::Form::Select::Field>
+          </div>
+        </div>
+      {{/each}}
+    {{/let}}
+  </div>
+
+</section>

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -11,7 +11,7 @@
   <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
   <p class="dummy-paragraph">The
     <code class="dummy-code">Form::Select</code>
-    component has different variants, with their own APIs:</p>
+    component has two different variants, with their own APIs:</p>
   <ul>
     <li class="dummy-paragraph">
       <code class="dummy-code">Form::Select::Base</code>
@@ -24,12 +24,6 @@
       - the "field" parent component: the
       <code class="dummy-code">&lt;select&gt;</code>
       control, with label, helper text and error messaging (in a wrapping container)
-    </li>
-    <li class="dummy-paragraph">
-      <code class="dummy-code">Form::Select::Group</code>
-      - the "group" parent component: a
-      <code class="dummy-code">&lt;legend&gt;</code>
-      (optional), a list of fields, and error messaging
     </li>
   </ul>
   <h4 class="dummy-h4">Form::Select::Base</h4>
@@ -80,7 +74,7 @@
     <code class="dummy-code">Options</code>
     key.</p>
   <dl class="dummy-component-props" aria-labelledby="component-api-form-text-select-base-contextual-components">
-    <dt>&lt;[C].Options&gt; <code>yielded component</code></dt>
+    <dt>&lt;[F].Options&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the
         <code class="dummy-code">&lt;select&gt;</code>
@@ -159,7 +153,7 @@
     <code class="dummy-code">Error</code>
     keys.</p>
   <dl class="dummy-component-props" aria-labelledby="component-api-form-text-select-field-contextual-components">
-    <dt>&lt;[C].Options&gt; <code>yielded component</code></dt>
+    <dt>&lt;[F].Options&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the
         <code class="dummy-code">&lt;select&gt;</code>
@@ -170,7 +164,7 @@
         <code class="dummy-code">&lt;optgroup&gt;</code>
         elements.</p>
     </dd>
-    <dt>&lt;[C].Label&gt; <code>yielded component</code></dt>
+    <dt>&lt;[F].Label&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the <code class="dummy-code">&lt;label&gt;</code> element.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
@@ -184,7 +178,7 @@
           <code class="dummy-code">controlId</code>
           value of the control.</em></p>
     </dd>
-    <dt>&lt;[C].HelperText&gt; <code>yielded component</code></dt>
+    <dt>&lt;[F].HelperText&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the "helper text" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
@@ -198,7 +192,7 @@
           <code class="dummy-code">controlId</code>
           value of the control.</em></p>
     </dd>
-    <dt>&lt;[C].Error&gt; <code>yielded component</code></dt>
+    <dt>&lt;[F].Error&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the "error" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text

--- a/packages/components/tests/integration/components/hds/form/select/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/base-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/select/base', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Base id="test-form-select" />`);
+    assert.dom('#test-form-select').exists();
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Base id="test-form-select" />`);
+    assert.dom('#test-form-select').hasClass('hds-form-select');
+  });
+
+  // OPTIONS
+
+  test('it should render the options passed via contextual component', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Select::Base id="test-form-select" as |C|><C.Options><option value="abc123">This is the option</option></C.Options></Hds::Form::Select::Base>`
+    );
+    assert.dom('#test-form-select option').exists();
+    assert.dom('#test-form-select option').hasText('This is the option');
+    assert.dom('#test-form-select option').hasValue('abc123');
+  });
+
+  // WIDTH
+
+  test('it should render the select with a fixed width if a @width value is passed', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Select::Base @width="248px" id="test-form-select" />`
+    );
+    assert.dom('#test-form-select').hasStyle({ width: '248px' });
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Select::Base id="test-form-select" @isInvalid={{true}} />`
+    );
+    assert.dom('#test-form-select').hasClass('hds-form-select--is-invalid');
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Select::Base id="test-form-select" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-select').hasClass('my-class');
+    assert.dom('#test-form-select').hasAttribute('data-test1');
+    assert.dom('#test-form-select').hasAttribute('data-test2', 'test');
+  });
+});

--- a/packages/components/tests/integration/components/hds/form/select/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/field-test.js
@@ -1,0 +1,108 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/select/field', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Field />`);
+    assert.dom('select').exists();
+  });
+  test('it should render the input with a specific CSS class', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Field />`);
+    assert.dom('select').hasClass('hds-form-field__control');
+  });
+
+  // OPTIONS
+
+  test('it should render the options passed via contextual component', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Select::Field id="test-form-select" as |F|><F.Options><option value="abc123">This is the option</option></F.Options></Hds::Form::Select::Field>`
+    );
+    assert.dom('select option').exists();
+    assert.dom('select option').hasText('This is the option');
+    assert.dom('select option').hasValue('abc123');
+  });
+
+  // WIDTH
+
+  test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Field @width="248px" />`);
+    assert.dom('select').hasStyle({ width: '248px' });
+  });
+
+  // INVALID
+
+  test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
+    await render(hbs`<Hds::Form::Select::Field @isInvalid={{true}} />`);
+    assert.dom('select').hasClass('hds-form-select--is-invalid');
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Select::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Select::Field>`
+    );
+    assert.dom('.hds-form-field__label').exists();
+    assert.dom('.hds-form-field__helper-text').exists();
+    assert.dom('.hds-form-field__control').exists();
+    assert.dom('.hds-form-field__error').exists();
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::Select::Field />`);
+    assert.dom('.hds-form-field__label').doesNotExist();
+    assert.dom('.hds-form-field__helper-text').doesNotExist();
+    assert.dom('.hds-form-field__error').doesNotExist();
+  });
+  test('it automatically provides all the ID relations between the elements', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<Hds::Form::Select::Field as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+          <F.Error>This is the error</F.Error>
+        </Hds::Form::Select::Field>`
+    );
+    // the control ID is dynamically generated
+    let control = this.element.querySelector('.hds-form-field__control');
+    let controlId = control.id;
+    assert.dom('.hds-form-field__label').hasAttribute('for', controlId);
+    assert
+      .dom('.hds-form-field__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-field__control')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`
+      );
+    assert
+      .dom('.hds-form-field__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the input', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Select::Field class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('select').hasClass('my-class');
+    assert.dom('select').hasAttribute('data-test1');
+    assert.dom('select').hasAttribute('data-test2', 'test');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

> **Note**
> This is not the final version: we will complete the component (documentation included) when the design specs are finalized.

This PR adds the `Select` form control to the system in two variants:
- `base`
- `field`

---

For the nomenclature see this illustration:
<img width="1055" alt="screenshot_1564" src="https://user-images.githubusercontent.com/686239/174313189-d9149463-3bb6-48bf-9efb-242f127caa98.png">

_Notice: the branch has been extracted from `form-controls/spike-playground` in #285 via a diff with the `main` branch and then cherry-picked only the changes needed for this PR._

### :hammer_and_wrench: Detailed description

In this PR we (me and @alex-ju) have:
- added the "base" and "field" `Select` form controls as components
- added the documentation page for the `Select`
- added integration tests and percy testing

Preview of the documentation page: https://hds-components-git-form-controls-04-select-hashicorp.vercel.app/components/form/select

Notice: the page is not linked in the index file of the dummy/scrappy website on purpose, so it's not visible to the public.

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
