### PR TITLE
Add missing Percy tests for some components

### DIFF
--- a/packages/components/tests/acceptance/percy-test.js
+++ b/packages/components/tests/acceptance/percy-test.js
@@ -41,6 +41,9 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/components/button');
     await percySnapshot('Button');
 
+    await visit('/components/button-set');
+    await percySnapshot('ButtonSet');
+
     await visit('/components/card');
     await percySnapshot('Card');
 
@@ -56,6 +59,9 @@ module('Acceptance | Percy test', function (hooks) {
 
     await visit('/components/form/radio');
     await percySnapshot('Form - Radio');
+
+    await visit('/components/form/radio-card');
+    await percySnapshot('Form - RadioCard');
 
     await visit('/components/form/select');
     await percySnapshot('Form - Select');
@@ -78,11 +84,17 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/components/link/standalone');
     await percySnapshot('Link Standalone');
 
+    await visit('/components/tag');
+    await percySnapshot('Tag');
+
     await visit('/components/toast');
     await percySnapshot('Toast');
 
     await visit('/components/stepper');
     await percySnapshot('Stepper - Indicator');
+
+    await visit('/overrides/power-select');
+    await percySnapshot('PowerSelect');
 
     assert.ok(true);
   });


### PR DESCRIPTION
### :pushpin: Summary

I have noticed that some components are not covered by Percy visual regression testing.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added missing Percy tests for the following components:
  - `ButtonSet`
  - `Form::RadioCard`
  - `Tag`
  - `PowerSelect`

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
