### PR TITLE
`Table` component - Small fix for live region of `TableSortable`

### DIFF
--- a/packages/components/addon/components/hds/table/table-sortable.js
+++ b/packages/components/addon/components/hds/table/table-sortable.js
@@ -19,11 +19,8 @@ export default class HdsTableTableSortableComponent extends Component {
       this.args.setSortOrder('asc');
     }
 
-    const currentColHeading = event.target;
-    const currColHeadingText = currentColHeading.textContent;
-
     const liveRegion = document.querySelector(`#${this.a11yMessageId}`);
-    liveRegion.textContent = `Sorted by ${currColHeadingText} ${this.args.sortOrder}ending`;
+    liveRegion.textContent = `Sorted by ${column} ${this.args.sortOrder}ending`;
     setTimeout(function () {
       liveRegion.textContent = '';
     }, 2000);


### PR DESCRIPTION
### :pushpin: Summary

This is a small PR opened as follow-up of this conversation:
https://github.com/hashicorp/design-system/pull/615/files#r991380830

### :hammer_and_wrench: Detailed description

In this PR I have:
- replaced `currColHeadingText` with `column` in `setSortBy` method of `TableSortable`

***

### 👀 How to review

👉 Review by files changed