### PR TITLE
Addresses some a11y issues in stepper component

### DIFF
--- a/packages/components/addon/components/hds/stepper/index.hbs
+++ b/packages/components/addon/components/hds/stepper/index.hbs
@@ -1,0 +1,3 @@
+<div role="list" class="hds-stepper" ...attributes>
+  {{yield}}
+</div>

--- a/packages/components/addon/components/hds/stepper/indicator/step.hbs
+++ b/packages/components/addon/components/hds/stepper/indicator/step.hbs
@@ -1,6 +1,6 @@
 <div class={{this.classNames}} ...attributes role="listitem" aria-label={{@status}}>
-  <div class="hds-stepper-indicator-step__svg-hexagon" aria-hidden="true">
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="hds-stepper-indicator-step__svg-hexagon">
+    <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="m3.664 6.264 6.99-4.42a2.5 2.5 0 0 1 2.67-.002l7.01 4.422A2.5 2.5 0 0 1 21.5 8.38v7.242a2.5 2.5 0 0 1-1.166 2.115l-7.01 4.422a2.5 2.5 0 0 1-2.67-.002l-6.99-4.42A2.5 2.5 0 0 1 2.5 15.623V8.377a2.5 2.5 0 0 1 1.164-2.113Z"
         stroke-width="1"

--- a/packages/components/app/components/hds/stepper/index.js
+++ b/packages/components/app/components/hds/stepper/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/stepper/index';

--- a/packages/components/tests/dummy/app/templates/components/stepper.hbs
+++ b/packages/components/tests/dummy/app/templates/components/stepper.hbs
@@ -6,12 +6,12 @@
   <p class="dummy-paragraph">A stepper indicator helps the user maintain context and directionality when advancing
     through a multi-step flow or feature, and in certain circumstances acts as a navigational device between steps. It
     is generally assembled as part of a larger stepper pattern.</p>
-  <p class="dummy-paragraph">For practical accessibility purposes, consider a stepper (the whole component) to be a list of items, with each step
-    being a list item.</p>
+  <p class="dummy-paragraph">For practical accessibility purposes, consider a stepper (the whole component) to be a list
+    of items, with each step being a list item.</p>
   <p class="dummy-paragraph">
     As of this writing the HDS team publishes two separate (but related)
     <code class="dummy-code">Stepper::Indicator</code>
-    components that serve different hierarchal purposes.
+    components that serve different hierarchical purposes.
     <ol>
       <li>The
         <code class="dummy-code">Indicator::Step</code>

--- a/packages/components/tests/dummy/app/templates/components/stepper.hbs
+++ b/packages/components/tests/dummy/app/templates/components/stepper.hbs
@@ -6,7 +6,7 @@
   <p class="dummy-paragraph">A stepper indicator helps the user maintain context and directionality when advancing
     through a multi-step flow or feature, and in certain circumstances acts as a navigational device between steps. It
     is generally assembled as part of a larger stepper pattern.</p>
-  <p>For practical accesibility purposes, consider a stepper (the whole component) to be a list of items, with each step
+  <p class="dummy-paragraph">For practical accessibility purposes, consider a stepper (the whole component) to be a list of items, with each step
     being a list item.</p>
   <p class="dummy-paragraph">
     As of this writing the HDS team publishes two separate (but related)

--- a/packages/components/tests/dummy/app/templates/components/stepper.hbs
+++ b/packages/components/tests/dummy/app/templates/components/stepper.hbs
@@ -6,6 +6,8 @@
   <p class="dummy-paragraph">A stepper indictor helps the user maintain context and directionality when advancing
     through a multi-step flow or feature, and in certain circumstances acts as a navigational device between steps. It
     is generally assembled as part of a larger stepper pattern.</p>
+  <p>For practical accesibility purposes, consider a stepper (the whole component) to be a list of items, with each step
+    being a list item.</p>
   <p class="dummy-paragraph">
     As of this writing the HDS team publishes two separate (but related)
     <code class="dummy-code">Stepper::Indicator</code>
@@ -17,7 +19,7 @@
         sequentially.</li>
       <li>The
         <code class="dummy-code">Indicator::Task</code>
-        component: used either on it's own to denote smaller task-oriented flows or in combination with the
+        component: used either on its own to denote smaller task-oriented flows or in combination with the
         <code class="dummy-code">Step</code>
         indicator to list multiple tasks within a step.</li>
     </ol>
