### PR TITLE
New docs website / Add support for custom classes to HTML elements generated from markdown

### DIFF
--- a/addons/field-guide/addon/controllers/show.js
+++ b/addons/field-guide/addon/controllers/show.js
@@ -33,18 +33,24 @@ const mapElementsToClassNames = {
 // https://github.com/showdownjs/showdown/wiki/Showdown-Options
 
 const showdownConfig = {
-  // enable support for tables in markdown (see: https://showdownjs.com/docs/available-options/#tables)
+  // enable support for tables in markdown
+  // see: https://showdownjs.com/docs/available-options/#tables
   tables: true,
-  // enable support for strikethrough in markdown (see: https://showdownjs.com/docs/available-options/#strikethrough)
+  // enable support for strikethrough in markdown
+  // see: https://showdownjs.com/docs/available-options/#strikethrough
   strikethrough: true,
-  // enable support for image sizes in markdown (see: https://showdownjs.com/docs/available-options/#parseimgdimensions)
+  // enable support for image sizes in markdown
+  // see: https://showdownjs.com/docs/available-options/#parseimgdimensions
   parseImgDimensions: true,
-  // enable custom ID for a heading (see: https://showdownjs.com/docs/available-options/#customizedheaderid)
+  // enable custom ID for a heading
+  // see: https://showdownjs.com/docs/available-options/#customizedheaderid
   // notice: later it may be replaced with a more comprehensive way to handle HTML attributes (similar to https://github.com/arve0/markdown-it-attrs)
   customizedHeaderId: true,
-  // enable generations of heading IDs compatible with GitHub style (see: https://showdownjs.com/docs/available-options/#ghcompatibleheaderid)
+  // enable generations of heading IDs compatible with GitHub style
+  // see: https://showdownjs.com/docs/available-options/#ghcompatibleheaderid
   ghCompatibleHeaderId: true,
-  // add default class for each HTML element generated (see: https://showdownjs.com/docs/tutorials/add-default-class-to-html/)
+  // add default class for each HTML element generated
+  // see: https://github.com/showdownjs/showdown/wiki/Extensions + https://showdownjs.com/docs/tutorials/add-default-class-to-html/
   extensions: Object.keys(mapElementsToClassNames).map((element) => ({
     type: 'output',
     // this is a custom regex, modified from the one found in the original tutolrial, to make it more solid and encompass more use cases

--- a/addons/field-guide/addon/controllers/show.js
+++ b/addons/field-guide/addon/controllers/show.js
@@ -22,8 +22,8 @@ const mapElementsToClassNames = {
   tbody: 'doc-markdown-tbody',
   tr: 'doc-markdown-tr',
   td: 'doc-markdown-td',
-  // th: 'doc-markdown-th', // COMMENTING FOR PROBLEMS WITH THE REGEX (`th/thead`)
-  // pre: 'doc-markdown-pre', // COMMENTING FOR PROBLEMS WITH THE REGEX (`p/pre`)
+  th: 'doc-markdown-th',
+  pre: 'doc-markdown-pre',
   code: 'doc-markdown-code',
   hr: 'doc-markdown-hr',
 };
@@ -47,12 +47,11 @@ const showdownConfig = {
   // add default class for each HTML element generated (see: https://showdownjs.com/docs/tutorials/add-default-class-to-html/)
   extensions: Object.keys(mapElementsToClassNames).map((element) => ({
     type: 'output',
-    // [1] - this is the original regex found in the article linked above
-    regex: new RegExp(`<${element}(.*)>`, 'g'),
-    // [2] - below a set of custom regex (more solid and encompassing more use cases)
+    // this is a custom regex, modified from the one found in the original tutolrial, to make it more solid and encompass more use cases
+    // for testing see: https://regex101.com/r/jLk7wN/2 + https://regex101.com/r/jLk7wN/5
+    regex: new RegExp(`<${element}>|<${element} (.*)>`, 'g'),
     // TODO! with `code` and `pre` this is replaced by the `language` classes, we have to find a way to concatenate the strings (not sure how though)
     // maybe a solition here? https://regex101.com/r/I2FB9N/1
-    // regex: new RegExp(`<?[^>\s]*(.*)>`, 'g'), // https://regex101.com/r/jLk7wN/2
     replace: `<${element} class="${mapElementsToClassNames[element]}" $1>`,
   })),
 };

--- a/addons/field-guide/addon/controllers/show.js
+++ b/addons/field-guide/addon/controllers/show.js
@@ -3,7 +3,6 @@ import showdown from 'showdown';
 import config from 'ember-get-config';
 
 const mapElementsToClassNames = {
-  // TODO decide if shorten them to `doc-md-[...]`
   h1: 'doc-markdown-h1',
   h2: 'doc-markdown-h2',
   h3: 'doc-markdown-h3',

--- a/addons/field-guide/addon/controllers/show.js
+++ b/addons/field-guide/addon/controllers/show.js
@@ -2,6 +2,32 @@ import Controller from '@ember/controller';
 import showdown from 'showdown';
 import config from 'ember-get-config';
 
+const mapElementsToClassNames = {
+  // TODO decide if shorten them to `doc-md-[...]`
+  h1: 'doc-markdown-h1',
+  h2: 'doc-markdown-h2',
+  h3: 'doc-markdown-h3',
+  h4: 'doc-markdown-h4',
+  h5: 'doc-markdown-h5',
+  h6: 'doc-markdown-h6',
+  p: 'doc-markdown-p',
+  blockquote: 'doc-markdown-blockquote',
+  ul: 'doc-markdown-ul',
+  ol: 'doc-markdown-ol',
+  li: 'doc-markdown-li',
+  img: 'doc-markdown-img',
+  a: 'doc-markdown-a',
+  table: 'doc-markdown-table',
+  thead: 'doc-markdown-thead',
+  tbody: 'doc-markdown-tbody',
+  tr: 'doc-markdown-tr',
+  td: 'doc-markdown-td',
+  // th: 'doc-markdown-th', // COMMENTING FOR PROBLEMS WITH THE REGEX (`th/thead`)
+  // pre: 'doc-markdown-pre', // COMMENTING FOR PROBLEMS WITH THE REGEX (`p/pre`)
+  code: 'doc-markdown-code',
+  hr: 'doc-markdown-hr',
+};
+
 // SET SHOWDOWN SETTINGS HERE:
 // https://showdownjs.com/docs/available-options/
 // https://github.com/showdownjs/showdown/wiki/Showdown-Options
@@ -18,6 +44,17 @@ const showdownConfig = {
   customizedHeaderId: true,
   // enable generations of heading IDs compatible with GitHub style (see: https://showdownjs.com/docs/available-options/#ghcompatibleheaderid)
   ghCompatibleHeaderId: true,
+  // add default class for each HTML element generated (see: https://showdownjs.com/docs/tutorials/add-default-class-to-html/)
+  extensions: Object.keys(mapElementsToClassNames).map((element) => ({
+    type: 'output',
+    // [1] - this is the original regex found in the article linked above
+    regex: new RegExp(`<${element}(.*)>`, 'g'),
+    // [2] - below a set of custom regex (more solid and encompassing more use cases)
+    // TODO! with `code` and `pre` this is replaced by the `language` classes, we have to find a way to concatenate the strings (not sure how though)
+    // maybe a solition here? https://regex101.com/r/I2FB9N/1
+    // regex: new RegExp(`<?[^>\s]*(.*)>`, 'g'), // https://regex101.com/r/jLk7wN/2
+    replace: `<${element} class="${mapElementsToClassNames[element]}" $1>`,
+  })),
 };
 export default class ShowController extends Controller {
   fieldGuideConfig = config['field-guide'];

--- a/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/basic-spacing.md
+++ b/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/basic-spacing.md
@@ -1,0 +1,71 @@
+# Header 1
+
+This is a normal paragraph following a header. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+There should be whitespace between paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+There should be whitespace between paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+## Header 2
+
+> This is a blockquote following a header. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+Lorem ipsum dolor sit amet.
+
+> This is a blockquote following a paragraph.
+
+Lorem ipsum dolor sit amet.
+
+> There should be no margin above this first sentence.
+>
+> Blockquotes should be a lighter gray with a gray border along the left side.
+>
+> There should be no margin below this final sentence.
+
+### Header 3
+
+```
+This is a code block following a header.
+```
+
+Lorem ipsum dolor sit amet.
+
+```
+This is a code block following a paragraph.
+```
+
+#### Header 4
+
+* This is a list following a header.
+* This is a list following a header.
+* This is a list following a header.
+
+Lorem ipsum dolor sit amet.
+
+* This is a list following a paragraph.
+* This is a list following a paragraph.
+* This is a list following a paragraph.
+
+##### Header 5
+
+| This      | Table           |
+|-----------|-----------------|
+| Is        | Following       |
+| A         | Header          |
+
+Lorem ipsum dolor sit amet.
+
+| This      | Table           |
+|-----------|-----------------|
+| Is        | Following       |
+| A         | Header          |
+
+###### Header 6
+
+![](http://placekitten.com/g/300/200/)
+
+The image above is an image following a header.
+
+![](http://placekitten.com/g/300/200/)
+
+The image above is an image following a paragraph.

--- a/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/basic-styling.md
+++ b/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/basic-styling.md
@@ -1,279 +1,57 @@
-<div class="doc-markdown-content">
+# Header 1
+## Header 2
+### Header 3
+#### Header 4
+##### Header 5
+###### Header 6
+
+----------------
+
+This is a normal paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
 
 Text can be **bold**, _italic_, or ~~strikethrough~~, and can contain emoji like 👋 🙂 🚨 🚀.
 
 Inline [links](https://github.com) should be styled according to the design specifications.
 
-There should be whitespace between paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+----------------
 
-There should be whitespace between paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
-
-> There should be no margin above this first sentence.
+> This is some text inside a blockquote
 >
-> Blockquotes should be a lighter gray with a gray border along the left side.
+> And this is more text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 >
-> There should be no margin below this final sentence.
+> And this is the closing text.
 
-# Header 1
+----------------
 
-This is a normal paragraph following a header. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+* This is an unordered list.
+* This is an unordered list.
+* This is an unordered list.
 
-## Header 2
+1. This is an ordered list.
+2. This is an ordered list.
+3. This is an ordered list.
 
-> This is a blockquote following a header. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+----------------
 
-### Header 3
+
+A simple image
+
+![](http://placekitten.com/g/300/200/)
+
+----------------
+
+A simple inline code snippet `var foo = "bar";` like this.
+
+A simple code block.
 
 ```
-This is a code block following a header.
+var foo = "bar";
 ```
 
-#### Header 4
-
-* This is an unordered list following a header.
-* This is an unordered list following a header.
-* This is an unordered list following a header.
-
-##### Header 5
-
-1. This is an ordered list following a header.
-2. This is an ordered list following a header.
-3. This is an ordered list following a header.
-
-###### Header 6
+----------------
 
 | What      | Follows         |
 |-----------|-----------------|
 | A table   | A header        |
 | A table   | A header        |
 | A table   | A header        |
-
-----------------
-
-There's a horizontal rule above and below this.
-
-----------------
-
-This is an unordered list (using `*`):
-
-* Salt-n-Pepa
-* Bel Biv DeVoe
-* Kid 'N Play
-
-This is also an unordered list (using `-`):
-
-- Salt-n-Pepa
-- Bel Biv DeVoe
-- Kid 'N Play
-
-And this is also an unordered list (using `+`):
-
-+ Salt-n-Pepa
-+ Bel Biv DeVoe
-+ Kid 'N Play
-
-This instad is an ordered list:
-
-1. Michael Jackson
-2. Michael Bolton
-3. Michael Bublé
-
-This is an ordered list that uses the same number for all the items:
-
-1. Michael Jackson
-1. Michael Bolton
-1. Michael Bublé
-
-This is an ordered list that uses letters instead of numbers (doens't work):
-
-A. Michael Jackson
-A. Michael Bolton
-A. Michael Bublé
-
-This is a nested list (using `*`):
-
-* Jackson 5
-    * Michael
-    * Tito
-    * Jackie
-    * Marlon
-    * Jermaine
-* TMNT
-    * Leonardo
-    * Michelangelo
-    * Donatello
-    * Raphael
-
-This is a nested list (using `-`):
-
-- Jackson 5
-    - Michael
-    - Tito
-    - Jackie
-    - Marlon
-    - Jermaine
-- TMNT
-    - Leonardo
-    - Michelangelo
-    - Donatello
-    - Raphael
-
-This is a deeply nested list:
-
-*   Lorem ipsum dolor sit amet,
-    *   Consectetuer adipiscing elit.
-    *   Aliquam hendrerit mi posuere lectus.
-        *   Vestibulum enim wisi.
-        *   Viverra nec, fringilla.
-        *   In laoreet vitae risus.
-            *   Donec sit amet nisl.
-            *   Aliquam semper ipsum
-        *   Sit amet velit.
-    *   Suspendisse id sem consectetuer
-*   Libero luctus adipiscing.
-
-This is a list with hanging indents:
-
-*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-    Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
-    viverra nec, fringilla in, laoreet vitae, risus.
-*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
-    Suspendisse id sem consectetuer libero luctus adipiscing.
-
-This is a list with one item separated by a blank line (this will force it to wrap all the list items in `<p>` tags in the HTML output):
-
-*   Bird
-
-*   Magic
-*   Johnson
-
-This is a list that contains other block elements:
-
-*   A normal list item
-*   A list item with a blockquote:
-
-    > This is a blockquote
-    > inside a list item.
-* A list item with a code block
-
-    ```js
-    var foo = 'bar';
-    console.log(foo);
-    ```
-
-----------------
-
-> This is a blockquote that contains other block elements
->
-> #### A heading level 4
-> A normal paragraph
-> - A list
-> - with items
->
-> ```
-> Some code snippet
-> ```
-
-----------------
-
-Tables should have bold headings and alternating shaded rows.
-
-| Artist            | Album           | Year |
-|-------------------|-----------------|------|
-| Michael Jackson   | Thriller        | 1982 |
-| Prince            | Purple Rain     | 1984 |
-| Beastie Boys      | License to Ill  | 1986 |
-
-If a table is too wide, it should condense down and/or scroll horizontally.
-
-| Artist            | Album           | Year | Label       | Awards   | Songs     |
-|-------------------|-----------------|------|-------------|----------|-----------|
-| Michael Jackson   | Thriller        | 1982 | Epic Records | Grammy Award for Album of the Year, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Selling Album, Grammy Award for Best Engineered Album, Non-Classical | Wanna Be Startin' Somethin', Baby Be Mine, The Girl Is Mine, Thriller, Beat It, Billie Jean, Human Nature, P.Y.T. (Pretty Young Thing), The Lady in My Life |
-| Prince            | Purple Rain     | 1984 | Warner Brothers Records | Grammy Award for Best Score Soundtrack for Visual Media, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Soundtrack/Cast Recording, Grammy Award for Best Rock Performance by a Duo or Group with Vocal | Let's Go Crazy, Take Me With U, The Beautiful Ones, Computer Blue, Darling Nikki, When Doves Cry, I Would Die 4 U, Baby I'm a Star, Purple Rain |
-| Beastie Boys      | License to Ill  | 1986 | Mercury Records | noawardsbutthistablecelliswide | Rhymin & Stealin, The New Style, She's Crafty, Posse in Effect, Slow Ride, Girls, (You Gotta) Fight for Your Right, No Sleep Till Brooklyn, Paul Revere, Hold It Now, Hit It, Brass Monkey, Slow and Low, Time to Get Ill |
-
-Normal markdown tables can contain only inline elements (and the content can be aligned too):
-
-| Tables        | Are           | Cool  |
-| ------------- |:-------------:| -----:|
-| **col 3 is**  | right-aligned | $1600 |
-| col 2 is      | *centered*    |   $12 |
-| zebra stripes | ~~are neat~~  |    $1 |
-| `inline code` | can be added  |   too |
-
-If you need to use block elements inside a table, you have to use HTML code:
-
-<table>
-    <tr>
-        <td> Block type </td>
-        <td> Example </td>
-    </tr>
-    <tr>
-        <td> Code </td>
-        <td>
-            ```json
-            {
-            "id": 10,
-            "username": "marcoeidinger",
-            "created_at": "2021-02-097T20:45:26.433Z",
-            "updated_at": "2015-02-10T19:27:16.540Z"
-            }
-            ```
-        </td>
-    </tr>
-    <tr>
-        <td> Blackquote </td>
-        <td>
-            > blockquote text
-        </td>
-    </tr>
-</table>
-
-----------------
-
-Code snippets like `var foo = "bar";` can be shown inline.
-
-Also, `this should vertically align` ~~`with this`~~ ~~and this~~.
-
-Code can also be shown in a block element.
-```
-var foo = "bar";
-```
-
-Code can also use syntax highlighting.
-```javascript
-var foo = "bar";
-```
-
-```
-Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.
-```
-
-```javascript
-var foo = "The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.";
-```
-
-Inline code inside table cells should still be distinguishable.
-
-| Language    | Code               |
-|-------------|--------------------|
-| JavaScript  | `var foo = "bar";` |
-| Ruby        | `foo = "bar"`      |
-
-----------------
-
-Small images should be shown at their actual size.
-
-![](http://placekitten.com/g/300/200/)
-
-Large images should always scale down and fit in the content container.
-
-![](http://placekitten.com/g/1200/800/)
-
-Inline `<img>` images should be rendered at the defined size, without overflowing the container.
-
-<img width="400" alt="kittem" src="http://placekitten.com/g/300/200/">
-<img width="1200" alt="kittem" src="http://placekitten.com/g/1200/800/">
-
-
-</div>

--- a/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-code.md
+++ b/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-code.md
@@ -1,0 +1,27 @@
+----------------
+
+A simple inline code snippet `var foo = "bar";` like this.
+
+----------------
+
+A simple code block.
+
+```
+var foo = "bar";
+```
+
+A code block with syntax declaration.
+
+```javascript
+var foo = "bar";
+```
+
+A long code block.
+
+```
+Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.
+```
+
+```javascript
+var foo = "The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.";
+```

--- a/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-images.md
+++ b/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-images.md
@@ -1,0 +1,28 @@
+
+A simple small image (using markdown syntax).
+
+![](http://placekitten.com/g/300/200/)
+
+A larger image (using markdown syntax).
+
+![](http://placekitten.com/g/1200/800/)
+
+A larger image (using markdown syntax) scaled down to a specific size (uses a [custom syntax](https://github.com/showdownjs/showdown/wiki/Showdown-Options#parseimgdimensions)).
+
+![](http://placekitten.com/g/1200/800/ =120x120)
+
+An image with alt text and title (using markdown syntax).
+
+![a nice kitten for you](http://placekitten.com/g/300/200/ "this is a kitten")
+
+An image with alt text and title (using markdown syntax) **and** size.
+
+![a nice kitten for you](http://placekitten.com/g/1200/800/ =120x120 "this is a kitten")
+
+--------
+
+Some images declared as inline `<img>` HTML.
+
+<img width="400" alt="kitten" src="http://placekitten.com/g/300/200/">
+
+<img width="1200" alt="kitten" src="http://placekitten.com/g/1200/800/">

--- a/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-lists.md
+++ b/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-lists.md
@@ -1,0 +1,119 @@
+* This is an unordered list.
+* This is an unordered list.
+* This is an unordered list.
+
+1. This is an ordered list.
+2. This is an ordered list.
+3. This is an ordered list.
+
+This is an unordered list (using `*`):
+
+* Salt-n-Pepa
+* Bel Biv DeVoe
+* Kid 'N Play
+
+This is also an unordered list (using `-`):
+
+- Salt-n-Pepa
+- Bel Biv DeVoe
+- Kid 'N Play
+
+And this is also an unordered list (using `+`):
+
++ Salt-n-Pepa
++ Bel Biv DeVoe
++ Kid 'N Play
+
+This instad is an ordered list:
+
+1. Michael Jackson
+2. Michael Bolton
+3. Michael Bublé
+
+This is an ordered list that uses the same number for all the items:
+
+1. Michael Jackson
+1. Michael Bolton
+1. Michael Bublé
+
+This is an ordered list that uses letters instead of numbers (doens't work):
+
+A. Michael Jackson
+A. Michael Bolton
+A. Michael Bublé
+
+----------------
+
+This is a nested list (using `*`):
+
+* Jackson 5
+    * Michael
+    * Tito
+    * Jackie
+    * Marlon
+    * Jermaine
+* TMNT
+    * Leonardo
+    * Michelangelo
+    * Donatello
+    * Raphael
+
+This is a nested list (using `-`):
+
+- Jackson 5
+    - Michael
+    - Tito
+    - Jackie
+    - Marlon
+    - Jermaine
+- TMNT
+    - Leonardo
+    - Michelangelo
+    - Donatello
+    - Raphael
+
+This is a deeply nested list:
+
+*   Lorem ipsum dolor sit amet,
+    *   Consectetuer adipiscing elit.
+    *   Aliquam hendrerit mi posuere lectus.
+        *   Vestibulum enim wisi.
+        *   Viverra nec, fringilla.
+        *   In laoreet vitae risus.
+            *   Donec sit amet nisl.
+            *   Aliquam semper ipsum
+        *   Sit amet velit.
+    *   Suspendisse id sem consectetuer
+*   Libero luctus adipiscing.
+
+----------------
+
+This is a list with hanging indents:
+
+*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+    Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
+    viverra nec, fringilla in, laoreet vitae, risus.
+*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
+    Suspendisse id sem consectetuer libero luctus adipiscing.
+
+This is a list with one item separated by a blank line (this will force it to wrap all the list items in `<p>` tags in the HTML output):
+
+*   Bird
+
+*   Magic
+*   Johnson
+
+This is a list that contains other block elements:
+
+*   A normal list item
+*   A list item with a blockquote:
+
+    > This is a blockquote
+    > inside a list item.
+
+* A list item with a code block
+
+    ```js
+    var foo = 'bar';
+    console.log(foo);
+    ```

--- a/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-tables.md
+++ b/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-tables.md
@@ -1,0 +1,58 @@
+Tables should have bold headings and alternating shaded rows.
+
+| Artist            | Album           | Year |
+|-------------------|-----------------|------|
+| Michael Jackson   | Thriller        | 1982 |
+| Prince            | Purple Rain     | 1984 |
+| Beastie Boys      | License to Ill  | 1986 |
+
+If a table is too wide, it should condense down and/or scroll horizontally.
+
+| Artist            | Album           | Year | Label       | Awards   | Songs     |
+|-------------------|-----------------|------|-------------|----------|-----------|
+| Michael Jackson   | Thriller        | 1982 | Epic Records | Grammy Award for Album of the Year, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Selling Album, Grammy Award for Best Engineered Album, Non-Classical | Wanna Be Startin' Somethin', Baby Be Mine, The Girl Is Mine, Thriller, Beat It, Billie Jean, Human Nature, P.Y.T. (Pretty Young Thing), The Lady in My Life |
+| Prince            | Purple Rain     | 1984 | Warner Brothers Records | Grammy Award for Best Score Soundtrack for Visual Media, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Soundtrack/Cast Recording, Grammy Award for Best Rock Performance by a Duo or Group with Vocal | Let's Go Crazy, Take Me With U, The Beautiful Ones, Computer Blue, Darling Nikki, When Doves Cry, I Would Die 4 U, Baby I'm a Star, Purple Rain |
+| Beastie Boys      | License to Ill  | 1986 | Mercury Records | noawardsbutthistablecelliswide | Rhymin & Stealin, The New Style, She's Crafty, Posse in Effect, Slow Ride, Girls, (You Gotta) Fight for Your Right, No Sleep Till Brooklyn, Paul Revere, Hold It Now, Hit It, Brass Monkey, Slow and Low, Time to Get Ill |
+
+Normal markdown tables can contain only inline elements (and the content can be aligned too):
+
+| Tables        | Are           | Cool  |
+| ------------- |:-------------:| -----:|
+| **col 3 is**  | right-aligned | $1600 |
+| col 2 is      | *centered*    |   $12 |
+| zebra stripes | ~~are neat~~  |    $1 |
+| `inline code` | can be added  |   too |
+
+If you need to use block elements inside a table, you have to use HTML code:
+
+<table>
+    <tr>
+        <td> Block type </td>
+        <td> Example </td>
+    </tr>
+    <tr>
+        <td> Code </td>
+        <td>
+            ```json
+            {
+            "id": 10,
+            "username": "marcoeidinger",
+            "created_at": "2021-02-097T20:45:26.433Z",
+            "updated_at": "2015-02-10T19:27:16.540Z"
+            }
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td> Blackquote </td>
+        <td>
+            > blockquote text
+        </td>
+    </tr>
+    <tr>
+        <td> Ember component </td>
+        <td>
+            <DocNpmVersion class="doc-test-markdown-basic-styling" />
+        </td>
+    </tr>
+</table>

--- a/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/with-ember-components.md
+++ b/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/with-ember-components.md
@@ -1,0 +1,43 @@
+# Test with inline Ember component
+
+Ember component directly declared in the markdown "root"
+
+<DocNpmVersion class="doc-test-markdown-basic-styling" />
+
+------
+
+Ember component inside a `<div>`
+
+<div>
+    <DocNpmVersion class="doc-test-markdown-basic-styling" />
+</div>
+
+------
+
+Ember component inside a markdown blockquote
+
+> <DocNpmVersion class="doc-test-markdown-basic-styling" />
+
+------
+
+Ember component inside a markdown list
+
+- <DocNpmVersion class="doc-test-markdown-basic-styling" />
+
+------
+
+Ember component inside a markdown table
+
+| Lorem ipsum                                               |
+|-----------------------------------------------------------|
+| <DocNpmVersion class="doc-test-markdown-basic-styling" /> |
+
+Ember component inside an HTML table
+
+<table>
+    <tr>
+        <td>
+            <DocNpmVersion class="doc-test-markdown-basic-styling" />
+        </td>
+    </tr>
+</table>

--- a/website/app/styles/markdown/_debug.scss
+++ b/website/app/styles/markdown/_debug.scss
@@ -1,19 +1,42 @@
-.doc-markdown-content {
-  > h1,
-  > h2,
-  > h3,
-  > h4,
-  > h5,
-  > h6,
-  > p,
-  > blockquote,
-  > ul,
-  > ol,
-  > dl,
-  > table,
-  > pre,
-  > details,
-  > hr {
-    outline: 2px solid magenta;
+.doc-markdown-h1,
+.doc-markdown-h2,
+.doc-markdown-h3,
+.doc-markdown-h4,
+.doc-markdown-h5,
+.doc-markdown-h6,
+.doc-markdown-p,
+.doc-markdown-blockquote,
+.doc-markdown-ul,
+.doc-markdown-ol,
+.doc-markdown-li,
+.doc-markdown-img,
+.doc-markdown-a,
+.doc-markdown-table,
+.doc-markdown-tr,
+.doc-markdown-td,
+.doc-markdown-th,
+.doc-markdown-pre,
+.doc-markdown-code,
+.doc-markdown-hr {
+  outline: 2px solid magenta;
+}
+
+.doc-markdown-blockquote {
+  border-left: 2px solid green;
+}
+
+.doc-markdown-ul,
+.doc-markdown-ol {
+  border: 4px solid cyan;
+
+  > li + li {
+    border-top: 5px solid coral;
   }
 }
+
+
+.doc-markdown-hr {
+  height: 12px;
+  background-color: midnightblue;
+}
+

--- a/website/app/styles/markdown/index.scss
+++ b/website/app/styles/markdown/index.scss
@@ -6,4 +6,6 @@
 @import "./lists";
 @import "./tables";
 @import "./other-elements";
-@import "./debug";
+
+// debugging
+// @import "./debug";

--- a/website/app/styles/markdown/lists.scss
+++ b/website/app/styles/markdown/lists.scss
@@ -1,82 +1,22 @@
-@mixin top-list-level() {
-  > ul,
-  > ol {
-    @content;
+// LISTS
+
+.doc-markdown-ul,
+.doc-markdown-ol {
+  padding-left: 16px;
+
+  > li > p {
+    margin-top: 12px;
+  }
+
+  > li + li {
+    margin-top: 12px;
   }
 }
 
-@mixin generic-list-level() {
-  > ul,
-  > ol {
-    & {
-      @content;
-    }
-  }
-}
-
-@mixin nested-list-levels() { // we support up to 4 nested levels
-  > ul > li > ul,
-  > ul > li > ol,
-  > ol > li > ul,
-  > ol > li > ol,
-  > ul > li > ul > li > ul,
-  > ul > li > ul > li > ol,
-  > ul > li > ol > li > ul,
-  > ul > li > ol > li > ol,
-  > ol > li > ul > li > ul,
-  > ol > li > ul > li > ol,
-  > ol > li > ol > li > ul,
-  > ol > li > ol > li > ol,
-  > ul > li > ul > li > ul > li > ul,
-  > ul > li > ul > li > ul > li > ol,
-  > ul > li > ul > li > ol > li > ul,
-  > ul > li > ul > li > ol > li > ol,
-  > ul > li > ol > li > ul > li > ul,
-  > ul > li > ol > li > ul > li > ol,
-  > ul > li > ol > li > ol > li > ul,
-  > ul > li > ol > li > ol > li > ol,
-  > ol > li > ul > li > ul > li > ul,
-  > ol > li > ul > li > ul > li > ol,
-  > ol > li > ul > li > ol > li > ul,
-  > ol > li > ul > li > ol > li > ol,
-  > ol > li > ol > li > ul > li > ul,
-  > ol > li > ol > li > ul > li > ol,
-  > ol > li > ol > li > ol > li > ul,
-  > ol > li > ol > li > ol > li > ol {
-    @content;
-  }
-}
-
-@mixin all-list-levels() {
-  @include top-list-level() {
-    @content;
-  }
-
-  @include nested-list-levels() {
-    @content;
-  }
-}
-
-.doc-markdown-content {
-
-  // LISTS
-
-  @include all-list-levels() {
-    padding-left: 16px;
-    border: 4px solid cyan;
-
-    > li > p {
-      margin-top: 12px;
-    }
-
-    > li + li {
-      margin-top: 12px;
-      border-left: 2px solid coral;
-    }
-  }
-
-  @include nested-list-levels() {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
+.doc-markdown-ul .doc-markdown-ul,
+.doc-markdown-ul .doc-markdown-ol,
+.doc-markdown-ol .doc-markdown-ul,
+.doc-markdown-ol .doc-markdown-ol {
+  margin-top: 0;
+  margin-bottom: 0;
 }

--- a/website/app/styles/markdown/other-elements.scss
+++ b/website/app/styles/markdown/other-elements.scss
@@ -1,60 +1,59 @@
-.doc-markdown-content {
+// LINKS
 
-  // IMAGES
+.doc-markdown-a {
+  color: teal;
+}
 
-  > img,
-  > p img,
-  > li img,
-  > th img,
-  > td img {
-    box-sizing: content-box;
-    max-width: 100%;
-    background-color: #fff; // TODO
+// IMAGES
 
-    &[align="right"] {
-      padding-left: 20px;
-    }
+.doc-markdown-img {
+  box-sizing: content-box;
+  max-width: 100%;
+  background-color: #fff; // TODO
 
-    &[align="left"] {
-      padding-right: 20px;
-    }
+  &[align="right"] {
+    padding-left: 20px;
   }
 
-  // CODE SNIPPETS
-  // TODO do we need this or in reality we will not use them directly?
+  &[align="left"] {
+    padding-right: 20px;
+  }
+}
 
-  code { // for the typographic styles see "typography"
+// CODE SNIPPETS
+// TODO do we need this or in reality we will not use them directly?
+
+.doc-markdown-code { // for the typographic styles see "typography"
+  margin: 0;
+  padding: 4px 8px;
+  color: white; // TODO
+  background-color: black; // TODO
+  border-radius: 3px;
+}
+
+.doc-markdown-pre {
+  word-wrap: normal;
+
+  .doc-markdown-code {
+    display: inline;
+    max-width: auto;
     margin: 0;
-    padding: 4px 8px;
-    color: white; // TODO
-    background-color: black; // TODO
-    border-radius: 3px;
-  }
-
-  pre {
-    word-wrap: normal;
-
-    > code {
-      display: inline;
-      max-width: auto;
-      margin: 0;
-      padding: 0;
-      overflow: visible;
-      white-space: pre;
-      word-wrap: normal;
-      word-break: normal;
-      background: transparent;
-      border: 0;
-    }
-  }
-
-  // HORIZONTAL RULE
-
-  > hr {
-    height: 12px;
-    margin: 16px 0;
     padding: 0;
-    background-color: midnightblue; // TODO
+    overflow: visible;
+    white-space: pre;
+    word-wrap: normal;
+    word-break: normal;
+    background: transparent;
     border: 0;
   }
+}
+
+// HORIZONTAL RULE
+
+.doc-markdown-hr {
+  height: 1px;
+  margin: 16px 0;
+  padding: 0;
+  background-color: lightgray; // TODO
+  border: 0;
 }

--- a/website/app/styles/markdown/other-elements.scss
+++ b/website/app/styles/markdown/other-elements.scss
@@ -7,17 +7,8 @@
 // IMAGES
 
 .doc-markdown-img {
-  box-sizing: content-box;
   max-width: 100%;
   background-color: #fff; // TODO
-
-  &[align="right"] {
-    padding-left: 20px;
-  }
-
-  &[align="left"] {
-    padding-right: 20px;
-  }
 }
 
 // CODE SNIPPETS

--- a/website/app/styles/markdown/root.scss
+++ b/website/app/styles/markdown/root.scss
@@ -1,3 +1,5 @@
+// TODO we have to change approach for this, I think
+
 .doc-markdown-content {
   > *:first-child {
     margin-top: 0 !important;

--- a/website/app/styles/markdown/tables.scss
+++ b/website/app/styles/markdown/tables.scss
@@ -1,35 +1,33 @@
-.doc-markdown-content {
+// TABLES
 
-  // TABLES
+.doc-markdown-table {
+  display: block;
+  width: 100%;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
 
-  table {
-    display: block;
-    width: 100%;
-    width: max-content;
-    max-width: 100%;
-    overflow: auto;
-
-    th {
-      font-weight: bold; // TODO
-    }
-
-    th,
-    td {
-      padding: 6px 12px;
-      border: 1px solid olivedrab; // TODO
-    }
-
-    tr {
-      background-color: pink; // TODO
-      border-top: 1px solid coral; // TODO
-
-      &:nth-child(2n) {
-        background-color: maroon; // TODO
-      }
-    }
-
-    img {
-      background-color: transparent;
-    }
+  // TODO why is needed?
+  .doc-markdown-img {
+    background-color: transparent;
   }
+}
+
+.doc-markdown-tr {
+  background-color: pink; // TODO
+  border-top: 1px solid coral; // TODO
+
+  &:nth-child(2n) {
+    background-color: maroon; // TODO
+  }
+}
+
+.doc-markdown-th {
+  font-weight: bold; // TODO
+}
+
+.doc-markdown-th,
+.doc-markdown-td {
+  padding: 6px 12px;
+  border: 1px solid olivedrab; // TODO
 }

--- a/website/app/styles/markdown/typography.scss
+++ b/website/app/styles/markdown/typography.scss
@@ -1,96 +1,86 @@
 @use "../typography/mixins";
 
-.doc-markdown-content {
 
-  // HEADINGS
+// HEADINGS
 
-  > h1 {
-    @include doc-font-style-h1 ($responsive: false);
-    margin-top: 16px;
-    margin-bottom: 12px;
+.doc-markdown-h1 {
+  @include doc-font-style-h1 ($responsive: false);
+  margin-top: 16px;
+  margin-bottom: 12px;
+}
+
+.doc-markdown-h2 {
+  @include doc-font-style-h2 ($responsive: false);
+  margin-top: 16px;
+  margin-bottom: 12px;
+}
+
+.doc-markdown-h3 {
+  @include doc-font-style-h3 ($responsive: false);
+  margin-top: 16px;
+  margin-bottom: 12px;
+}
+
+.doc-markdown-h4 {
+  @include doc-font-style-h4 ($responsive: false);
+  margin-top: 16px;
+  margin-bottom: 12px;
+}
+
+.doc-markdown-h5 {
+  @include doc-font-style-h5 ();
+  margin-top: 16px;
+  margin-bottom: 12px;
+}
+
+.doc-markdown-h6 {
+  @include doc-font-style-h6 ();
+  margin-top: 16px;
+  margin-bottom: 12px;
+}
+
+.doc-markdown-h1,
+.doc-markdown-h2,
+.doc-markdown-h3,
+.doc-markdown-h4,
+.doc-markdown-h5,
+.doc-markdown-h6 {
+  .doc-markdown-code {
+    font-size: inherit;
   }
+}
 
-  > h2 {
-    @include doc-font-style-h2 ($responsive: false);
-    margin-top: 16px;
-    margin-bottom: 12px;
-  }
+// BODY COPY
 
-  > h3 {
-    @include doc-font-style-h3 ($responsive: false);
-    margin-top: 16px;
-    margin-bottom: 12px;
-  }
+.doc-markdown-p,
+.doc-markdown-ul,
+.doc-markdown-ol {
+  @include doc-font-style-body();
+  margin-top: 0;
+  margin-bottom: 12px;
+}
 
-  > h4 {
-    @include doc-font-style-h4 ($responsive: false);
-    margin-top: 16px;
-    margin-bottom: 12px;
-  }
+.doc-markdown-blockquote {
+  margin: 0 0 12px 0;
+  padding: 0 0 0 16px;
+  border-left: 2px solid lightgray;
 
-  > h5 {
-    @include doc-font-style-h5 ();
-    margin-top: 16px;
-    margin-bottom: 12px;
-  }
+  @include doc-font-style-body();
 
-  > h6 {
-    @include doc-font-style-h6 ();
-    margin-top: 16px;
-    margin-bottom: 12px;
-  }
-
-  > h1,
-  > h2,
-  > h3,
-  > h4,
-  > h5,
-  > h6 {
-    > code {
-      font-size: inherit;
-    }
-  }
-
-  // BODY COPY
-
-  > p,
-  > ul,
-  > ol {
-    @include doc-font-style-body();
+  > :first-child {
     margin-top: 0;
-    margin-bottom: 12px;
   }
 
-  // top level element + nested elements (reasonably no more than two levels)
-  > blockquote,
-  > ul > li > blockquote,
-  > ol > li > blockquote,
-  > ul > li > ul > li > blockquote,
-  > ul > li > ol > li > blockquote,
-  > ol > li > ul > li > blockquote,
-  > ol > li > ol > li > blockquote {
-    margin-top: 0;
-    margin-bottom: 12px;
-    padding: 0 0 0 16px;
-    border-left: 2px solid green;
-
-    @include doc-font-style-body();
-
-    > :first-child {
-      margin-top: 0;
-    }
-
-    > :last-child {
-      margin-bottom: 0;
-    }
+  > :last-child {
+    margin-bottom: 0;
   }
+}
 
-  // CODE
+// CODE
 
-  > pre > code,
-  > code {
-    @include doc-font-style-code ();
-    margin-top: 0;
-    margin-bottom: 12px;
-  }
+.doc-markdown-pre,
+.doc-markdown-code {
+  @include doc-font-style-code ();
+  margin-top: 0;
+  margin-bottom: 12px;
 }

--- a/website/docs/testing/00-testing-markdown-formatting/basic-spacing.md
+++ b/website/docs/testing/00-testing-markdown-formatting/basic-spacing.md
@@ -1,0 +1,71 @@
+# Header 1
+
+This is a normal paragraph following a header. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+There should be whitespace between paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+There should be whitespace between paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+## Header 2
+
+> This is a blockquote following a header. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+
+Lorem ipsum dolor sit amet.
+
+> This is a blockquote following a paragraph.
+
+Lorem ipsum dolor sit amet.
+
+> There should be no margin above this first sentence.
+>
+> Blockquotes should be a lighter gray with a gray border along the left side.
+>
+> There should be no margin below this final sentence.
+
+### Header 3
+
+```
+This is a code block following a header.
+```
+
+Lorem ipsum dolor sit amet.
+
+```
+This is a code block following a paragraph.
+```
+
+#### Header 4
+
+* This is a list following a header.
+* This is a list following a header.
+* This is a list following a header.
+
+Lorem ipsum dolor sit amet.
+
+* This is a list following a paragraph.
+* This is a list following a paragraph.
+* This is a list following a paragraph.
+
+##### Header 5
+
+| This      | Table           |
+|-----------|-----------------|
+| Is        | Following       |
+| A         | Header          |
+
+Lorem ipsum dolor sit amet.
+
+| This      | Table           |
+|-----------|-----------------|
+| Is        | Following       |
+| A         | Header          |
+
+###### Header 6
+
+![](http://placekitten.com/g/300/200/)
+
+The image above is an image following a header.
+
+![](http://placekitten.com/g/300/200/)
+
+The image above is an image following a paragraph.

--- a/website/docs/testing/00-testing-markdown-formatting/basic-styling.md
+++ b/website/docs/testing/00-testing-markdown-formatting/basic-styling.md
@@ -1,279 +1,57 @@
-<div class="doc-markdown-content">
+# Header 1
+## Header 2
+### Header 3
+#### Header 4
+##### Header 5
+###### Header 6
+
+----------------
+
+This is a normal paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
 
 Text can be **bold**, _italic_, or ~~strikethrough~~, and can contain emoji like 👋 🙂 🚨 🚀.
 
 Inline [links](https://github.com) should be styled according to the design specifications.
 
-There should be whitespace between paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+----------------
 
-There should be whitespace between paragraphs. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
-
-> There should be no margin above this first sentence.
+> This is some text inside a blockquote
 >
-> Blockquotes should be a lighter gray with a gray border along the left side.
+> And this is more text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 >
-> There should be no margin below this final sentence.
+> And this is the closing text.
 
-# Header 1
+----------------
 
-This is a normal paragraph following a header. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+* This is an unordered list.
+* This is an unordered list.
+* This is an unordered list.
 
-## Header 2
+1. This is an ordered list.
+2. This is an ordered list.
+3. This is an ordered list.
 
-> This is a blockquote following a header. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at magna eget, porttitor lobortis nulla.
+----------------
 
-### Header 3
+
+A simple image
+
+![](http://placekitten.com/g/300/200/)
+
+----------------
+
+A simple inline code snippet `var foo = "bar";` like this.
+
+A simple code block.
 
 ```
-This is a code block following a header.
+var foo = "bar";
 ```
 
-#### Header 4
-
-* This is an unordered list following a header.
-* This is an unordered list following a header.
-* This is an unordered list following a header.
-
-##### Header 5
-
-1. This is an ordered list following a header.
-2. This is an ordered list following a header.
-3. This is an ordered list following a header.
-
-###### Header 6
+----------------
 
 | What      | Follows         |
 |-----------|-----------------|
 | A table   | A header        |
 | A table   | A header        |
 | A table   | A header        |
-
-----------------
-
-There's a horizontal rule above and below this.
-
-----------------
-
-This is an unordered list (using `*`):
-
-* Salt-n-Pepa
-* Bel Biv DeVoe
-* Kid 'N Play
-
-This is also an unordered list (using `-`):
-
-- Salt-n-Pepa
-- Bel Biv DeVoe
-- Kid 'N Play
-
-And this is also an unordered list (using `+`):
-
-+ Salt-n-Pepa
-+ Bel Biv DeVoe
-+ Kid 'N Play
-
-This instad is an ordered list:
-
-1. Michael Jackson
-2. Michael Bolton
-3. Michael Bublé
-
-This is an ordered list that uses the same number for all the items:
-
-1. Michael Jackson
-1. Michael Bolton
-1. Michael Bublé
-
-This is an ordered list that uses letters instead of numbers (doens't work):
-
-A. Michael Jackson
-A. Michael Bolton
-A. Michael Bublé
-
-This is a nested list (using `*`):
-
-* Jackson 5
-    * Michael
-    * Tito
-    * Jackie
-    * Marlon
-    * Jermaine
-* TMNT
-    * Leonardo
-    * Michelangelo
-    * Donatello
-    * Raphael
-
-This is a nested list (using `-`):
-
-- Jackson 5
-    - Michael
-    - Tito
-    - Jackie
-    - Marlon
-    - Jermaine
-- TMNT
-    - Leonardo
-    - Michelangelo
-    - Donatello
-    - Raphael
-
-This is a deeply nested list:
-
-*   Lorem ipsum dolor sit amet,
-    *   Consectetuer adipiscing elit.
-    *   Aliquam hendrerit mi posuere lectus.
-        *   Vestibulum enim wisi.
-        *   Viverra nec, fringilla.
-        *   In laoreet vitae risus.
-            *   Donec sit amet nisl.
-            *   Aliquam semper ipsum
-        *   Sit amet velit.
-    *   Suspendisse id sem consectetuer
-*   Libero luctus adipiscing.
-
-This is a list with hanging indents:
-
-*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-    Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
-    viverra nec, fringilla in, laoreet vitae, risus.
-*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
-    Suspendisse id sem consectetuer libero luctus adipiscing.
-
-This is a list with one item separated by a blank line (this will force it to wrap all the list items in `<p>` tags in the HTML output):
-
-*   Bird
-
-*   Magic
-*   Johnson
-
-This is a list that contains other block elements:
-
-*   A normal list item
-*   A list item with a blockquote:
-
-    > This is a blockquote
-    > inside a list item.
-* A list item with a code block
-
-    ```js
-    var foo = 'bar';
-    console.log(foo);
-    ```
-
-----------------
-
-> This is a blockquote that contains other block elements
->
-> #### A heading level 4
-> A normal paragraph
-> - A list
-> - with items
->
-> ```
-> Some code snippet
-> ```
-
-----------------
-
-Tables should have bold headings and alternating shaded rows.
-
-| Artist            | Album           | Year |
-|-------------------|-----------------|------|
-| Michael Jackson   | Thriller        | 1982 |
-| Prince            | Purple Rain     | 1984 |
-| Beastie Boys      | License to Ill  | 1986 |
-
-If a table is too wide, it should condense down and/or scroll horizontally.
-
-| Artist            | Album           | Year | Label       | Awards   | Songs     |
-|-------------------|-----------------|------|-------------|----------|-----------|
-| Michael Jackson   | Thriller        | 1982 | Epic Records | Grammy Award for Album of the Year, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Selling Album, Grammy Award for Best Engineered Album, Non-Classical | Wanna Be Startin' Somethin', Baby Be Mine, The Girl Is Mine, Thriller, Beat It, Billie Jean, Human Nature, P.Y.T. (Pretty Young Thing), The Lady in My Life |
-| Prince            | Purple Rain     | 1984 | Warner Brothers Records | Grammy Award for Best Score Soundtrack for Visual Media, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Soundtrack/Cast Recording, Grammy Award for Best Rock Performance by a Duo or Group with Vocal | Let's Go Crazy, Take Me With U, The Beautiful Ones, Computer Blue, Darling Nikki, When Doves Cry, I Would Die 4 U, Baby I'm a Star, Purple Rain |
-| Beastie Boys      | License to Ill  | 1986 | Mercury Records | noawardsbutthistablecelliswide | Rhymin & Stealin, The New Style, She's Crafty, Posse in Effect, Slow Ride, Girls, (You Gotta) Fight for Your Right, No Sleep Till Brooklyn, Paul Revere, Hold It Now, Hit It, Brass Monkey, Slow and Low, Time to Get Ill |
-
-Normal markdown tables can contain only inline elements (and the content can be aligned too):
-
-| Tables        | Are           | Cool  |
-| ------------- |:-------------:| -----:|
-| **col 3 is**  | right-aligned | $1600 |
-| col 2 is      | *centered*    |   $12 |
-| zebra stripes | ~~are neat~~  |    $1 |
-| `inline code` | can be added  |   too |
-
-If you need to use block elements inside a table, you have to use HTML code:
-
-<table>
-    <tr>
-        <td> Block type </td>
-        <td> Example </td>
-    </tr>
-    <tr>
-        <td> Code </td>
-        <td>
-            ```json
-            {
-            "id": 10,
-            "username": "marcoeidinger",
-            "created_at": "2021-02-097T20:45:26.433Z",
-            "updated_at": "2015-02-10T19:27:16.540Z"
-            }
-            ```
-        </td>
-    </tr>
-    <tr>
-        <td> Blackquote </td>
-        <td>
-            > blockquote text
-        </td>
-    </tr>
-</table>
-
-----------------
-
-Code snippets like `var foo = "bar";` can be shown inline.
-
-Also, `this should vertically align` ~~`with this`~~ ~~and this~~.
-
-Code can also be shown in a block element.
-```
-var foo = "bar";
-```
-
-Code can also use syntax highlighting.
-```javascript
-var foo = "bar";
-```
-
-```
-Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.
-```
-
-```javascript
-var foo = "The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.";
-```
-
-Inline code inside table cells should still be distinguishable.
-
-| Language    | Code               |
-|-------------|--------------------|
-| JavaScript  | `var foo = "bar";` |
-| Ruby        | `foo = "bar"`      |
-
-----------------
-
-Small images should be shown at their actual size.
-
-![](http://placekitten.com/g/300/200/)
-
-Large images should always scale down and fit in the content container.
-
-![](http://placekitten.com/g/1200/800/)
-
-Inline `<img>` images should be rendered at the defined size, without overflowing the container.
-
-<img width="400" alt="kittem" src="http://placekitten.com/g/300/200/">
-<img width="1200" alt="kittem" src="http://placekitten.com/g/1200/800/">
-
-
-</div>

--- a/website/docs/testing/00-testing-markdown-formatting/more-complex-code.md
+++ b/website/docs/testing/00-testing-markdown-formatting/more-complex-code.md
@@ -1,0 +1,27 @@
+----------------
+
+A simple inline code snippet `var foo = "bar";` like this.
+
+----------------
+
+A simple code block.
+
+```
+var foo = "bar";
+```
+
+A code block with syntax declaration.
+
+```javascript
+var foo = "bar";
+```
+
+A long code block.
+
+```
+Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.
+```
+
+```javascript
+var foo = "The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.";
+```

--- a/website/docs/testing/00-testing-markdown-formatting/more-complex-images.md
+++ b/website/docs/testing/00-testing-markdown-formatting/more-complex-images.md
@@ -1,0 +1,28 @@
+
+A simple small image (using markdown syntax).
+
+![](http://placekitten.com/g/300/200/)
+
+A larger image (using markdown syntax).
+
+![](http://placekitten.com/g/1200/800/)
+
+A larger image (using markdown syntax) scaled down to a specific size (uses a [custom syntax](https://github.com/showdownjs/showdown/wiki/Showdown-Options#parseimgdimensions)).
+
+![](http://placekitten.com/g/1200/800/ =120x120)
+
+An image with alt text and title (using markdown syntax).
+
+![a nice kitten for you](http://placekitten.com/g/300/200/ "this is a kitten")
+
+An image with alt text and title (using markdown syntax) **and** size.
+
+![a nice kitten for you](http://placekitten.com/g/1200/800/ =120x120 "this is a kitten")
+
+--------
+
+Some images declared as inline `<img>` HTML.
+
+<img width="400" alt="kitten" src="http://placekitten.com/g/300/200/">
+
+<img width="1200" alt="kitten" src="http://placekitten.com/g/1200/800/">

--- a/website/docs/testing/00-testing-markdown-formatting/more-complex-lists.md
+++ b/website/docs/testing/00-testing-markdown-formatting/more-complex-lists.md
@@ -1,0 +1,119 @@
+* This is an unordered list.
+* This is an unordered list.
+* This is an unordered list.
+
+1. This is an ordered list.
+2. This is an ordered list.
+3. This is an ordered list.
+
+This is an unordered list (using `*`):
+
+* Salt-n-Pepa
+* Bel Biv DeVoe
+* Kid 'N Play
+
+This is also an unordered list (using `-`):
+
+- Salt-n-Pepa
+- Bel Biv DeVoe
+- Kid 'N Play
+
+And this is also an unordered list (using `+`):
+
++ Salt-n-Pepa
++ Bel Biv DeVoe
++ Kid 'N Play
+
+This instad is an ordered list:
+
+1. Michael Jackson
+2. Michael Bolton
+3. Michael Bublé
+
+This is an ordered list that uses the same number for all the items:
+
+1. Michael Jackson
+1. Michael Bolton
+1. Michael Bublé
+
+This is an ordered list that uses letters instead of numbers (doens't work):
+
+A. Michael Jackson
+A. Michael Bolton
+A. Michael Bublé
+
+----------------
+
+This is a nested list (using `*`):
+
+* Jackson 5
+    * Michael
+    * Tito
+    * Jackie
+    * Marlon
+    * Jermaine
+* TMNT
+    * Leonardo
+    * Michelangelo
+    * Donatello
+    * Raphael
+
+This is a nested list (using `-`):
+
+- Jackson 5
+    - Michael
+    - Tito
+    - Jackie
+    - Marlon
+    - Jermaine
+- TMNT
+    - Leonardo
+    - Michelangelo
+    - Donatello
+    - Raphael
+
+This is a deeply nested list:
+
+*   Lorem ipsum dolor sit amet,
+    *   Consectetuer adipiscing elit.
+    *   Aliquam hendrerit mi posuere lectus.
+        *   Vestibulum enim wisi.
+        *   Viverra nec, fringilla.
+        *   In laoreet vitae risus.
+            *   Donec sit amet nisl.
+            *   Aliquam semper ipsum
+        *   Sit amet velit.
+    *   Suspendisse id sem consectetuer
+*   Libero luctus adipiscing.
+
+----------------
+
+This is a list with hanging indents:
+
+*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+    Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
+    viverra nec, fringilla in, laoreet vitae, risus.
+*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
+    Suspendisse id sem consectetuer libero luctus adipiscing.
+
+This is a list with one item separated by a blank line (this will force it to wrap all the list items in `<p>` tags in the HTML output):
+
+*   Bird
+
+*   Magic
+*   Johnson
+
+This is a list that contains other block elements:
+
+*   A normal list item
+*   A list item with a blockquote:
+
+    > This is a blockquote
+    > inside a list item.
+
+* A list item with a code block
+
+    ```js
+    var foo = 'bar';
+    console.log(foo);
+    ```

--- a/website/docs/testing/00-testing-markdown-formatting/more-complex-tables.md
+++ b/website/docs/testing/00-testing-markdown-formatting/more-complex-tables.md
@@ -1,0 +1,58 @@
+Tables should have bold headings and alternating shaded rows.
+
+| Artist            | Album           | Year |
+|-------------------|-----------------|------|
+| Michael Jackson   | Thriller        | 1982 |
+| Prince            | Purple Rain     | 1984 |
+| Beastie Boys      | License to Ill  | 1986 |
+
+If a table is too wide, it should condense down and/or scroll horizontally.
+
+| Artist            | Album           | Year | Label       | Awards   | Songs     |
+|-------------------|-----------------|------|-------------|----------|-----------|
+| Michael Jackson   | Thriller        | 1982 | Epic Records | Grammy Award for Album of the Year, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Selling Album, Grammy Award for Best Engineered Album, Non-Classical | Wanna Be Startin' Somethin', Baby Be Mine, The Girl Is Mine, Thriller, Beat It, Billie Jean, Human Nature, P.Y.T. (Pretty Young Thing), The Lady in My Life |
+| Prince            | Purple Rain     | 1984 | Warner Brothers Records | Grammy Award for Best Score Soundtrack for Visual Media, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Soundtrack/Cast Recording, Grammy Award for Best Rock Performance by a Duo or Group with Vocal | Let's Go Crazy, Take Me With U, The Beautiful Ones, Computer Blue, Darling Nikki, When Doves Cry, I Would Die 4 U, Baby I'm a Star, Purple Rain |
+| Beastie Boys      | License to Ill  | 1986 | Mercury Records | noawardsbutthistablecelliswide | Rhymin & Stealin, The New Style, She's Crafty, Posse in Effect, Slow Ride, Girls, (You Gotta) Fight for Your Right, No Sleep Till Brooklyn, Paul Revere, Hold It Now, Hit It, Brass Monkey, Slow and Low, Time to Get Ill |
+
+Normal markdown tables can contain only inline elements (and the content can be aligned too):
+
+| Tables        | Are           | Cool  |
+| ------------- |:-------------:| -----:|
+| **col 3 is**  | right-aligned | $1600 |
+| col 2 is      | *centered*    |   $12 |
+| zebra stripes | ~~are neat~~  |    $1 |
+| `inline code` | can be added  |   too |
+
+If you need to use block elements inside a table, you have to use HTML code:
+
+<table>
+    <tr>
+        <td> Block type </td>
+        <td> Example </td>
+    </tr>
+    <tr>
+        <td> Code </td>
+        <td>
+            ```json
+            {
+            "id": 10,
+            "username": "marcoeidinger",
+            "created_at": "2021-02-097T20:45:26.433Z",
+            "updated_at": "2015-02-10T19:27:16.540Z"
+            }
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td> Blackquote </td>
+        <td>
+            > blockquote text
+        </td>
+    </tr>
+    <tr>
+        <td> Ember component </td>
+        <td>
+            <DocNpmVersion class="doc-test-markdown-basic-styling" />
+        </td>
+    </tr>
+</table>

--- a/website/docs/testing/00-testing-markdown-formatting/with-ember-components.md
+++ b/website/docs/testing/00-testing-markdown-formatting/with-ember-components.md
@@ -1,0 +1,43 @@
+# Test with inline Ember component
+
+Ember component directly declared in the markdown "root"
+
+<DocNpmVersion class="doc-test-markdown-basic-styling" />
+
+------
+
+Ember component inside a `<div>`
+
+<div>
+    <DocNpmVersion class="doc-test-markdown-basic-styling" />
+</div>
+
+------
+
+Ember component inside a markdown blockquote
+
+> <DocNpmVersion class="doc-test-markdown-basic-styling" />
+
+------
+
+Ember component inside a markdown list
+
+- <DocNpmVersion class="doc-test-markdown-basic-styling" />
+
+------
+
+Ember component inside a markdown table
+
+| Lorem ipsum                                               |
+|-----------------------------------------------------------|
+| <DocNpmVersion class="doc-test-markdown-basic-styling" /> |
+
+Ember component inside an HTML table
+
+<table>
+    <tr>
+        <td>
+            <DocNpmVersion class="doc-test-markdown-basic-styling" />
+        </td>
+    </tr>
+</table>


### PR DESCRIPTION
### :pushpin: Summary

In this PR I have updated the `showdown` configuration to allow adding custom classes to the generated HTML elements.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated `showdown` configuration to add custom classes to generated HTML elements
- refactored CSS for markdown to use the newly added specific classes instead of direct descendants (`>`)
  - now styles for "markdown elements" are ready to be finalized (once the design specs are final)
- modified markdown testing examples to better cover all scenarios and be more easy to update and use

### 🌈 Previews

**Markdown test samples:**

- [Basic Styling](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/testing/00-testing-markdown-formatting/basic-styling/)
- [Basic Spacing](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/testing/00-testing-markdown-formatting/basic-spacing/)
- [More complex code](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/testing/00-testing-markdown-formatting/more-complex-code/)
- [More complex images](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/testing/00-testing-markdown-formatting/more-complex-images/)
- [More complex lists](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/testing/00-testing-markdown-formatting/more-complex-lists/)
- [More complex tables](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/testing/00-testing-markdown-formatting/more-complex-tables/)
- [With Ember components](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/testing/00-testing-markdown-formatting/with-ember-components/)

**Design documentation pages** (migrated in #685 by @jorytindall)

- [Alert](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/components/alert/04--design-guidelines/)
- [Badge](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/components/badge/04--design-guidelines/)
- [Breadcrumb](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/components/breadcrumb/04--design-guidelines/)
- [Button](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/components/button/04--design-guidelines/)
- [Dropdown](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/components/dropdown/04--design-guidelines/)
- [Form::Select](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/components/dropdown/04--design-guidelines/)
- [Toast](https://hds-website-git-new-docs-website-add-support-f-57ff69-hashicorp.vercel.app/components/toast/04--design-guidelines/)

### 🤔 Things to discuss/decide
- [ ] for the custom class names use `doc-markdown-[...]` (it's longer but more explicit/clear) or `doc-md-[...]` (may be cryptic but it's shorter)?

### :link: External links

- JIRA tickets:
  - https://hashicorp.atlassian.net/browse/HDS-823
  - https://hashicorp.atlassian.net/browse/HDS-1028

- There is a similar way to do something similar in `markdown-it`: https://github.com/markdown-it/markdown-it/issues/536

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
