### PR TITLE
Fix required attribute on form fields

### DIFF
--- a/.changeset/fast-bugs-admire.md
+++ b/.changeset/fast-bugs-admire.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix `required` attribute on form fields

--- a/packages/components/addon/components/hds/form/checkbox/field.hbs
+++ b/packages/components/addon/components/hds/form/checkbox/field.hbs
@@ -12,10 +12,10 @@
       class="hds-form-field__control"
       @value={{@value}}
       name={{@name}}
+      required={{@isRequired}}
       ...attributes
       id={{F.id}}
       aria-describedby={{F.ariaDescribedBy}}
-      required={{@isRequired}}
     />
   </F.Control>
 </Hds::Form::Field>

--- a/packages/components/addon/components/hds/form/radio/field.hbs
+++ b/packages/components/addon/components/hds/form/radio/field.hbs
@@ -12,10 +12,10 @@
       class="hds-form-field__control"
       @value={{@value}}
       name={{@name}}
+      required={{@isRequired}}
       ...attributes
       id={{F.id}}
       aria-describedby={{F.ariaDescribedBy}}
-      required={{@isRequired}}
     />
   </F.Control>
 </Hds::Form::Field>

--- a/packages/components/addon/components/hds/form/select/field.hbs
+++ b/packages/components/addon/components/hds/form/select/field.hbs
@@ -15,10 +15,10 @@
       @value={{@value}}
       @isInvalid={{@isInvalid}}
       @width={{@width}}
+      required={{@isRequired}}
       ...attributes
       id={{F.id}}
       aria-describedby={{F.ariaDescribedBy}}
-      required={{@isRequired}}
       as |S|
     >
       {{yield (hash Options=S.Options)}}

--- a/packages/components/addon/components/hds/form/text-input/field.hbs
+++ b/packages/components/addon/components/hds/form/text-input/field.hbs
@@ -16,10 +16,10 @@
       @value={{@value}}
       @isInvalid={{@isInvalid}}
       @width={{@width}}
+      required={{@isRequired}}
       ...attributes
       id={{F.id}}
       aria-describedby={{F.ariaDescribedBy}}
-      required={{@isRequired}}
     />
   </F.Control>
 </Hds::Form::Field>

--- a/packages/components/addon/components/hds/form/textarea/field.hbs
+++ b/packages/components/addon/components/hds/form/textarea/field.hbs
@@ -16,10 +16,10 @@
       @isInvalid={{@isInvalid}}
       @width={{@width}}
       @height={{@height}}
+      required={{@isRequired}}
       ...attributes
       id={{F.id}}
       aria-describedby={{F.ariaDescribedBy}}
-      required={{@isRequired}}
     />
   </F.Control>
 </Hds::Form::Field>

--- a/packages/components/addon/components/hds/form/toggle/field.hbs
+++ b/packages/components/addon/components/hds/form/toggle/field.hbs
@@ -12,10 +12,10 @@
       {{! template-lint-disable no-capital-arguments }}
       @_wrapperClass="hds-form-field__control"
       @value={{@value}}
+      required={{@isRequired}}
       ...attributes
       id={{F.id}}
       aria-describedby={{F.ariaDescribedBy}}
-      required={{@isRequired}}
     />
   </F.Control>
 </Hds::Form::Field>

--- a/packages/components/tests/integration/components/hds/form/select/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/field-test.js
@@ -124,6 +124,16 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
     assert.dom('label .hds-form-indicator').exists();
     assert.dom('label .hds-form-indicator').hasText('(Optional)');
   });
+  test('it should not append an indicator to the label text when the required attribute is set', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Select::Field required as |F|>
+            <F.Label>This is the label</F.Label>
+          </Hds::Form::Select::Field>`
+    );
+    assert.dom('select').hasAttribute('required');
+    assert.dom('label .hds-form-indicator').doesNotExist();
+  });
 
   // ATTRIBUTES
 

--- a/packages/components/tests/integration/components/hds/form/text-input/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/field-test.js
@@ -131,6 +131,16 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
     assert.dom('label .hds-form-indicator').exists();
     assert.dom('label .hds-form-indicator').hasText('(Optional)');
   });
+  test('it should not append an indicator to the label text when the required attribute is set', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::TextInput::Field required as |F|>
+            <F.Label>This is the label</F.Label>
+          </Hds::Form::TextInput::Field>`
+    );
+    assert.dom('input').hasAttribute('required');
+    assert.dom('label .hds-form-indicator').doesNotExist();
+  });
 
   // ATTRIBUTES
 

--- a/packages/components/tests/integration/components/hds/form/textarea/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/field-test.js
@@ -128,6 +128,16 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
     assert.dom('label .hds-form-indicator').exists();
     assert.dom('label .hds-form-indicator').hasText('(Optional)');
   });
+  test('it should not append an indicator to the label text when the required attribute is set', async function (assert) {
+    assert.expect(2);
+    await render(
+      hbs`<Hds::Form::Textarea::Field required as |F|>
+            <F.Label>This is the label</F.Label>
+          </Hds::Form::Textarea::Field>`
+    );
+    assert.dom('textarea').hasAttribute('required');
+    assert.dom('label .hds-form-indicator').doesNotExist();
+  });
 
   // ATTRIBUTES
 


### PR DESCRIPTION
### :pushpin: Summary

Fix `required` attribute on form fields

### :hammer_and_wrench: Detailed description

We currently set the `required` attribute on a form control based on the `@isRequired` argument (which is used to apply a visual indicator to the label element), but there are cases where the native validation is used, but the indicator is not required. To accommodate for this cases, we allow the required attribute to be set at the component level.

### :link: External links

Merging this will help with [form component migration in Waypoint](https://github.com/hashicorp/cloud-ui/pull/3281).

***

### 👀 How to review

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
