### PR TITLE
`Tabs` additional polish (HDS-747)

### DIFF
--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -46,7 +46,7 @@ export default class HdsTabsIndexComponent extends Component {
   }
 
   @action
-  handleClick(tabIndex) {
+  handleClick(tabIndex, event) {
     this.selectedTabIndex = tabIndex;
     this.setTabIndicator(tabIndex);
 
@@ -57,9 +57,8 @@ export default class HdsTabsIndexComponent extends Component {
       inline: 'nearest',
     });
 
-    if (typeof this.args.onTabClick === 'function') {
-      const tabElem = this.tabNodes[tabIndex];
-      this.args.onTabClick(tabElem, ...arguments);
+    if (typeof this.args.onClickTab === 'function') {
+      this.args.onClickTab(event);
     }
   }
 

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -56,6 +56,11 @@ export default class HdsTabsIndexComponent extends Component {
       block: 'nearest',
       inline: 'nearest',
     });
+
+    if (typeof this.args.onTabClick === 'function') {
+      const tabElem = this.tabNodes[tabIndex];
+      this.args.onTabClick(tabElem, ...arguments);
+    }
   }
 
   @action

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -68,6 +68,7 @@ $indicator-height: 3px;
     $bottom: 6px,
     $left: 6px,
   );
+
   position: static;
   padding: 0;
   color: inherit;
@@ -75,6 +76,13 @@ $indicator-height: 3px;
   border: none;
   border-radius: var(--token-form-control-border-radius);
   cursor: pointer;
