### PR TITLE
`Card::Container` component - Add extra `level` args for `hover` and `active` states

### DIFF
--- a/.changeset/thin-camels-happen.md
+++ b/.changeset/thin-camels-happen.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Added `@levelHover` and `@levelActive` arguments to `Card::Container` component

--- a/packages/components/addon/components/hds/card/container.js
+++ b/packages/components/addon/components/hds/card/container.js
@@ -5,8 +5,6 @@ export const DEFAULT_LEVEL = 'base';
 export const DEFAULT_BACKGROUND = 'neutral-primary';
 export const DEFAULT_OVERFLOW = 'hidden';
 export const LEVELS = ['base', 'mid', 'high'];
-export const HOVER_LEVELS = ['base', 'mid', 'high'];
-export const ACTIVE_LEVELS = ['base', 'mid', 'high'];
 export const BACKGROUNDS = ['neutral-primary', 'neutral-secondary'];
 export const OVERFLOWS = ['hidden', 'visible'];
 
@@ -44,10 +42,10 @@ export default class HdsCardContainerComponent extends Component {
 
     if (levelHover) {
       assert(
-        `@levelHover for "Hds::Card::Container" must be one of the following: ${HOVER_LEVELS.join(
+        `@levelHover for "Hds::Card::Container" must be one of the following: ${LEVELS.join(
           ', '
         )}, received: ${levelHover}`,
-        HOVER_LEVELS.includes(levelHover)
+        LEVELS.includes(levelHover)
       );
     }
 
@@ -66,10 +64,10 @@ export default class HdsCardContainerComponent extends Component {
 
     if (levelActive) {
       assert(
-        `@levelActive for "Hds::Card::Container" must be one of the following: ${ACTIVE_LEVELS.join(
+        `@levelActive for "Hds::Card::Container" must be one of the following: ${LEVELS.join(
           ', '
         )}, received: ${levelActive}`,
-        ACTIVE_LEVELS.includes(levelActive)
+        LEVELS.includes(levelActive)
       );
     }
 

--- a/packages/components/addon/components/hds/card/container.js
+++ b/packages/components/addon/components/hds/card/container.js
@@ -5,6 +5,8 @@ export const DEFAULT_LEVEL = 'base';
 export const DEFAULT_BACKGROUND = 'neutral-primary';
 export const DEFAULT_OVERFLOW = 'hidden';
 export const LEVELS = ['base', 'mid', 'high'];
+export const HOVER_LEVELS = ['base', 'mid', 'high'];
+export const ACTIVE_LEVELS = ['base', 'mid', 'high'];
 export const BACKGROUNDS = ['neutral-primary', 'neutral-secondary'];
 export const OVERFLOWS = ['hidden', 'visible'];
 
@@ -28,6 +30,50 @@ export default class HdsCardContainerComponent extends Component {
     );
 
     return level;
+  }
+
+  /**
+   * Sets the "elevation" level for the component on ":hover" state
+   * Accepted values: base, mid, high
+   *
+   * @param levelHover
+   * @type {string}
+   */
+  get levelHover() {
+    let { levelHover } = this.args;
+
+    if (levelHover) {
+      assert(
+        `@levelHover for "Hds::CardContainer" must be one of the following: ${HOVER_LEVELS.join(
+          ', '
+        )}, received: ${levelHover}`,
+        HOVER_LEVELS.includes(levelHover)
+      );
+    }
+
+    return levelHover;
+  }
+
+  /**
+   * Sets the "elevation" level for the component on ":active" state
+   * Accepted values: base, mid, high
+   *
+   * @param levelActive
+   * @type {string}
+   */
+  get levelActive() {
+    let { levelActive } = this.args;
+
+    if (levelActive) {
+      assert(
+        `@levelActive for "Hds::CardContainer" must be one of the following: ${ACTIVE_LEVELS.join(
+          ', '
+        )}, received: ${levelActive}`,
+        ACTIVE_LEVELS.includes(levelActive)
+      );
+    }
+
+    return levelActive;
   }
 
   /**
@@ -80,10 +126,26 @@ export default class HdsCardContainerComponent extends Component {
   get classNames() {
     let classes = ['hds-card__container'];
 
-    // add an "elevation" class helper based on the @level and @hasBorder arguments
+    // add "elevation" classes based on the @level and @hasBorder arguments
     classes.push(
-      `hds-${this.args.hasBorder ? 'surface' : 'elevation'}-${this.level}`
+      `hds-card__container--level-${
+        this.args.hasBorder ? 'surface' : 'elevation'
+      }-${this.level}`
     );
+    if (this.levelHover) {
+      classes.push(
+        `hds-card__container--hover-level-${
+          this.args.hasBorder ? 'surface' : 'elevation'
+        }-${this.levelHover}`
+      );
+    }
+    if (this.levelActive) {
+      classes.push(
+        `hds-card__container--active-level-${
+          this.args.hasBorder ? 'surface' : 'elevation'
+        }-${this.levelActive}`
+      );
+    }
 
     // add a class based on the @background argument
     classes.push(`hds-card__container--background-${this.background}`);

--- a/packages/components/addon/components/hds/card/container.js
+++ b/packages/components/addon/components/hds/card/container.js
@@ -23,7 +23,7 @@ export default class HdsCardContainerComponent extends Component {
     let { level = DEFAULT_LEVEL } = this.args;
 
     assert(
-      `@level for "Hds::CardContainer" must be one of the following: ${LEVELS.join(
+      `@level for "Hds::Card::Container" must be one of the following: ${LEVELS.join(
         ', '
       )}, received: ${level}`,
       LEVELS.includes(level)
@@ -44,7 +44,7 @@ export default class HdsCardContainerComponent extends Component {
 
     if (levelHover) {
       assert(
-        `@levelHover for "Hds::CardContainer" must be one of the following: ${HOVER_LEVELS.join(
+        `@levelHover for "Hds::Card::Container" must be one of the following: ${HOVER_LEVELS.join(
           ', '
         )}, received: ${levelHover}`,
         HOVER_LEVELS.includes(levelHover)
@@ -66,7 +66,7 @@ export default class HdsCardContainerComponent extends Component {
 
     if (levelActive) {
       assert(
-        `@levelActive for "Hds::CardContainer" must be one of the following: ${ACTIVE_LEVELS.join(
+        `@levelActive for "Hds::Card::Container" must be one of the following: ${ACTIVE_LEVELS.join(
           ', '
         )}, received: ${levelActive}`,
         ACTIVE_LEVELS.includes(levelActive)
@@ -88,7 +88,7 @@ export default class HdsCardContainerComponent extends Component {
     let { background = DEFAULT_BACKGROUND } = this.args;
 
     assert(
-      `@background for "Hds::CardContainer" must be one of the following: ${BACKGROUNDS.join(
+      `@background for "Hds::Card::Container" must be one of the following: ${BACKGROUNDS.join(
         ', '
       )}, received: ${background}`,
       BACKGROUNDS.includes(background)
@@ -109,7 +109,7 @@ export default class HdsCardContainerComponent extends Component {
     let { overflow = DEFAULT_OVERFLOW } = this.args;
 
     assert(
-      `@overflow for "Hds::CardContainer" must be one of the following: ${OVERFLOWS.join(
+      `@overflow for "Hds::Card::Container" must be one of the following: ${OVERFLOWS.join(
         ', '
       )}, received: ${overflow}`,
       OVERFLOWS.includes(overflow)

--- a/packages/components/app/styles/components/card/container.scss
+++ b/packages/components/app/styles/components/card/container.scss
@@ -6,7 +6,10 @@
 //
 
 
+$hds-card-container-style: ( 'surface', 'elevation' );
 $hds-card-container-levels: ( 'base', 'mid', 'high' );
+$hds-card-container-hover-levels: ( 'base', 'mid', 'high' );
+$hds-card-container-active-levels: ( 'base', 'mid', 'high' );
 
 $hds-card-container-border-radius: 6px;
 
@@ -16,6 +19,27 @@ $hds-card-container-border-radius: 6px;
   position: relative;
 }
 
+// LEVEL (elevation style as "drop" + "border" shadow effects)
+
+@each $style in $hds-card-container-style {
+  @each $level in $hds-card-container-levels {
+    .hds-card__container--level-#{$style}-#{$level} {
+      box-shadow: var(--token-#{$style}-#{$level}-box-shadow);
+    }
+  }
+  @each $level in $hds-card-container-hover-levels {
+    .hds-card__container--hover-level-#{$style}-#{$level}:hover,
+    .hds-card__container--hover-level-#{$style}-#{$level}.mock-hover {
+      box-shadow: var(--token-#{$style}-#{$level}-box-shadow);
+    }
+  }
+  @each $level in $hds-card-container-active-levels {
+    .hds-card__container--active-level-#{$style}-#{$level}:active,
+    .hds-card__container--active-level-#{$style}-#{$level}.mock-active {
+      box-shadow: var(--token-#{$style}-#{$level}-box-shadow);
+    }
+  }
+}
 
 // BACKGROUND
 

--- a/packages/components/app/styles/components/card/container.scss
+++ b/packages/components/app/styles/components/card/container.scss
@@ -8,8 +8,6 @@
 
 $hds-card-container-style: ( 'surface', 'elevation' );
 $hds-card-container-levels: ( 'base', 'mid', 'high' );
-$hds-card-container-hover-levels: ( 'base', 'mid', 'high' );
-$hds-card-container-active-levels: ( 'base', 'mid', 'high' );
 
 $hds-card-container-border-radius: 6px;
 
@@ -22,18 +20,21 @@ $hds-card-container-border-radius: 6px;
 // LEVEL (elevation style as "drop" + "border" shadow effects)
 
 @each $style in $hds-card-container-style {
+  // IMPORTANT: we need to keep separate loops, because we want the "hover" state
+  // to override the "rest" state, and the "active" state to override the "hover" state
+  // so the order of the declaration matters, they need to be one group after another group
   @each $level in $hds-card-container-levels {
     .hds-card__container--level-#{$style}-#{$level} {
       box-shadow: var(--token-#{$style}-#{$level}-box-shadow);
     }
   }
-  @each $level in $hds-card-container-hover-levels {
+  @each $level in $hds-card-container-levels {
     .hds-card__container--hover-level-#{$style}-#{$level}:hover,
     .hds-card__container--hover-level-#{$style}-#{$level}.mock-hover {
       box-shadow: var(--token-#{$style}-#{$level}-box-shadow);
     }
   }
-  @each $level in $hds-card-container-active-levels {
+  @each $level in $hds-card-container-levels {
     .hds-card__container--active-level-#{$style}-#{$level}:active,
     .hds-card__container--active-level-#{$style}-#{$level}.mock-active {
       box-shadow: var(--token-#{$style}-#{$level}-box-shadow);

--- a/packages/components/tests/dummy/app/routes/components/card.js
+++ b/packages/components/tests/dummy/app/routes/components/card.js
@@ -1,11 +1,20 @@
 import Route from '@ember/routing/route';
 
 import {
+  DEFAULT_LEVEL as CONTAINER_DEFAULT_LEVEL,
   LEVELS as CONTAINER_LEVELS,
+  HOVER_LEVELS as CONTAINER_HOVER_LEVELS,
+  ACTIVE_LEVELS as CONTAINER_ACTIVE_LEVELS,
   BACKGROUNDS as CONTAINER_BACKGROUNDS,
 } from '@hashicorp/design-system-components/components/hds/card/container';
 export default class ComponentsCardRoute extends Route {
   model() {
-    return { CONTAINER_LEVELS, CONTAINER_BACKGROUNDS };
+    return {
+      CONTAINER_DEFAULT_LEVEL,
+      CONTAINER_LEVELS,
+      CONTAINER_HOVER_LEVELS,
+      CONTAINER_ACTIVE_LEVELS,
+      CONTAINER_BACKGROUNDS,
+    };
   }
 }

--- a/packages/components/tests/dummy/app/routes/components/card.js
+++ b/packages/components/tests/dummy/app/routes/components/card.js
@@ -3,8 +3,6 @@ import Route from '@ember/routing/route';
 import {
   DEFAULT_LEVEL as CONTAINER_DEFAULT_LEVEL,
   LEVELS as CONTAINER_LEVELS,
-  HOVER_LEVELS as CONTAINER_HOVER_LEVELS,
-  ACTIVE_LEVELS as CONTAINER_ACTIVE_LEVELS,
   BACKGROUNDS as CONTAINER_BACKGROUNDS,
 } from '@hashicorp/design-system-components/components/hds/card/container';
 export default class ComponentsCardRoute extends Route {
@@ -12,8 +10,6 @@ export default class ComponentsCardRoute extends Route {
     return {
       CONTAINER_DEFAULT_LEVEL,
       CONTAINER_LEVELS,
-      CONTAINER_HOVER_LEVELS,
-      CONTAINER_ACTIVE_LEVELS,
       CONTAINER_BACKGROUNDS,
     };
   }

--- a/packages/components/tests/dummy/app/styles/pages/db-card.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-card.scss
@@ -1,13 +1,31 @@
 // CARD
 
+
+.dummy-card-sample-grid {
+    align-items: start;
+    background-color: #FAFAFA;
+    display: grid;
+    grid-gap: 0 2rem;
+    grid-template-columns: repeat(3, 1fr);
+    padding: 2rem;
+    width: fit-content;
+
+    .dummy-card-sample-grid__title {
+        grid-column: 1 / 4;
+        margin: 2rem 0 1rem;
+
+        &:first-child {
+            margin-top: 0;
+        }
+    }
+}
+
 .dummy-card-base-sample {
     align-items: flex-start;
     background-color: #FAFAFA;
     display: flex;
     flex-wrap: wrap;
-    gap: 2rem;
-    list-style: none;
-    margin: 0;
+    gap: 0rem 2rem;
     min-width: fit-content;
     padding: 2rem;
     width: fit-content;

--- a/packages/components/tests/dummy/app/styles/pages/db-card.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-card.scss
@@ -1,46 +1,55 @@
 // CARD
 
+.dummy-card-how-to-custom-layout {
+  .my-custom-class-to-set-the-card-layout {
+    width: 300px;
+  }
+  .my-custom-class-to-set-the-content-layout {
+    padding: 40px;
+    text-align: center;
+  }
+}
 
 .dummy-card-sample-grid {
-    align-items: start;
-    background-color: #FAFAFA;
-    display: grid;
-    grid-gap: 0 2rem;
-    grid-template-columns: repeat(3, 1fr);
-    padding: 2rem;
-    width: fit-content;
+  align-items: start;
+  background-color: #fafafa;
+  display: grid;
+  grid-gap: 0 2rem;
+  grid-template-columns: repeat(3, 1fr);
+  padding: 2rem;
+  width: fit-content;
 
-    .dummy-card-sample-grid__title {
-        grid-column: 1 / 4;
-        margin: 2rem 0 1rem;
+  .dummy-card-sample-grid__title {
+    grid-column: 1 / 4;
+    margin: 2rem 0 1rem;
 
-        &:first-child {
-            margin-top: 0;
-        }
+    &:first-child {
+      margin-top: 0;
     }
+  }
 }
 
 .dummy-card-base-sample {
-    align-items: flex-start;
-    background-color: #FAFAFA;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0rem 2rem;
-    min-width: fit-content;
-    padding: 2rem;
-    width: fit-content;
+  align-items: flex-start;
+  background-color: #fafafa;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0rem 2rem;
+  min-width: fit-content;
+  padding: 2rem;
+  width: fit-content;
 }
 
 .dummy-card-overflow__wrapper-relative {
-    position: relative;
+  position: relative;
 }
 
 .dummy-card-overflow__content-absolute {
-    background-color: #3f51b5;
-    border-radius: 8px;
-    height: 20px;
-    position: absolute;
-    right: -20px;
-    top: 20px;
-    width: 30px;
+  background-color: #3f51b5;
+  border-radius: 8px;
+  height: 20px;
+  position: absolute;
+  right: -20px;
+  top: 20px;
+  width: 30px;
 }

--- a/packages/components/tests/dummy/app/templates/components/card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/card.hbs
@@ -110,6 +110,18 @@
         <DummyPlaceholder @text={{level}} @width="200" @height="200" @background="transparent" />
       </Hds::Card::Container>
     {{/each}}
+    <p class="dummy-paragraph dummy-card-sample-grid__title">"levelHover"</p>
+    {{#each @model.CONTAINER_HOVER_LEVELS as |level|}}
+      <Hds::Card::Container @levelHover={{level}} mock-state-value="hover">
+        <DummyPlaceholder @text={{level}} @width="200" @height="100" @background="transparent" />
+      </Hds::Card::Container>
+    {{/each}}
+    <p class="dummy-paragraph dummy-card-sample-grid__title">"levelActive"</p>
+    {{#each @model.CONTAINER_ACTIVE_LEVELS as |level|}}
+      <Hds::Card::Container @levelActive={{level}} mock-state-value="active">
+        <DummyPlaceholder @text={{level}} @width="200" @height="100" @background="transparent" />
+      </Hds::Card::Container>
+    {{/each}}
   </div>
 
   <h4 class="dummy-h4">Border:</h4>
@@ -143,6 +155,23 @@
         <DummyPlaceholder @text="visible" @width="200" @height="200" @background="#e1f5fe" />
         <div class="dummy-card-overflow__content-absolute"></div>
       </div>
+    </Hds::Card::Container>
+  </div>
+
+  <h4 class="dummy-h4">Interaction:</h4>
+  <p class="dummy-paragraph">Change of state (Normal → Hover → Active)</p>
+  <div class="dummy-card-base-sample">
+    <Hds::Card::Container @level="base" @levelHover="mid" @levelActive="base">
+      <DummyPlaceholder @text="base → mid → base" @width="200" @height="200" @background="transparent" />
+    </Hds::Card::Container>
+    <Hds::Card::Container @level="mid" @levelHover="high" @levelActive="mid">
+      <DummyPlaceholder @text="mid → high → mid" @width="200" @height="200" @background="transparent" />
+    </Hds::Card::Container>
+    <Hds::Card::Container @hasBorder={{true}} @level="base" @levelHover="mid" @levelActive="base">
+      <DummyPlaceholder @text="base → mid → base" @width="200" @height="200" @background="transparent" />
+    </Hds::Card::Container>
+    <Hds::Card::Container @hasBorder={{true}} @level="mid" @levelHover="high" @levelActive="mid">
+      <DummyPlaceholder @text="mid → high → mid" @width="200" @height="200" @background="transparent" />
     </Hds::Card::Container>
   </div>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/card.hbs
@@ -44,14 +44,16 @@
       <ol>
         <li class="default">neutral-primary</li>
         <li>neutral-secondary</li>
-      </ol>      <p><em>Notice: later we may decide/need to add more colors, but for now we have found only these two use cases.</em></p>
+      </ol>
+      <p><em>Notice: later we may decide/need to add more colors, but for now we have found only these two use cases.</em></p>
     </dd>
     <dt>hasBorder <code>boolean</code></dt>
     <dd>
       <p>This controls if the card has a visual "edge", an external border (technically is an extra 1px shadow on top of
         the other drop shadows).</p>
       <p><em>Notice: the color of the border is pre-defined. If you need a custom border you have to wrap your content
-          in an element and assign the border to it (in that case, remember to inherit the border radius).</em></p>    </dd>
+          in an element and assign the border to it (in that case, remember to inherit the border radius).</em></p>
+    </dd>
     <dt>overflow <code>enum</code></dt>
     <dd>
       <p>This controls if the main wrapper (who has a border-radius applied) has overflow = visible or hidden. We expect
@@ -103,8 +105,9 @@
 
 <section data-test-percy>
   <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
-  <h4 class="dummy-h4">Level:</h4>
-  <div class="dummy-card-base-sample">
+  <h4 class="dummy-h4">Elevation:</h4>
+  <div class="dummy-card-sample-grid">
+    <p class="dummy-paragraph dummy-card-sample-grid__title">"level"</p>
     {{#each @model.CONTAINER_LEVELS as |level|}}
       <Hds::Card::Container @level={{level}}>
         <DummyPlaceholder @text={{level}} @width="200" @height="200" @background="transparent" />

--- a/packages/components/tests/dummy/app/templates/components/card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/card.hbs
@@ -10,9 +10,9 @@
     <dd>
       <p>This controls the level of elevation ("shadow" visual effect). Acceptable values:</p>
       <ol>
-        <li class="default">base</li>
-        <li>mid</li>
-        <li>high</li>
+        {{#each @model.CONTAINER_LEVELS as |level|}}
+          <li class={{if (eq level @model.CONTAINER_DEFAULT_LEVEL) "default"}}>{{level}}</li>
+        {{/each}}
       </ol>
       <p><em>Notice:
           <code class="dummy-code">low</code>
@@ -20,22 +20,38 @@
           <code class="dummy-code">higher</code>
           are not correct values for this component (by design).</em></p>
     </dd>
+    <dt>levelHover <code>enum</code></dt>
+    <dd>
+      <p>This controls the level of elevation on <code class="dummy-code">:hover</code> state. Acceptable values:</p>
+      <ol>
+        {{#each @model.CONTAINER_HOVER_LEVELS as |level|}}
+          <li>{{level}}</li>
+        {{/each}}
+      </ol>
+    </dd>
+    <dt>levelActive <code>enum</code></dt>
+    <dd>
+      <p>This controls the level of elevation on <code class="dummy-code">:active</code> state. Acceptable values:</p>
+      <ol>
+        {{#each @model.CONTAINER_ACTIVE_LEVELS as |level|}}
+          <li>{{level}}</li>
+        {{/each}}
+      </ol>
+    </dd>
     <dt>background <code>enum</code></dt>
     <dd>
       <p>This controls the background color. Acceptable values:</p>
       <ol>
         <li class="default">neutral-primary</li>
         <li>neutral-secondary</li>
-      </ol>
-      <p><em>Notice: later we may decide/need to add more colors, but for now we have found only these two use cases.</em></p>
+      </ol>      <p><em>Notice: later we may decide/need to add more colors, but for now we have found only these two use cases.</em></p>
     </dd>
     <dt>hasBorder <code>boolean</code></dt>
     <dd>
       <p>This controls if the card has a visual "edge", an external border (technically is an extra 1px shadow on top of
         the other drop shadows).</p>
       <p><em>Notice: the color of the border is pre-defined. If you need a custom border you have to wrap your content
-          in an element and assign the border to it (in that case, remember to inherit the border radius).</em></p>
-    </dd>
+          in an element and assign the border to it (in that case, remember to inherit the border radius).</em></p>    </dd>
     <dt>overflow <code>enum</code></dt>
     <dd>
       <p>This controls if the main wrapper (who has a border-radius applied) has overflow = visible or hidden. We expect

--- a/packages/components/tests/dummy/app/templates/components/card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/card.hbs
@@ -73,6 +73,8 @@
 
 <section>
   <h3 class="dummy-h3" id="how-to-use"><a href="#how-to-use" class="dummy-link-section">§</a> How to use</h3>
+
+  <h4 class="dummy-h4">Basic use</h4>
   <p class="dummy-paragraph">Invocation of the component would look something like this:</p>
   {{! prettier-ignore-start }}
   <CodeBlock
@@ -82,6 +84,96 @@
     '
   />
   {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Card::Container @level="mid" @hasBorder="true">[Your content here]</Hds::Card::Container>
+  <p class="dummy-paragraph"><em>Notice: as you can see the layout of the card itself, and its content, is left to the
+      consumer of the component. The
+      <code class="dummy-code">Hds::Card::Container</code>
+      is nothing more than a block container – a
+      <code class="dummy-code">&lt;div&gt;</code>
+      – that provides styling for the elevation, border and backgroung. Sizing of the card, internal padding, and
+      content alignment, are all left to the consumer of the component.</em>
+  </p>
+  <p class="dummy-paragraph">In this example we apply custom classes to control the layout of the card and its content:</p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <div class="my-custom-class-to-set-the-card-layout">
+        <Hds::Card::Container @level="mid" @hasBorder="true">
+          <div class="my-custom-class-to-set-the-content-layout">
+            [Your content here]
+          </div>
+        </Hds::Card::Container>
+      </div>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <div class="dummy-card-how-to-custom-layout">
+    <div class="my-custom-class-to-set-the-card-layout">
+      <Hds::Card::Container @level="mid" @hasBorder="true">
+        <div class="my-custom-class-to-set-the-content-layout">
+          [Your content here]
+        </div>
+      </Hds::Card::Container>
+    </div>
+  </div>
+  <p class="dummy-paragraph">In this case we've added an external element that wraps the card, with a custom class that
+    controls the width of the wrapper itself (but could also be a CSS
+    <code class="dummy-code">flex</code>
+    or
+    <code class="dummy-code">grid</code>
+    container, for example) and an internal element that wraps the content and applies padding around it (resulting in
+    visual internal padding for the card) and aligns the text to the center.
+  </p>
+
+  <h4 class="dummy-h4">Interactive states</h4>
+  <p class="dummy-paragraph">At the moment there are not specifications or recommended ways for how the card component
+    should behave when used for interactive elements. This is something we will work on in the future. Despite this,
+    some products have implemented designs that provide visual feeback to the user interacting with a card by changing
+    the elevation style (on
+    <code class="dummy-code">:hover</code>
+    or
+    <code class="dummy-code">:active</code>).</p>
+  <p class="dummy-paragraph">As a stopgap measure, we have introduced two specific arguments
+    <code class="dummy-code">@levelHover</code>
+    and
+    <code class="dummy-code">@levelActive</code>
+    to allow users to declare the specific "level" they want to use for each of these interactive states.
+  </p>
+  <p class="dummy-paragraph">In the following example the card transitions between these elevation
+    <em>mid → high → mid</em>
+    depending on these interation states
+    <em>rest → hover → active</em>:
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <div class="my-custom-class-to-set-the-card-layout">
+        <Hds::Card::Container @level="mid" @levelHover="high" @levelActive="mid" @hasBorder="true">
+          <div class="my-custom-class-to-set-the-content-layout">
+            [Your content here]
+          </div>
+        </Hds::Card::Container>
+      </div>
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <div class="dummy-card-how-to-custom-layout">
+    <div class="my-custom-class-to-set-the-card-layout">
+      <Hds::Card::Container @level="mid" @levelHover="high" @levelActive="mid" @hasBorder="true">
+        <div class="my-custom-class-to-set-the-content-layout">
+          [Your content here]
+        </div>
+      </Hds::Card::Container>
+    </div>
+  </div>
+  <p class="dummy-paragraph">🚨<strong>Important</strong>:
+    <em>this is just an example and not a recommendation: if you have any doubt about which level to use for the
+      different states, please speak with your product designer or with the HDS team.</em></p>
 </section>
 
 <section>
@@ -114,15 +206,15 @@
       </Hds::Card::Container>
     {{/each}}
     <p class="dummy-paragraph dummy-card-sample-grid__title">"levelHover"</p>
-    {{#each @model.CONTAINER_HOVER_LEVELS as |level|}}
+    {{#each @model.CONTAINER_LEVELS as |level|}}
       <Hds::Card::Container @levelHover={{level}} mock-state-value="hover">
-        <DummyPlaceholder @text={{level}} @width="200" @height="100" @background="transparent" />
+        <DummyPlaceholder @text={{level}} @width="200" @height="60" @background="transparent" />
       </Hds::Card::Container>
     {{/each}}
     <p class="dummy-paragraph dummy-card-sample-grid__title">"levelActive"</p>
-    {{#each @model.CONTAINER_ACTIVE_LEVELS as |level|}}
+    {{#each @model.CONTAINER_LEVELS as |level|}}
       <Hds::Card::Container @levelActive={{level}} mock-state-value="active">
-        <DummyPlaceholder @text={{level}} @width="200" @height="100" @background="transparent" />
+        <DummyPlaceholder @text={{level}} @width="200" @height="60" @background="transparent" />
       </Hds::Card::Container>
     {{/each}}
   </div>
@@ -158,23 +250,6 @@
         <DummyPlaceholder @text="visible" @width="200" @height="200" @background="#e1f5fe" />
         <div class="dummy-card-overflow__content-absolute"></div>
       </div>
-    </Hds::Card::Container>
-  </div>
-
-  <h4 class="dummy-h4">Interaction:</h4>
-  <p class="dummy-paragraph">Change of state (Normal → Hover → Active)</p>
-  <div class="dummy-card-base-sample">
-    <Hds::Card::Container @level="base" @levelHover="mid" @levelActive="base">
-      <DummyPlaceholder @text="base → mid → base" @width="200" @height="200" @background="transparent" />
-    </Hds::Card::Container>
-    <Hds::Card::Container @level="mid" @levelHover="high" @levelActive="mid">
-      <DummyPlaceholder @text="mid → high → mid" @width="200" @height="200" @background="transparent" />
-    </Hds::Card::Container>
-    <Hds::Card::Container @hasBorder={{true}} @level="base" @levelHover="mid" @levelActive="base">
-      <DummyPlaceholder @text="base → mid → base" @width="200" @height="200" @background="transparent" />
-    </Hds::Card::Container>
-    <Hds::Card::Container @hasBorder={{true}} @level="mid" @levelHover="high" @levelActive="mid">
-      <DummyPlaceholder @text="mid → high → mid" @width="200" @height="200" @background="transparent" />
     </Hds::Card::Container>
   </div>
 </section>

--- a/packages/components/tests/integration/components/hds/card/container-test.js
+++ b/packages/components/tests/integration/components/hds/card/container-test.js
@@ -1,33 +1,47 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | hds/card/container', function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Card::Container id="test-card-container" />`);
+    assert.dom('#test-card-container').exists();
+  });
   test('it should render with a CSS class that matches the component name', async function (assert) {
     await render(hbs`<Hds::Card::Container id="test-card-container" />`);
     assert.dom('#test-card-container').hasClass('hds-card__container');
   });
 
-  // LEVEL + BORDER
+  // LEVEL(S) + BORDER
 
   test('it should have the base level elevation as the default if no @level prop is declared', async function (assert) {
     await render(hbs`<Hds::Card::Container id="test-card-container" />`);
-    assert.dom('#test-card-container').hasClass('hds-elevation-base');
+    assert
+      .dom('#test-card-container')
+      .hasClass('hds-card__container--level-elevation-base');
   });
   test('it should have the correct level class based on the @level prop', async function (assert) {
     await render(
       hbs`<Hds::Card::Container id="test-card-container" @level="mid" />`
     );
-    assert.dom('#test-card-container').hasClass('hds-elevation-mid');
+    assert
+      .dom('#test-card-container')
+      .hasClass('hds-card__container--level-elevation-mid');
   });
   test('it should have a "surface" elavation the @hasBorder prop is true', async function (assert) {
     await render(
       hbs`<Hds::Card::Container id="test-card-container" @hasBorder={{true}} />`
     );
-    assert.dom('#test-card-container').hasClass('hds-surface-base');
+    assert
+      .dom('#test-card-container')
+      .hasClass('hds-card__container--level-surface-base');
   });
 
   // BACKGROUND
@@ -62,5 +76,44 @@ module('Integration | Component | hds/card/container', function (hooks) {
     assert
       .dom('#test-card-container')
       .hasClass('hds-card__container--overflow-visible');
+  });
+
+  // ASSERTIONS
+
+  test('it should throw an assertion if an incorrect value for @level is provided', async function (assert) {
+    const errorMessage =
+      '@level for "Hds::Card::Container" must be one of the following: base, mid, high, received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Card::Container @level="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+  test('it should throw an assertion if an incorrect value for @levelHover is provided', async function (assert) {
+    const errorMessage =
+      '@levelHover for "Hds::Card::Container" must be one of the following: base, mid, high, received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Card::Container @levelHover="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+  test('it should throw an assertion if an incorrect value for @levelActive is provided', async function (assert) {
+    const errorMessage =
+      '@levelActive for "Hds::Card::Container" must be one of the following: base, mid, high, received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Card::Container @levelActive="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

When we implemented the `Card::Container` component (long time ago) we didn't include the specifications for the user interaction with the card (`hover`, `active` and `focused` states) because at that time we considered it only as "container" (hence, the name).

Since then the component has been used in multiple places/products for interactive cards, requiring different visual treatment for the different interaction states. Last in time, [this request](https://hashicorp.slack.com/archives/C7KTUHNUS/p1656122163303119) by @DingoEatingFuzz. As the component is built today, the only way to achieve these states would be via JS (with `onMouseOver/Enter/Leave`), which is not great.

After discussion with the team, we have acknowledged that defining all the possible "correct" states would require a proper audit, and some work on the design side to come up with the correct specs, but at the moment we don't have capacity for this. So we agreed for an intermediate solution: adding two new arguments `@levelHover` and `@levelActive` that would allow the consumers to specify via component API the elevation "level" to use on `:hover` and `:active`, delegating to their product designers which level to use for the different states.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added `@levelHover` and `@levelActive` arguments to `Card::Container` component
- updated the “Component API” and the “Showcase” documentation for the `Card::Container`
  - small changes to the doc file due to linting
- updated the integration tests for `Card::Container`

Preview: https://hds-components-git-card-add-extra-level-args-hashicorp.vercel.app/components/card

#### Things to discuss 

@heatherlarsen while technically this solution works, I _think_ it would be better to expose not just the three levels `base/mid/high` for the default level, but all the possible elevation styles, `base/low/mid/high/higher/[overlay?]` and let the consumers decide which one to use (we provide guidance, not control). This would allow them to have more space for different states combinations, while at the moment using the `Card::Container` as is is very limited. What do you think?

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.