### PR TITLE
Fix missing closing curly bracket in doc file

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -789,7 +789,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Form::Select::Base aria-label="Target infrastructure" @isRequired=\{{true} \{{on "blur" myAction}} as |S|>
+      <Hds::Form::Select::Base aria-label="Target infrastructure" @isRequired=\{{true}} \{{on "blur" myAction}} as |S|>
         <S.Options>
           <option value="Kubernetes">Kubernetes</option>
           <option value="Other">Other</option>


### PR DESCRIPTION
### :hammer_and_wrench: Detailed description

In this PR I have:
- fixed a missing closing curly bracket in a doc file that was causing issues in the conversion to markdown

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