@@ -35,7 +37,7 @@
     <code class="dummy-code">hover</code>,
     <code class="dummy-code">active</code>, and
     <code class="dummy-code">focus</code>.</p>
-  <h4 class="dummy-h4">Stepper::Indicator::Step</h4>
+  <h4 class="dummy-h4" id="component-api-stepper-indicator">Stepper::Indicator::Step</h4>
   <p class="dummy-paragraph">Here is the API for the <code class="dummy-code">Indicator::Step</code> component:</p>
   <dl class="dummy-component-props" aria-labelledby="component-api-stepper-indicator">
     <dt>status <code>enum</code></dt>
@@ -48,8 +50,6 @@
         <li>complete</li>
       </ol>
     </dd>
-  </dl>
-  <dl class="dummy-component-props" aria-labelledby="component-api-stepper-indicator">
     <dt>isInteractive <code>boolean</code></dt>
     <dd>
       <p>Default: <span class="default">true</span></p>
@@ -58,16 +58,14 @@
         is not interactive and has no hover state. Usage for this variant is generally recommended for onboarding-type
         sequences or list-item steps.</p>
     </dd>
-  </dl>
-  <dl class="dummy-component-props" aria-labelledby="component-api-stepper-indicator">
     <dt>text <code>string</code></dt>
     <dd>
       <p>Generally corresponds with the numerical value of the index of the item in an array of multiple steps.</p>
     </dd>
   </dl>
-  <h4 class="dummy-h4">Stepper::Indicator::Task</h4>
+  <h4 class="dummy-h4" id="component-api-stepper-indicator-task">Stepper::Indicator::Task</h4>
   <p class="dummy-paragraph">Here is the API for the <code class="dummy-code">Indicator::Task</code> component:</p>
-  <dl class="dummy-component-props" aria-labelledby="component-api-stepper-indicator">
+  <dl class="dummy-component-props" aria-labelledby="component-api-stepper-indicator-task">
     <dt>status <code>enum</code></dt>
     <dd>
       <p>Acceptable values:</p>
@@ -78,8 +76,6 @@
         <li>complete</li>
       </ol>
     </dd>
-  </dl>
-  <dl class="dummy-component-props" aria-labelledby="component-api-stepper-indicator">
     <dt>isInteractive <code>boolean</code></dt>
     <dd>
       <p>Default: <span class="default">true</span></p>
@@ -106,7 +102,9 @@
     '
   />
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Stepper::Indicator::Step @text="1" @status="incomplete" />
+  <Hds::Stepper>
+    <Hds::Stepper::Indicator::Step @text="1" @status="incomplete" />
+  </Hds::Stepper>
   <h5 class="dummy-h5">Adding interactivity</h5>
   <CodeBlock
     @language="markup"
@@ -115,8 +113,11 @@
     '
   />
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Stepper::Indicator::Step @text="1" @status="incomplete" @isInteractive={{true}} />
-  <h5 class="dummy-h5">Notating status</h5>
+  <Hds::Stepper>
+    <Hds::Stepper::Indicator::Step @text="1" @status="incomplete" @isInteractive={{true}} />
+  </Hds::Stepper>
+
+  <h5 class="dummy-h5">Indicating status</h5>
   <CodeBlock
     @language="markup"
     @code='
@@ -124,8 +125,11 @@
     '
   />
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Stepper::Indicator::Step @text="1" @status="progress" @isInteractive={{true}} />
-  <h5 class="dummy-h5">Notating processing</h5>
+  <Hds::Stepper>
+    <Hds::Stepper::Indicator::Step @text="1" @status="progress" @isInteractive={{true}} />
+  </Hds::Stepper>
+
+  <h5 class="dummy-h5">Indicating processing</h5>
   <CodeBlock
     @language="markup"
     @code='
@@ -133,7 +137,10 @@
     '
   />
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Stepper::Indicator::Step @text="1" @status="processing" @isInteractive={{true}} />
+  <Hds::Stepper>
+    <Hds::Stepper::Indicator::Step @text="1" @status="processing" @isInteractive={{true}} />
+  </Hds::Stepper>
+
   <h5 class="dummy-h5">Rendering a complete step</h5>
   <CodeBlock
     @language="markup"
