### PR TITLE
`Radiocard` component - Use placeholder for "custom" content

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -652,7 +652,9 @@
       <G.RadioCard @checked={{item.checked}} @value={{item.value}} {{on "change" this.onChange}} as |R|>
         <R.Icon @name="hexagon" />
         <R.Label>{{item.label}}</R.Label>
-        <R.Generic>{{item.generic}}</R.Generic>
+        <R.Generic>
+          <DummyPlaceholder @text={{item.generic}} @height="50" @background="#eee" />
+        </R.Generic>
       </G.RadioCard>
     {{/each}}
   </Hds::Form::RadioCard::Group>


### PR DESCRIPTION
### :pushpin: Summary

We have a `DummyPlaceholder` component that we use whenever we want to showcase a "generic" content. We can use it for the generic content in the RadioCard component, so it's also more in line with a similar generic placeholder in Figma:
<img width="349" alt="screenshot_1833" src="https://user-images.githubusercontent.com/686239/193080933-7dcf7fe2-6127-46bf-aa80-54f088882ea3.png">

### :hammer_and_wrench: Detailed description

In this PR I have:
- replaced the textual  generic content with the “placeholder” element

### :camera_flash: Screenshots

**Before:**
<img width="1048" alt="screenshot_1831" src="https://user-images.githubusercontent.com/686239/193080096-d07ba0cc-dde0-4aad-b1bb-d2ea63c4c13a.png">

**After:**
<img width="1047" alt="screenshot_1832" src="https://user-images.githubusercontent.com/686239/193080524-5879db90-fadd-410c-bc1f-e7b695f772b8.png">

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
