### PR TITLE
Form controls - Remove `active` state

### DIFF
--- a/packages/components/app/styles/components/form/checkbox.scss
+++ b/packages/components/app/styles/components/form/checkbox.scss
@@ -60,16 +60,6 @@ $hds-form-checkbox-control-border-radius: 3px;
     outline-offset: 1px;
   }
 
-  // active
-
-  &:active:not(:checked),
-  &.mock-active:not(:checked),
-  &:active:checked,
-  &.mock-active:checked {
-    background-color: var(--token-color-palette-blue-400);
-    border-color: var(--token-color-palette-blue-400);
-  }
-
   // INVALID
 
   &.hds-form-checkbox--is-invalid:not(:checked) {
@@ -87,23 +77,6 @@ $hds-form-checkbox-control-border-radius: 3px;
   &.hds-form-checkbox--is-invalid:hover:checked,
   &.hds-form-checkbox--is-invalid.mock-hover:checked {
     background-color: var(--token-color-palette-red-300);
-    border-color: var(--token-color-palette-red-400);
-  }
-
-  // TODO add handling of focus-visible
-  &.hds-form-checkbox--is-invalid:focus:not(:checked),
-  &.hds-form-checkbox--is-invalid.mock-focus:not(:checked),
-  &.hds-form-checkbox--is-invalid:focus:checked,
-  &.hds-form-checkbox--is-invalid.mock-focus:checked {
-    border-color: var(--token-color-focus-critical-internal);
-    outline-color: var(--token-color-focus-critical-external);
-  }
-
-  &.hds-form-checkbox--is-invalid:active:not(:checked),
-  &.hds-form-checkbox--is-invalid.mock-active:not(:checked),
-  &.hds-form-checkbox--is-invalid:active:checked,
-  &.hds-form-checkbox--is-invalid.mock-active:checked {
-    background-color: var(--token-color-palette-red-400);
     border-color: var(--token-color-palette-red-400);
   }
 

--- a/packages/components/app/styles/components/form/radio.scss
+++ b/packages/components/app/styles/components/form/radio.scss
@@ -59,16 +59,6 @@ $hds-form-radio-control-size: 16px;
     outline-offset: 1px;
   }
 
-  // active
-
-  &:active:not(:checked),
-  &.mock-active:not(:checked),
-  &:active:checked,
-  &.mock-active:checked {
-    background-color: var(--token-color-palette-blue-400);
-    border-color: var(--token-color-palette-blue-400);
-  }
-
   // INVALID
 
   &.hds-form-radio--is-invalid:not(:checked) {
@@ -86,23 +76,6 @@ $hds-form-radio-control-size: 16px;
   &.hds-form-radio--is-invalid:hover:checked,
   &.hds-form-radio--is-invalid.mock-hover:checked {
     background-color: var(--token-color-palette-red-300);
-    border-color: var(--token-color-palette-red-400);
-  }
-
-  // TODO add handling of focus-visible
-  &.hds-form-radio--is-invalid:focus:not(:checked),
-  &.hds-form-radio--is-invalid.mock-focus:not(:checked),
-  &.hds-form-radio--is-invalid:focus:checked,
-  &.hds-form-radio--is-invalid.mock-focus:checked {
-    border-color: var(--token-color-focus-critical-internal);
-    outline-color: var(--token-color-focus-critical-external);
-  }
-
-  &.hds-form-radio--is-invalid:active:not(:checked),
-  &.hds-form-radio--is-invalid.mock-active:not(:checked),
-  &.hds-form-radio--is-invalid:active:checked,
-  &.hds-form-radio--is-invalid.mock-active:checked {
-    background-color: var(--token-color-palette-red-400);
     border-color: var(--token-color-palette-red-400);
   }
 

--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -30,12 +30,6 @@
     outline-offset: 0px;
   }
 
-  &:active,
-  &.mock-active {
-    background-color: var(--token-color-surface-interactive-disabled);
-    border-color: var(--token-color-border-primary);
-  }
-
   // DISABLED
 
   &:disabled {

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -39,11 +39,6 @@
     outline-offset: 0px;
   }
 
-  &:active,
-  &.mock-active {
-    border-color: var(--token-color-focus-action-internal);
-  }
-
   // READONLY
 
   &:read-only,

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -40,11 +40,6 @@
     outline-offset: 0px;
   }
 
-  &:active,
-  &.mock-active {
-    border-color: var(--token-color-focus-action-internal);
-  }
-
   // READONLY
 
   &:read-only,

