### PR TITLE
Fix source for `CodeBlock` in `Button` and `Stepper` documentation

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -182,12 +182,14 @@
     element.
   </p>
   {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" @isIconOnly={{true}} />
+      <Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" @isIconOnly=\{{true}} />
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" @isIconOnly={{true}} />
@@ -255,12 +257,14 @@
     by default.
   </p>
   {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Button @text="Copy to clipboard" @isFullWidth={{true}} />
+      <Hds::Button @text="Copy to clipboard" @isFullWidth=\{{true}} />
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Button @text="Copy to clipboard" @isFullWidth={{true}} />

--- a/packages/components/tests/dummy/app/templates/components/stepper.hbs
+++ b/packages/components/tests/dummy/app/templates/components/stepper.hbs
@@ -96,98 +96,145 @@
     and
     <code class="dummy-code">task</code>
     which can be used in conjunction, or separately depending on hierarchical needs or requirements.</p>
+
   <h4 class="dummy-h4">Stepper::Step::Indicator</h4>
   <h5 class="dummy-h5">Basic use</h5>
+  {{! prettier-ignore-start }}
   <CodeBlock
     @language="markup"
     @code='
       <Hds::Stepper::Step::Indicator @text="1" @status="incomplete" />
     '
   />
+  {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Stepper::Step::Indicator @text="1" @status="incomplete" />
+
   <h5 class="dummy-h5">Adding interactivity</h5>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Stepper::Step::Indicator @text="1" @status="incomplete" @isInteractive={{true}} />
+      <Hds::Stepper::Step::Indicator @text="1" @status="incomplete" @isInteractive=\{{true}} />
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Stepper::Step::Indicator @text="1" @status="incomplete" @isInteractive={{true}} />
+
   <h5 class="dummy-h5">Indicating status</h5>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Stepper::Step::Indicator @text="1" @status="progress" @isInteractive={{true}} />
+      <Hds::Stepper::Step::Indicator @text="1" @status="progress" @isInteractive=\{{true}} />
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Stepper::Step::Indicator @text="1" @status="progress" @isInteractive={{true}} />
+
   <h5 class="dummy-h5">Indicating processing</h5>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Stepper::Step::Indicator @text="1" @status="processing" @isInteractive={{true}} />
+      <Hds::Stepper::Step::Indicator @text="1" @status="processing" @isInteractive=\{{true}} />
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Stepper::Step::Indicator @text="1" @status="processing" @isInteractive={{true}} />
+
   <h5 class="dummy-h5">Rendering a complete step</h5>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Stepper::Step::Indicator @text="1" @status="complete" @isInteractive={{true}} />
+      <Hds::Stepper::Step::Indicator @text="1" @status="complete" @isInteractive=\{{true}} />
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Stepper::Step::Indicator @text="1" @status="complete" @isInteractive={{true}} />
+
   <h4 class="dummy-h4">Stepper::Task::Indicator</h4>
   <h5 class="dummy-h5">Basic use</h5>
+  {{! prettier-ignore-start }}
   <CodeBlock
     @language="markup"
     @code='
       <Hds::Stepper::Task::Indicator @status="incomplete" />
     '
   />
+  {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Stepper::Task::Indicator @status="incomplete" />
+
   <h5 class="dummy-h5">Adding interactivity</h5>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Stepper::Task::Indicator @status="incomplete" @isInteractive={{true}} />
+      <Hds::Stepper::Task::Indicator @status="incomplete" @isInteractive=\{{true}} />
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Stepper::Task::Indicator @status="incomplete" @isInteractive={{true}} />
+
   <h5 class="dummy-h5">Indicating status</h5>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Stepper::Task::Indicator @status="progress" @isInteractive={{true}} />
+      <Hds::Stepper::Task::Indicator @status="progress" @isInteractive=\{{true}} />
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Stepper::Task::Indicator @status="progress" @isInteractive={{true}} />
+
   <h5 class="dummy-h5">Indicating processing</h5>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Stepper::Task::Indicator @status="processing" @isInteractive={{true}} />
+      <Hds::Stepper::Task::Indicator @status="processing" @isInteractive=\{{true}} />
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Stepper::Task::Indicator @status="processing" @isInteractive={{true}} />
+
   <h5 class="dummy-h5">Rendering a complete task</h5>
+  {{! prettier-ignore-start }}
+  {{! template-lint-disable no-unbalanced-curlies }}
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Stepper::Task::Indicator @status="complete" @isInteractive={{true}} />
+      <Hds::Stepper::Task::Indicator @status="complete" @isInteractive=\{{true}} />
     '
   />
+  {{! template-lint-enable no-unbalanced-curlies }}
+  {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Stepper::Task::Indicator @status="complete" @isInteractive={{true}} />
+
 </section>
 
 <section>


### PR DESCRIPTION
### :pushpin: Summary

While working on the conversion from HTML/HBS to Markdown for the new website, the script triggered some errors because in some cases the `@code` argument of the `<CodeBlock>` was interpreted as Ember code, not a string (the `{{` were not escaped).

### :hammer_and_wrench: Detailed description

In this PR I have:
- fixed the source for CodeBlock in `Button` and `Stepper` documentation

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
