### PR TITLE
`Tabs` - accessibility refactors

### DIFF
--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -53,24 +53,24 @@ export default class HdsTabsIndexComponent extends Component {
   handleKeyUp(tabIndex, e) {
     const leftArrow = 37;
     const rightArrow = 39;
-    const downArrow = 40;
+    const enterKey =	13;
+    const spaceKey = 32;
 
     if (e.keyCode === rightArrow) {
       const nextTabIndex = (tabIndex + 1) % this.tabIds.length;
-      this.selectTab(nextTabIndex, e);
+      this.focusTab(nextTabIndex, e);
     } else if (e.keyCode === leftArrow) {
       const prevTabIndex =
         (tabIndex + this.tabIds.length - 1) % this.tabIds.length;
-      this.selectTab(prevTabIndex, e);
-    } else if (e.keyCode === downArrow) {
-      this.setSelectedPanelFocus(tabIndex, e);
+      this.focusTab(prevTabIndex, e);
+    } else if (e.keyCode === enterKey || e.keyCode === spaceKey) {
+      this.selectedTabIndex = tabIndex;
     }
   }
 
-  // Select tab for keyboard & mouse navigation:
-  selectTab(tabIndex, e) {
+  // Focus tab for keyboard & mouse navigation:
+  focusTab(tabIndex, e) {
     e.preventDefault();
-    this.selectedTabIndex = tabIndex;
     this.tabNodes[tabIndex].focus();
   }
 

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -53,7 +53,7 @@ export default class HdsTabsIndexComponent extends Component {
   handleKeyUp(tabIndex, e) {
     const leftArrow = 37;
     const rightArrow = 39;
-    const enterKey =	13;
+    const enterKey = 13;
     const spaceKey = 32;
 
     if (e.keyCode === rightArrow) {

--- a/packages/components/addon/components/hds/tabs/panel.hbs
+++ b/packages/components/addon/components/hds/tabs/panel.hbs
@@ -1,6 +1,5 @@
 <section
   class={{this.classNames}}
-  tabindex="-1"
   role="tabpanel"
   aria-labelledby={{this.tabId}}
   id={{this.panelId}}

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -65,8 +65,3 @@ $indicator-height: 3px;
 
 .hds-tabs__tab-icon { margin-right: 6px; }
 .hds-tabs__tab-badge { margin-left: 6px; }
-
-// TODO: Do we want to have a visibile focus style for the tabPanel or not?
-.hds-tabs__panel {
-  @include hds-focus-ring-with-pseudo-element($top: 4px, $right: 6px, $bottom: 4px, $left: 6px);
-}


### PR DESCRIPTION
### :pushpin: Summary

This PR is to refactor keyboard controls and remove panel focus. Once approved, it will be merged into this [sub branch](https://github.com/hashicorp/design-system/pull/588).

https://hds-components-git-tabs-accessibility-refactors-hashicorp.vercel.app/components/tabs#showcase

**References**:
- previous PR comments: https://github.com/hashicorp/design-system/pull/566#discussion_r975899588
- thread where this change was discussed: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1664402723593409

### :hammer_and_wrench: Detailed description
* Removed down arrow navigation
* Changed tab keyboard nav behavior so Panel is displayed using "space" or "enter" keys
* Removed focus behavior and styling from Panels
<!-- 
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser

### :link: External links
Issues, RFC, etc. -->

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
