### PR TITLE
ensure lockfile is updated during changeset versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:
-          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          version: yarn version
           publish: yarn release
         env:
           # Token setup in hashibot-hds' account

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "@changesets/cli": "^2.23.0"
   },
   "scripts": {
-    "release": "yarn changeset publish"
+    "release": "yarn changeset publish",
+    "version": "yarn changeset version && yarn install --mode update-lockfile"
   },
   "packageManager": "yarn@3.2.1"
 }


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

Ensure the yarn.lock lockfile is correctly updated after changeset versions our packages.

### :hammer_and_wrench: Detailed description

Our most recent release [failed](https://github.com/hashicorp/design-system/runs/7520939756?check_suite_focus=true) because yarn noticed that lockfile changes would have happened. This lockfile update _should_ have happened when the initial version PR was created.  This PR adds a step that piggybacks on the `yarn changeset version` command to use yarn's `update-lockfile` mode to update the lockfile. [From the yarn docs](https://yarnpkg.com/cli/install/#details):

> update-lockfile will skip the link step altogether, and only fetch packages that are missing from the lockfile (or that have no associated checksums). This mode is typically used by tools like Renovate or Dependabot to keep a lockfile up-to-date without incurring the full install cost.

Note: This wasn't a problem in yarn v1 because the workspace packages were not tracked in the lockfile, however in yarn 3 they now are.

Note 2: I did test this locally and it seems like it did work as expected. 

### :link: External links

[Jira](https://hashicorp.atlassian.net/browse/HDS-436)

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
