### PR TITLE
Fix the default button type value in doc

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -267,11 +267,10 @@
     <code class="dummy-code">reset</code>. The default
     <code class="dummy-code">type</code>
     for the button is
-    <code class="dummy-code">button</code>. If the button is used inside of a form, its
+    <code class="dummy-code">submit</code>. To prevent a button from submitting a form, set
     <code class="dummy-code">type</code>
-    should be
-    <code class="dummy-code">submit</code>. To use a different value, declare a different value for
-    <code class="dummy-code">type</code>:
+    to
+    <code class="dummy-code">button</code>.
   </p>
   {{! prettier-ignore-start }}
   <CodeBlock


### PR DESCRIPTION
### :pushpin: Summary

Fix the default button type value mentioned in the documentation

### :hammer_and_wrench: Detailed description

The default type for a button is `submit`, not `button`, so I've updated the documentation accordingly. I also find '_To use a different value, declare a different value_' redundant, but happy to keep it if someone feels strongly about it.

### :link: External links

Found this as I checked the guidance we provide before replying to [a query in Slack](https://hashicorp.slack.com/archives/C7KTUHNUS/p1657841679203199).

***
