### PR TITLE
[basic table] Small refactor to make striping optional

### DIFF
--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -1,4 +1,4 @@
-<table class="hds-table" data-test-table ...attributes>
+<table class="hds-table {{if @isStriped "hds-table--striped"}}" data-test-table ...attributes>
   <thead class="hds-table__thead" data-test-table-head>
     <Hds::Table::Row>
       {{yield

--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -1,4 +1,4 @@
-<table class="hds-table {{if @isStriped "hds-table--striped"}}" data-test-table ...attributes>
+<table class="hds-table {{if @isStriped 'hds-table--striped'}}" data-test-table ...attributes>
   <thead class="hds-table__thead" data-test-table-head>
     <Hds::Table::Row>
       {{yield

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -14,6 +14,14 @@
   border-spacing: 0;
 }
 
+.hds-table--striped {
+  tbody {
+    tr:nth-child(odd) {
+      background-color: var(--token-color-surface-faint);
+    }
+  }
+}
+
 .hds-table__thead {
   border-bottom: 1px solid var(--token-color-border-primary);
 
@@ -69,13 +77,8 @@
   font-weight: var(--token-typography-font-weight-regular);
   background-color: var(--token-color-surface-primary);
 
-
   tr {
     border-bottom: 1px solid var(--token-color-border-primary);
-
-    &:nth-child(odd) {
-      background-color: var(--token-color-surface-faint);
-    }
   }
 
   td {

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -343,6 +343,23 @@ export default class ComponentsTableRoute extends Route {
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
+    Static table with striped rows
+  </h4>
+  <Hds::Table @model={{this.model}} @isStriped={{true}}>
+    <:head>
+      <th>Artist</th>
+      <th>Album</th>
+      <th>Release Year</th>
+    </:head>
+    <:body as |row|>
+      <Hds::Table::Row>
+        <td>{{row.artist}}</td>
+        <td>{{row.album}}</td>
+        <td>{{row.year}}</td>
+      </Hds::Table::Row>
+    </:body>
+  </Hds::Table>
+  <h4 class="dummy-h4">
     Static table with no model defined
   </h4>
   <Hds::Table>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR makes table striping style optional instead of the default. 

### :hammer_and_wrench: Detailed description

When invoking the component: `<Hds::Table @isStriped={{true}}>`

### :camera_flash: Screenshots

![CleanShot 2022-09-28 at 13 00 48](https://user-images.githubusercontent.com/4587451/192855453-2dedb379-0ec7-4b29-bcc5-b21082a90913.png)


### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
