### PR TITLE
don't attempt to replaceMockStates in fastboot mode

### DIFF
--- a/website/app/controllers/application.js
+++ b/website/app/controllers/application.js
@@ -22,6 +22,7 @@ function replaceMockStates() {
 
 export default class ComponentsController extends Controller {
   @service router;
+  @service fastboot;
 
   constructor() {
     super(...arguments);
@@ -29,7 +30,9 @@ export default class ComponentsController extends Controller {
   }
 
   routeDidChange() {
-    scheduleOnce('afterRender', this, replaceMockStates);
+    if (!this.fastboot.isFastBoot) {
+      scheduleOnce('afterRender', this, replaceMockStates);
+    }
   }
 
   willDestroy() {


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

don't attempt to replaceMockStates in fastboot mode

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

Leverages the [fastboot service](https://ember-fastboot.com/docs/user-guide#the-fastboot-service) to not attempt to run code that access `document` if we are in fastboot mode. Can be verified running the app locally and not seeing the errors in the console. 

https://hashicorp.atlassian.net/browse/HDS-771

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
