### PR TITLE
update default branch name for sync workflow

### DIFF
--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Open a PR
         uses: peter-evans/create-pull-request@v3
         with:
+          branch: 'hds-icon-export'
           commit-message: 'sync & build of flight icons'
           title: 'Updated export of icons from Figma'
           body: ''


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

Before: `create-pull-request/patch`
Now: `hds-icon-export`