### PR TITLE
Add “Why system fonts?” banner on top of Typography doc page

### DIFF
--- a/packages/components/tests/dummy/app/templates/foundations/typography.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations/typography.hbs
@@ -2,6 +2,17 @@
 
 <h2 class="dummy-h2">Typography</h2>
 
+<section class="dummy-link-cta-button-banner">
+  <h3>Why system fonts?</h3>
+  <p>Each OS comes with a specific typeface. By telling our components “use the system’s default typeface, whatever that
+    is,” we’re giving our apps fewer things to have to look for, so they load faster. This is important in big apps,
+    where you need every little bit of performance help you can get. This of course, means that it might appear a little
+    different on each OS, but contextually to that user on that OS, it will not seem out of place at all.</p>
+  <p>System fonts also offer many benefits that many web fonts don’t. They are broadly tested and have many styles and
+    variations to support internationalization, code, tabular data, data viz, etc... As a new design system, we need to
+    be pragmatic, and system fonts seem to cover our present and potential future use cases.</p>
+</section>
+
 <section>
   <h3 class="dummy-h3" id="how-to-use"><a href="#how-to-use" class="dummy-link-section">§</a> How to use</h3>
   <p class="dummy-paragraph">The suggested way to apply the typographic definitions to a UI element is using the


### PR DESCRIPTION
### :pushpin: Summary

Following this thread: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1660855718916189

### :hammer_and_wrench: Detailed description

In this PR I have:
- added “Why system fonts?” banner on top of Typography doc page

Preview: https://hds-components-git-system-fonts-docs-hashicorp.vercel.app/foundations/typography

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
