### PR TITLE
Removed punctuation from h2s on index

### DIFF
--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -2,7 +2,7 @@
   <div class="dummy-index">
     <div>
       <h2 class="dummy-h2">
-        Foundations:
+        Foundations
       </h2>
       <ol>
         <li class="dummy-paragraph">
@@ -32,7 +32,7 @@
         </li>
       </ol>
       <h2 class="dummy-h2">
-        Icons:
+        Icons
       </h2>
       <ol>
         <li class="dummy-paragraph">
@@ -44,7 +44,7 @@
     </div>
     <div>
       <h2 class="dummy-h2">
-        Components:
+        Components
       </h2>
       <ol>
         <li class="dummy-paragraph">
@@ -151,7 +151,7 @@
     </div>
     <div>
       <h2 class="dummy-h2">
-        Utilities:
+        Utilities
       </h2>
       <ol>
         <li class="dummy-paragraph">
@@ -168,7 +168,7 @@
     </div>
     <div>
       <h2 class="dummy-h2">
-        Other:
+        Other
       </h2>
       <ol>
         <li class="dummy-paragraph">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR removes colon punctuation from the h2 elements on the index page.


### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
