### PR TITLE
Remove CSS attribute sorting notes

### DIFF
--- a/packages/components/app/styles/components/alert.scss
+++ b/packages/components/app/styles/components/alert.scss
@@ -1,8 +1,5 @@
 //
-// ALERT
-//
-// properties within each class are sorted alphabetically
-//
+// ALERT COMPONENT
 //
 
 @use "../mixins/focus-ring" as *;

--- a/packages/components/app/styles/components/avatar.scss
+++ b/packages/components/app/styles/components/avatar.scss
@@ -1,7 +1,5 @@
 //
-// AVATAR
-//
-// properties within each class are sorted alphabetically
+// AVATAR COMPONENT
 //
 
 .hds-avatar {

--- a/packages/components/app/styles/components/badge-count.scss
+++ b/packages/components/app/styles/components/badge-count.scss
@@ -1,7 +1,5 @@
 //
-// BADGE-COUNT
-//
-// properties within each class are sorted alphabetically
+// BADGE-COUNT COMPONENT
 //
 
 @use "sass:math";

--- a/packages/components/app/styles/components/badge.scss
+++ b/packages/components/app/styles/components/badge.scss
@@ -1,8 +1,5 @@
 //
-// BADGE
-//
-// properties within each class are sorted alphabetically
-//
+// BADGE COMPONENT
 //
 
 $hds-badge-types: ( "flat","inverted","outlined" );

--- a/packages/components/app/styles/components/breadcrumb.scss
+++ b/packages/components/app/styles/components/breadcrumb.scss
@@ -1,9 +1,7 @@
 //
-// BREADCRUMB
+// BREADCRUMB COMPONENT
 //
-// properties within each class are sorted alphabetically
 // notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
-//
 //
 
 @use "../mixins/focus-ring" as *;

--- a/packages/components/app/styles/components/button-set.scss
+++ b/packages/components/app/styles/components/button-set.scss
@@ -1,7 +1,5 @@
 //
-// BUTTON-SET
-//
-// properties within each class are sorted alphabetically
+// BUTTON-SET COMPONENT
 //
 
 .hds-button-set {

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -1,9 +1,7 @@
 //
 // BUTTON COMPONENT
 //
-// properties within each class are sorted alphabetically
 // notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
-//
 //
 
 $hds-button-sizes: ( "small", "medium", "large" );

--- a/packages/components/app/styles/components/card/container.scss
+++ b/packages/components/app/styles/components/card/container.scss
@@ -1,10 +1,6 @@
 //
 // CARD COMPONENT > CONTAINER
 //
-// properties within each class are sorted alphabetically
-//
-//
-
 
 $hds-card-container-style: ( "surface", "elevation" );
 $hds-card-container-levels: ( "base", "mid", "high" );

--- a/packages/components/app/styles/components/disclosure.scss
+++ b/packages/components/app/styles/components/disclosure.scss
@@ -1,8 +1,6 @@
 //
 // DISCLOSURE COMPONENT
 //
-// properties within each class are sorted alphabetically
-//
 
 .hds-disclosure {
   position: relative;

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -14,9 +14,7 @@
 //
 // DROPDOWN COMPONENT
 //
-// properties within each class are sorted alphabetically
 // notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
-//
 //
 
 @use "../mixins/focus-ring" as *;

--- a/packages/components/app/styles/components/empty-state.scss
+++ b/packages/components/app/styles/components/empty-state.scss
@@ -1,3 +1,7 @@
+//
+// EMPTY-STATE COMPONENT
+//
+
 .hds-empty-state {
   display: block;
   max-width: 40ch;

--- a/packages/components/app/styles/components/form/checkbox.scss
+++ b/packages/components/app/styles/components/form/checkbox.scss
@@ -1,8 +1,6 @@
 //
 // FORM > CHECKBOX
 //
-// properties within each class are sorted alphabetically
-//
 
 
 // "BASE" CONTROL

--- a/packages/components/app/styles/components/form/error.scss
+++ b/packages/components/app/styles/components/form/error.scss
@@ -1,8 +1,6 @@
 //
 // FORM > ERROR
 //
-// properties within each class are sorted alphabetically
-//
 
 .hds-form-error {
   display: flex;

--- a/packages/components/app/styles/components/form/field.scss
+++ b/packages/components/app/styles/components/form/field.scss
@@ -1,8 +1,6 @@
 //
 // FORM > FIELD
 //
-// properties within each class are sorted alphabetically
-//
 
 
 // "VERTICAL" LAYOUT

--- a/packages/components/app/styles/components/form/group.scss
+++ b/packages/components/app/styles/components/form/group.scss
@@ -1,8 +1,6 @@
 //
 // FORM > GROUP
 //
-// properties within each class are sorted alphabetically
-//
 
 .hds-form-group { // notice: this is a <fieldset> element
   display: block;

--- a/packages/components/app/styles/components/form/helper-text.scss
+++ b/packages/components/app/styles/components/form/helper-text.scss
@@ -1,8 +1,6 @@
 //
 // FORM > HELPER-TEXT
 //
-// properties within each class are sorted alphabetically
-//
 
 .hds-form-helper-text {
   display: block;

--- a/packages/components/app/styles/components/form/indicator.scss
+++ b/packages/components/app/styles/components/form/indicator.scss
@@ -1,8 +1,6 @@
 //
 // FORM > INDICATOR
 //
-// properties within each class are sorted alphabetically
-//
 
 // Used for the 'optional' indicator
 .hds-form-indicator--optional {

--- a/packages/components/app/styles/components/form/label.scss
+++ b/packages/components/app/styles/components/form/label.scss
@@ -1,8 +1,6 @@
 //
 // FORM > LABEL
 //
-// properties within each class are sorted alphabetically
-//
 
 .hds-form-label {
   display: block;

--- a/packages/components/app/styles/components/form/legend.scss
+++ b/packages/components/app/styles/components/form/legend.scss
@@ -1,8 +1,6 @@
 //
 // FORM > LEGEND
 //
-// properties within each class are sorted alphabetically
-//
 
 .hds-form-legend {
   display: block;

--- a/packages/components/app/styles/components/form/radio-card.scss
+++ b/packages/components/app/styles/components/form/radio-card.scss
@@ -1,4 +1,7 @@
+//
 // FORM > RADIO-CARD
+//
+
 
 // RadioCard Group
 

--- a/packages/components/app/styles/components/form/radio.scss
+++ b/packages/components/app/styles/components/form/radio.scss
@@ -1,8 +1,6 @@
 //
 // FORM > RADIO
 //
-// properties within each class are sorted alphabetically
-//
 
 
 // "BASE" CONTROL

--- a/packages/components/app/styles/components/form/select.scss
+++ b/packages/components/app/styles/components/form/select.scss
@@ -1,8 +1,7 @@
 //
 // FORM > SELECT
 //
-// properties within each class are sorted alphabetically
-//
+
 
 // "BASE" CONTROL
 

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -1,8 +1,7 @@
 //
 // FORM > TEXT-INPUT
 //
-// properties within each class are sorted alphabetically
-//
+
 
 // "BASE" CONTROL
 

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -1,8 +1,7 @@
 //
 // FORM > TEXTAREA
 //
-// properties within each class are sorted alphabetically
-//
+
 
 // "BASE" CONTROL
 

--- a/packages/components/app/styles/components/form/toggle.scss
+++ b/packages/components/app/styles/components/form/toggle.scss
@@ -1,8 +1,6 @@
 //
 // FORM > TOGGLE
 //
-// properties within each class are sorted alphabetically
-//
 
 
 // "BASE" CONTROL

--- a/packages/components/app/styles/components/icon-tile.scss
+++ b/packages/components/app/styles/components/icon-tile.scss
@@ -1,8 +1,5 @@
 //
-// ICON-TILE
-//
-// properties within each class are sorted alphabetically
-//
+// ICON-TILE COMPONENT
 //
 
 $hds-icon-tile-sizes: ( "small", "medium", "large" );

--- a/packages/components/app/styles/components/link/inline.scss
+++ b/packages/components/app/styles/components/link/inline.scss
@@ -1,10 +1,8 @@
 //
 // LINK > INLINE COMPONENT
 //
-// properties within each class are sorted alphabetically
 // notice: pseudo-classes for the states *must* follow the order link > visited > focus > hover > active
 // see https://github.com/hashicorp/design-system-components/issues/132
-//
 //
 
 .hds-link-inline {

--- a/packages/components/app/styles/components/link/standalone.scss
+++ b/packages/components/app/styles/components/link/standalone.scss
@@ -1,9 +1,7 @@
 //
 // LINK > STANDALONE COMPONENT
 //
-// properties within each class are sorted alphabetically
 // notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
-//
 //
 
 @use "../../mixins/focus-ring" as *;

--- a/packages/components/app/styles/components/stepper/step-indicator.scss
+++ b/packages/components/app/styles/components/stepper/step-indicator.scss
@@ -1,8 +1,6 @@
 //
 // STEPPER > INDICATOR > STEP
 //
-// properties within each class are sorted alphabetically
-//
 
 $hds-stepper-indicator-step-statuses: ( "incomplete", "progress", "processing", "complete" );
 $hds-stepper-indicator-step-size: 24px;

--- a/packages/components/app/styles/components/stepper/task-indicator.scss
+++ b/packages/components/app/styles/components/stepper/task-indicator.scss
@@ -1,8 +1,6 @@
 //
 // STEPPER > INDICATOR > TASK
 //
-// properties within each class are sorted alphabetically
-//
 
 $hds-stepper-indicator-task-statuses: ( "incomplete", "progress", "processing", "complete" );
 $hds-stepper-indicator-task-size: 16px;

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -1,9 +1,6 @@
 //
 // TAG COMPONENT
 //
-// properties within each class are sorted alphabetically
-//
-//
 
 @use "../mixins/focus-ring" as *;
 

--- a/packages/components/app/styles/components/toast.scss
+++ b/packages/components/app/styles/components/toast.scss
@@ -1,8 +1,5 @@
 //
-// TOAST
-//
-// properties within each class are sorted alphabetically
-//
+// TOAST COMPONENT
 //
 
 .hds-toast {

--- a/packages/components/blueprints/hds-component/files/app/styles/components/__name__.scss
+++ b/packages/components/blueprints/hds-component/files/app/styles/components/__name__.scss
@@ -1,6 +1,4 @@
 //
 // <%= folderizedModuleName %>
 //
-// properties within each class are sorted alphabetically
-//
 


### PR DESCRIPTION
### :pushpin: Summary

Remove CSS attribute sorting notes

### :hammer_and_wrench: Detailed description

This is a follow-up on #562 where we moved from alphabetical to idiomatic. Now that we enforce the CSS property order via Stylelint there's probably less value in keeping the note, so we remove it from the blueprint and update the existing files to align with the generator.

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
