### PR TITLE
Fix a few (minor) content issues in the documentation

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
+++ b/packages/components/tests/dummy/app/templates/components/breadcrumb.hbs
@@ -3,6 +3,7 @@
 <h2 class="dummy-h2">Breadcrumb</h2>
 
 <section>
+  <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>
   <p class="dummy-paragraph">
     A “breadcrumb” (or “breadcrumb trail”) is a type of secondary navigation that reveals the user's location in a
     website or Web application.
@@ -196,6 +197,7 @@
     <img class="dummy-figma-docs" src="/assets/images/breadcrumb-design-usage.png" alt="" role="none" />
   </div>
 </section>
+
 <section>
   <h3 class="dummy-h3" id="accessibility"><a href="#accessibility" class="dummy-link-section">§</a> Accessibility</h3>
   <p class="dummy-paragraph">This component has been designed and implemented with accessibility in mind. However, if
@@ -240,6 +242,7 @@
     </li>
   </ul>
 </section>
+
 <section data-test-percy>
   <h3 class="dummy-h3" id="showcase"><a href="#showcase" class="dummy-link-section">§</a> Showcase</h3>
 

--- a/packages/components/tests/dummy/app/templates/components/card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/card.hbs
@@ -183,9 +183,9 @@
 </section>
 
 <section>
+  <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
+    Design guidelines</h3>
   <div class="dummy-design-guidelines">
-    <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
-      Design guidelines</h3>
     <p class="dummy-paragraph"><a href="https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/?node-id=2%3A11">Figma UI Kit</a></p>
   </div>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/empty-state.hbs
+++ b/packages/components/tests/dummy/app/templates/components/empty-state.hbs
@@ -64,9 +64,9 @@
 </section>
 
 <section>
+  <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
+    Design guidelines</h3>
   <div class="dummy-design-guidelines">
-    <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
-      Design guidelines</h3>
     <p class="dummy-paragraph">To be released at a future date.</p>
   </div>
 </section>

--- a/packages/components/tests/dummy/app/templates/foundations/elevation.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations/elevation.hbs
@@ -71,9 +71,9 @@
 </section>
 
 <section>
+  <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
+    Design guidelines</h3>
   <div class="dummy-design-guidelines">
-    <h3 class="dummy-h3" id="design-guidelines"><a href="#design-guidelines" class="dummy-link-section">§</a>
-      Design guidelines</h3>
     <p class="dummy-paragraph"><a href="https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/?node-id=1988%3A2">Figma UI
         Kit</a></p>
     <br />


### PR DESCRIPTION
### :pushpin: Summary

Just a small PR that moves the section titles for some documentation pages in the "correct position" in the DOM (to be consistent with all the other pages).

This was a blocker for some automatic code manipulation that I am working on.