### PR TITLE
[DRAFT] New docs website / Basic test for `Doc::DoDont` component (with yielded markdown)

### DIFF
--- a/website-html-to-markdown/moveover/testing/06-test-do-dont/index.js
+++ b/website-html-to-markdown/moveover/testing/06-test-do-dont/index.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+
+export default class FileWithFrontmatter extends Component {
+  get test() {
+    console.log(this, this.attributes);
+    return 'this is a test';
+  }
+}

--- a/website-html-to-markdown/moveover/testing/06-test-do-dont/index.md
+++ b/website-html-to-markdown/moveover/testing/06-test-do-dont/index.md
@@ -1,0 +1,51 @@
+# Test "do/dont" component
+
+This is a test using the `Doc::DoDont` component
+
+<!-- THIS DOES NOT WORK AS INTENTED -->
+<Doc::DoDont as |dd|>
+  <dd.Do>
+    Do this:
+    - this
+    - and this
+  </dd.Do>
+  <dd.Dont>
+    But don't do this:
+    - not this
+    - and expecially not this
+    > this should be a block quote
+  </dd.Dont>
+</Doc::DoDont>
+
+<!-- THIS DOES NOT WORK AT ALL (IT CRASHES THE APP) -->
+<!--
+<Doc::DoDont as |dd|>
+<dd.Do>
+Do this:
+- this
+- and this
+</dd.Do>
+<dd.Dont>
+But don't do this:
+- not this
+- and expecially not this
+> this should be a block quote
+</dd.Dont>
+</Doc::DoDont>
+-->
+
+<!-- THIS DOES NOT WORK AT ALL (IT CRASHES THE APP) -->
+<!--
+<doc-do-dont>
+  Do this:
+  - this
+  - and this
+</doc-do-dont>
+-->
+
+<!-- THIS GENERATES A DIV WITHOUT A <p> WRAPPER -->
+<div>
+Do this:
+- this
+- and this
+</div>

--- a/website/app/components/doc/do-dont/index.hbs
+++ b/website/app/components/doc/do-dont/index.hbs
@@ -1,0 +1,4 @@
+<div class="doc-do-dont">
+  {{yield (hash Do=(component "doc/do-dont/item" instruction="do"))}}
+  {{yield (hash Dont=(component "doc/do-dont/item" instruction="dont"))}}
+</div>

--- a/website/app/components/doc/do-dont/item.hbs
+++ b/website/app/components/doc/do-dont/item.hbs
@@ -1,0 +1,3 @@
+<div class="doc-do-dont__item doc-do-dont__item--{{@instruction}}">
+  {{yield}}
+</div>

