### PR TITLE
Form controls - Update the “overview” sections of the form controls

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
@@ -4,7 +4,8 @@
 
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
-  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  <p class="dummy-paragraph">An input of type "checkbox" is a form element that allows users to select one or more items
+    from a list of individual items.</p>
 </section>
 
 <section>

--- a/packages/components/tests/dummy/app/templates/components/form/radio.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio.hbs
@@ -4,7 +4,8 @@
 
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
-  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  <p class="dummy-paragraph">An input of type "radio" is a form element that allows users to select a single item from a
+    list of related options.</p>
 </section>
 
 <section>

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -4,7 +4,8 @@
 
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
-  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  <p class="dummy-paragraph">A select is a form element that provides users with a way to select amongst a set of
+    options.</p>
 </section>
 
 <section>

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -4,7 +4,7 @@
 
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
-  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  <p class="dummy-paragraph">A text input is a form element that provides users with a way to read, input, or edit data.</p>
 </section>
 
 <section>

--- a/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
@@ -4,7 +4,9 @@
 
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
-  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  <p class="dummy-paragraph">A textarea input provides all the same features as the
+    <LinkTo @route="components.form.text-input">text input</LinkTo>, with the difference that it accepts a multi-line
+    text.</p>
 </section>
 
 <section>

--- a/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
@@ -4,7 +4,8 @@
 
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
-  <p class="dummy-paragraph">🚧 TODO 🚧</p>
+  <p class="dummy-paragraph">A toggle is a form element that allows users to select between two mutually exclusive
+    states.</p>
 </section>
 
 <section>


### PR DESCRIPTION
### :pushpin: Summary

The "overview" sections of the form controls had still "TODO" placeholder text. I've used the overview text found in the CRDs as starting point, and come up with a set of definitions for the `Overview` sections of the documentation pages.

_Notice: please suggest better definitions, if you see they can be improved._

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the “overview” sections of the form controls with short descriptions of the components

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
