### PR TITLE
Updates to showcase section for accessibility

### DIFF
--- a/packages/components/blueprints/hds-component-test/files/tests/dummy/app/templates/components/__name__.hbs
+++ b/packages/components/blueprints/hds-component-test/files/tests/dummy/app/templates/components/__name__.hbs
@@ -54,12 +54,11 @@
 
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   {{! ADD YOUR CONTENT HERE }}
 
   {{! This below is just an example of invocation, to get started }}
   <Hds::<%= columnizedModuleName %>>This is the Hds::<%= columnizedModuleName %> component </Hds::<%= columnizedModuleName %>>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/components/dummy-section/showcase.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-section/showcase.hbs
@@ -1,0 +1,11 @@
+<section data-test-percy aria-hidden="true">
+  <h3 class="dummy-h3" id={{or @id "showcase"}}><a href="#{{or @id 'showcase'}}" class="dummy-link-section">§</a>
+    {{or @title "Showcase"}}</h3>
+  <div class="dummy-banner dummy-banner--info" data-test-section-showcase-not-accessible>
+    <p class="dummy-paragraph"><strong>Notice</strong>: if you inspect the source code for this section, you may see
+      that some of the following examples are not necesssarily full compliant from an accessibility perspective. That's
+      because they're meant to be visual-only examples. If you have any doubt or question about it, please contact the
+      HDS team.</p>
+  </div>
+  {{yield}}
+</section>

--- a/packages/components/tests/dummy/app/components/dummy-section/showcase.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-section/showcase.hbs
@@ -3,7 +3,7 @@
     {{or @title "Showcase"}}</h3>
   <div class="dummy-banner dummy-banner--info" data-test-section-showcase-not-accessible>
     <p class="dummy-paragraph"><strong>Notice</strong>: if you inspect the source code for this section, you may see
