### PR TITLE
Fix label indicator for assistive tech

### DIFF
--- a/.changeset/orange-shirts-end.md
+++ b/.changeset/orange-shirts-end.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix label indicator for assistive technologies

--- a/packages/components/addon/components/hds/form/label/index.hbs
+++ b/packages/components/addon/components/hds/form/label/index.hbs
@@ -1,4 +1,4 @@
 <label class={{this.classNames}} for={{@controlId}} ...attributes>
-  {{yield}}
+  {{yield}}{{#if (or @isRequired @isOptional)}}&nbsp;{{/if}}
   <Hds::Form::Indicator @isRequired={{@isRequired}} @isOptional={{@isOptional}} />
 </label>


### PR DESCRIPTION
### :pushpin: Summary

Fix label indicator for assistive tech

### :hammer_and_wrench: Detailed description

There is currently an issue where Chrome (at least) merges the label text with the indicator text, which may cause potential issues to assistive tech, particularly screen readers. After trying a few options to preserve a space from code to browser (including an HTML encoded standard space `&#32;`) the only working solution I could find that generates a new text node (hence prevents the text from being merged without space) is the use of `&nbsp;` right after the label text.

While not proud of this solution, is the only way forward I could find.

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="1511" alt="label indicator AT before" src="https://user-images.githubusercontent.com/788096/184934299-5a2126c3-ad09-4b49-bcda-ec3b66148206.png">


</td><td>

<img width="1510" alt="label indicator AT after" src="https://user-images.githubusercontent.com/788096/184936729-1e2cee2d-4095-4748-990e-5a92373743c0.png">


</td></tr>
</table>

### :link: External links

[Jira issue](https://hashicorp.atlassian.net/browse/HDS-548)

***

### 👀 How to review

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
