### PR TITLE
Remove `aria-describedby` in alert component

### DIFF
--- a/.changeset/tame-dots-study.md
+++ b/.changeset/tame-dots-study.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Remove stray aria-describedby in alert component

--- a/packages/components/addon/components/hds/alert/index.hbs
+++ b/packages/components/addon/components/hds/alert/index.hbs
@@ -1,4 +1,4 @@
-<div class={{this.classNames}} role={{this.role}} aria-live="polite" aria-describedby="content" ...attributes>
+<div class={{this.classNames}} role={{this.role}} aria-live="polite" ...attributes>
   {{#if this.icon}}
     <div class="hds-alert__icon">
       <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} @isInlineBlock={{false}} />


### PR DESCRIPTION
### :pushpin: Summary

Remove `aria-describedby="content"` in alert component

### :hammer_and_wrench: Detailed description

There is no container with `id="content"` – this was a leftover from testing various options with assistive tech in #400

### :link: External links

Raised by @jgwhite [via Slack](https://hashicorp.slack.com/archives/CPB8GS9QT/p1656503569921329) as part of a wider conversation around the need to provide a name (`title`, `aria-label` or `aria-labelledby`) for the alert component when the `role` is set to `alertdialog`.

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
