### PR TITLE
Form controls - Update CSS styling following latest design specs

### DIFF
--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -33,13 +33,10 @@ $hds-button-focus-border-width: 3px;
 
   // This covers all of the browsers and focus scenarios (due to the custom focus design).
   &:disabled,
-  &[disabled],
   &.mock-disabled,
   &:disabled:focus,
-  &[disabled]:focus,
   &.mock-disabled:focus,
   &:disabled:hover,
-  &[disabled]:hover,
   &.mock-disabled:hover {
     background-color: var(--token-color-surface-faint);
     border-color: var(--token-color-border-primary);
@@ -258,13 +255,10 @@ $size-props: (
   }
 
   &:disabled,
-  &[disabled],
   &.mock-disabled,
   &:disabled:focus,
-  &[disabled]:focus,
   &.mock-disabled:focus,
   &:disabled:hover,
-  &[disabled]:hover,
   &.mock-disabled:hover {
     background-color: transparent;
     border-color: transparent;

--- a/packages/components/app/styles/components/form/checkbox.scss
+++ b/packages/components/app/styles/components/form/checkbox.scss
@@ -56,8 +56,8 @@ $hds-form-checkbox-control-border-radius: 3px;
   &.mock-focus:checked,
   &.mock-focus:not(:checked) {
     border-color: var(--token-color-palette-blue-400);
-    outline: 2px solid var(--token-color-focus-action-external);
-    outline-offset: 0px;
+    outline: 3px solid var(--token-color-focus-action-external);
+    outline-offset: 1px;
   }
 
   // active

--- a/packages/components/app/styles/components/form/checkbox.scss
+++ b/packages/components/app/styles/components/form/checkbox.scss
@@ -118,5 +118,6 @@ $hds-form-checkbox-control-border-radius: 3px;
     box-shadow: none;
     // notice: the "tick" color is hardcoded here!
     background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%238C909C'/%3e%3c/svg%3e");
+    cursor: not-allowed;
   }
 }

--- a/packages/components/app/styles/components/form/checkbox.scss
+++ b/packages/components/app/styles/components/form/checkbox.scss
@@ -90,6 +90,15 @@ $hds-form-checkbox-control-border-radius: 3px;
     border-color: var(--token-color-palette-red-400);
   }
 
+  // TODO add handling of focus-visible
+  &.hds-form-checkbox--is-invalid:focus:not(:checked),
+  &.hds-form-checkbox--is-invalid.mock-focus:not(:checked),
+  &.hds-form-checkbox--is-invalid:focus:checked,
+  &.hds-form-checkbox--is-invalid.mock-focus:checked {
+    border-color: var(--token-color-focus-critical-internal);
+    outline-color: var(--token-color-focus-critical-external);
+  }
+
   &.hds-form-checkbox--is-invalid:active:not(:checked),
   &.hds-form-checkbox--is-invalid.mock-active:not(:checked),
   &.hds-form-checkbox--is-invalid:active:checked,

--- a/packages/components/app/styles/components/form/error.scss
+++ b/packages/components/app/styles/components/form/error.scss
@@ -11,7 +11,6 @@
 }
 
 .hds-form-error__icon {
-  color: var(--token-color-foreground-critical-on-surface);
   flex: none;
   height: 14px;
   margin: 2px 8px 2px 0;

--- a/packages/components/app/styles/components/form/radio.scss
+++ b/packages/components/app/styles/components/form/radio.scss
@@ -112,6 +112,8 @@ $hds-form-radio-control-size: 16px;
   &.hds-form-checkbox--is-invalid:disabled:not(:checked) {
     background-color: var(--token-color-surface-strong);
     border-color: var(--token-color-border-primary);
+    box-shadow: none;
+    cursor: not-allowed;
   }
   &:disabled:checked,
   &.hds-form-checkbox--is-invalid:disabled:checked {
@@ -120,5 +122,6 @@ $hds-form-radio-control-size: 16px;
     box-shadow: none;
     // notice: the "dot" color is hardcoded here!
     background-image: url("data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%23656a76'/%3e%3c/svg%3e");
+    cursor: not-allowed;
   }
 }

