### PR TITLE
`Tabs` animation (HDS-607)

### DIFF
--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -1,3 +1,5 @@
+{{! template-lint-disable no-invalid-role }}
+
 <div class={{this.classNames}} {{did-insert this.didInsert}} ...attributes>
   <div class="hds-tabs__tablist-wrapper">
     <ul class="hds-tabs__tablist" role="tablist">
@@ -14,6 +16,7 @@
           )
         )
       }}
+      <li class="hds-tabs__tab-indicator" role="presentation"></li>
     </ul>
   </div>
 

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -89,11 +89,8 @@ export default class HdsTabsIndexComponent extends Component {
     const tabWidth = tabElem.parentNode.offsetWidth;
 
     // Set CSS custom properties for indicator
-    tabsParentElem.style.setProperty(
-      '--indicatior-left-pos',
-      tabLeftPos + 'px'
-    );
-    tabsParentElem.style.setProperty('--indicatior-width', tabWidth + 'px');
+    tabsParentElem.style.setProperty('--indicator-left-pos', tabLeftPos + 'px');
+    tabsParentElem.style.setProperty('--indicator-width', tabWidth + 'px');
   }
 
   /**

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -23,6 +23,7 @@ export default class HdsTabsIndexComponent extends Component {
       }
     });
     this.selectedTabIndex = initialTabIndex;
+    this.setTabIndicator(initialTabIndex);
 
     assert('Only one tab may use isSelected argument', selectedCount <= 1);
 
@@ -47,6 +48,7 @@ export default class HdsTabsIndexComponent extends Component {
   @action
   handleClick(tabIndex) {
     this.selectedTabIndex = tabIndex;
+    this.setTabIndicator(tabIndex);
   }
 
   @action
@@ -77,6 +79,21 @@ export default class HdsTabsIndexComponent extends Component {
   setSelectedPanelFocus(tabIndex, e) {
     e.preventDefault();
     this.panelNodes[tabIndex].focus();
+  }
+
+  setTabIndicator(tabIndex) {
+    const tabElem = this.tabNodes[tabIndex];
+    const tabsParentElem = tabElem.closest('.hds-tabs');
+
+    const tabLeftPos = tabElem.parentNode.offsetLeft;
+    const tabWidth = tabElem.parentNode.offsetWidth;
+
+    // Set CSS custom properties for indicator
+    tabsParentElem.style.setProperty(
+      '--indicatior-left-pos',
+      tabLeftPos + 'px'
+    );
+    tabsParentElem.style.setProperty('--indicatior-width', tabWidth + 'px');
   }
 
   /**

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -24,6 +24,8 @@ $indicator-height: 3px;
 
 .hds-tabs__tab {
   position: relative;
+  // adjust tab position so focused tab outline sits right above indicator:
+  bottom: round(calc($indicator-height / 2 * -1));
   display: flex;
   align-items: center;
   height: 36px;

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -6,7 +6,10 @@
 
 $indicator-height: 3px;
 
-// .hds-tabs {}
+.hds-tabs {
+  --indicatior-left-pos: 0;
+  --indicatior-width: 3em;
+}
 
 // Sub-components:
 .hds-tabs__tablist-wrapper {
@@ -24,37 +27,33 @@ $indicator-height: 3px;
 }
 
 .hds-tabs__tab {
-  position: relative; // for positioning indicator
-  // adjust position to make indicator overlap tabs bottom border:
-  bottom: round(calc($indicator-height / 2 * -1));
+  position: relative;
   display: flex;
   align-items: center;
   height: 36px;
   margin: 0;
   padding: 0 12px;
+  color: var(--token-color-foreground-primary);
   white-space: nowrap;
   text-decoration: none;
   list-style: none;
 
+  &:hover,
+  .mock-hover:not(.hds-badge-count) {
+    color: var(--token-color-foreground-action);
+  }
+
   &.hds-tabs__tab--is-selected {
-    /* indicator TODO: refactor as needed for animation */
-    &::after {
-      position: absolute;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      display: block;
-      height: $indicator-height;
-      background-color: var(--token-color-foreground-action);
-      border-radius: 3px;
-      content: "";
+    color: var(--token-color-foreground-action);
+
+    &:hover,
+    .mock-hover:not(.hds-badge-count) {
+      color: var(--token-color-foreground-action-hover);
     }
 
-    // indicator:
-    &:hover::after { background-color: var(--token-color-foreground-action-hover); }
-
-    .hds-tabs__tab-button {
-      color: var(--token-color-foreground-action);
+    &:hover ~ .hds-tabs__tab-indicator,
+    .mock-hover:not(.hds-badge-count) .hds-tabs__tab-indicator {
+      background: var(--token-color-foreground-action-hover);
     }
   }
 }
