### PR TITLE
Determine alert component's role based on the presence of actions

### DIFF
--- a/.changeset/quiet-pears-glow.md
+++ b/.changeset/quiet-pears-glow.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Determine alert component's role based on the presence of interactive elements

--- a/packages/components/addon/components/hds/alert/index.hbs
+++ b/packages/components/addon/components/hds/alert/index.hbs
@@ -1,11 +1,11 @@
-<div class={{this.classNames}} role="alert" aria-live="polite" ...attributes>
+<div class={{this.classNames}} role={{this.role}} aria-live="polite" aria-describedby="content" ...attributes>
   {{#if this.icon}}
     <div class="hds-alert__icon">
       <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} @isInlineBlock={{false}} />
     </div>
   {{/if}}
 
-  <div class="hds-alert__content">
+  <div class="hds-alert__content" {{did-insert this.didInsertContent}}>
     <div class="hds-alert__text">
       {{yield (hash Title=(component "hds/alert/title"))}}
       {{yield (hash Description=(component "hds/alert/description"))}}

--- a/packages/components/addon/components/hds/alert/index.js
+++ b/packages/components/addon/components/hds/alert/index.js
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 import { assert } from '@ember/debug';
+import { tracked } from '@glimmer/tracking';
 
 export const TYPES = ['page', 'inline', 'compact'];
 export const DEFAULT_COLOR = 'neutral';
@@ -19,6 +21,8 @@ export const MAPPING_COLORS_TO_ICONS = {
 };
 
 export default class HdsAlertIndexComponent extends Component {
+  @tracked role = 'alert';
+
   constructor() {
     super(...arguments);
 
@@ -124,5 +128,13 @@ export default class HdsAlertIndexComponent extends Component {
     classes.push(`hds-alert--color-${this.color}`);
 
     return classes.join(' ');
+  }
+
+  @action
+  didInsertContent(element) {
+    let actions = element.querySelectorAll('button, a');
+    if (actions.length) {
+      this.role = 'alertdialog';
+    }
   }
 }

--- a/packages/components/tests/integration/components/hds/alert/index-test.js
+++ b/packages/components/tests/integration/components/hds/alert/index-test.js
@@ -141,6 +141,13 @@ module('Integration | Component | hds/alert/index', function (hooks) {
     assert.dom('#test-alert').hasAttribute('role', 'alert');
   });
 
+  test('it should render with an `alertdialog` role when actions are provided', async function (assert) {
+    await render(
+      hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Button @text="I am a button" @size="small" /></Hds::Alert>`
+    );
+    assert.dom('#test-alert').hasAttribute('role', 'alertdialog');
+  });
+
   // ASSERTIONS
 
   test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

Determine alert component's role based on the presence of actions.

### :hammer_and_wrench: Detailed description

When actions (`Button` or `Link::Standalone`) are provided we set the alert component's role to `alertdialog` as a minimal step to conveying to screen reader users that interactive elements are presented within this component.

### :link: External links

[Asana ticket](https://app.asana.com/0/1202168297424991/1202323895888804)

***

### 👀 How to review

Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
