### PR TITLE
Fix text wrapping in alert description

### DIFF
--- a/.changeset/pretty-crabs-applaud.md
+++ b/.changeset/pretty-crabs-applaud.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix text wrapping in alert description

--- a/packages/components/app/styles/components/alert.scss
+++ b/packages/components/app/styles/components/alert.scss
@@ -57,6 +57,7 @@
 .hds-alert__description {
   color: var(--token-color-foreground-primary);
   font-weight: var(--token-typography-font-weight-regular);
+  word-break: break-word;
 
   .hds-alert__title + & {
     margin-top: 4px;


### PR DESCRIPTION
### :pushpin: Summary

Fix text wrapping in alert description

### :hammer_and_wrench: Detailed description

Set `word-break: break-word` to force wrapping on long strings, such as SSH keys.

### :camera_flash: Screenshots

<table><tr><th>Before</th><th>After</th></tr>
<tr><td>

![toast-word-break-before](https://user-images.githubusercontent.com/788096/182341579-61fa8e81-3c85-45de-bf84-7c2a1a06b2a6.png)


</td><td>

![toast-word-break-after](https://user-images.githubusercontent.com/788096/182341597-5f5023c4-11ec-488b-bdf9-637528ec7fed.png)


</td></tr>
</table>

### :link: External links

Fixes #515

***

### 👀 How to review

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
