### PR TITLE
Replace `CodeBlock` to visualize variables with a custom "dummy" component

### DIFF
--- a/packages/components/tests/dummy/app/components/dummy-vars-list/index.hbs
+++ b/packages/components/tests/dummy/app/components/dummy-vars-list/index.hbs
@@ -1,0 +1,8 @@
+<ul class="dummy-vars-list">
+  {{#each @items as |item|}}
+    <li class="dummy-vars-list__item">
+      <code>{{item}}</code>
+      <CopyButton @clipboardText="{{item}}">Copy</CopyButton>
+    </li>
+  {{/each}}
+</ul>

--- a/packages/components/tests/dummy/app/controllers/foundations/elevation.js
+++ b/packages/components/tests/dummy/app/controllers/foundations/elevation.js
@@ -4,25 +4,23 @@ import { ELEVATIONS, SURFACES } from '../../routes/foundations/elevation';
 
 export default class ElevationController extends Controller {
   get cssVariables() {
-    const cssVariables = [];
+    const cssVariables = { elevations: [], surfaces: [] };
     ELEVATIONS.forEach((elevation) => {
-      cssVariables.push(`--hds-elevation-${elevation}-box-shadow`);
+      cssVariables.elevations.push(`--hds-elevation-${elevation}-box-shadow`);
     });
-    cssVariables.push('');
     SURFACES.forEach((surface) => {
-      cssVariables.push(`--hds-surface-${surface}-box-shadow`);
+      cssVariables.surfaces.push(`--hds-surface-${surface}-box-shadow`);
     });
-    return `${cssVariables.join('\n')}`;
+    return cssVariables;
   }
   get cssHelpers() {
-    const cssHelpers = [];
+    const cssHelpers = { elevations: [], surfaces: [] };
     ELEVATIONS.forEach((elevation) => {
-      cssHelpers.push(`.hds-elevation-${elevation}`);
+      cssHelpers.elevations.push(`.hds-elevation-${elevation}`);
     });
-    cssHelpers.push('');
     SURFACES.forEach((surface) => {
-      cssHelpers.push(`.hds-surface-${surface}`);
+      cssHelpers.surfaces.push(`.hds-surface-${surface}`);
     });
-    return `${cssHelpers.join('\n')}`;
+    return cssHelpers;
   }
 }

--- a/packages/components/tests/dummy/app/controllers/foundations/typography.js
+++ b/packages/components/tests/dummy/app/controllers/foundations/typography.js
@@ -22,19 +22,21 @@ export default class TypographyController extends Controller {
   get stylesCombinations() {
     return STYLES_COMBINATIONS;
   }
-  get csshelpers() {
-    const helpers = [];
+  get cssHelpers() {
+    const cssHelpers = {
+      families: [],
+      weights: [],
+      styles: [],
+    };
     this.families.forEach((family) => {
-      helpers.push(`.hds-font-family-${family}`);
+      cssHelpers.families.push(`.hds-font-family-${family}`);
     });
-    helpers.push('');
     this.weights.forEach((weight) => {
-      helpers.push(`.hds-font-weight-${weight}`);
+      cssHelpers.weights.push(`.hds-font-weight-${weight}`);
     });
-    helpers.push('');
     this.styles.forEach((style) => {
-      helpers.push(`.hds-typography-${style}`);
+      cssHelpers.styles.push(`.hds-typography-${style}`);
     });
-    return `${helpers.join('\n')}`;
+    return cssHelpers;
   }
 }

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -44,6 +44,7 @@
 @import "./components/dummy-placeholder";
 @import "./components/dummy-sidebar";
 @import "./components/dummy-stepper-indicator-banner.scss";
+@import "./components/dummy-vars-list";
 
 *,
 *:before,

--- a/packages/components/tests/dummy/app/styles/components/dummy-vars-list.scss
+++ b/packages/components/tests/dummy/app/styles/components/dummy-vars-list.scss
@@ -1,0 +1,36 @@
+// DUMMY VARS LIST
+
+.dummy-vars-list {
+  margin: 1.5rem 0;
+  padding: 1rem;
+  list-style: none;
+  background: var(--background);
+  background: #f5f5f5;
+  border-radius: 0.5rem;
+}
+
+.dummy-vars-list__item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
+  & + & {
+    margin-top: 0.5rem;
+  }
+
+  code {
+    font-weight: 700;
+    font-size: 0.9rem;
+    font-family: monaco, Consolas, "Lucida Console", monospace;
+    line-height: 24px;
+  }
+
+  button {
+    visibility: hidden;
+    cursor: pointer;
+  }
+
+  &:hover button {
+    visibility: visible;
+  }
+}

--- a/packages/components/tests/dummy/app/templates/foundations/elevation.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations/elevation.hbs
@@ -28,9 +28,8 @@
   />
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">These are the <strong>CSS variables</strong> that you can use:</p>
-  {{! prettier-ignore-start }}
-  <CodeBlock @language="css" @code={{this.cssVariables}} />
-  {{! prettier-ignore-end }}
+  <DummyVarsList @items={{this.cssVariables.elevations}} />
+  <DummyVarsList @items={{this.cssVariables.surfaces}} />
   <p class="dummy-paragraph"><strong>🚨 IMPORTANT: 🚨</strong></p>
   <ul>
     <li class="dummy-paragraph">the "elevation" and "surface" CSS variables can be used
@@ -54,9 +53,8 @@
   />
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">These are the <strong>CSS helper classes</strong> that you can use:</p>
-  {{! prettier-ignore-start }}
-  <CodeBlock @language="css" @code={{this.cssHelpers}} />
-  {{! prettier-ignore-end }}
+  <DummyVarsList @items={{this.cssHelpers.elevations}} />
+  <DummyVarsList @items={{this.cssHelpers.surfaces}} />
   <p class="dummy-paragraph">To use this classes you have to import the CSS file
     <code class="dummy-code">[products|devdot]/css/helpers/elevation.css</code>
     from the

--- a/packages/components/tests/dummy/app/templates/foundations/typography.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations/typography.hbs
@@ -92,9 +92,9 @@
   />
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">These are the <strong>CSS helper classes</strong> that you can use:</p>
-  {{! prettier-ignore-start }}
-  <CodeBlock @language="css" @code={{this.csshelpers}} />
-  {{! prettier-ignore-end }}
+  <DummyVarsList @items={{this.cssHelpers.families}} />
+  <DummyVarsList @items={{this.cssHelpers.weights}} />
+  <DummyVarsList @items={{this.cssHelpers.styles}} />
   <p class="dummy-paragraph">To use this classes you have to import the CSS file
     <code class="dummy-code">[products|devdot]/css/helpers/typography.css</code>
     from the


### PR DESCRIPTION
### :pushpin: Summary

While working on the migration from HTML to Markdown for the new website, I had issues converting the “Typography” and “Elevation” documentation pages because they were using the `<CodeBlock>` component to visualize the list of css helpers and variables. 

I have decided the best way to unblock my progress was to create a new "dummy" custom component, to show a list of variables in a web page.

As a bonus, now the variables can be copied by the users, as asked in the recent survey run by @heatherlarsen.

### :hammer_and_wrench: Detailed description

In this PR I have:
- introduced a new "dummy" component to list `vars` strings and copy them 
- replaced the `CodeBlock` elements in “Typography” and “Elevation” documentation pages with this list

**Before:**
- https://design-system-components-hashicorp.vercel.app/foundations/typography
- https://design-system-components-hashicorp.vercel.app/foundations/elevation

**After**
- https://hds-components-git-remove-codeblock-in-typogra-1fc591-hashicorp.vercel.app/foundations/typography
- https://hds-components-git-remove-codeblock-in-typogra-1fc591-hashicorp.vercel.app/foundations/elevation

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
