### PR TITLE
Enable programmatic close on dropdown component

### DIFF
--- a/.changeset/many-fishes-visit.md
+++ b/.changeset/many-fishes-visit.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Enable programmatic close on dropdown component

--- a/packages/components/addon/components/hds/disclosure/index.hbs
+++ b/packages/components/addon/components/hds/disclosure/index.hbs
@@ -11,7 +11,7 @@
   </div>
   {{#if this.isOpen}}
     <div class="hds-disclosure__content" tabindex="-1">
-      {{yield to="content"}}
+      {{yield (hash close=this.close) to="content"}}
     </div>
   {{/if}}
 </div>

--- a/packages/components/addon/components/hds/disclosure/index.js
+++ b/packages/components/addon/components/hds/disclosure/index.js
@@ -29,20 +29,20 @@ export default class HdsDisclosureComponent extends Component {
       !event.relatedTarget || // click or tap a non-related target (e.g. outside the element)
       !this.element.contains(event.relatedTarget) // move focus to a target outside the element
     ) {
-      this.deactivate();
+      this.close();
     }
   }
 
   @action
   onKeyUp(event) {
     if (event.key === 'Escape') {
-      this.deactivate();
+      this.close();
       this.toggleRef.focus();
     }
   }
 
   @action
-  deactivate() {
+  close() {
     if (this.isOpen) {
       this.isOpen = false;
     }

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -7,10 +7,11 @@
       )
     }}
   </:toggle>
