### PR TITLE
HDS-335 Add missing required tag to icon arg

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
@@ -96,7 +96,11 @@
       <p>The text of the link.</p>
       <p><em>If no text value is defined an error will be thrown.</em></p>
     </dd>
-    <dt>icon <code>string</code></dt>
+    <dt>
+      icon
+      <code>string</code>
+      <strong class="required">required</strong>
+    </dt>
     <dd>
       <p>
         Use this parameter to show an icon. Acceptable value: any Flight icon name.


### PR DESCRIPTION
### :pushpin: Summary

Adding a "required" tag to the "icon" arg for Link::Standalone which I missed in my previous PR.

Published docs: https://design-system-components-hashicorp.vercel.app/components/link/standalone

### :camera_flash: Screenshots
PRed update:    
<img width="748" alt="Screen Shot 2022-07-25 at 11 45 46 AM" src="https://user-images.githubusercontent.com/108769823/180851402-b5bfcb56-10b2-4d9b-a2d2-2761250cce3b.png">

### :link: External links

Previous PR: https://github.com/hashicorp/design-system/pull/467

***

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
