### PR TITLE
Fix computation error on disclosure (take 2 🙈)

### DIFF
--- a/.changeset/nine-fishes-dance.md
+++ b/.changeset/nine-fishes-dance.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix computation error on disclosure (take 2)


### PR DESCRIPTION
### :pushpin: Summary

Fix computation error on disclosure utility component.

### :hammer_and_wrench: Detailed description

In https://github.com/hashicorp/design-system/pull/456 I wrongly identified the issue – the solution made the `cloud-ui` tests pass, but only sometimes. After managing to replicate the failing tests locally and testing with https://github.com/hashicorp/cloud-ui/pull/3098 it turns out the racing happens between the `@action` functions (`onFocusOut`, `onKeyUp`) triggering the same `notifyPropertyChange` via `close` in a short amount of time (even shorter in automated tests). I tried many options to prevent this error from happening in tests without avail. The only solution I could find that prevents tests in `cloud-ui` from failing intermittently is to move what happens in the `close` function to the next runloop – hence I'm proposing this to unblock the adoption of this component until a wiser solution may be determined.

***

### Preview
Failing/ﬂaky test in HCP consul

#### Before
<img width="1512" alt="Screenshot 2022-07-18 at 18 14 40" src="https://user-images.githubusercontent.com/788096/179566411-1648636b-f6c7-4f35-a003-cd902f1f7dc2.png">


#### After
<img width="1511" alt="Screenshot 2022-07-18 at 18 11 33" src="https://user-images.githubusercontent.com/788096/179566224-8aa34471-24b4-45ff-ac3a-5ee5358cb493.png">


### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
