### PR TITLE
`Tabs` component - Add layout highlight toggle to documentation page

### DIFF
--- a/packages/components/tests/acceptance/percy-test.js
+++ b/packages/components/tests/acceptance/percy-test.js
@@ -81,6 +81,10 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/components/toast');
     await percySnapshot('Toast');
 
+    await visit('/components/tabs');
+    await click('button#dummy-toggle-highlight');
+    await percySnapshot('Tabs');
+
     await visit('/components/stepper');
     await percySnapshot('Stepper - Indicator');
 

--- a/packages/components/tests/dummy/app/controllers/components/tabs.js
+++ b/packages/components/tests/dummy/app/controllers/components/tabs.js
@@ -1,0 +1,12 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class TabsController extends Controller {
+  @tracked showHighlight = false;
+
+  @action
+  toggleHighlight() {
+    this.showHighlight = !this.showHighlight;
+  }
+}

--- a/packages/components/tests/dummy/app/styles/pages/db-tab.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-tab.scss
@@ -19,3 +19,8 @@
   display: contents;
   list-style: none;
 }
+
+.dummy-tabs-layout-highlight {
+  .hds-tabs__tab { outline: 1px dashed #78909c; }
+}
+

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -246,64 +246,70 @@
   <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
 
   <h4 class="dummy-h4">Tab</h4>
-  {{! TODO: Add toggle to outline individual Tab components to show layout. See Fomr/Base-Elements }}
+  <button id="dummy-toggle-highlight" type="button" {{on "click" this.toggleHighlight}}>{{if
+      this.showHighlight
+      "Hide"
+      "Show"
+    }}
+    layout highlight</button>
+  <div class="{{if this.showHighlight 'dummy-tabs-layout-highlight'}}">
+    <h5 class="dummy-h6">Content</h5>
+    <div class="dummy-tab-base-sample">
+      <div>
+        <span class="dummy-text-small">Text only</span>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab>Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+      </div>
+      <div>
+        <span class="dummy-text-small">Icon + Text</span>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab @icon="hexagon">Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+      </div>
+      <div>
+        <span class="dummy-text-small">Text + Counter</span>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab @count="10">Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+      </div>
+      <div>
+        <span class="dummy-text-small">Icon + Text + Counter</span>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab @icon="hexagon" @count="10">Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+      </div>
+    </div>
 
-  <h5 class="dummy-h6">Content</h5>
-  <div class="dummy-tab-base-sample">
-    <div>
-      <span class="dummy-text-small">Text only</span>
-      <ul class="dummy-tab-ul-tab-wrapper">
-        <Hds::Tabs::Tab>Lorem ipsum</Hds::Tabs::Tab>
-      </ul>
-    </div>
-    <div>
-      <span class="dummy-text-small">Icon + Text</span>
-      <ul class="dummy-tab-ul-tab-wrapper">
-        <Hds::Tabs::Tab @icon="hexagon">Lorem ipsum</Hds::Tabs::Tab>
-      </ul>
-    </div>
-    <div>
-      <span class="dummy-text-small">Text + Counter</span>
-      <ul class="dummy-tab-ul-tab-wrapper">
-        <Hds::Tabs::Tab @count="10">Lorem ipsum</Hds::Tabs::Tab>
-      </ul>
-    </div>
-    <div>
-      <span class="dummy-text-small">Icon + Text + Counter</span>
-      <ul class="dummy-tab-ul-tab-wrapper">
-        <Hds::Tabs::Tab @icon="hexagon" @count="10">Lorem ipsum</Hds::Tabs::Tab>
-      </ul>
-    </div>
-  </div>
-
-  <h5 class="dummy-h6">States</h5>
-  <div class="dummy-tab-base-sample">
-    <div class="dummy-tab-base-sample-item">
-      <span class="dummy-text-small">Default:</span>
-      <ul class="dummy-tab-ul-tab-wrapper">
-        <Hds::Tabs::Tab>Lorem ipsum</Hds::Tabs::Tab>
-      </ul>
-      <ul class="dummy-tab-ul-tab-wrapper">
-        <Hds::Tabs::Tab @icon="hexagon" @count="10">Lorem ipsum</Hds::Tabs::Tab>
-      </ul>
-    </div>
-    <div class="dummy-tab-base-sample-item">
-      <span class="dummy-text-small">Hover:</span>
-      <ul class="dummy-tab-ul-tab-wrapper">
-        <Hds::Tabs::Tab mock-state-value="hover">Lorem ipsum</Hds::Tabs::Tab>
-      </ul>
-      <ul class="dummy-tab-ul-tab-wrapper">
-        <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value="hover">Lorem ipsum</Hds::Tabs::Tab>
-      </ul>
-    </div>
-    <div class="dummy-tab-base-sample-item">
-      <span class="dummy-text-small">Focus:</span>
-      <ul class="dummy-tab-ul-tab-wrapper">
-        <Hds::Tabs::Tab mock-state-value="focus" mock-state-selector="button">Lorem ipsum</Hds::Tabs::Tab>
-      </ul>
-      <ul class="dummy-tab-ul-tab-wrapper">
-        <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value="focus" mock-state-selector="button">Lorem ipsum</Hds::Tabs::Tab>
-      </ul>
+    <h5 class="dummy-h6">States</h5>
+    <div class="dummy-tab-base-sample">
+      <div class="dummy-tab-base-sample-item">
+        <span class="dummy-text-small">Default:</span>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab>Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab @icon="hexagon" @count="10">Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+      </div>
+      <div class="dummy-tab-base-sample-item">
+        <span class="dummy-text-small">Hover:</span>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab mock-state-value="hover">Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value="hover">Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+      </div>
+      <div class="dummy-tab-base-sample-item">
+        <span class="dummy-text-small">Focus:</span>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab mock-state-value="focus" mock-state-selector="button">Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+        <ul class="dummy-tab-ul-tab-wrapper">
+          <Hds::Tabs::Tab @icon="hexagon" @count="10" mock-state-value="focus" mock-state-selector="button">Lorem ipsum</Hds::Tabs::Tab>
+        </ul>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of this comment: https://github.com/hashicorp/design-system/pull/607#issuecomment-1268756504

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a button that toggles the layout highlighting to the `Tabs` page
- adde Percy tests for `Tabs` page

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