-      that some of the following examples are not necesssarily full compliant from an accessibility perspective. That's
+      that some of the following examples are not necessarily fully compliant from an accessibility perspective. That's
       because they're meant to be visual-only examples. If you have any doubt or question about it, please contact the
       HDS team.</p>
   </div>

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -171,7 +171,8 @@ body.dummy-app {
   header,
   aside,
   footer,
-  main section:not([data-test-percy]) {
+  main section:not([data-test-percy]),
+  section[data-test-percy] [data-test-section-showcase-not-accessible] {
     display: none !important;
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -684,8 +684,7 @@
   </ul>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <p class="dummy-paragraph">👀 Note: the compact alert is borderless, but shown with a dotted border throughout the
     "Showcase" for clarity.</p>
@@ -844,4 +843,4 @@
     </Hds::Alert>
   </div>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/badge.hbs
+++ b/packages/components/tests/dummy/app/templates/components/badge.hbs
@@ -228,8 +228,7 @@
   </p>
 </section>
 
-<DummySection::Showcase
- @id="bc-showcase">
+<DummySection::Showcase @id="bc-showcase">
 
   <h4 class="dummy-h4">Content</h4>
   <div class="dummy-badge-base-sample">

--- a/packages/components/tests/dummy/app/templates/components/badge.hbs
+++ b/packages/components/tests/dummy/app/templates/components/badge.hbs
@@ -86,8 +86,7 @@
   </div>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase @id="showcase">
   <h4 class="dummy-h4">Content</h4>
   <div class="dummy-badge-base-sample">
     <Hds::Badge @text="Only text" />
@@ -160,7 +159,7 @@
       {{/each}}
     </div>
   {{/each}}
-</section>
+</DummySection::Showcase>
 
 {{! ###################### }}
 
@@ -229,8 +228,8 @@
   </p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="bc-showcase"><a href="#bc-showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase
+ @id="bc-showcase">
 
   <h4 class="dummy-h4">Content</h4>
   <div class="dummy-badge-base-sample">
@@ -272,4 +271,4 @@
       {{/each}}
     </div>
   {{/each}}
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
+++ b/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
@@ -240,8 +240,7 @@
     </li>
   </ul>
 </section>
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">Variants</h4>
 
@@ -398,4 +397,4 @@
     </Hds::Breadcrumb>
   </div>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -543,8 +543,7 @@
   </ul>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
   <h4 class="dummy-h4">Generated element</h4>
   <div class="dummy-button-generated-list">
     <div>
@@ -670,4 +669,4 @@
       </div>
     </div>
   </div>
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/card.hbs
@@ -195,8 +195,7 @@
     though, this is a very unlikely situation).</p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
   <h4 class="dummy-h4">Elevation:</h4>
   <div class="dummy-card-sample-grid">
     <p class="dummy-paragraph dummy-card-sample-grid__title">"level"</p>
@@ -252,4 +251,4 @@
       </div>
     </Hds::Card::Container>
   </div>
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -920,8 +920,7 @@
   </ul>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">Toggles</h4>
   <h5 class="dummy-h5">Toggle::Button</h5>
@@ -1204,4 +1203,4 @@
     </ul>
     {{! template-lint-enable no-inline-styles }}
   </div>
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -898,8 +898,7 @@
   </ul>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">Label</h4>
   <span class="dummy-text-small">With simple text</span>
@@ -1403,4 +1402,4 @@
     {{/let}}
   </div>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
@@ -277,8 +277,7 @@
   <p class="dummy-paragraph">🚧 TODO 🚧</p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">"Base" control</h4>
   <h5 class="dummy-h6">Interaction status</h5>
@@ -574,4 +573,4 @@
     </Hds::Form::Checkbox::Group>
   </div>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/form/radio.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio.hbs
@@ -277,8 +277,7 @@
   <p class="dummy-paragraph">🚧 TODO 🚧</p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">"Base" control</h4>
   <h5 class="dummy-h6">Interaction status</h5>
@@ -578,4 +577,4 @@
     </Hds::Form::Radio::Group>
   </div>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -245,8 +245,7 @@
   <p class="dummy-paragraph">🚧 TODO 🚧</p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">"Base" control</h4>
   <h5 class="dummy-h6">Interaction status</h5>
@@ -433,4 +432,4 @@
     {{/let}}
   </div>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -436,9 +436,7 @@
   </ul>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
-
+<DummySection::Showcase>
   <h4 class="dummy-h4">"Base" control</h4>
   <h5 class="dummy-h6">Interaction status</h5>
   <div class="dummy-form-text-input-base-sample">
@@ -644,5 +642,4 @@
       {{/each}}
     {{/let}}
   </div>
-
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
@@ -223,8 +223,7 @@
   <p class="dummy-paragraph">🚧 TODO 🚧</p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">"Base" control</h4>
   <h5 class="dummy-h6">Interaction status</h5>
@@ -403,4 +402,4 @@
     {{/let}}
   </div>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
@@ -271,8 +271,7 @@
   <p class="dummy-paragraph">🚧 TODO 🚧</p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">"Base" control</h4>
   <h5 class="dummy-h6">Interaction status</h5>
@@ -615,4 +614,4 @@
     </Hds::Form::Toggle::Group>
   </div>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/icon-tile.hbs
+++ b/packages/components/tests/dummy/app/templates/components/icon-tile.hbs
@@ -109,8 +109,7 @@
   </p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
   <h4 class="dummy-h4">Size</h4>
   <ul class="dummy-icon-tile-side-by-side">
     <li>
@@ -171,4 +170,4 @@
       </div>
     </li>
   </ul>
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/link/inline.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/inline.hbs
@@ -335,8 +335,7 @@
   <pre>TODO</pre>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">Generated element</h4>
 
@@ -465,4 +464,4 @@
       {{/each}}
     {{/each}}
   </div>
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
@@ -353,8 +353,7 @@
   </div>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">Generated element</h4>
 
@@ -430,4 +429,4 @@
       {{/each}}
     {{/each}}
   </div>
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/components/toast.hbs
+++ b/packages/components/tests/dummy/app/templates/components/toast.hbs
@@ -465,8 +465,7 @@
   </ul>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">Color</h4>
   <div class="dummy-toast-base-sample">
@@ -568,4 +567,4 @@
       <T.Link::Standalone @icon="plus" @text="Standalone" @href="#" @color="secondary" />
     </Hds::Toast>
   </div>
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/foundations/colors.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations/colors.hbs
@@ -63,9 +63,7 @@
     you have to override it.</p>
 </section>
 
-<section data-test-percy>
-
-  <h3 class="dummy-h3" id="colors-semantic"><a href="#colors-semantic" class="dummy-link-section">§</a> Semantic</h3>
+<DummySection::Showcase @id="colors-semantic">
 
   <h4 class="dummy-h4">Foreground</h4>
   <p class="dummy-paragraph">Use for text and icons.</p>
@@ -146,4 +144,4 @@
   {{else}}
     <p class="dummy-paragraph">No tokens found for "palette" colors 🤷‍♀️</p>
   {{/each-in}}
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/foundations/elevation.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations/elevation.hbs
@@ -85,8 +85,7 @@
   </div>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
   <h4 class="dummy-h4">Elevation:</h4>
   <p class="dummy-paragraph">Standalone shadow effects</p>
   <div class="dummy-elevation-sample">
@@ -105,4 +104,4 @@
       </div>
     {{/each}}
   </div>
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/foundations/focus-ring.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations/focus-ring.hbs
@@ -108,8 +108,7 @@
 
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
   <h4 class="dummy-h4">Focus ring:</h4>
   <p class="dummy-paragraph">Standalone "focus ring" effect</p>
   <div class="dummy-focus-ring-samples">
@@ -136,4 +135,4 @@
       </div>
     </div>
   </div>
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/foundations/typography.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations/typography.hbs
@@ -112,8 +112,7 @@
     >Please refer to this document for more details</a>.</p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">Families</h4>
   {{#each this.families as |family|}}
@@ -148,4 +147,4 @@
     {{/each-in}}
   </div>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
@@ -105,8 +105,7 @@
     block).</p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">Variants</h4>
 
@@ -198,4 +197,4 @@
     </Hds::Disclosure>
   </div>
 
-</section>
+</DummySection::Showcase>

--- a/packages/components/tests/dummy/app/templates/utilities/interactive.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities/interactive.hbs
@@ -208,8 +208,7 @@
       >LinkTo component API specs</a>.</em></p>
 </section>
 
-<section data-test-percy>
-  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+<DummySection::Showcase>
 
   <h4 class="dummy-h4">Generated elements</h4>
 
@@ -252,4 +251,4 @@
     <pre>⚠️ We can't render this component in this application (it will work only on Ember engines).</pre>
   </div>
 
-</section>
+</DummySection::Showcase>


### PR DESCRIPTION
### :pushpin: Summary

In a follow-up meeting with @MelSumner re. this discussion https://github.com/hashicorp/design-system/pull/385#discussion_r902610004 we agreed that a good reasonable pragmatic compromise 🙂 would be the following:
- clearly indicate under every "showcase" that the examples under that section are not to be used as a reference from the accessibility, because they're meant to be visual-only examples
-  add a `aria-hidden="true"` so @MelSumner doesn't get impacted when testing the page for accessibility issues
- to avoid making these changes to for every page, introduce a "section" dummy component that can be used for all the showcase sections, to centralize these choices in a single place (in case we need to change/update things in the future)

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a `DummySection::Accessibility` component, containing the banner message about the “showcase” section potentially not being accessible/conformant
- updated CSS to hide from Percy the newly added “banner” to the “showcase” section, so all the existing tests remain intact
- replaced standard showcase `<sections>` with new `<DummySection::Showcase>` component

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
