### PR TITLE
Fix computation error on disclosure utility

### DIFF
--- a/.changeset/spotty-cars-work.md
+++ b/.changeset/spotty-cars-work.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix computation error on disclosure utility

--- a/packages/components/addon/components/hds/disclosure/index.js
+++ b/packages/components/addon/components/hds/disclosure/index.js
@@ -18,7 +18,12 @@ export default class HdsDisclosureComponent extends Component {
     if (!this.toggleRef) {
       this.toggleRef = event.currentTarget;
     }
-    this.isOpen = !this.isOpen;
+    // we're using an explicit conditional statement to toggle the `isOpen` property to avoid a backtracking rerender assertion caused by setting and getting a `@tracked` property in the same computation
+    if (this.isOpen) {
+      this.isOpen = false;
+    } else {
+      this.isOpen = true;
+    }
     // we explicitly apply a focus state to the toggle element to overcome a bug in WebKit (see b8abfcf)
     this.toggleRef.focus();
   }


### PR DESCRIPTION
### :pushpin: Summary

Fix computation error on disclosure utility component

### :hammer_and_wrench: Detailed description

Ember, possibly on certain versions (3.2x), doesn't support setting and getting a `@tracked` property in the same computation. To avoid this type of errors, we're using an explicit conditional statement to toggle the `isOpen` property, so we get the property in a computation and set it in a different one.

Sample error:
```
Error: You attempted to update `isOpen` on `HdsDisclosureComponent`, but it had already been used previously in the same computation.  Attempting to update a value after using it in a computation can cause logical errors, infinite revalidation bugs, and performance issues, and is not supported.
```

### :link: External links

[Issue raised in Slack](https://hashicorp.slack.com/archives/CPB8GS9QT/p1657913533488579)

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
