### PR TITLE
Add `name` property on checkbox and radio groups

### DIFF
--- a/packages/components/addon/components/hds/form/checkbox/field.hbs
+++ b/packages/components/addon/components/hds/form/checkbox/field.hbs
@@ -10,6 +10,7 @@
     <Hds::Form::Checkbox::Base
       class="hds-form-field__control"
       @value={{@value}}
+      name={{@name}}
       ...attributes
       id={{F.id}}
       aria-describedby={{F.ariaDescribedBy}}

--- a/packages/components/addon/components/hds/form/checkbox/group.hbs
+++ b/packages/components/addon/components/hds/form/checkbox/group.hbs
@@ -1,4 +1,11 @@
-<Hds::Form::Fieldset @layout={{@layout}} @isRequired={{@isRequired}} @isOptional={{@isOptional}} ...attributes as |F|>
+<Hds::Form::Fieldset
+  @layout={{@layout}}
+  @name={{@name}}
+  @isRequired={{@isRequired}}
+  @isOptional={{@isOptional}}
+  ...attributes
+  as |F|
+>
   {{! Notice: the order of the elements is not relevant here, because it's controlled at "Hds::Form::Fieldset" component level }}
   {{yield (hash Legend=F.Legend isRequired=F.isRequired isOptional=F.isOptional)}}
   {{yield (hash HelperText=F.HelperText Error=F.Error)}}
@@ -6,7 +13,7 @@
     {{yield
       (hash
         Checkbox::Field=(component
-          "hds/form/checkbox/field" contextualClass="hds-form-group__control-field" isRequired=@isRequired
+          "hds/form/checkbox/field" contextualClass="hds-form-group__control-field" isRequired=@isRequired name=@name
         )
       )
     }}

--- a/packages/components/addon/components/hds/form/radio/field.hbs
+++ b/packages/components/addon/components/hds/form/radio/field.hbs
@@ -10,6 +10,7 @@
     <Hds::Form::Radio::Base
       class="hds-form-field__control"
       @value={{@value}}
+      name={{@name}}
       ...attributes
       id={{F.id}}
       aria-describedby={{F.ariaDescribedBy}}

--- a/packages/components/addon/components/hds/form/radio/group.hbs
+++ b/packages/components/addon/components/hds/form/radio/group.hbs
@@ -1,4 +1,11 @@
-<Hds::Form::Fieldset @layout={{@layout}} @isRequired={{@isRequired}} @isOptional={{@isOptional}} ...attributes as |F|>
+<Hds::Form::Fieldset
+  @layout={{@layout}}
+  @name={{@name}}
+  @isRequired={{@isRequired}}
+  @isOptional={{@isOptional}}
+  ...attributes
+  as |F|
+>
   {{! Notice: the order of the elements is not relevant here, because it's controlled at "Hds::Form::Fieldset" component level }}
   {{yield (hash Legend=F.Legend isRequired=F.isRequired isOptional=F.isOptional)}}
   {{yield (hash HelperText=F.HelperText Error=F.Error)}}
@@ -6,7 +13,7 @@
     {{yield
       (hash
         Radio::Field=(component
-          "hds/form/radio/field" contextualClass="hds-form-group__control-field" isRequired=@isRequired
+          "hds/form/radio/field" contextualClass="hds-form-group__control-field" isRequired=@isRequired name=@name
         )
       )
     }}

--- a/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
@@ -173,6 +173,13 @@
         <li>horizontal</li>
       </ol>
     </dd>
+    <dt>name <code>string</code></dt>
+    <dd>
+      <p>Sets the
+        <code class="dummy-code">name</code>
+        attribute for each form control within the group.
+      </p>
+    </dd>
     <dt>isRequired <code>boolean</code></dt>
     <dd>
       <p>Appends a
@@ -583,8 +590,8 @@
   {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
-    @code="
-      <Hds::Form::Checkbox::Group as |G|>
+    @code='
+      <Hds::Form::Checkbox::Group @name="datacenter-demo1" as |G|>
         <G.Legend>Valid datacenters</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>NYC1</F.Label>
@@ -599,12 +606,12 @@
           <F.Label>SF1</F.Label>
         </G.Checkbox::Field>
       </Hds::Form::Checkbox::Group>
-    "
+    '
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group as |G|>
+  <Hds::Form::Checkbox::Group @name="datacenter-demo1" as |G|>
     <G.Legend>Valid datacenters</G.Legend>
     <G.Checkbox::Field as |F|>
       <F.Label>NYC1</F.Label>
@@ -644,7 +651,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
+      <Hds::Form::Checkbox::Group @layout="horizontal" @name="datacenter-demo2" as |G|>
         <G.Legend>Valid datacenters</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>NYC1</F.Label>
@@ -664,7 +671,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
+  <Hds::Form::Checkbox::Group @layout="horizontal" @name="datacenter-demo2" as |G|>
     <G.Legend>Valid datacenters</G.Legend>
     <G.Checkbox::Field as |F|>
       <F.Label>NYC1</F.Label>
@@ -686,8 +693,8 @@
   {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
-    @code="
-      <Hds::Form::Checkbox::Group as |G|>
+    @code='
+      <Hds::Form::Checkbox::Group @name="methods-demo1" as |G|>
         <G.Legend>Methods</G.Legend>
         <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
         <G.Checkbox::Field checked as |F|>
@@ -700,12 +707,12 @@
           <F.Label>PUT</F.Label>
         </G.Checkbox::Field>
       </Hds::Form::Checkbox::Group>
-    "
+    '
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group as |G|>
+  <Hds::Form::Checkbox::Group @name="methods-demo1" as |G|>
     <G.Legend>Methods</G.Legend>
     <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
     <G.Checkbox::Field checked as |F|>
@@ -738,7 +745,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Checkbox::Group as |G|>
+      <Hds::Form::Checkbox::Group @name="methods-demo2" as |G|>
         <G.Legend>Methods <Hds::Badge @size="small" @text="Beta" @color="highlight" /></G.Legend>
         <G.HelperText>All methods are applied by default unless specified. See <Hds::Link::Inline @href="#">HTTP protocol</Hds::Link::Inline> for more details.</G.HelperText>
         <G.Checkbox::Field checked as |F|>
@@ -756,7 +763,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group as |G|>
+  <Hds::Form::Checkbox::Group @name="methods-demo2" as |G|>
     <G.Legend>Methods <Hds::Badge @size="small" @text="Beta" @color="highlight" /></G.Legend>
     <G.HelperText>All methods are applied by default unless specified. See
       <Hds::Link::Inline @href="#">HTTP protocol</Hds::Link::Inline>
@@ -792,7 +799,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Checkbox::Group @isRequired=\{{true}} @layout="horizontal" as |G|>
+      <Hds::Form::Checkbox::Group @isRequired=\{{true}} @layout="horizontal" @name="methods-demo3" as |G|>
         <G.Legend>Methods</G.Legend>
         <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
         <G.Checkbox::Field checked as |F|><F.Label>POST</F.Label></G.Checkbox::Field>
@@ -800,7 +807,7 @@
         <G.Checkbox::Field checked as |F|><F.Label>PUT</F.Label></G.Checkbox::Field>
       </Hds::Form::Checkbox::Group>
       <br />
-      <Hds::Form::Checkbox::Group @isOptional=\{{true}} @layout="horizontal" as |G|>
+      <Hds::Form::Checkbox::Group @isOptional=\{{true}} @layout="horizontal" @name="methods-demo4" as |G|>
         <G.Legend>Methods</G.Legend>
         <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
         <G.Checkbox::Field checked as |F|><F.Label>POST</F.Label></G.Checkbox::Field>
@@ -812,7 +819,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group @isRequired={{true}} @layout="horizontal" as |G|>
+  <Hds::Form::Checkbox::Group @isRequired={{true}} @layout="horizontal" @name="methods-demo3" as |G|>
     <G.Legend>Methods</G.Legend>
     <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
     <G.Checkbox::Field checked as |F|>
@@ -826,7 +833,7 @@
     </G.Checkbox::Field>
   </Hds::Form::Checkbox::Group>
   <br />
-  <Hds::Form::Checkbox::Group @isOptional={{true}} @layout="horizontal" as |G|>
+  <Hds::Form::Checkbox::Group @isOptional={{true}} @layout="horizontal" @name="methods-demo4" as |G|>
     <G.Legend>Methods</G.Legend>
     <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
     <G.Checkbox::Field checked as |F|>
@@ -860,7 +867,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
+      <Hds::Form::Checkbox::Group @layout="horizontal" @name="datacenter-demo3" as |G|>
         <G.Legend>Valid datacenters</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>NYC1</F.Label>
@@ -881,7 +888,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
+  <Hds::Form::Checkbox::Group @layout="horizontal" @name="datacenter-demo3" as |G|>
     <G.Legend>Valid datacenters</G.Legend>
     <G.Checkbox::Field as |F|>
       <F.Label>NYC1</F.Label>
@@ -920,7 +927,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Checkbox::Group @layout="vertical" as |G|>
+      <Hds::Form::Checkbox::Group @layout="vertical" @name="datacenter-demo4" as |G|>
         <G.Legend>Valid datacenters</G.Legend>
         <G.Checkbox::Field name="datacenter1" @id="datacenter-NYC1" @value="NYC1" \{{on "change" myAction}} as |F|>
           <F.Label>NYC1</F.Label>
@@ -944,7 +951,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group @layout="vertical" as |G|>
+  <Hds::Form::Checkbox::Group @layout="vertical" @name="datacenter-demo4" as |G|>
     <G.Legend>Valid datacenters</G.Legend>
     <G.Checkbox::Field name="datacenter1" @id="datacenter-NYC1" @value="NYC1" {{on "change" this.noop}} as |F|>
       <F.Label>NYC1</F.Label>
@@ -1297,7 +1304,7 @@
     <div>
       <span class="dummy-text-small">With legend</span>
       <br />
-      <Hds::Form::Checkbox::Group as |G|>
+      <Hds::Form::Checkbox::Group @name="control-vertical-01" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>Label of control #1</F.Label>
@@ -1313,7 +1320,7 @@
     <div>
       <span class="dummy-text-small">With legend / With helper text</span>
       <br />
-      <Hds::Form::Checkbox::Group as |G|>
+      <Hds::Form::Checkbox::Group @name="control-vertical-02" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>Label of control #1</F.Label>
@@ -1332,7 +1339,7 @@
     <div>
       <span class="dummy-text-small">Without legend</span>
       <br />
-      <Hds::Form::Checkbox::Group as |G|>
+      <Hds::Form::Checkbox::Group @name="control-vertical-03" as |G|>
         <G.Checkbox::Field as |F|>
           <F.Label>Label of control #1</F.Label>
         </G.Checkbox::Field>
@@ -1347,7 +1354,7 @@
     <div>
       <span class="dummy-text-small">Without Legend / With helper text</span>
       <br />
-      <Hds::Form::Checkbox::Group as |G|>
+      <Hds::Form::Checkbox::Group @name="control-vertical-04" as |G|>
         <G.Checkbox::Field as |F|>
           <F.Label>Label of control #1</F.Label>
           <F.HelperText>Helper text for control #1</F.HelperText>
@@ -1365,7 +1372,7 @@
     <div>
       <span class="dummy-text-small">With helper text at group level</span>
       <br />
-      <Hds::Form::Checkbox::Group as |G|>
+      <Hds::Form::Checkbox::Group @name="control-vertical-05" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.HelperText>Helper text for the entire group</G.HelperText>
         <G.Checkbox::Field as |F|>
@@ -1382,7 +1389,7 @@
     <div>
       <span class="dummy-text-small">With error at group level</span>
       <br />
-      <Hds::Form::Checkbox::Group as |G|>
+      <Hds::Form::Checkbox::Group @name="control-vertical-06" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>Label of control #1</F.Label>
@@ -1401,7 +1408,7 @@
   <h5 class="dummy-h5">Horizontal layout</h5>
   <span class="dummy-text-small">With legend</span>
   <br />
-  <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
+  <Hds::Form::Checkbox::Group @layout="horizontal" @name="control-horizontal-01" as |G|>
     <G.Legend>Legend of the group</G.Legend>
     <G.Checkbox::Field as |F|>
       <F.Label>Label of control #1</F.Label>
@@ -1416,7 +1423,7 @@
   <br />
   <span class="dummy-text-small">Without legend</span>
   <br />
-  <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
+  <Hds::Form::Checkbox::Group @layout="horizontal" @name="control-horizontal-02" as |G|>
     <G.Checkbox::Field as |F|>
       <F.Label>Label of control #1</F.Label>
     </G.Checkbox::Field>
@@ -1430,7 +1437,7 @@
   <br />
   <span class="dummy-text-small">With helper text at group level</span>
   <br />
-  <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
+  <Hds::Form::Checkbox::Group @layout="horizontal" @name="control-horizontal-03" as |G|>
     <G.Legend>Legend of the group</G.Legend>
     <G.HelperText>Helper text for the entire group</G.HelperText>
     <G.Checkbox::Field as |F|>
@@ -1446,7 +1453,7 @@
   <br />
   <span class="dummy-text-small">With error at group level</span>
   <br />
-  <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
+  <Hds::Form::Checkbox::Group @layout="horizontal" @name="control-horizontal-04" as |G|>
     <G.Legend>Legend of the group</G.Legend>
     <G.Checkbox::Field as |F|>
       <F.Label>Label of control #1</F.Label>
@@ -1463,7 +1470,7 @@
   <span class="dummy-text-small">With controls on multiple lines</span>
   <br />
   <div class="dummy-form-checkbox-max-width-container">
-    <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
+    <Hds::Form::Checkbox::Group @layout="horizontal" @name="control-horizontal-05" as |G|>
       <G.Legend>Lorem ipsum dolor</G.Legend>
       <G.Checkbox::Field as |F|>
         <F.Label>Sit amet</F.Label>
@@ -1491,7 +1498,7 @@
     <div>
       <span class="dummy-text-small">With legend + Required</span>
       <br />
-      <Hds::Form::Checkbox::Group @isRequired={{true}} as |G|>
+      <Hds::Form::Checkbox::Group @isRequired={{true}} @name="control-required" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>Label of control #1</F.Label>
@@ -1507,7 +1514,7 @@
     <div>
       <span class="dummy-text-small">With legend + Optional</span>
       <br />
-      <Hds::Form::Checkbox::Group @isOptional={{true}} as |G|>
+      <Hds::Form::Checkbox::Group @isOptional={{true}} @name="control-optional" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>Label of control #1</F.Label>

--- a/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
@@ -590,8 +590,8 @@
   {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
-    @code='
-      <Hds::Form::Checkbox::Group @name="datacenter-demo1" as |G|>
+    @code="
+      <Hds::Form::Checkbox::Group as |G|>
         <G.Legend>Valid datacenters</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>NYC1</F.Label>
@@ -606,12 +606,12 @@
           <F.Label>SF1</F.Label>
         </G.Checkbox::Field>
       </Hds::Form::Checkbox::Group>
-    '
+    "
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group @name="datacenter-demo1" as |G|>
+  <Hds::Form::Checkbox::Group as |G|>
     <G.Legend>Valid datacenters</G.Legend>
     <G.Checkbox::Field as |F|>
       <F.Label>NYC1</F.Label>
@@ -651,7 +651,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Checkbox::Group @layout="horizontal" @name="datacenter-demo2" as |G|>
+      <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
         <G.Legend>Valid datacenters</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>NYC1</F.Label>
@@ -671,7 +671,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group @layout="horizontal" @name="datacenter-demo2" as |G|>
+  <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
     <G.Legend>Valid datacenters</G.Legend>
     <G.Checkbox::Field as |F|>
       <F.Label>NYC1</F.Label>
@@ -867,7 +867,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Checkbox::Group @layout="horizontal" @name="datacenter-demo3" as |G|>
+      <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
         <G.Legend>Valid datacenters</G.Legend>
         <G.Checkbox::Field as |F|>
           <F.Label>NYC1</F.Label>
@@ -888,7 +888,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group @layout="horizontal" @name="datacenter-demo3" as |G|>
+  <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
     <G.Legend>Valid datacenters</G.Legend>
     <G.Checkbox::Field as |F|>
       <F.Label>NYC1</F.Label>
@@ -917,6 +917,58 @@
         controls), in reality is very unlikely that you will need to (in case, please speak with the design system team)</em></li>
   </ul>
 
+  <h5 class="dummy-h5">Name attribute</h5>
+  <p class="dummy-paragraph">It's possible to provide a shared name between for the controls in in a group using the
+    <code class="dummy-code">@name</code>
+    argument:</p>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Form::Checkbox::Group @layout="horizontal" @name="datacenter-group" as |G|>
+        <G.Legend>Valid datacenters</G.Legend>
+        <G.Checkbox::Field as |F|>
+          <F.Label>NYC1</F.Label>
+        </G.Checkbox::Field>
+        <G.Checkbox::Field checked as |F|>
+          <F.Label>DC1</F.Label>
+        </G.Checkbox::Field>
+        <G.Checkbox::Field checked as |F|>
+          <F.Label>NYC2</F.Label>
+        </G.Checkbox::Field>
+        <G.Checkbox::Field as |F|>
+          <F.Label>SF1</F.Label>
+        </G.Checkbox::Field>
+      </Hds::Form::Checkbox::Group>
+    '
+  />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Form::Checkbox::Group @layout="horizontal" @name="datacenter-group" as |G|>
+    <G.Legend>Valid datacenters</G.Legend>
+    <G.Checkbox::Field as |F|>
+      <F.Label>NYC1</F.Label>
+    </G.Checkbox::Field>
+    <G.Checkbox::Field checked as |F|>
+      <F.Label>DC1</F.Label>
+    </G.Checkbox::Field>
+    <G.Checkbox::Field checked as |F|>
+      <F.Label>NYC2</F.Label>
+    </G.Checkbox::Field>
+    <G.Checkbox::Field as |F|>
+      <F.Label>SF1</F.Label>
+    </G.Checkbox::Field>
+  </Hds::Form::Checkbox::Group>
+  <p class="dummy-paragraph"><em>Notice: which one to use – single name vs distinct names for multiple checkboxes –
+      depends on the context where these checkboxes are used. If you are not sure and want to know more see
+      <a
+        href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#handling_multiple_checkboxes"
+        target="_blank"
+        rel="noopener noreferrer"
+      >this explanation</a>.</em></p>
+
   <h5 class="dummy-h5">"Field" items</h5>
   <p class="dummy-paragraph">As explained above, a "group" of checkboxes is made of one or more "field" checkbox
     components (<code class="dummy-code">Form::Checkbox::Field</code>). So all the arguments, attributes and modifiers
@@ -927,7 +979,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Checkbox::Group @layout="vertical" @name="datacenter-demo4" as |G|>
+      <Hds::Form::Checkbox::Group @layout="vertical" as |G|>
         <G.Legend>Valid datacenters</G.Legend>
         <G.Checkbox::Field name="datacenter1" @id="datacenter-NYC1" @value="NYC1" \{{on "change" myAction}} as |F|>
           <F.Label>NYC1</F.Label>
@@ -938,7 +990,7 @@
           <F.HelperText>CoreSite- K Street</F.HelperText>
         </G.Checkbox::Field>
         <G.Checkbox::Field name="datacenter3" @id="datacenter-NYC2" checked @value="NYC2" \{{on "change" myAction}} as |F|>
-          <F.Label>NYC1</F.Label>
+          <F.Label>NYC2</F.Label>
           <F.HelperText>H5 Data Center - 325 Hudson Street</F.HelperText>
         </G.Checkbox::Field>
         <G.Checkbox::Field name="datacenter4" @id="datacenter-SF1" @value="SF1" \{{on "change" myAction}} as |F|>
@@ -951,7 +1003,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Checkbox::Group @layout="vertical" @name="datacenter-demo4" as |G|>
+  <Hds::Form::Checkbox::Group @layout="vertical" as |G|>
     <G.Legend>Valid datacenters</G.Legend>
     <G.Checkbox::Field name="datacenter1" @id="datacenter-NYC1" @value="NYC1" {{on "change" this.noop}} as |F|>
       <F.Label>NYC1</F.Label>
@@ -962,7 +1014,7 @@
       <F.HelperText>CoreSite- K Street</F.HelperText>
     </G.Checkbox::Field>
     <G.Checkbox::Field name="datacenter3" @id="datacenter-NYC2" @value="NYC2" checked {{on "change" this.noop}} as |F|>
-      <F.Label>NYC1</F.Label>
+      <F.Label>NYC2</F.Label>
       <F.HelperText>H5 Data Center - 325 Hudson Street</F.HelperText>
     </G.Checkbox::Field>
     <G.Checkbox::Field name="datacenter4" @id="datacenter-SF1" @value="SF1" {{on "change" this.noop}} as |F|>

--- a/packages/components/tests/dummy/app/templates/components/form/radio.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio.hbs
@@ -178,6 +178,13 @@
         <li>horizontal</li>
       </ol>
     </dd>
+    <dt>name <code>string</code></dt>
+    <dd>
+      <p>Sets the
+        <code class="dummy-code">name</code>
+        attribute for each form control within the group.
+      </p>
+    </dd>
     <dt>isRequired <code>boolean</code></dt>
     <dd>
       <p>Appends a
@@ -300,18 +307,18 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Radio::Group as |G|>
+      <Hds::Form::Radio::Group @name="datacenter-demo1" as |G|>
         <G.Legend>Choose datacenter</G.Legend>
-        <G.Radio::Field name="datacenter-demo1" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>NYC1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo1" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>DC1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo1" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>NYC2</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo1" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>SF1</F.Label>
         </G.Radio::Field>
       </Hds::Form::Radio::Group>
@@ -320,18 +327,18 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Radio::Group as |G|>
+  <Hds::Form::Radio::Group @name="datacenter-demo1" as |G|>
     <G.Legend>Choose datacenter</G.Legend>
-    <G.Radio::Field name="datacenter-demo1" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>NYC1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo1" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>DC1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo1" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>NYC2</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo1" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>SF1</F.Label>
     </G.Radio::Field>
   </Hds::Form::Radio::Group>
@@ -365,18 +372,18 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+      <Hds::Form::Radio::Group @layout="horizontal" @name="datacenter-demo2" as |G|>
         <G.Legend>Choose datacenter</G.Legend>
-        <G.Radio::Field name="datacenter-demo2" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>NYC1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo2" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>DC1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo2" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>NYC2</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo2" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>SF1</F.Label>
         </G.Radio::Field>
       </Hds::Form::Radio::Group>
@@ -385,18 +392,18 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+  <Hds::Form::Radio::Group @layout="horizontal" @name="datacenter-demo2" as |G|>
     <G.Legend>Choose datacenter</G.Legend>
-    <G.Radio::Field name="datacenter-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>NYC1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>DC1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>NYC2</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>SF1</F.Label>
     </G.Radio::Field>
   </Hds::Form::Radio::Group>
@@ -408,19 +415,19 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+      <Hds::Form::Radio::Group @layout="horizontal" @name="datacenter-demo3" as |G|>
         <G.Legend>Choose datacenter</G.Legend>
         <G.HelperText>Select which datacenter to use for the initial setup.</G.HelperText>
-        <G.Radio::Field name="datacenter-demo2" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>NYC1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo2" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>DC1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo2" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>NYC2</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo2" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>SF1</F.Label>
         </G.Radio::Field>
       </Hds::Form::Radio::Group>
@@ -429,19 +436,19 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+  <Hds::Form::Radio::Group @layout="horizontal" @name="datacenter-demo3" as |G|>
     <G.Legend>Choose datacenter</G.Legend>
     <G.HelperText>Select which datacenter to use for the initial setup.</G.HelperText>
-    <G.Radio::Field name="datacenter-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>NYC1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>DC1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>NYC2</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>SF1</F.Label>
     </G.Radio::Field>
   </Hds::Form::Radio::Group>
@@ -465,16 +472,16 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+      <Hds::Form::Radio::Group @layout="horizontal" @name="method-demo1" as |G|>
         <G.Legend>Method <Hds::Badge @size="small" @text="Beta" @color="highlight" /></G.Legend>
         <G.HelperText>Choose which HTTP method to use for the communication channel. See <Hds::Link::Inline @href="#">HTTP protocol</Hds::Link::Inline> for more details.</G.HelperText>
-        <G.Radio::Field name="method-demo1" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>POST</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="method-demo1" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>GET</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="method-demo1" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>PUT</F.Label>
         </G.Radio::Field>
       </Hds::Form::Radio::Group>
@@ -483,18 +490,18 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+  <Hds::Form::Radio::Group @layout="horizontal" @name="method-demo1" as |G|>
     <G.Legend>Method <Hds::Badge @size="small" @text="Beta" @color="highlight" /></G.Legend>
     <G.HelperText>Choose which HTTP method to use for the communication channel. See
       <Hds::Link::Inline @href="#">HTTP protocol</Hds::Link::Inline>
       for more details.</G.HelperText>
-    <G.Radio::Field name="method-demo1" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>POST</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="method-demo1" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>GET</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="method-demo1" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>PUT</F.Label>
     </G.Radio::Field>
   </Hds::Form::Radio::Group>
@@ -519,50 +526,50 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Radio::Group @isRequired=\{{true}} @layout="horizontal" as |G|>
+      <Hds::Form::Radio::Group @isRequired=\{{true}} @layout="horizontal" @name="method-demo2" as |G|>
         <G.Legend>Method</G.Legend>
         <G.HelperText>Choose which HTTP method to use for the communication channel.</G.HelperText>
-        <G.Radio::Field name="method-demo2" as |F|><F.Label>POST</F.Label></G.Radio::Field>
-        <G.Radio::Field name="method-demo2" as |F|><F.Label>GET</F.Label></G.Radio::Field>
-        <G.Radio::Field name="method-demo2" as |F|><F.Label>PUT</F.Label></G.Radio::Field>
+        <G.Radio::Field as |F|><F.Label>POST</F.Label></G.Radio::Field>
+        <G.Radio::Field as |F|><F.Label>GET</F.Label></G.Radio::Field>
+        <G.Radio::Field as |F|><F.Label>PUT</F.Label></G.Radio::Field>
       </Hds::Form::Radio::Group>
       <br />
-      <Hds::Form::Radio::Group @isOptional=\{{true}} @layout="horizontal" as |G|>
+      <Hds::Form::Radio::Group @isOptional=\{{true}} @layout="horizontal" @name="method-demo3" as |G|>
         <G.Legend>Method</G.Legend>
         <G.HelperText>Choose which HTTP method to use for the communication channel.</G.HelperText>
-        <G.Radio::Field name="method-demo3" as |F|><F.Label>POST</F.Label></G.Radio::Field>
-        <G.Radio::Field name="method-demo3" as |F|><F.Label>GET</F.Label></G.Radio::Field>
-        <G.Radio::Field name="method-demo3" as |F|><F.Label>PUT</F.Label></G.Radio::Field>
+        <G.Radio::Field as |F|><F.Label>POST</F.Label></G.Radio::Field>
+        <G.Radio::Field as |F|><F.Label>GET</F.Label></G.Radio::Field>
+        <G.Radio::Field as |F|><F.Label>PUT</F.Label></G.Radio::Field>
       </Hds::Form::Radio::Group>
     '
   />
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Radio::Group @isRequired={{true}} @layout="horizontal" as |G|>
+  <Hds::Form::Radio::Group @isRequired={{true}} @layout="horizontal" @name="method-demo2" as |G|>
     <G.Legend>Methods</G.Legend>
     <G.HelperText>Choose which HTTP method to use for the communication channel.</G.HelperText>
-    <G.Radio::Field name="method-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>POST</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="method-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>GET</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="method-demo2" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>PUT</F.Label>
     </G.Radio::Field>
   </Hds::Form::Radio::Group>
   <br />
-  <Hds::Form::Radio::Group @isOptional={{true}} @layout="horizontal" as |G|>
+  <Hds::Form::Radio::Group @isOptional={{true}} @layout="horizontal" @name="method-demo3" as |G|>
     <G.Legend>Methods</G.Legend>
     <G.HelperText>Choose which HTTP method to use for the communication channel.</G.HelperText>
-    <G.Radio::Field name="method-demo3" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>POST</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="method-demo3" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>GET</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="method-demo3" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>PUT</F.Label>
     </G.Radio::Field>
   </Hds::Form::Radio::Group>
@@ -587,18 +594,18 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+      <Hds::Form::Radio::Group @layout="horizontal" @name="datacenter-demo4" as |G|>
         <G.Legend>Choose datacenter</G.Legend>
-        <G.Radio::Field name="datacenter-demo4" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>NYC1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo4" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>DC1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo4" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>NYC2</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo4" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>SF1</F.Label>
         </G.Radio::Field>
         <G.Error>Error: you need to choose at least one datacenter.</G.Error>
@@ -608,18 +615,18 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+  <Hds::Form::Radio::Group @layout="horizontal" @name="datacenter-demo4" as |G|>
     <G.Legend>Choose datacenter</G.Legend>
-    <G.Radio::Field name="datacenter-demo4" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>NYC1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo4" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>DC1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo4" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>NYC2</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo4" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>SF1</F.Label>
     </G.Radio::Field>
     <G.Error>Error: you need to choose at least one datacenter.</G.Error>
@@ -647,21 +654,21 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Radio::Group @layout="vertical" as |G|>
+      <Hds::Form::Radio::Group @layout="vertical" @name="datacenter-demo5" as |G|>
         <G.Legend>Choose datacenter</G.Legend>
-        <G.Radio::Field name="datacenter-demo5" @id="datacenter-NYC1" checked @value="NYC1" \{{on "change" myAction}} as |F|>
+        <G.Radio::Field @id="datacenter-NYC1" checked @value="NYC1" \{{on "change" myAction}} as |F|>
           <F.Label>NYC1</F.Label>
           <F.HelperText>CoreSite- 32 Avenue of the Americas</F.HelperText>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo5" @id="datacenter-DC1" @value="DC1" \{{on "change" myAction}} as |F|>
+        <G.Radio::Field @id="datacenter-DC1" @value="DC1" \{{on "change" myAction}} as |F|>
           <F.Label>DC1</F.Label>
           <F.HelperText>CoreSite- K Street</F.HelperText>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo5" @id="datacenter-NYC2" @value="NYC2" \{{on "change" myAction}} as |F|>
+        <G.Radio::Field @id="datacenter-NYC2" @value="NYC2" \{{on "change" myAction}} as |F|>
           <F.Label>NYC1</F.Label>
           <F.HelperText>H5 Data Center - 325 Hudson Street</F.HelperText>
         </G.Radio::Field>
-        <G.Radio::Field name="datacenter-demo5" @id="datacenter-SF1" @value="SF1" \{{on "change" myAction}} as |F|>
+        <G.Radio::Field @id="datacenter-SF1" @value="SF1" \{{on "change" myAction}} as |F|>
           <F.Label>SF1</F.Label>
           <F.HelperText>INAP - 650 Townsend Street</F.HelperText>
         </G.Radio::Field>
@@ -671,28 +678,21 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Radio::Group @layout="vertical" as |G|>
+  <Hds::Form::Radio::Group @layout="vertical" @name="datacenter-demo5" as |G|>
     <G.Legend>Choose datacenter</G.Legend>
-    <G.Radio::Field
-      name="datacenter-demo5"
-      @id="datacenter-NYC1"
-      checked
-      @value="NYC1"
-      {{on "change" this.noop}}
-      as |F|
-    >
+    <G.Radio::Field @id="datacenter-NYC1" checked @value="NYC1" {{on "change" this.noop}} as |F|>
       <F.Label>NYC1</F.Label>
       <F.HelperText>CoreSite- 32 Avenue of the Americas</F.HelperText>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo5" @id="datacenter-DC1" @value="DC1" {{on "change" this.noop}} as |F|>
+    <G.Radio::Field @id="datacenter-DC1" @value="DC1" {{on "change" this.noop}} as |F|>
       <F.Label>DC1</F.Label>
       <F.HelperText>CoreSite- K Street</F.HelperText>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo5" @id="datacenter-NYC2" @value="NYC2" {{on "change" this.noop}} as |F|>
+    <G.Radio::Field @id="datacenter-NYC2" @value="NYC2" {{on "change" this.noop}} as |F|>
       <F.Label>NYC1</F.Label>
       <F.HelperText>H5 Data Center - 325 Hudson Street</F.HelperText>
     </G.Radio::Field>
-    <G.Radio::Field name="datacenter-demo5" @id="datacenter-SF1" @value="SF1" {{on "change" this.noop}} as |F|>
+    <G.Radio::Field @id="datacenter-SF1" @value="SF1" {{on "change" this.noop}} as |F|>
       <F.Label>SF1</F.Label>
       <F.HelperText>INAP - 650 Townsend Street</F.HelperText>
     </G.Radio::Field>
@@ -912,15 +912,15 @@
     <div>
       <span class="dummy-text-small">With legend</span>
       <br />
-      <Hds::Form::Radio::Group as |G|>
+      <Hds::Form::Radio::Group @name="control-vertical-01" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field name="control-vertical-01" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-01" checked="checked" as |F|>
+        <G.Radio::Field checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-01" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #3</F.Label>
         </G.Radio::Field>
       </Hds::Form::Radio::Group>
@@ -928,14 +928,14 @@
     <div>
       <span class="dummy-text-small">Without legend</span>
       <br />
-      <Hds::Form::Radio::Group as |G|>
-        <G.Radio::Field name="control-vertical-02" as |F|>
+      <Hds::Form::Radio::Group @name="control-vertical-02" as |G|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-02" checked="checked" as |F|>
+        <G.Radio::Field checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-02" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #3</F.Label>
         </G.Radio::Field>
       </Hds::Form::Radio::Group>
@@ -943,17 +943,17 @@
     <div>
       <span class="dummy-text-small">With legend / With helper text</span>
       <br />
-      <Hds::Form::Radio::Group as |G|>
+      <Hds::Form::Radio::Group @name="control-vertical-03" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field name="control-vertical-03" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #1</F.Label>
           <F.HelperText>Helper text for control #1</F.HelperText>
         </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-03" checked="checked" as |F|>
+        <G.Radio::Field checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
           <F.HelperText>Helper text for control #2</F.HelperText>
         </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-03" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #3</F.Label>
           <F.HelperText>Helper text for control #3</F.HelperText>
         </G.Radio::Field>
@@ -962,16 +962,16 @@
     <div>
       <span class="dummy-text-small">Without Legend / With helper text</span>
       <br />
-      <Hds::Form::Radio::Group as |G|>
-        <G.Radio::Field name="control-vertical-04" as |F|>
+      <Hds::Form::Radio::Group @name="control-vertical-04" as |G|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #1</F.Label>
           <F.HelperText>Helper text for control #1</F.HelperText>
         </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-04" checked="checked" as |F|>
+        <G.Radio::Field checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
           <F.HelperText>Helper text for control #2</F.HelperText>
         </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-04" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #3</F.Label>
           <F.HelperText>Helper text for control #3</F.HelperText>
         </G.Radio::Field>
@@ -980,16 +980,16 @@
     <div>
       <span class="dummy-text-small">With helper text at group level</span>
       <br />
-      <Hds::Form::Radio::Group as |G|>
+      <Hds::Form::Radio::Group @name="control-vertical-05" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.HelperText>Helper text for the entire group</G.HelperText>
-        <G.Radio::Field name="control-vertical-05" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-05" checked="checked" as |F|>
+        <G.Radio::Field checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-05" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #3</F.Label>
         </G.Radio::Field>
       </Hds::Form::Radio::Group>
@@ -997,7 +997,7 @@
     <div>
       <span class="dummy-text-small">With error at group level</span>
       <br />
-      <Hds::Form::Radio::Group as |G|>
+      <Hds::Form::Radio::Group @name="control-vertical-06" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.Radio::Field name="control-vertical-06" as |F|>
           <F.Label>Label of control #1</F.Label>
@@ -1016,52 +1016,52 @@
   <h5 class="dummy-h5">Horizontal layout</h5>
   <span class="dummy-text-small">With legend</span>
   <br />
-  <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+  <Hds::Form::Radio::Group @layout="horizontal" @name="control-horizontal-01" as |G|>
     <G.Legend>Legend of the group</G.Legend>
-    <G.Radio::Field name="control-horizontal-01" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>Label of control #1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="control-horizontal-01" checked="checked" as |F|>
+    <G.Radio::Field checked="checked" as |F|>
       <F.Label>Label of control #2</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="control-horizontal-01" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>Label of control #3</F.Label>
     </G.Radio::Field>
   </Hds::Form::Radio::Group>
   <br />
   <span class="dummy-text-small">Without legend</span>
   <br />
-  <Hds::Form::Radio::Group @layout="horizontal" as |G|>
-    <G.Radio::Field name="control-horizontal-02" as |F|>
+  <Hds::Form::Radio::Group @layout="horizontal" @name="control-horizontal-02" as |G|>
+    <G.Radio::Field as |F|>
       <F.Label>Label of control #1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="control-horizontal-02" checked="checked" as |F|>
+    <G.Radio::Field checked="checked" as |F|>
       <F.Label>Label of control #2</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="control-horizontal-02" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>Label of control #3</F.Label>
     </G.Radio::Field>
   </Hds::Form::Radio::Group>
   <br />
   <span class="dummy-text-small">With helper text at group level</span>
   <br />
-  <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+  <Hds::Form::Radio::Group @layout="horizontal" @name="control-horizontal-03" as |G|>
     <G.Legend>Legend of the group</G.Legend>
     <G.HelperText>Helper text for the entire group</G.HelperText>
-    <G.Radio::Field name="control-horizontal-03" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>Label of control #1</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="control-horizontal-03" checked="checked" as |F|>
+    <G.Radio::Field checked="checked" as |F|>
       <F.Label>Label of control #2</F.Label>
     </G.Radio::Field>
-    <G.Radio::Field name="control-horizontal-03" as |F|>
+    <G.Radio::Field as |F|>
       <F.Label>Label of control #3</F.Label>
     </G.Radio::Field>
   </Hds::Form::Radio::Group>
   <br />
   <span class="dummy-text-small">With error at group level</span>
   <br />
-  <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+  <Hds::Form::Radio::Group @layout="horizontal" @name="control-horizontal-04" as |G|>
     <G.Legend>Legend of the group</G.Legend>
     <G.Radio::Field name="control-horizontal-04" as |F|>
       <F.Label>Label of control #1</F.Label>
@@ -1078,24 +1078,24 @@
   <span class="dummy-text-small">With controls on multiple lines</span>
   <br />
   <div class="dummy-form-radio-max-width-container">
-    <Hds::Form::Radio::Group @layout="horizontal" as |G|>
+    <Hds::Form::Radio::Group @layout="horizontal" @name="control-horizontal-05" as |G|>
       <G.Legend>Lorem ipsum dolor</G.Legend>
-      <G.Radio::Field name="dummy-form-control-max-width" as |F|>
+      <G.Radio::Field as |F|>
         <F.Label>Sit amet</F.Label>
       </G.Radio::Field>
-      <G.Radio::Field name="control-max-width" checked="checked" as |F|>
+      <G.Radio::Field checked="checked" as |F|>
         <F.Label>Consectetur adipiscing</F.Label>
       </G.Radio::Field>
-      <G.Radio::Field name="control-max-width" as |F|>
+      <G.Radio::Field as |F|>
         <F.Label>Elit</F.Label>
       </G.Radio::Field>
-      <G.Radio::Field name="control-max-width" as |F|>
+      <G.Radio::Field as |F|>
         <F.Label>Pellentesque erat</F.Label>
       </G.Radio::Field>
-      <G.Radio::Field name="control-max-width" as |F|>
+      <G.Radio::Field as |F|>
         <F.Label>Lacinia</F.Label>
       </G.Radio::Field>
-      <G.Radio::Field name="control-max-width" as |F|>
+      <G.Radio::Field as |F|>
         <F.Label>At magna</F.Label>
       </G.Radio::Field>
     </Hds::Form::Radio::Group>
@@ -1106,15 +1106,15 @@
     <div>
       <span class="dummy-text-small">With legend + Required</span>
       <br />
-      <Hds::Form::Radio::Group @isRequired={{true}} as |G|>
+      <Hds::Form::Radio::Group @isRequired={{true}} @name="control-required" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field name="control-horizontal-01" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="control-horizontal-01" checked="checked" as |F|>
+        <G.Radio::Field checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="control-horizontal-01" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #3</F.Label>
         </G.Radio::Field>
       </Hds::Form::Radio::Group>
@@ -1122,15 +1122,15 @@
     <div>
       <span class="dummy-text-small">With legend + Optional</span>
       <br />
-      <Hds::Form::Radio::Group @isOptional={{true}} as |G|>
+      <Hds::Form::Radio::Group @isOptional={{true}} @name="control-optional" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field name="control-horizontal-01" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #1</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="control-horizontal-01" checked="checked" as |F|>
+        <G.Radio::Field checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
         </G.Radio::Field>
-        <G.Radio::Field name="control-horizontal-01" as |F|>
+        <G.Radio::Field as |F|>
           <F.Label>Label of control #3</F.Label>
         </G.Radio::Field>
       </Hds::Form::Radio::Group>

--- a/packages/components/tests/dummy/app/templates/components/form/radio.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio.hbs
@@ -363,6 +363,9 @@
       <code class="dummy-code">aria-describedby</code>
       attributes automatically generated and correcly linked one with the other).</li>
   </ul>
+  <p class="dummy-paragraph">The
+    <code class="dummy-code">@name</code>
+    argument offers an easy way to provide the same name for all the radio controls in a single place.</p>
 
   <h5 class="dummy-h5">Layout</h5>
   <p class="dummy-paragraph">You can choose between two different layout orientations, to better fit your spacing

--- a/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
@@ -82,10 +82,10 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     assert.expect(3);
     await render(
-      hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" name="my-name" data-test />`
     );
     assert.dom('input').hasClass('my-class');
-    assert.dom('input').hasAttribute('data-test1');
-    assert.dom('input').hasAttribute('data-test2', 'test');
+    assert.dom('input').hasAttribute('name', 'my-name');
+    assert.dom('input').hasAttribute('data-test');
   });
 });

--- a/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
@@ -79,13 +79,15 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
 
   // ATTRIBUTES
 
-  test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    assert.expect(3);
+  // we have added an extra assertion for the "name" attribute here, even if not strictly necessary, to make sure is not overwritten in any way
+  test('it should spread all the attributes (including "name") passed to the component on the input', async function (assert) {
+    assert.expect(4);
     await render(
-      hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" name="my-name" data-test />`
+      hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" />`
     );
     assert.dom('input').hasClass('my-class');
-    assert.dom('input').hasAttribute('name', 'my-name');
-    assert.dom('input').hasAttribute('data-test');
+    assert.dom('input').hasAttribute('data-test1');
+    assert.dom('input').hasAttribute('data-test2', 'test');
+    assert.dom('input').hasAttribute('name', 'test-name');
   });
 });

