### PR TITLE
Fixed invocation of `Hds::Toast` with `onDismiss` argument missing the `@` prefix

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/toast.hbs
+++ b/packages/components/tests/dummy/app/templates/components/toast.hbs
@@ -248,7 +248,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Toast @color="success" onDismiss=\{{...}} as |T|>
+      <Hds::Toast @color="success" @onDismiss=\{{...}} as |T|>
         <T.Title>Title here</T.Title>
         <T.Description>
           The description can contain
@@ -266,7 +266,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast @color="success" onDismiss={{this.noop}} as |T|>
+  <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
     <T.Title>Title here</T.Title>
     <T.Description>
       The description can contain
@@ -295,7 +295,7 @@
   <CodeBlock
     @language="markup"
     @code='
-      <Hds::Toast @color="success" onDismiss=\{{...}} as |T|>
+      <Hds::Toast @color="success" @onDismiss=\{{...}} as |T|>
         <T.Title>Title here</T.Title>
         <T.Description>First line of description.</T.Description>
         <T.Description>Second line of description.</T.Description>
@@ -305,7 +305,7 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <p class="dummy-paragraph">Renders to:</p>
-  <Hds::Toast @color="success" onDismiss={{this.noop}} as |T|>
+  <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
     <T.Title>Title here</T.Title>
     <T.Description>First line of description.</T.Description>
     <T.Description>Second line of description.</T.Description>

--- a/packages/components/tests/dummy/app/templates/components/toast.hbs
+++ b/packages/components/tests/dummy/app/templates/components/toast.hbs
@@ -329,7 +329,7 @@
         <T.Description>Description here</T.Description>
         <T.Generic>
           [your content here]
-        </T.generic>
+        </T.Generic>
       </Hds::Toast>
     "
   />


### PR DESCRIPTION

### :pushpin: Summary

While working on the migration of the Markdown documentation files, I noticed that in the `Toast` documentation page there were some declarations of the `Toast` component with an `onDismiss` argument that was missing the `@` prefix.

### :hammer_and_wrench: Detailed description

In this PR I have:
- fixed invocation of `Hds::Toast` with `onDismiss` argument missing the `@` prefix in the `Toast` documentation page
  - in doing so, I have also fixed a wrong case in a closing tag name

***

### 👀 How to review

👉 Review by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
