### PR TITLE
[basic table] Adds support for table row component

### DIFF
--- a/packages/components/.gitignore
+++ b/packages/components/.gitignore
@@ -21,6 +21,7 @@
 /yarn-error.log
 .DS_Store
 node_modules/
+.vscode/settings.json
 
 # ember-try
 /.node_modules.ember-try/

--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -1,15 +1,19 @@
 <table class="hds-table" data-test-table ...attributes>
   <thead class="hds-table__thead" data-test-table-head>
-    <tr>
+    <Hds::Table::Row>
       {{yield
         (hash SortBy=(component "hds/table/sort-by" currentField=@sortProperty sortDescending=this.sortDescending))
         to="head"
       }}
-    </tr>
+    </Hds::Table::Row>
   </thead>
   <tbody class="hds-table__tbody" data-test-table-body>
-    {{#each @model as |row|}}
-      {{yield row to="body"}}
-    {{/each}}
+    {{#if @model}}
+      {{#each @model as |row|}}
+        {{yield row to="body"}}
+      {{/each}}
+    {{else}}
+      {{yield to="body"}}
+    {{/if}}
   </tbody>
 </table>

--- a/packages/components/addon/components/hds/table/row.hbs
+++ b/packages/components/addon/components/hds/table/row.hbs
@@ -1,3 +1,3 @@
-<tr class="hds-table__row">
+<tr class="hds-table__row" ...attributes>
   {{yield}}
 </tr>

--- a/packages/components/addon/components/hds/table/row.hbs
+++ b/packages/components/addon/components/hds/table/row.hbs
@@ -1,0 +1,3 @@
+<tr class="hds-table__row">
+  {{yield}}
+</tr>

--- a/packages/components/app/components/hds/table/row.js
+++ b/packages/components/app/components/hds/table/row.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/table/row';

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -4,67 +4,70 @@
 // properties within each class are sorted alphabetically
 //
 .hds-table {
-  border-collapse: collapse;
-  border-radius: 6px;
-  border-spacing: 0;
-  border: 1px solid var(--token-color-border-primary);
-  font-family:var(--token-typography-font-stack-text);
-  font-size: var(--token-typography-body-200-font-size);
-  line-height: var(--token-typography-body-200-line-height);
   width: 100%;
+  font-size: var(--token-typography-body-200-font-size);
+  font-family: var(--token-typography-font-stack-text);
+  line-height: var(--token-typography-body-200-line-height);
+  border: 1px solid var(--token-color-border-primary);
+  border-radius: 6px;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
+
 .hds-table__thead {
   border-bottom: 1px solid var(--token-color-border-primary);
-  
+
   th {
-    background-color: var(--token-color-surface-strong);
+    padding: 8px 16px;
     color: var(--token-color-foreground-strong);
     font-weight: var(--token-typography-font-weight-semibold);
-    padding: 8px 16px;
     text-align: left;
+    background-color: var(--token-color-surface-strong);
 
     &.hds-table__th--sortable {
-      padding: 0; //we're taking it out here because we need it on the interactive content instead
+      padding: 0; // we're taking it out here because we need it on the interactive content instead
     }
 
-    &.text-right { // for num support
-      text-align: right;
-    }
     a { // will refactor this to a button. Use Hds::Button?
-      align-items: center;
-      border: 3px solid transparent;
-      color: var(--token-color-foreground-strong);
       display: flex;
+      align-items: center;
       padding: 8px 16px;
+      color: var(--token-color-foreground-strong);
       text-decoration: none;
+      border: 3px solid transparent;
 
       &:visited {
         color: var(--token-color-foreground-strong);
       }
+
       &:hover {
+        color: var(--token-color-foreground-strong);
         background-color: var(--token-color-palette-neutral-200);
-        color: var(--token-color-foreground-strong);
       }
-      &:focus, &:focus-visible {
+
+      &:focus,
+      &:focus-visible {
+        color: var(--token-color-foreground-strong);
         border-color: var(--token-color-focus-action-external);
-        color: var(--token-color-foreground-strong);
       }
+
       &:active {
-        background-color: var(--token-color-palette-neutral-300);
         color: var(--token-color-foreground-strong);
+        background-color: var(--token-color-palette-neutral-300);
       }
 
       svg { // in case they don't use flight icons
-        color: var(--token-color-focus-action-external);
         margin-left: 8px;
+        color: var(--token-color-focus-action-external);
       }
     }
   }
 }
+
 .hds-table__tbody {
-  background-color: var(--token-color-surface-primary);
   color: var(--token-color-foreground-primary);
   font-weight: var(--token-typography-font-weight-regular);
+  background-color: var(--token-color-surface-primary);
 
 
   tr {
@@ -74,6 +77,7 @@
       background-color: var(--token-color-surface-faint);
     }
   }
+
   td {
     padding: 12px 16px;
   }

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -326,7 +326,7 @@ export default class ComponentsTableRoute extends Route {
     Showcase
   </h3>
   <h4 class="dummy-h4">
-    Static Table (non-sortable)
+    Static table (non-sortable) with model defined
   </h4>
   <Hds::Table @model={{this.model}}>
     <:head>
@@ -335,32 +335,15 @@ export default class ComponentsTableRoute extends Route {
       <th>Release Year</th>
     </:head>
     <:body as |row|>
-      <tr>
+      <Hds::Table::Row>
         <td>{{row.artist}}</td>
         <td>{{row.album}}</td>
         <td>{{row.year}}</td>
-      </tr>
+      </Hds::Table::Row>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
-    Sortable Table
-  </h4>
-  <Hds::Table @model={{this.model}} @sortProperty={{this.sortby}} @sortDescending={{false}}>
-    <:head as |h|>
-      <h.SortBy @field="artist">Artist</h.SortBy>
-      <h.SortBy @field="album">Album</h.SortBy>
-      <h.SortBy @field="year">Release Year</h.SortBy>
-    </:head>
-    <:body as |row|>
-      <tr>
-        <td>{{row.artist}}</td>
-        <td>{{row.album}}</td>
-        <td>{{row.year}}</td>
-      </tr>
-    </:body>
-  </Hds::Table>
-  <h4 class="dummy-h4">
-    No Model Defined
+    Static table with no model defined
   </h4>
   <Hds::Table>
     <:head>
@@ -383,6 +366,23 @@ export default class ComponentsTableRoute extends Route {
         <td>Cell Content</td>
         <td>Cell Content</td>
         <td>Cell Content</td>
+      </Hds::Table::Row>
+    </:body>
+  </Hds::Table>
+  <h4 class="dummy-h4">
+    Sortable table
+  </h4>
+  <Hds::Table @model={{this.model}} @sortProperty={{this.sortby}} @sortDescending={{false}}>
+    <:head as |h|>
+      <h.SortBy @field="artist">Artist</h.SortBy>
+      <h.SortBy @field="album">Album</h.SortBy>
+      <h.SortBy @field="year">Release Year</h.SortBy>
+    </:head>
+    <:body as |row|>
+      <Hds::Table::Row>
+        <td>{{row.artist}}</td>
+        <td>{{row.album}}</td>
+        <td>{{row.year}}</td>
       </Hds::Table::Row>
     </:body>
   </Hds::Table>

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -359,4 +359,31 @@ export default class ComponentsTableRoute extends Route {
       </tr>
     </:body>
   </Hds::Table>
+  <h4 class="dummy-h4">
+    No Model Defined
+  </h4>
+  <Hds::Table>
+    <:head>
+      <th>Cell Header</th>
+      <th>Cell Header</th>
+      <th>Cell Header</th>
+    </:head>
+    <:body>
+      <Hds::Table::Row>
+        <td>Cell Content</td>
+        <td>Cell Content</td>
+        <td>Cell Content</td>
+      </Hds::Table::Row>
+      <Hds::Table::Row>
+        <td>Cell Content</td>
+        <td>Cell Content</td>
+        <td>Cell Content</td>
+      </Hds::Table::Row>
+      <Hds::Table::Row>
+        <td>Cell Content</td>
+        <td>Cell Content</td>
+        <td>Cell Content</td>
+      </Hds::Table::Row>
+    </:body>
+  </Hds::Table>
 </section>

--- a/packages/components/tests/integration/components/hds/table/row-test.js
+++ b/packages/components/tests/integration/components/hds/table/row-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/table/row', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Hds::Table::Row />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Hds::Table::Row>
+        template block text
+      </Hds::Table::Row>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a template-only table/row component. Resolves [HDS-699].(https://hashicorp.atlassian.net/browse/HDS-699)

### :hammer_and_wrench: Detailed description

- added `<Hds::Table::Row>` component
- Updated `<Hds::Table>` to use the row
- Added conditional for table body that allows `@model` to be optional for row rendering (users would provide their own content)
- Updated documentation, specifically the Showcase section

### :camera_flash: Screenshots

![CleanShot 2022-09-28 at 11 04 41](https://user-images.githubusercontent.com/4587451/192829562-f8d97def-a52d-40af-b182-fdfcbf92d0a9.png)

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-699]: https://hashicorp.atlassian.net/browse/HDS-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