--- a/packages/components/tests/integration/components/hds/form/checkbox/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/group-test.js
@@ -29,7 +29,7 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
               <F.Error>This is the control error</F.Error>
             </G.Checkbox::Field>
             <G.Error>This is the group error</G.Error>
-        </Hds::Form::Checkbox::Group>`
+          </Hds::Form::Checkbox::Group>`
     );
     assert.dom('.hds-form-group__legend').exists();
     assert.dom('.hds-form-group__legend').hasText('This is the legend');
@@ -64,6 +64,29 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
     assert.dom('.hds-form-group__legend').doesNotExist();
     assert.dom('.hds-form-group__helper-text').doesNotExist();
     assert.dom('.hds-form-group__error').doesNotExist();
+  });
+
+  // NAME
+
+  test('it renders the defined name on all controls within a group', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Checkbox::Group @name="datacenter-demo" as |G|>
+            <G.Legend>Choose datacenter</G.Legend>
+            <G.Checkbox::Field data-test="first-control" as |F|>
+              <F.Label>NYC1</F.Label>
+            </G.Checkbox::Field>
+            <G.Checkbox::Field data-test="second-control" as |F|>
+              <F.Label>DC1</F.Label>
+            </G.Checkbox::Field>
+          </Hds::Form::Checkbox::Group>`
+    );
+    assert
+      .dom('[data-test="first-control"]')
+      .hasAttribute('name', 'datacenter-demo');
+    assert
+      .dom('[data-test="second-control"]')
+      .hasAttribute('name', 'datacenter-demo');
   });
 
   // REQUIRED AND OPTIONAL

--- a/packages/components/tests/integration/components/hds/form/radio/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/field-test.js
@@ -78,13 +78,15 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
 
   // ATTRIBUTES
 
-  test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    assert.expect(3);
+  // we have added an extra assertion for the "name" attribute here, even if not strictly necessary, to make sure is not overwritten in any way
+  test('it should spread all the attributes (includind "name") passed to the component on the input', async function (assert) {
+    assert.expect(4);
     await render(
-      hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" name="my-name" data-test />`
+      hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" />`
     );
     assert.dom('input').hasClass('my-class');
