### PR TITLE
Add small variant to `Hds::Dropdown::ToggleButton`

### DIFF
--- a/.changeset/tall-students-hunt.md
+++ b/.changeset/tall-students-hunt.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Add small variant to `Hds::Dropdown::ToggleButton`

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -18,6 +18,7 @@
   @icon="chevron-down"
   @iconPosition="trailing"
   @color={{this.color}}
+  @size={{@size}}
   ...attributes
   aria-expanded={{if @isOpen "true" "false"}}
   {{on "click" this.onClick}}

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -155,6 +155,14 @@
         <li>secondary</li>
       </ol>
     </dd>
+    <dt>size <code>enum</code></dt>
+    <dd>
+      <p>Acceptable values:</p>
+      <ol>
+        <li class="default">medium</li>
+        <li>small</li>
+      </ol>
+    </dd>
     <dt>...attributes</dt>
     <dd>
       <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
@@ -1000,6 +1008,17 @@
     <div>
       <span class="dummy-text-small">secondary</span>
       <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color="secondary" />
+    </div>
+  </div>
+  <br />
+  <div class="dummy-dropdown-toggle-button-sample">
+    <div>
+      <span class="dummy-text-small">primary small</span>
+      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @size="small" />
+    </div>
+    <div>
+      <span class="dummy-text-small">secondary small</span>
+      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @size="small" @color="secondary" />
     </div>
   </div>
   <h5 class="dummy-h5">Toggle::Icon</h5>

--- a/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
@@ -52,6 +52,21 @@ module(
       assert.dom('#test-toggle-button').hasClass('hds-button--color-secondary');
     });
 
+    // SIZE
+
+    test('it should render the medium size as the default if no size is declared', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" id="test-toggle-button" />`
+      );
+      assert.dom('#test-toggle-button').hasClass('hds-button--size-medium');
+    });
+    test('it should render the correct CSS size class if the @size prop is declared', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" @size="small" id="test-toggle-button" />`
+      );
+      assert.dom('#test-toggle-button').hasClass('hds-button--size-small');
+    });
+
     // A11Y
 
     test('it should render with the correct aria-expanded attribute on the toggle element', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

Add small variant to `Hds::Dropdown::ToggleButton`

### :hammer_and_wrench: Detailed description

In this PR we're exposing the `size` argument of the `Hds::Button` to the `Hds::Dropdown::ToggleButton`, allowing the `ToggleButton` subcomponent to render in a `small` size.

[👉 Preview Dropdown component](https://hds-components-e0ppou8pf-hashicorp.vercel.app/components/dropdown#showcase)

### :link: External links

[Jira issue](https://hashicorp.atlassian.net/browse/HDS-610)

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
