### PR TITLE
Added EmptyState component

### DIFF
--- a/.changeset/gold-dragons-impress.md
+++ b/.changeset/gold-dragons-impress.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Added EmptyState component

--- a/packages/components/addon/components/hds/empty-state/body.hbs
+++ b/packages/components/addon/components/hds/empty-state/body.hbs
@@ -1,0 +1,3 @@
+<div class="hds-empty-state__body" ...attributes>
+  {{yield}}
+</div>

--- a/packages/components/addon/components/hds/empty-state/footer.hbs
+++ b/packages/components/addon/components/hds/empty-state/footer.hbs
@@ -1,0 +1,3 @@
+<div class="hds-empty-state__footer" ...attributes>
+  {{yield}}
+</div>

--- a/packages/components/addon/components/hds/empty-state/header.hbs
+++ b/packages/components/addon/components/hds/empty-state/header.hbs
@@ -1,0 +1,3 @@
+<div class="hds-empty-state__header" ...attributes>
+  {{yield}}
+</div>

--- a/packages/components/addon/components/hds/empty-state/index.hbs
+++ b/packages/components/addon/components/hds/empty-state/index.hbs
@@ -1,0 +1,9 @@
+<div class="hds-empty-state" ...attributes>
+  {{yield
+    (hash
+      Header=(component "hds/empty-state/header")
+      Body=(component "hds/empty-state/body")
+      Footer=(component "hds/empty-state/footer")
+    )
+  }}
+</div>

--- a/packages/components/app/components/hds/empty-state/body.js
+++ b/packages/components/app/components/hds/empty-state/body.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/empty-state/body';

--- a/packages/components/app/components/hds/empty-state/footer.js
+++ b/packages/components/app/components/hds/empty-state/footer.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/empty-state/footer';

--- a/packages/components/app/components/hds/empty-state/header.js
+++ b/packages/components/app/components/hds/empty-state/header.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/empty-state/header';

--- a/packages/components/app/components/hds/empty-state/index.js
+++ b/packages/components/app/components/hds/empty-state/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/empty-state/index';

--- a/packages/components/app/styles/@hashicorp/design-system-components.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-components.scss
@@ -17,6 +17,7 @@
 @use "../components/card";
 @use "../components/disclosure";
 @use "../components/dropdown";
+@use "../components/empty-state";
 @use "../components/form"; // multiple components
 @use "../components/icon-tile";
 @use "../components/link/inline";

--- a/packages/components/app/styles/components/empty-state.scss
+++ b/packages/components/app/styles/components/empty-state.scss
@@ -11,18 +11,15 @@
   }
 }
 .hds-empty-state__body {
+  font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;
-  font-size: 1rem;
   + * {
     margin-block-start: 1rem;
   }
 }
 .hds-empty-state__header {
+  font-size: 1.25rem;
   font-weight: 700;
   line-height: 1.2;
-  font-size: 1.25rem;
-}
-.hds-empty-state__footer {
-  // the PDS equivalent has no styling declared for the footer
 }

--- a/packages/components/app/styles/components/empty-state.scss
+++ b/packages/components/app/styles/components/empty-state.scss
@@ -1,0 +1,28 @@
+.hds-empty-state {
+  color: var(--token-color-foreground-faint);
+  display: block;
+  margin: 0 auto;
+  max-width: 40ch;
+  padding: 0;
+  
+  > * {
+    margin: 0;
+    padding: 0;
+  }
+}
+.hds-empty-state__body {
+  font-weight: 400;
+  line-height: 1.5;
+  font-size: 1rem;
+  + * {
+    margin-block-start: 1rem;
+  }
+}
+.hds-empty-state__header {
+  font-weight: 700;
+  line-height: 1.2;
+  font-size: 1.25rem;
+}
+.hds-empty-state__footer {
+  // the PDS equivalent has no styling declared for the footer
+}

