### PR TITLE
update Ember to 4.8.1

### DIFF
--- a/flight-website/package.json
+++ b/flight-website/package.json
@@ -58,7 +58,7 @@
     "ember-prism": "^0.11.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~4.7.0",
+    "ember-source": "~4.8.1",
     "ember-template-lint": "^4.14.0",
     "ember-template-lint-plugin-prettier": "^4.0.0",
     "ember-test-selectors": "^6.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,7 +77,7 @@
     "ember-prism": "^0.12.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~4.7.0",
+    "ember-source": "~4.8.1",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^4.14.0",
     "ember-template-lint-plugin-prettier": "^4.0.0",

--- a/packages/ember-flight-icons/package.json
+++ b/packages/ember-flight-icons/package.json
@@ -60,7 +60,7 @@
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~4.7.0",
+    "ember-source": "~4.8.1",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^4.14.0",
     "ember-template-lint-plugin-prettier": "^4.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -56,7 +56,7 @@
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~4.7.0",
+    "ember-source": "~4.8.1",
     "ember-template-lint": "^4.14.0",
     "ember-truth-helpers": "^3.1.1",
     "eslint": "^7.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,7 +2856,7 @@ __metadata:
     ember-page-title: ^7.0.0
     ember-qunit: ^5.1.5
     ember-resolver: ^8.0.3
-    ember-source: ~4.7.0
+    ember-source: ~4.8.1
     ember-source-channel-url: ^3.0.0
     ember-template-lint: ^4.14.0
     ember-template-lint-plugin-prettier: ^4.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,7 +2772,7 @@ __metadata:
     ember-prism: ^0.12.0
     ember-qunit: ^5.1.5
     ember-resolver: ^8.0.3
-    ember-source: ~4.7.0
+    ember-source: ~4.8.1
     ember-source-channel-url: ^3.0.0
     ember-style-modifier: ^0.8.0
     ember-template-lint: ^4.14.0
@@ -10495,6 +10495,42 @@ __metadata:
     semver: ^7.3.7
     silent-error: ^1.1.1
   checksum: 9a8d022ae718c04a5595e8e423b4b74f36a20dc7d66fab05939e20c835a97e32ba6fa3b6056a8126d681c93c7d19b328d4f734c0fbbf87360abb69c4fe03f339
+  languageName: node
+  linkType: hard
+
+"ember-source@npm:~4.8.1":
+  version: 4.8.1
+  resolution: "ember-source@npm:4.8.1"
+  dependencies:
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/plugin-transform-block-scoping": ^7.16.0
+    "@ember/edition-utils": ^1.2.0
+    "@glimmer/vm-babel-plugins": 0.84.2
+    babel-plugin-debug-macros: ^0.3.4
+    babel-plugin-filter-imports: ^4.0.0
+    broccoli-concat: ^4.2.5
+    broccoli-debug: ^0.6.4
+    broccoli-file-creator: ^2.1.1
+    broccoli-funnel: ^3.0.8
+    broccoli-merge-trees: ^4.2.0
+    chalk: ^4.0.0
+    ember-auto-import: ^2.4.1
+    ember-cli-babel: ^7.26.11
+    ember-cli-get-component-path-option: ^1.0.0
+    ember-cli-is-package-missing: ^1.0.0
+    ember-cli-normalize-entity-name: ^1.0.0
+    ember-cli-path-utils: ^1.0.0
+    ember-cli-string-utils: ^1.1.0
+    ember-cli-typescript-blueprint-polyfill: ^0.1.0
+    ember-cli-version-checker: ^5.1.2
+    ember-router-generator: ^2.0.0
+    inflection: ^1.13.2
+    resolve: ^1.22.0
+    semver: ^7.3.7
+    silent-error: ^1.1.1
+  peerDependencies:
+    "@glimmer/component": ^1.1.2
+  checksum: 657d2550ba1e50099f19777482a20ffa9240574dc5b10db04de87660616db48ceb2e590f39b18ab514aac42094c2a6c9b6106398355cb2e4221e3ba32eb013b7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10464,40 +10464,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-source@npm:~4.7.0":
-  version: 4.7.0
-  resolution: "ember-source@npm:4.7.0"
-  dependencies:
-    "@babel/helper-module-imports": ^7.16.7
-    "@babel/plugin-transform-block-scoping": ^7.16.0
-    "@ember/edition-utils": ^1.2.0
-    "@glimmer/vm-babel-plugins": 0.84.2
-    babel-plugin-debug-macros: ^0.3.4
-    babel-plugin-filter-imports: ^4.0.0
-    broccoli-concat: ^4.2.5
-    broccoli-debug: ^0.6.4
-    broccoli-file-creator: ^2.1.1
-    broccoli-funnel: ^3.0.8
-    broccoli-merge-trees: ^4.2.0
-    chalk: ^4.0.0
-    ember-auto-import: ^2.4.1
-    ember-cli-babel: ^7.26.11
-    ember-cli-get-component-path-option: ^1.0.0
-    ember-cli-is-package-missing: ^1.0.0
-    ember-cli-normalize-entity-name: ^1.0.0
-    ember-cli-path-utils: ^1.0.0
-    ember-cli-string-utils: ^1.1.0
-    ember-cli-typescript-blueprint-polyfill: ^0.1.0
-    ember-cli-version-checker: ^5.1.2
-    ember-router-generator: ^2.0.0
-    inflection: ^1.13.2
-    resolve: ^1.22.0
-    semver: ^7.3.7
-    silent-error: ^1.1.1
-  checksum: 9a8d022ae718c04a5595e8e423b4b74f36a20dc7d66fab05939e20c835a97e32ba6fa3b6056a8126d681c93c7d19b328d4f734c0fbbf87360abb69c4fe03f339
-  languageName: node
-  linkType: hard
-
 "ember-source@npm:~4.8.1":
   version: 4.8.1
   resolution: "ember-source@npm:4.8.1"
@@ -12171,7 +12137,7 @@ __metadata:
     ember-prism: ^0.11.0
     ember-qunit: ^5.1.5
     ember-resolver: ^8.0.3
-    ember-source: ~4.7.0
+    ember-source: ~4.8.1
     ember-template-lint: ^4.14.0
     ember-template-lint-plugin-prettier: ^4.0.0
     ember-test-selectors: ^6.0.0
@@ -22566,7 +22532,7 @@ __metadata:
     ember-page-title: ^7.0.0
     ember-qunit: ^5.1.5
     ember-resolver: ^8.0.3
-    ember-source: ~4.7.0
+    ember-source: ~4.8.1
     ember-template-lint: ^4.14.0
     ember-truth-helpers: ^3.1.1
     eslint: ^7.32.0


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the version of Ember used. See blog post: https://blog.emberjs.com/ember-4-8-1-released/ 

### :hammer_and_wrench: Detailed description

- [x] components
- [x] ember-flight-icons
- [x] flight-website
- [x] website


Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
