### PR TITLE
Make `EmptyState` and `Avatar` non-public

### DIFF
--- a/.changeset/gold-dragons-impress.md
+++ b/.changeset/gold-dragons-impress.md
@@ -1,5 +1,0 @@
----
-"@hashicorp/design-system-components": minor
----
-
-Added EmptyState component

--- a/.changeset/young-students-teach.md
+++ b/.changeset/young-students-teach.md
@@ -1,5 +1,0 @@
----
-"@hashicorp/design-system-components": minor
----
-
-Added avatar component

--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -52,11 +52,11 @@
             Alert
           </LinkTo>
         </li>
-        <li class="dummy-paragraph">
+        <!--li class="dummy-paragraph">
           <LinkTo @route="components.avatar">
             Avatar
           </LinkTo>
-        </li>
+        </li-->
         <li class="dummy-paragraph">
           <LinkTo @route="components.badge">
             Badge
@@ -87,11 +87,11 @@
             Dropdown
           </LinkTo>
         </li>
-        <li class="dummy-paragraph">
+        <!--li class="dummy-paragraph">
           <LinkTo @route="components.empty-state">
             EmptyState
           </LinkTo>
-        </li>
+        </li-->
         <li class="dummy-paragraph">
           <LinkTo @route="components.form.base-elements">
             Form / Base elements


### PR DESCRIPTION
### :pushpin: Summary

Make `EmptyState` and `Avatar` components non-public.

### :hammer_and_wrench: Detailed description

As discussed in the sync, it sounds like we're not ready to release these components as they are, so we'll remove the changelog entries and hide the index page links for now.

