### PR TITLE
Form controls - Bring back `group` variant for `Toggle`

### DIFF
--- a/packages/components/addon/components/hds/form/toggle/group.hbs
+++ b/packages/components/addon/components/hds/form/toggle/group.hbs
@@ -1,0 +1,7 @@
+<Hds::Form::Fieldset @layout={{@layout}} ...attributes as |F|>
+  {{! Notice: the order of the elements is not relevant here, because it's controlled at "Hds::Form::Fieldset" component level }}
+  {{yield (hash Legend=F.Legend HelperText=F.HelperText Error=F.Error)}}
+  <F.Control>
+    {{yield (hash Toggle::Field=(component "hds/form/toggle/field" contextualClass="hds-form-group__control-field"))}}
+  </F.Control>
+</Hds::Form::Fieldset>

--- a/packages/components/app/components/hds/form/toggle/group.js
+++ b/packages/components/app/components/hds/form/toggle/group.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/form/toggle/group';

--- a/packages/components/app/styles/components/form/group.scss
+++ b/packages/components/app/styles/components/form/group.scss
@@ -18,7 +18,7 @@
 
 .hds-form-group__control-fields-wrapper {
   // when the group contains a "legend", we reduce the visual weight of the "label"
-  .hds-form-group__legend + & {
+  .hds-form-group__legend ~ & {
     .hds-form-label {
       font-weight: var(--token-typography-font-weight-regular);
     }

--- a/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
@@ -373,4 +373,246 @@
     </div>
   </div>
 
+  <h4 class="dummy-h4">"Group" of controls</h4>
+  <h5 class="dummy-h5">Vertical layout / Single field</h5>
+  <div class="dummy-form-toggle-grid-sample">
+    <div>
+      <span class="dummy-text-small">With legend</span>
+      <br />
+      <Hds::Form::Toggle::Group as |G|>
+        <G.Legend>Legend of the group</G.Legend>
+        <G.Toggle::Field checked="checked" as |F|>
+          <F.Label>This is the label</F.Label>
+        </G.Toggle::Field>
+      </Hds::Form::Toggle::Group>
+    </div>
+    <div>
+      <span class="dummy-text-small">With legend / With helper text</span>
+      <br />
+      <Hds::Form::Toggle::Group as |G|>
+        <G.Legend>Legend of the group</G.Legend>
+        <G.Toggle::Field checked="checked" as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+        </G.Toggle::Field>
+      </Hds::Form::Toggle::Group>
+    </div>
+    <div>
+      <span class="dummy-text-small">With helper text at group level</span>
+      <br />
+      <Hds::Form::Toggle::Group as |G|>
+        <G.Legend>Legend of the group</G.Legend>
+        <G.HelperText>Helper text for the entire group</G.HelperText>
+        <G.Toggle::Field checked="checked" as |F|>
+          <F.Label>This is the label</F.Label>
+        </G.Toggle::Field>
+      </Hds::Form::Toggle::Group>
+    </div>
+    <div>
+      <span class="dummy-text-small">With error at group level</span>
+      <br />
+      <Hds::Form::Toggle::Group as |G|>
+        <G.Legend>Legend of the group</G.Legend>
+        <G.Toggle::Field @isInvalid={{true}} checked="checked" as |F|>
+          <F.Label>This is the label</F.Label>
+        </G.Toggle::Field>
+        <G.Error>Error for the entire group</G.Error>
+      </Hds::Form::Toggle::Group>
+    </div>
+  </div>
+
+  <h5 class="dummy-h5">Vertical layout / Multiple fields</h5>
+  <div class="dummy-form-toggle-grid-sample">
+    <div>
+      <span class="dummy-text-small">With legend</span>
+      <br />
+      <Hds::Form::Toggle::Group as |G|>
+        <G.Legend>Legend of the group</G.Legend>
+        <G.Toggle::Field as |F|>
+          <F.Label>Label of control #1</F.Label>
+        </G.Toggle::Field>
+        <G.Toggle::Field checked="checked" as |F|>
+          <F.Label>Label of control #2</F.Label>
+        </G.Toggle::Field>
+        <G.Toggle::Field as |F|>
+          <F.Label>Label of control #3</F.Label>
+        </G.Toggle::Field>
+      </Hds::Form::Toggle::Group>
+    </div>
+    <div>
+      <span class="dummy-text-small">With legend / With helper text</span>
+      <br />
+      <Hds::Form::Toggle::Group as |G|>
+        <G.Legend>Legend of the group</G.Legend>
+        <G.Toggle::Field as |F|>
+          <F.Label>Label of control #1</F.Label>
+          <F.HelperText>Helper text for control #1</F.HelperText>
+        </G.Toggle::Field>
+        <G.Toggle::Field checked="checked" as |F|>
+          <F.Label>Label of control #2</F.Label>
+          <F.HelperText>Helper text for control #2</F.HelperText>
+        </G.Toggle::Field>
+        <G.Toggle::Field as |F|>
+          <F.Label>Label of control #3</F.Label>
+          <F.HelperText>Helper text for control #3</F.HelperText>
+        </G.Toggle::Field>
+      </Hds::Form::Toggle::Group>
+    </div>
+    <div>
+      <span class="dummy-text-small">Without legend</span>
+      <br />
+      <Hds::Form::Toggle::Group as |G|>
+        <G.Toggle::Field as |F|>
+          <F.Label>Label of control #1</F.Label>
+        </G.Toggle::Field>
+        <G.Toggle::Field checked="checked" as |F|>
+          <F.Label>Label of control #2</F.Label>
+        </G.Toggle::Field>
+        <G.Toggle::Field as |F|>
+          <F.Label>Label of control #3</F.Label>
+        </G.Toggle::Field>
+      </Hds::Form::Toggle::Group>
+    </div>
+    <div>
+      <span class="dummy-text-small">Without Legend / With helper text</span>
+      <br />
+      <Hds::Form::Toggle::Group as |G|>
+        <G.Toggle::Field as |F|>
+          <F.Label>Label of control #1</F.Label>
+          <F.HelperText>Helper text for control #1</F.HelperText>
+        </G.Toggle::Field>
+        <G.Toggle::Field checked="checked" as |F|>
+          <F.Label>Label of control #2</F.Label>
+          <F.HelperText>Helper text for control #2</F.HelperText>
+        </G.Toggle::Field>
+        <G.Toggle::Field as |F|>
+          <F.Label>Label of control #3</F.Label>
+          <F.HelperText>Helper text for control #3</F.HelperText>
+        </G.Toggle::Field>
+      </Hds::Form::Toggle::Group>
+    </div>
+    <div>
+      <span class="dummy-text-small">With helper text at group level</span>
+      <br />
+      <Hds::Form::Toggle::Group as |G|>
+        <G.Legend>Legend of the group</G.Legend>
+        <G.HelperText>Helper text for the entire group</G.HelperText>
+        <G.Toggle::Field as |F|>
+          <F.Label>Label of control #1</F.Label>
+        </G.Toggle::Field>
+        <G.Toggle::Field checked="checked" as |F|>
+          <F.Label>Label of control #2</F.Label>
+        </G.Toggle::Field>
+        <G.Toggle::Field as |F|>
+          <F.Label>Label of control #3</F.Label>
+        </G.Toggle::Field>
+      </Hds::Form::Toggle::Group>
+    </div>
+    <div>
+      <span class="dummy-text-small">With error at group level</span>
+      <br />
+      <Hds::Form::Toggle::Group as |G|>
+        <G.Legend>Legend of the group</G.Legend>
+        <G.Toggle::Field @isInvalid={{true}} as |F|>
+          <F.Label>Label of control #1</F.Label>
+        </G.Toggle::Field>
+        <G.Toggle::Field checked="checked" @isInvalid={{true}} as |F|>
+          <F.Label>Label of control #2</F.Label>
+        </G.Toggle::Field>
+        <G.Toggle::Field @isInvalid={{true}} as |F|>
+          <F.Label>Label of control #3</F.Label>
+        </G.Toggle::Field>
+        <G.Error>Error for the entire group</G.Error>
+      </Hds::Form::Toggle::Group>
+    </div>
+  </div>
+
+  <h5 class="dummy-h5">Horizontal layout</h5>
+  <span class="dummy-text-small">With legend</span>
+  <br />
+  <Hds::Form::Toggle::Group @layout="horizontal" as |G|>
+    <G.Legend>Legend of the group</G.Legend>
+    <G.Toggle::Field as |F|>
+      <F.Label>Label of control #1</F.Label>
+    </G.Toggle::Field>
+    <G.Toggle::Field checked="checked" as |F|>
+      <F.Label>Label of control #2</F.Label>
+    </G.Toggle::Field>
+    <G.Toggle::Field as |F|>
+      <F.Label>Label of control #3</F.Label>
+    </G.Toggle::Field>
+  </Hds::Form::Toggle::Group>
+  <br />
+  <span class="dummy-text-small">Without legend</span>
+  <br />
+  <Hds::Form::Toggle::Group @layout="horizontal" as |G|>
+    <G.Toggle::Field as |F|>
+      <F.Label>Label of control #1</F.Label>
+    </G.Toggle::Field>
+    <G.Toggle::Field checked="checked" as |F|>
+      <F.Label>Label of control #2</F.Label>
+    </G.Toggle::Field>
+    <G.Toggle::Field as |F|>
+      <F.Label>Label of control #3</F.Label>
+    </G.Toggle::Field>
+  </Hds::Form::Toggle::Group>
+  <br />
+  <span class="dummy-text-small">With helper text at group level</span>
+  <br />
+  <Hds::Form::Toggle::Group @layout="horizontal" as |G|>
+    <G.Legend>Legend of the group</G.Legend>
+    <G.HelperText>Helper text for the entire group</G.HelperText>
+    <G.Toggle::Field as |F|>
+      <F.Label>Label of control #1</F.Label>
+    </G.Toggle::Field>
+    <G.Toggle::Field checked="checked" as |F|>
+      <F.Label>Label of control #2</F.Label>
+    </G.Toggle::Field>
+    <G.Toggle::Field as |F|>
+      <F.Label>Label of control #3</F.Label>
+    </G.Toggle::Field>
+  </Hds::Form::Toggle::Group>
+  <br />
+  <span class="dummy-text-small">With error at group level</span>
+  <br />
+  <Hds::Form::Toggle::Group @layout="horizontal" as |G|>
+    <G.Legend>Legend of the group</G.Legend>
+    <G.Toggle::Field @isInvalid={{true}} as |F|>
+      <F.Label>Label of control #1</F.Label>
+    </G.Toggle::Field>
+    <G.Toggle::Field checked="checked" @isInvalid={{true}} as |F|>
+      <F.Label>Label of control #2</F.Label>
+    </G.Toggle::Field>
+    <G.Toggle::Field @isInvalid={{true}} as |F|>
+      <F.Label>Label of control #3</F.Label>
+    </G.Toggle::Field>
+    <G.Error>Error for the entire group</G.Error>
+  </Hds::Form::Toggle::Group>
+  <br />
+  <span class="dummy-text-small">With controls on multiple lines</span>
+  <br />
+  <div class="dummy-form-checkbox-max-width-container">
+    <Hds::Form::Toggle::Group @layout="horizontal" as |G|>
+      <G.Legend>Lorem ipsum dolor</G.Legend>
+      <G.Toggle::Field as |F|>
+        <F.Label>Sit amet</F.Label>
+      </G.Toggle::Field>
+      <G.Toggle::Field checked="checked" as |F|>
+        <F.Label>Consectetur adipiscing</F.Label>
+      </G.Toggle::Field>
+      <G.Toggle::Field as |F|>
+        <F.Label>Elit</F.Label>
+      </G.Toggle::Field>
+      <G.Toggle::Field as |F|>
+        <F.Label>Pellentesque erat</F.Label>
+      </G.Toggle::Field>
+      <G.Toggle::Field as |F|>
+        <F.Label>Lacinia</F.Label>
+      </G.Toggle::Field>
+      <G.Toggle::Field checked="checked" as |F|>
+        <F.Label>At magna</F.Label>
+      </G.Toggle::Field>
+    </Hds::Form::Toggle::Group>
+  </div>
+
 </section>

--- a/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
@@ -162,6 +162,87 @@
           element is automatically generated.</em></p>
     </dd>
   </dl>
+  <h4 class="dummy-h4">Form::Toggle::Group</h4>
+  <p class="dummy-paragraph" id="component-api-form-toggle-group">Here is the API for the "group" component:</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-toggle-group">
+    <dt>layout <code>enum</code></dt>
+    <dd>
+      <p>
+        Sets the layout of group.
+      </p>
+
+      <p>Acceptable values:</p>
+      <ol>
+        <li class="default">vertical</li>
+        <li>horizontal</li>
+      </ol>
+    </dd>
+  </dl>
+  <h5 class="dummy-h5">Contextual components</h5>
+  <p class="dummy-paragraph" id="component-api-form-toggle-group-contextual-components">Legend, group of fields and
+    error content are passed to the group as yielded components, using the
+    <code class="dummy-code">Legend</code>,
+    <code class="dummy-code">Toggle::Field</code>,
+    <code class="dummy-code">Error</code>
+    keys.</p>
+  <p class="dummy-paragraph"><em>Notice: the group of elements is automatically wrapped in a
+      <code class="dummy-code">&lt;fieldset&gt;</code>
+      element.</em></p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-form-toggle-group-contextual-components">
+    <dt>&lt;[G].Legend&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is an (optional) container that yields its content inside the
+        <code class="dummy-code">&lt;legend&gt;</code>
+        element.</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <p>For details about its API check the
+        <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Legend</code></LinkTo>
+        component.</p>
+    </dd>
+    <dt>&lt;[G].HelperText&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the "helper text" block (at group level).</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <p>For details about its API check the
+        <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::HelperText</code></LinkTo>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">id</code>
+          attribute of the element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[G].Toggle::Field&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is used to yield one or more fields inside the group.</p>
+      <p>For details about its API check the
+        <code class="dummy-code">Toggle::Field</code>
+        component above.</p>
+    </dd>
+    <dt>&lt;[G].Error&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the "error" block (at group level).</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+      <dl class="dummy-component-props">
+        <dt>[E].Message <code>yielded component</code></dt>
+        <dd>
+          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+            individual items using
+            <code class="dummy-code">Error.Message</code>.
+          </p>
+        </dd>
+      </dl>
+      <p>For details about its API check the
+        <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
+        component.</p>
+      <p><em>Notice: the
+          <code class="dummy-code">id</code>
+          attribute of the
+          <code class="dummy-code">Error</code>
+          element is automatically generated.</em></p>
+    </dd>
+  </dl>
 </section>
 
 <section>

--- a/packages/components/tests/integration/components/hds/form/toggle/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/group-test.js
@@ -1,0 +1,80 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, resetOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/form/toggle/group', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`<Hds::Form::Toggle::Group id="test-form-toggle" />`);
+    assert.dom('#test-form-toggle').exists();
+  });
+
+  // YIELDED (CONTEXTUAL) COMPONENTS
+
+  test('it renders the yielded contextual components and subcomponents', async function (assert) {
+    assert.expect(12);
+    await render(
+      hbs`<Hds::Form::Toggle::Group as |G|>
+            <G.Legend>This is the legend</G.Legend>
+            <G.HelperText>This is the group helper text</G.HelperText>
+            <G.Toggle::Field checked="checked" @value="abc123" as |F|>
+              <F.Label>This is the control label</F.Label>
+              <F.HelperText>This is the control helper text</F.HelperText>
+              <F.Error>This is the control error</F.Error>
+            </G.Toggle::Field>
+            <G.Error>This is the group error</G.Error>
+        </Hds::Form::Toggle::Group>`
+    );
+    assert.dom('.hds-form-group__legend').exists();
+    assert.dom('.hds-form-group__legend').hasText('This is the legend');
+    assert.dom('.hds-form-group__helper-text').exists();
+    assert
+      .dom('.hds-form-group__helper-text')
+      .hasText('This is the group helper text');
+    assert
+      .dom('.hds-form-group__control-fields-wrapper .hds-form-field__label')
+      .exists();
+    assert
+      .dom(
+        '.hds-form-group__control-fields-wrapper .hds-form-field__helper-text'
+      )
+      .exists();
+    assert
+      .dom('.hds-form-group__control-fields-wrapper .hds-form-field__control')
+      .exists();
+    assert.dom('.hds-form-group__control-fields-wrapper input').isChecked();
+    assert
+      .dom('.hds-form-group__control-fields-wrapper input')
+      .hasValue('abc123');
+    assert
+      .dom('.hds-form-group__control-fields-wrapper .hds-form-field__error')
+      .exists();
+    assert.dom('.hds-form-group__error').exists();
+    assert.dom('.hds-form-group__error').hasText('This is the group error');
+  });
+  test('it does not render the yielded contextual components if not provided', async function (assert) {
+    assert.expect(3);
+    await render(hbs`<Hds::Form::Toggle::Group />`);
+    assert.dom('.hds-form-group__legend').doesNotExist();
+    assert.dom('.hds-form-group__helper-text').doesNotExist();
+    assert.dom('.hds-form-group__error').doesNotExist();
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the element', async function (assert) {
+    assert.expect(3);
+    await render(
+      hbs`<Hds::Form::Toggle::Group id="test-form-toggle" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-form-toggle').hasClass('my-class');
+    assert.dom('#test-form-toggle').hasAttribute('data-test1');
+    assert.dom('#test-form-toggle').hasAttribute('data-test2', 'test');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

After the initial implementation, we decided to remove the group variant for the Toggle component from the code implementation as well as the documentation.

Now, looking at the use cases described in the Figma file for this component, we have found that actually is used in the form of a “single item group” to emulate a label and a control with a secondary label.

[See Slack thread here for details](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1656583124340899).

### :hammer_and_wrench: Detailed description

In this PR I have:
- added back the `Toggle::Group` component
- added back the “Component API” and "Showcase" documentation for `Toggle::Group`
- added back the integration tests for `Toggle::Group`
- fixed a CSS declaration to include more use cases (Legend + Helper + Control, so Legend and Control are just siblings, not directly one after the other)

Preview: https://hds-components-git-form-controls-toggle-group-hashicorp.vercel.app/components/form/toggle

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
