### PR TITLE
Add link to “unofficial design system search” website to index page

### DIFF
--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -118,13 +118,19 @@
     </div>
     <div>
       <h2 class="dummy-h2">
-        Content:
+        Other:
       </h2>
       <ol>
         <li class="dummy-paragraph">
           <LinkTo @route="content.writing-guidelines">
             🚧 Writing guidelines
           </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
+          <a href="https://unofficial-design-system-search.vercel.app/" rel="noopener noreferrer">
+            Lay of the land (Storybooks)
+            <FlightIcon @name="external-link" />
+          </a>
         </li>
       </ol>
     </div>


### PR DESCRIPTION
### :pushpin: Summary

As suggested by @johncowen in [this Slack message](https://hashicorp.slack.com/archives/C7KTUHNUS/p1655995139606259), it would be nice to have a link to the "[unofficial design system search](https://unofficial-design-system-search.vercel.app/)" (a.k.a. "lay of the land") Storybook aggregator in the dummy website. 

I thought to add it to the index page, under the "Other" category (previously called "Content") but if you have better ideas please let me know in the review.

### :camera_flash: Screenshots

<img width="1295" alt="screenshot_1590" src="https://user-images.githubusercontent.com/686239/175361858-3ddddd6f-7109-4f81-8f00-41cfcdc983ba.png">

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
