### PR TITLE
Set default number of rows on textarea component

### DIFF
--- a/packages/components/addon/components/hds/form/textarea/base.hbs
+++ b/packages/components/addon/components/hds/form/textarea/base.hbs
@@ -1,2 +1,2 @@
 {{! Notice: this is not the native HTML <textarea> but the Ember component <Textarea> }}
-<Textarea class={{this.classNames}} {{style width=@width}} ...attributes @value={{@value}} />
+<Textarea class={{this.classNames}} {{style width=@width}} rows="4" ...attributes @value={{@value}} />

--- a/packages/components/tests/integration/components/hds/form/textarea/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/base-test.js
@@ -24,6 +24,17 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
     assert.dom('#test-form-textarea').hasValue('abc123');
   });
 
+  // ROWS
+
+  test('it should render the textarea with the default number of rows', async function (assert) {
+    await render(hbs`<Hds::Form::Textarea::Base />`);
+    assert.dom('textarea').hasAttribute('rows', '4');
+  });
+  test('it should render the textarea with a custom number of rows', async function (assert) {
+    await render(hbs`<Hds::Form::Textarea::Base rows="2" />`);
+    assert.dom('textarea').hasAttribute('rows', '2');
+  });
+
   // INVALID
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

Set default number of rows on textarea component

### :hammer_and_wrench: Detailed description

As requested by design, the default value for `rows` on textarea would be 4 – have updated `Form::Textarea::Base` and `Form::Textarea::Field`.

### :link: External links

[Jira issue](https://hashicorp.atlassian.net/browse/HDS-246?focusedCommentId=83720)

***
