### PR TITLE
[DRAFT] New docs website / Testing of the `show` template/controller

### DIFF
--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -1,9 +1,12 @@
 import Controller from '@ember/controller';
-import showdown from 'showdown';
+// import showdown from 'showdown';
 
 export default class ShowController extends Controller {
   get renderedContent() {
-    const converter = new showdown.Converter();
-    return converter.makeHtml(this.model.content);
+    console.log(this.model);
+    // const converter = new showdown.Converter();
+    // return converter.makeHtml(this.model.content);
+    // TODO! why a converter here, if the model already returns an HTML???
+    return this.model.html;
   }
 }

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import showdown from 'showdown';
+
+export default class ShowController extends Controller {
+  get renderedContent() {
+    const converter = new showdown.Converter();
+    return converter.makeHtml(this.model.content);
+  }
+}

--- a/website/app/templates/show.hbs
+++ b/website/app/templates/show.hbs
@@ -1,0 +1,3 @@
+{{page-title 'SHOW'}}
+
+<DynamicTemplate @templateString={{this.renderedContent}} @componentId={{this.model.id}}/>


### PR DESCRIPTION
### :pushpin: Summary

This is a test I made to understand if (and how) we could leverage the fact that all the routes generated via markdown files stored in the `docs` folder respond to the same template/controller called `show`.

What I did was to create a template and a controller inside the `website` application (exactly the same as the ones provided by `field-guide`) and see what happened.

### 🕵️‍♀️ Findings

- if the files are added while the web server is running, the pages are rendered correctly and the content in markdown is visible (using the custom template)
  -  notice: adding also a `show` router I was able to generate in output also the frontmatter values
- but if I stop the server an restart it (with `yarn build`) I receive an error related to how (I think) Ember compiles the files
  - let's see what happens in the CI 
<img width="601" alt="screenshot_2030" src="https://user-images.githubusercontent.com/686239/200415634-36cfeab2-2180-480f-b2ba-f742dbb03561.png">

This for me is a strong indication that we should simply copy the files from `field-guide` inside the `website` app (essentially forking it) and then adapt the application to what we need to do. Otherwise we are investing a large amount of time trying to figure out things, without being able to build something out of our findings.

### :link: External links

JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-875