### PR TITLE
Add design tokens for `code-200` and `code-300` typographic styles

### DIFF
--- a/.changeset/tall-beds-guess.md
+++ b/.changeset/tall-beds-guess.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-tokens": patch
+---
+
+Added design tokens for `code-200` and `code-300` typographic styles

--- a/packages/components/tests/dummy/app/routes/foundations/typography.js
+++ b/packages/components/tests/dummy/app/routes/foundations/typography.js
@@ -10,7 +10,7 @@ export const DISPLAY_STYLES = [
   'display-100',
 ];
 export const BODY_STYLES = ['body-300', 'body-200', 'body-100'];
-export const CODE_STYLES = ['code-100'];
+export const CODE_STYLES = ['code-300', 'code-200', 'code-100'];
 // we add all the allowed combinations here, per design specs
 export const STYLES_COMBINATIONS = {
   'display-500': ['bold'],
@@ -21,8 +21,9 @@ export const STYLES_COMBINATIONS = {
   'body-300': ['regular', 'medium', 'semibold'],
   'body-200': ['regular', 'medium', 'semibold'],
   'body-100': ['regular', 'medium', 'semibold'],
-  // TODO! ask @heather what are the conditions here
-  'code-100': ['regular', 'medium', 'semibold', 'bold'],
+  'code-300': ['regular', 'bold'],
+  'code-200': ['regular', 'bold'],
+  'code-100': ['regular', 'bold'],
 };
 
 export default class FoundationsElevationRoute extends Route {

--- a/packages/tokens/dist/devdot/css/helpers/typography.css
+++ b/packages/tokens/dist/devdot/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Sat, 16 Jul 2022 14:15:33 GMT
+ * Generated on Thu, 01 Sep 2022 22:06:03 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }
@@ -19,3 +19,5 @@
 .hds-typography-body-200 { font-family: var(--token-typography-body-200-font-family); font-size: var(--token-typography-body-200-font-size); line-height: var(--token-typography-body-200-line-height); margin: 0; padding: 0; }
 .hds-typography-body-100 { font-family: var(--token-typography-body-100-font-family); font-size: var(--token-typography-body-100-font-size); line-height: var(--token-typography-body-100-line-height); margin: 0; padding: 0; }
 .hds-typography-code-100 { font-family: var(--token-typography-code-100-font-family); font-size: var(--token-typography-code-100-font-size); line-height: var(--token-typography-code-100-line-height); margin: 0; padding: 0; }
+.hds-typography-code-200 { font-family: var(--token-typography-code-200-font-family); font-size: var(--token-typography-code-200-font-size); line-height: var(--token-typography-code-200-line-height); margin: 0; padding: 0; }
+.hds-typography-code-300 { font-family: var(--token-typography-code-300-font-family); font-size: var(--token-typography-code-300-font-size); line-height: var(--token-typography-code-300-line-height); margin: 0; padding: 0; }

--- a/packages/tokens/dist/devdot/css/tokens.css
+++ b/packages/tokens/dist/devdot/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 19 Jul 2022 13:53:00 GMT
+ * Generated on Thu, 01 Sep 2022 22:06:03 GMT
  */
 
 :root {
@@ -274,4 +274,10 @@
   --token-typography-code-100-font-family: ui-monospace, Menlo, Consolas, monospace;
   --token-typography-code-100-font-size: 0.8125rem; /* 13px/0.8125rem */
   --token-typography-code-100-line-height: 1.23; /* 16px */
+  --token-typography-code-200-font-family: ui-monospace, Menlo, Consolas, monospace;
+  --token-typography-code-200-font-size: 0.875rem; /* 14px/0.875rem */
+  --token-typography-code-200-line-height: 1.125; /* 18px */
+  --token-typography-code-300-font-family: ui-monospace, Menlo, Consolas, monospace;
+  --token-typography-code-300-font-size: 1rem; /* 16px/1rem */
+  --token-typography-code-300-line-height: 1.25; /* 20px */
 }

--- a/packages/tokens/dist/docs/devdot/tokens.json
+++ b/packages/tokens/dist/docs/devdot/tokens.json
@@ -5748,5 +5748,119 @@
       "code-100",
       "line-height"
     ]