--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -23,6 +23,7 @@ Router.map(function () {
     this.route('button-set');
     this.route('card');
     this.route('dropdown');
+    this.route('empty-state');
     this.route('form', function () {
       this.route('base-elements');
       this.route('checkbox');

--- a/packages/components/tests/dummy/app/routes/components/empty-state.js
+++ b/packages/components/tests/dummy/app/routes/components/empty-state.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ComponentsEmptyStateRoute extends Route {}

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -24,6 +24,7 @@
 @import "./pages/db-toast";
 @import "./pages/db-tokens";
 @import "./pages/db-typography";
+@import "./pages/empty-state/db-index";
 @import "./pages/form/db-base-elements";
 @import "./pages/form/db-checkbox";
 @import "./pages/form/db-radio";

--- a/packages/components/tests/dummy/app/styles/pages/empty-state/db-index.scss
+++ b/packages/components/tests/dummy/app/styles/pages/empty-state/db-index.scss
@@ -1,0 +1,1 @@
+// EMPTY-STATE > INDEX

--- a/packages/components/tests/dummy/app/templates/components/empty-state.hbs
+++ b/packages/components/tests/dummy/app/templates/components/empty-state.hbs
@@ -1,0 +1,83 @@
+{{page-title "Card component"}}
+
+<h2 class="dummy-h2">EmptyState</h2>
+<p class="dummy-paragraph">The EmptyState component provides a means to arrange simple content in UI views that
+  communicate a lack of data to end users.</p>
+<p class="dummy-paragraph">This component will display as a centered block within its parent component.</p>
+
+<section>
+  <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
+  <p class="dummy-paragraph">Here is the API for the component:</p>
+  <dl class="dummy-component-props" aria-labelledby="component-api">
+  </dl>
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="how-to-use"><a href="#how-to-use" class="dummy-link-section">§</a> How to use</h3>
+  <p class="dummy-paragraph">The EmptyState component is a block-yielding component that contains three child
+    components: a header, body and footer. Each child component is also a block yield. While none of the child
+    components are explicitly required, use of at least the header or body components are recommended.</p>
+  <h4 class="dummy-h4">Basic use</h4>
+  <p class="dummy-paragraph">Invocation of the component would look something like this:</p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code="
+      <Hds::EmptyState as |E|>
+        <E.Header>Meaningful Header Text</E.Header>
+        <E.Body>Body text content that provides a meaningful message to the end user.</E.Body>
+        <E.Footer>Footer Content - text, or a link or maybe even a (secondary) button.</E.Footer>
+      </Hds::EmptyState>
+    "
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::EmptyState as |E|>
+    <E.Header>Meaningful Header Text</E.Header>
+    <E.Body>Body text content that provides a meaningful message to the end user</E.Body>
+    <E.Footer>Footer Content - text, or a link or maybe even a (secondary) button.</E.Footer>
+  </Hds::EmptyState>
+
+  <h4 class="dummy-h4">Header and Body</h4>
+  <p class="dummy-paragraph">Invocation of the component would look something like this:</p>
+  {{! prettier-ignore-start }}
+  <CodeBlock
+    @language="markup"
+    @code="
+      <Hds::EmptyState as |E|>
+        <E.Header>Header Text</E.Header>
+        <E.Body>Body Text</E.Body>
+      </Hds::EmptyState>
+    "
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::EmptyState as |E|>
+    <E.Header>Header Text</E.Header>
+    <E.Body>Body Text</E.Body>
+  </Hds::EmptyState>
+</section>
+
+<section>
+  <div class="dummy-design-guidelines">
+    <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
+      Design guidelines</h3>
+    <p class="dummy-paragraph">To be released at a future date.</p>
+  </div>
+</section>
+
+<section>
+  <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
+  <p class="dummy-paragraph">This component and its child components are rendered as blocks for developers to place
+    content into. Developers should ensure that the content is conformant with WCAG 2.1 AA Success Criteria.</p>
+</section>
+
+<section data-test-percy>
+  <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
+  <h4 class="dummy-h4">Basic use:</h4>
+  <Hds::EmptyState as |E|>
+    <E.Header>Meaningful Header Text</E.Header>
+    <E.Body>Body text content that provides a meaningful message to the end user</E.Body>
+    <E.Footer>Footer Content - text, or a link or maybe even a (secondary) button.</E.Footer>
+  </Hds::EmptyState>
+</section>

--- a/packages/components/tests/dummy/app/templates/components/empty-state.hbs
+++ b/packages/components/tests/dummy/app/templates/components/empty-state.hbs
@@ -9,6 +9,11 @@
   <h3 class="dummy-h3" id="component-api"><a href="#component-api" class="dummy-link-section">§</a> Component API</h3>
   <p class="dummy-paragraph">Here is the API for the component:</p>
   <dl class="dummy-component-props" aria-labelledby="component-api">
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code>
+        spreading is supported on this component (and its child components)</p>
+    </dd>
   </dl>
 </section>
 

--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -88,6 +88,11 @@
           </LinkTo>
         </li>
         <li class="dummy-paragraph">
+          <LinkTo @route="components.empty-state">
+            EmptyState
+          </LinkTo>
+        </li>
+        <li class="dummy-paragraph">
           <LinkTo @route="components.form.base-elements">
             Form / Base elements
           </LinkTo>

--- a/packages/components/tests/integration/components/hds/empty-state/body-test.js
+++ b/packages/components/tests/integration/components/hds/empty-state/body-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/empty-state/body', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Template block usage:
+    await render(hbs`
+      <Hds::EmptyState::Body>template block text</Hds::EmptyState::Body>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`
+      <Hds::EmptyState::Body id="test-empty-state-body"><p>template block text</p></Hds::EmptyState::Body>
+    `);
+
+    assert.dom('#test-empty-state-body').hasClass('hds-empty-state__body');
+  });
+});

--- a/packages/components/tests/integration/components/hds/empty-state/footer-test.js
+++ b/packages/components/tests/integration/components/hds/empty-state/footer-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/empty-state/footer', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Template block usage:
+    await render(hbs`
+      <Hds::EmptyState::Footer>template block text</Hds::EmptyState::Footer>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`
+      <Hds::EmptyState::Footer id="test-empty-state-footer"><p>template block text</p></Hds::EmptyState::Footer>
+    `);
+
+    assert.dom('#test-empty-state-footer').hasClass('hds-empty-state__footer');
+  });
+});

