### PR TITLE
Fix spacing in RadioCard

### DIFF
--- a/packages/components/addon/components/hds/form/radio-card/index.hbs
+++ b/packages/components/addon/components/hds/form/radio-card/index.hbs
@@ -1,6 +1,6 @@
 <label class={{this.classNames}} {{did-insert this.setAriaDescribedBy}} {{style maxWidth=@maxWidth}}>
   <span class="hds-form-radio-card__content">
-    {{yield (hash Icon=(component "flight-icon" size="24"))}}
+    {{yield (hash Icon=(component "flight-icon" size="24" isInlineBlock=false))}}
     {{yield (hash Label=(component "hds/form/radio-card/label"))}}
     {{yield (hash Badge=(component "hds/badge"))}}
     {{yield (hash Description=(component "hds/form/radio-card/description"))}}

--- a/packages/components/app/styles/components/form/radio-card.scss
+++ b/packages/components/app/styles/components/form/radio-card.scss
@@ -79,6 +79,11 @@
 
 .hds-form-radio-card--align-center {
   text-align: center;
+
+  // stylelint-disable-next-line selector-class-pattern
+  .flight-icon {
+    margin: auto;
+  }
 }
 
 // CONTROL POSITION

--- a/packages/components/app/styles/components/form/radio-card.scss
+++ b/packages/components/app/styles/components/form/radio-card.scss
@@ -110,7 +110,7 @@
   padding: var(--token-form-radiocard-content-padding);
 
   .hds-badge {
-    margin-bottom: 8px;
+    margin-bottom: 12px;
   }
 }
 
@@ -126,7 +126,6 @@
 
 .hds-form-radio-card__description {
   display: block;
-  margin-top: 12px;
   color: var(--token-form-helper-text-color);
 }
 

--- a/packages/components/app/styles/components/form/radio-card.scss
+++ b/packages/components/app/styles/components/form/radio-card.scss
@@ -131,7 +131,7 @@
 
 .hds-form-radio-card__description {
   display: block;
-  color: var(--token-form-helper-text-color);
+  color: var(--token-color-foreground-primary);
 }
 
 .hds-form-radio-card__control-wrapper {

--- a/packages/components/tests/dummy/app/styles/pages/form/db-radio-card.scss
+++ b/packages/components/tests/dummy/app/styles/pages/form/db-radio-card.scss
@@ -9,8 +9,8 @@
 
 .dummy-form-radio-card-custom-content {
   @include dummyFontFamily();
-  margin-bottom: 0;
-  padding-left: 0;
+  margin: 0;
+  padding: 0;
   color: #3b3d45;
   font-size: 13px;
   line-height: 18px;


### PR DESCRIPTION
### :pushpin: Summary

Fix badge-description spacing in RadioCard – now, by error it adds up to `20px`

### :hammer_and_wrench: Detailed description

When a badge exists, the spacing between badge and description should be `12px`
When the badge doesn't exist the spacing between label and description should be `8px`

To match these rules we adjust the CSS properties accordingly and try to rely on `margin-bottom` only, especially when dealing with spacing between optional elements.

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