-  <:content>
+  <:content as |c|>
     <ul class={{this.listClassNames}} {{style width=@width}}>
       {{yield
         (hash
+          close=c.close
           CopyItem=(component "hds/dropdown/list-item/copy-item")
           Description=(component "hds/dropdown/list-item/description")
           Generic=(component "hds/dropdown/list-item/generic")

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -448,7 +448,7 @@
         &lt;dd.Interactive @route="..." @text="Item One" /&gt;
         &lt;dd.Interactive @route="..." @text="Item Two" /&gt;
         &lt;dd.Interactive @route="..." @text="Item Three" /&gt;
-        &lt;dd.Interactive @route="..." @text="Item Four (closes on click)" \{{on "click" dd.close}} /&gt;
+        &lt;dd.Interactive @text="Item Four (closes on click)" \{{on "click" dd.close}} /&gt;
         &lt;dd.Separator /&gt;
         &lt;dd.Interactive @route="..." @text="Delete" @color="critical" @icon="trash" /&gt;
       &lt;/Hds::Dropdown&gt;
@@ -466,7 +466,7 @@
           <dd.Interactive @route="components.dropdown" @text="Item One" />
           <dd.Interactive @route="components.dropdown" @text="Item Two" />
           <dd.Interactive @route="components.dropdown" @text="Item Three" />
-          <dd.Interactive @route="components.dropdown" @text="Item Four (closes on click)" {{on "click" dd.close}} />
+          <dd.Interactive @text="Item Four (closes on click)" {{on "click" dd.close}} />
           <dd.Separator />
           <dd.Interactive @route="components.dropdown" @text="Delete" @color="critical" @icon="trash" />
         </Hds::Dropdown>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -86,6 +86,10 @@
           <code class="dummy-code">@width</code>
           parameter is provided then the list will have a fixed width.</em></p>
     </dd>
+    <dt>close <code>function</code></dt>
+    <dd>
+      <p>Function that can be called to programmatically close the dropdown.</p>
+    </dd>
     <dt>onClose <code>function</code></dt>
     <dd>
       <p>Callback function invoked when the dropdown is closed (if provided).</p>
@@ -444,7 +448,7 @@
         &lt;dd.Interactive @route="..." @text="Item One" /&gt;
         &lt;dd.Interactive @route="..." @text="Item Two" /&gt;
         &lt;dd.Interactive @route="..." @text="Item Three" /&gt;
-        &lt;dd.Interactive @route="..." @text="Item Four" /&gt;
+        &lt;dd.Interactive @route="..." @text="Item Four (closes on click)" \{{on "click" dd.close}} /&gt;
         &lt;dd.Separator /&gt;
         &lt;dd.Interactive @route="..." @text="Delete" @color="critical" @icon="trash" /&gt;
       &lt;/Hds::Dropdown&gt;
@@ -462,7 +466,7 @@
           <dd.Interactive @route="components.dropdown" @text="Item One" />
           <dd.Interactive @route="components.dropdown" @text="Item Two" />
           <dd.Interactive @route="components.dropdown" @text="Item Three" />
-          <dd.Interactive @route="components.dropdown" @text="Item Four" />
+          <dd.Interactive @route="components.dropdown" @text="Item Four (closes on click)" {{on "click" dd.close}} />
           <dd.Separator />
           <dd.Interactive @route="components.dropdown" @text="Delete" @color="critical" @icon="trash" />
         </Hds::Dropdown>

--- a/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
@@ -143,7 +143,7 @@
             <a href="https://google.com">Link to Google</a>
           </li>
           <li>
-            <a href="https://apple.com" {{on "click" c.close}}>Link to Apple (closes the disclosed content on click)</a>
+            <button type="button" {{on "click" c.close}}>Button that closes the disclosed content on click</button>
           </li>
         </ul>
       </:content>
@@ -166,7 +166,7 @@
             <a href="https://google.com">Link to Google</a>
           </li>
           <li>
-            <a href="https://apple.com" {{on "click" c.close}}>Link to Apple (closes the disclosed content on click)</a>
+            <button type="button" {{on "click" c.close}}>Button that closes the disclosed content on click</button>
           </li>
         </ul>
       </:content>
@@ -191,7 +191,7 @@
             <a href="https://google.com">Link to Google</a>
           </li>
           <li>
-            <a href="https://apple.com" {{on "click" c.close}}>Link to Apple (closes the disclosed content on click)</a>
+            <button type="button" {{on "click" c.close}}>Button that closes the disclosed content on click</button>
           </li>
         </ul>
       </:content>

--- a/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
@@ -31,6 +31,10 @@
     <dd>
       <p>This is a named block where to pass the actual content that is shown/hidden upon toggling.</p>
     </dd>
+    <dt>[:content].close <code> function</code></dt>
+    <dd>
+      <p>Function that can be called to programmatically close the dropdown.</p>
+    </dd>
     <dt>onClose <code>function</code></dt>
     <dd>
       <p>Callback function invoked when the dropdown is closed (if provided).</p>
@@ -133,13 +137,13 @@
       <:toggle as |t|>
         <button type="button" {{on "click" t.onClickToggle}}>Click me</button>
       </:toggle>
-      <:content>
+      <:content as |c|>
         <ul class="dummy-disclosure-content-list-of-links">
           <li>
             <a href="https://google.com">Link to Google</a>
           </li>
           <li>
-            <a href="https://apple.com">Link with a much longer text</a>
+            <a href="https://apple.com" {{on "click" c.close}}>Link to Apple (closes the disclosed content on click)</a>
           </li>
         </ul>
       </:content>
@@ -156,13 +160,13 @@
       <:toggle as |t|>
         <Hds::Button @icon="chevron-down" @iconPosition="trailing" @text="Click me" {{on "click" t.onClickToggle}} />
       </:toggle>
-      <:content>
+      <:content as |c|>
         <ul class="dummy-disclosure-content-list-of-links">
           <li>
             <a href="https://google.com">Link to Google</a>
           </li>
           <li>
-            <a href="https://apple.com">Link with a much longer text</a>
+            <a href="https://apple.com" {{on "click" c.close}}>Link to Apple (closes the disclosed content on click)</a>
           </li>
         </ul>
       </:content>
@@ -181,13 +185,13 @@
           <Hds::Button @icon="chevron-down" @iconPosition="trailing" @text="Click me" {{on "click" t.onClickToggle}} />
         </div>
       </:toggle>
-      <:content>
+      <:content as |c|>
         <ul class="dummy-disclosure-content-list-of-links">
           <li>
             <a href="https://google.com">Link to Google</a>
           </li>
           <li>
-            <a href="https://apple.com">Link with a much longer text</a>
+            <a href="https://apple.com" {{on "click" c.close}}>Link to Apple (closes the disclosed content on click)</a>
           </li>
         </ul>
       </:content>

--- a/packages/components/tests/integration/components/hds/disclosure/index-test.js
+++ b/packages/components/tests/integration/components/hds/disclosure/index-test.js
@@ -96,4 +96,26 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
     assert.dom('.hds-disclosure__content').doesNotExist();
     assert.dom('a#test-disclosure-link').doesNotExist();
   });
+
+  // CLOSE DISCLOSED CONTENT ON CLICK
+
+  test('it should hide the "content" when an interactive element triggers `close`', async function (assert) {
+    assert.expect(4);
+    await render(hbs`
+      <Hds::Disclosure id="test-disclosure">
+        <:toggle as |t|>
+          <button type="button" id="test-disclosure-button" {{on "click" t.onClickToggle}} />
+        </:toggle>
+        <:content as |c|>
+          <a id="test-disclosure-link" href="#" {{on "click" c.close}}>test</a>
+        </:content>
+      </Hds::Disclosure>
+    `);
+    await click('button#test-disclosure-button');
+    assert.dom('.hds-disclosure__content').exists();
+    assert.dom('a#test-disclosure-link').exists();
+    await click('a#test-disclosure-link');
+    assert.dom('.hds-disclosure__content').doesNotExist();
+    assert.dom('a#test-disclosure-link').doesNotExist();
+  });
 });