+
+  // Expand click target area
+  &::after {
+    position: absolute;
+    content: "";
+    inset: 0;
+  }
 }
 
 .hds-tabs__tab-icon {

--- a/packages/components/tests/dummy/app/controllers/components/tabs.js
+++ b/packages/components/tests/dummy/app/controllers/components/tabs.js
@@ -11,7 +11,8 @@ export default class TabsController extends Controller {
   }
 
   @action
-  logClickedTab(tabElem) {
-    console.log(`${tabElem.id} Tab clicked!`);
+  logClickedTab(event) {
+    const tabId = event.target.id;
+    console.log(`${tabId} Tab clicked!`);
   }
 }

--- a/packages/components/tests/dummy/app/controllers/components/tabs.js
+++ b/packages/components/tests/dummy/app/controllers/components/tabs.js
@@ -9,4 +9,9 @@ export default class TabsController extends Controller {
   toggleHighlight() {
     this.showHighlight = !this.showHighlight;
   }
+
+  @action
+  logClickedTab(tabElem) {
+    console.log(`${tabElem.id} Tab clicked!`);
+  }
 }

--- a/packages/components/tests/dummy/app/controllers/components/tabs.js
+++ b/packages/components/tests/dummy/app/controllers/components/tabs.js
@@ -13,6 +13,6 @@ export default class TabsController extends Controller {
   @action
   logClickedTab(event) {
     const tabId = event.target.id;
-    console.log(`${tabId} Tab clicked!`);
+    console.log(`Tab with ID "${tabId}" clicked!`);
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -39,7 +39,7 @@
   <p class="dummy-paragraph" id="component-api-tabs">Here is the API for the main (“container”) component:</p>
 
   <dl class="dummy-component-props" aria-labelledby="component-api-tabs">
-    <dt>onTabClick <code>function</code></dt>
+    <dt>onClickTab <code>function</code></dt>
     <dd>Pass an optional function which is called when a Tab is clicked.</dd>
     <dt>...attributes</dt>
     <dd>
@@ -190,12 +190,12 @@
   </Hds::Tabs>
 
   <h4 class="dummy-h4">Pass in a function that gets called when a tab is clicked</h4>
-  {{! template-lint-disable no-unbalanced-curlies }}
   {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code="
-      <Hds::Tabs @onTabClick=\{{this.logClickedTab}} as |T|>
+      <Hds::Tabs @onClickTab=\{{this.logClickedTab}} as |T|>
         <T.Tab>One</T.Tab>
         <T.Tab>Two</T.Tab>
         <T.Tab>Three</T.Tab>
@@ -207,6 +207,16 @@
     "
   />
   {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Tabs @onClickTab="{{this.logClickedTab}}" as |T|>
+    <T.Tab>One</T.Tab>
+    <T.Tab>Two</T.Tab>
+    <T.Tab>Three</T.Tab>
+
+    <T.Panel>Content 1</T.Panel>
+    <T.Panel>Content 2</T.Panel>
+    <T.Panel>Content 3</T.Panel>
+  </Hds::Tabs>
 </section>
 
 <section>
@@ -407,7 +417,7 @@
   <h5 class="dummy-h6">Call a passed function when a tab is clicked</h5>
   <p class="dummy-paragraph">Logs the tab id to the console</p>
 
-  <Hds::Tabs @onTabClick={{this.logClickedTab}} as |T|>
+  <Hds::Tabs @onClickTab={{this.logClickedTab}} as |T|>
     <T.Tab>One</T.Tab>
     <T.Tab>Two</T.Tab>
     <T.Tab>Three</T.Tab>

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -52,14 +52,19 @@
   <dl class="dummy-component-props" aria-labelledby="component-api-tab">
     <dt>count <code>string</code></dt>
     <dd>
-      <p>Displays an optional count in the Tab.</p>
-      <p>Accepts the text value that should go in the badge counter.</p>
+      <p>
+        Displays an optional <a href="/components/badge-count" target="_blank" rel="noopener noreferrer">BadgeCount</a> in the Tab.
+      </p>
+      <p>
+        Accepts the text value that should go in the 
+        <a href="/components/badge-count" target="_blank" rel="noopener noreferrer">BadgeCount</a>.
+      </p>
     </dd>
 
     <dt>icon</dt>
     <dd>
-      <p>Displays an optional FlightIcon.</p>
-      <p>Accepts the name of the FlightIcon.</p>
+      <p>Displays an optional <a href="https://flight-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">FlightIcon</a>.</p>
+      <p>Accepts the name of the <a href="https://flight-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">FlightIcon</a>.</p>
     </dd>
 
     <dt>isSelected <code>boolean</code></dt>

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -54,15 +54,8 @@
   <dl class="dummy-component-props" aria-labelledby="component-api-tab">
     <dt>count <code>string</code></dt>
     <dd>
-      <p>
-        Displays an optional
-        <a href="/components/badge-count" target="_blank" rel="noopener noreferrer">BadgeCount</a>
-        in the Tab.
-      </p>
-      <p>
-        Accepts the text value that should go in the
-        <a href="/components/badge-count" target="_blank" rel="noopener noreferrer">BadgeCount</a>.
-      </p>
+      <p>Displays an optional "count" indicator in the tab. Accepts the text value that should go in the
+        <a href="/components/badge-count">BadgeCount</a>.</p>
     </dd>
 
     <dt>icon</dt>

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -54,8 +54,15 @@
   <dl class="dummy-component-props" aria-labelledby="component-api-tab">
     <dt>count <code>string</code></dt>
     <dd>
-      <p>Displays an optional "count" indicator in the tab. Accepts the text value that should go in the
-        <a href="/components/badge-count">BadgeCount</a>.</p>
+      <p>
+        Displays an optional
+        <a href="/components/badge-count" target="_blank" rel="noopener noreferrer">BadgeCount</a>
+        in the Tab.
+      </p>
+      <p>
+        Accepts the text value that should go in the
+        <a href="/components/badge-count" target="_blank" rel="noopener noreferrer">BadgeCount</a>.
+      </p>
     </dd>
 
     <dt>icon</dt>
@@ -180,6 +187,35 @@
     <T.Panel>Content 1</T.Panel>
     <T.Panel>Content 2</T.Panel>
     <T.Panel>Content 3!</T.Panel>
+  </Hds::Tabs>
+
+  <h4 class="dummy-h4">Pass in a function that gets called when a tab is clicked</h4>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  <CodeBlock
+    @language="markup"
+    @code="
+      <Hds::Tabs @onClickTab=\{{this.logClickedTab}} as |T|>
+        <T.Tab>One</T.Tab>
+        <T.Tab>Two</T.Tab>
+        <T.Tab>Three</T.Tab>
+
+        <T.Panel>Content one</T.Panel>
+        <T.Panel>Content two</T.Panel>
+        <T.Panel>Content three</T.Panel>
+      </Hds::Tabs>
+    "
+  />
+  {{! prettier-ignore-end }}
+  <p class="dummy-paragraph">Renders to:</p>
+  <Hds::Tabs @onClickTab="{{this.logClickedTab}}" as |T|>
+    <T.Tab>One</T.Tab>
+    <T.Tab>Two</T.Tab>
+    <T.Tab>Three</T.Tab>
+
+    <T.Panel>Content 1</T.Panel>
+    <T.Panel>Content 2</T.Panel>
+    <T.Panel>Content 3</T.Panel>
   </Hds::Tabs>
 </section>
 

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -188,35 +188,6 @@
     <T.Panel>Content 2</T.Panel>
     <T.Panel>Content 3!</T.Panel>
   </Hds::Tabs>
-
-  <h4 class="dummy-h4">Pass in a function that gets called when a tab is clicked</h4>
-  {{! prettier-ignore-start }}
-  {{! template-lint-disable no-unbalanced-curlies }}
-  <CodeBlock
-    @language="markup"
-    @code="
-      <Hds::Tabs @onClickTab=\{{this.logClickedTab}} as |T|>
-        <T.Tab>One</T.Tab>
-        <T.Tab>Two</T.Tab>
-        <T.Tab>Three</T.Tab>
-
-        <T.Panel>Content one</T.Panel>
-        <T.Panel>Content two</T.Panel>
-        <T.Panel>Content three</T.Panel>
-      </Hds::Tabs>
-    "
-  />
-  {{! prettier-ignore-end }}
-  <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Tabs @onClickTab="{{this.logClickedTab}}" as |T|>
-    <T.Tab>One</T.Tab>
-    <T.Tab>Two</T.Tab>
-    <T.Tab>Three</T.Tab>
-
-    <T.Panel>Content 1</T.Panel>
-    <T.Panel>Content 2</T.Panel>
-    <T.Panel>Content 3</T.Panel>
-  </Hds::Tabs>
 </section>
 
 <section>

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -55,18 +55,22 @@
     <dt>count <code>string</code></dt>
     <dd>
       <p>
-        Displays an optional <a href="/components/badge-count" target="_blank" rel="noopener noreferrer">BadgeCount</a> in the Tab.
+        Displays an optional
+        <a href="/components/badge-count" target="_blank" rel="noopener noreferrer">BadgeCount</a>
+        in the Tab.
       </p>
       <p>
-        Accepts the text value that should go in the 
+        Accepts the text value that should go in the
         <a href="/components/badge-count" target="_blank" rel="noopener noreferrer">BadgeCount</a>.
       </p>
     </dd>
 
     <dt>icon</dt>
     <dd>
-      <p>Displays an optional <a href="https://flight-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">FlightIcon</a>.</p>
-      <p>Accepts the name of the <a href="https://flight-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">FlightIcon</a>.</p>
+      <p>Displays an optional
+        <a href="https://flight-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">FlightIcon</a>.</p>
+      <p>Accepts the name of the
+        <a href="https://flight-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">FlightIcon</a>.</p>
     </dd>
 
     <dt>isSelected <code>boolean</code></dt>
@@ -186,10 +190,11 @@
   </Hds::Tabs>
 
   <h4 class="dummy-h4">Pass in a function that gets called when a tab is clicked</h4>
-  {{! prettier-ignore-end }}
+  {{! template-lint-disable no-unbalanced-curlies }}
+  {{! prettier-ignore-start }}
   <CodeBlock
     @language="markup"
-    @code='
+    @code="
       <Hds::Tabs @onTabClick=\{{this.logClickedTab}} as |T|>
         <T.Tab>One</T.Tab>
         <T.Tab>Two</T.Tab>
@@ -199,7 +204,7 @@
         <T.Panel>Content two</T.Panel>
         <T.Panel>Content three</T.Panel>
       </Hds::Tabs>
-    '
+    "
   />
   {{! prettier-ignore-end }}
 </section>

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -39,6 +39,8 @@
   <p class="dummy-paragraph" id="component-api-tabs">Here is the API for the main (“container”) component:</p>
 
   <dl class="dummy-component-props" aria-labelledby="component-api-tabs">
+    <dt>onTabClick <code>function</code></dt>
+    <dd>Pass an optional function which is called when a Tab is clicked.</dd>
     <dt>...attributes</dt>
     <dd>
       <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
@@ -182,6 +184,24 @@
     <T.Panel>Content 2</T.Panel>
     <T.Panel>Content 3!</T.Panel>
   </Hds::Tabs>
+
+  <h4 class="dummy-h4">Pass in a function that gets called when a tab is clicked</h4>
+  {{! prettier-ignore-end }}
+  <CodeBlock
+    @language="markup"
+    @code='
+      <Hds::Tabs @onTabClick=\{{this.logClickedTab}} as |T|>
+        <T.Tab>One</T.Tab>
+        <T.Tab>Two</T.Tab>
+        <T.Tab>Three</T.Tab>
+
+        <T.Panel>Content one</T.Panel>
+        <T.Panel>Content two</T.Panel>
+        <T.Panel>Content three</T.Panel>
+      </Hds::Tabs>
+    '
+  />
+  {{! prettier-ignore-end }}
 </section>
 
 <section>
@@ -377,5 +397,18 @@
     <T.Panel><DummyPlaceholder @text="Content eight" @height="50" @background="#eee" /></T.Panel>
     <T.Panel><DummyPlaceholder @text="Content nine" @height="50" @background="#eee" /></T.Panel>
     <T.Panel><DummyPlaceholder @text="Content ten" @height="50" @background="#eee" /></T.Panel>
+  </Hds::Tabs>
+
+  <h5 class="dummy-h6">Call a passed function when a tab is clicked</h5>
+  <p class="dummy-paragraph">Logs the tab id to the console</p>
+
+  <Hds::Tabs @onTabClick={{this.logClickedTab}} as |T|>
+    <T.Tab>One</T.Tab>
+    <T.Tab>Two</T.Tab>
+    <T.Tab>Three</T.Tab>
+
+    <T.Panel><DummyPlaceholder @text="Content one" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><DummyPlaceholder @text="Content two" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><DummyPlaceholder @text="Content three" @height="50" @background="#eee" /></T.Panel>
   </Hds::Tabs>
 </section>

--- a/packages/components/tests/integration/components/hds/tabs/index-test.js
+++ b/packages/components/tests/integration/components/hds/tabs/index-test.js
@@ -163,6 +163,58 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
     assert.dom('[data-test="secound tab"] .hds-tabs__tab-button').isFocused();
   });
 
+  test('It should display the associated panel when a focused tab is activated', async function (assert) {
+    const enterKey = 13;
+    const spaceKey = 32;
+
+    await render(hbs`
+      <Hds::Tabs as |T|>
+        <T.Tab data-test="first tab">One</T.Tab>
+        <T.Tab data-test="secound tab">Two</T.Tab>
+        <T.Panel data-test="first panel">Content 1</T.Panel>
+        <T.Panel data-test="secound panel">Content 2</T.Panel>
+      </Hds::Tabs>
+    `);
+
+    // focus 2nd tab:
+    await focus('[data-test="secound tab"] .hds-tabs__tab-button');
+    // activate the tab using the enterKey:
+    await triggerKeyEvent(
+      '[data-test="secound tab"] .hds-tabs__tab-button',
+      'keyup',
+      enterKey
+    );
+    // test that the tab and panel have been activated:
+    assert
+      .dom('[data-test="secound tab"]')
+      .hasClass('hds-tabs__tab--is-selected');
+    assert
+      .dom('[data-test="secound tab"] .hds-tabs__tab-button')
+      .hasAttribute('aria-selected');
+    assert
+      .dom('[data-test="secound panel"]')
+      .doesNotHaveAttribute('hidden');
+
+      // focus 1st tab:
+    await focus('[data-test="first tab"] .hds-tabs__tab-button');
+    // activate the tab using the spaceKey:
+    await triggerKeyEvent(
+      '[data-test="first tab"] .hds-tabs__tab-button',
+      'keyup',
+      spaceKey
+    );
+    // test that the tab and panel have been activated:
+    assert
+      .dom('[data-test="first tab"]')
+      .hasClass('hds-tabs__tab--is-selected');
+    assert
+      .dom('[data-test="first tab"] .hds-tabs__tab-button')
+      .hasAttribute('aria-selected');
+    assert
+      .dom('[data-test="first panel"]')
+      .doesNotHaveAttribute('hidden');
+  });
+
   // Test Tab options:
 
   test('it should render an icon when passed into a tab', async function (assert) {

--- a/packages/components/tests/integration/components/hds/tabs/index-test.js
+++ b/packages/components/tests/integration/components/hds/tabs/index-test.js
@@ -137,16 +137,16 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
     await render(hbs`
       <Hds::Tabs as |T|>
         <T.Tab data-test="first tab">One</T.Tab>
-        <T.Tab data-test="secound tab">Two</T.Tab>
+        <T.Tab data-test="second tab">Two</T.Tab>
         <T.Panel data-test="first panel">Content 1</T.Panel>
-        <T.Panel data-test="secound panel">Content 2</T.Panel>
+        <T.Panel data-test="second panel">Content 2</T.Panel>
       </Hds::Tabs>
     `);
     // focus 2nd tab:
-    await focus('[data-test="secound tab"] .hds-tabs__tab-button');
+    await focus('[data-test="second tab"] .hds-tabs__tab-button');
     // navigate to the previous (1st) tab using right arrow key:
     await triggerKeyEvent(
-      '[data-test="secound tab"] .hds-tabs__tab-button',
+      '[data-test="second tab"] .hds-tabs__tab-button',
       'keyup',
       rightArrowKey
     );
@@ -160,7 +160,7 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
       leftArrowKey
     );
     // test that the navigated to tab is now focused:
-    assert.dom('[data-test="secound tab"] .hds-tabs__tab-button').isFocused();
+    assert.dom('[data-test="second tab"] .hds-tabs__tab-button').isFocused();
   });
 
   test('It should display the associated panel when a focused tab is activated', async function (assert) {
@@ -170,28 +170,28 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
     await render(hbs`
       <Hds::Tabs as |T|>
         <T.Tab data-test="first tab">One</T.Tab>
-        <T.Tab data-test="secound tab">Two</T.Tab>
+        <T.Tab data-test="second tab">Two</T.Tab>
         <T.Panel data-test="first panel">Content 1</T.Panel>
-        <T.Panel data-test="secound panel">Content 2</T.Panel>
+        <T.Panel data-test="second panel">Content 2</T.Panel>
       </Hds::Tabs>
     `);
 
     // focus 2nd tab:
-    await focus('[data-test="secound tab"] .hds-tabs__tab-button');
+    await focus('[data-test="second tab"] .hds-tabs__tab-button');
     // activate the tab using the enterKey:
     await triggerKeyEvent(
-      '[data-test="secound tab"] .hds-tabs__tab-button',
+      '[data-test="second tab"] .hds-tabs__tab-button',
       'keyup',
       enterKey
     );
     // test that the tab and panel have been activated:
     assert
-      .dom('[data-test="secound tab"]')
+      .dom('[data-test="second tab"]')
       .hasClass('hds-tabs__tab--is-selected');
     assert
-      .dom('[data-test="secound tab"] .hds-tabs__tab-button')
+      .dom('[data-test="second tab"] .hds-tabs__tab-button')
       .hasAttribute('aria-selected');
-    assert.dom('[data-test="secound panel"]').doesNotHaveAttribute('hidden');
+    assert.dom('[data-test="second panel"]').doesNotHaveAttribute('hidden');
 
     // focus 1st tab:
     await focus('[data-test="first tab"] .hds-tabs__tab-button');

--- a/packages/components/tests/integration/components/hds/tabs/index-test.js
+++ b/packages/components/tests/integration/components/hds/tabs/index-test.js
@@ -191,11 +191,9 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
     assert
       .dom('[data-test="secound tab"] .hds-tabs__tab-button')
       .hasAttribute('aria-selected');
-    assert
-      .dom('[data-test="secound panel"]')
-      .doesNotHaveAttribute('hidden');
+    assert.dom('[data-test="secound panel"]').doesNotHaveAttribute('hidden');
 
-      // focus 1st tab:
+    // focus 1st tab:
     await focus('[data-test="first tab"] .hds-tabs__tab-button');
     // activate the tab using the spaceKey:
     await triggerKeyEvent(
@@ -210,9 +208,7 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
     assert
       .dom('[data-test="first tab"] .hds-tabs__tab-button')
       .hasAttribute('aria-selected');
-    assert
-      .dom('[data-test="first panel"]')
-      .doesNotHaveAttribute('hidden');
+    assert.dom('[data-test="first panel"]').doesNotHaveAttribute('hidden');
   });
 
   // Test Tab options:


### PR DESCRIPTION
### :pushpin: Summary

This PR is to further polish and refine the Tabs basic version to prepare for release. Once approved, it will be merged into the [feature branch](https://github.com/hashicorp/design-system/pull/548) for final review before release.

### :hammer_and_wrench: Detailed description
* Update docs to add links to child components passed into Tab
* Expand target area of Tabs
* Add test of keyboard controls for activating Tabs
* Add `onTabClick` argument to Tabs to pass a function that's called when a Tab is clicked

<!--
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
https://hashicorp.atlassian.net/browse/HDS-747

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
