### PR TITLE
Fix assertions messages (for consistency)

### DIFF
--- a/packages/components/addon/components/hds/badge-count/index.js
+++ b/packages/components/addon/components/hds/badge-count/index.js
@@ -23,7 +23,7 @@ export default class HdsBadgeCountIndexComponent extends Component {
     assert(
       `@size for "Hds::BadgeCount" must be one of the following: ${SIZES.join(
         ', '
-      )}, received: ${size}`,
+      )}; received: ${size}`,
       SIZES.includes(size)
     );
 
@@ -44,7 +44,7 @@ export default class HdsBadgeCountIndexComponent extends Component {
     assert(
       `@type for "Hds::BadgeCount" must be one of the following: ${TYPES.join(
         ', '
-      )}, received: ${type}`,
+      )}; received: ${type}`,
       TYPES.includes(type)
     );
 
@@ -65,7 +65,7 @@ export default class HdsBadgeCountIndexComponent extends Component {
     assert(
       `@color for "Hds::BadgeCount" must be one of the following: ${COLORS.join(
         ', '
-      )}, received: ${color}`,
+      )}; received: ${color}`,
       COLORS.includes(color)
     );
 

--- a/packages/components/addon/components/hds/badge/index.js
+++ b/packages/components/addon/components/hds/badge/index.js
@@ -30,7 +30,7 @@ export default class HdsBadgeIndexComponent extends Component {
     assert(
       `@size for "Hds::Badge" must be one of the following: ${SIZES.join(
         ', '
-      )}, received: ${size}`,
+      )}; received: ${size}`,
       SIZES.includes(size)
     );
 
@@ -51,7 +51,7 @@ export default class HdsBadgeIndexComponent extends Component {
     assert(
       `@type for "Hds::Badge" must be one of the following: ${TYPES.join(
         ', '
-      )}, received: ${type}`,
+      )}; received: ${type}`,
       TYPES.includes(type)
     );
 
@@ -72,7 +72,7 @@ export default class HdsBadgeIndexComponent extends Component {
     assert(
       `@color for "Hds::Badge" must be one of the following: ${COLORS.join(
         ', '
-      )}, received: ${color}`,
+      )}; received: ${color}`,
       COLORS.includes(color)
     );
 

--- a/packages/components/addon/components/hds/breadcrumb/item.js
+++ b/packages/components/addon/components/hds/breadcrumb/item.js
@@ -14,7 +14,7 @@ export default class HdsBreadcrumbItemComponent extends Component {
 
     if (maxWidth) {
       assert(
-        `@maxWidth for "Hds::Breadcrumb::Item" must be a size as number in 'px' or in 'em' (eg. '200px' or '24em'), received: ${maxWidth}`,
+        `@maxWidth for "Hds::Breadcrumb::Item" must be a size as number in 'px' or in 'em' (eg. '200px' or '24em'); received: ${maxWidth}`,
         maxWidth.match(/^\d+(px|em)$/)
       );
 

--- a/packages/components/addon/components/hds/card/container.js
+++ b/packages/components/addon/components/hds/card/container.js
@@ -23,7 +23,7 @@ export default class HdsCardContainerComponent extends Component {
     assert(
       `@level for "Hds::Card::Container" must be one of the following: ${LEVELS.join(
         ', '
-      )}, received: ${level}`,
+      )}; received: ${level}`,
       LEVELS.includes(level)
     );
 
@@ -44,7 +44,7 @@ export default class HdsCardContainerComponent extends Component {
       assert(
         `@levelHover for "Hds::Card::Container" must be one of the following: ${LEVELS.join(
           ', '
-        )}, received: ${levelHover}`,
+        )}; received: ${levelHover}`,
         LEVELS.includes(levelHover)
       );
     }
@@ -66,7 +66,7 @@ export default class HdsCardContainerComponent extends Component {
       assert(
         `@levelActive for "Hds::Card::Container" must be one of the following: ${LEVELS.join(
           ', '
-        )}, received: ${levelActive}`,
+        )}; received: ${levelActive}`,
         LEVELS.includes(levelActive)
       );
     }
@@ -88,7 +88,7 @@ export default class HdsCardContainerComponent extends Component {
     assert(
       `@background for "Hds::Card::Container" must be one of the following: ${BACKGROUNDS.join(
         ', '
-      )}, received: ${background}`,
+      )}; received: ${background}`,
       BACKGROUNDS.includes(background)
     );
 
@@ -109,7 +109,7 @@ export default class HdsCardContainerComponent extends Component {
     assert(
       `@overflow for "Hds::Card::Container" must be one of the following: ${OVERFLOWS.join(
         ', '
-      )}, received: ${overflow}`,
+      )}; received: ${overflow}`,
       OVERFLOWS.includes(overflow)
     );
 

--- a/packages/components/addon/components/hds/form/field/index.js
+++ b/packages/components/addon/components/hds/form/field/index.js
@@ -37,7 +37,7 @@ export default class HdsFormFieldIndexComponent extends Component {
     assert(
       `@type for "Hds::Form::Field" must be one of the following: ${LAYOUT_TYPES.join(
         ', '
-      )}, received: ${layout}`,
+      )}; received: ${layout}`,
       LAYOUT_TYPES.includes(layout)
     );
 