-    assert.dom('input').hasAttribute('name', 'my-name');
-    assert.dom('input').hasAttribute('data-test');
+    assert.dom('input').hasAttribute('data-test1');
+    assert.dom('input').hasAttribute('data-test2', 'test');
+    assert.dom('input').hasAttribute('name', 'test-name');
   });
 });

--- a/packages/components/tests/integration/components/hds/form/radio/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/field-test.js
@@ -81,10 +81,10 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     assert.expect(3);
     await render(
-      hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" name="my-name" data-test />`
     );
     assert.dom('input').hasClass('my-class');
-    assert.dom('input').hasAttribute('data-test1');
-    assert.dom('input').hasAttribute('data-test2', 'test');
+    assert.dom('input').hasAttribute('name', 'my-name');
+    assert.dom('input').hasAttribute('data-test');
   });
 });

--- a/packages/components/tests/integration/components/hds/form/radio/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/group-test.js
@@ -29,7 +29,7 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
               <F.Error>This is the control error</F.Error>
             </G.Radio::Field>
             <G.Error>This is the group error</G.Error>
-        </Hds::Form::Radio::Group>`
+          </Hds::Form::Radio::Group>`
     );
     assert.dom('.hds-form-group__legend').exists();
     assert.dom('.hds-form-group__legend').hasText('This is the legend');