--- a/website/app/components/doc/wcag-success-criteria-list/index.hbs
+++ b/website/app/components/doc/wcag-success-criteria-list/index.hbs
@@ -1,0 +1,7 @@
+<ul class="doc-wcag-success-criteria-list">
+  {{#each this.items as |item|}}
+    <li class="doc-wcag-success-criteria-list">
+      {{item}}
+    </li>
+  {{/each}}
+</ul>

--- a/website/app/components/doc/wcag-success-criteria-list/index.js
+++ b/website/app/components/doc/wcag-success-criteria-list/index.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class DocWcagSuccessCriteriaListComponent extends Component {
+  get items() {
+    return this.args.items ? this.args.items.split('|') : [];
+  }
+}

--- a/website/docs/components/dropdown/05--accessibility.md
+++ b/website/docs/components/dropdown/05--accessibility.md
@@ -13,7 +13,7 @@ The following are known potential issues, and developers should keep these in mi
 
 This section is for reference only. This component intends to conform to the following WCAG success criteria:
 
-<dummy-wcag-success-criteria-list data-list="1.3.1|1.3.2|1.4.1|1.4.3|1.4.4|1.4.10|1.4.11|1.4.12|2.1.1|2.1.2|2.4.3|2.4.7">Placeholder for the WCAG Success Criteria List component - Don't delete!</dummy-wcag-success-criteria-list>
+<Doc::WcagSuccessCriteriaList @items="1.3.1|1.3.2|1.4.1|1.4.3|1.4.4|1.4.10|1.4.11|1.4.12|2.1.1|2.1.2|2.4.3|2.4.7" />
 
 *   1.3.1: [Information and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
 *   1.3.2: [Meaningful Sequence](https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence.html)

--- a/website/docs/testing/06-test-do-dont/index.js
+++ b/website/docs/testing/06-test-do-dont/index.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+
+export default class FileWithFrontmatter extends Component {
+  get test() {
+    console.log(this, this.attributes);
+    return 'this is a test';
+  }
+}

--- a/website/docs/testing/06-test-do-dont/index.md
+++ b/website/docs/testing/06-test-do-dont/index.md
@@ -1,0 +1,51 @@
+# Test "do/dont" component
+
+This is a test using the `Doc::DoDont` component
+
+<!-- THIS DOES NOT WORK AS INTENTED -->
+<Doc::DoDont as |dd|>
+  <dd.Do>
+    Do this:
+    - this
+    - and this
+  </dd.Do>
+  <dd.Dont>
+    But don't do this:
+    - not this
+    - and expecially not this
+    > this should be a block quote
+  </dd.Dont>
+</Doc::DoDont>
+
+<!-- THIS DOES NOT WORK AT ALL (IT CRASHES THE APP) -->
+<!--
+<Doc::DoDont as |dd|>
+<dd.Do>
+Do this:
+- this
+- and this
+</dd.Do>
+<dd.Dont>
+But don't do this:
+- not this
+- and expecially not this
+> this should be a block quote
+</dd.Dont>
+</Doc::DoDont>
+-->
+
+<!-- THIS DOES NOT WORK AT ALL (IT CRASHES THE APP) -->
+<!--
+<doc-do-dont>
+  Do this:
+  - this
+  - and this
+</doc-do-dont>
+-->
+
+<!-- THIS GENERATES A DIV WITHOUT A <p> WRAPPER -->
+<div>
+Do this:
+- this
+- and this
+</div>


### PR DESCRIPTION
### :pushpin: Summary

Scope of this simple test was to see what happens, with the current implementation, to an Ember component that yields some content in markdown format: how it's interpreted, how it's rendered, what we can do on our side, etc.

### :hammer_and_wrench: Detailed description

I have created a very simple `Doc::DoDont` component that exposes "items" as contextual components that simply yield their content (with some `<div>`s acting as containers/wrappers.

I considered four code samples.

**Normal formatting:**
```
<Doc::DoDont as |dd|>
  <dd.Do>
    Do this:
    - this
    - and this
  </dd.Do>
  <dd.Dont>
    But don't do this:
    - not this
    - and expecially not this
    > this should be a block quote
  </dd.Dont>
</Doc::DoDont>
```
This was rendered in this way:
<img width="572" alt="screenshot_2025" src="https://user-images.githubusercontent.com/686239/200388520-cd0b09f9-6060-4c66-adfb-1592f6c0916f.png">
The content is interpreted as inline text. 
Plus, the component is wrapped in a `<p>` element:
<img width="531" alt="screenshot_2026" src="https://user-images.githubusercontent.com/686239/200388959-39ceb812-9c80-4bc5-9366-6697d596c73e.png">

**Formatted with no whitespace before the content:**
```
<Doc::DoDont as |dd|>
<dd.Do>
Do this:
- this
- and this
</dd.Do>
<dd.Dont>
But don't do this:
- not this
- and expecially not this
> this should be a block quote
</dd.Dont>
</Doc::DoDont>
```
This crashed the app, because the content was (partially) intended as markdown, but the wrapping of the HTML elements was completely off:
<img width="780" alt="screenshot_2023" src="https://user-images.githubusercontent.com/686239/200389024-19136cf1-4cbb-432c-a181-9c4e6bbcd268.png">
<img width="771" alt="modified" src="https://user-images.githubusercontent.com/686239/200389323-21c6c6e1-8db1-413f-9281-743a19b2c82c.png">

<doc-do-dont>
  Do this:
  - this
  - and this
</doc-do-dont>

```
<doc-do-dont>
  Do this:
  - this
  - and this
</doc-do-dont>
```
This also crashed the app (for the same reason above).
<img width="434" alt="screenshot_2027" src="https://user-images.githubusercontent.com/686239/200389794-f0d3019d-4e9f-4ef1-8136-436b6e4c6937.png">

**A simple div:**
```
<div>
Do this:
- this
- and this
</div>
```
This generates a simple `<div>` with no `<p>` wrapper, and the content is interpreted as inline text, not markdown.
<img width="341" alt="screenshot_2029" src="https://user-images.githubusercontent.com/686239/200390262-ebe07fc2-02a4-422e-81e5-45654f820158.png">
<img width="193" alt="screenshot_2028" src="https://user-images.githubusercontent.com/686239/200390266-adb0b639-4303-4764-8be3-6f809d5182ac.png">

### 🤔 What next?

I think we have to consider our options at this point: I am not so sure we will be able to implement custom ember components that can render their content (as children) in markdown format, unless we pass the markdown code as a string (as argument), which leads to a lot of other problems (can we nest custom components? will we have linting or autosuggestion?).
In theory we could imagine that for some simple components, like this one, we interpret the yielded content and convert it from markdown to HTML, but AFAIK the yielded content is not accessible in the backing class of a component, so... not sure how we can solve this.
Plus, I am not sure how the Ember compilation works in relation with the Markdown to HTML conversion: in which order does it happen? 

I think we should have a brainstorming session, and see what we can do (and maybe have someone else have a go to the problem as well and see what alternatives they can come up with).

Also, I suspect we may have to involve Bryce Kalow for a "consultation" and see from his point of view (and experience) what he thinks of what we're trying to achieve (maybe we're asking too much, looking at the MDX files for DevDot documentation, it seems to me that there are not many custom components used inside the markdown files).