### PR TITLE
Update `stylelint` to support `flight` classnames

### DIFF
--- a/packages/components/.stylelintrc.js
+++ b/packages/components/.stylelintrc.js
@@ -48,12 +48,12 @@ module.exports = {
     // see: https://stylelint.io/user-guide/rules/list/number-leading-zero/
     'number-leading-zero': 'always',
 
-    // we've decided to enforce the `.hds|.mock` naming convention (plus, using the default stylelint rule one doesn't work for us, because we're using BEM)
+    // we've decided to enforce the `.hds|.mock|.flight` naming convention (plus, using the default stylelint rule one doesn't work for us, because we're using BEM)
     // see: https://stylelint.io/user-guide/rules/list/selector-class-pattern/
     'selector-class-pattern': [
       // found this pattern here: https://github.com/humanmade/coding-standards/pull/199
       // '^(?<block>(?:[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)(?<element>(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*))?(?<modifier>(?:--[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)?$',
-      '^hds-(?<block>(?:[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)(?<element>(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*))?(?<modifier>(?:--[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)?$|^mock-(?:[a-z][a-z0-9]*)$',
+      '^hds-(?<block>(?:[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)(?<element>(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*))?(?<modifier>(?:--[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)?$|^mock-(?:[a-z][a-z0-9]*)$||^flight-(?:[a-z][a-z0-9]*)$',
       { resolveNestedSelectors: true },
     ],
 


### PR DESCRIPTION
### :pushpin: Summary

This is needed to fix a linting error in @MelSumner PR #542.

<img width="1371" alt="screenshot_2045" src="https://user-images.githubusercontent.com/686239/201647031-caaeb58b-9890-496e-8496-1f9940eb81b2.png">


### :hammer_and_wrench: Detailed description

In this PR I have:
- update `stylelint` configuration file to support `flight` classnames (it's handled by a regex)

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
