### PR TITLE
explicitly add ember-style-modifiers as a dependency

### DIFF
--- a/.changeset/rich-pillows-bake.md
+++ b/.changeset/rich-pillows-bake.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+explicitly add ember-style-modifiers as a dependency

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,6 +44,7 @@
     "ember-cli-sass": "^10.0.1",
     "ember-keyboard": "^8.1.0",
     "ember-named-blocks-polyfill": "^0.2.5",
+    "ember-style-modifier": "^0.8.0",
     "ember-truth-helpers": "^3.0.0",
     "sass": "^1.43.4"
   },
@@ -77,7 +78,6 @@
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.7.0",
     "ember-source-channel-url": "^3.0.0",
-    "ember-style-modifier": "^0.8.0",
     "ember-template-lint": "^4.14.0",
     "ember-template-lint-plugin-prettier": "^4.0.0",
     "ember-try": "^2.0.0",


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
explicitly add ember-style-modifiers as a dependency as we use this functionality directly in our addon code

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

This is another case where it was working by accident as this is a common dependency of other addons that apps like HCP already rely on

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
