### PR TITLE
Add Tag component

### DIFF
--- a/.changeset/silver-peaches-stare.md
+++ b/.changeset/silver-peaches-stare.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Add tag component

--- a/packages/components/addon/components/hds/tag/index.hbs
+++ b/packages/components/addon/components/hds/tag/index.hbs
@@ -1,7 +1,7 @@
 <span class="hds-tag" ...attributes>
   {{#if this.onDismiss}}
     <button class="hds-tag__dismiss" type="button" aria-label="Dismiss {{this.text}}" {{on "click" this.onDismiss}}>
-      <FlightIcon @name="x" @size="16" @isInlineBlock={{false}} />
+      <FlightIcon class="hds-tag__dismiss-icon" @name="x" @size="16" @isInlineBlock={{false}} />
     </button>
   {{/if}}
   {{#if (or @href @route)}}

--- a/packages/components/addon/components/hds/tag/index.hbs
+++ b/packages/components/addon/components/hds/tag/index.hbs
@@ -15,13 +15,11 @@
       @isRouteExternal={{@isRouteExternal}}
       @href={{@href}}
       @isHrefExternal={{@isHrefExternal}}
-      title="{{this.text}}"
-      {{style maxWidth=@maxWidth}}
     >
       {{this.text}}
     </Hds::Interactive>
   {{else}}
-    <span class="hds-tag__text" title="{{this.text}}" {{style maxWidth=@maxWidth}}>
+    <span class="hds-tag__text">
       {{this.text}}
     </span>
   {{/if}}

--- a/packages/components/addon/components/hds/tag/index.hbs
+++ b/packages/components/addon/components/hds/tag/index.hbs
@@ -15,11 +15,13 @@
       @isRouteExternal={{@isRouteExternal}}
       @href={{@href}}
       @isHrefExternal={{@isHrefExternal}}
+      title="{{this.text}}"
+      {{style maxWidth=@maxWidth}}
     >
       {{this.text}}
     </Hds::Interactive>
   {{else}}
-    <span class="hds-tag__text">
+    <span class="hds-tag__text" title="{{this.text}}" {{style maxWidth=@maxWidth}}>
       {{this.text}}
     </span>
   {{/if}}

--- a/packages/components/addon/components/hds/tag/index.hbs
+++ b/packages/components/addon/components/hds/tag/index.hbs
@@ -1,4 +1,4 @@
-<span class="hds-tag" ...attributes>
+<span class={{this.classNames}} ...attributes>
   {{#if this.onDismiss}}
     <button class="hds-tag__dismiss" type="button" aria-label="Dismiss {{this.text}}" {{on "click" this.onDismiss}}>
       <FlightIcon class="hds-tag__dismiss-icon" @name="x" @size="16" @isInlineBlock={{false}} />

--- a/packages/components/addon/components/hds/tag/index.hbs
+++ b/packages/components/addon/components/hds/tag/index.hbs
@@ -1,0 +1,26 @@
+<span class="hds-tag" ...attributes>
+  {{#if this.onDismiss}}
+    <button class="hds-tag__dismiss" type="button" aria-label="Dismiss {{this.text}}" {{on "click" this.onDismiss}}>
+      <FlightIcon @name="x" @size="16" @isInlineBlock={{false}} />
+    </button>
+  {{/if}}
+  {{#if (or @href @route)}}
+    <Hds::Interactive
+      class="hds-tag__link"
+      @current-when={{@current-when}}
+      @models={{hds-link-to-models @model @models}}
+      @query={{hds-link-to-query @query}}
+      @replace={{@replace}}
+      @route={{@route}}
+      @isRouteExternal={{@isRouteExternal}}
+      @href={{@href}}
+      @isHrefExternal={{@isHrefExternal}}
+    >
+      {{this.text}}
+    </Hds::Interactive>
+  {{else}}
+    <span class="hds-tag__text">
+      {{this.text}}
+    </span>
+  {{/if}}
+</span>

--- a/packages/components/addon/components/hds/tag/index.js
+++ b/packages/components/addon/components/hds/tag/index.js
@@ -1,6 +1,9 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
+export const DEFAULT_COLOR = 'primary';
+export const COLORS = ['primary', 'secondary'];
+
 export default class HdsTagIndexComponent extends Component {
   /**
    * @param onDismiss
@@ -28,5 +31,38 @@ export default class HdsTagIndexComponent extends Component {
     assert('@text for "Hds::Tag" must have a valid value', text !== undefined);
 
     return text;
+  }
+
+  /**
+   * @param color
+   * @type {string}
+   * @default primary
+   * @description Determines the color of link to be used; acceptable values are `primary` and `secondary`
+   */
+  get color() {
+    let { color = DEFAULT_COLOR } = this.args;
+
+    assert(
+      `@color for "Hds::Tag" must be one of the following: ${COLORS.join(
+        ', '
+      )}; received: ${color}`,
+      COLORS.includes(color)
+    );
+
+    return color;
+  }
+
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-tag'];
+
+    // add a class based on the @color argument
+    classes.push(`hds-tag--color-${this.color}`);
+
+    return classes.join(' ');
   }
 }

--- a/packages/components/addon/components/hds/tag/index.js
+++ b/packages/components/addon/components/hds/tag/index.js
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+export default class HdsTagIndexComponent extends Component {
+  /**
+   * @param onDismiss
+   * @type {function}
+   * @default () => {}
+   */
+  get onDismiss() {
+    let { onDismiss } = this.args;
+
+    if (typeof onDismiss === 'function') {
+      return onDismiss;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * @param text
+   * @type {string}
+   * @description The text of the tag. If no text value is defined, an error will be thrown.
+   */
+  get text() {
+    let { text } = this.args;
+
+    assert('@text for "Hds::Tag" must have a valid value', text !== undefined);
+
+    return text;
+  }
+}

--- a/packages/components/addon/components/hds/tag/index.js
+++ b/packages/components/addon/components/hds/tag/index.js
@@ -40,16 +40,22 @@ export default class HdsTagIndexComponent extends Component {
    * @description Determines the color of link to be used; acceptable values are `primary` and `secondary`
    */
   get color() {
-    let { color = DEFAULT_COLOR } = this.args;
-
-    assert(
-      `@color for "Hds::Tag" must be one of the following: ${COLORS.join(
-        ', '
-      )}; received: ${color}`,
-      COLORS.includes(color)
-    );
-
-    return color;
+    if (this.args.href || this.args.route) {
+      let { color = DEFAULT_COLOR } = this.args;
+      assert(
+        `@color for "Hds::Tag" must be one of the following: ${COLORS.join(
+          ', '
+        )}; received: ${color}`,
+        COLORS.includes(color)
+      );
+      return color;
+    } else if (this.args.color) {
+      assert(
+        '@color can only be applied to "Hds::Tag" along with either @href or @route',
+        this.args.href || this.args.route
+      );
+    }
+    return false;
   }
 
   /**
@@ -61,7 +67,9 @@ export default class HdsTagIndexComponent extends Component {
     let classes = ['hds-tag'];
 
     // add a class based on the @color argument
-    classes.push(`hds-tag--color-${this.color}`);
+    if (this.color) {
+      classes.push(`hds-tag--color-${this.color}`);
+    }
 
     return classes.join(' ');
   }

--- a/packages/components/app/components/hds/tag/index.js
+++ b/packages/components/app/components/hds/tag/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/tag/index';

--- a/packages/components/app/styles/@hashicorp/design-system-components.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-components.scss
@@ -19,6 +19,7 @@
 @use "../components/icon-tile";
 @use "../components/link/inline";
 @use "../components/link/standalone";
+@use "../components/tag";
 @use "../components/toast";
 // END COMPONENT CSS FILES IMPORTS
 

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -5,7 +5,7 @@
 //
 //
 
-$hds-tag-border-radius: 20px;
+$hds-tag-border-radius: 13px;
 
 .hds-tag {
   align-items: stretch;

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -6,6 +6,7 @@
 //
 
 $hds-tag-border-radius: 13px;
+$hds-tag-text-max-width: 120px;
 
 .hds-tag {
   align-items: stretch;
@@ -40,6 +41,10 @@ $hds-tag-border-radius: 13px;
   border-radius: inherit;
   flex: 1 0 0;
   padding: 4px 8px;
+  max-width: $hds-tag-text-max-width;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hds-tag__link {
@@ -47,6 +52,10 @@ $hds-tag-border-radius: 13px;
   color: var(--token-color-foreground-action);
   flex: 1 0 0;
   padding: 4px 8px;
+  max-width: $hds-tag-text-max-width;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   &:hover,
   &.mock-hover {

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -5,6 +5,8 @@
 //
 //
 
+@use "../mixins/focus-ring" as *;
+
 $hds-tag-border-radius: 13px;
 
 .hds-tag {
@@ -28,7 +30,7 @@ $hds-tag-border-radius: 13px;
   border-bottom-right-radius: 0;
   border: none; // reset default button border
   margin: 0; // reset default button margin
-  padding: 6px 4px 6px 6px;
+  padding: 6px 2px 6px 8px;
 }
 
 .hds-tag__dismiss-icon {
@@ -40,14 +42,14 @@ $hds-tag-border-radius: 13px;
 .hds-tag__link {
   border-radius: inherit;
   flex: 1 0 0;
-  padding: 4px 8px;
+  padding: 3px 10px 5px 10px;
 }
 
 .hds-tag__dismiss ~ .hds-tag__text,
 .hds-tag__dismiss ~ .hds-tag__link {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  padding-left: 4px;
+  padding: 3px 8px 5px 6px;
 }
 
 // INTERACTIVE ELEMENTS
@@ -69,14 +71,12 @@ $hds-tag-border-radius: 13px;
 
   &:focus,
   &.mock-focus {
-    box-shadow: 0px 0px 0px 1px var(--token-color-focus-action-internal), 0px 0px 0px 4px var(--token-color-focus-action-external);
-    outline-color: transparent; // prevent default outline as we use box-shadow for custom styling
-    outline-style: solid;
+    @include hds-focus-ring-basic();
     z-index: 1; // ensures focus is not obscured by adjacent elements
   }
 }
 
-// COLORS
+// COLORS (FOR LINK)
 
 .hds-tag--color-primary {
   .hds-tag__link {

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -67,37 +67,18 @@ $hds-tag-border-radius: 20px;
   background-color: var(--token-color-surface-faint);
   cursor: pointer;
 
-  &:hover {
+  &:hover,
+  &.mock-hover {
     background-color: var(--token-color-surface-interactive-hover);
   }
 
-  &:active {
+  &:active,
+  &.mock-active{
     background-color: var(--token-color-surface-interactive-active);
   }
 
-  &:focus {
-    box-shadow: 0px 0px 0px 1px var(--token-color-focus-action-internal), 0px 0px 0px 4px var(--token-color-focus-action-external);
-    outline-color: transparent; // prevent default outline as we use box-shadow for custom styling
-    outline-style: solid;
-    z-index: 1; // ensures focus is not obscured by adjacent elements
-  }
-}
-
-// mock classes are applied at the component level
-.mock-hover {
-  .hds-tag__link {
-    background-color: var(--token-color-surface-interactive-hover);
-  }
-}
-
-.mock-active {
-  .hds-tag__link {
-    background-color: var(--token-color-surface-interactive-active);
-  }
-}
-
-.mock-focus {
-  .hds-tag__link {
+  &:focus,
+  &.mock-focus {
     box-shadow: 0px 0px 0px 1px var(--token-color-focus-action-internal), 0px 0px 0px 4px var(--token-color-focus-action-external);
     outline-color: transparent; // prevent default outline as we use box-shadow for custom styling
     outline-style: solid;

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -9,6 +9,7 @@ $hds-tag-border-radius: 20px;
 
 .hds-tag {
   align-items: stretch;
+  background-color: var(--token-color-surface-interactive);
   border: 1px solid var(--token-color-border-strong);
   border-radius: $hds-tag-border-radius;
   color: var(--token-color-foreground-primary);

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -11,7 +11,7 @@ $hds-tag-border-radius: 13px;
 
 .hds-tag {
   align-items: stretch;
-  background-color: var(--token-color-surface-primary);
+  background-color: var(--token-color-surface-interactive);
   border: 1px solid var(--token-color-border-strong);
   border-radius: $hds-tag-border-radius;
   color: var(--token-color-foreground-primary);
@@ -56,7 +56,7 @@ $hds-tag-border-radius: 13px;
 
 .hds-tag__dismiss,
 .hds-tag__link {
-  background-color: var(--token-color-surface-faint);
+  background-color: var(--token-color-surface-interactive);
   cursor: pointer;
 
   &:hover,

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -34,6 +34,7 @@ $hds-tag-border-radius: 13px;
 }
 
 .hds-tag__dismiss-icon {
+  color: var(--token-color-foreground-primary);
   height: 12px;
   width: 12px;
 }

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -7,7 +7,8 @@
 
 @use "../mixins/focus-ring" as *;
 
-$hds-tag-border-radius: 13px;
+// we set a higher value than the line-height (~13px) to accommodate cases where the text wraps
+$hds-tag-border-radius: 50px;
 
 .hds-tag {
   align-items: stretch;

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -11,7 +11,7 @@ $hds-tag-border-radius: 13px;
 
 .hds-tag {
   align-items: stretch;
-  background-color: var(--token-color-surface-interactive);
+  background-color: var(--token-color-surface-primary);
   border: 1px solid var(--token-color-border-strong);
   border-radius: $hds-tag-border-radius;
   color: var(--token-color-foreground-primary);

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -23,7 +23,9 @@ $hds-tag-border-radius: 13px;
 
 .hds-tag__dismiss {
   flex: 0 0 auto;
-  border-radius: $hds-tag-border-radius 0 0 $hds-tag-border-radius;
+  border-radius: inherit;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border: none; // reset default button border
   margin: 0; // reset default button margin
   padding: 6px 4px 6px 6px;
@@ -35,13 +37,13 @@ $hds-tag-border-radius: 13px;
 }
 
 .hds-tag__text {
-  border-radius: $hds-tag-border-radius;
+  border-radius: inherit;
   flex: 1 0 0;
   padding: 4px 8px;
 }
 
 .hds-tag__link {
-  border-radius: $hds-tag-border-radius;
+  border-radius: inherit;
   color: var(--token-color-foreground-action);
   flex: 1 0 0;
   padding: 4px 8px;
@@ -59,7 +61,8 @@ $hds-tag-border-radius: 13px;
 
 .hds-tag__dismiss ~ .hds-tag__text,
 .hds-tag__dismiss ~ .hds-tag__link {
-  border-radius: 0 $hds-tag-border-radius $hds-tag-border-radius 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
   padding-left: 4px;
 }
 

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -27,11 +27,11 @@ $hds-tag-border-radius: 13px;
   border: none; // reset default button border
   margin: 0; // reset default button margin
   padding: 6px 4px 6px 6px;
+}
 
-  .flight-icon {
-    height: 12px;
-    width: 12px;
-  }
+.hds-tag__dismiss-icon {
+  height: 12px;
+  width: 12px;
 }
 
 .hds-tag__text {

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -36,27 +36,11 @@ $hds-tag-border-radius: 13px;
   width: 12px;
 }
 
-.hds-tag__text {
-  border-radius: inherit;
-  flex: 1 0 0;
-  padding: 4px 8px;
-}
-
+.hds-tag__text,
 .hds-tag__link {
   border-radius: inherit;
-  color: var(--token-color-foreground-action);
   flex: 1 0 0;
   padding: 4px 8px;
-
-  &:hover,
-  &.mock-hover {
-    color: var(--token-color-foreground-action-hover);
-  }
-
-  &:active,
-  &.mock-active{
-    color: var(--token-color-foreground-action-active);
-  }
 }
 
 .hds-tag__dismiss ~ .hds-tag__text,
@@ -65,6 +49,8 @@ $hds-tag-border-radius: 13px;
   border-bottom-left-radius: 0;
   padding-left: 4px;
 }
+
+// INTERACTIVE ELEMENTS
 
 .hds-tag__dismiss,
 .hds-tag__link {
@@ -87,5 +73,29 @@ $hds-tag-border-radius: 13px;
     outline-color: transparent; // prevent default outline as we use box-shadow for custom styling
     outline-style: solid;
     z-index: 1; // ensures focus is not obscured by adjacent elements
+  }
+}
+
+// COLORS
+
+.hds-tag--color-primary {
+  .hds-tag__link {
+    color: var(--token-color-foreground-action);
+
+    &:hover,
+    &.mock-hover {
+      color: var(--token-color-foreground-action-hover);
+    }
+
+    &:active,
+    &.mock-active{
+      color: var(--token-color-foreground-action-active);
+    }
+  }
+}
+
+.hds-tag--color-secondary {
+  .hds-tag__link {
+    color: var(--token-color-foreground-strong);
   }
 }

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -6,7 +6,6 @@
 //
 
 $hds-tag-border-radius: 13px;
-$hds-tag-text-max-width: 120px;
 
 .hds-tag {
   align-items: stretch;
@@ -41,10 +40,6 @@ $hds-tag-text-max-width: 120px;
   border-radius: inherit;
   flex: 1 0 0;
   padding: 4px 8px;
-  max-width: $hds-tag-text-max-width;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .hds-tag__link {
@@ -52,10 +47,6 @@ $hds-tag-text-max-width: 120px;
   color: var(--token-color-foreground-action);
   flex: 1 0 0;
   padding: 4px 8px;
-  max-width: $hds-tag-text-max-width;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 
   &:hover,
   &.mock-hover {

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -1,0 +1,106 @@
+//
+// TAG COMPONENT
+//
+// properties within each class are sorted alphabetically
+//
+//
+
+$hds-tag-border-radius: 20px;
+
+.hds-tag {
+  align-items: stretch;
+  border: 1px solid var(--token-color-border-strong);
+  border-radius: $hds-tag-border-radius;
+  color: var(--token-color-foreground-primary);
+  display: inline-flex;
+  font-family: var(--token-typography-font-stack-text);
+  font-size: 0.8125rem; // 13px
+  font-weight: var(--token-typography-font-weight-medium);
+  line-height: 1rem; // 16px
+  vertical-align: middle;
+}
+
+.hds-tag__dismiss {
+  flex: 0 0 auto;
+  border-radius: $hds-tag-border-radius 0 0 $hds-tag-border-radius;
+  border: none; // reset default button border
+  margin: 0; // reset default button margin
+  padding: 6px 4px 6px 6px;
+
+  .flight-icon {
+    height: 12px;
+    width: 12px;
+  }
+}
+
+.hds-tag__text {
+  border-radius: $hds-tag-border-radius;
+  flex: 1 0 0;
+  padding: 4px 8px;
+}
+
+.hds-tag__link {
+  border-radius: $hds-tag-border-radius;
+  color: var(--token-color-foreground-action);
+  flex: 1 0 0;
+  padding: 4px 8px;
+
+  &:hover,
+  &.mock-hover {
+    color: var(--token-color-foreground-action-hover);
+  }
+
+  &:active,
+  &.mock-active{
+    color: var(--token-color-foreground-action-active);
+  }
+}
+
+.hds-tag__dismiss ~ .hds-tag__text,
+.hds-tag__dismiss ~ .hds-tag__link {
+  border-radius: 0 $hds-tag-border-radius $hds-tag-border-radius 0;
+  padding-left: 4px;
+}
+
+.hds-tag__dismiss,
+.hds-tag__link {
+  background-color: var(--token-color-surface-faint);
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--token-color-surface-interactive-hover);
+  }
+
+  &:active {
+    background-color: var(--token-color-surface-interactive-active);
+  }
+
+  &:focus {
+    box-shadow: 0px 0px 0px 1px var(--token-color-focus-action-internal), 0px 0px 0px 4px var(--token-color-focus-action-external);
+    outline-color: transparent; // prevent default outline as we use box-shadow for custom styling
+    outline-style: solid;
+    z-index: 1; // ensures focus is not obscured by adjacent elements
+  }
+}
+
+// mock classes are applied at the component level
+.mock-hover {
+  .hds-tag__link {
+    background-color: var(--token-color-surface-interactive-hover);
+  }
+}
+
+.mock-active {
+  .hds-tag__link {
+    background-color: var(--token-color-surface-interactive-active);
+  }
+}
+
+.mock-focus {
+  .hds-tag__link {
+    box-shadow: 0px 0px 0px 1px var(--token-color-focus-action-internal), 0px 0px 0px 4px var(--token-color-focus-action-external);
+    outline-color: transparent; // prevent default outline as we use box-shadow for custom styling
+    outline-style: solid;
+    z-index: 1; // ensures focus is not obscured by adjacent elements
+  }
+}

--- a/packages/components/tests/dummy/app/controllers/components/tag.js
+++ b/packages/components/tests/dummy/app/controllers/components/tag.js
@@ -1,0 +1,8 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class TagController extends Controller {
+  // notice: this is used as "noop" function for the onDismiss callback of the Tag component
+  @action
+  noop() {}
+}

--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -36,6 +36,7 @@ Router.map(function () {
       this.route('standalone');
     });
     this.route('toast');
+    this.route('tag');
   });
   this.route('content', function () {
     this.route('writing-guidelines');

--- a/packages/components/tests/dummy/app/routes/components/tag.js
+++ b/packages/components/tests/dummy/app/routes/components/tag.js
@@ -1,9 +1,10 @@
 import Route from '@ember/routing/route';
+import { COLORS } from '@hashicorp/design-system-components/components/hds/tag';
 
 export default class ComponentsTagRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
     const STATES = ['default', 'hover', 'active', 'focus'];
-    return { STATES };
+    return { COLORS, STATES };
   }
 }

--- a/packages/components/tests/dummy/app/routes/components/tag.js
+++ b/packages/components/tests/dummy/app/routes/components/tag.js
@@ -1,0 +1,9 @@
+import Route from '@ember/routing/route';
+
+export default class ComponentsTagRoute extends Route {
+  model() {
+    // these are used only for presentation purpose in the showcase
+    const STATES = ['default', 'hover', 'active', 'focus'];
+    return { STATES };
+  }
+}

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -19,6 +19,7 @@
 @import "./pages/db-interactive";
 @import "./pages/db-link-inline";
 @import "./pages/db-link-standalone";
+@import "./pages/db-tag";
 @import "./pages/db-toast";
 @import "./pages/db-tokens";
 @import "./pages/db-typography";

--- a/packages/components/tests/dummy/app/styles/pages/db-tag.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-tag.scss
@@ -1,0 +1,51 @@
+// TAG
+
+.dummy-tag-states-grid {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: repeat(4, 1fr);;
+  margin: 0;
+  padding: 0;
+}
+
+.dummy-tag-base-sample {
+    align-items: flex-start;
+    display: flex;
+    gap: 0.25rem;
+    list-style: none;
+    margin: 0;
+    min-width: fit-content;
+    padding: 0.125rem;
+}
+
+.dummy-tag-containers {
+  align-items: start;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dummy-tag-containers__block {
+  display: block;
+
+  .hds-tag {
+    margin:0 0 0.5rem 0;
+  }
+}
+
+.dummy-tag-containers__flex {
+  display: flex;
+
+  .hds-tag {
+    margin:0 0.25rem 0.5rem 0;
+  }
+}
+
+.dummy-tag-containers__grid {
+  display: grid;
+  justify-items: start;
+
+  .hds-tag {
+    margin:0 0.25rem 0.5rem 0;
+  }
+}

--- a/packages/components/tests/dummy/app/styles/pages/db-tag.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-tag.scss
@@ -6,6 +6,10 @@
   grid-template-columns: repeat(4, 1fr);;
   margin: 0;
   padding: 0;
+
+  .dummy-tag-states-grid__title {
+      grid-column: 1 / 5;
+  }
 }
 
 .dummy-tag-states-subgrid {

--- a/packages/components/tests/dummy/app/styles/pages/db-tag.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-tag.scss
@@ -42,6 +42,7 @@
 
 .dummy-tag-containers__flex {
   display: flex;
+  flex-wrap: wrap;
 
   .hds-tag {
     margin:0 0.25rem 0.5rem 0;

--- a/packages/components/tests/dummy/app/styles/pages/db-tag.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-tag.scss
@@ -8,6 +8,13 @@
   padding: 0;
 }
 
+.dummy-tag-states-subgrid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: flex-start;
+}
+
 .dummy-tag-base-sample {
     align-items: flex-start;
     display: flex;

--- a/packages/components/tests/dummy/app/styles/pages/db-tag.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-tag.scss
@@ -22,7 +22,7 @@
 .dummy-tag-base-sample {
     align-items: flex-start;
     display: flex;
-    gap: 0.25rem;
+    gap: 0.5rem;
     list-style: none;
     margin: 0;
     min-width: fit-content;
@@ -40,7 +40,7 @@
   display: block;
 
   .hds-tag {
-    margin:0 0 0.5rem 0;
+    margin:0 0.25rem 0.75rem 0;
   }
 }
 
@@ -49,7 +49,7 @@
   flex-wrap: wrap;
 
   .hds-tag {
-    margin:0 0.25rem 0.5rem 0;
+    margin:0 0.5rem 0.75rem 0;
   }
 }
 
@@ -58,6 +58,6 @@
   justify-items: start;
 
   .hds-tag {
-    margin:0 0.25rem 0.5rem 0;
+    margin:0 0.5rem 0.75rem 0;
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -38,6 +38,11 @@
 
 <section>
   <h3 class="dummy-h3" id="how-to-use"><a href="#how-to-use" class="dummy-link-section">§</a> How to use</h3>
+  <p class="dummy-paragraph">
+    Use tags to indicate an object's categorization, i.e., for filtering. Use a
+    <LinkTo @route="components.badge">badge</LinkTo>
+    instead for static metadata, status, or to indicate a new feature.
+  </p>
   <p class="dummy-paragraph">Invocation of the component would look something like this:</p>
   {{! prettier-ignore-start }}
   {{! template-lint-disable no-unbalanced-curlies }}
@@ -82,12 +87,7 @@
         <span class="dummy-text-small">{{capitalize state}}:</span>
         <br />
         <div class="dummy-tag-states-subgrid">
-          <Hds::Tag
-            @text="My tag"
-            @onDismiss={{this.noop}}
-            mock-state-value={{state}}
-            mock-state-selector="button"
-          />
+          <Hds::Tag @text="My tag" @onDismiss={{this.noop}} mock-state-value={{state}} mock-state-selector="button" />
         </div>
       </div>
     {{/each}}

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -104,6 +104,7 @@
           <div class="dummy-tag-containers__{{display}}">
             <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
             <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
+            <Hds::Tag @text="My slightly longer tag" @onDismiss={{this.noop}} />
             <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
           </div>
         </div>

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -73,8 +73,23 @@
       <div>
         <span class="dummy-text-small">{{capitalize state}}:</span>
         <br />
-        <Hds::Tag @text="My tag" @onDismiss={{this.noop}} @route="components.tag" mock-state-value={{state}} />
-        <Hds::Tag @text="My tag" @route="components.tag" mock-state-value={{state}} />
+        <div class="dummy-tag-states-subgrid">
+          <Hds::Tag
+            @text="My tag"
+            @onDismiss={{this.noop}}
+            @route="components.tag"
+            mock-state-value={{state}}
+            mock-state-selector="button"
+          />
+          <Hds::Tag
+            @text="My tag"
+            @onDismiss={{this.noop}}
+            @route="components.tag"
+            mock-state-value={{state}}
+            mock-state-selector="a"
+          />
+          <Hds::Tag @text="My tag" @route="components.tag" mock-state-value={{state}} mock-state-selector="a" />
+        </div>
       </div>
     {{/each}}
   </div>

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -1,0 +1,98 @@
+{{page-title "Tag component"}}
+
+<h2 class="dummy-h2">Tag</h2>
+
+<section>
+  <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
+  <p class="dummy-paragraph" id="component-api-tag">Here is the API for the component:</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api-tag">
+    <dt>text <code>string</code></dt>
+    <dd>
+      <p>The text of the tag; or link text when the
+        <em>@route</em>
+        or
+        <em>@href</em>
+        are set.</p>
+      <p><em>If no text value is defined an error will be thrown.</em></p>
+    </dd>
+    <dt>onDismiss <code>function</code></dt>
+    <dd>
+      <p>
+        The tag can be dismissed by the user. When a function is passed, the "dismiss" button is displayed.
+      </p>
+    </dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+    </dd>
+  </dl>
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="how-to-use"><a href="#how-to-use" class="dummy-link-section">§</a> How to use</h3>
+  <p class="dummy-paragraph">Invocation of the component would look something like this:</p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Tag @text="My text tag" @onDismiss=\{{ your function here }} />
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
+    Design guidelines</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
+  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+</section>
+
+<section data-test-percy>
+  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+  <h4 class="dummy-h4">Content</h4>
+  <div class="dummy-tag-base-sample">
+    <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
+    <Hds::Tag @text="My text tag" />
+    <Hds::Tag @text="My link tag" @onDismiss={{this.noop}} @route="components.tag" />
+    <Hds::Tag @text="My link tag" @route="components.tag" />
+  </div>
+  <div class="dummy-tag-base-sample">
+    <p>This is a paragraph: <Hds::Tag @text="My text tag" /></p>
+  </div>
+
+  <h4 class="dummy-h4">States</h4>
+  <div class="dummy-tag-states-grid">
+    {{#each @model.STATES as |state|}}
+      <div>
+        <span class="dummy-text-small">{{capitalize state}}:</span>
+        <br />
+        <Hds::Tag @text="My tag" @onDismiss={{this.noop}} @route="components.tag" mock-state-value={{state}} />
+        <Hds::Tag @text="My tag" @route="components.tag" mock-state-value={{state}} />
+      </div>
+    {{/each}}
+  </div>
+
+  <h4 class="dummy-h4">Containers</h4>
+  <div class="dummy-tag-containers">
+    {{#let (array "block" "flex" "grid") as |displays|}}
+      {{#each displays as |display|}}
+        <div>
+          <span class="dummy-text-small">Parent with <code class="dummy-code">display: {{display}}</code></span>
+          <br />
+          <div class="dummy-tag-containers__{{display}}">
+            <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
+            <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
+            <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
+          </div>
+        </div>
+      {{/each}}
+    {{/let}}
+  </div>
+</section>

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -15,6 +15,12 @@
         are set.</p>
       <p><em>If no text value is defined an error will be thrown.</em></p>
     </dd>
+    <dt>maxWidth <code>string</code></dt>
+    <dd>
+      <p>A visual truncation is applied when this value is exceeded by the tag content.</p>
+      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p>Default: <span class="default">120px</span></p>
+    </dd>
     <dt>onDismiss <code>function</code></dt>
     <dd>
       <p>

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -81,6 +81,8 @@
     <LinkTo @route="components.badge">badge</LinkTo>
     instead for static metadata, status, or to indicate a new feature.
   </p>
+
+  <h4 class="dummy-h4">Basic use</h4>
   <p class="dummy-paragraph">Invocation of the component would look something like this:</p>
   {{! prettier-ignore-start }}
   {{! template-lint-disable no-unbalanced-curlies }}
@@ -92,6 +94,54 @@
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">In this case, since no
+    <code class="dummy-code">@href</code>
+    or
+    <code class="dummy-code">@route</code>
+    argument is provided it will render the tag as plain text.
+  </p>
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
+
+  <h4 class="dummy-h4">Color</h4>
+  <p class="dummy-paragraph">
+    There are two available colors for a link:
+    <code class="dummy-code">primary</code>
+    and
+    <code class="dummy-code">secondary</code>. The default is
+    <code class="dummy-code">primary</code>.
+  </p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Tag @color="primary" @text="My link tag" @route="components.tag" @onDismiss=\{{ your function here }} />
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Tag @color="primary" @text="My link tag" @route="components.tag" @onDismiss={{this.noop}} />
+  <Hds::Tag @color="secondary" @text="My link tag" @route="components.tag" @onDismiss={{this.noop}} />
+
+  <h4 class="dummy-h4">Dismiss</h4>
+  <p class="dummy-paragraph">
+    In most cases the tag needs to be dismissable. If you don't provide a callback function to the
+    <code class="dummy-code">onDismiss</code>
+    argument the "dismiss/remove" button will not be rendered.
+  </p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Tag @color="primary" @text="My link tag" @route="components.tag" />
+    '
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Tag @text="My link tag" @route="components.tag" />
 </section>
 
 <section>

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -157,7 +157,88 @@
 
 <section>
   <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
-  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  <h4 class="dummy-h4">
+    Applicable WCAG Success Criteria (Reference)
+  </h4>
+  <p class="dummy-paragraph">
+    This section is for reference only. This component intends to conform to the following WCAG success criteria:
+  </p>
+  <ul class="dummy-list">
+    <li>1.4.1:
+      <a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >Use of Color</a>
+    </li>
+    <li>1.4.3:
+      <a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >Contrast (Minimum)</a>
+    </li>
+    <li>1.4.4:
+      <a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >Resize text</a>
+    </li>
+    <li>1.4.11:
+      <a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >Non-text Contrast</a>
+    </li>
+    <li>1.4.12:
+      <a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >Text Spacing</a>
+    </li>
+    <li>1.4.13:
+      <a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >Content on Hover or Focus</a>
+    </li>
+    <li>2.1.1:
+      <a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >Keyboard</a>
+    </li>
+    <li>2.4.7:
+      <a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >Focus Visible</a>
+    </li>
+    <li>3.2.1:
+      <a href="https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html" rel="noopener noreferrer" target="_blank">On
+        Focus</a>
+    </li>
+    <li>4.1.1:
+      <a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >Parsing</a>
+    </li>
+    <li>4.1.2:
+      <a
+        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >Name, Role, Value</a>
+    </li>
+  </ul>
 </section>
 
 <section data-test-percy>

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -15,6 +15,14 @@
         are set.</p>
       <p><em>If no text value is defined an error will be thrown.</em></p>
     </dd>
+    <dt>color <code>enum</code></dt>
+    <dd>
+      <p>Acceptable values:</p>
+      <ol>
+        <li class="default">primary</li>
+        <li>secondary</li>
+      </ol>
+    </dd>
     <dt>onDismiss <code>function</code></dt>
     <dd>
       <p>
@@ -77,20 +85,46 @@
           <Hds::Tag
             @text="My tag"
             @onDismiss={{this.noop}}
-            @route="components.tag"
             mock-state-value={{state}}
             mock-state-selector="button"
           />
-          <Hds::Tag
-            @text="My tag"
-            @onDismiss={{this.noop}}
-            @route="components.tag"
-            mock-state-value={{state}}
-            mock-state-selector="a"
-          />
-          <Hds::Tag @text="My tag" @route="components.tag" mock-state-value={{state}} mock-state-selector="a" />
         </div>
       </div>
+    {{/each}}
+
+    {{#each @model.COLORS as |color|}}
+      <h5 class="dummy-h5 dummy-tag-states-grid__title">{{capitalize color}}</h5>
+      {{#each @model.STATES as |state|}}
+        <div>
+          <span class="dummy-text-small">{{capitalize state}}:</span>
+          <br />
+          <div class="dummy-tag-states-subgrid">
+            <Hds::Tag
+              @color={{color}}
+              @text="My link tag"
+              @onDismiss={{this.noop}}
+              @route="components.tag"
+              mock-state-value={{state}}
+              mock-state-selector="button"
+            />
+            <Hds::Tag
+              @color={{color}}
+              @text="My link tag"
+              @onDismiss={{this.noop}}
+              @route="components.tag"
+              mock-state-value={{state}}
+              mock-state-selector="a"
+            />
+            <Hds::Tag
+              @color={{color}}
+              @text="My link tag"
+              @route="components.tag"
+              mock-state-value={{state}}
+              mock-state-selector="a"
+            />
+          </div>
+        </div>
+      {{/each}}
     {{/each}}
   </div>
 

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -23,6 +23,44 @@
         <li>secondary</li>
       </ol>
     </dd>
+    <dt>href</dt>
+    <dd>
+      <p>This is the URL parameter that is passed down to the
+        <code>&lt;a&gt;</code>
+        element.</p>
+    </dd>
+    <dt>isHrefExternal <code>boolean</code></dt>
+    <dd>
+      <p>Default: <span class="default">true</span></p>
+      <p>This controls if the
+        <code>&lt;a&gt;</code>
+        link is external and so for security reasons we need to add the
+        <code>target="_blank"</code>
+        and
+        <code>rel="noopener noreferrer"</code>
+        attributes to it.</p>
+    </dd>
+    <dt>route/models/model/query/current-when/replace</dt>
+    <dd>
+      <p>These are the parameters that are passed down as arguments to the
+        <code>&lt;LinkTo&gt;</code>
+        /
+        <code>&lt;LinkToExternal&gt;</code>
+        components.</p>
+    </dd>
+    <dt>isRouteExternal <code>boolean</code></dt>
+    <dd>
+      <p>Default: <span class="default">false</span></p>
+      <p>This controls if the "LinkTo" is external to the Ember engine (<a
+          href="https://ember-engines.com/docs/link-to-external"
+          target="_blank"
+          rel="noopener noreferrer"
+        >more details here</a>) in which case it will use a
+        <code>&lt;LinkToExternal&gt;</code>
+        instead of a simple
+        <code>&lt;LinkTo&gt;</code>
+        for the @route.</p>
+    </dd>
     <dt>onDismiss <code>function</code></dt>
     <dd>
       <p>

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -15,12 +15,6 @@
         are set.</p>
       <p><em>If no text value is defined an error will be thrown.</em></p>
     </dd>
-    <dt>maxWidth <code>string</code></dt>
-    <dd>
-      <p>A visual truncation is applied when this value is exceeded by the tag content.</p>
-      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
-      <p>Default: <span class="default">120px</span></p>
-    </dd>
     <dt>onDismiss <code>function</code></dt>
     <dd>
       <p>

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -15,14 +15,6 @@
         are set.</p>
       <p><em>If no text value is defined an error will be thrown.</em></p>
     </dd>
-    <dt>color <code>enum</code></dt>
-    <dd>
-      <p>Acceptable values:</p>
-      <ol>
-        <li class="default">primary</li>
-        <li>secondary</li>
-      </ol>
-    </dd>
     <dt>href</dt>
     <dd>
       <p>This is the URL parameter that is passed down to the
@@ -60,6 +52,19 @@
         instead of a simple
         <code>&lt;LinkTo&gt;</code>
         for the @route.</p>
+    </dd>
+    <dt>color <code>enum</code></dt>
+    <dd>
+      <p>Sets the color of a link and it is allowed only when
+        <em>@route</em>
+        or
+        <em>@href</em>
+        are set.</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li class="default">primary</li>
+        <li>secondary</li>
+      </ol>
     </dd>
     <dt>onDismiss <code>function</code></dt>
     <dd>

--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -93,6 +93,11 @@
           </LinkTo>
         </li>
         <li class="dummy-paragraph">
+          <LinkTo @route="components.tag">
+            Tag
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
           <LinkTo @route="components.toast">
             Toast
           </LinkTo>

--- a/packages/components/tests/integration/components/hds/tag/index-test.js
+++ b/packages/components/tests/integration/components/hds/tag/index-test.js
@@ -1,10 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | hds/tag/index', function (hooks) {
   setupRenderingTest(hooks);
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
 
   test('it renders the default tag with text', async function (assert) {
     await render(hbs`<Hds::Tag @text="My tag" />`);
@@ -29,5 +32,34 @@ module('Integration | Component | hds/tag/index', function (hooks) {
     assert
       .dom('button.hds-tag__dismiss')
       .hasAttribute('aria-label', 'Dismiss My tag');
+  });
+
+  // COLOR
+
+  test('it should render the primary color as the default if no @color prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Tag @text="My text tag" @href="/" id="test-link-tag"/>`
+    );
+    assert.dom('#test-link-tag').hasClass('hds-tag--color-primary');
+  });
+  test('it should render the correct CSS color class if the @color prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Tag @text="My text tag" @href="/" @color="secondary" id="test-link-tag"/>`
+    );
+    assert.dom('#test-link-tag').hasClass('hds-tag--color-secondary');
+  });
+  test('it should throw an assertion if an incorrect value for @color is provided', async function (assert) {
+    const errorMessage =
+      '@color for "Hds::Tag" must be one of the following: primary, secondary; received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(
+      hbs`<Hds::Tag @text="My text tag" @href="/" @color="foo" id="test-link-tag"/>`
+    );
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
   });
 });

--- a/packages/components/tests/integration/components/hds/tag/index-test.js
+++ b/packages/components/tests/integration/components/hds/tag/index-test.js
@@ -36,19 +36,19 @@ module('Integration | Component | hds/tag/index', function (hooks) {
 
   // COLOR
 
-  test('it should render the primary color as the default if no @color prop is declared', async function (assert) {
+  test('it should render the primary color as the default if no @color prop is declared when the text is a link', async function (assert) {
     await render(
       hbs`<Hds::Tag @text="My text tag" @href="/" id="test-link-tag"/>`
     );
     assert.dom('#test-link-tag').hasClass('hds-tag--color-primary');
   });
-  test('it should render the correct CSS color class if the @color prop is declared', async function (assert) {
+  test('it should render the correct CSS color class if the @color prop is declared when the text is a link', async function (assert) {
     await render(
       hbs`<Hds::Tag @text="My text tag" @href="/" @color="secondary" id="test-link-tag"/>`
     );
     assert.dom('#test-link-tag').hasClass('hds-tag--color-secondary');
   });
-  test('it should throw an assertion if an incorrect value for @color is provided', async function (assert) {
+  test('it should throw an assertion if an incorrect value for @color is provided when the text is a link', async function (assert) {
     const errorMessage =
       '@color for "Hds::Tag" must be one of the following: primary, secondary; received: foo';
     assert.expect(2);

--- a/packages/components/tests/integration/components/hds/tag/index-test.js
+++ b/packages/components/tests/integration/components/hds/tag/index-test.js
@@ -55,9 +55,19 @@ module('Integration | Component | hds/tag/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(
-      hbs`<Hds::Tag @text="My text tag" @href="/" @color="foo" id="test-link-tag"/>`
-    );
+    await render(hbs`<Hds::Tag @text="My text tag" @href="/" @color="foo"/>`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+  test('it should throw an assertion if @color is provided without @href or @route', async function (assert) {
+    const errorMessage =
+      '@color can only be applied to "Hds::Tag" along with either @href or @route';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Tag @text="My text tag" @color="foo"/>`);
     assert.throws(function () {
       throw new Error(errorMessage);
     });

--- a/packages/components/tests/integration/components/hds/tag/index-test.js
+++ b/packages/components/tests/integration/components/hds/tag/index-test.js
@@ -1,0 +1,33 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/tag/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the default tag with text', async function (assert) {
+    await render(hbs`<Hds::Tag @text="My tag" />`);
+    assert.dom(this.element).hasText('My tag');
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Tag @text="My tag" id="test-tag" />`);
+    assert.dom('#test-tag').hasClass('hds-tag');
+  });
+
+  // DISMISS
+
+  test('it should not render the "dismiss" button by default', async function (assert) {
+    await render(hbs`<Hds::Tag @text="My tag" />`);
+    assert.dom('button.hds-tag__dismiss').doesNotExist();
+  });
+  test('it should render the "dismiss" button if a callback function is passed to the @onDismiss argument', async function (assert) {
+    assert.expect(2);
+    this.set('NOOP', () => {});
+    await render(hbs`<Hds::Tag @text="My tag" @onDismiss={{this.NOOP}} />`);
+    assert.dom('button.hds-tag__dismiss').exists();
+    assert
+      .dom('button.hds-tag__dismiss')
+      .hasAttribute('aria-label', 'Dismiss My tag');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

Add `Hds::Tag` component based on [current design](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/branch/6UTRhciO3hMNBgJyK3aXuY/HDS-Product---Components?node-id=12899%3A33230).

[👉 Preview Tag component](https://hds-components-git-alex-ju-add-tag-component-hashicorp.vercel.app/components/tag)

### :hammer_and_wrench: Detailed description

We're introducing a Tag component (for categorizing or filtering content) comprising of:
 - a dismiss button (displayed when an `onDismiss` function is provided)
 - a text; when `@href` or `@route` is provided we use the `Hds::Interactive` utility component, benefitting from all the logic behind it, otherwise we render a plain text

**Note**
~~We are currently discussing approaches for when the text is long (considering how to handle overflowing text), so we expect to add additional code to handle these scenarios.~~
Tried truncation, but is not conformant, so we'll fall back with text wrapping.

### :link: External links

[Jira issue](https://hashicorp.atlassian.net/browse/HDS-121?atlOrigin=eyJpIjoiNjcwMmU5OGVmMTE3NGEzYWE0NDBmZDgwNDRmYWE3ZjIiLCJwIjoiaiJ9)

***

### 👀 How to review

👉 Review commit-by-commit

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
