### PR TITLE
Remove unused `percy-test.js` file in `flight-website`

### DIFF
--- a/flight-website/app/routes/percy-test.js
+++ b/flight-website/app/routes/percy-test.js
@@ -1,5 +1,0 @@
-/* eslint-disable */
-// Route name including "test" causes N/A eslint error
-import Route from '@ember/routing/route';
-
-export default class PercyTestRoute extends Route {}


### PR DESCRIPTION
### :pushpin: Summary

There is a route file `percy-test.js` file in the `flight-website` that is actually not used (the test is run in the `ember-flight-icon` app, as integration test).

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