+  },
+  {
+    "value": "ui-monospace, Menlo, Consolas, monospace",
+    "original": {
+      "value": "{typography.font-stack.code.value}"
+    },
+    "name": "token-typography-code-200-font-family",
+    "attributes": {
+      "category": "typography",
+      "type": "code-200",
+      "item": "font-family"
+    },
+    "path": [
+      "typography",
+      "code-200",
+      "font-family"
+    ]
+  },
+  {
+    "value": "0.875rem",
+    "type": "font-size",
+    "comment": "14px/0.875rem",
+    "original": {
+      "value": "14",
+      "type": "font-size",
+      "comment": "14px/0.875rem"
+    },
+    "name": "token-typography-code-200-font-size",
+    "attributes": {
+      "category": "typography",
+      "type": "code-200",
+      "item": "font-size"
+    },
+    "path": [
+      "typography",
+      "code-200",
+      "font-size"
+    ]
+  },
+  {
+    "value": "1.125",
+    "comment": "18px",
+    "original": {
+      "value": "1.125",
+      "comment": "18px"
+    },
+    "name": "token-typography-code-200-line-height",
+    "attributes": {
+      "category": "typography",
+      "type": "code-200",
+      "item": "line-height"
+    },
+    "path": [
+      "typography",
+      "code-200",
+      "line-height"
+    ]
+  },
+  {
+    "value": "ui-monospace, Menlo, Consolas, monospace",
+    "original": {
+      "value": "{typography.font-stack.code.value}"
+    },
+    "name": "token-typography-code-300-font-family",
+    "attributes": {
+      "category": "typography",
+      "type": "code-300",
+      "item": "font-family"
+    },
+    "path": [
+      "typography",
+      "code-300",
+      "font-family"
+    ]
+  },
+  {
+    "value": "1rem",
+    "type": "font-size",
+    "comment": "16px/1rem",
+    "original": {
+      "value": "16",
+      "type": "font-size",
+      "comment": "16px/1rem"
+    },
+    "name": "token-typography-code-300-font-size",
+    "attributes": {
+      "category": "typography",
+      "type": "code-300",
+      "item": "font-size"
+    },
+    "path": [
+      "typography",
+      "code-300",
+      "font-size"
+    ]
+  },
+  {
+    "value": "1.25",
+    "comment": "20px",
+    "original": {
+      "value": "1.25",
+      "comment": "20px"
+    },
+    "name": "token-typography-code-300-line-height",
+    "attributes": {
+      "category": "typography",
+      "type": "code-300",
+      "item": "line-height"
+    },
+    "path": [
+      "typography",
+      "code-300",
+      "line-height"
+    ]
   }
 ]

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -5702,5 +5702,119 @@
       "code-100",
       "line-height"
     ]
+  },
+  {
+    "value": "ui-monospace, Menlo, Consolas, monospace",
+    "original": {
+      "value": "{typography.font-stack.code.value}"
+    },
+    "name": "token-typography-code-200-font-family",
+    "attributes": {
+      "category": "typography",
+      "type": "code-200",
+      "item": "font-family"
+    },
+    "path": [
+      "typography",
+      "code-200",
+      "font-family"
+    ]
+  },
+  {
+    "value": "0.875rem",
+    "type": "font-size",
+    "comment": "14px/0.875rem",
+    "original": {
+      "value": "14",
+      "type": "font-size",
+      "comment": "14px/0.875rem"
+    },
+    "name": "token-typography-code-200-font-size",
+    "attributes": {
+      "category": "typography",
+      "type": "code-200",
+      "item": "font-size"
+    },
+    "path": [
+      "typography",
+      "code-200",
+      "font-size"
+    ]
+  },
+  {
+    "value": "1.125",
+    "comment": "18px",
+    "original": {
+      "value": "1.125",
+      "comment": "18px"
+    },
+    "name": "token-typography-code-200-line-height",
+    "attributes": {
+      "category": "typography",
+      "type": "code-200",
+      "item": "line-height"
+    },
+    "path": [
+      "typography",
+      "code-200",
+      "line-height"
+    ]
+  },
+  {
+    "value": "ui-monospace, Menlo, Consolas, monospace",
+    "original": {
+      "value": "{typography.font-stack.code.value}"
+    },
+    "name": "token-typography-code-300-font-family",
+    "attributes": {
+      "category": "typography",
+      "type": "code-300",
+      "item": "font-family"
+    },
+    "path": [
+      "typography",
+      "code-300",
+      "font-family"
+    ]
+  },
+  {
+    "value": "1rem",
+    "type": "font-size",
+    "comment": "16px/1rem",
+    "original": {
+      "value": "16",
+      "type": "font-size",
+      "comment": "16px/1rem"
+    },
+    "name": "token-typography-code-300-font-size",
+    "attributes": {
+      "category": "typography",
+      "type": "code-300",
+      "item": "font-size"
+    },
+    "path": [
+      "typography",
+      "code-300",
+      "font-size"
+    ]
+  },
+  {
+    "value": "1.25",
+    "comment": "20px",
+    "original": {
+      "value": "1.25",
+      "comment": "20px"
+    },
+    "name": "token-typography-code-300-line-height",
+    "attributes": {
+      "category": "typography",
+      "type": "code-300",
+      "item": "line-height"
+    },
+    "path": [
+      "typography",
+      "code-300",
+      "line-height"
+    ]
   }
 ]

