### PR TITLE
HDS-603 Add HTML structure and preliminary Tabs styles

### DIFF
--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -1,60 +1,55 @@
 <div class={{this.classNames}} ...attributes>
   {{!-- {{yield}} --}}
 
-  {{!-- Hds-TabList --}}
+  {{! Hds-TabList }}
   <div class="hds-tab-list">
-    <ul 
-      class="hds-tab-list__list"
-      role="tablist"
-    >
-      {{!-- Hds-Tab --}}
-      <li 
-        class="hds-tab"
-        role="presentation"
-      >
-        <a 
-          role="tab" 
-          href="#section1" 
-          id="tab1" 
-          {{!-- aria-selected="true"  TODO: Set by arg: "isSelected" --}}
-          {{!-- tabindex="-1"  TODO: Set if not aria-selected ("isSelected") --}}
+    <ul class="hds-tab-list__list" role="tablist">
+      {{! Hds-Tab }}
+      <li class="hds-tab" role="presentation">
+        <a
+          role="tab"
+          href="#section1"
+          id="tab1"
+          {{! aria-selected="true"  TODO: Set by arg: "isSelected" }}
+          {{! tabindex="-1"  TODO: Set if not aria-selected ("isSelected") }}
         >
-          Tab 1 {{this.isSelected}}
+          Tab 1
+          {{this.isSelected}}
         </a>
       </li>
-      <li 
-        class="hds-tab"
-        role="presentation"
-      >
-        <a 
+      <li class="hds-tab" role="presentation">
+        <a
           role="tab"
-          href="#section2" 
+          href="#section2"
           id="tab2"
-          {{!-- aria-selected="true"  TODO: Set by arg: "isSelected" --}}
-          {{!-- tabindex="-1"  TODO: Set if not aria-selected ("isSelected"), Focus will be added by JS --}}
+          {{! aria-selected="true"  TODO: Set by arg: "isSelected" }}
+          {{! tabindex="-1"  TODO: Set if not aria-selected ("isSelected"), Focus will be added by JS }}
         >
-          Tab 2 {{this.isSelected}}
+          Tab 2
+          {{this.isSelected}}
         </a>
       </li>
     </ul>
   </div>
 
-  {{!-- Hds-TabPanel --}}
-  <section 
+  {{! Hds-TabPanel }}
+  <section
     class="hds-tab-panel"
-    role="tabpanel" 
-    id="section1" 
+    role="tabpanel"
+    id="section1"
     aria-labelledby="tab1"
-    {{!-- hidden --}} {{!-- TODO: set by arg --}}
+    {{! hidden }}
+    {{! TODO: set by arg }}
   >
     Tab 1 Content
   </section>
-  <section 
+  <section
     class="hds-tab-panel"
-    role="tabpanel" 
-    id="section2" 
+    role="tabpanel"
+    id="section2"
     aria-labelledby="tab2"
-    {{!-- hidden --}} {{!-- TODO: set by arg --}}
+    {{! hidden }}
+    {{! TODO: set by arg }}
   >
     Tab 2 Content
   </section>

--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -1,3 +1,6 @@
+{{! template-lint-disable no-invalid-role }}
+{{! template-lint-disable require-context-role }}
+
 <div class={{this.classNames}} ...attributes>
   {{!-- {{yield}} --}}
 
@@ -53,7 +56,7 @@
   </section>
 </div>
 
