### PR TITLE
Restore the `[disabled]` CSS selector for the `Button` component

### DIFF
--- a/.changeset/short-carrots-remain.md
+++ b/.changeset/short-carrots-remain.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fixed issue with "disabled" visual state for "Hds::Button" when is a link

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -32,11 +32,19 @@ $hds-button-focus-border-width: 3px;
   }
 
   // This covers all of the browsers and focus scenarios (due to the custom focus design).
+  //
+  // IMPORTANT: we need to use also the [disabled] selector because if the "disabled" attribute is applied to a "Button as link",
+  // the ":disabled" pseudo-selector is not applied to the element in the browser (rightly) because a link can't be disabled
+  // but from the product perspective there may be use cases where they need to have a "Button as link" that looks disabled anyway
+  //
   &:disabled,
+  &[disabled],
   &.mock-disabled,
   &:disabled:focus,
+  &[disabled]:focus,
   &.mock-disabled:focus,
   &:disabled:hover,
+  &[disabled]:hover,
   &.mock-disabled:hover {
     background-color: var(--token-color-surface-faint);
     border-color: var(--token-color-border-primary);
@@ -254,11 +262,19 @@ $size-props: (
     }
   }
 
+  //
+  // IMPORTANT: we need to use also the [disabled] selector because if the "disabled" attribute is applied to a "Button as link",
+  // the ":disabled" pseudo-selector is not applied to the element in the browser (rightly) because a link can't be disabled
+  // but from the product perspective there may be use cases where they need to have a "Button as link" that looks disabled anyway
+  //
   &:disabled,
+  &[disabled],
   &.mock-disabled,
   &:disabled:focus,
+  &[disabled]:focus,
   &.mock-disabled:focus,
   &:disabled:hover,
+  &[disabled]:hover,
   &.mock-disabled:hover {
     background-color: transparent;
     border-color: transparent;

--- a/packages/components/tests/dummy/app/styles/pages/db-button.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-button.scss
@@ -22,6 +22,10 @@
     display: flex;
     flex-wrap: wrap;
     gap: 1rem;
+
+    .hds-button + .hds-button {
+        margin-top: 8px;
+    }
 }
 
 .dummy-button-states-grid {

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -551,6 +551,7 @@
       <span class="dummy-text-small">default ⇒ <code class="dummy-code">&lt;button&gt;</code></span>
       <br />
       <Hds::Button @icon="plus" @text="Lorem ipsum dolor" @color="primary" />
+      <Hds::Button @icon="plus" @text="Lorem ipsum dolor" @color="primary" disabled />
     </div>
     <div>
       <span class="dummy-text-small">with
@@ -559,6 +560,7 @@
         <code class="dummy-code">&lt;a&gt;</code></span>
       <br />
       <Hds::Button @icon="plus" @text="Lorem ipsum dolor" @color="primary" @href="#" />
+      <Hds::Button @icon="plus" @text="Lorem ipsum dolor" @color="primary" @href="#" disabled />
     </div>
     <div>
       <span class="dummy-text-small">with
@@ -569,6 +571,7 @@
         <code class="dummy-code">&lt;a&gt;</code></span>
       <br />
       <Hds::Button @icon="plus" @text="Lorem ipsum dolor" @color="primary" @route="index" />
+      <Hds::Button @icon="plus" @text="Lorem ipsum dolor" @color="primary" @route="index" disabled />
     </div>
   </div>
 


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of this Slack message by @natmegs : https://hashicorp.slack.com/archives/C7KTUHNUS/p1657120562403179?thread_ts=1657067106.675829&cid=C7KTUHNUS

In 55dc2c917a602a3989fe7612a051a24c7c61809c I've (mistakenly) removed the `[disabled]` selector from the `Hds::Button` component, while removing a similar selector for some form controls, because I was relying on the `:disabled` pseudo selector.

In reality, when a button is a link (a `@route` or `@href` argument is passed to it), and the `disabled` attribute is applied to it, the browser doesn't apply the `:disabled` CSS selector to it (rightly, because a link can't be disabled).

But from the product perspective there may be use cases where they need to have a "Button as link" that looks disabled anyway, so we have to bring back the previous extra CSS selectors (and add a comment to this doesn't happen anymore).

### :hammer_and_wrench: Detailed description

In this PR I have:
- restored the `[disabled]` CSS selector for the `Button` component, needed for when the element is a link
- updated the documentation so we don’t miss this case in the future (also in Percy)

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
