### PR TITLE
New docs website / Add support for tables in markdown in Showdown

### DIFF
--- a/addons/field-guide/addon/controllers/show.js
+++ b/addons/field-guide/addon/controllers/show.js
@@ -6,7 +6,11 @@ export default class ShowController extends Controller {
   fieldGuideConfig = config['field-guide'];
 
   get renderedContent() {
-    const converter = new showdown.Converter();
+    // SET SHOWDOWN SETTINGS HERE:
+    const showdownConfig = {
+      tables: true,
+    };
+    const converter = new showdown.Converter(showdownConfig);
     return converter.makeHtml(this.model.content);
   }
 }

--- a/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/basic-styling.md
+++ b/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/basic-styling.md
@@ -201,38 +201,6 @@ Normal markdown tables can contain only inline elements (and the content can be 
 | zebra stripes | ~~are neat~~  |    $1 |
 | `inline code` | can be added  |   too |
 
-<table role="table">
-    <thead>
-        <tr>
-            <th>Tables</th>
-            <th align="center">Are</th>
-            <th align="right">Cool</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><strong>col 3 is</strong></td>
-            <td align="center">right-aligned</td>
-            <td align="right">$1600</td>
-        </tr>
-        <tr>
-            <td>col 2 is</td>
-            <td align="center"><em>centered</em></td>
-            <td align="right">$12</td>
-        </tr>
-        <tr>
-            <td>zebra stripes</td>
-            <td align="center"><del>are neat</del></td>
-            <td align="right">$1</td>
-        </tr>
-        <tr>
-            <td><code class="notranslate">inline code</code></td>
-            <td align="center">can be added</td>
-            <td align="right">too</td>
-        </tr>
-    </tbody>
-</table>
-
 If you need to use block elements inside a table, you have to use HTML code:
 
 <table>

--- a/website/docs/testing/00-testing-markdown-formatting/basic-styling.md
+++ b/website/docs/testing/00-testing-markdown-formatting/basic-styling.md
@@ -1,0 +1,279 @@
+<div class="doc-markdown-content">
+
+Text can be **bold**, _italic_, or ~~strikethrough~~, and can contain emoji like 👋 🙂 🚨 🚀.
+
+Inline [links](https://github.com) should be styled according to the design specifications.
+
+There should be whitespace between paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+There should be whitespace between paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+> There should be no margin above this first sentence.
+>
+> Blockquotes should be a lighter gray with a gray border along the left side.
+>
+> There should be no margin below this final sentence.
+
+# Header 1
+
+This is a normal paragraph following a header. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+## Header 2
+
+> This is a blockquote following a header. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+### Header 3
+
+```
+This is a code block following a header.
+```
+
+#### Header 4
+
+* This is an unordered list following a header.
+* This is an unordered list following a header.
+* This is an unordered list following a header.
+
+##### Header 5
+
+1. This is an ordered list following a header.
+2. This is an ordered list following a header.
+3. This is an ordered list following a header.
+
+###### Header 6
+
+| What      | Follows         |
+|-----------|-----------------|
+| A table   | A header        |
+| A table   | A header        |
+| A table   | A header        |
+
+----------------
+
+There's a horizontal rule above and below this.
+
+----------------
+
+This is an unordered list (using `*`):
+
+* Salt-n-Pepa
+* Bel Biv DeVoe
+* Kid 'N Play
+
+This is also an unordered list (using `-`):
+
+- Salt-n-Pepa
+- Bel Biv DeVoe
+- Kid 'N Play
+
+And this is also an unordered list (using `+`):
+
++ Salt-n-Pepa
++ Bel Biv DeVoe
++ Kid 'N Play
+
+This instad is an ordered list:
+
+1. Michael Jackson
+2. Michael Bolton
+3. Michael Bublé
+
+This is an ordered list that uses the same number for all the items:
+
+1. Michael Jackson
+1. Michael Bolton
+1. Michael Bublé
+
+This is an ordered list that uses letters instead of numbers (doens't work):
+
+A. Michael Jackson
+A. Michael Bolton
+A. Michael Bublé
+
+This is a nested list (using `*`):
+
+* Jackson 5
+    * Michael
+    * Tito
+    * Jackie
+    * Marlon
+    * Jermaine
+* TMNT
+    * Leonardo
+    * Michelangelo
+    * Donatello
+    * Raphael
+
+This is a nested list (using `-`):
+
+- Jackson 5
+    - Michael
+    - Tito
+    - Jackie
+    - Marlon
+    - Jermaine
+- TMNT
+    - Leonardo
+    - Michelangelo
+    - Donatello
+    - Raphael
+
+This is a deeply nested list:
+
+*   Lorem ipsum dolor sit amet,
+    *   Consectetuer adipiscing elit.
+    *   Aliquam hendrerit mi posuere lectus.
+        *   Vestibulum enim wisi.
+        *   Viverra nec, fringilla.
+        *   In laoreet vitae risus.
+            *   Donec sit amet nisl.
+            *   Aliquam semper ipsum
+        *   Sit amet velit.
+    *   Suspendisse id sem consectetuer
+*   Libero luctus adipiscing.
+
+This is a list with hanging indents:
+
+*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+    Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
+    viverra nec, fringilla in, laoreet vitae, risus.
+*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
+    Suspendisse id sem consectetuer libero luctus adipiscing.
+
+This is a list with one item separated by a blank line (this will force it to wrap all the list items in `<p>` tags in the HTML output):
+
+*   Bird
+
+*   Magic
+*   Johnson
+
+This is a list that contains other block elements:
+
+*   A normal list item
+*   A list item with a blockquote:
+
+    > This is a blockquote
+    > inside a list item.
+* A list item with a code block
+
+    ```js
+    var foo = 'bar';
+    console.log(foo);
+    ```
+
+----------------
+
+> This is a blockquote that contains other block elements
+>
+> #### A heading level 4
+> A normal paragraph
+> - A list
+> - with items
+>
+> ```
+> Some code snippet
+> ```
+
+----------------
+
+Tables should have bold headings and alternating shaded rows.
+
+| Artist            | Album           | Year |
+|-------------------|-----------------|------|
+| Michael Jackson   | Thriller        | 1982 |
+| Prince            | Purple Rain     | 1984 |
+| Beastie Boys      | License to Ill  | 1986 |
+
+If a table is too wide, it should condense down and/or scroll horizontally.
+
+| Artist            | Album           | Year | Label       | Awards   | Songs     |
+|-------------------|-----------------|------|-------------|----------|-----------|
+| Michael Jackson   | Thriller        | 1982 | Epic Records | Grammy Award for Album of the Year, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Selling Album, Grammy Award for Best Engineered Album, Non-Classical | Wanna Be Startin' Somethin', Baby Be Mine, The Girl Is Mine, Thriller, Beat It, Billie Jean, Human Nature, P.Y.T. (Pretty Young Thing), The Lady in My Life |
+| Prince            | Purple Rain     | 1984 | Warner Brothers Records | Grammy Award for Best Score Soundtrack for Visual Media, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Soundtrack/Cast Recording, Grammy Award for Best Rock Performance by a Duo or Group with Vocal | Let's Go Crazy, Take Me With U, The Beautiful Ones, Computer Blue, Darling Nikki, When Doves Cry, I Would Die 4 U, Baby I'm a Star, Purple Rain |
+| Beastie Boys      | License to Ill  | 1986 | Mercury Records | noawardsbutthistablecelliswide | Rhymin & Stealin, The New Style, She's Crafty, Posse in Effect, Slow Ride, Girls, (You Gotta) Fight for Your Right, No Sleep Till Brooklyn, Paul Revere, Hold It Now, Hit It, Brass Monkey, Slow and Low, Time to Get Ill |
+
+Normal markdown tables can contain only inline elements (and the content can be aligned too):
+
+| Tables        | Are           | Cool  |
+| ------------- |:-------------:| -----:|
+| **col 3 is**  | right-aligned | $1600 |
+| col 2 is      | *centered*    |   $12 |
+| zebra stripes | ~~are neat~~  |    $1 |
+| `inline code` | can be added  |   too |
+
+If you need to use block elements inside a table, you have to use HTML code:
+
+<table>
+    <tr>
+        <td> Block type </td>
+        <td> Example </td>
+    </tr>
+    <tr>
+        <td> Code </td>
+        <td>
+            ```json
+            {
+            "id": 10,
+            "username": "marcoeidinger",
+            "created_at": "2021-02-097T20:45:26.433Z",
+            "updated_at": "2015-02-10T19:27:16.540Z"
+            }
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td> Blackquote </td>
+        <td>
+            > blockquote text
+        </td>
+    </tr>
+</table>
+
+----------------
+
+Code snippets like `var foo = "bar";` can be shown inline.
+
+Also, `this should vertically align` ~~`with this`~~ ~~and this~~.
+
+Code can also be shown in a block element.
+```
+var foo = "bar";
+```
+
+Code can also use syntax highlighting.
+```javascript
+var foo = "bar";
+```
+
+```
+Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.
+```
+
+```javascript
+var foo = "The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.";
+```
+
+Inline code inside table cells should still be distinguishable.
+
+| Language    | Code               |
+|-------------|--------------------|
+| JavaScript  | `var foo = "bar";` |
+| Ruby        | `foo = "bar"`      |
+
+----------------
+
+Small images should be shown at their actual size.
+
+![](http://placekitten.com/g/300/200/)
+
+Large images should always scale down and fit in the content container.
+
+![](http://placekitten.com/g/1200/800/)
+
+Inline `<img>` images should be rendered at the defined size, without overflowing the container.
+
+<img width="400" alt="kittem" src="http://placekitten.com/g/300/200/">
+<img width="1200" alt="kittem" src="http://placekitten.com/g/1200/800/">
+
+
+</div>


### PR DESCRIPTION
### :pushpin: Summary

This PR enables the support of markdown tables in our porting of `field-guide` by providing custom settings to `showdown`.

### :link: External links

JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-819

Issue in `field-guide`: https://github.com/empress/field-guide/issues/73

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
