### PR TITLE
Add note in the `Dropdown` docs to highlight possible quirk in the `close` execution

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -89,6 +89,24 @@
     <dt>close <code>function</code></dt>
     <dd>
       <p>Function that can be called to programmatically close the dropdown.</p>
+      <p><em>Notice: if this function is invoked using an
+          <code class="dummy-code">&lcub;&lcub;on click&rcub;&rcub;</code>
+          modifier applied to the
+          <code class="dummy-code">ListItem::Interactive</code>
+          element, there is a quirk behaviour of the Ember
+          <code class="dummy-code">&lt;LinkTo&gt;</code>
+          component that will require some workaround to have the events executed in the right order (this happens only
+          if it has a
+          <code class="dummy-code">@route</code>
+          argument).
+          <a href="https://github.com/jgwhite" target="_blank" rel="noopener noreferrer">Jamie White</a>
+          has detailed the issue and a possible solution
+          <a
+            href="https://github.com/hashicorp/design-system/pull/399#issuecomment-1171186772"
+            target="_blank"
+            rel="noopener noreferrer"
+          >in this GitHub comment</a>.
+        </em></p>
     </dd>
     <dt>onClose <code>function</code></dt>
     <dd>


### PR DESCRIPTION
### :pushpin: Summary

@jgwhite has found a strange behaviour of the `Dropdown::ListItem::Interactive` when it's invoking the `close` method for the `Dropdown` component ([documented in this comment](https://github.com/hashicorp/design-system/pull/399#issuecomment-1171186772)). 

As [suggested in this Slack thread](https://hashicorp.slack.com/archives/C7KTUHNUS/p1656594075707879?thread_ts=1655822117.326639&cid=C7KTUHNUS), it's better to document this quirk behaviour of the `<LinkTo>` Ember component in the `Dropdown` documentation and link to @jgwhite comment, that contains a detail explanation of the problem and a suggested solution (🙌).

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a note in the `Dropdown` docs to highlight possible quirk in the `close` execution

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