@@ -142,8 +149,12 @@
     '
   />
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Stepper::Indicator::Step @text="1" @status="complete" @isInteractive={{true}} />
+  <Hds::Stepper>
+    <Hds::Stepper::Indicator::Step @text="1" @status="complete" @isInteractive={{true}} />
+  </Hds::Stepper>
+
   <h4 class="dummy-h4">Stepper::Indicator::Task</h4>
+
   <h5 class="dummy-h5">Basic use</h5>
   <CodeBlock
     @language="markup"
@@ -152,7 +163,9 @@
     '
   />
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Stepper::Indicator::Task @status="incomplete" />
+  <Hds::Stepper>
+    <Hds::Stepper::Indicator::Task @status="incomplete" />
+  </Hds::Stepper>
   <h5 class="dummy-h5">Adding interactivity</h5>
   <CodeBlock
     @language="markup"
@@ -161,8 +174,11 @@
     '
   />
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Stepper::Indicator::Task @status="incomplete" @isInteractive={{true}} />
-  <h5 class="dummy-h5">Notating status</h5>
+  <Hds::Stepper>
+    <Hds::Stepper::Indicator::Task @status="incomplete" @isInteractive={{true}} />
+  </Hds::Stepper>
+
+  <h5 class="dummy-h5">Indicating status</h5>
   <CodeBlock
     @language="markup"
     @code='
@@ -170,8 +186,11 @@
     '
   />
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Stepper::Indicator::Task @status="progress" @isInteractive={{true}} />
-  <h5 class="dummy-h5">Notating processing</h5>
+  <Hds::Stepper>
+    <Hds::Stepper::Indicator::Task @status="progress" @isInteractive={{true}} />
+  </Hds::Stepper>
+
+  <h5 class="dummy-h5">Indicating processing</h5>
   <CodeBlock
     @language="markup"
     @code='
@@ -179,7 +198,10 @@
     '
   />
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Stepper::Indicator::Task @status="processing" @isInteractive={{true}} />
+  <Hds::Stepper>
+    <Hds::Stepper::Indicator::Task @status="processing" @isInteractive={{true}} />
+  </Hds::Stepper>
+
   <h5 class="dummy-h5">Rendering a complete task</h5>
   <CodeBlock
     @language="markup"
@@ -188,7 +210,9 @@
     '
   />
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Stepper::Indicator::Task @status="complete" @isInteractive={{true}} />
+  <Hds::Stepper>
+    <Hds::Stepper::Indicator::Task @status="complete" @isInteractive={{true}} />
+  </Hds::Stepper>
 </section>
 
 <section>
@@ -210,12 +234,19 @@
 
 <section>
   <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
-  <p class="dummy-paragraph">These criteria while relevant in the application of the
+  <p class="dummy-paragraph">The
     <code class="dummy-code">Stepper::Indicator</code>
-    components, are best applied in the context of a larger step or task
-    <strong>pattern</strong>
-    and should be adhered to as such.</p>
+    components are not WCAG-conformant on their own. In order to meet conformance requirements, the following steps must
+    be taken:</p>
+  <ol class="dummy-list">
+    <li>They must be wrapped in a div element with the role of list applied</li>
+    <li>They must be given a meaningful name. The desired outcome: if there were two steppers on the same page, each
+      step should have a uniquely meaningful name so that the user can differentiate.</li>
+  </ol>
+
   <h4 class="dummy-h4">Applicable WCAG Success Criteria (Reference)</h4>
+  <p class="dummy-paragraph">Once the Stepper is completely composed, authors should ensure that the following WCAG
+    Success Criteria are met:</p>
   <ul class="dummy-list">
     <li><a
         href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html"
@@ -296,7 +327,9 @@
       <div>
         <span class="dummy-text-small">{{capitalize status}}</span>
         <br />
-        <Hds::Stepper::Indicator::Step @status={{status}} @text="1" />
+        <Hds::Stepper>
+          <Hds::Stepper::Indicator::Step @status={{status}} @text="1" />
+        </Hds::Stepper>
       </div>
     {{/each}}
   </div>
@@ -307,12 +340,14 @@
         <div>
           <span class="dummy-text-small">{{capitalize status}}/{{state}}</span>
           <br />
-          <Hds::Stepper::Indicator::Step
-            @status={{status}}
-            @text="1"
-            @isInteractive={{true}}
-            mock-state-value={{state}}
-          />
+          <Hds::Stepper>
+            <Hds::Stepper::Indicator::Step
+              @status={{status}}
+              @text="1"
+              @isInteractive={{true}}
+              mock-state-value={{state}}
+            />
+          </Hds::Stepper>
         </div>
       {{/each}}
     </div>