--- a/packages/components/app/styles/components/form/toggle.scss
+++ b/packages/components/app/styles/components/form/toggle.scss
@@ -137,16 +137,6 @@ $hds-form-toggle-border-radius: math.div($hds-form-toggle-control-height, 2);
     }
   }
 
-  // active
-
-  :active:not(:checked) + &,
-  .mock-active:not(:checked) + &,
-  :active:checked + &,
-  .mock-active:checked + & {
-    background-color: var(--token-color-palette-blue-400);
-    --border-color: var(--token-color-palette-blue-400);
-  }
-
   // INVALID
 
   .hds-form-toggle--is-invalid :not(:checked) + & {
@@ -165,25 +155,6 @@ $hds-form-toggle-border-radius: math.div($hds-form-toggle-control-height, 2);
   .hds-form-toggle--is-invalid .mock-hover:checked + & {
     --border-color: var(--token-color-palette-red-300);
     background-color: var(--token-color-palette-red-400);
-  }
-
-  // TODO add handling of focus-visible
-  .hds-form-toggle--is-invalid :focus:not(:checked) + &,
-  .hds-form-toggle--is-invalid .mock-focus:not(:checked) + &,
-  .hds-form-toggle--is-invalid :focus:checked + &,
-  .hds-form-toggle--is-invalid .mock-focus:checked + & {
-    --border-color: var(--token-color-focus-critical-internal);
-    &::before {
-      border-color: var(--token-color-focus-critical-external);
-    }
-  }
-
-  .hds-form-toggle--is-invalid :active:not(:checked) + &,
-  .hds-form-toggle--is-invalid .mock-active:not(:checked) + &,
-  .hds-form-toggle--is-invalid :active:checked + &,
-  .hds-form-toggle--is-invalid .mock-active:checked + & {
-    background-color: var(--token-color-palette-red-400);
-    --border-color: var(--token-color-palette-red-400);
   }
 
   // DISABLED

--- a/packages/components/tests/dummy/app/routes/components/form/checkbox.js
+++ b/packages/components/tests/dummy/app/routes/components/form/checkbox.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default class ComponentsFormCheckboxRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
-    const STATES = ['default', 'hover', 'active', 'focus'];
+    const STATES = ['default', 'hover', 'focus'];
     return {
       STATES,
     };

--- a/packages/components/tests/dummy/app/routes/components/form/radio.js
+++ b/packages/components/tests/dummy/app/routes/components/form/radio.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default class ComponentsFormRadioRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
-    const STATES = ['default', 'hover', 'active', 'focus'];
+    const STATES = ['default', 'hover', 'focus'];
     return {
       STATES,
     };

--- a/packages/components/tests/dummy/app/routes/components/form/select.js
+++ b/packages/components/tests/dummy/app/routes/components/form/select.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default class ComponentsFormSelectRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
-    const STATES = ['default', 'hover', 'active', 'focus'];
+    const STATES = ['default', 'hover', 'focus'];
     return {
       STATES,
     };

--- a/packages/components/tests/dummy/app/routes/components/form/text-input.js
+++ b/packages/components/tests/dummy/app/routes/components/form/text-input.js
@@ -5,7 +5,7 @@ import { TYPES } from '@hashicorp/design-system-components/components/hds/form/t
 export default class ComponentsFormTextInputRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
-    const STATES = ['default', 'hover', 'active', 'focus'];
+    const STATES = ['default', 'hover', 'focus'];
     return {
       TYPES,
       STATES,

--- a/packages/components/tests/dummy/app/routes/components/form/textarea.js
+++ b/packages/components/tests/dummy/app/routes/components/form/textarea.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default class ComponentsFormTextareaRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
-    const STATES = ['default', 'hover', 'active', 'focus'];
+    const STATES = ['default', 'hover', 'focus'];
     return {
       STATES,
     };

--- a/packages/components/tests/dummy/app/routes/components/form/toggle.js
+++ b/packages/components/tests/dummy/app/routes/components/form/toggle.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default class ComponentsFormToggleRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
-    const STATES = ['default', 'hover', 'active', 'focus'];
+    const STATES = ['default', 'hover', 'focus'];
     return {
       STATES,
     };

--- a/packages/components/tests/dummy/app/styles/pages/form/db-checkbox.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-checkbox.scss
@@ -5,11 +5,11 @@
   gap: 2rem;
 }
 
-.dummy-form-checkbox-grid-sample {
-  align-items: start;
+.dummy-form-checkbox-states-grid {
   display: grid;
-  grid-gap: 1rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-gap: 1rem 5rem;
+  grid-template-columns: repeat(3, 1fr);
+  width: fit-content;
 }
 
 .dummy-form-checkbox-states-subgrid {
@@ -17,6 +17,13 @@
   grid-gap: 0.6rem 1rem;
   grid-template-columns: 1fr 1fr;
   width: min-content;
+}
+
+.dummy-form-checkbox-grid-sample {
+  align-items: start;
+  display: grid;
+  grid-gap: 1rem 5rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .dummy-form-checkbox-containers {

--- a/packages/components/tests/dummy/app/styles/pages/form/db-radio.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-radio.scss
@@ -5,11 +5,11 @@
   gap: 2rem;
 }
 
-.dummy-form-radio-grid-sample {
-  align-items: start;
+.dummy-form-radio-states-grid {
   display: grid;
-  grid-gap: 1rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-gap: 1rem 5rem;
+  grid-template-columns: repeat(3, 1fr);
+  width: fit-content;
 }
 
 .dummy-form-radio-states-subgrid {
@@ -17,6 +17,13 @@
   grid-gap: 0.6rem 1rem;
   grid-template-columns: 1fr 1fr;
   width: min-content;
+}
+
+.dummy-form-radio-grid-sample {
+  align-items: start;
+  display: grid;
+  grid-gap: 1rem 5rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .dummy-form-radio-containers {

--- a/packages/components/tests/dummy/app/styles/pages/form/db-select.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-select.scss
@@ -9,7 +9,7 @@
   align-items: start;
   display: grid;
   grid-gap: 1rem 3rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .dummy-form-select-containers {

--- a/packages/components/tests/dummy/app/styles/pages/form/db-text-input.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-text-input.scss
@@ -16,7 +16,7 @@
   align-items: start;
   display: grid;
   grid-gap: 1rem 3rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .dummy-form-text-input-containers {

--- a/packages/components/tests/dummy/app/styles/pages/form/db-textarea.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-textarea.scss
@@ -9,7 +9,7 @@
   align-items: start;
   display: grid;
   grid-gap: 1rem 3rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .dummy-form-textarea-sublist {

--- a/packages/components/tests/dummy/app/styles/pages/form/db-toggle.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-toggle.scss
@@ -5,11 +5,11 @@
   gap: 2rem;
 }
 
-.dummy-form-toggle-grid-sample {
-  align-items: start;
+.dummy-form-toggle-states-grid {
   display: grid;
-  grid-gap: 1rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-gap: 1rem 5rem;
+  grid-template-columns: repeat(3, 1fr);
+  width: fit-content;
 }
 
 .dummy-form-toggle-states-subgrid {
@@ -17,6 +17,13 @@
   grid-gap: 0.6rem 1rem;
   grid-template-columns: 1fr 1fr;
   width: min-content;
+}
+
+.dummy-form-toggle-grid-sample {
+  align-items: start;
+  display: grid;
+  grid-gap: 1rem 5rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .dummy-form-toggle-containers {

--- a/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
@@ -295,7 +295,7 @@
     </div>
   </div>
   <h5 class="dummy-h6">States (Base / Disabled / Invalid)</h5>
-  <div class="dummy-form-checkbox-grid-sample">
+  <div class="dummy-form-checkbox-states-grid">
     {{#each @model.STATES as |state|}}
       <div>
         <span class="dummy-text-small">{{capitalize state}}:</span>
@@ -303,10 +303,13 @@
         <div class="dummy-form-checkbox-states-subgrid" mock-state-value={{state}} mock-state-selector="input">
           <Hds::Form::Checkbox::Base aria-label="Checkbox" />
           <Hds::Form::Checkbox::Base checked="checked" aria-label="Checked checkbox" />
-          <Hds::Form::Checkbox::Base disabled="disabled" aria-label="Disabled checkbox" />
-          <Hds::Form::Checkbox::Base checked="checked" disabled="disabled" aria-label="Checked, disabled checkbox" />
           <Hds::Form::Checkbox::Base @isInvalid={{true}} aria-label="Invalid checkbox" />
           <Hds::Form::Checkbox::Base checked="checked" @isInvalid={{true}} aria-label="Checked, invalid checkbox" />
+          {{! template-lint-disable simple-unless }}
+          {{#unless (eq state "focus")}}
+            <Hds::Form::Checkbox::Base disabled="disabled" aria-label="Disabled checkbox" />
+            <Hds::Form::Checkbox::Base checked="checked" disabled="disabled" aria-label="Checked, disabled checkbox" />
+          {{/unless}}
         </div>
       </div>
     {{/each}}
@@ -343,6 +346,7 @@
       </Hds::Form::Checkbox::Field>
     </div>
   </div>
+  <br />
   <div class="dummy-form-checkbox-grid-sample">
     <div>
       <span class="dummy-text-small">Label + Error</span>

--- a/packages/components/tests/dummy/app/templates/components/form/radio.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio.hbs
@@ -295,7 +295,7 @@
     </div>
   </div>
   <h5 class="dummy-h6">States (Base / Disabled / Invalid)</h5>
-  <div class="dummy-form-radio-grid-sample">
+  <div class="dummy-form-radio-states-grid">
     {{#each @model.STATES as |state|}}
       <div>
         <span class="dummy-text-small">{{capitalize state}}:</span>
@@ -303,10 +303,13 @@
         <div class="dummy-form-radio-states-subgrid" mock-state-value={{state}} mock-state-selector="input">
           <Hds::Form::Radio::Base aria-label="Radio" />
           <Hds::Form::Radio::Base checked="checked" aria-label="Checked radio" />
-          <Hds::Form::Radio::Base disabled="disabled" aria-label="Disabled radio" />
-          <Hds::Form::Radio::Base checked="checked" disabled="disabled" aria-label="Checked, disabled radio" />
           <Hds::Form::Radio::Base @isInvalid={{true}} aria-label="Invalid radio" />
           <Hds::Form::Radio::Base checked="checked" @isInvalid={{true}} aria-label="Checked, invalid radio" />
+          {{! template-lint-disable simple-unless }}
+          {{#unless (eq state "focus")}}
+            <Hds::Form::Radio::Base disabled="disabled" aria-label="Disabled radio" />
+            <Hds::Form::Radio::Base checked="checked" disabled="disabled" aria-label="Checked, disabled radio" />
+          {{/unless}}
         </div>
       </div>
     {{/each}}
@@ -347,6 +350,7 @@
       </Hds::Form::Radio::Field>
     </div>
   </div>
+  <br />
   <div class="dummy-form-radio-grid-sample">
     <div>
       <span class="dummy-text-small">Label + Error</span>

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -264,25 +264,28 @@
   </div>
   <h5 class="dummy-h6">States</h5>
   <div class="dummy-form-select-grid-sample">
-    {{#let (array "base" "disabled" "invalid") as |variants|}}
+    {{#let (array "base" "invalid" "disabled") as |variants|}}
       {{#each variants as |variant|}}
         {{#each @model.STATES as |state|}}
-          <div>
-            <span class="dummy-text-small">{{capitalize variant}} / {{capitalize state}}:</span>
-            <br />
-            <div class="dummy-form-select-sublist" mock-state-value={{state}} mock-state-selector="select">
-              <Hds::Form::Select::Field
-                disabled={{if (eq variant "disabled") "disabled"}}
-                @isInvalid={{if (eq variant "invalid") true}}
-                as |F|
-              >
-                <F.Options>
-                  <option>Lorem ipsum dolor</option>
-                  <option>Sine qua non est</option>
-                </F.Options>
-              </Hds::Form::Select::Field>
+          {{! template-lint-disable simple-unless }}
+          {{#unless (and (eq variant "disabled") (eq state "focus"))}}
+            <div>
+              <span class="dummy-text-small">{{capitalize variant}} / {{capitalize state}}:</span>
+              <br />
+              <div class="dummy-form-select-sublist" mock-state-value={{state}} mock-state-selector="select">
+                <Hds::Form::Select::Field
+                  disabled={{if (eq variant "disabled") "disabled"}}
+                  @isInvalid={{if (eq variant "invalid") true}}
+                  as |F|
+                >
+                  <F.Options>
+                    <option>Lorem ipsum dolor</option>
+                    <option>Sine qua non est</option>
+                  </F.Options>
+                </Hds::Form::Select::Field>
+              </div>
             </div>
-          </div>
+          {{/unless}}
         {{/each}}
       {{/each}}
     {{/let}}

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -470,46 +470,59 @@
   </div>
   <h5 class="dummy-h6">States</h5>
   <div class="dummy-form-text-input-grid-sample">
-    {{#let (array "base" "disabled" "readonly" "invalid") as |variants|}}
+    {{#let (array "base" "invalid" "readonly" "disabled") as |variants|}}
       {{#each variants as |variant|}}
         {{#each @model.STATES as |state|}}
-          <div>
-            <span class="dummy-text-small">{{capitalize variant}} / {{capitalize state}}:</span>
-            <br />
-            <div class="dummy-form-text-input-sublist" mock-state-value={{state}} mock-state-selector="input">
-              <Hds::Form::TextInput::Base
-                disabled={{if (eq variant "disabled") "disabled"}}
-                readonly={{if (eq variant "readonly") "readonly"}}
-                @isInvalid={{if (eq variant "invalid") true}}
-              />
-              <Hds::Form::TextInput::Base
-                placeholder="Placeholder"
-                disabled={{if (eq variant "disabled") "disabled"}}
-                readonly={{if (eq variant "readonly") "readonly"}}
-                @isInvalid={{if (eq variant "invalid") true}}
-              />
-              <Hds::Form::TextInput::Base
-                @value="Lorem ipsum dolor"
-                disabled={{if (eq variant "disabled") "disabled"}}
-                readonly={{if (eq variant "readonly") "readonly"}}
-                @isInvalid={{if (eq variant "invalid") true}}
-              />
-              <Hds::Form::TextInput::Base
-                @type="date"
-                @value="Lorem ipsum dolor"
-                disabled={{if (eq variant "disabled") "disabled"}}
-                readonly={{if (eq variant "readonly") "readonly"}}
-                @isInvalid={{if (eq variant "invalid") true}}
-              />
-              <Hds::Form::TextInput::Base
-                @type="time"
-                @value="Lorem ipsum dolor"
-                disabled={{if (eq variant "disabled") "disabled"}}
-                readonly={{if (eq variant "readonly") "readonly"}}
-                @isInvalid={{if (eq variant "invalid") true}}
-              />
+          {{! template-lint-disable simple-unless }}
+          {{#unless (and (eq variant "disabled") (eq state "focus"))}}
+            <div>
+              <span class="dummy-text-small">{{capitalize variant}} / {{capitalize state}}:</span>
+              <br />
+              <div class="dummy-form-text-input-sublist" mock-state-value={{state}} mock-state-selector="input">
+                <div>
+                  <Hds::Form::TextInput::Base
+                    disabled={{if (eq variant "disabled") "disabled"}}
+                    readonly={{if (eq variant "readonly") "readonly"}}
+                    @isInvalid={{if (eq variant "invalid") true}}
+                  />
+                </div>
+                <div>
+                  <Hds::Form::TextInput::Base
+                    placeholder="Placeholder"
+                    disabled={{if (eq variant "disabled") "disabled"}}
+                    readonly={{if (eq variant "readonly") "readonly"}}
+                    @isInvalid={{if (eq variant "invalid") true}}
+                  />
+                </div>
+                <div>
+                  <Hds::Form::TextInput::Base
+                    @value="Lorem ipsum dolor"
+                    disabled={{if (eq variant "disabled") "disabled"}}
+                    readonly={{if (eq variant "readonly") "readonly"}}
+                    @isInvalid={{if (eq variant "invalid") true}}
+                  />
+                </div>
+                <div>
+                  <Hds::Form::TextInput::Base
+                    @type="date"
+                    @value="Lorem ipsum dolor"
+                    disabled={{if (eq variant "disabled") "disabled"}}
+                    readonly={{if (eq variant "readonly") "readonly"}}
+                    @isInvalid={{if (eq variant "invalid") true}}
+                  />
+                </div>
+                <div>
+                  <Hds::Form::TextInput::Base
+                    @type="time"
+                    @value="Lorem ipsum dolor"
+                    disabled={{if (eq variant "disabled") "disabled"}}
+                    readonly={{if (eq variant "readonly") "readonly"}}
+                    @isInvalid={{if (eq variant "invalid") true}}
+                  />
+                </div>
+              </div>
             </div>
-          </div>
+          {{/unless}}
         {{/each}}
       {{/each}}
     {{/let}}

--- a/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
@@ -247,32 +247,35 @@
   </div>
   <h5 class="dummy-h6">States</h5>
   <div class="dummy-form-textarea-grid-sample">
-    {{#let (array "base" "disabled" "readonly" "invalid") as |variants|}}
+    {{#let (array "base" "invalid" "readonly" "disabled") as |variants|}}
       {{#each variants as |variant|}}
         {{#each @model.STATES as |state|}}
-          <div>
-            <span class="dummy-text-small">{{capitalize variant}} / {{capitalize state}}:</span>
-            <br />
-            <div class="dummy-form-textarea-sublist" mock-state-value={{state}} mock-state-selector="textarea">
-              <Hds::Form::Textarea::Base
-                disabled={{if (eq variant "disabled") "disabled"}}
-                readonly={{if (eq variant "readonly") "readonly"}}
-                @isInvalid={{if (eq variant "invalid") true}}
-              />
-              <Hds::Form::Textarea::Base
-                placeholder="Placeholder"
-                disabled={{if (eq variant "disabled") "disabled"}}
-                readonly={{if (eq variant "readonly") "readonly"}}
-                @isInvalid={{if (eq variant "invalid") true}}
-              />
-              <Hds::Form::Textarea::Base
-                @value="Ut enim ad minim veniam, quis nostrud exercitation ullamco"
-                disabled={{if (eq variant "disabled") "disabled"}}
-                readonly={{if (eq variant "readonly") "readonly"}}
-                @isInvalid={{if (eq variant "invalid") true}}
-              />
+          {{! template-lint-disable simple-unless }}
+          {{#unless (and (eq variant "disabled") (eq state "focus"))}}
+            <div>
+              <span class="dummy-text-small">{{capitalize variant}} / {{capitalize state}}:</span>
+              <br />
+              <div class="dummy-form-textarea-sublist" mock-state-value={{state}} mock-state-selector="textarea">
+                <Hds::Form::Textarea::Base
+                  disabled={{if (eq variant "disabled") "disabled"}}
+                  readonly={{if (eq variant "readonly") "readonly"}}
+                  @isInvalid={{if (eq variant "invalid") true}}
+                />
+                <Hds::Form::Textarea::Base
+                  placeholder="Placeholder"
+                  disabled={{if (eq variant "disabled") "disabled"}}
+                  readonly={{if (eq variant "readonly") "readonly"}}
+                  @isInvalid={{if (eq variant "invalid") true}}
+                />
+                <Hds::Form::Textarea::Base
+                  @value="Ut enim ad minim veniam, quis nostrud exercitation ullamco"
+                  disabled={{if (eq variant "disabled") "disabled"}}
+                  readonly={{if (eq variant "readonly") "readonly"}}
+                  @isInvalid={{if (eq variant "invalid") true}}
+                />
+              </div>
             </div>
-          </div>
+          {{/unless}}
         {{/each}}
       {{/each}}
     {{/let}}

--- a/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
@@ -208,7 +208,7 @@
     </div>
   </div>
   <h5 class="dummy-h6">States (Base / Disabled / Invalid)</h5>
-  <div class="dummy-form-toggle-grid-sample">
+  <div class="dummy-form-toggle-states-grid">
     {{#each @model.STATES as |state|}}
       <div>
         <span class="dummy-text-small">{{capitalize state}}:</span>
@@ -216,10 +216,13 @@
         <div class="dummy-form-toggle-states-subgrid" mock-state-value={{state}} mock-state-selector="input">
           <Hds::Form::Toggle::Base aria-label="Toggle" />
           <Hds::Form::Toggle::Base checked="checked" aria-label="Checked toggle" />
-          <Hds::Form::Toggle::Base disabled="disabled" aria-label="Disabled toggle" />
-          <Hds::Form::Toggle::Base checked="checked" disabled="disabled" aria-label="Checked, disabled toggle" />
           <Hds::Form::Toggle::Base @isInvalid={{true}} aria-label="Invalid toggle" />
           <Hds::Form::Toggle::Base checked="checked" @isInvalid={{true}} aria-label="Checked, invalid toggle" />
+          {{! template-lint-disable simple-unless }}
+          {{#unless (eq state "focus")}}
+            <Hds::Form::Toggle::Base disabled="disabled" aria-label="Disabled toggle" />
+            <Hds::Form::Toggle::Base checked="checked" disabled="disabled" aria-label="Checked, disabled toggle" />
+          {{/unless}}
         </div>
       </div>
     {{/each}}
@@ -256,6 +259,7 @@
       </Hds::Form::Toggle::Field>
     </div>
   </div>
+  <br />
   <div class="dummy-form-toggle-grid-sample">
     <div>
       <span class="dummy-text-small">Label + Error</span>


### PR DESCRIPTION
### :pushpin: Summary

While reviewing the merged Figma branch with the designs for the `Text Input` I've noticed that there are no designs for the `active` state, which makes sense: for form controls, there's no such thing (essentially an input is focused, not active), so we can remove the styling and the documentation for this state.

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed the CSS styling for the `active` state of form controls
- removed the `active` state from showcase of form controls
- reorganized the showcase to improve readability of states and general layout improvements

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
