### PR TITLE
Add `layout` property to `RadioCard`

### DIFF
--- a/.changeset/eighty-fishes-sin.md
+++ b/.changeset/eighty-fishes-sin.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Add `@layout` parameter to `RadioCard`

--- a/packages/components/addon/components/hds/form/radio-card/group.hbs
+++ b/packages/components/addon/components/hds/form/radio-card/group.hbs
@@ -18,6 +18,7 @@
           name=@name
           alignment=@alignment
           controlPosition=@controlPosition
+          layout=@layout
           extraAriaDescribedBy=F.ariaDescribedBy
         )
       )

--- a/packages/components/addon/components/hds/form/radio-card/index.js
+++ b/packages/components/addon/components/hds/form/radio-card/index.js
@@ -7,8 +7,10 @@ import { schedule } from '@ember/runloop';
 
 export const DEFAULT_CONTROL_POSITION = 'bottom';
 export const DEFAULT_ALIGNMENT = 'left';
+export const DEFAULT_LAYOUT = 'fluid';
 export const CONTROL_POSITIONS = ['bottom', 'left'];
 export const ALIGNMENTS = ['left', 'center'];
+export const LAYOUTS = ['fluid', 'fixed'];
 
 export default class HdsFormRadioCardIndexComponent extends Component {
   @tracked ariaDescribedBy = this.args.extraAriaDescribedBy;
@@ -65,6 +67,34 @@ export default class HdsFormRadioCardIndexComponent extends Component {
   }
 
   /**
+   * Sets the layout of the card within the group
+   * Accepted values: fluid, fixed
+   *
+   * @param layout
+   * @type {string}
+   * @default 'fluid'
+   */
+  get layout() {
+    let { layout = DEFAULT_LAYOUT } = this.args;
+
+    assert(
+      `@layout for "Hds::Form::RadioCard" must be one of the following: ${LAYOUTS.join(
+        ', '
+      )}; received: ${layout}`,
+      LAYOUTS.includes(layout)
+    );
+
+    // if the `@layout` is set to 'fixed' we need a `@maxWidth` value to constrain the card to
+    if (layout === 'fixed') {
+      assert(
+        `@maxWidth for "Hds::Form::RadioCard" with @layout "fixed" is required`,
+        this.args.maxWidth
+      );
+    }
+    return layout;
+  }
+
+  /**
    * Get the class names to apply to the component.
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
@@ -84,6 +114,9 @@ export default class HdsFormRadioCardIndexComponent extends Component {
 
     // add a class based on the @alignment argument
     classes.push(`hds-form-radio-card--align-${this.alignment}`);
+
+    // add a class based on the @layout argument
+    classes.push(`hds-form-radio-card--layout-${this.layout}`);
 
     return classes.join(' ');
   }

--- a/packages/components/app/styles/components/form/radio-card.scss
+++ b/packages/components/app/styles/components/form/radio-card.scss
@@ -15,8 +15,17 @@
   }
 
   .hds-form-radio-card {
-    flex: 1;
     margin: calc(var(--token-form-radiocard-group-gap) / 2);
+  }
+
+  // LAYOUT
+
+  .hds-form-radio-card--layout-fluid {
+    flex: 1 0 0;
+  }
+
+  .hds-form-radio-card--layout-fixed {
+    flex: 1 0 100%;
   }
 }
 

--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -63,14 +63,37 @@
         <li>center</li>
       </ol>
     </dd>
+    <dt>layout <code>string</code></dt>
+    <dd>
+      <p>Acceptable values:</p>
+      <ol>
+        <li class="default">fluid</li>
+        <li>fixed</li>
+      </ol>
+      <p><em>Notice: by default the card will expand to fit the parent container. When used in a group the cards will
+          equally share the width to fit the available space. If the
+          <code class="dummy-code">@layout</code>
+          parameter is set to
+          <code class="dummy-code">fixed</code>
+          a
+          <code class="dummy-code">@maxWidth</code>
+          value must be specified to constrain the card.
+        </em></p>
+    </dd>
     <dt>maxWidth <code>string</code></dt>
     <dd>
       <p>Acceptable values: any valid CSS width (%, vw, etc)</p>
-      <p><em>Notice: by default the card will expand to fit the parent container. When used in a group the cards will
-          equally share the width to fit the available space. If a
-          <code class="dummy-code">@maxWidth</code>
-          parameter is provided then the card will be constrained to the specified value.
-        </em></p>
+      <p>When used with a
+        <code class="dummy-code">fluid</code>
+        layout, this parameter will determine the number of cards shown per row (for example
+        <code class="dummy-code">25%</code>
+        will result in 4 cards).
+      </p>
+      <p>
+        When used with a
+        <code class="dummy-code">fixed</code>
+        layout, this parameter will preserve the width of the card and wrap cards on multiple rows if necessary.
+      </p>
     </dd>
     <dt>extraAriaDescribedBy <code>string</code></dt>
     <dd>
@@ -207,6 +230,25 @@
         attribute on the controls when user input is required.
       </p>
       <p>Default: <span class="default">false</span></p>
+    </dd>
+    <dt>layout <code>string</code></dt>
+    <dd>
+      <p>Acceptable values:</p>
+      <ol>
+        <li class="default">fluid</li>
+        <li>fixed</li>
+      </ol>
+      <p><em>Notice: by default the cards will expand to fit the parent container and will equally share the width to
+          fit the available space. If the
+          <code class="dummy-code">@layout</code>
+          parameter is set to
+          <code class="dummy-code">fixed</code>
+          a
+          <code class="dummy-code">@maxWidth</code>
+          value must be specified for each
+          <code class="dummy-code">RadioCard</code>
+          to constrain them.
+        </em></p>
     </dd>
   </dl>
   <h5 class="dummy-h5">Contextual components</h5>
@@ -736,6 +778,53 @@
         <R.Description>{{item.description}}</R.Description>
       </G.RadioCard>
     {{/each}}
+  </Hds::Form::RadioCard::Group>
+  <br />
+
+  <h4 class="dummy-h4">Group layout</h4>
+  <span class="dummy-text-small">Fluid</span>
+  <Hds::Form::RadioCard::Group @name="radio-card-layout-fluid" @layout="fluid" as |G|>
+    <G.Legend>Group legend</G.Legend>
+    <G.RadioCard @maxWidth="50%" @checked={{true}} {{on "change" this.onChange}} as |R|>
+      <R.Icon @name="hexagon" />
+      <R.Label>Radio card label 1</R.Label>
+      <R.Description>This is the radio card description text.</R.Description>
+    </G.RadioCard>
+    <G.RadioCard @maxWidth="50%" {{on "change" this.onChange}} as |R|>
+      <R.Icon @name="hexagon" />
+      <R.Label>Radio card label 2</R.Label>
+      <R.Description>This is the radio card description text.</R.Description>
+    </G.RadioCard>
+  </Hds::Form::RadioCard::Group>
+  <br />
+  <span class="dummy-text-small">Fixed</span>
+  <Hds::Form::RadioCard::Group @name="radio-card-layout-fixed" @layout="fixed" as |G|>
+    <G.Legend>Group legend</G.Legend>
+    <G.RadioCard @maxWidth="244px" @checked={{true}} {{on "change" this.onChange}} as |R|>
+      <R.Icon @name="hexagon" />
+      <R.Label>Radio card label 1</R.Label>
+      <R.Description>This is the radio card description text.</R.Description>
+    </G.RadioCard>
+    <G.RadioCard @maxWidth="244px" {{on "change" this.onChange}} as |R|>
+      <R.Icon @name="hexagon" />
+      <R.Label>Radio card label 2</R.Label>
+      <R.Description>This is the radio card description text.</R.Description>
+    </G.RadioCard>
+    <G.RadioCard @maxWidth="244px" {{on "change" this.onChange}} as |R|>
+      <R.Icon @name="hexagon" />
+      <R.Label>Radio card label 3</R.Label>
+      <R.Description>This is the radio card description text.</R.Description>
+    </G.RadioCard>
+    <G.RadioCard @maxWidth="244px" {{on "change" this.onChange}} as |R|>
+      <R.Icon @name="hexagon" />
+      <R.Label>Radio card label 4</R.Label>
+      <R.Description>This is the radio card description text.</R.Description>
+    </G.RadioCard>
+    <G.RadioCard @maxWidth="244px" {{on "change" this.onChange}} as |R|>
+      <R.Icon @name="hexagon" />
+      <R.Label>Radio card label 5</R.Label>
+      <R.Description>This is the radio card description text.</R.Description>
+    </G.RadioCard>
   </Hds::Form::RadioCard::Group>
   <br />
 

--- a/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
@@ -79,15 +79,15 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
       .hasAttribute('aria-describedby', `${groupHelperTextId} ${groupErrorId}`);
   });
 
-  // ARGUMENT FORWARDING: NAME, ALIGNMENT, CONTROL POSITION
+  // ARGUMENT FORWARDING: NAME, ALIGNMENT, CONTROL POSITION, LAYOUT
 
   test('it should render the component with CSS classes that reflect the arguments provided', async function (assert) {
     await render(
-      hbs`<Hds::Form::RadioCard::Group @name="test-name" @alignment="center" @controlPosition="left" as |G|>
+      hbs`<Hds::Form::RadioCard::Group @name="test-name" @alignment="center" @controlPosition="left" @layout="fixed" as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.RadioCard data-test="first-control"/>
-            <G.RadioCard data-test="second-control"/>
+            <G.RadioCard @maxWidth="50%" data-test="first-control"/>
+            <G.RadioCard @maxWidth="50%" data-test="second-control"/>
             <G.Error>This is the group error</G.Error>
           </Hds::Form::RadioCard::Group>`
     );
@@ -101,6 +101,9 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
     assert
       .dom('.hds-form-radio-card')
       .hasClass('hds-form-radio-card--control-left');
+    assert
+      .dom('.hds-form-radio-card')
+      .hasClass('hds-form-radio-card--layout-fixed');
   });
 
   // REQUIRED AND OPTIONAL

--- a/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
@@ -77,7 +77,7 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     assert.dom('input').hasAttribute('data-test2', 'test');
   });
 
-  // ASSERTIONS: ALIGNMENT, CONTROL POSITION
+  // ASSERTIONS: ALIGNMENT, CONTROL POSITION, LAYOUT
 
   test('it should throw an assertion if an incorrect value for @alignment is provided', async function (assert) {
     const errorMessage =
@@ -100,6 +100,32 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
     await render(hbs`<Hds::Form::RadioCard @controlPosition="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+
+  test('it should throw an assertion if an incorrect value for @layout is provided', async function (assert) {
+    const errorMessage =
+      '@layout for "Hds::Form::RadioCard" must be one of the following: fluid, fixed; received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Form::RadioCard @layout="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+
+  test('it should throw an assertion if @layout is fixed and no @maxWidth value is provided', async function (assert) {
+    const errorMessage =
+      '@maxWidth for "Hds::Form::RadioCard" with @layout "fixed" is required';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Form::RadioCard @layout="fixed" />`);
     assert.throws(function () {
       throw new Error(errorMessage);
     });


### PR DESCRIPTION
### :pushpin: Summary

Add `@layout` property to `RadioCard`

### :hammer_and_wrench: Detailed description

Based on [feedback from our consumers](https://hashicorp.slack.com/archives/C7KTUHNUS/p1668039146943259), we extend the current layout behaviour for `RadioCard` items in a group to accommodate usecases where the cards have a fixed (or relatively fixed) width and wrap on multiple rows when exceeding parent's width. To achieve this we make the current behaviour default and name it `fluid` and we add a `fixed` layout where `@maxWidth` acts as a width and prevents flex items from growing, so they align naturally to left/start.

### :link: External links

[Slack thread](https://hashicorp.slack.com/archives/C7KTUHNUS/p1668039146943259)

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
