### PR TITLE
reduce ember-try testing surface area

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -51,7 +51,7 @@ jobs:
           - ember-release
           - ember-beta
          # - ember-canary
-          - ember-classic
+         # - ember-classic
          # - embroider-safe
          # - embroider-optimized
 

--- a/.github/workflows/ci-ember-flight-icons.yml
+++ b/.github/workflows/ci-ember-flight-icons.yml
@@ -47,14 +47,14 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.24
-          - ember-lts-3.28
+         # - ember-lts-3.24
+         # - ember-lts-3.28
           - ember-release
           - ember-beta
          # - ember-canary
-          - ember-classic
-          - embroider-safe
-        # - embroider-optimized
+         # - ember-classic
+         # - embroider-safe
+         # - embroider-optimized
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
As discussed, this PR will limit the scenarios we are testing against to reduce duplication and overall lower the number of test scenarios we are checking

### :hammer_and_wrench: Detailed description

In practice ember-flight-icons is being tested implicitly by the tests we are running in the components package, so if something breaks we should still be made aware of it.

For now we agreed to keep `ember-beta` in the scenarios as we'd want to be able to be proactive with any breaking changes introduced there.

<!-- If more details are appropriate, add them here. What code changed, and why? -->

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