@@ -324,7 +359,9 @@
       <div>
         <span class="dummy-text-small">{{capitalize status}}</span>
         <br />
-        <Hds::Stepper::Indicator::Task @status={{status}} @text="1" />
+        <Hds::Stepper>
+          <Hds::Stepper::Indicator::Task @status={{status}} @text="1" />
+        </Hds::Stepper>
       </div>
     {{/each}}
   </div>
@@ -335,7 +372,9 @@
         <div>
           <span class="dummy-text-small">{{capitalize status}}/{{state}}</span>
           <br />
-          <Hds::Stepper::Indicator::Task @status={{status}} @isInteractive={{true}} mock-state-value={{state}} />
+          <Hds::Stepper>
+            <Hds::Stepper::Indicator::Task @status={{status}} @isInteractive={{true}} mock-state-value={{state}} />
+          </Hds::Stepper>
         </div>
       {{/each}}
     </div>

--- a/packages/components/tests/dummy/app/templates/components/stepper.hbs
+++ b/packages/components/tests/dummy/app/templates/components/stepper.hbs
@@ -3,7 +3,7 @@
 <h2 class="dummy-h2">Stepper Component</h2>
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
-  <p class="dummy-paragraph">A stepper indictor helps the user maintain context and directionality when advancing
+  <p class="dummy-paragraph">A stepper indicator helps the user maintain context and directionality when advancing
     through a multi-step flow or feature, and in certain circumstances acts as a navigational device between steps. It
     is generally assembled as part of a larger stepper pattern.</p>
   <p>For practical accesibility purposes, consider a stepper (the whole component) to be a list of items, with each step

--- a/packages/components/tests/integration/components/hds/stepper/index-test.js
+++ b/packages/components/tests/integration/components/hds/stepper/index-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/stepper/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Hds::Stepper::Index />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Hds::Stepper::Index>
+        template block text
+      </Hds::Stepper::Index>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR attempts to address some of the WCAG conformance issues with the stepper component. 

### :hammer_and_wrench: Detailed description

Changes made: 

1. Component: Added template-only component `Hds::Stepper` to provide and element with the appropriate role 
1. Component: moved `aria-hidden` to the SVG itself instead of the wrapper due to the way some browsers try to fix what they perceive as author error
1. Docs: Updated the rendered code with the new component
1. Docs: Added additional prose to the accessibility section
1. Docs: Updated some prose for readability
1. Docs: Fixed cases of multiple non-unique IDs on the same page
1. Docs: Fixed incorrect markup for `<dl>` in API section

If we decide to move forward with these proposed changes, there's a couple other TODOs:
- update sample code
- maybe add a test for a composed version of the component

Other remaining issues to discuss:

1. I do not think that the task indicators are visible enough. If we cannot have this design updated, we need to very clearly indicate that using them would be in violation of WCAG (and list which Criteria they fail in their current state).
2. It seems confusing that `isInteractive` adds a pointer for hover state but there is no visible focus (and if none is added, it would fail the [Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html) Success Criteria). I wonder if we can shore this up a bit. Since the icon itself isn't interactive, perhaps we should change this API to `hasInteractive`, and put the hover and focus styling on the anticipated nested `<a>` element, or something like that?
3. I do not understand how this component is supposed to add interactivity; more complete instructions and examples are needed. Should it be used as a block component and nest an interactive element in that? If so, which ones are okay? Just a plain link? Are we styling that? We should clarify all of these things.
4. The prose does not use plain language; recommend edits to make it easier to read/understand (and fit the tone of the other components)
5. After testing with `prefers-reduced-motion`, I recommend re-visiting the design. Filed [HDS-441](https://hashicorp.atlassian.net/browse/HDS-441) with video. 
6. After reviewing the full pattern in a call, I understand the eventual goals better and we should improve a couple of parent/child relationships and how they have been defined.



### :camera_flash: Screenshots

Before this PR: 
![image](https://user-images.githubusercontent.com/4587451/181634530-3eff5e21-4b30-4b7f-aeda-9a958cbbd61f.png)

After this PR:
![CleanShot 2022-07-28 at 15 47 34](https://user-images.githubusercontent.com/4587451/181634633-b06f67a1-e99d-4be8-a431-a0d28fc0de74.png)


### :link: External links

<!-- Issues, RFC, etc. -->

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
