### PR TITLE
Added context banner for component docs

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -12,9 +12,9 @@
   <h4>When to use a Context Switcher</h4>
   <p>Context switchers (coming soon) are ideal for navigation menus and for selecting between different contexts within
     a single page, ie. switching between versions, languages, etc.</p>
-  <p><em>Note: While we currently allow navigation from the dropdown component, we'd like to move this interaction to the
-    context switcher when it becomes available, so there are intentional, consistent interactions taking place between
-    the two. This will help guide the user in understanding what to expect when opening each kind of menu.</em></p>
+  <p><em>Note: While we currently allow navigation from the dropdown component, we'd like to move this interaction to
+      the context switcher when it becomes available, so there are intentional, consistent interactions taking place
+      between the two. This will help guide the user in understanding what to expect when opening each kind of menu.</em></p>
 </section>
 
 <section>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -1,6 +1,21 @@
 {{page-title "Dropdown Component"}}
 
 <h2 class="dummy-h2">Dropdown Component</h2>
+<section class="dummy-link-cta-button-banner">
+  <h3>Dropdown, Select, Context Switcher...oh my!</h3>
+  <h4>When to use a Dropdown</h4>
+  <p>Dropdowns work great for overflow menus, where supplementary actions can be hidden in a menu. Dropdowns can be
+    identified by their button-like trigger and chevron icon.</p>
+  <h4>When to use a Select</h4>
+  <p>Use Selects in Forms when needing to provide the user with options to select from. Selects can be identified by
+    their input-like trigger and caret icon.</p>
+  <h4>When to use a Context Switcher</h4>
+  <p>Context switchers (coming soon) are ideal for navigation menus and for selecting between different contexts within
+    a single page, ie. switching between versions, languages, etc.</p>
+  <p><em>Note: While we currently allow navigation from the dropdown component, we'd like to move this interaction to the
+    context switcher when it becomes available, so there are intentional, consistent interactions taking place between
+    the two. This will help guide the user in understanding what to expect when opening each kind of menu.</em></p>
+</section>
 
 <section>
   <p class="dummy-paragraph">

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -1,6 +1,21 @@
 {{page-title "Form::Select Component"}}
 
 <h2 class="dummy-h2">Form::Select</h2>
+<section class="dummy-link-cta-button-banner">
+  <h3>Dropdown, Select, Context Switcher...oh my!</h3>
+  <h4>When to use a Dropdown</h4>
+  <p>Dropdowns work great for overflow menus, where supplementary actions can be hidden in a menu. Dropdowns can be
+    identified by their button-like trigger and chevron icon.</p>
+  <h4>When to use a Select</h4>
+  <p>Use Selects in Forms when needing to provide the user with options to select from. Selects can be identified by
+    their input-like trigger and caret icon.</p>
+  <h4>When to use a Context Switcher</h4>
+  <p>Context switchers (coming soon) are ideal for navigation menus and for selecting between different contexts within
+    a single page, ie. switching between versions, languages, etc.</p>
+  <p><em>Note: While we currently allow navigation from the dropdown component, we'd like to move this interaction to the
+    context switcher when it becomes available, so there are intentional, consistent interactions taking place between
+    the two. This will help guide the user in understanding what to expect when opening each kind of menu.</em></p>
+</section>
 
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -12,9 +12,9 @@
   <h4>When to use a Context Switcher</h4>
   <p>Context switchers (coming soon) are ideal for navigation menus and for selecting between different contexts within
     a single page, ie. switching between versions, languages, etc.</p>
-  <p><em>Note: While we currently allow navigation from the dropdown component, we'd like to move this interaction to the
-    context switcher when it becomes available, so there are intentional, consistent interactions taking place between
-    the two. This will help guide the user in understanding what to expect when opening each kind of menu.</em></p>
+  <p><em>Note: While we currently allow navigation from the dropdown component, we'd like to move this interaction to
+      the context switcher when it becomes available, so there are intentional, consistent interactions taking place
+      between the two. This will help guide the user in understanding what to expect when opening each kind of menu.</em></p>
 </section>
 
 <section>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves HDS-500 by adding an informational banner to the dropdown and select docs pages, per design request.

### :camera_flash: Screenshots

<img width="1061" alt="CleanShot 2022-08-15 at 15 53 52@2x" src="https://user-images.githubusercontent.com/4587451/184716549-b2576b04-0153-41fc-9595-eeef2537b4b9.png">

### :link: External links

JIRA ticket: [HDS-500](https://hashicorp.atlassian.net/browse/HDS-500)

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
