### PR TITLE
Add `multiple`/`size` styles to select component

### DIFF
--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -67,3 +67,34 @@
     }
   }
 }
+
+// MULTIPLE/SIZE
+
+.hds-form-select {
+  &[multiple],
+  &[size]{
+    background: none;
+
+    option {
+      border-radius: 3px;
+      margin: 2px auto;
+
+      &:hover {
+        color: var(--token-color-foreground-action);
+      }
+      &:disabled {
+        color: var(--token-color-foreground-disabled);
+      }
+      &:checked {
+        color: var(--token-color-foreground-high-contrast);
+        background: var(--token-color-palette-blue-200);
+      }
+    }
+
+    optgroup {
+      color: var(--token-color-foreground-strong);
+      font-weight: var(--token-typography-font-weight-semibold);
+      font-style: normal; // reset Firefox default
+    }
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -637,17 +637,17 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Select::Field name="infrastructure" multiple size="4" as |F|>
+      <Hds::Form::Select::Field name="infrastructure" multiple size="8" as |F|>
         <F.Label>Target infrastructure</F.Label>
         <F.Options>
           <optgroup label="Most common">
             <option value="Kubernetes">Kubernetes</option>
             <option value="AWS">AWS</option>
-            <option value="Azure">Azure</option>
+            <option value="Azure" disabled>Azure</option>
           </optgroup>
           <optgroup label="Others">
-            <option value="Alibaba">Alibaba</option>
-            <option value="CloudWise">CloudWise</option>
+            <option value="Alibaba" selected>Alibaba</option>
+            <option value="CloudWise" selected>CloudWise</option>
             <option value="SWA">SWA</option>
             <option value="Other">Other</option>
           </optgroup>
@@ -658,17 +658,17 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Form::Select::Field name="infrastructure" multiple size="4" as |F|>
+  <Hds::Form::Select::Field name="infrastructure" multiple size="8" as |F|>
     <F.Label>Target infrastructure</F.Label>
     <F.Options>
       <optgroup label="Most common">
         <option value="Kubernetes">Kubernetes</option>
         <option value="AWS">AWS</option>
-        <option value="Azure">Azure</option>
+        <option value="Azure" disabled>Azure</option>
       </optgroup>
       <optgroup label="Others">
-        <option value="Alibaba">Alibaba</option>
-        <option value="CloudWise">CloudWise</option>
+        <option value="Alibaba" selected>Alibaba</option>
+        <option value="CloudWise" selected>CloudWise</option>
         <option value="SWA">SWA</option>
         <option value="Other">Other</option>
       </optgroup>


### PR DESCRIPTION
### :pushpin: Summary

Add `multiple`/`size` styles to select component.

### :hammer_and_wrench: Detailed description

We don't expect to find this variation in our products, but as we allow these two attributes in the select component we want to make sure they look decently well when they're enabled.

Tried to keep the `multiple`/`size` styles separated from the main select styles, for readability.
Added some states in examples so we can catch any visual regression, but happy to scrap them if we don't want to encourage this.

**Note:**
The selected options are still light blue in Chrome when the `<select>` element is in focus, as there is not way to override them, unfortunately (cc: @heatherlarsen). More on this on Chromium bug tracker [Issue 398417](https://bugs.chromium.org/p/chromium/issues/detail?id=398417) and [Chromium group chat](https://groups.google.com/a/chromium.org/g/blink-reviews/c/2FeNfAR8FAQ).

### :camera_flash: Screenshots

<table>
<tr><th>Browser</th><th>Before</th><th>After</th></tr>
<tr><td>Chrome</td><td>

<img width="145" alt="select-multiple-chrome-before" src="https://user-images.githubusercontent.com/788096/181584795-4ff05684-be6e-4ab7-900e-46e6d1c3ac1e.png">


</td><td>

<img width="145" alt="select-multiple-chrome-after" src="https://user-images.githubusercontent.com/788096/181584809-f5202165-8ecb-4d80-905f-72b4364d2197.png">


</td></tr>
<tr><td>Firefox</td><td>

<img width="145" alt="select-multiple-firefox-before" src="https://user-images.githubusercontent.com/788096/181584859-1f3ff095-85ec-4f65-a78c-087863c2fb59.png">


</td><td>

<img width="145" alt="select-multiple-firefox-after" src="https://user-images.githubusercontent.com/788096/181584878-118e4f55-9776-4e32-88a9-d26f228c0444.png">


</td></tr>
</table>

Note: Safari doesn't support custom styling on these elements/states it seems.

### :link: External links

[Design reference](https://www.figma.com/file/vPHO3jpKMaBlvIwVnfbOuW/PowerSelect-styles?node-id=14537%3A35556)

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
