### PR TITLE
Remove alert banner in `Breadcrumb` page

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
+++ b/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
@@ -3,15 +3,6 @@
 <h2 class="dummy-h2">Breadcrumb</h2>
 
 <section>
-  <div class="dummy-banner dummy-banner--alert">
-    <p class="dummy-paragraph"><strong>🚨 ATTENTION 🚨</strong></p>
-    <p class="dummy-paragraph">Despite being ready this component can't be used in production code yet. The reason is
-      that, in order to be fully adopted in the Cloud UI codebase, it requires some refactoring on the way breadcrumbs
-      are implemented in Cloud UI.</p>
-    <p class="dummy-paragraph">If you need to adopt it in your codebase please speak with the HDS team first so they can
-      help you.</p>
-  </div>
-
   <p class="dummy-paragraph">
     A “breadcrumb” (or “breadcrumb trail”) is a type of secondary navigation that reveals the user's location in a
     website or Web application.


### PR DESCRIPTION
### :pushpin: Summary

Now that the `Hds::Breadcrumb` component has been adopted in Cloud UI (https://github.com/hashicorp/cloud-ui/pull/2252) we can remove the alert banner at the top of the `breadcrumb` documentation page.

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed the alert banner in the `Breadcrumb` page

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