@@ -68,15 +67,11 @@ $indicator-height: 3px;
   );
   position: static;
   padding: 0;
-  color: var(--token-color-foreground-primary);
+  color: inherit;
   background-color: transparent;
   border: none;
   border-radius: var(--token-form-control-border-radius);
-
-  &:hover,
-  &.mock-hover {
-    color: var(--token-color-foreground-action-hover);
-  }
+  cursor: pointer;
 }
 
 .hds-tabs__tab-icon {
@@ -85,4 +80,26 @@ $indicator-height: 3px;
 
 .hds-tabs__tab-badge {
   margin-left: 6px;
+}
+
+.hds-tabs__tablist-wrapper { position: relative; }
+
+.hds-tabs__tab-indicator {
+  position: absolute;
+  right: 0;
+  // adjust position to make indicator overlap tabs bottom border:
+  bottom: floor(calc($indicator-height / 2));
+  left: var(--indicatior-left-pos);
+  z-index: 10;
+  display: block;
+  width: var(--indicatior-width);
+  height: $indicator-height;
+  background-color: var(--token-color-foreground-action);
+  border-radius: 3px;
+
+  @media screen and (prefers-reduced-motion: no-preference) {
+    transition-timing-function: cubic-bezier(0.5, 1, 0.89, 1);
+    transition-duration: 0.6s;
+    transition-property: left, width;
+  }
 }

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -8,7 +8,6 @@ $indicator-height: 3px;
 
 // Sub-components:
 .hds-tabs__tablist-wrapper {
-  position: relative;
   padding-bottom: round(calc($indicator-height / 2));
   // overflow-x: auto;
   // -webkit-overflow-scrolling: touch;
@@ -16,16 +15,25 @@ $indicator-height: 3px;
 }
 
 .hds-tabs__tablist {
+  position: relative;
   display: flex;
   margin: 0;
   padding: 0;
-  border-bottom: 1px solid var(--token-color-border-primary);
+
+  // bottom gray border:
+  &::before {
+    position: absolute;
+    right: 0;
+    bottom: floor(calc($indicator-height / 2));
+    left: 0;
+    display: block;
+    border-top: 1px solid var(--token-color-border-primary);
+    content: "";
+  }
 }
 
 .hds-tabs__tab {
   position: relative;
-  // adjust tab position so focused tab outline sits right above indicator:
-  bottom: round(calc($indicator-height / 2 * -1));
   display: flex;
   align-items: center;
   height: 36px;
@@ -81,8 +89,8 @@ $indicator-height: 3px;
 .hds-tabs__tab-indicator {
   position: absolute;
   right: 0;
-  // adjust position to make indicator overlap tabs bottom border:
-  bottom: floor(calc($indicator-height / 2));
+  bottom: $indicator-height;
+  bottom: 0;
   left: var(--indicator-left-pos);
   z-index: 10;
   display: block;

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -39,21 +39,19 @@ $indicator-height: 3px;
   list-style: none;
 
   &:hover,
-  .mock-hover:not(.hds-badge-count) {
+  .mock-hover {
     color: var(--token-color-foreground-action);
   }
 
   &.hds-tabs__tab--is-selected {
     color: var(--token-color-foreground-action);
 
-    &:hover,
-    .mock-hover:not(.hds-badge-count) {
+    &:hover {
       color: var(--token-color-foreground-action-hover);
-    }
 
-    &:hover ~ .hds-tabs__tab-indicator,
-    .mock-hover:not(.hds-badge-count) .hds-tabs__tab-indicator {
-      background: var(--token-color-foreground-action-hover);
+      & ~ .hds-tabs__tab-indicator {
+        background: var(--token-color-foreground-action-hover);
+      }
     }
   }
 }

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -6,13 +6,9 @@
 
 $indicator-height: 3px;
 
-.hds-tabs {
-  --indicatior-left-pos: 0;
-  --indicatior-width: 3em;
-}
-
 // Sub-components:
 .hds-tabs__tablist-wrapper {
+  position: relative;
   padding-bottom: round(calc($indicator-height / 2));
   // overflow-x: auto;
   // -webkit-overflow-scrolling: touch;
@@ -39,7 +35,7 @@ $indicator-height: 3px;
   list-style: none;
 
   &:hover,
-  .mock-hover {
+  &.mock-hover {
     color: var(--token-color-foreground-action);
   }
 
@@ -80,17 +76,15 @@ $indicator-height: 3px;
   margin-left: 6px;
 }
 
-.hds-tabs__tablist-wrapper { position: relative; }
-
 .hds-tabs__tab-indicator {
   position: absolute;
   right: 0;
   // adjust position to make indicator overlap tabs bottom border:
   bottom: floor(calc($indicator-height / 2));
-  left: var(--indicatior-left-pos);
+  left: var(--indicator-left-pos);
   z-index: 10;
   display: block;
-  width: var(--indicatior-width);
+  width: var(--indicator-width);
   height: $indicator-height;
   background-color: var(--token-color-foreground-action);
   border-radius: 3px;

--- a/packages/components/tests/dummy/app/styles/pages/db-tab.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-tab.scss
@@ -6,10 +6,6 @@
   align-items: flex-start;
   min-width: fit-content;
   margin: 0;
-
-  .hds-tabs__tab {
-    outline: 1px dotted #eee;
-  }
 }
 
 .dummy-tab-base-sample-item {

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -250,28 +250,24 @@
   <div class="dummy-tab-base-sample">
     <div>
       <span class="dummy-text-small">Text only</span>
-      <br />
       <ul class="dummy-tab-ul-tab-wrapper">
         <Hds::Tabs::Tab>Lorem ipsum</Hds::Tabs::Tab>
       </ul>
     </div>
     <div>
       <span class="dummy-text-small">Icon + Text</span>
-      <br />
       <ul class="dummy-tab-ul-tab-wrapper">
         <Hds::Tabs::Tab @icon="hexagon">Lorem ipsum</Hds::Tabs::Tab>
       </ul>
     </div>
     <div>
       <span class="dummy-text-small">Text + Counter</span>
-      <br />
       <ul class="dummy-tab-ul-tab-wrapper">
         <Hds::Tabs::Tab @count="10">Lorem ipsum</Hds::Tabs::Tab>
       </ul>
     </div>
     <div>
       <span class="dummy-text-small">Icon + Text + Counter</span>
-      <br />
       <ul class="dummy-tab-ul-tab-wrapper">
         <Hds::Tabs::Tab @icon="hexagon" @count="10">Lorem ipsum</Hds::Tabs::Tab>
       </ul>
@@ -284,10 +280,10 @@
       <div class="dummy-tab-base-sample-item">
         <span class="dummy-text-small">{{capitalize state}}:</span>
         <ul class="dummy-tab-ul-tab-wrapper">
-          <Hds::Tabs::Tab mock-state-value={{state}} mock-state-selector="a">Lorem ipsum</Hds::Tabs::Tab>
+          <Hds::Tabs::Tab mock-state-value={{state}} mock-state-selector="*">Lorem ipsum</Hds::Tabs::Tab>
         </ul>
         <ul class="dummy-tab-ul-tab-wrapper">
-          <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value={{state}} mock-state-selector="a">Lorem ipsum</Hds::Tabs::Tab>
+          <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value={{state}} mock-state-selector="*">Lorem ipsum</Hds::Tabs::Tab>
         </ul>
       </div>
     {{/each}}

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -194,6 +194,7 @@
       >Figma UI Kit</a>
     </p>
     <div class="dummy-paragraph">
+      {{!-- TODO: Update & replace image --}}
       <img
         class="dummy-figma-docs"
         src="/assets/images/tabs-design-usage.png"
@@ -245,6 +246,7 @@
   <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
 
   <h4 class="dummy-h4">Tab</h4>
+  {{!-- TODO: Add toggle to outline individual Tab components to show layout. See Fomr/Base-Elements --}}
 
   <h5 class="dummy-h6">Content</h5>
   <div class="dummy-tab-base-sample">

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -194,7 +194,7 @@
       >Figma UI Kit</a>
     </p>
     <div class="dummy-paragraph">
-      {{!-- TODO: Update & replace image --}}
+      {{! TODO: Update & replace image }}
       <img
         class="dummy-figma-docs"
         src="/assets/images/tabs-design-usage.png"
@@ -246,7 +246,7 @@
   <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
 
   <h4 class="dummy-h4">Tab</h4>
-  {{!-- TODO: Add toggle to outline individual Tab components to show layout. See Fomr/Base-Elements --}}
+  {{! TODO: Add toggle to outline individual Tab components to show layout. See Fomr/Base-Elements }}
 
   <h5 class="dummy-h6">Content</h5>
   <div class="dummy-tab-base-sample">

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -276,17 +276,33 @@
 
   <h5 class="dummy-h6">States</h5>
   <div class="dummy-tab-base-sample">
-    {{#each @model.TAG_STATES as |state|}}
-      <div class="dummy-tab-base-sample-item">
-        <span class="dummy-text-small">{{capitalize state}}:</span>
-        <ul class="dummy-tab-ul-tab-wrapper">
-          <Hds::Tabs::Tab mock-state-value={{state}} mock-state-selector="*">Lorem ipsum</Hds::Tabs::Tab>
-        </ul>
-        <ul class="dummy-tab-ul-tab-wrapper">
-          <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value={{state}} mock-state-selector="*">Lorem ipsum</Hds::Tabs::Tab>
-        </ul>
-      </div>
-    {{/each}}
+    <div class="dummy-tab-base-sample-item">
+      <span class="dummy-text-small">Default:</span>
+      <ul class="dummy-tab-ul-tab-wrapper">
+        <Hds::Tabs::Tab>Lorem ipsum</Hds::Tabs::Tab>
+      </ul>
+      <ul class="dummy-tab-ul-tab-wrapper">
+        <Hds::Tabs::Tab @icon="hexagon" @count="10">Lorem ipsum</Hds::Tabs::Tab>
+      </ul>
+    </div>
+    <div class="dummy-tab-base-sample-item">
+      <span class="dummy-text-small">Hover:</span>
+      <ul class="dummy-tab-ul-tab-wrapper">
+        <Hds::Tabs::Tab mock-state-value="hover">Lorem ipsum</Hds::Tabs::Tab>
+      </ul>
+      <ul class="dummy-tab-ul-tab-wrapper">
+        <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value="hover">Lorem ipsum</Hds::Tabs::Tab>
+      </ul>
+    </div>
+    <div class="dummy-tab-base-sample-item">
+      <span class="dummy-text-small">Focus:</span>
+      <ul class="dummy-tab-ul-tab-wrapper">
+        <Hds::Tabs::Tab mock-state-value="focus" mock-state-selector="button">Lorem ipsum</Hds::Tabs::Tab>
+      </ul>
+      <ul class="dummy-tab-ul-tab-wrapper">
+        <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value="focus" mock-state-selector="button">Lorem ipsum</Hds::Tabs::Tab>
+      </ul>
+    </div>
   </div>
 
   <h4 class="dummy-h4">Panel</h4>

--- a/packages/components/tests/integration/components/hds/tabs/index-test.js
+++ b/packages/components/tests/integration/components/hds/tabs/index-test.js
@@ -7,7 +7,14 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders the component', async function (assert) {
-    await render(hbs`<Hds::Tabs />`);
+    await render(hbs`
+      <Hds::Tabs id="test-tabs" as |T|>
+        <T.Tab data-test="tab">One</T.Tab>
+        <T.Tab>Two</T.Tab>
+        <T.Panel data-test="panel">Content 1</T.Panel>
+        <T.Panel>Content 2</T.Panel>
+      </Hds::Tabs>
+  `);
     assert.dom(this.element).exists();
   });
 

--- a/packages/components/tests/integration/components/hds/tabs/index-test.js
+++ b/packages/components/tests/integration/components/hds/tabs/index-test.js
@@ -8,10 +8,10 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
 
   test('it renders the component', async function (assert) {
     await render(hbs`
-      <Hds::Tabs id="test-tabs" as |T|>
-        <T.Tab data-test="tab">One</T.Tab>
+      <Hds::Tabs as |T|>
+        <T.Tab>One</T.Tab>
         <T.Tab>Two</T.Tab>
-        <T.Panel data-test="panel">Content 1</T.Panel>
+        <T.Panel>Content 1</T.Panel>
         <T.Panel>Content 2</T.Panel>
       </Hds::Tabs>
   `);


### PR DESCRIPTION
### :pushpin: Summary

This PR is to add animation to the indicator bar underlining the currently selected Tab. Once approved, it will be merged into the [feature branch](https://github.com/hashicorp/design-system/pull/548).

https://hds-components-git-hds-607-tabs-animation-hashicorp.vercel.app/components/tabs#showcase

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
https://hashicorp.atlassian.net/browse/HDS-607
https://www.figma.com/file/SvPCXDDW9Cv2j5isTALGNT/%F0%9F%92%80-FY23-Q3?node-id=30%3A25985

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
