### PR TITLE
move website deps to devDeps

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,8 @@
     "@ember/test-helpers": "^2.8.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@hashicorp/design-system-components": "workspace:^",
+    "@hashicorp/ember-flight-icons": "workspace:^",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.4.2",
@@ -45,14 +47,17 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",
+    "ember-cli-string-helpers": "^6.1.0",
     "ember-cli-terser": "^4.0.2",
     "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^2.1.2",
+    "ember-math-helpers": "^2.18.2",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.7.0",
     "ember-template-lint": "^4.14.0",
+    "ember-truth-helpers": "^3.1.1",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-ember": "^11.0.6",
@@ -76,12 +81,5 @@
   },
   "ember": {
     "edition": "octane"
-  },
-  "dependencies": {
-    "@hashicorp/design-system-components": "workspace:^",
-    "@hashicorp/ember-flight-icons": "workspace:^",
-    "ember-cli-string-helpers": "^6.1.0",
-    "ember-math-helpers": "^2.18.2",
-    "ember-truth-helpers": "^3.1.1"
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

moves website deps to devDeps

### :hammer_and_wrench: Detailed description

I had noted that this was probably good hygiene, but it seems like practically speaking this also impacts how changesets treats package updates. https://github.com/hashicorp/design-system/pull/620 shows how this is causing changeset to actually version the website package because one of its `dependencies` has had a version bump.

After moving these to `devDependencies` and running `yarn changeset version` locally to test I see that we're no longer versioning the website package which seems more like what we want.

<img width="452" alt="Screen Shot 2022-10-10 at 08 37 02" src="https://user-images.githubusercontent.com/1672302/194878984-f8739b32-4baf-455a-a8c6-353a78574a1a.png">


### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
