### PR TITLE
Allow custom `height` on textarea

### DIFF
--- a/packages/components/addon/components/hds/form/textarea/base.hbs
+++ b/packages/components/addon/components/hds/form/textarea/base.hbs
@@ -1,2 +1,2 @@
 {{! Notice: this is not the native HTML <textarea> but the Ember component <Textarea> }}
-<Textarea class={{this.classNames}} {{style width=@width}} rows="4" ...attributes @value={{@value}} />
+<Textarea class={{this.classNames}} {{style width=@width height=@height}} rows="4" ...attributes @value={{@value}} />

--- a/packages/components/addon/components/hds/form/textarea/field.hbs
+++ b/packages/components/addon/components/hds/form/textarea/field.hbs
@@ -14,6 +14,7 @@
       @value={{@value}}
       @isInvalid={{@isInvalid}}
       @width={{@width}}
+      @height={{@height}}
       ...attributes
       id={{F.id}}
       aria-describedby={{F.ariaDescribedBy}}

--- a/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
@@ -60,6 +60,17 @@
           <code class="dummy-code">@width</code>
           parameter is provided then the control will have a fixed width.</em></p>
     </dd>
+    <dt>height <code>string</code></dt>
+    <dd>
+      <p>Acceptable values: any valid CSS height (px, rem, etc)</p>
+      <p><em>Notice: by default the
+          <code class="dummy-code">&lt;textarea&gt;</code>
+          has a
+          <code class="dummy-code">height</code>
+          determined by the browser to accommodate 4 lines of text. If a
+          <code class="dummy-code">@height</code>
+          parameter is provided then the control will have a fixed height.</em></p>
+    </dd>
     <dt>...attributes</dt>
     <dd>
       <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>


### PR DESCRIPTION
### :pushpin: Summary

Allow custom `height` on textarea.

### :hammer_and_wrench: Detailed description

We update the `Hds::Form::Textarea::Base` and `Hds::Form::Textarea::Field` to support a `@height` argument.

### :link: External links

[Jira issue](https://hashicorp.atlassian.net/jira/software/c/projects/HDS/boards/445?modal=detail&selectedIssue=HDS-309)

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
