### PR TITLE
Update `Dropdown` documentation

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -212,7 +212,8 @@
       <p>Elements passed as children of this sub-component are yielded inside the list item.</p>
       <p>🚨
         <em>Notice: when using the "generic" list item the developer is completely responsible for any element yielded,
-          including the accessibility of that element.</em></p>
+          including the accessibility of that element, as well as the layout of the content (we provide only the
+          horizontal padding for consistency with the other items).</em></p>
     </dd>
     <dt>...attributes</dt>
     <dd>
@@ -565,6 +566,10 @@
       </li>
     </ul>
   </nav>
+  <p class="dummy-paragraph">
+    <em>Notice: when using the "generic" list item the developer is completely responsible for any element yielded,
+      including the accessibility of that element, as well as the layout of the content (we provide only the horizontal
+      padding for consistency with the other items).</em></p>
 
   <h5 class="dummy-h5">ToggleIcon for "overflow" dropdown menus</h5>
   <p class="dummy-paragraph">


### PR DESCRIPTION
### :pushpin: Summary

Following @amyrlam comment here https://github.com/hashicorp/cloud-ui/pull/3095#discussion_r922538005 I've realized that is not made explicit in the documentation that the layout of the content of the `Generic` item in the `Hds::Dropdown` component is left to the consumers (we only provide horizontal padding for consistency with the other elements).

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated dropdown documentation to make explicit that the layout of the `generic` content is left to the consumer

Preview: https://hds-components-git-update-drodown-documentation-hashicorp.vercel.app/components/dropdown

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
