### PR TITLE
Fix whitespace issue in `Link::Inline` and `Interactive` utility component

### DIFF
--- a/.changeset/moody-nails-buy.md
+++ b/.changeset/moody-nails-buy.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix whitespace issue in `Link::Inline` and `Interactive` utility component

--- a/packages/components/addon/components/hds/interactive/index.hbs
+++ b/packages/components/addon/components/hds/interactive/index.hbs
@@ -1,7 +1,8 @@
 {{! IMPORTANT: we removed the newlines before/after the yield to reduce the issues with unexpected whitespaces (see https://github.com/hashicorp/design-system/pull/231#issuecomment-1123502499) }}
+{{! IMPORTANT: we need to add "squishies" here (~) because otherwise the whitespace added by Ember becomes visible in the link (being an inline element) - See https://handlebarsjs.com/guide/expressions.html#whitespace-control }}
 {{! NOTICE: we can't support the direct use of the "href" HTML attribute via ...attributes in the <a> elements, because we need to rely on the "@href" Ember argument to differentiate between different types of generated output }}
-{{#if @route}}
-  {{#if this.isRouteExternal}}
+{{~#if @route~}}
+  {{~#if this.isRouteExternal~}}
     <LinkToExternal
       @current-when={{@current-when}}
       @models={{hds-link-to-models @model @models}}
@@ -10,7 +11,7 @@
       @route={{@route}}
       ...attributes
     >{{yield}}</LinkToExternal>
-  {{else}}
+  {{~else~}}
     <LinkTo
       @current-when={{@current-when}}
       @models={{hds-link-to-models @model @models}}
@@ -19,15 +20,13 @@
       @route={{@route}}
       ...attributes
     >{{yield}}</LinkTo>
-  {{/if}}
-{{else if @href}}
-  {{#if this.isHrefExternal}}
+  {{~/if~}}
+{{~else if @href~}}
+  {{~#if this.isHrefExternal~}}
     <a target="_blank" rel="noopener noreferrer" ...attributes href={{@href}} {{on "keyup" this.onKeyUp}}>{{yield}}</a>
-  {{else}}
+  {{~else~}}
     <a ...attributes href={{@href}} {{on "keyup" this.onKeyUp}}>{{yield}}</a>
-  {{/if}}
-{{else}}
-  <button type="button" ...attributes>
-    {{yield}}
-  </button>
-{{/if}}
+  {{~/if~}}
+{{~else~}}
+  <button type="button" ...attributes>{{yield}}</button>
+{{~/if~}}


### PR DESCRIPTION
### :pushpin: Summary

Fix whitespace issue in `Link::Inline` and `Interactive` utility component.

### :hammer_and_wrench: Detailed description

'Squishies' all the way. To make sure we're not leaving any whitespace behind, I added the designated whitespace control character `~` to all conditional statements in the `Hds::Interactive` template, with direct effects on the `Link::Inline` component. This would probably become the norm for any inline components in the library.

### :camera_flash: Screenshots

[Check visual regression diff in Percy 🦔](https://percy.io/HashiCorp/ds-components/builds/22655613/changed/1263124198?browser=firefox&browser_ids=30%2C31&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1280&widths=375%2C1280)

#### Before

<img width="1319" alt="Screenshot 2022-11-02 at 18 58 30" src="https://user-images.githubusercontent.com/788096/199578207-be0e3f35-b88b-4fcf-90fe-161a41e910af.png">


#### After

<img width="1318" alt="Screenshot 2022-11-02 at 18 58 15" src="https://user-images.githubusercontent.com/788096/199578218-545f1b62-791e-4ca7-862d-38f4e4e516b1.png">


### :link: External links

Addressing the issue flagged in https://github.com/hashicorp/design-system/pull/231#issuecomment-1123502499 and by @efgold [via Slack](https://hashicorp.slack.com/archives/C7KTUHNUS/p1667410562831179) and [via GitHub](https://github.com/hashicorp/design-system/issues/669)

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
