### PR TITLE
Add component-level design tokens for `RadioCard` component

### DIFF
--- a/packages/components/app/styles/components/form/radio-card.scss
+++ b/packages/components/app/styles/components/form/radio-card.scss
@@ -4,7 +4,7 @@
 
 .hds-form-group--radio-cards {
   .hds-form-group__control-fields-wrapper {
-    margin: -8px;
+    margin: calc(-1 * var(--token-form-radiocard-group-gap) / 2);
   }
 
   .hds-form-group__legend {
@@ -13,7 +13,7 @@
 
   .hds-form-radio-card {
     flex: 1;
-    margin: 8px;
+    margin: calc(var(--token-form-radiocard-group-gap) / 2);
   }
 }
 
@@ -23,8 +23,8 @@
   display: flex;
   flex-direction: column;
   background-color: var(--token-color-surface-primary);
-  border: 1px solid var(--token-color-border-primary);
-  border-radius: 6px;
+  border: var(--token-form-radiocard-border-width) solid var(--token-color-border-primary);
+  border-radius: var(--token-form-radiocard-border-radius);
   box-shadow: var(--token-elevation-mid-box-shadow);
   cursor: pointer;
 
@@ -38,7 +38,7 @@
   &:hover,
   &.mock-hover {
     box-shadow: var(--token-elevation-high-box-shadow);
-    transition: 0.2s;
+    transition: var(--token-form-radiocard-transition-duration);
   }
 
   &:focus-within,
@@ -85,7 +85,7 @@
 
 .hds-form-radio-card--control-bottom {
   .hds-form-radio-card__control-wrapper {
-    border-top-width: 1px;
+    border-top-width: var(--token-form-radiocard-border-width);
     border-top-style: solid;
     border-bottom-right-radius: inherit;
     border-bottom-left-radius: inherit;
@@ -98,7 +98,7 @@
   .hds-form-radio-card__control-wrapper {
     display: flex;
     align-items: center;
-    border-right-width: 1px;
+    border-right-width: var(--token-form-radiocard-border-width);
     border-right-style: solid;
     border-top-left-radius: inherit;
     border-bottom-left-radius: inherit;
@@ -107,7 +107,7 @@
 
 .hds-form-radio-card__content {
   flex: 1;
-  padding: 24px;
+  padding: var(--token-form-radiocard-content-padding);
 
   .hds-badge {
     margin-bottom: 8px;
@@ -131,7 +131,7 @@
 }
 
 .hds-form-radio-card__control-wrapper {
-  padding: 8px;
+  padding: var(--token-form-radiocard-control-padding);
   background-color: var(--token-color-surface-faint);
   border-color: var(--token-color-border-primary);
 }

--- a/packages/tokens/dist/devdot/css/tokens.css
+++ b/packages/tokens/dist/devdot/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 01 Sep 2022 22:06:03 GMT
+ * Generated on Wed, 28 Sep 2022 11:15:46 GMT
  */
 
 :root {
@@ -215,6 +215,12 @@
   --token-form-radio-background-image-size: 12px;
   --token-form-radio-background-image-data-url: url("data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%23ffffff'/%3e%3c/svg%3e"); /* notice: the 'dot' color is hardcoded here! */
   --token-form-radio-background-image-data-url-disabled: url("data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%238C909C'/%3e%3c/svg%3e"); /* notice: the 'dot' color is hardcoded here! */
+  --token-form-radiocard-group-gap: 16px;
+  --token-form-radiocard-border-width: 1px;
+  --token-form-radiocard-border-radius: 6px;
+  --token-form-radiocard-content-padding: 24px;
+  --token-form-radiocard-control-padding: 8px;
+  --token-form-radiocard-transition-duration: 0.2s;
   --token-form-select-background-image-size: 16px;
   --token-form-select-background-image-position-right-x: 7px;
   --token-form-select-background-image-position-top-y: 9px;

--- a/packages/tokens/dist/docs/devdot/tokens.json
+++ b/packages/tokens/dist/docs/devdot/tokens.json
@@ -4603,6 +4603,128 @@
       "value": "16",
       "type": "size"
     },
+    "name": "token-form-radiocard-group-gap",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard-group",
+      "item": "gap"
+    },
+    "path": [
+      "form",
+      "radiocard-group",
+      "gap"
+    ]
+  },
+  {
+    "value": "1px",
+    "type": "size",
+    "original": {
+      "value": "1",
+      "type": "size"
+    },
+    "name": "token-form-radiocard-border-width",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard",
+      "item": "border",
+      "subitem": "width"
+    },
+    "path": [
+      "form",
+      "radiocard",
+      "border",
+      "width"
+    ]
+  },
+  {
+    "value": "6px",
+    "type": "size",
+    "original": {
+      "value": "6",
+      "type": "size"
+    },
+    "name": "token-form-radiocard-border-radius",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard",
+      "item": "border",
+      "subitem": "radius"
+    },
+    "path": [
+      "form",
+      "radiocard",
+      "border",
+      "radius"
+    ]
+  },
+  {
+    "value": "24px",
+    "type": "size",
+    "original": {
+      "value": "24",
+      "type": "size"
+    },
+    "name": "token-form-radiocard-content-padding",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard",
+      "item": "content-padding"
+    },
+    "path": [
+      "form",
+      "radiocard",
+      "content-padding"
+    ]
+  },
+  {
+    "value": "8px",
+    "type": "size",
+    "original": {
+      "value": "8",
+      "type": "size"
+    },
+    "name": "token-form-radiocard-control-padding",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard",
+      "item": "control-padding"
+    },
+    "path": [
+      "form",
+      "radiocard",
+      "control-padding"
+    ]
+  },
+  {
+    "value": "0.2s",
+    "type": "time",
+    "unit": "s",
+    "original": {
+      "value": "0.2",
+      "type": "time",
+      "unit": "s"
+    },
+    "name": "token-form-radiocard-transition-duration",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard",
+      "item": "transition",
+      "subitem": "duration"
+    },
+    "path": [
+      "form",
+      "radiocard",
+      "transition",
+      "duration"
+    ]
+  },
+  {
+    "value": "16px",
+    "type": "size",
+    "original": {
+      "value": "16",
+      "type": "size"
+    },
     "name": "token-form-select-background-image-size",
     "attributes": {
       "category": "form",

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -4557,6 +4557,128 @@
       "value": "16",
       "type": "size"
     },
+    "name": "token-form-radiocard-group-gap",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard-group",
+      "item": "gap"
+    },
+    "path": [
+      "form",
+      "radiocard-group",
+      "gap"
+    ]
+  },
+  {
+    "value": "1px",
+    "type": "size",
+    "original": {
+      "value": "1",
+      "type": "size"
+    },
+    "name": "token-form-radiocard-border-width",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard",
+      "item": "border",
+      "subitem": "width"
+    },
+    "path": [
+      "form",
+      "radiocard",
+      "border",
+      "width"
+    ]
+  },
+  {
+    "value": "6px",
+    "type": "size",
+    "original": {
+      "value": "6",
+      "type": "size"
+    },
+    "name": "token-form-radiocard-border-radius",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard",
+      "item": "border",
+      "subitem": "radius"
+    },
+    "path": [
+      "form",
+      "radiocard",
+      "border",
+      "radius"
+    ]
+  },
+  {
+    "value": "24px",
+    "type": "size",
+    "original": {
+      "value": "24",
+      "type": "size"
+    },
+    "name": "token-form-radiocard-content-padding",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard",
+      "item": "content-padding"
+    },
+    "path": [
+      "form",
+      "radiocard",
+      "content-padding"
+    ]
+  },
+  {
+    "value": "8px",
+    "type": "size",
+    "original": {
+      "value": "8",
+      "type": "size"
+    },
+    "name": "token-form-radiocard-control-padding",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard",
+      "item": "control-padding"
+    },
+    "path": [
+      "form",
+      "radiocard",
+      "control-padding"
+    ]
+  },
+  {
+    "value": "0.2s",
+    "type": "time",
+    "unit": "s",
+    "original": {
+      "value": "0.2",
+      "type": "time",
+      "unit": "s"
+    },
+    "name": "token-form-radiocard-transition-duration",
+    "attributes": {
+      "category": "form",
+      "type": "radiocard",
+      "item": "transition",
+      "subitem": "duration"
+    },
+    "path": [
+      "form",
+      "radiocard",
+      "transition",
+      "duration"
+    ]
+  },
+  {
+    "value": "16px",
+    "type": "size",
+    "original": {
+      "value": "16",
+      "type": "size"
+    },
     "name": "token-form-select-background-image-size",
     "attributes": {
       "category": "form",

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 01 Sep 2022 22:06:03 GMT
+ * Generated on Wed, 28 Sep 2022 11:15:46 GMT
  */
 
 :root {
@@ -213,6 +213,12 @@
   --token-form-radio-background-image-size: 12px;
   --token-form-radio-background-image-data-url: url("data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%23ffffff'/%3e%3c/svg%3e"); /* notice: the 'dot' color is hardcoded here! */
   --token-form-radio-background-image-data-url-disabled: url("data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%238C909C'/%3e%3c/svg%3e"); /* notice: the 'dot' color is hardcoded here! */
+  --token-form-radiocard-group-gap: 16px;
+  --token-form-radiocard-border-width: 1px;
+  --token-form-radiocard-border-radius: 6px;
+  --token-form-radiocard-content-padding: 24px;
+  --token-form-radiocard-control-padding: 8px;
+  --token-form-radiocard-transition-duration: 0.2s;
   --token-form-select-background-image-size: 16px;
   --token-form-select-background-image-position-right-x: 7px;
   --token-form-select-background-image-position-top-y: 9px;

--- a/packages/tokens/src/products/shared/form/radiocard.json
+++ b/packages/tokens/src/products/shared/form/radiocard.json
@@ -1,0 +1,37 @@
+{
+    "form": {
+        "radiocard-group": {
+            "gap": {
+                "value": "16",
+                "type": "size"
+            }
+        },
+        "radiocard": {
+            "border": {
+                "width": {
+                    "value": "1",
+                    "type": "size"
+                },
+                "radius": {
+                    "value": "6",
+                    "type": "size"
+                }
+            },
+            "content-padding": {
+                "value": "24",
+                "type": "size"
+            },
+            "control-padding": {
+                "value": "8",
+                "type": "size"
+            },
+            "transition": {
+                "duration": {
+                    "value": "0.2",
+                    "type": "time",
+                    "unit": "s"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### :pushpin: Summary

As a follow-up of #576 this PR intends to add component-level design tokens for the `RadioCard` component

### :hammer_and_wrench: Detailed description

In this PR I have:
- added component-level design tokens for `RadioCard` component
- re-generated design tokens in output
- updated `RadioCard` styles to use component-specific design tokens

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
