### PR TITLE
clarify ember support

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -9,8 +9,9 @@ A package containing the components for the HashiCorp Design System.
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.24 or above
-* Ember CLI v3.24 or above
+* Ember.js v3.28 or above
+  * Note: The library _should_ work with earlier versions of Ember, but we only test with Ember 3.28 and newer
+* Ember CLI v3.28 or above
 * Node.js v12 or above
 
 

--- a/packages/ember-flight-icons/README.md
+++ b/packages/ember-flight-icons/README.md
@@ -15,8 +15,9 @@ Goals:
 
 ## Compatibility
 
-* Ember.js v3.24 or above
-* Ember CLI v3.24 or above
+* Ember.js v3.28 or above
+  * Note: The library _should_ work with earlier versions of Ember, but we only test with Ember 3.28 and newer
+* Ember CLI v3.28 or above
 * Node.js v12 or above
 
 ## Installation and Usage


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
https://github.com/hashicorp/design-system/issues/662 noted that we specify support for Ember 3.24 when in reality our explicit support is for 3.28 and newer, with 3.24 more of a best effort. This PR makes a slight adjustment to the readmes to make that more clear.