### PR TITLE
Fix boolean arguments values

### DIFF
--- a/packages/components/addon/components/hds/badge/index.hbs
+++ b/packages/components/addon/components/hds/badge/index.hbs
@@ -1,7 +1,7 @@
 <div class={{this.classNames}} ...attributes>
   {{#if @icon}}
     <div class="hds-badge__icon">
-      <FlightIcon @name={{this.icon}} @size="16" @stretched="true" />
+      <FlightIcon @name={{this.icon}} @size="16" @stretched={{true}} />
     </div>
   {{/if}}
   {{#if this.isIconOnly}}

--- a/packages/components/addon/components/hds/icon-tile/index.hbs
+++ b/packages/components/addon/components/hds/icon-tile/index.hbs
@@ -1,18 +1,18 @@
 <div class={{this.classNames}} aria-hidden="true" ...attributes>
   {{#if @icon}}
     <div class="hds-icon-tile__icon">
-      <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched="true" />
+      <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} />
     </div>
   {{/if}}
   {{#if @logo}}
     <div class="hds-icon-tile__logo">
-      <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched="true" />
+      <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} />
     </div>
   {{/if}}
   {{#if this.iconSecondary}}
     <div class="hds-icon-tile__extra">
       <div class="hds-icon-tile__extra-icon">
-        <FlightIcon @name={{this.iconSecondary}} @size="16" @stretched="true" />
+        <FlightIcon @name={{this.iconSecondary}} @size="16" @stretched={{true}} />
       </div>
     </div>
   {{/if}}

--- a/packages/components/tests/dummy/app/templates/components/card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/card.hbs
@@ -77,15 +77,17 @@
   <h4 class="dummy-h4">Basic use</h4>
   <p class="dummy-paragraph">Invocation of the component would look something like this:</p>
   {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Card::Container @level="mid" @hasBorder="true">[Your content here]</Hds::Card::Container>
+      <Hds::Card::Container @level="mid" @hasBorder=\{{true}}>[Your content here]</Hds::Card::Container>
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Card::Container @level="mid" @hasBorder="true">[Your content here]</Hds::Card::Container>
+  <Hds::Card::Container @level="mid" @hasBorder={{true}}>[Your content here]</Hds::Card::Container>
   <p class="dummy-paragraph"><em>Notice: as you can see the layout of the card itself, and its content, is left to the
       consumer of the component. The
       <code class="dummy-code">Hds::Card::Container</code>
@@ -96,11 +98,12 @@
   </p>
   <p class="dummy-paragraph">In this example we apply custom classes to control the layout of the card and its content:</p>
   {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
       <div class="my-custom-class-to-set-the-card-layout">
-        <Hds::Card::Container @level="mid" @hasBorder="true">
+        <Hds::Card::Container @level="mid" @hasBorder=\{{true}}>
           <div class="my-custom-class-to-set-the-content-layout">
             [Your content here]
           </div>
@@ -108,11 +111,12 @@
       </div>
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <div class="dummy-card-how-to-custom-layout">
     <div class="my-custom-class-to-set-the-card-layout">
-      <Hds::Card::Container @level="mid" @hasBorder="true">
+      <Hds::Card::Container @level="mid" @hasBorder={{true}}>
         <div class="my-custom-class-to-set-the-content-layout">
           [Your content here]
         </div>
@@ -148,11 +152,12 @@
     <em>rest → hover → active</em>:
   </p>
   {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
       <div class="my-custom-class-to-set-the-card-layout">
-        <Hds::Card::Container @level="mid" @levelHover="high" @levelActive="mid" @hasBorder="true">
+        <Hds::Card::Container @level="mid" @levelHover="high" @levelActive="mid" @hasBorder=\{{true}}>
           <div class="my-custom-class-to-set-the-content-layout">
             [Your content here]
           </div>
@@ -160,11 +165,12 @@
       </div>
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <div class="dummy-card-how-to-custom-layout">
     <div class="my-custom-class-to-set-the-card-layout">
-      <Hds::Card::Container @level="mid" @levelHover="high" @levelActive="mid" @hasBorder="true">
+      <Hds::Card::Container @level="mid" @levelHover="high" @levelActive="mid" @hasBorder={{true}}>
         <div class="my-custom-class-to-set-the-content-layout">
           [Your content here]
         </div>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -1264,7 +1264,7 @@
       {{/each}}
       <Hds::Dropdown::ListItem::CopyItem
         @text="success: 91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d"
-        @isSuccess="true"
+        @isSuccess={{true}}
         mock-state-value="success"
         mock-state-selector="button"
       />

--- a/packages/components/tests/integration/components/hds/form/label/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/label/index-test.js
@@ -45,7 +45,7 @@ module('Integration | Component | hds/form/label/index', function (hooks) {
   test('it appends an indicator to the label text when user input is required', async function (assert) {
     assert.expect(2);
     await render(
-      hbs`<Hds::Form::Label @isRequired="true" id="test-form-label">This is the label</Hds::Form::Label>`
+      hbs`<Hds::Form::Label @isRequired={{true}} id="test-form-label">This is the label</Hds::Form::Label>`
     );
     assert.dom('#test-form-label .hds-form-indicator').exists();
     assert.dom('#test-form-label .hds-form-indicator').hasText('Required');
@@ -53,7 +53,7 @@ module('Integration | Component | hds/form/label/index', function (hooks) {
   test('it appends an indicator to the label text when user input is optional', async function (assert) {
     assert.expect(2);
     await render(
-      hbs`<Hds::Form::Label @isOptional="true" id="test-form-label">This is the label</Hds::Form::Label>`
+      hbs`<Hds::Form::Label @isOptional={{true}} id="test-form-label">This is the label</Hds::Form::Label>`
     );
     assert.dom('#test-form-label > .hds-form-indicator').exists();
     assert.dom('#test-form-label .hds-form-indicator').hasText('(Optional)');

--- a/packages/components/tests/integration/components/hds/form/legend/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/legend/index-test.js
@@ -49,7 +49,7 @@ module('Integration | Component | hds/form/legend/index', function (hooks) {
   test('it appends an indicator to the legend text when user input is required', async function (assert) {
     assert.expect(2);
     await render(
-      hbs`<Hds::Form::Legend id="test-form-legend" @isRequired="true">This is the legend</Hds::Form::Legend>`
+      hbs`<Hds::Form::Legend id="test-form-legend" @isRequired={{true}}>This is the legend</Hds::Form::Legend>`
     );
     assert.dom('#test-form-legend .hds-form-indicator').exists();
     assert.dom('#test-form-legend .hds-form-indicator').hasText('Required');
@@ -57,7 +57,7 @@ module('Integration | Component | hds/form/legend/index', function (hooks) {
   test('it appends an indicator to the legend text when user input is optional', async function (assert) {
     assert.expect(2);
     await render(
-      hbs`<Hds::Form::Legend id="test-form-legend" @isOptional="true">This is the legend</Hds::Form::Legend>`
+      hbs`<Hds::Form::Legend id="test-form-legend" @isOptional={{true}}>This is the legend</Hds::Form::Legend>`
     );
     assert.dom('#test-form-legend > .hds-form-indicator').exists();
     assert.dom('#test-form-legend .hds-form-indicator').hasText('(Optional)');

--- a/packages/ember-flight-icons/tests/dummy/app/templates/percy-test.hbs
+++ b/packages/ember-flight-icons/tests/dummy/app/templates/percy-test.hbs
@@ -23,10 +23,10 @@
   <div style="display: flex; gap: 8px;">
     {{! template-lint-disable no-inline-styles }}
     <div style="width: 12px; height: 12px;">
-      <FlightIcon @name="bug" @size="16" @stretched="true" />
+      <FlightIcon @name="bug" @size="16" @stretched={{true}} />
     </div>
     <div style="width: 32px; height: 32px;">
-      <FlightIcon @name="bug" @size="24" @stretched="true" />
+      <FlightIcon @name="bug" @size="24" @stretched={{true}} />
     </div>
   </div>
 </div>


### PR DESCRIPTION
### :pushpin: Summary

In our documentation (and in some cases code) we have a few places where we have declared a boolean argument as `@argument="true"` which may be misleading, because if one would do `@argument="false"` it would be evaluated to `true` anyway. Better to avoid this confusion and be explicit in the intent, using the notation `@argument={{true}}`.

This resolves #572.

### :hammer_and_wrench: Detailed description

In this PR I have:
- replaced values for boolean arguments with proper boolean definitions (not strings)

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