--- a/packages/components/addon/components/hds/form/text-input/base.js
+++ b/packages/components/addon/components/hds/form/text-input/base.js
@@ -28,7 +28,7 @@ export default class HdsFormTextInputBaseComponent extends Component {
     assert(
       `@type for "Hds::Form::TextInput" must be one of the following: ${TYPES.join(
         ', '
-      )}, received: ${type}`,
+      )}; received: ${type}`,
       TYPES.includes(type)
     );
 

--- a/packages/components/addon/components/hds/icon-tile/index.js
+++ b/packages/components/addon/components/hds/icon-tile/index.js
@@ -32,7 +32,7 @@ export default class HdsIconTileIndexComponent extends Component {
     assert(
       `@size for "Hds::IconTile" must be one of the following: ${SIZES.join(
         ', '
-      )}, received: ${size}`,
+      )}; received: ${size}`,
       SIZES.includes(size)
     );
 
@@ -59,7 +59,7 @@ export default class HdsIconTileIndexComponent extends Component {
     assert(
       `@color for "Hds::IconTile" must be one of the following: ${COLORS.join(
         ', '
-      )}, received: ${color}`,
+      )}; received: ${color}`,
       COLORS.includes(color)
     );
 
@@ -112,7 +112,7 @@ export default class HdsIconTileIndexComponent extends Component {
       assert(
         `@logo for "Hds::IconTile" must be one of the following: ${PRODUCTS.join(
           ', '
-        )}, received: ${logo}`,
+        )}; received: ${logo}`,
         PRODUCTS.includes(logo)
       );
     }

--- a/packages/components/addon/components/hds/stepper/step/indicator.js
+++ b/packages/components/addon/components/hds/stepper/step/indicator.js
@@ -17,7 +17,7 @@ export default class HdsStepperIndicatorStepIndexComponent extends Component {
     assert(
       `@status for "Hds::Stepper::Step::Indicator" must be one of the following: ${STATUSES.join(
         ', '
-      )}, received: ${status}`,
+      )}; received: ${status}`,
       STATUSES.includes(status)
     );
 

--- a/packages/components/addon/components/hds/stepper/task/indicator.js
+++ b/packages/components/addon/components/hds/stepper/task/indicator.js
@@ -23,7 +23,7 @@ export default class HdsStepperIndicatorTaskIndexComponent extends Component {
     assert(
       `@status for "Hds::Stepper::Task::Indicator" must be one of the following: ${STATUSES.join(
         ', '
-      )}, received: ${status}`,
+      )}; received: ${status}`,
       STATUSES.includes(status)
     );
 

--- a/packages/components/tests/integration/components/hds/breadcrumb/item-test.js
+++ b/packages/components/tests/integration/components/hds/breadcrumb/item-test.js
@@ -46,7 +46,7 @@ module('Integration | Component | hds/breadcrumb/item', function (hooks) {
   // ASSERTIONS
 
   test('it should throw an assertion if @maxWidth is not in px/em', async function (assert) {
-    const errorMessage = `@maxWidth for "Hds::Breadcrumb::Item" must be a size as number in 'px' or in 'em' (eg. '200px' or '24em'), received: 123`;
+    const errorMessage = `@maxWidth for "Hds::Breadcrumb::Item" must be a size as number in 'px' or in 'em' (eg. '200px' or '24em'); received: 123`;
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/packages/components/tests/integration/components/hds/card/container-test.js
+++ b/packages/components/tests/integration/components/hds/card/container-test.js
@@ -82,7 +82,7 @@ module('Integration | Component | hds/card/container', function (hooks) {
 
   test('it should throw an assertion if an incorrect value for @level is provided', async function (assert) {
     const errorMessage =
-      '@level for "Hds::Card::Container" must be one of the following: base, mid, high, received: foo';
+      '@level for "Hds::Card::Container" must be one of the following: base, mid, high; received: foo';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
@@ -94,7 +94,7 @@ module('Integration | Component | hds/card/container', function (hooks) {
   });
   test('it should throw an assertion if an incorrect value for @levelHover is provided', async function (assert) {
     const errorMessage =
-      '@levelHover for "Hds::Card::Container" must be one of the following: base, mid, high, received: foo';
+      '@levelHover for "Hds::Card::Container" must be one of the following: base, mid, high; received: foo';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
@@ -106,7 +106,7 @@ module('Integration | Component | hds/card/container', function (hooks) {
   });
   test('it should throw an assertion if an incorrect value for @levelActive is provided', async function (assert) {
     const errorMessage =
-      '@levelActive for "Hds::Card::Container" must be one of the following: base, mid, high, received: foo';
+      '@levelActive for "Hds::Card::Container" must be one of the following: base, mid, high; received: foo';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/packages/components/tests/integration/components/hds/form/text-input/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/base-test.js
@@ -77,7 +77,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {
     const errorMessage =
-      '@type for "Hds::Form::TextInput" must be one of the following: text, email, password, url, search, date, time, received: foo';
+      '@type for "Hds::Form::TextInput" must be one of the following: text, email, password, url, search, date, time; received: foo';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/packages/components/tests/integration/components/hds/icon-tile/index-test.js
+++ b/packages/components/tests/integration/components/hds/icon-tile/index-test.js
@@ -117,7 +117,7 @@ module('Integration | Component | hds/icon-tile/index', function (hooks) {
   });
   test('it should throw an assertion if a wrong @logo value is passed', async function (assert) {
     const errorMessage =
-      '@logo for "Hds::IconTile" must be one of the following: boundary, consul, hcp, nomad, packer, terraform, vagrant, vault, waypoint, received: test';
+      '@logo for "Hds::IconTile" must be one of the following: boundary, consul, hcp, nomad, packer, terraform, vagrant, vault, waypoint; received: test';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);


### PR DESCRIPTION
### :pushpin: Summary

While working on another task, I noticed some of the assertions messages were using `; received:` others `, received:`. For consistency (often they are copy&pasted, and test may fail just for this small difference) I preferred to standardize them.

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
