### PR TITLE
[Table] Adds support for table density

### DIFF
--- a/packages/components/addon/components/hds/table/index.js
+++ b/packages/components/addon/components/hds/table/index.js
@@ -87,7 +87,7 @@ export default class HdsTableIndexComponent extends Component {
 
     // add a class based on the @density argument
     if (this.density) {
-      classes.push(`hds-table--${this.density}`);
+      classes.push(`hds-table--density-${this.density}`);
     }
 
     return classes.join(' ');

--- a/packages/components/addon/components/hds/table/index.js
+++ b/packages/components/addon/components/hds/table/index.js
@@ -52,12 +52,11 @@ export default class HdsTableIndexComponent extends Component {
     return this.args.isStriped ?? true;
   }
 
-  // values are still being decided by design. For now, we'll use packed, default, and spacious.
   /**
    * @param density
    * @type {string}
-   * @default 'default'
-   * @description Determines the density of the table cells; defaults to 'default'.
+   * @default 'medium'
+   * @description Determines the density of the table cells; options are "short", "medium" and "tall". If no density is defined, "medium" is used.
    */
   get density() {
     let { density = DEFAULT_DENSITY } = this.args;

--- a/packages/components/addon/components/hds/table/index.js
+++ b/packages/components/addon/components/hds/table/index.js
@@ -48,6 +48,17 @@ export default class HdsTableIndexComponent extends Component {
     return this.args.isStriped ?? true;
   }
 
+  // values are still being decided by design. For now, we'll use packed, medium, and spacious. We've suggested "size" like we use for some of the other components like the button.
+  /**
+   * @param density
+   * @type {string}
+   * @default 'default'
+   * @description Determines the density of the table cells; defaults to 'medium'.
+   */
+  get density() {
+    return this.args.density ?? 'default';
+  }
+
   /**
    * Get the class names to apply to the component.
    * @method classNames
@@ -59,6 +70,11 @@ export default class HdsTableIndexComponent extends Component {
     // add a class based on the @isStriped argument
     if (this.isStriped) {
       classes.push('hds-table--striped');
+    }
+
+    // add a class based on the @density argument
+    if (this.density) {
+      classes.push(`hds-table--${this.density}`);
     }
 
     return classes.join(' ');

--- a/packages/components/addon/components/hds/table/index.js
+++ b/packages/components/addon/components/hds/table/index.js
@@ -3,8 +3,8 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 
-const DENSITIES = ['packed', 'default', 'spacious'];
-const DEFAULT_DENSITY = 'default';
+const DENSITIES = ['short', 'medium', 'tall'];
+const DEFAULT_DENSITY = 'medium';
 
 export default class HdsTableIndexComponent extends Component {
   @tracked sortBy = this.args.sortBy;

--- a/packages/components/addon/components/hds/table/index.js
+++ b/packages/components/addon/components/hds/table/index.js
@@ -1,6 +1,10 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { assert } from '@ember/debug';
+
+const DENSITIES = ['packed', 'default', 'spacious'];
+const DEFAULT_DENSITY = 'default';
 
 export default class HdsTableIndexComponent extends Component {
   @tracked sortBy = this.args.sortBy;
@@ -48,15 +52,24 @@ export default class HdsTableIndexComponent extends Component {
     return this.args.isStriped ?? true;
   }
 
-  // values are still being decided by design. For now, we'll use packed, medium, and spacious. We've suggested "size" like we use for some of the other components like the button.
+  // values are still being decided by design. For now, we'll use packed, default, and spacious.
   /**
    * @param density
    * @type {string}
    * @default 'default'
-   * @description Determines the density of the table cells; defaults to 'medium'.
+   * @description Determines the density of the table cells; defaults to 'default'.
    */
   get density() {
-    return this.args.density ?? 'default';
+    let { density = DEFAULT_DENSITY } = this.args;
+
+    assert(
+      `@density for "Hds::Table" must be one of the following: ${DENSITIES.join(
+        ', '
+      )}; received: ${density}`,
+      DENSITIES.includes(density)
+    );
+
+    return density;
   }
 
   /**

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -16,8 +16,38 @@
 
 .hds-table--striped {
   tbody {
-    tr:nth-child(odd) {
+    tr:nth-child(even) {
       background-color: var(--token-color-surface-faint);
+    }
+  }
+}
+
+.hds-table--packed {
+  tbody {
+    tr {
+      td {
+        padding: 4px 16px;
+      }
+    }
+  }
+}
+
+.hds-table--default {
+  tbody {
+    tr {
+      td {
+        padding: 12px 16px;
+      }
+    }
+  }
+}
+
+.hds-table--spacious {
+  tbody {
+    tr {
+      td {
+        padding: 20px 16px;
+      }
     }
   }
 }
@@ -25,23 +55,25 @@
 .hds-table__thead {
   border-bottom: 1px solid var(--token-color-border-primary);
 
-  th {
+  .hds-table__th,
+  .hds-table__th-sort {
     padding: 8px 16px;
     color: var(--token-color-foreground-strong);
     font-weight: var(--token-typography-font-weight-semibold);
     text-align: left;
     background-color: var(--token-color-surface-strong);
+  }
 
-    &.hds-table__th-sort {
-      padding: 0; // we're taking it out here because we need it on the interactive content instead
-    }
+  .hds-table__th-sort {
+    padding: 0; // we're taking it out here because we need it on the interactive content instead
 
-    button { // will refactor this to a button. Use Hds::Button?
+    button {
       display: flex;
       align-items: center;
       width: 100%;
       padding: 8px 16px;
       color: var(--token-color-foreground-strong);
+      font-weight: var(--token-typography-font-weight-semibold);
       text-decoration: none;
       background-color: transparent;
       border: 3px solid transparent;
@@ -53,6 +85,7 @@
       &:hover {
         color: var(--token-color-foreground-strong);
         background-color: var(--token-color-palette-neutral-200);
+        cursor: pointer;
       }
 
       &:focus,
@@ -68,7 +101,7 @@
 
       svg { // in case they don't use flight icons
         margin-left: 8px;
-        color: var(--token-color-focus-action-external);
+        color: var(--token-color-foreground-action);
       }
     }
   }
@@ -79,11 +112,7 @@
   font-weight: var(--token-typography-font-weight-regular);
   background-color: var(--token-color-surface-primary);
 
-  tr {
+  .hds-table__tr {
     border-bottom: 1px solid var(--token-color-border-primary);
-  }
-
-  td {
-    padding: 12px 16px;
   }
 }

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -23,16 +23,16 @@
   }
 }
 
-.hds-table--density-packed td {
+.hds-table--density-short td {
   padding: 4px 16px;
 }
 
 
-.hds-table--density-default td {
+.hds-table--density-medium td {
   padding: 12px 16px;
 }
 
-.hds-table--density-spacious td {
+.hds-table--density-tall td {
   padding: 20px 16px;
 }
 

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -8,6 +8,7 @@
   font-size: var(--token-typography-body-200-font-size);
   font-family: var(--token-typography-font-stack-text);
   line-height: var(--token-typography-body-200-line-height);
+  table-layout: fixed;
   border: 1px solid var(--token-color-border-primary);
   border-radius: 6px;
   border-collapse: collapse;

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -40,9 +40,12 @@
 
   .hds-table__th,
   .hds-table__th-sort {
+    height: 48px;
     padding: 8px 16px;
     color: var(--token-color-foreground-strong);
     font-weight: var(--token-typography-font-weight-semibold);
+    font-size: 14px;
+    line-height: 1.4;
     text-align: left;
     background-color: var(--token-color-surface-strong);
   }
@@ -54,9 +57,12 @@
       display: flex;
       align-items: center;
       width: 100%;
+      height: 100%;
       padding: 8px 16px;
       color: var(--token-color-foreground-strong);
       font-weight: var(--token-typography-font-weight-semibold);
+      font-size: 14px;
+      line-height: 1.4;
       text-decoration: none;
       background-color: transparent;
       border: 3px solid transparent;

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -22,34 +22,17 @@
   }
 }
 
-.hds-table--packed {
-  tbody {
-    tr {
-      td {
-        padding: 4px 16px;
-      }
-    }
-  }
+.hds-table--density-packed td {
+  padding: 4px 16px;
 }
 
-.hds-table--default {
-  tbody {
-    tr {
-      td {
-        padding: 12px 16px;
-      }
-    }
-  }
+
+.hds-table--density-default td {
+  padding: 12px 16px;
 }
 
-.hds-table--spacious {
-  tbody {
-    tr {
-      td {
-        padding: 20px 16px;
-      }
-    }
-  }
+.hds-table--density-spacious td {
+  padding: 20px 16px;
 }
 
 .hds-table__thead {

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -343,6 +343,44 @@ export default class ComponentsTableRoute extends Route {
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
+    Static table styled as "packed"
+  </h4>
+  <Hds::Table @model={{this.model.data}} @density="packed">
+    <:head>
+      <Hds::Table::Tr>
+        <Hds::Table::Th>Artist</Hds::Table::Th>
+        <Hds::Table::Th>Album</Hds::Table::Th>
+        <Hds::Table::Th>Release Year</Hds::Table::Th>
+      </Hds::Table::Tr>
+    </:head>
+    <:body as |data|>
+      <Hds::Table::Tr>
+        <td>{{data.artist}}</td>
+        <td>{{data.album}}</td>
+        <td>{{data.year}}</td>
+      </Hds::Table::Tr>
+    </:body>
+  </Hds::Table>
+  <h4 class="dummy-h4">
+    Static table styled as "spacious"
+  </h4>
+  <Hds::Table @model={{this.model.data}} @density="spacious">
+    <:head>
+      <Hds::Table::Tr>
+        <Hds::Table::Th>Artist</Hds::Table::Th>
+        <Hds::Table::Th>Album</Hds::Table::Th>
+        <Hds::Table::Th>Release Year</Hds::Table::Th>
+      </Hds::Table::Tr>
+    </:head>
+    <:body as |data|>
+      <Hds::Table::Tr>
+        <td>{{data.artist}}</td>
+        <td>{{data.album}}</td>
+        <td>{{data.year}}</td>
+      </Hds::Table::Tr>
+    </:body>
+  </Hds::Table>
+  <h4 class="dummy-h4">
     Static table with no model defined
   </h4>
   <Hds::Table>

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -343,9 +343,9 @@ export default class ComponentsTableRoute extends Route {
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
-    Static table styled as "packed"
+    Static table with density set to "short"
   </h4>
-  <Hds::Table @model={{this.model.data}} @density="packed">
+  <Hds::Table @model={{this.model.data}} @density="short">
     <:head>
       <Hds::Table::Tr>
         <Hds::Table::Th>Artist</Hds::Table::Th>
@@ -362,9 +362,9 @@ export default class ComponentsTableRoute extends Route {
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
-    Static table styled as "spacious"
+    Static table with density set to "tall"
   </h4>
-  <Hds::Table @model={{this.model.data}} @density="spacious">
+  <Hds::Table @model={{this.model.data}} @density="tall">
     <:head>
       <Hds::Table::Tr>
         <Hds::Table::Th>Artist</Hds::Table::Th>

--- a/packages/components/tests/integration/components/hds/table/index-test.js
+++ b/packages/components/tests/integration/components/hds/table/index-test.js
@@ -18,7 +18,12 @@ module('Integration | Component | hds/table/index', function (hooks) {
 
   test('it should render with a CSS class appropriate for the @density value', async function (assert) {
     await render(hbs`<Hds::Table @density="packed" />`);
-    assert.dom('[data-test-table]').hasClass('hds-table--packed');
+    assert.dom('[data-test-table]').hasClass('hds-table--density-packed');
+  });
+
+  test('it should render with a CSS class appropriate if no @density value is set', async function (assert) {
+    await render(hbs`<Hds::Table />`);
+    assert.dom('[data-test-table]').hasClass('hds-table--density-default');
   });
 
   test('it should support splattributes', async function (assert) {

--- a/packages/components/tests/integration/components/hds/table/index-test.js
+++ b/packages/components/tests/integration/components/hds/table/index-test.js
@@ -17,13 +17,13 @@ module('Integration | Component | hds/table/index', function (hooks) {
   });
 
   test('it should render with a CSS class appropriate for the @density value', async function (assert) {
-    await render(hbs`<Hds::Table @density="packed" />`);
-    assert.dom('[data-test-table]').hasClass('hds-table--density-packed');
+    await render(hbs`<Hds::Table @density="short" />`);
+    assert.dom('[data-test-table]').hasClass('hds-table--density-short');
   });
 
   test('it should render with a CSS class appropriate if no @density value is set', async function (assert) {
     await render(hbs`<Hds::Table />`);
-    assert.dom('[data-test-table]').hasClass('hds-table--density-default');
+    assert.dom('[data-test-table]').hasClass('hds-table--density-medium');
   });
 
   test('it should support splattributes', async function (assert) {

--- a/packages/components/tests/integration/components/hds/table/index-test.js
+++ b/packages/components/tests/integration/components/hds/table/index-test.js
@@ -16,6 +16,11 @@ module('Integration | Component | hds/table/index', function (hooks) {
     assert.dom('[data-test-table]').hasClass('hds-table');
   });
 
+  test('it should render with a CSS class appropriate for the @density value', async function (assert) {
+    await render(hbs`<Hds::Table @density="packed" />`);
+    assert.dom('[data-test-table]').hasClass('hds-table--packed');
+  });
+
   test('it should support splattributes', async function (assert) {
     await render(hbs`<Hds::Table id="test-table" />`);
     assert.dom('[data-test-table]').hasAttribute('id', 'test-table');


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds support for table density. Tracked internally with [HDS-816](https://hashicorp.atlassian.net/browse/HDS-814).

### :hammer_and_wrench: Detailed description

- added support for density. Current acceptable values are "packed", "default", and "spacious".
- added CSS classes for density
- added assertion if incorrect value is defined
- added test to make sure that correct class is applied if density is defined

➡️ ➡️ ➡️ **Note: there are some other small CSS fixes but the primary CSS update will come in a separate PR.** 

### :camera_flash: Screenshots

![CleanShot 2022-10-27 at 11 44 37](https://user-images.githubusercontent.com/4587451/198350138-f712686c-2600-43a9-a859-451cec58390b.png)

### 👀 How to review
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