--- a/packages/tokens/dist/products/css/helpers/typography.css
+++ b/packages/tokens/dist/products/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Sat, 16 Jul 2022 14:15:33 GMT
+ * Generated on Thu, 01 Sep 2022 22:06:03 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }
@@ -19,3 +19,5 @@
 .hds-typography-body-200 { font-family: var(--token-typography-body-200-font-family); font-size: var(--token-typography-body-200-font-size); line-height: var(--token-typography-body-200-line-height); margin: 0; padding: 0; }
 .hds-typography-body-100 { font-family: var(--token-typography-body-100-font-family); font-size: var(--token-typography-body-100-font-size); line-height: var(--token-typography-body-100-line-height); margin: 0; padding: 0; }
 .hds-typography-code-100 { font-family: var(--token-typography-code-100-font-family); font-size: var(--token-typography-code-100-font-size); line-height: var(--token-typography-code-100-line-height); margin: 0; padding: 0; }
+.hds-typography-code-200 { font-family: var(--token-typography-code-200-font-family); font-size: var(--token-typography-code-200-font-size); line-height: var(--token-typography-code-200-line-height); margin: 0; padding: 0; }
+.hds-typography-code-300 { font-family: var(--token-typography-code-300-font-family); font-size: var(--token-typography-code-300-font-size); line-height: var(--token-typography-code-300-line-height); margin: 0; padding: 0; }

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 19 Jul 2022 13:53:00 GMT
+ * Generated on Thu, 01 Sep 2022 22:06:03 GMT
  */
 
 :root {
@@ -272,4 +272,10 @@
   --token-typography-code-100-font-family: ui-monospace, Menlo, Consolas, monospace;
   --token-typography-code-100-font-size: 0.8125rem; /* 13px/0.8125rem */
   --token-typography-code-100-line-height: 1.23; /* 16px */
+  --token-typography-code-200-font-family: ui-monospace, Menlo, Consolas, monospace;
+  --token-typography-code-200-font-size: 0.875rem; /* 14px/0.875rem */
+  --token-typography-code-200-line-height: 1.125; /* 18px */
+  --token-typography-code-300-font-family: ui-monospace, Menlo, Consolas, monospace;
+  --token-typography-code-300-font-size: 1rem; /* 16px/1rem */
+  --token-typography-code-300-line-height: 1.25; /* 20px */
 }

--- a/packages/tokens/src/products/shared/typography.json
+++ b/packages/tokens/src/products/shared/typography.json
@@ -204,6 +204,34 @@
                 "value": "1.23",
                 "comment": "16px"
             }
+        },
+        "code-200": {
+            "font-family": {
+                "value": "{typography.font-stack.code.value}"
+            },
+            "font-size": {
+                "value": "14",
+                "type": "font-size",
+                "comment": "14px/0.875rem"
+            },
+            "line-height": {
+                "value": "1.125",
+                "comment": "18px"
+            }
+        },
+        "code-300": {
+            "font-family": {
+                "value": "{typography.font-stack.code.value}"
+            },
+            "font-size": {
+                "value": "16",
+                "type": "font-size",
+                "comment": "16px/1rem"
+            },
+            "line-height": {
+                "value": "1.25",
+                "comment": "20px"
+            }
         }
     }
 }


### PR DESCRIPTION
### :pushpin: Summary

This ticket is a follow-up of an equivalent update for the `code` typographic style in Figma (already released).

<img width="828" alt="screenshot_1763" src="https://user-images.githubusercontent.com/686239/188022482-85db189c-6449-4e1a-9854-13d3e78004e2.png">

### :hammer_and_wrench: Detailed description

In this PR I have:
- added design tokens declarations for `code-200` and `code-300` typographic styles
- re-generated design tokens in output
- updated the `typography` helper classes documentation

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-25

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