--- a/packages/components/tests/integration/components/hds/empty-state/header-test.js
+++ b/packages/components/tests/integration/components/hds/empty-state/header-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/empty-state/header', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Template block usage:
+    await render(hbs`
+      <Hds::EmptyState::Header>template block text</Hds::EmptyState::Header>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`
+      <Hds::EmptyState::Header id="test-empty-state-header"><p>template block text</p></Hds::EmptyState::Header>
+    `);
+
+    assert.dom('#test-empty-state-header').hasClass('hds-empty-state__header');
+  });
+});

--- a/packages/components/tests/integration/components/hds/empty-state/index-test.js
+++ b/packages/components/tests/integration/components/hds/empty-state/index-test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/empty-state/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should render', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    // Template block usage:
+    await render(hbs`
+      <Hds::EmptyState>template block text</Hds::EmptyState>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`
+      <Hds::EmptyState id="test-empty-state"><p>template block text</p></Hds::EmptyState>
+    `);
+
+    assert.dom('#test-empty-state').hasClass('hds-empty-state');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds the `<Hds::EmptyState>` component.

### :hammer_and_wrench: Detailed description

* Intends to replace the PDS version
* PDS Storybook: https://unofficial-design-system-search.vercel.app/?path=/story/structure-design-system_components-emptystate--index
* PDS Code: https://github.com/hashicorp/structure/tree/main/packages/pds-ember/addon/components/pds/empty-state
* template-only component that yields to three child template-only components: header, body, footer
* copy/pasted styles then slightly adjusted (colors, unit-less line-heights)
* footer has the appropriate class (and a test for it) but there were no styles, so it's not in the .scss file.

### :link: External links

https://hashicorp.atlassian.net/browse/HDS-512 


### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
