### PR TITLE
install deps for icons sync with --immutable

### DIFF
--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -18,7 +18,7 @@ jobs:
           cache-dependency-path: yarn.lock
   
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Sync icons
         env:


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

--frozen-lockfile is deprecated in yarn3. See this recent run [where this was noted](https://github.com/hashicorp/design-system/runs/7509643214?check_suite_focus=true#step:4:7). This now matches [how we do it in other github actions](https://github.com/hashicorp/design-system/blob/ed96740352c8a1bda0cebbcec41eb6eb7de0a67d/.github/workflows/ci-components.yml#L30).

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
