### PR TITLE
Add a link to the “components rollout” Asana board to the scrappy website

### DIFF
--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -132,6 +132,12 @@
             <FlightIcon @name="external-link" />
           </a>
         </li>
+        <li class="dummy-paragraph">
+          <a href="https://app.asana.com/0/1201682967139602/list" rel="noopener noreferrer">
+            Components Rollout (Asana)
+            <FlightIcon @name="external-link" />
+          </a>
+        </li>
       </ol>
     </div>
   </div>


### PR DESCRIPTION
### :pushpin: Summary

Micro PR to add a link to the “components rollout” Asana board to scrappy website index page.

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