-{{! Temporary comment for rough planning purposes only. 
+{{! Temporary comment for rough planning purposes only.
 Not meant to represent literal final implementations. Comment will be deleted eventually.
 
 Component Structure:

--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -1,4 +1,83 @@
-{{! ADD YOUR TEMPLATE CONTENT HERE }}
 <div class={{this.classNames}} ...attributes>
-  {{yield}}
+  {{!-- {{yield}} --}}
+
+  {{!-- Hds-TabList --}}
+  <div class="hds-tab-list">
+    <ul 
+      class="hds-tab-list__list"
+      role="tablist"
+    >
+      {{!-- Hds-Tab --}}
+      <li 
+        class="hds-tab"
+        role="presentation"
+      >
+        <a 
+          role="tab" 
+          href="#section1" 
+          id="tab1" 
+          {{!-- aria-selected="true"  TODO: Set by arg: "isSelected" --}}
+          {{!-- tabindex="-1"  TODO: Set if not aria-selected ("isSelected") --}}
+        >
+          Tab 1 {{this.isSelected}}
+        </a>
+      </li>
+      <li 
+        class="hds-tab"
+        role="presentation"
+      >
+        <a 
+          role="tab"
+          href="#section2" 
+          id="tab2"
+          {{!-- aria-selected="true"  TODO: Set by arg: "isSelected" --}}
+          {{!-- tabindex="-1"  TODO: Set if not aria-selected ("isSelected"), Focus will be added by JS --}}
+        >
+          Tab 2 {{this.isSelected}}
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  {{!-- Hds-TabPanel --}}
+  <section 
+    class="hds-tab-panel"
+    role="tabpanel" 
+    id="section1" 
+    aria-labelledby="tab1"
+    {{!-- hidden --}} {{!-- TODO: set by arg --}}
+  >
+    Tab 1 Content
+  </section>
+  <section 
+    class="hds-tab-panel"
+    role="tabpanel" 
+    id="section2" 
+    aria-labelledby="tab2"
+    {{!-- hidden --}} {{!-- TODO: set by arg --}}
+  >
+    Tab 2 Content
+  </section>
 </div>
+
+{{!
+Component Structure:
+
+Tabs
+  TabList
+    Tab
+      Content:
+        FlightIcon (optional)
+        text content (required)
+        BadgeCount (optional)
+      Args:
+        isSelected (boolean, default = false) // Select first tab by default?
+        hasIcon (boolean, default = false)
+        hasCount (boolean, default = false)
+    Tab (2+ required)
+    ...
+    ScrollNavigation (displays if more tabs than fit container)
+  TabPanel
+  TabPabel
+  ...
+ }}

--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -2,7 +2,7 @@
   {{!-- {{yield}} --}}
 
   {{! Hds-TabList }}
-  <div class="hds-tab-list">
+  <div class="hds-tab-list hds-typography-body-200">
     <ul class="hds-tab-list__list" role="tablist">
       {{! Hds-Tab }}
       <li class="hds-tab" role="presentation">
@@ -53,7 +53,9 @@
   </section>
 </div>
 
-{{!
+{{! Temporary comment for rough planning purposes only. 
+Not meant to represent literal final implementations. Comment will be deleted eventually.
+
 Component Structure:
 
 Tabs

--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -14,7 +14,6 @@
           {{! tabindex="-1"  TODO: Set if not aria-selected ("isSelected") }}
         >
           Tab 1
-          {{this.isSelected}}
         </a>
       </li>
       <li class="hds-tab" role="presentation">
@@ -26,7 +25,6 @@
           {{! tabindex="-1"  TODO: Set if not aria-selected ("isSelected"), Focus will be added by JS }}
         >
           Tab 2
-          {{this.isSelected}}
         </a>
       </li>
     </ul>

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -2,6 +2,8 @@
 // TABS
 //
 
+@use "../mixins/focus-ring" as *;
+
 $indicator-height: 3px;
 
 .hds-tabs {}
@@ -44,6 +46,7 @@ $indicator-height: 3px;
   }
 
   a {
+    @include hds-focus-ring-with-pseudo-element();
     color: var(--token-color-foreground-primary);
     border-radius: var(--token-form-control-border-radius);
     text-decoration: none;
@@ -52,11 +55,6 @@ $indicator-height: 3px;
 
     &:hover {
       color: var(--token-color-foreground-action-hover);
-    }
-
-    &:focus {
-      outline: none;
-      box-shadow: var(--token-focus-ring-action-box-shadow);
     }
   }
 }

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -27,7 +27,6 @@ $indicator-height: 3px;
 }
 
 .hds-tab {
-  padding: 3px 6px;
   position: relative; // for positioning temp indicator
 
   // temporary indicator
@@ -44,12 +43,12 @@ $indicator-height: 3px;
   }
 
   a {
-    @include hds-focus-ring-with-pseudo-element();
+    @include hds-focus-ring-with-pseudo-element($top: 4px, $right: 6px, $bottom: 4px, $left: 6px);
     color: var(--token-color-foreground-primary);
     border-radius: var(--token-form-control-border-radius);
     text-decoration: none;
     display: block;
-    padding: 3px 6px;
+    padding: 8px 12px;
 
     &:hover {
       color: var(--token-color-foreground-action-hover);

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -12,9 +12,9 @@ $indicator-height: 3px;
 // TODO: MOVE!
 .hds-tab-list {
   padding-bottom: round(calc($indicator-height / 2));
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  white-space: nowrap;
+  // overflow-x: auto;
+  // -webkit-overflow-scrolling: touch;
+  // white-space: nowrap; // move
 
   // Un-nest after moving
   .hds-tab-list__list {
@@ -28,7 +28,7 @@ $indicator-height: 3px;
 
 .hds-tab {
   padding: 3px 6px;
-  position: relative; // temporary: for positioning temp indicator
+  position: relative; // for positioning temp indicator
 
   // temporary indicator
   &:first-child:after {

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -11,8 +11,6 @@ $indicator-height: 3px;
 // Sub-components:
 // TODO: MOVE!
 .hds-tab-list {
-  font-family: var(--token-typography-body-200-font-family);
-  font-weight: var(--token-typography-font-weight-medium);
   padding-bottom: round(calc($indicator-height / 2));
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -37,11 +37,10 @@ $indicator-height: 3px;
     content: "";
     display: block;
     height: $indicator-height;
-    margin-bottom: round(calc($indicator-height / 2 * -1));
     position: absolute;
     left: 0;
     right: 0;
-    bottom: 0;
+    bottom: round(calc($indicator-height / 2 * -1));
   }
 
   a {

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -51,7 +51,7 @@ $indicator-height: 3px;
     padding: 3px 6px;
 
     &:hover {
-      color: var(--token-color-foreground-action);
+      color: var(--token-color-foreground-action-hover);
     }
 
     &:focus {

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -11,7 +11,7 @@ $indicator-height: 3px;
 .hds-tab-list {
   font-family: var(--token-typography-body-200-font-family);
   font-weight: var(--token-typography-font-weight-medium);
-  padding-bottom: ($indicator-height / 2);
+  padding-bottom: round(calc($indicator-height / 2));
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   white-space: nowrap;
@@ -31,13 +31,13 @@ $indicator-height: 3px;
   position: relative; // temporary: for positioning temp indicator
 
   // temporary indicator
-  &:hover:after {
+  &:first-child:after {
     background: var(--token-color-foreground-action);
     border-radius: 3px;
     content: "";
     display: block;
     height: $indicator-height;
-    margin-bottom: -($indicator-height / 2);
+    margin-bottom: round(calc($indicator-height / 2 * -1));
     position: absolute;
     left: 0;
     right: 0;

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -1,9 +1,69 @@
 //
 // TABS
 //
-// properties within each class are sorted alphabetically
-//
 
-.hds-tabs {
-  // outline: 2px dotted red;
+$indicator-height: 3px;
+
+.hds-tabs {}
+
+// Sub-components:
+// TODO: MOVE!
+.hds-tab-list {
+  font-family: var(--token-typography-body-200-font-family);
+  font-weight: var(--token-typography-font-weight-medium);
+  padding-bottom: ($indicator-height / 2);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  white-space: nowrap;
+
+  // Un-nest after moving
+  .hds-tab-list__list {
+    border-bottom: 1px solid var(--token-color-border-primary);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+  }
+}
+
+.hds-tab {
+  padding: 3px 6px;
+  position: relative; // temporary: for positioning temp indicator
+
+  // temporary indicator
+  &:hover:after {
+    background: var(--token-color-foreground-action);
+    border-radius: 3px;
+    content: "";
+    display: block;
+    height: $indicator-height;
+    margin-bottom: -($indicator-height / 2);
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+
+  a {
+    color: var(--token-color-foreground-primary);
+    border-radius: var(--token-form-control-border-radius);
+    text-decoration: none;
+    display: block;
+    padding: 3px 6px;
+
+    &:hover {
+      color: var(--token-color-foreground-action);
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: var(--token-focus-ring-action-box-shadow);
+    }
+  }
+}
+
+.hds-tab-panel {
+  &:not(:target) {
+    display: none;
+  }
 }

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -194,6 +194,5 @@
 <section data-test-percy>
   <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
 
-  <Hds::Tabs>
-  </Hds::Tabs>
+  <Hds::Tabs />
 </section>

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -195,6 +195,5 @@
   <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
 
   <Hds::Tabs>
-    This is the Hds::Tabs component
   </Hds::Tabs>
 </section>


### PR DESCRIPTION
### :pushpin: Summary

Basic preliminary HTML structure and styling for Tabs.

https://hds-components-git-hds-603-tabs-component-css-hashicorp.vercel.app/components/tabs#section2

**Notes:** 
* Styles & DOM for indicator will probably be restructured once I implement functionality.
* This branch will be merged into the [feature branch](https://github.com/hashicorp/design-system/pull/548/files) once approved. (It will not be merged directly into the `main` branch.)

### :hammer_and_wrench: Detailed description

Update: I disabled the warnings based on Melanie's feedback.

I'm getting linting errors related to accessibility that seem to me like they shouldn't be problems but would be happy for feedback.

```
8:6  error  Use of presentation role on <li> detected. Semantic elements should not be used for presentation.  no-invalid-role
20:6  error  Use of presentation role on <li> detected. Semantic elements should not be used for presentation.  no-invalid-role
10:10  error  You have an element with the role of "tab" but it is missing the required (immediate) parent element of "[tablist]". Reference: https://www.w3.org/TR/wai-aria-1.1/#tab.  require-context-role
22:10  error  You have an element with the role of "tab" but it is missing the required (immediate) parent element of "[tablist]". Reference: https://www.w3.org/TR/wai-aria-1.1/#tab.  require-context-role
```

### :camera_flash: Screenshots
<img width="590" alt="Screen Shot 2022-08-30 at 2 47 46 PM" src="https://user-images.githubusercontent.com/108769823/187549617-68d1d6e9-95f2-4e22-9be4-8434f643f361.png">

### :link: External links

<!-- Issues, RFC, etc. -->

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
