### PR TITLE
Remove `assert.expect(n)` declarations in the integration tests

### DIFF
--- a/packages/components/tests/integration/components/hds/alert/index-test.js
+++ b/packages/components/tests/integration/components/hds/alert/index-test.js
@@ -30,7 +30,6 @@ module('Integration | Component | hds/alert/index', function (hooks) {
 
   test('it should render an icon by default depending on the type and color', async function (assert) {
     // here we don't test all the possible combinations, only some of them as precaution
-    assert.expect(6);
     await render(hbs`<Hds::Alert @type="inline" />`);
     assert.dom('.flight-icon-info').exists();
     await render(hbs`<Hds::Alert @type="compact" />`);
@@ -46,7 +45,6 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   });
 
   test('if an icon is declared, the icon should render in the component and override the default one', async function (assert) {
-    assert.expect(2);
     await render(hbs`<Hds::Alert @type="inline" @icon="clipboard-copy" />`);
     assert.dom('.flight-icon-clipboard-copy').exists();
     await render(hbs`<Hds::Alert @type="compact" @icon="clipboard-copy" />`);
@@ -73,7 +71,6 @@ module('Integration | Component | hds/alert/index', function (hooks) {
     assert.dom(this.element).hasText('This is the description');
   });
   test('it should render rich HTML when the "description" contextual component contains HTML tags', async function (assert) {
-    assert.expect(8);
     await render(
       hbs`<Hds::Alert @type="inline" as |A|><A.Description>Hello <strong>strong</strong> and <em>em</em> and <code>code</code> and <a href='#'>link</a></A.Description></Hds::Alert>`
     );
@@ -86,7 +83,6 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   // ACTIONS
 
   test('it should render an Hds::Button component yielded to the "actions" container', async function (assert) {
-    assert.expect(5);
     await render(
       hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Button @text="I am a button" @size="small" @color="secondary" /></Hds::Alert>`
     );
@@ -99,7 +95,6 @@ module('Integration | Component | hds/alert/index', function (hooks) {
       .hasText('I am a button');
   });
   test('it should render an Hds::Link::Standalone component yielded to the "actions" container', async function (assert) {
-    assert.expect(5);
     await render(
       hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Link::Standalone @icon="plus" @text="I am a link" @href="#" @size="small" @color="secondary" /></Hds::Alert>`
     );
@@ -115,7 +110,6 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   // GENERIC
 
   test('it should render any content passed to the "generic" contextual component', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Generic><pre>test</pre></A.Generic></Hds::Alert>`
     );
@@ -142,7 +136,6 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   });
 
   test('it should render with an `alertdialog` role and auto-generated `aria-labelledby` when title and actions are provided', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Title>This is the title</A.Title><A.Button @text="I am a button" @size="small" /></Hds::Alert>`
     );
@@ -152,7 +145,6 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   });
 
   test('it should render with an `alertdialog` role and auto-generated `aria-labelledby` when description and actions are provided', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Description>This is the title</A.Description><A.Button @text="I am a button" @size="small" /></Hds::Alert>`
     );
@@ -164,7 +156,6 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   });
 
   test('it should render with an `alertdialog` role and `aria-labelledby` when title and actions are provided', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Title id="custom-id">This is the title</A.Title><A.Button @text="I am a button" @size="small" /></Hds::Alert>`
     );

--- a/packages/components/tests/integration/components/hds/breadcrumb/index-test.js
+++ b/packages/components/tests/integration/components/hds/breadcrumb/index-test.js
@@ -25,7 +25,6 @@ module('Integration | Component | hds/breadcrumb/index', function (hooks) {
   // A11Y
 
   test('it should render with the correct semantic tags and aria attributes', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Breadcrumb id="test-breadcrumb" />`);
     assert.dom('#test-breadcrumb').hasTagName('nav');
     assert.dom('#test-breadcrumb').hasAria('label', 'breadcrumbs');

--- a/packages/components/tests/integration/components/hds/breadcrumb/item-test.js
+++ b/packages/components/tests/integration/components/hds/breadcrumb/item-test.js
@@ -27,7 +27,6 @@ module('Integration | Component | hds/breadcrumb/item', function (hooks) {
     assert.dom('#test-breadcrumb-item > a').exists();
   });
   test('it should not render a if @current is true', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Breadcrumb::Item id="test-breadcrumb-item" @text="text renders" @current={{true}} />`
     );
@@ -35,7 +34,6 @@ module('Integration | Component | hds/breadcrumb/item', function (hooks) {
     assert.dom('#test-breadcrumb-item .hds-breadcrumb__current').exists();
   });
   test('it should render the item with icon and text if @icon and @text are provided', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Breadcrumb::Item id="test-breadcrumb-item" @text="text renders" @icon="activity" />`
     );

--- a/packages/components/tests/integration/components/hds/breadcrumb/truncation-test.js
+++ b/packages/components/tests/integration/components/hds/breadcrumb/truncation-test.js
@@ -31,7 +31,6 @@ module('Integration | Component | hds/breadcrumb/truncation', function (hooks) {
       .doesNotExist();
   });
   test('it should yield (and render) the content', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation"><a id="test-breadcrumb-truncation-link" href="#">test</a></Hds::Breadcrumb::Truncation>`
     );
@@ -44,7 +43,6 @@ module('Integration | Component | hds/breadcrumb/truncation', function (hooks) {
   // A11Y
 
   test('it should render with the correct aria-expanded attribute on the toggle element', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" />`
     );

--- a/packages/components/tests/integration/components/hds/disclosure/index-test.js
+++ b/packages/components/tests/integration/components/hds/disclosure/index-test.js
@@ -24,7 +24,6 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
   // TOGGLE + CONTENT
 
   test('it should render the "toggle" block but not the "content', async function (assert) {
-    assert.expect(3);
     await render(hbs`
       <Hds::Disclosure>
         <:toggle>
@@ -37,7 +36,6 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
     assert.dom('.hds-disclosure__content').doesNotExist();
   });
   test('it should render the "content" when the "toggle" is clicked', async function (assert) {
-    assert.expect(2);
     await render(hbs`
       <Hds::Disclosure>
         <:toggle as |t|>
@@ -56,7 +54,6 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
   // ESCAPE KEY
 
   test('it should hide the "content" when the "toggle" is deactivated via "Escape"', async function (assert) {
-    assert.expect(4);
     await render(hbs`
       <Hds::Disclosure id="test-disclosure">
         <:toggle as |t|>
@@ -78,7 +75,6 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
   // FOCUS OUT
 
   test('it should hide the "content" when the focus is moved outside', async function (assert) {
-    assert.expect(4);
     await render(hbs`
       <Hds::Disclosure id="test-disclosure">
         <:toggle as |t|>
@@ -100,7 +96,6 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
   // CLOSE DISCLOSED CONTENT ON CLICK
 
   test('it should hide the "content" when an interactive element triggers `close`', async function (assert) {
-    assert.expect(4);
     await render(hbs`
       <Hds::Disclosure id="test-disclosure">
         <:toggle as |t|>

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -18,7 +18,6 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
   // NAMED YIELDS
 
   test('it renders the "toggle" sub-components', async function (assert) {
-    assert.expect(2);
     await render(hbs`
       <Hds::Dropdown id="test-dropdown" as |dd|>
         <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
@@ -29,7 +28,6 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown #test-toggle-icon').exists();
   });
   test('it renders the "list-item" sub-components', async function (assert) {
-    assert.expect(6);
     await render(hbs`
       <Hds::Dropdown id="test-dropdown" as |dd|>
         <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
@@ -109,7 +107,6 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Dropdown id="test-dropdown" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/copy-item-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/copy-item-test.js
@@ -20,7 +20,6 @@ module(
     });
 
     test('it should render the "list-item/copy-item" as a <li> element with a CSS class that matches the component name', async function (assert) {
-      assert.expect(3);
       await render(
         hbs`<Hds::Dropdown::ListItem::CopyItem @text="copy-item" id="test-list-item-copy-item" />`
       );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/description-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/description-test.js
@@ -20,7 +20,6 @@ module(
     });
 
     test('it should render the "list-item/description" as a <li> element with a CSS class that matches the component name', async function (assert) {
-      assert.expect(3);
       await render(
         hbs`<Hds::Dropdown::ListItem::Description @text="description" id="test-list-item-description" />`
       );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/generic-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/generic-test.js
@@ -14,7 +14,6 @@ module(
     });
 
     test('it should render the "list-item/generic" as a <li> element with a CSS class that matches the component name', async function (assert) {
-      assert.expect(3);
       await render(
         hbs`<Hds::Dropdown::ListItem::Generic id="test-list-item-generic" />`
       );
@@ -28,7 +27,6 @@ module(
     // CONTENT
 
     test('it should render the yielded content', async function (assert) {
-      assert.expect(2);
       await render(
         hbs`<Hds::Dropdown::ListItem::Generic><pre>test</pre></Hds::Dropdown::ListItem::Generic>`
       );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/interactive-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/interactive-test.js
@@ -24,7 +24,6 @@ module(
     });
 
     test('it should render the "list-item/interactive" as a <li> element with a CSS class that matches the component name', async function (assert) {
-      assert.expect(2);
       await render(
         hbs`<Hds::Dropdown::ListItem::Interactive @text="interactive" />`
       );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/separator-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/separator-test.js
@@ -16,7 +16,6 @@ module(
     });
 
     test('it should render the "list-item/separator" as a <li> element with a CSS class that matches the component name', async function (assert) {
-      assert.expect(3);
       await render(
         hbs`<Hds::Dropdown::ListItem::Separator @text="separator" id="test-list-item-separator" />`
       );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/title-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/title-test.js
@@ -18,7 +18,6 @@ module(
     });
 
     test('it should render the "list-item/title" as a <li> element with a CSS class that matches the component name', async function (assert) {
-      assert.expect(3);
       await render(
         hbs`<Hds::Dropdown::ListItem::Title @text="title" id="test-list-item-title" />`
       );

--- a/packages/components/tests/integration/components/hds/form/checkbox/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/base-test.js
@@ -18,7 +18,6 @@ module('Integration | Component | hds/form/checkbox/base', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
@@ -36,7 +36,6 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components', async function (assert) {
-    assert.expect(5);
     await render(
       hbs`<Hds::Form::Checkbox::Field checked="checked" as |F|>
           <F.Label>This is the label</F.Label>
@@ -51,14 +50,12 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::Checkbox::Field />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
   });
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Checkbox::Field @extraAriaDescribedBy="extra" as |F|>
           <F.Label>This is the label</F.Label>
@@ -88,7 +85,6 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
 
   // we have added an extra assertion for the "name" attribute here, even if not strictly necessary, to make sure is not overwritten in any way
   test('it should spread all the attributes (including "name") passed to the component on the input', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" />`
     );

--- a/packages/components/tests/integration/components/hds/form/checkbox/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/group-test.js
@@ -18,7 +18,6 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components and subcomponents', async function (assert) {
-    assert.expect(12);
     await render(
       hbs`<Hds::Form::Checkbox::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -59,14 +58,12 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
     assert.dom('.hds-form-group__error').hasText('This is the group error');
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::Checkbox::Group />`);
     assert.dom('.hds-form-group__legend').doesNotExist();
     assert.dom('.hds-form-group__helper-text').doesNotExist();
     assert.dom('.hds-form-group__error').doesNotExist();
   });
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(1);
     await render(
       hbs`<Hds::Form::Checkbox::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -103,7 +100,6 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
   // NAME
 
   test('it renders the defined name on all controls within a group', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Checkbox::Group @name="datacenter-demo" as |G|>
             <G.Legend>Choose datacenter</G.Legend>
@@ -126,7 +122,6 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it should append an indicator to the legend text and set the required attribute when user input is required', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Checkbox::Group @isRequired={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -140,7 +135,6 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
     assert.dom('input').hasAttribute('required');
   });
   test('it should append an indicator to the legend text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Checkbox::Group @isOptional={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -156,7 +150,6 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Checkbox::Group id="test-form-checkbox" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/error/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/error/index-test.js
@@ -30,7 +30,6 @@ module('Integration | Component | hds/form/error/index', function (hooks) {
     assert.dom('#test-form-error').hasText('This is the error');
   });
   test('it renders an error with the yielded content', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Error id="test-form-error"><pre>This is an HTML element inside the error</pre></Hds::Form::Error>`
     );
@@ -40,7 +39,6 @@ module('Integration | Component | hds/form/error/index', function (hooks) {
       .hasText('This is an HTML element inside the error');
   });
   test('it renders multiple error messages as contextual components', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Error id="test-form-error" as |E|><E.Message>First error message</E.Message><E.Message>Second error message</E.Message></Hds::Form::Error>`
     );
@@ -61,7 +59,6 @@ module('Integration | Component | hds/form/error/index', function (hooks) {
     assert.dom('#error-my-control-id').exists();
   });
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Error id="test-form-error" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/field/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/field/index-test.js
@@ -29,7 +29,6 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components', async function (assert) {
-    assert.expect(8);
     await render(
       hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" as |F|>
           <F.Label>This is the label</F.Label>
@@ -50,7 +49,6 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
     assert.dom('.hds-form-field__error').hasText('This is the error');
   });
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" as |F|>
           <F.Label>This is the label</F.Label>
@@ -79,7 +77,6 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
       .hasAttribute('id', `error-${controlId}`);
   });
   test('it automatically provides all the ID relations between the elements with a custom @id', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" @id="my-custom-id" as |F|>
           <F.Label>This is the label</F.Label>
@@ -104,7 +101,6 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
       .hasAttribute('id', `error-${controlId}`);
   });
   test('it provides all the ID relations between the elements and allows extra `aria-describedby` attributes', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" @extraAriaDescribedBy="extra" as |F|>
           <F.Label>This is the label</F.Label>
@@ -136,7 +132,6 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it should append an indicator to the label text when user input is required', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Field @isRequired={{true}} as |F|>
             <F.Label>This is the label</F.Label>
@@ -146,7 +141,6 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
     assert.dom('label .hds-form-indicator').hasText('Required');
   });
   test('it should append an indicator to the label text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Field @isOptional={{true}} as |F|>
             <F.Label>This is the label</F.Label>
@@ -159,7 +153,6 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Field id="test-form-field" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/fieldset/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/fieldset/index-test.js
@@ -29,7 +29,6 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components', async function (assert) {
-    assert.expect(8);
     await render(
       hbs`<Hds::Form::Fieldset @layout="vertical" id="test-form-fieldset" as |F|>
           <F.Legend>This is the legend</F.Legend>
@@ -52,7 +51,6 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
     assert.dom('.hds-form-group__error').hasText('This is the group error');
   });
   test('it automatically provides IDs for helper text and error', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Fieldset @layout="vertical" as |F|>
           <F.Legend>This is the legend</F.Legend>
@@ -75,7 +73,6 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it should append an indicator to the legend text when user input is required', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Fieldset @isRequired={{true}} as |F|>
           <F.Legend>This is the legend</F.Legend>
@@ -85,7 +82,6 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
     assert.dom('legend .hds-form-indicator').hasText('Required');
   });
   test('it should append an indicator to the legend text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Fieldset @isOptional={{true}} as |F|>
           <F.Legend>This is the legend</F.Legend>
@@ -98,7 +94,6 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Fieldset id="test-form-fieldset" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/helper-text/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/helper-text/index-test.js
@@ -32,7 +32,6 @@ module(
       assert.dom('#test-form-helper-text').hasText('This is the helper text');
     });
     test('it renders a helper text with the yielded content', async function (assert) {
-      assert.expect(2);
       await render(
         hbs`<Hds::Form::HelperText id="test-form-helper-text"><pre>This is an HTML element inside the helper text</pre></Hds::Form::HelperText>`
       );
@@ -51,7 +50,6 @@ module(
       assert.dom('#helper-text-my-control-id').exists();
     });
     test('it should spread all the attributes passed to the component', async function (assert) {
-      assert.expect(3);
       await render(
         hbs`<Hds::Form::HelperText id="test-form-helper-text" class="my-class" data-test1 data-test2="test" />`
       );

--- a/packages/components/tests/integration/components/hds/form/label/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/label/index-test.js
@@ -30,7 +30,6 @@ module('Integration | Component | hds/form/label/index', function (hooks) {
     assert.dom('#test-form-label').hasText('This is the label');
   });
   test('it renders a label with the yielded content', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Label id="test-form-label"><pre>This is an HTML element inside the label</pre></Hds::Form::Label>`
     );
@@ -43,7 +42,6 @@ module('Integration | Component | hds/form/label/index', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it appends an indicator to the label text when user input is required', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Label @isRequired={{true}} id="test-form-label">This is the label</Hds::Form::Label>`
     );
@@ -51,7 +49,6 @@ module('Integration | Component | hds/form/label/index', function (hooks) {
     assert.dom('#test-form-label .hds-form-indicator').hasText('Required');
   });
   test('it appends an indicator to the label text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Label @isOptional={{true}} id="test-form-label">This is the label</Hds::Form::Label>`
     );
@@ -68,7 +65,6 @@ module('Integration | Component | hds/form/label/index', function (hooks) {
     assert.dom('#test-form-label').hasAttribute('for', 'my-control-id');
   });
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Label id="test-form-label" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/legend/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/legend/index-test.js
@@ -34,7 +34,6 @@ module('Integration | Component | hds/form/legend/index', function (hooks) {
     assert.dom('#test-form-legend').hasText('This is the legend');
   });
   test('it renders a legend with the yielded content', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Legend id="test-form-legend"><pre>This is an HTML element inside the legend</pre></Hds::Form::Legend>`
     );
@@ -47,7 +46,6 @@ module('Integration | Component | hds/form/legend/index', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it appends an indicator to the legend text when user input is required', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Legend id="test-form-legend" @isRequired={{true}}>This is the legend</Hds::Form::Legend>`
     );
@@ -55,7 +53,6 @@ module('Integration | Component | hds/form/legend/index', function (hooks) {
     assert.dom('#test-form-legend .hds-form-indicator').hasText('Required');
   });
   test('it appends an indicator to the legend text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Legend id="test-form-legend" @isOptional={{true}}>This is the legend</Hds::Form::Legend>`
     );
@@ -66,7 +63,6 @@ module('Integration | Component | hds/form/legend/index', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Legend id="test-form-legend" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
@@ -28,7 +28,6 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
   // CONTEXTUAL COMPONENTS
 
   test('it renders the contextual components', async function (assert) {
-    assert.expect(8);
     await render(
       hbs`<Hds::Form::RadioCard::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -50,7 +49,6 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
     assert.dom('.hds-form-group__error').hasText('This is the group error');
   });
   test('it does not render the contextual components if not provided', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::RadioCard::Group />`);
     assert.dom('.hds-form-group__legend').doesNotExist();
     assert.dom('.hds-form-group__helper-text').doesNotExist();
@@ -60,7 +58,6 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
   // ACCESSIBILITY
 
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(1);
     await render(
       hbs`<Hds::Form::RadioCard::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -85,7 +82,6 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
   // ARGUMENT FORWARDING: NAME, ALIGNMENT, CONTROL POSITION
 
   test('it should render the component with CSS classes that reflect the arguments provided', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::RadioCard::Group @name="test-name" @alignment="center" @controlPosition="left" as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -110,7 +106,6 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it should append an indicator to the legend text when user input is required', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::RadioCard::Group @isRequired={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -121,7 +116,6 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
     assert.dom('legend .hds-form-indicator').hasText('Required');
   });
   test('it should append an indicator to the legend text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::RadioCard::Group @isOptional={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -135,7 +129,6 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::RadioCard::Group id="test-radio-card-group" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
@@ -22,7 +22,6 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
   // NAME, VALUE
 
   test('it should render the input with the arguments provided', async function (assert) {
-    assert.expect(2);
     await render(hbs`<Hds::Form::RadioCard @name="name" @value="value" />`);
     assert.dom('input').hasValue('value');
     assert.dom('input').hasAttribute('name', 'name');
@@ -31,7 +30,6 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
   // CHECKED, DISABLED
 
   test('it should render the component with CSS classes that reflect the arguments provided', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::RadioCard @checked="checked" @disabled="disabled" />`
     );
@@ -42,7 +40,6 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
   // CONTEXTUAL COMPONENTS
 
   test('it renders the contextual components', async function (assert) {
-    assert.expect(5);
     await render(
       hbs`<Hds::Form::RadioCard as |R|>
             <R.Icon @name="hexagon"/>
@@ -59,7 +56,6 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     assert.dom('.custom').exists();
   });
   test('it does not render the contextual components if not provided', async function (assert) {
-    assert.expect(5);
     await render(hbs`<Hds::Form::RadioCard />`);
     assert.dom('.flight-icon').doesNotExist();
     assert.dom('.hds-form-radio-card__label').doesNotExist();
@@ -71,7 +67,6 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    assert.expect(5);
     await render(
       hbs`<Hds::Form::RadioCard id="my-id" name="my-name" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/radio/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/base-test.js
@@ -18,7 +18,6 @@ module('Integration | Component | hds/form/radio/base', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Radio::Base id="test-form-radio" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/radio/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/field-test.js
@@ -36,7 +36,6 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Radio::Field as |F|>
           <F.Label>This is the label</F.Label>
@@ -50,14 +49,12 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::Radio::Field />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
   });
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Radio::Field @extraAriaDescribedBy="extra" as |F|>
           <F.Label>This is the label</F.Label>
@@ -87,7 +84,6 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
 
   // we have added an extra assertion for the "name" attribute here, even if not strictly necessary, to make sure is not overwritten in any way
   test('it should spread all the attributes (includind "name") passed to the component on the input', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" />`
     );

--- a/packages/components/tests/integration/components/hds/form/radio/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/group-test.js
@@ -18,7 +18,6 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components and subcomponents', async function (assert) {
-    assert.expect(12);
     await render(
       hbs`<Hds::Form::Radio::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -59,14 +58,12 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
     assert.dom('.hds-form-group__error').hasText('This is the group error');
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::Radio::Group />`);
     assert.dom('.hds-form-group__legend').doesNotExist();
     assert.dom('.hds-form-group__helper-text').doesNotExist();
     assert.dom('.hds-form-group__error').doesNotExist();
   });
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(1);
     await render(
       hbs`<Hds::Form::Radio::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -103,7 +100,6 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
   // NAME
 
   test('it renders the defined name on all controls within a group', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Radio::Group @name="datacenter-demo" as |G|>
             <G.Legend>Choose datacenter</G.Legend>
@@ -126,7 +122,6 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it should append an indicator to the legend text and set the required attribute when user input is required', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Radio::Group @isRequired={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -140,7 +135,6 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
     assert.dom('input').hasAttribute('required');
   });
   test('it should append an indicator to the legend text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Radio::Group @isOptional={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -156,7 +150,6 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Radio::Group id="test-form-radio" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/select/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/base-test.js
@@ -47,7 +47,6 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Select::Base id="test-form-select" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/select/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/field-test.js
@@ -54,7 +54,6 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Select::Field as |F|>
           <F.Label>This is the label</F.Label>
@@ -68,14 +67,12 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::Select::Field />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
   });
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Select::Field @extraAriaDescribedBy="extra" as |F|>
           <F.Label>This is the label</F.Label>
@@ -104,7 +101,6 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it should append an indicator to the label text and set the required attribute when user input is required', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Select::Field @isRequired={{true}} as |F|>
             <F.Label>This is the label</F.Label>
@@ -115,7 +111,6 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
     assert.dom('select').hasAttribute('required');
   });
   test('it should append an indicator to the label text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Select::Field @isOptional={{true}} as |F|>
             <F.Label>This is the label</F.Label>
@@ -125,7 +120,6 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
     assert.dom('label .hds-form-indicator').hasText('(Optional)');
   });
   test('it should not append an indicator to the label text when the required attribute is set', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Select::Field required as |F|>
             <F.Label>This is the label</F.Label>
@@ -138,7 +132,6 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Select::Field class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/text-input/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/base-test.js
@@ -64,7 +64,6 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::TextInput::Base id="test-form-text-input" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/text-input/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/field-test.js
@@ -61,7 +61,6 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::TextInput::Field as |F|>
           <F.Label>This is the label</F.Label>
@@ -75,14 +74,12 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::TextInput::Field />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
   });
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::TextInput::Field @extraAriaDescribedBy="extra" as |F|>
           <F.Label>This is the label</F.Label>
@@ -111,7 +108,6 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it should append an indicator to the label text and set the required attribute when user input is required', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::TextInput::Field @isRequired={{true}} as |F|>
             <F.Label>This is the label</F.Label>
@@ -122,7 +118,6 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
     assert.dom('input').hasAttribute('required');
   });
   test('it should append an indicator to the label text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::TextInput::Field @isOptional={{true}} as |F|>
             <F.Label>This is the label</F.Label>
@@ -132,7 +127,6 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
     assert.dom('label .hds-form-indicator').hasText('(Optional)');
   });
   test('it should not append an indicator to the label text when the required attribute is set', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::TextInput::Field required as |F|>
             <F.Label>This is the label</F.Label>
@@ -145,7 +139,6 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::TextInput::Field class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/textarea/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/base-test.js
@@ -47,7 +47,6 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Textarea::Base id="test-form-textarea" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/textarea/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/field-test.js
@@ -58,7 +58,6 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Textarea::Field as |F|>
           <F.Label>This is the label</F.Label>
@@ -72,14 +71,12 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::Textarea::Field />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
   });
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Textarea::Field @extraAriaDescribedBy="extra" as |F|>
           <F.Label>This is the label</F.Label>
@@ -108,7 +105,6 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it should append an indicator to the label text and set the required attribute when user input is required', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Textarea::Field @isRequired={{true}} as |F|>
             <F.Label>This is the label</F.Label>
@@ -119,7 +115,6 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
     assert.dom('textarea').hasAttribute('required');
   });
   test('it should append an indicator to the label text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Textarea::Field @isOptional={{true}} as |F|>
             <F.Label>This is the label</F.Label>
@@ -129,7 +124,6 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
     assert.dom('label .hds-form-indicator').hasText('(Optional)');
   });
   test('it should not append an indicator to the label text when the required attribute is set', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Textarea::Field required as |F|>
             <F.Label>This is the label</F.Label>
@@ -142,7 +136,6 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Textarea::Field class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/toggle/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/base-test.js
@@ -11,7 +11,6 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
     assert.dom('#test-form-toggle').exists();
   });
   test('it should render with a CSS class that matches the component name', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::Toggle::Base id="test-form-toggle" />`);
     // Notice: the "toggle" component has a slightly different DOM structure than the other form controls
     assert.dom('.hds-form-toggle').exists();
@@ -22,7 +21,6 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Toggle::Base id="test-form-toggle" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/toggle/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/field-test.js
@@ -37,7 +37,6 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Toggle::Field as |F|>
           <F.Label>This is the label</F.Label>
@@ -51,14 +50,12 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::Toggle::Field />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
   });
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(4);
     await render(
       hbs`<Hds::Form::Toggle::Field @extraAriaDescribedBy="extra" as |F|>
           <F.Label>This is the label</F.Label>
@@ -88,7 +85,6 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Toggle::Field checked="checked" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/form/toggle/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/group-test.js
@@ -18,7 +18,6 @@ module('Integration | Component | hds/form/toggle/group', function (hooks) {
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components and subcomponents', async function (assert) {
-    assert.expect(12);
     await render(
       hbs`<Hds::Form::Toggle::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -59,14 +58,12 @@ module('Integration | Component | hds/form/toggle/group', function (hooks) {
     assert.dom('.hds-form-group__error').hasText('This is the group error');
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    assert.expect(3);
     await render(hbs`<Hds::Form::Toggle::Group />`);
     assert.dom('.hds-form-group__legend').doesNotExist();
     assert.dom('.hds-form-group__helper-text').doesNotExist();
     assert.dom('.hds-form-group__error').doesNotExist();
   });
   test('it automatically provides all the ID relations between the elements', async function (assert) {
-    assert.expect(1);
     await render(
       hbs`<Hds::Form::Toggle::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -103,7 +100,6 @@ module('Integration | Component | hds/form/toggle/group', function (hooks) {
   // REQUIRED AND OPTIONAL
 
   test('it should append an indicator to the legend text and set the required attribute when user input is required', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Toggle::Group @isRequired={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -117,7 +113,6 @@ module('Integration | Component | hds/form/toggle/group', function (hooks) {
     assert.dom('input').hasAttribute('required');
   });
   test('it should append an indicator to the legend text when user input is optional', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Form::Toggle::Group @isOptional={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
@@ -133,7 +128,6 @@ module('Integration | Component | hds/form/toggle/group', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Form::Toggle::Group id="test-form-toggle" class="my-class" data-test1 data-test2="test" />`
     );

--- a/packages/components/tests/integration/components/hds/interactive/index-test.js
+++ b/packages/components/tests/integration/components/hds/interactive/index-test.js
@@ -20,13 +20,11 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
     assert.dom('#test-interactive').hasTagName('button');
   });
   test('it should render a <a> link if @href is passed', async function (assert) {
-    assert.expect(2);
     await render(hbs`<Hds::Interactive @href="#" id="test-interactive" />`);
     assert.dom('#test-interactive').hasTagName('a');
     assert.dom('#test-interactive').hasAttribute('href', '#');
   });
   test('it should render a <a> link if @route is passed', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Interactive @route="utilities.interactive" id="test-interactive" />`
     );
@@ -39,13 +37,11 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
   // TARGET/REL ATTRIBUTES
 
   test('it should render a <a> link with the right "target" and "rel" attributes if @href is passed', async function (assert) {
-    assert.expect(2);
     await render(hbs`<Hds::Interactive @href="#" id="test-interactive" />`);
     assert.dom('#test-interactive').hasAttribute('target', '_blank');
     assert.dom('#test-interactive').hasAttribute('rel', 'noopener noreferrer');
   });
   test('it should render a <a> link with custom "target" and "rel" attributes if they are passed as attributes', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Interactive @href="#" id="test-interactive" target="test-target" rel="test-rel" />`
     );
@@ -53,7 +49,6 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
     assert.dom('#test-interactive').hasAttribute('rel', 'test-rel');
   });
   test('it should render a <a> link withhout "target" and "rel" attributes if @isHrefExternal is false', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Interactive @href="#" @isHrefExternal={{false}} id="test-interactive" />`
     );
@@ -64,7 +59,6 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
   // ATTRIBUTES
 
   test('it should spread all the attributes passed to the <button> element', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Interactive id="test-interactive" class="my-class" data-test1 data-test2="test" />`
     );
@@ -73,7 +67,6 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
     assert.dom('button#test-interactive').hasAttribute('data-test2', 'test');
   });
   test('it should spread all the attributes passed to the <a> element', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Interactive @href="#" id="test-interactive" class="my-class" data-test1 data-test2="test" />`
     );
@@ -82,7 +75,6 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
     assert.dom('a#test-interactive').hasAttribute('data-test2', 'test');
   });
   test('it should spread all the attributes passed to the <LinkTo> element', async function (assert) {
-    assert.expect(3);
     await render(
       hbs`<Hds::Interactive @route="index" id="test-interactive" class="my-class" data-test1 data-test2="test" />`
     );
@@ -94,7 +86,6 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
   // YIELDING
 
   test('it should yield the children of the <button> element', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Interactive id="test-interactive"><pre>test</pre></Hds::Interactive>`
     );
@@ -102,7 +93,6 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
     assert.dom('button#test-interactive > pre').hasText('test');
   });
   test('it should yield the children of the <a> element', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Interactive @href="#" id="test-interactive"><pre>test</pre></Hds::Interactive>`
     );
@@ -110,7 +100,6 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
     assert.dom('a#test-interactive > pre').hasText('test');
   });
   test('it should yield the children of the <LinkTo> element', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Interactive @route="index" id="test-interactive"><pre>test</pre></Hds::Interactive>`
     );

--- a/packages/components/tests/integration/components/hds/link/inline-test.js
+++ b/packages/components/tests/integration/components/hds/link/inline-test.js
@@ -23,7 +23,6 @@ module('Integration | Component | hds/link/inline', function (hooks) {
   // ICON
 
   test('it should render the icon in the trailing position by default', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Link::Inline @href="/" @icon="film" id="test-link">watch video</Hds::Link::Inline>`
     );
@@ -55,7 +54,6 @@ module('Integration | Component | hds/link/inline', function (hooks) {
   // YIELDING
 
   test('it should yield the children of the <a> element', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Link::Inline @href="/" id="test-link"><span>test</span></Hds::Link::Inline>`
     );
@@ -66,13 +64,11 @@ module('Integration | Component | hds/link/inline', function (hooks) {
   // TARGET/REL ATTRIBUTES
 
   test('it should render a <a> link with the right "target" and "rel" attributes if @href is passed', async function (assert) {
-    assert.expect(2);
     await render(hbs`<Hds::Link::Inline @href="/" id="test-link" />`);
     assert.dom('#test-link').hasAttribute('target', '_blank');
     assert.dom('#test-link').hasAttribute('rel', 'noopener noreferrer');
   });
   test('it should render a <a> link with custom "target" and "rel" attributes if they are passed as attributes', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Link::Inline @href="/" id="test-link" target="test-target" rel="test-rel" />`
     );
@@ -80,7 +76,6 @@ module('Integration | Component | hds/link/inline', function (hooks) {
     assert.dom('#test-link').hasAttribute('rel', 'test-rel');
   });
   test('it should render a <a> link withhout "target" and "rel" attributes if @isHrefExternal is false', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Link::Inline @href="/" @isHrefExternal={{false}} id="test-link" />`
     );

--- a/packages/components/tests/integration/components/hds/link/standalone-test.js
+++ b/packages/components/tests/integration/components/hds/link/standalone-test.js
@@ -79,7 +79,6 @@ module('Integration | Component | hds/link/standalone', function (hooks) {
   // TARGET/REL ATTRIBUTES
 
   test('it should render a <a> link with the right "target" and "rel" attributes if @href is passed', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Link::Standalone @text="watch video" @href="/" @icon="film" id="test-link" />`
     );
@@ -87,7 +86,6 @@ module('Integration | Component | hds/link/standalone', function (hooks) {
     assert.dom('#test-link').hasAttribute('rel', 'noopener noreferrer');
   });
   test('it should render a <a> link with custom "target" and "rel" attributes if they are passed as attributes', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Link::Standalone @text="watch video" @href="/" @icon="film" id="test-link" target="test-target" rel="test-rel" />`
     );
@@ -95,7 +93,6 @@ module('Integration | Component | hds/link/standalone', function (hooks) {
     assert.dom('#test-link').hasAttribute('rel', 'test-rel');
   });
   test('it should render a <a> link without "target" and "rel" attributes if @isHrefExternal is false', async function (assert) {
-    assert.expect(2);
     await render(
       hbs`<Hds::Link::Standalone @text="watch video" @href="/" @icon="film" @isHrefExternal={{false}} id="test-link" />`
     );

--- a/packages/components/tests/integration/components/hds/tag/index-test.js
+++ b/packages/components/tests/integration/components/hds/tag/index-test.js
@@ -25,7 +25,6 @@ module('Integration | Component | hds/tag/index', function (hooks) {
     assert.dom('button.hds-tag__dismiss').doesNotExist();
   });
   test('it should render the "dismiss" button if a callback function is passed to the @onDismiss argument', async function (assert) {
-    assert.expect(2);
     this.set('NOOP', () => {});
     await render(hbs`<Hds::Tag @text="My tag" @onDismiss={{this.NOOP}} />`);
     assert.dom('button.hds-tag__dismiss').exists();


### PR DESCRIPTION
### :pushpin: Summary

While looking at how @KristinLBradley was writing integration tests, I noticed she didn't use `assert.expect(n)` in her tests, and this made me realize that probably we don't actually need them (they introduce a cost of maintenance when we add/remove one of the assertions in the tests).

Checking [the documentation](https://api.qunitjs.com/assert/expect/) seems it's mainly used with a zero value (_"indicates that a test may pass without making any assertions"_), so I have decided to open a PR to remove these declarations from the integration tests (where they were useless).

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed all the `assert.expect(n)` declarations in the integration tests (with the exception of the assertions tests, where they're actually needed)

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