@@ -64,6 +64,29 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
     assert.dom('.hds-form-group__legend').doesNotExist();
     assert.dom('.hds-form-group__helper-text').doesNotExist();
     assert.dom('.hds-form-group__error').doesNotExist();
+  });
+
+  // NAME
+
+  test('it renders the defined name on all controls within a group', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Radio::Group @name="datacenter-demo" as |G|>
+            <G.Legend>Choose datacenter</G.Legend>
+            <G.Radio::Field data-test="first-control" as |F|>
+              <F.Label>NYC1</F.Label>
+            </G.Radio::Field>
+            <G.Radio::Field data-test="second-control" as |F|>
+              <F.Label>DC1</F.Label>
+            </G.Radio::Field>
+          </Hds::Form::Radio::Group>`
+    );
+    assert
+      .dom('[data-test="first-control"]')
+      .hasAttribute('name', 'datacenter-demo');
+    assert
+      .dom('[data-test="second-control"]')
+      .hasAttribute('name', 'datacenter-demo');
   });
 
   // REQUIRED AND OPTIONAL


### PR DESCRIPTION
### :pushpin: Summary

Add `name` property on checkbox and radio groups.

### :hammer_and_wrench: Detailed description

We're introducing the `@name` property to checkbox and radio groups as a mean to set the `name` attribute consistently across form controls within the same group. We preserve the `name` attribute as the primary way of setting the attribute in field and basic.

### :link: External links

[Jira issue](https://hashicorp.atlassian.net/jira/software/c/projects/HDS/boards/445?modal=detail&selectedIssue=HDS-258&assignee=626686c4a32183006f22f5b6)

***

### 👀 How to review

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
