### PR TITLE
[Table] add example of badge in th cell

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -329,7 +329,7 @@ export default class ComponentsTableRoute extends Route {
   <Hds::Table @model={{this.model.data}}>
     <:head>
       <Hds::Table::Tr>
-        <Hds::Table::Th>Artist</Hds::Table::Th>
+        <Hds::Table::Th>Artist <Hds::Badge @text="New" @color="success" @type="outlined" /></Hds::Table::Th>
         <Hds::Table::Th>Album</Hds::Table::Th>
         <Hds::Table::Th>Release Year</Hds::Table::Th>
       </Hds::Table::Tr>

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -329,7 +329,8 @@ export default class ComponentsTableRoute extends Route {
   <Hds::Table @model={{this.model.data}}>
     <:head>
       <Hds::Table::Tr>
-        <Hds::Table::Th>Artist <Hds::Badge @text="New" @color="success" @type="outlined" /></Hds::Table::Th>
+        <Hds::Table::Th>Artist
+          <Hds::Badge @text="New" @color="success" @type="outlined" @size="small" /></Hds::Table::Th>
         <Hds::Table::Th>Album</Hds::Table::Th>
         <Hds::Table::Th>Release Year</Hds::Table::Th>
       </Hds::Table::Tr>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds an example of a badge in a `th` element. 

### :camera_flash: Screenshots

![CleanShot 2022-10-20 at 11 16 33](https://user-images.githubusercontent.com/4587451/197003278-aa03f014-af31-4c71-b43d-cf541e1aaaa2.png)

@jorytindall We'll need to look at the design since it doesn't pass color contrast: 
![CleanShot 2022-10-20 at 11 14 48](https://user-images.githubusercontent.com/4587451/197003130-4cb38d26-f69b-4ffe-be6c-282bb29dcce0.png)

### :link: External links


### 👀 How to review
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
