### PR TITLE
Badge component - Add font weight declaration

### DIFF
--- a/.changeset/mean-weeks-guess.md
+++ b/.changeset/mean-weeks-guess.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Updated font-weight to "medium" for "Badge" and "BadgeCount" components

--- a/packages/components/app/styles/components/badge-count.scss
+++ b/packages/components/app/styles/components/badge-count.scss
@@ -17,6 +17,7 @@ $hds-badge-count-border-width: 1px;
   border: $hds-badge-count-border-width solid transparent;
   display: inline-flex;
   font-family: var(--token-typography-font-stack-text);
+  font-weight: var(--token-typography-font-weight-medium);
   max-width: 100%;
 }
 

--- a/packages/components/app/styles/components/badge.scss
+++ b/packages/components/app/styles/components/badge.scss
@@ -29,6 +29,7 @@
 .hds-badge__text {
   flex: 1 0 0;
   font-family: var(--token-typography-font-stack-text);
+  font-weight: var(--token-typography-font-weight-medium);
 }
 
 


### PR DESCRIPTION
### :pushpin: Summary

Following this comment by @heatherlarsen https://github.com/hashicorp/design-system/pull/425#discussion_r914230335 I've realized we never explicitly set the `font-weight` property for the text in the `Badge` component. This has two problems: 1) it inherits from the container, as Heather noticed, and 2) it was using the wrong weight, it should be "medium".

### :hammer_and_wrench: Detailed description

In this PR I have:
- added font-weight “medium” to the text in the `Badge` component

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
