### PR TITLE
resolve @ember/render-modifiers to ^2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "release": "yarn changeset publish",
     "version": "yarn changeset version && yarn install --mode update-lockfile"
   },
-  "packageManager": "yarn@3.2.4"
+  "packageManager": "yarn@3.2.4",
+  "resolutions": {
+    "@ember/render-modifiers": "^2.0.0"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,17 +2052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ember/render-modifiers@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@ember/render-modifiers@npm:1.0.2"
-  dependencies:
-    ember-cli-babel: ^7.10.0
-    ember-modifier-manager-polyfill: ^1.1.0
-  checksum: 74220450d3a8635f1ce6c3d9ce5d7f4d8e7336e48a20b1e28b6acf9f671f0938855dff60a06eb1ad5700fadb42e2c0ffa3adef404788966da99db8ab393e9944
-  languageName: node
-  linkType: hard
-
-"@ember/render-modifiers@npm:^1.0.2 || ^2.0.0, @ember/render-modifiers@npm:^2.0.0, @ember/render-modifiers@npm:^2.0.4":
+"@ember/render-modifiers@npm:^2.0.0":
   version: 2.0.4
   resolution: "@ember/render-modifiers@npm:2.0.4"
   dependencies:
@@ -9821,7 +9811,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-modifier-manager-polyfill@npm:^1.1.0, ember-modifier-manager-polyfill@npm:^1.2.0":
+"ember-modifier-manager-polyfill@npm:^1.2.0":
   version: 1.2.0
   resolution: "ember-modifier-manager-polyfill@npm:1.2.0"
   dependencies:


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
This change forces the monorepo to use a 2.x version of the `@ember/render-modifiers` package to work around an issue blocking the `{{did-insert}}` helper from working correctly in the new website.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

The website project relies on `field-guide` which has a dependency on `ember-prism` which has a dependency on an old `1.x` version of `@ember/render-modifiers`. That version has logic to do a "capabilities" check to see if the current version of Ember is 3.13 which breaks when used in our newer website app. This logic [was removed](https://github.com/emberjs/ember-render-modifiers/commit/9d6b718a08d58be0418d055039657fbf993ea4b8) and `ember-prism` [has been updated to use this](https://github.com/shipshapecode/ember-prism/pull/375), however, upgrading ember-prism in field-guide [has not happened yet](https://github.com/empress/field-guide/pull/46).

This PR leverages yarn's resolution feature to force the issue and only use the lastest version of `@ember/render-modifiers` within the monorepo.

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

![image](https://user-images.githubusercontent.com/1672302/197608610-a10922c1-b105-4686-91b6-451151920c67.png)

#### Before

```bash
~/c/w/design-system (new-docs-website/spike-html-to-markdown↑19↓208|●3✚1) $ yarn why @ember/render-modifiers
├─ ember-basic-dropdown@npm:6.0.1
│  └─ @ember/render-modifiers@npm:2.0.4 [411b6] (via npm:^1.0.2 || ^2.0.0 [411b6])
│
├─ ember-cli-clipboard@npm:0.16.0
│  └─ @ember/render-modifiers@npm:2.0.4 [411b6] (via npm:^1.0.2 || ^2.0.0 [411b6])
│
├─ ember-prism@npm:0.10.0
│  └─ @ember/render-modifiers@npm:1.0.2 (via npm:^1.0.2)
│
└─ ember-prism@npm:0.12.0
   └─ @ember/render-modifiers@npm:2.0.4 [411b6] (via npm:^1.0.2 || ^2.0.0 [411b6])
```

#### After
```bash
~/c/w/design-system (br-render|✔) $ yarn why @ember/render-modifiers
├─ ember-basic-dropdown@npm:6.0.1
│  └─ @ember/render-modifiers@npm:2.0.4 [411b6] (via npm:^2.0.0 [411b6])
│
├─ ember-cli-clipboard@npm:0.16.0
│  └─ @ember/render-modifiers@npm:2.0.4 [411b6] (via npm:^2.0.0 [411b6])
│
├─ ember-prism@npm:0.10.0
│  └─ @ember/render-modifiers@npm:2.0.4 [411b6] (via npm:^2.0.0 [411b6])
│
└─ ember-prism@npm:0.12.0
   └─ @ember/render-modifiers@npm:2.0.4 [411b6] (via npm:^2.0.0 [411b6])
```


### :link: External links

* https://hashicorp.atlassian.net/browse/HDS-772

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
