### PR TITLE
limit dependabot percy check to one package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,3 @@ updates:
       interval: "weekly"
     allow: 
       - dependency-name: "@percy/*"
-  - package-ecosystem: "npm" 
-    directory: "packages/ember-flight-icons/" 
-    versioning-strategy: increase
-    schedule:
-      interval: "weekly"
-    allow: 
-      - dependency-name: "@percy/*"
-  - package-ecosystem: "npm" 
-    directory: "flight-website/" 
-    versioning-strategy: increase
-    schedule:
-      interval: "weekly"
-    allow: 
-      - dependency-name: "@percy/*"
-


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
In an ideal world dependabot would open a single PR that updates a dependency across all the packages that use it, but we do not live in an ideal world. This PR seeks to limit the noise and unnecessary PRs opened by dependabot to a single PR which we can then manually adjust to update across all our packages.