--- a/packages/components/app/styles/components/form/radio.scss
+++ b/packages/components/app/styles/components/form/radio.scss
@@ -89,6 +89,15 @@ $hds-form-radio-control-size: 16px;
     border-color: var(--token-color-palette-red-400);
   }
 
+  // TODO add handling of focus-visible
+  &.hds-form-radio--is-invalid:focus:not(:checked),
+  &.hds-form-radio--is-invalid.mock-focus:not(:checked),
+  &.hds-form-radio--is-invalid:focus:checked,
+  &.hds-form-radio--is-invalid.mock-focus:checked {
+    border-color: var(--token-color-focus-critical-internal);
+    outline-color: var(--token-color-focus-critical-external);
+  }
+
   &.hds-form-radio--is-invalid:active:not(:checked),
   &.hds-form-radio--is-invalid.mock-active:not(:checked),
   &.hds-form-radio--is-invalid:active:checked,

--- a/packages/components/app/styles/components/form/radio.scss
+++ b/packages/components/app/styles/components/form/radio.scss
@@ -55,8 +55,8 @@ $hds-form-radio-control-size: 16px;
   &.mock-focus:checked,
   &.mock-focus:not(:checked) {
     border-color: var(--token-color-palette-blue-400);
-    outline: 2px solid var(--token-color-focus-action-external);
-    outline-offset: 0px;
+    outline: 3px solid var(--token-color-focus-action-external);
+    outline-offset: 1px;
   }
 
   // active

--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -41,6 +41,7 @@
   &:disabled {
     background-color: var(--token-color-surface-strong);
     border-color: var(--token-color-border-primary);
+    cursor: not-allowed;
   }
 
   // INVALID

--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -46,6 +46,18 @@
   // INVALID
 
   &.hds-form-select--is-invalid {
-    border-color: var(--token-color-foreground-critical);
+    border-color: #C00005; // TODO convert to form-controls design token
+
+    &:hover,
+    &.mock-hover {
+      border-color: #940004; // TODO convert to form-controls design token
+    }
+
+    // TODO add handling of focus-visible
+    &:focus,
+    &.mock-focus {
+      border-color: var(--token-color-focus-critical-internal);
+      outline-color: var(--token-color-focus-critical-external);
+    }
   }
 }

