### PR TITLE
`Tabs` bug fix: Explicitly set aria-selected to true or false (HDS-976)

### DIFF
--- a/.changeset/eight-zoos-breathe.md
+++ b/.changeset/eight-zoos-breathe.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+HDS-976 Explicitly set aria-selcted to true or false

--- a/packages/components/addon/components/hds/tabs/tab.hbs
+++ b/packages/components/addon/components/hds/tabs/tab.hbs
@@ -9,7 +9,7 @@
     role="tab"
     type="button"
     id={{this.tabId}}
-    aria-selected={{this.isSelected}}
+    aria-selected={{if this.isSelected "true" "false"}}
     tabindex={{unless this.isSelected "-1"}}
     data-is-selected={{this.isInitialTab}}
     {{did-insert this.didInsertNode}}

--- a/packages/components/tests/integration/components/hds/tabs/index-test.js
+++ b/packages/components/tests/integration/components/hds/tabs/index-test.js
@@ -61,7 +61,7 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
       .hasClass('hds-tabs__tab--is-selected');
     assert
       .dom('[data-test="selected tab"] .hds-tabs__tab-button')
-      .hasAttribute('aria-selected');
+      .hasAttribute('aria-selected', 'true');
     assert.dom('[data-test="selected panel"]').doesNotHaveAttribute('hidden');
 
     assert
@@ -69,7 +69,7 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
       .doesNotHaveClass('hds-tabs__tab--is-selected');
     assert
       .dom('[data-test="NOT selected tab"] .hds-tabs__tab-button')
-      .doesNotHaveAttribute('aria-selected');
+      .hasAttribute('aria-selected', 'false');
     assert.dom('[data-test="NOT selected panel"]').hasAttribute('hidden');
   });
 
@@ -87,7 +87,7 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
       .hasClass('hds-tabs__tab--is-selected');
     assert
       .dom('[data-test="selected tab"] .hds-tabs__tab-button')
-      .hasAttribute('aria-selected');
+      .hasAttribute('aria-selected', 'true');
     assert.dom('[data-test="selected panel"]').doesNotHaveAttribute('hidden');
 
     assert
@@ -95,7 +95,7 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
       .doesNotHaveClass('hds-tabs__tab--is-selected');
     assert
       .dom('[data-test="NOT selected tab"] .hds-tabs__tab-button')
-      .doesNotHaveAttribute('aria-selected');
+      .hasAttribute('aria-selected', 'false');
     assert.dom('[data-test="NOT selected panel"]').hasAttribute('hidden');
   });
 
@@ -114,7 +114,7 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
       .hasClass('hds-tabs__tab--is-selected');
     assert
       .dom('[data-test="clicked tab"] .hds-tabs__tab-button')
-      .hasAttribute('aria-selected');
+      .hasAttribute('aria-selected', 'true');
     assert
       .dom('[data-test="clicked tab panel"]')
       .doesNotHaveAttribute('hidden');
@@ -124,7 +124,7 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
       .doesNotHaveClass('hds-tabs__tab--is-selected');
     assert
       .dom('[data-test="NOT clicked tab"] .hds-tabs__tab-button')
-      .doesNotHaveAttribute('aria-selected');
+      .hasAttribute('aria-selected', 'false');
     assert.dom('[data-test="NOT clicked tab panel"]').hasAttribute('hidden');
   });
 
@@ -190,7 +190,7 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
       .hasClass('hds-tabs__tab--is-selected');
     assert
       .dom('[data-test="second tab"] .hds-tabs__tab-button')
-      .hasAttribute('aria-selected');
+      .hasAttribute('aria-selected', 'true');
     assert.dom('[data-test="second panel"]').doesNotHaveAttribute('hidden');
 
     // focus 1st tab:
@@ -207,7 +207,7 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
       .hasClass('hds-tabs__tab--is-selected');
     assert
       .dom('[data-test="first tab"] .hds-tabs__tab-button')
-      .hasAttribute('aria-selected');
+      .hasAttribute('aria-selected', 'true');
     assert.dom('[data-test="first panel"]').doesNotHaveAttribute('hidden');
   });
 


### PR DESCRIPTION
### :pushpin: Summary
Fix bug with keyboard navigation and aria-selected tags on Tab elements.

**Preview:** https://hds-components-git-hds-976-aria-selected-bug-hashicorp.vercel.app/components/tabs#showcase

### :hammer_and_wrench: Detailed description
* Set aria-selected value explicitly to "true" or "false". This prevents the issue with non-selected tabs being called out as selected by VoiceOver
* Updated integration tests for aria-selected

### :camera_flash: Screenshots
**Fix:** Instead of incorrectly saying tab is selected it first calls out the name of the tab then tells you how to select it.
<img width="803" alt="Screen Shot 2022-11-07 at 2 29 50 PM" src="https://user-images.githubusercontent.com/108769823/200432492-1be9e880-93b8-42c6-bc2a-128c4acfad7d.png">

### :link: External links
- https://hashicorp.atlassian.net/browse/HDS-976

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Use VoiceOver if you can to test
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
