### PR TITLE
[Table] Adds `caption` element support

### DIFF
--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -1,6 +1,8 @@
 <table class={{this.classNames}} ...attributes>
   {{#if this.isSortableTable}}
     <caption class="sr-only" aria-live="polite">{{this.sortedMessageText}}</caption>
+  {{else}}
+    <caption class="sr-only">{{@caption}}</caption>
   {{/if}}
   <thead class="hds-table__thead">
     {{#if this.isSortableTable}}

--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -1,6 +1,6 @@
 <table class={{this.classNames}} ...attributes>
   {{#if this.isSortableTable}}
-    <caption class="sr-only" aria-live="polite">{{this.sortedMessageText}}</caption>
+    <caption class="sr-only" aria-live="polite">{{@caption}} {{this.sortedMessageText}}</caption>
   {{else}}
     <caption class="sr-only">{{@caption}}</caption>
   {{/if}}

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -103,8 +103,8 @@
       </ol>
     </dd>
     <dt>caption <code>string</code></dt>
-    <dd><p>Adds a caption for users with assistive technology. If set on a sortable table, the provided table caption is
-        paired with the automatically generated sorted message text.</p></dd>
+    <dd><p>Adds a (non-visible) caption for users with assistive technology. If set on a sortable table, the provided
+        table caption is paired with the automatically generated sorted message text.</p></dd>
     <dt>...attributes</dt>
     <dd><p>Supported for the <code class="dummy-code">Hds::Table</code> component.</p></dd>
   </dl>

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -102,6 +102,9 @@
         <li>tall</li>
       </ol>
     </dd>
+    <dt>caption <code>string</code></dt>
+    <dd><p>Adds a caption for users with assistive technology. If set on a sortable table, the provided table caption is
+        paired with the automatically generated sorted message text.</p></dd>
     <dt>...attributes</dt>
     <dd><p>Supported for the <code class="dummy-code">Hds::Table</code> component.</p></dd>
   </dl>

--- a/packages/components/tests/integration/components/hds/table/index-test.js
+++ b/packages/components/tests/integration/components/hds/table/index-test.js
@@ -158,6 +158,35 @@ module('Integration | Component | hds/table/index', function (hooks) {
       .hasText('3');
   });
 
+  test('it should render caption if @caption is defined', async function (assert) {
+    this.set('model', [
+      { id: 1, name: 'Test 1', description: 'Test 1 description' },
+      { id: 2, name: 'Test 2', description: 'Test 2 description' },
+      { id: 3, name: 'Test 3', description: 'Test 3 description' },
+    ]);
+
+    await render(hbs`
+      <Hds::Table id="data-test-table" @model={{this.model}} @caption="a test caption">
+        <:head>
+          <Hds::Table::Tr>
+            <Hds::Table::Th>Id</Hds::Table::Th>
+            <Hds::Table::Th>Name</Hds::Table::Th>
+            <Hds::Table::Th>Description</Hds::Table::Th>
+          </Hds::Table::Tr>
+        </:head>
+        <:body as |row|>
+          <Hds::Table::Tr>
+            <td>{{row.id}}</td>
+            <td>{{row.name}}</td>
+            <td>{{row.description}}</td>
+          </Hds::Table::Tr>
+        </:body>
+      </Hds::Table>
+    `);
+
+    assert.dom('#data-test-table caption').hasText('a test caption');
+  });
+
   test('it should render a sortable table when appropriate', async function (assert) {
     setData(this);
 
@@ -169,7 +198,7 @@ module('Integration | Component | hds/table/index', function (hooks) {
     assert.dom('#data-test-table th:first-of-type').hasText('Artist');
   });
 
-  test('it should render a sortable table with an empty caption', async function (assert) {
+  test('it should render a sortable table with an empty caption if no caption is provided and table is unsorted', async function (assert) {
     setData(this);
 
     await renderSortableTable();


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds the ability to define a caption, for both sortable and non-sortable tables. 

### :hammer_and_wrench: Detailed description

After testing the table component out in cloud-ui, I discovered that the tables have caption elements. Updated the `Hds::Table` component to support user-provided captions. 

Also added a test and updated the documentation. 

![CleanShot 2022-11-07 at 11 04 11](https://user-images.githubusercontent.com/4587451/200371221-927f323b-48f6-4368-bc2f-63443463b929.png)


### 👀 How to review
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