--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -9,8 +9,8 @@
 .hds-form-select {
   border: 1px solid var(--token-color-palette-neutral-400);
   border-radius: 5px;
-  color: var(--token-color-foreground-primary);
-  padding: 7px;
+  color: var(--token-color-foreground-strong);
+  padding: 7px; // we have to take into account the border
   max-width: 100%;
 
   // STATUS

--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -27,7 +27,7 @@
   &.mock-focus {
     border-color: var(--token-color-focus-action-internal);
     // TODO: Safari doesn't apply a rounded border
-    outline: 2px solid var(--token-color-focus-action-external);
+    outline: 3px solid var(--token-color-focus-action-external);
     outline-offset: 0px;
   }
 

--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -11,9 +11,6 @@
   border-radius: 5px;
   box-shadow: var(--hds-elevation-inset-box-shadow);
   color: var(--token-color-foreground-primary);
-  font-family: var(--token-typography-body-200-font-family);
-  font-size: var(--token-typography-body-200-font-size);
-  line-height: var(--token-typography-body-200-line-height);
   padding: 7px;
   max-width: 100%;
 

--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -9,7 +9,6 @@
 .hds-form-select {
   border: 1px solid var(--token-color-palette-neutral-400);
   border-radius: 5px;
-  box-shadow: var(--hds-elevation-inset-box-shadow);
   color: var(--token-color-foreground-primary);
   padding: 7px;
   max-width: 100%;

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -11,9 +11,6 @@
   border-radius: 5px;
   box-shadow: var(--hds-elevation-inset-box-shadow);
   color: var(--token-color-foreground-strong);
-  font-family: var(--token-typography-body-200-font-family);
-  font-size: var(--token-typography-body-200-font-size);
-  line-height: var(--token-typography-body-200-line-height);
   padding: 7px;
   width: 100%;
   max-width: 100%;

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -56,8 +56,7 @@
 
   // DISABLED
 
-  &:disabled,
-  &[disabled] {
+  &:disabled {
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
     box-shadow: none;
@@ -99,7 +98,6 @@
     width: initial;
 
     // show the native icon dimmed if disabled (hidden in Chrome)
-    &[disabled]::-webkit-calendar-picker-indicator,
     &:disabled::-webkit-calendar-picker-indicator {
         visibility: visible;
         opacity: 0.5;

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -10,7 +10,7 @@
   border: 1px solid var(--token-color-palette-neutral-400);
   border-radius: 5px;
   box-shadow: var(--hds-elevation-inset-box-shadow);
-  color: var(--token-color-foreground-primary);
+  color: var(--token-color-foreground-strong);
   font-family: var(--token-typography-body-200-font-family);
   font-size: var(--token-typography-body-200-font-size);
   line-height: var(--token-typography-body-200-line-height);
@@ -52,6 +52,7 @@
   &[readonly] {
     background-color: var(--token-color-surface-strong);
     border-color: var(--token-color-palette-neutral-400);
+    color: var(--token-color-foreground-primary);
   }
 
   // DISABLED
@@ -60,6 +61,7 @@
   &[disabled] {
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
+    color: var(--token-color-foreground-disabled);
   }
 
   // INVALID

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -66,7 +66,19 @@
   // INVALID
 
   &.hds-form-text-input--is-invalid {
-    border-color: var(--token-color-foreground-critical);
+    border-color: #C00005; // TODO convert to form-controls design token
+
+    &:hover,
+    &.mock-hover {
+      border-color: #940004; // TODO convert to form-controls design token
+    }
+
+    // TODO add handling of focus-visible
+    &:focus,
+    &.mock-focus {
+      border-color: var(--token-color-focus-critical-internal);
+      outline-color: var(--token-color-focus-critical-external);
+    }
   }
 }
 

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -62,6 +62,7 @@
     border-color: var(--token-color-border-primary);
     box-shadow: none;
     color: var(--token-color-foreground-disabled);
+    cursor: not-allowed;
   }
 
   // INVALID

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -49,6 +49,7 @@
   &[readonly] {
     background-color: var(--token-color-surface-strong);
     border-color: var(--token-color-palette-neutral-400);
+    box-shadow: none;
     color: var(--token-color-foreground-primary);
   }
 
@@ -58,6 +59,7 @@
   &[disabled] {
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
+    box-shadow: none;
     color: var(--token-color-foreground-disabled);
   }
 

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -7,11 +7,12 @@
 // "BASE" CONTROL
 
 .hds-form-text-input {
+  background-color: var(--token-color-surface-primary);
   border: 1px solid var(--token-color-palette-neutral-400);
   border-radius: 5px;
   box-shadow: var(--hds-elevation-inset-box-shadow);
   color: var(--token-color-foreground-strong);
-  padding: 7px;
+  padding: 7px; // we have to take into account the border
   width: 100%;
   max-width: 100%;
 

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -34,7 +34,7 @@
   &.mock-focus {
     border-color: var(--token-color-focus-action-internal);
     // TODO: Safari doesn't apply a rounded border
-    outline: 2px solid var(--token-color-focus-action-external);
+    outline: 3px solid var(--token-color-focus-action-external);
     outline-offset: 0px;
   }
 

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -63,6 +63,7 @@
     border-color: var(--token-color-border-primary);
     box-shadow: none;
     color: var(--token-color-foreground-disabled);
+    cursor: not-allowed;
   }
 
   // INVALID

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -10,7 +10,7 @@
   border: 1px solid var(--token-color-palette-neutral-400);
   border-radius: 5px;
   box-shadow: var(--hds-elevation-inset-box-shadow);
-  color: var(--token-color-foreground-primary);
+  color: var(--token-color-foreground-strong);
   font-family: var(--token-typography-body-200-font-family);
   font-size: var(--token-typography-body-200-font-size);
   line-height: var(--token-typography-body-200-line-height);
@@ -53,6 +53,7 @@
   &[readonly] {
     background-color: var(--token-color-surface-strong);
     border-color: var(--token-color-palette-neutral-400);
+    color: var(--token-color-foreground-primary);
   }
 
   // DISABLED
@@ -61,6 +62,7 @@
   &[disabled] {
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
+    color: var(--token-color-foreground-disabled);
   }
 
   // INVALID

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -57,8 +57,7 @@
 
   // DISABLED
 
-  &:disabled,
-  &[disabled] {
+  &:disabled {
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
     box-shadow: none;

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -50,6 +50,7 @@
   &[readonly] {
     background-color: var(--token-color-surface-strong);
     border-color: var(--token-color-palette-neutral-400);
+    box-shadow: none;
     color: var(--token-color-foreground-primary);
   }
 
@@ -59,6 +60,7 @@
   &[disabled] {
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
+    box-shadow: none;
     color: var(--token-color-foreground-disabled);
   }
 

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -35,7 +35,7 @@
   &.mock-focus {
     border-color: var(--token-color-focus-action-internal);
     // TODO: Safari doesn't apply a rounded border
-    outline: 2px solid var(--token-color-focus-action-external);
+    outline: 3px solid var(--token-color-focus-action-external);
     outline-offset: 0px;
   }
 

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -67,6 +67,18 @@
   // INVALID
 
   &.hds-form-textarea--is-invalid {
-    border-color: var(--token-color-foreground-critical);
+    border-color: #C00005; // TODO convert to form-controls design token
+
+    &:hover,
+    &.mock-hover {
+      border-color: #940004; // TODO convert to form-controls design token
+    }
+
+    // TODO add handling of focus-visible
+    &:focus,
+    &.mock-focus {
+      border-color: var(--token-color-focus-critical-internal);
+      outline-color: var(--token-color-focus-critical-external);
+    }
   }
 }

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -11,9 +11,6 @@
   border-radius: 5px;
   box-shadow: var(--hds-elevation-inset-box-shadow);
   color: var(--token-color-foreground-strong);
-  font-family: var(--token-typography-body-200-font-family);
-  font-size: var(--token-typography-body-200-font-size);
-  line-height: var(--token-typography-body-200-line-height);
   padding: 4px 8px;
   resize: vertical;
   width: 100%;

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -7,11 +7,12 @@
 // "BASE" CONTROL
 
 .hds-form-textarea {
+  background-color: var(--token-color-surface-primary);
   border: 1px solid var(--token-color-palette-neutral-400);
   border-radius: 5px;
   box-shadow: var(--hds-elevation-inset-box-shadow);
   color: var(--token-color-foreground-strong);
-  padding: 4px 8px;
+  padding: 3px 7px; // we have to take into account the border
   resize: vertical;
   width: 100%;
   max-width: 100%;

--- a/packages/components/app/styles/components/form/toggle.scss
+++ b/packages/components/app/styles/components/form/toggle.scss
@@ -38,6 +38,10 @@ $hds-form-toggle-border-radius: math.div($hds-form-toggle-control-height, 2);
   right: 0;
   top: 0;
   z-index: 1;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
 }
 
 // facade (visible)

--- a/packages/components/app/styles/components/form/toggle.scss
+++ b/packages/components/app/styles/components/form/toggle.scss
@@ -163,6 +163,17 @@ $hds-form-toggle-border-radius: math.div($hds-form-toggle-control-height, 2);
     background-color: var(--token-color-palette-red-400);
   }
 
+  // TODO add handling of focus-visible
+  .hds-form-toggle--is-invalid :focus:not(:checked) + &,
+  .hds-form-toggle--is-invalid .mock-focus:not(:checked) + &,
+  .hds-form-toggle--is-invalid :focus:checked + &,
+  .hds-form-toggle--is-invalid .mock-focus:checked + & {
+    --border-color: var(--token-color-focus-critical-internal);
+    &::before {
+      border-color: var(--token-color-focus-critical-external);
+    }
+  }
+
   .hds-form-toggle--is-invalid :active:not(:checked) + &,
   .hds-form-toggle--is-invalid .mock-active:not(:checked) + &,
   .hds-form-toggle--is-invalid :active:checked + &,

--- a/packages/components/app/styles/components/form/toggle.scss
+++ b/packages/components/app/styles/components/form/toggle.scss
@@ -74,8 +74,8 @@ $hds-form-toggle-border-radius: math.div($hds-form-toggle-control-height, 2);
   // used for the focus
 
   &::before {
-    $border-width: 2px;
-    $shift: $border-width + 1px; // we need to take in account also the border width of the parent
+    $border-width: 3px;
+    $shift: $border-width + 2px; // we need to take in account also the border width of the parent
     border-radius: $hds-form-toggle-border-radius + $border-width;
     border-width: $border-width;
     bottom: -$shift;

--- a/packages/components/tests/dummy/app/styles/pages/form/db-checkbox.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-checkbox.scss
@@ -14,7 +14,7 @@
 
 .dummy-form-checkbox-states-subgrid {
   display: grid;
-  grid-gap: 0.5rem 1rem;
+  grid-gap: 0.6rem 1rem;
   grid-template-columns: 1fr 1fr;
   width: min-content;
 }

--- a/packages/components/tests/dummy/app/styles/pages/form/db-radio.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-radio.scss
@@ -14,7 +14,7 @@
 
 .dummy-form-radio-states-subgrid {
   display: grid;
-  grid-gap: 0.5rem 1rem;
+  grid-gap: 0.6rem 1rem;
   grid-template-columns: 1fr 1fr;
   width: min-content;
 }

--- a/packages/components/tests/dummy/app/styles/pages/form/db-select.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-select.scss
@@ -12,12 +12,6 @@
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
-.dummy-form-select-sublist {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
 .dummy-form-select-containers {
   align-items: start;
   display: grid;
@@ -42,7 +36,7 @@
   align-items: flex-start;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .dummy-form-select-custom-layout {

--- a/packages/components/tests/dummy/app/styles/pages/form/db-text-input.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-text-input.scss
@@ -41,7 +41,7 @@
 
 .dummy-form-text-input-sublist {
   > * + * {
-    margin-top: 0.5rem;
+    margin-top: 0.6rem;
   }
 }
 

--- a/packages/components/tests/dummy/app/styles/pages/form/db-textarea.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-textarea.scss
@@ -15,7 +15,7 @@
 .dummy-form-textarea-sublist {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .dummy-form-textarea-containers {

--- a/packages/components/tests/dummy/app/styles/pages/form/db-toggle.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-toggle.scss
@@ -14,7 +14,7 @@
 
 .dummy-form-toggle-states-subgrid {
   display: grid;
-  grid-gap: 0.5rem 1rem;
+  grid-gap: 0.6rem 1rem;
   grid-template-columns: 1fr 1fr;
   width: min-content;
 }


### PR DESCRIPTION
### :pushpin: Summary

Now that the `Text Input` component is approved and merged in Figma, and the `Checbox/Radio` components are under review, we can have a new pass at the CSS styling to match the design specs as much as possible (for all the form controls in general). 

In any case, the styles will be thoroughly reviewed one last time, before officially releasing the form controls (and in the process, we will create component-specific design tokens for form controls).

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated `base/readonly/disabled` text colors for `input` + `textarea`
- updated `focus` outlines values for all the base controls
- updated `focus + invalid` styling for all the base controls
- removed `box-shadow` where was not needed
- added `cursor: not-allowed` to all the disabled form controls
- other small changes and fine tunings

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [x] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
