### PR TITLE
Update the `Hds::Button` style when rendered as a link

### DIFF
--- a/.changeset/hip-rings-care.md
+++ b/.changeset/hip-rings-care.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Update the `Hds::Button` style when rendered as a link

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -17,6 +17,7 @@ $hds-button-focus-border-width: 3px;
   justify-content: center;
   width: auto;
   font-family: var(--token-typography-font-stack-text);
+  text-decoration: none;
   border: $hds-button-border-width solid transparent; // We need this to be transparent for a11y
   border-radius: $hds-button-border-radius;
   outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
@@ -26,6 +27,16 @@ $hds-button-focus-border-width: 3px;
   // the <a> element behaves differently than a <button>
   @at-root a#{&} {
     width: fit-content;
+
+    // for more background on the use of underlining as defined below read the following document: https://docs.google.com/document/d/1acLxdRqmy92vQ8ArShPxoBFmAV0StsbZrqEic6MVt20
+    &:hover,
+    &:focus,
+    &:active,
+    &.mock-hover,
+    &.mock-focus,
+    &.mock-active {
+      text-decoration: underline;
+    }
   }
 
   // This covers all of the browsers and focus scenarios (due to the custom focus design).


### PR DESCRIPTION
### :pushpin: Summary

Update the `Hds::Button` style when rendered as a link.

### :hammer_and_wrench: Detailed description

Based on recent feedback [we decided](https://docs.google.com/document/d/1acLxdRqmy92vQ8ArShPxoBFmAV0StsbZrqEic6MVt20/edit) to set the link text to be underlined only when the anchor is in one of the following states: hover, focus, active.

### :camera_flash: Screenshots

<img width="753" alt="button-style-update" src="https://user-images.githubusercontent.com/788096/199030700-dd577d68-10c0-43f6-9678-156325490778.png">


### :link: External links

[Jira issue](https://hashicorp.atlassian.net/browse/HDS-810)

***

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
