### PR TITLE
Fix badge vertical alignment

### DIFF
--- a/.changeset/eleven-ears-cover.md
+++ b/.changeset/eleven-ears-cover.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix badge vertical alignment

--- a/packages/components/app/styles/components/badge.scss
+++ b/packages/components/app/styles/components/badge.scss
@@ -18,6 +18,7 @@
   border: $hds-badge-border-width solid transparent;
   display: inline-flex;
   max-width: 100%;
+  vertical-align: middle;
 }
 
 .hds-badge__icon {

--- a/packages/components/tests/dummy/app/styles/pages/db-badge.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-badge.scss
@@ -19,6 +19,30 @@
     padding: 0.125rem;
 }
 
+.dummy-badge-containers {
+  align-items: start;
+  display: grid;
+  grid-gap: 3rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+
+  .hds-badge {
+    margin:0 0.5rem 0.5rem 0;
+  }
+}
+
+.dummy-badge-containers__block {
+  display: block;
+}
+
+.dummy-badge-containers__flex {
+  display: flex;
+}
+
+.dummy-badge-containers__grid {
+  display: grid;
+  justify-items: start;
+}
+
 .dummy-badge-base-sample--color-neutral-dark-mode {
     background: #0C0C0E;
 }

--- a/packages/components/tests/dummy/app/templates/components/badge.hbs
+++ b/packages/components/tests/dummy/app/templates/components/badge.hbs
@@ -102,6 +102,23 @@
       <Hds::Badge @icon="activity" @text="Lorem ipsum" /></p>
   </div>
 
+  <h5 class="dummy-h5">Containers</h5>
+  <div class="dummy-form-text-input-containers">
+    {{#let (array "block" "flex" "grid") as |displays|}}
+      {{#each displays as |display|}}
+        <div>
+          <span class="dummy-text-small">Parent with <code class="dummy-code">display: {{display}}</code></span>
+          <br />
+          <div class="dummy-form-text-input-containers__{{display}}">
+            <Hds::Badge @text="Only text" />
+            <Hds::Badge @icon="activity" @text="Text + icon" />
+            <Hds::Badge @icon="activity" @text="Only icon" @isIconOnly={{true}} />
+          </div>
+        </div>
+      {{/each}}
+    {{/let}}
+  </div>
+
   <h4 class="dummy-h4">Size</h4>
   <div class="dummy-badge-base-sample">
     {{#each @model.BADGE_SIZES as |size|}}

--- a/packages/components/tests/dummy/app/templates/components/badge.hbs
+++ b/packages/components/tests/dummy/app/templates/components/badge.hbs
@@ -103,16 +103,18 @@
   </div>
 
   <h5 class="dummy-h5">Containers</h5>
-  <div class="dummy-form-text-input-containers">
+  <div class="dummy-badge-containers">
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
         <div>
           <span class="dummy-text-small">Parent with <code class="dummy-code">display: {{display}}</code></span>
           <br />
-          <div class="dummy-form-text-input-containers__{{display}}">
-            <Hds::Badge @text="Only text" />
-            <Hds::Badge @icon="activity" @text="Text + icon" />
-            <Hds::Badge @icon="activity" @text="Only icon" @isIconOnly={{true}} />
+          <div class="dummy-badge-containers__{{display}}">
+            <Hds::Badge @text="Only text" /><Hds::Badge @icon="activity" @text="Text + icon" /><Hds::Badge
+              @icon="activity"
+              @text="Only icon"
+              @isIconOnly={{true}}
+            />
           </div>
         </div>
       {{/each}}


### PR DESCRIPTION
### :pushpin: Summary

Fix badge vertical alignment

### :hammer_and_wrench: Detailed description

When a mix of badges (with and without icon) are presented in a block element they are vertically misaligned.
In this PR we fix the alignment and add visuals to check how the component behaves with different `display` values on the parent element.

[Preview link](https://hds-components-git-alex-ju-fix-badge-vertical-6c42ca-hashicorp.vercel.app/components/badge#showcase)


Thanks @natmegs for [reporting the issue](https://hashicorp.slack.com/archives/CPB8GS9QT/p1656079573971139)! 🦸‍♀️ 

### :camera_flash: Screenshots

#### Before

![badge-before](https://user-images.githubusercontent.com/788096/175568122-def8b485-9b49-4c2c-bcdc-f2f7d81a413f.png)


#### After

![badge-after](https://user-images.githubusercontent.com/788096/175568137-4e67ea22-80f8-4a00-8a83-03b5f17e18d0.png)


***


Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