--- a/packages/components/tests/integration/components/hds/disclosure/index-test.js
+++ b/packages/components/tests/integration/components/hds/disclosure/index-test.js
@@ -104,18 +104,18 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
     await render(hbs`
       <Hds::Disclosure id="test-disclosure">
         <:toggle as |t|>
-          <button type="button" id="test-disclosure-button" {{on "click" t.onClickToggle}} />
+          <button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} />
         </:toggle>
         <:content as |c|>
-          <a id="test-disclosure-link" href="#" {{on "click" c.close}}>test</a>
+          <button id="test-content-button" {{on "click" c.close}}>test</button>
         </:content>
       </Hds::Disclosure>
     `);
-    await click('button#test-disclosure-button');
+    await click('button#test-toggle-button');
     assert.dom('.hds-disclosure__content').exists();
-    assert.dom('a#test-disclosure-link').exists();
-    await click('a#test-disclosure-link');
+    assert.dom('button#test-content-button').exists();
+    await click('button#test-content-button');
     assert.dom('.hds-disclosure__content').doesNotExist();
-    assert.dom('a#test-disclosure-link').doesNotExist();
+    assert.dom('button#test-content-button').doesNotExist();
   });
 });

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -91,6 +91,21 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown ul').hasStyle({ width: '248px' });
   });
 
+  // CLOSE DISCLOSED CONTENT ON CLICK
+
+  test('it should hide the content when an interactive element triggers `close`', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown @width="248px" id="test-dropdown" as |dd|>
+        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <dd.Interactive @route="components.dropdown" @text="interactive" id="test-list-item-interactive" {{on "click" dd.close}} />
+      </Hds::Dropdown>
+    `);
+    await click('button#test-toggle-button');
+    assert.dom('#test-dropdown #test-list-item-interactive').exists();
+    await click('#test-list-item-interactive');
+    assert.dom('#test-dropdown #test-list-item-interactive').doesNotExist();
+  });
+
   // SPLATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -95,9 +95,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
 
   test('it should hide the content when an interactive element triggers `close`', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown @width="248px" id="test-dropdown" as |dd|>
+      <Hds::Dropdown id="test-dropdown" as |dd|>
         <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Interactive @route="components.dropdown" @text="interactive" id="test-list-item-interactive" {{on "click" dd.close}} />
+        <dd.Interactive @text="interactive" id="test-list-item-interactive" {{on "click" dd.close}} />
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');


### PR DESCRIPTION
### :pushpin: Summary

Enable programmatic close on dropdown component.

### :hammer_and_wrench: Detailed description

Based on feedback from @jgwhite we realised that we're not exposing a way for developers to close a dropdown component. In this PR we start by renaming the `deactivate` function in disclosure utility component to `close` then forward it to the dropdown component.

A simplified example of a call would look like this:
```hbs
<Hds::Dropdown id="test-dropdown" as |dd|>
  <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
  <dd.Interactive @route="components.dropdown" @text="interactive" id="test-list-item-interactive" {{on "click" dd.close}} />
</Hds::Dropdown>
```

### :link: External links

[Jira issue](https://hashicorp.atlassian.net/browse/HDS-77)

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
