### PR TITLE
Remove unnecessary inline width/height attributes for image in Dropdown Icon toggle

### DIFF
--- a/.changeset/pretty-clocks-explode.md
+++ b/.changeset/pretty-clocks-explode.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Remove unnecessary inline width/height attributes for image in `Dropdown::Toggle::Icon` component

--- a/packages/components/addon/components/hds/dropdown/toggle/icon.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/icon.hbs
@@ -8,7 +8,7 @@
 >
   <div class="hds-dropdown-toggle-icon__wrapper">
     {{#if @imageSrc}}
-      <img src={{@imageSrc}} alt="" role="presentation" height="32" width="32" />
+      <img src={{@imageSrc}} alt="" role="presentation" />
     {{else if @icon}}
       <FlightIcon @name={{@icon}} @size="24" />
     {{/if}}


### PR DESCRIPTION
### :pushpin: Summary

Following [this thread](https://hashicorp.slack.com/archives/C03UR6RR56C/p1665433984551619), I have realized that we have left inline `width/height` attributes in the `img` element of the `Dropdown::Toggle::Icon`. Technically the size of the image is set via CSS so these attributes are not necessary (also wrong, in value) and confusing. Better to remove them.

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed the inline `width/height` attributes for the `<img>` element in the Dropdown Icon toggle

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
