### PR TITLE
`Tabs` - Showcase improvements

### DIFF
--- a/packages/components/addon/components/hds/tabs/panel.js
+++ b/packages/components/addon/components/hds/tabs/panel.js
@@ -15,11 +15,15 @@ export default class HdsTabsIndexComponent extends Component {
 
   @cached
   get nodeIndex() {
-    return this.args.panelIds.indexOf(this.panelId);
+    return this.args.panelIds
+      ? this.args.panelIds.indexOf(this.panelId)
+      : undefined;
   }
 
   get tabId() {
-    return this.args.tabIds[this.nodeIndex];
+    return this.nodeIndex !== undefined
+      ? this.args.tabIds[this.nodeIndex]
+      : undefined;
   }
 
   get isSelected() {
@@ -28,9 +32,11 @@ export default class HdsTabsIndexComponent extends Component {
 
   @action
   didInsertNode(element) {
-    this.elementId = element.id;
-    if (typeof this.args.didInsertNode === 'function') {
-      this.args.didInsertNode(this.elementId, ...arguments);
+    let { didInsertNode } = this.args;
+
+    if (typeof didInsertNode === 'function') {
+      this.elementId = element.id;
+      didInsertNode(this.elementId, ...arguments);
     }
   }
 

--- a/packages/components/addon/components/hds/tabs/tab.hbs
+++ b/packages/components/addon/components/hds/tabs/tab.hbs
@@ -8,7 +8,7 @@
   <a
     role="tab"
     class="hds-tabs__tab-link hds-typography-body-200 hds-font-weight-medium"
-    href={{concat "#" this.panelId}}
+    href={{if this.panelId (concat "#" this.panelId)}}
     id={{this.tabId}}
     aria-selected={{this.isSelected}}
     tabindex={{unless this.isSelected "-1"}}

--- a/packages/components/addon/components/hds/tabs/tab.js
+++ b/packages/components/addon/components/hds/tabs/tab.js
@@ -13,11 +13,13 @@ export default class HdsTabsIndexComponent extends Component {
 
   @cached
   get nodeIndex() {
-    return this.args.tabIds.indexOf(this.tabId);
+    return this.args.tabIds ? this.args.tabIds.indexOf(this.tabId) : undefined;
   }
 
   get panelId() {
-    return this.args.panelIds[this.nodeIndex];
+    return this.nodeIndex !== undefined
+      ? this.args.panelIds[this.nodeIndex]
+      : undefined;
   }
 
   /**
@@ -27,7 +29,10 @@ export default class HdsTabsIndexComponent extends Component {
    * @description Determines if the tab is the selected tab
    */
   get isSelected() {
-    return this.nodeIndex === this.args.selectedTabIndex;
+    return (
+      this.nodeIndex !== undefined &&
+      this.nodeIndex === this.args.selectedTabIndex
+    );
   }
 
   get isInitialTab() {
@@ -37,17 +42,33 @@ export default class HdsTabsIndexComponent extends Component {
 
   @action
   didInsertNode() {
-    this.args.didInsertNode(...arguments);
+    let { didInsertNode } = this.args;
+
+    if (typeof didInsertNode === 'function') {
+      didInsertNode(...arguments);
+    }
   }
 
   @action
   onClick() {
-    this.args.onClick(this.nodeIndex, ...arguments);
+    let { onClick } = this.args;
+
+    if (typeof onClick === 'function') {
+      onClick(this.nodeIndex, ...arguments);
+    } else {
+      return false;
+    }
   }
 
   @action
   onKeyUp() {
-    this.args.onKeyUp(this.nodeIndex, ...arguments);
+    let { onKeyUp } = this.args;
+
+    if (typeof onKeyUp === 'function') {
+      onKeyUp(this.nodeIndex, ...arguments);
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -20,12 +20,14 @@ $indicator-height: 3px;
   display: flex;
   margin: 0;
   padding: 0;
-  list-style: none;
   border-bottom: 1px solid var(--token-color-border-primary);
 }
 
 .hds-tabs__tab {
   position: relative; // for positioning indicator
+  margin: 0;
+  padding: 0;
+  list-style: none;
 
   &.hds-tabs__tab--is-selected {
     /* indicator TODO: refactor as needed for animation */
@@ -47,7 +49,12 @@ $indicator-height: 3px;
   }
 
   .hds-tabs__tab-link {
-    @include hds-focus-ring-with-pseudo-element($top: 4px, $right: 6px, $bottom: 4px, $left: 6px);
+    @include hds-focus-ring-with-pseudo-element(
+      $top: 4px,
+      $right: 6px,
+      $bottom: 4px,
+      $left: 6px
+    );
     display: flex;
     align-items: center;
     height: 36px;
@@ -57,11 +64,17 @@ $indicator-height: 3px;
     text-decoration: none;
     border-radius: var(--token-form-control-border-radius);
 
-    &:hover {
+    &:hover,
+    &.mock-hover {
       color: var(--token-color-foreground-action-hover);
     }
   }
 }
 
-.hds-tabs__tab-icon { margin-right: 6px; }
-.hds-tabs__tab-badge { margin-left: 6px; }
+.hds-tabs__tab-icon {
+  margin-right: 6px;
+}
+
+.hds-tabs__tab-badge {
+  margin-left: 6px;
+}

--- a/packages/components/tests/dummy/app/components/dummy-placeholder/index.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-placeholder/index.hbs
@@ -1,5 +1,7 @@
 <div class="dummy-placeholder" style={{this.style}} ...attributes>
   {{#if @text}}
-    <div class="dummy-placeholder__text">{{@text}}</div>
+    {{@text}}
+  {{else}}
+    {{yield}}
   {{/if}}
 </div>

--- a/packages/components/tests/dummy/app/routes/components/tabs.js
+++ b/packages/components/tests/dummy/app/routes/components/tabs.js
@@ -1,3 +1,9 @@
 import Route from '@ember/routing/route';
 
-export default class ComponentsTabsRoute extends Route {}
+export default class ComponentsTabsRoute extends Route {
+  model() {
+    // these are used only for presentation purpose in the showcase
+    const TAG_STATES = ['default', 'hover', 'focus'];
+    return { TAG_STATES };
+  }
+}

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -21,6 +21,7 @@
 @import "./pages/db-link-inline";
 @import "./pages/db-link-standalone";
 @import "./pages/db-power-select";
+@import "./pages/db-tab";
 @import "./pages/db-tag";
 @import "./pages/db-toast";
 @import "./pages/db-tokens";

--- a/packages/components/tests/dummy/app/styles/components/dummy-placeholder.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-placeholder.scss
@@ -1,25 +1,22 @@
 .dummy-placeholder {
-    align-items: center;
-    // diagonal lines
-    // background-image: url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M5 0H6L0 6V5L5 0Z' fill='%2300000033'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M6 5V6H5L6 5Z' fill='%2300000033'/%3E%3C/svg%3E");
-    // texture
-    // background-image: url("data:image/svg+xml,%3Csvg width='4' height='4' viewBox='0 0 4 4' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 3H2V4H1V3ZM3 1H4V2H3V1Z' fill='%2300000033'/%3E%3C/svg%3E");
-    display: flex;
-    justify-content: center;
-}
+  // diagonal lines
+  // background-image: url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M5 0H6L0 6V5L5 0Z' fill='%2300000033'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M6 5V6H5L6 5Z' fill='%2300000033'/%3E%3C/svg%3E");
+  // texture
+  // background-image: url("data:image/svg+xml,%3Csvg width='4' height='4' viewBox='0 0 4 4' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 3H2V4H1V3ZM3 1H4V2H3V1Z' fill='%2300000033'/%3E%3C/svg%3E");
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b6b6b; // if background is #EEE then this has the appropriate color contrast (4.59:1)
+  font-weight: bold;
+  font-size: 10px;
+  font-family: monaco, Consolas, "Lucida Console", monospace;
+  line-height: 1.2;
+  text-align: center;
+  text-shadow: 0 0 5px #fff;
 
-
-.dummy-placeholder__text {
-    color: #6B6B6B; // if background is #EEE then this has the appropriate color contrast (4.59:1)
-    font-family: monaco, Consolas, "Lucida Console", monospace;
-    font-size: 10px;
-    font-weight: bold;
-    line-height: 1.2;
-    text-align: center;
-    text-shadow: 0px 0px 5px #fff;
-
-    a > .dummy-placeholder & {
-        text-decoration: underline;
-        text-decoration-color: #CCC;
-    }
+  a,
+  a > & {
+    color: #333;
+    text-decoration: underline;
+  }
 }

--- a/packages/components/tests/dummy/app/styles/pages/db-tab.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-tab.scss
@@ -1,0 +1,22 @@
+// TAB
+
+.dummy-tab-base-sample {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  min-width: fit-content;
+  margin: 0;
+  list-style: none;
+
+  .hds-tabs__tab {
+    outline: 1px dotted #eee;
+  }
+}
+
+
+.dummy-tab-base-sample-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}

--- a/packages/components/tests/dummy/app/styles/pages/db-tab.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-tab.scss
@@ -6,17 +6,20 @@
   align-items: flex-start;
   min-width: fit-content;
   margin: 0;
-  list-style: none;
 
   .hds-tabs__tab {
     outline: 1px dotted #eee;
   }
 }
 
-
 .dummy-tab-base-sample-item {
   display: flex;
   flex-direction: column;
   gap: 8px;
   align-items: flex-start;
+}
+
+.dummy-tab-ul-tab-wrapper {
+  display: contents;
+  list-style: none;
 }

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -221,22 +221,30 @@
     <div>
       <span class="dummy-text-small">Text only</span>
       <br />
-      <Hds::Tabs::Tab>Lorem ipsum</Hds::Tabs::Tab>
+      <ul class="dummy-tab-ul-tab-wrapper">
+        <Hds::Tabs::Tab>Lorem ipsum</Hds::Tabs::Tab>
+      </ul>
     </div>
     <div>
       <span class="dummy-text-small">Icon + Text</span>
       <br />
-      <Hds::Tabs::Tab @icon="hexagon">Lorem ipsum</Hds::Tabs::Tab>
+      <ul class="dummy-tab-ul-tab-wrapper">
+        <Hds::Tabs::Tab @icon="hexagon">Lorem ipsum</Hds::Tabs::Tab>
+      </ul>
     </div>
     <div>
       <span class="dummy-text-small">Text + Counter</span>
       <br />
-      <Hds::Tabs::Tab @count="10">Lorem ipsum</Hds::Tabs::Tab>
+      <ul class="dummy-tab-ul-tab-wrapper">
+        <Hds::Tabs::Tab @count="10">Lorem ipsum</Hds::Tabs::Tab>
+      </ul>
     </div>
     <div>
       <span class="dummy-text-small">Icon + Text + Counter</span>
       <br />
-      <Hds::Tabs::Tab @icon="hexagon" @count="10">Lorem ipsum</Hds::Tabs::Tab>
+      <ul class="dummy-tab-ul-tab-wrapper">
+        <Hds::Tabs::Tab @icon="hexagon" @count="10">Lorem ipsum</Hds::Tabs::Tab>
+      </ul>
     </div>
   </div>
 
@@ -245,8 +253,12 @@
     {{#each @model.TAG_STATES as |state|}}
       <div class="dummy-tab-base-sample-item">
         <span class="dummy-text-small">{{capitalize state}}:</span>
-        <Hds::Tabs::Tab mock-state-value={{state}} mock-state-selector="a">Lorem ipsum</Hds::Tabs::Tab>
-        <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value={{state}} mock-state-selector="a">Lorem ipsum</Hds::Tabs::Tab>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab mock-state-value={{state}} mock-state-selector="a">Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value={{state}} mock-state-selector="a">Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
       </div>
     {{/each}}
   </div>

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -214,36 +214,90 @@
 <section data-test-percy>
   <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
 
-  <p class="dummy-paragraph"><strong>Basic usage:</strong></p>
+  <h4 class="dummy-h4">Tab</h4>
+
+  <h5 class="dummy-h6">Content</h5>
+  <div class="dummy-tab-base-sample">
+    <div>
+      <span class="dummy-text-small">Text only</span>
+      <br />
+      <Hds::Tabs::Tab>Lorem ipsum</Hds::Tabs::Tab>
+    </div>
+    <div>
+      <span class="dummy-text-small">Icon + Text</span>
+      <br />
+      <Hds::Tabs::Tab @icon="hexagon">Lorem ipsum</Hds::Tabs::Tab>
+    </div>
+    <div>
+      <span class="dummy-text-small">Text + Counter</span>
+      <br />
+      <Hds::Tabs::Tab @count="10">Lorem ipsum</Hds::Tabs::Tab>
+    </div>
+    <div>
+      <span class="dummy-text-small">Icon + Text + Counter</span>
+      <br />
+      <Hds::Tabs::Tab @icon="hexagon" @count="10">Lorem ipsum</Hds::Tabs::Tab>
+    </div>
+  </div>
+
+  <h5 class="dummy-h6">States</h5>
+  <div class="dummy-tab-base-sample">
+    {{#each @model.TAG_STATES as |state|}}
+      <div class="dummy-tab-base-sample-item">
+        <span class="dummy-text-small">{{capitalize state}}:</span>
+        <Hds::Tabs::Tab mock-state-value={{state}} mock-state-selector="a">Lorem ipsum</Hds::Tabs::Tab>
+        <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value={{state}} mock-state-selector="a">Lorem ipsum</Hds::Tabs::Tab>
+      </div>
+    {{/each}}
+  </div>
+
+  <h4 class="dummy-h4">Panel</h4>
+  <h5 class="dummy-h6">Content</h5>
+  <Hds::Tabs::Panel><DummyPlaceholder
+      @text="Panel with generic content"
+      @height="50"
+      @background="#eee"
+    /></Hds::Tabs::Panel>
+
+  <h4 class="dummy-h4">Tabs</h4>
+  <h5 class="dummy-h6">Basic usage</h5>
   <Hds::Tabs as |T|>
     <T.Tab>One</T.Tab>
     <T.Tab>Two</T.Tab>
     <T.Tab>Three</T.Tab>
 
-    <T.Panel>Content one <a href="#">Link to test tabbing</a></T.Panel>
-    <T.Panel>Content 2</T.Panel>
-    <T.Panel>Content 3!</T.Panel>
+    <T.Panel><DummyPlaceholder @height="50" @background="#eee"><span>Content one with
+          <a href="#">link to test tabbing</a></span></DummyPlaceholder></T.Panel>
+    <T.Panel><DummyPlaceholder @text="Content two" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><DummyPlaceholder @text="Content three" @height="50" @background="#eee" /></T.Panel>
   </Hds::Tabs>
 
-  <p class="dummy-paragraph"><strong>Using optional icon and badge count:</strong></p>
+  <h5 class="dummy-h6">With optional icon and badge count</h5>
   <Hds::Tabs as |T|>
     <T.Tab @count="5">One</T.Tab>
-    <T.Tab @icon="download">Two</T.Tab>
+    <T.Tab @icon="info">Two</T.Tab>
     <T.Tab>Three</T.Tab>
+    <T.Tab @icon="alert-triangle" @count="5">Four</T.Tab>
 
-    <T.Panel>Content one <a href="#">Link to test tabbing</a></T.Panel>
-    <T.Panel>Content 2</T.Panel>
-    <T.Panel>Content 3!</T.Panel>
+    <T.Panel><DummyPlaceholder @height="50" @background="#eee"><span>Content one with
+          <a href="#">link to test tabbing</a></span></DummyPlaceholder></T.Panel>
+    <T.Panel><DummyPlaceholder @text="Content two" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><DummyPlaceholder @text="Content three" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><DummyPlaceholder @text="Content four" @height="50" @background="#eee" /></T.Panel>
   </Hds::Tabs>
 
-  <p class="dummy-paragraph"><strong>With custom isSelected value:</strong></p>
+  <h5 class="dummy-h6">With pre-selected tab</h5>
   <Hds::Tabs as |T|>
     <T.Tab>One</T.Tab>
     <T.Tab>Two</T.Tab>
-    <T.Tab @isSelected="true">Three (I am selected on page load)</T.Tab>
+    <T.Tab @isSelected="true">Three (selected on page load)</T.Tab>
 
-    <T.Panel>Content one</T.Panel>
-    <T.Panel>Content #2</T.Panel>
-    <T.Panel>Content #3: I am displayed on page load!</T.Panel>
+    <T.Panel><DummyPlaceholder @text="Content one" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><DummyPlaceholder @text="Content two" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><DummyPlaceholder
+        @text="Content three (displayed on page load)"
+        @height="50"
+        @background="#eee"
+      /></T.Panel>
   </Hds::Tabs>
 </section>


### PR DESCRIPTION
### :pushpin: Summary

@KristinLBradley I have opened this PR to improve the showcase of the `Tabs` component, so it was easier for me to debug [possible layout issues](https://github.com/hashicorp/design-system/pull/588/files#r984485993) in the `Tab` element (easier to do when is in isolation); plus as a benefit we can make sure the `Tab` variants are covered by visual regression testing with Percy.

### :hammer_and_wrench: Detailed description

In this PR I have:
- done a small refactoring of the backing classes for `Tab` and `Panel` (see my comments inline)
- improved the showcase in the `Tabs` page

### :camera_flash: Screenshots
<img width="869" alt="screenshot_1840" src="https://user-images.githubusercontent.com/686239/193274840-92504f57-30d5-424f-b224-70921c9e9792.png">

### :link: External links

Related JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-606

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
