### PR TITLE
adding state example

### DIFF
--- a/packages/components/addon/components/hds/table/th-sort.hbs
+++ b/packages/components/addon/components/hds/table/th-sort.hbs
@@ -1,4 +1,4 @@
-<th scope="col" class="hds-table__th-sort" aria-sort={{this.ariaSort}} data-test-table-th-sort>
+<th scope="col" class="hds-table__th-sort" aria-sort={{this.ariaSort}} ...attributes>
   <button type="button" {{on "click" this.onClick}}>
     <div class="hds-table__th-sort--button-content">
       <span class="hds-typography-body-200 hds-font-weight-semibold">{{yield}}</span>

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -64,20 +64,24 @@ $hds-table-cell-padding-tall: 20px 16px;
           }
         }
 
-        &:hover {
+        &:hover,
+        &.mock-hover {
           color: var(--token-color-foreground-strong);
           background-color: var(--token-color-palette-neutral-200);
           cursor: pointer;
         }
 
         &:focus,
-        &:focus-visible { // using the mixin doesn't work for this one, so we copy the styles
+        &:focus-visible,
+        &.mock-focus,
+        &.mock-focus-visible { // using the mixin doesn't work for this one, so we copy the styles
           border: 1px solid var(--token-color-focus-action-external);
           outline: 0;
           box-shadow: inset 0 0 0 1px var(--token-color-focus-action-internal), 0 0 0 3px var(--token-color-focus-action-external);
         }
 
-        &:active {
+        &:active,
+        &.mock-active {
           color: var(--token-color-foreground-strong);
           background-color: var(--token-color-palette-neutral-300);
         }

--- a/packages/components/tests/dummy/app/routes/components/table.js
+++ b/packages/components/tests/dummy/app/routes/components/table.js
@@ -5,7 +5,7 @@ export default class ComponentsTableRoute extends Route {
   async model() {
     let response = await fetch('/api/folk.json');
     let { data } = await response.json();
-    const STATES = ['default', 'hover', 'focus', 'active'];
+    const STATES = ['active', 'default', 'hover', 'focus'];
 
     // make sure the variable is declared outside of the loop
     // so we can return it in the model response

--- a/packages/components/tests/dummy/app/routes/components/table.js
+++ b/packages/components/tests/dummy/app/routes/components/table.js
@@ -5,7 +5,7 @@ export default class ComponentsTableRoute extends Route {
   async model() {
     let response = await fetch('/api/folk.json');
     let { data } = await response.json();
-    const STATES = ['default', 'hover', 'active'];
+    const STATES = ['default', 'hover', 'focus', 'active'];
 
     // make sure the variable is declared outside of the loop
     // so we can return it in the model response
@@ -18,7 +18,5 @@ export default class ComponentsTableRoute extends Route {
       return { key, label: capitalize(key) };
     });
     return { data: dataResponse, columns, STATES };
-
-    // second model goes here if we want to have a second table
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -530,17 +530,17 @@ export default class ComponentsTableRoute extends Route {
     Showcase
   </h3>
   <h4 class="dummy-h4">States of the sortable table header (buttons)</h4>
-  <table class="hds-table">
-    <thead class="hds-table__thead">
-      <tr class="hds-table__tr">
+  <Hds::Table>
+    <:head>
+      <Hds::Table::Tr>
         {{#each @model.STATES as |state|}}
           <Hds::Table::ThSort mock-state-value={{state}} mock-state-selector="button">
             {{capitalize state}}
           </Hds::Table::ThSort>
         {{/each}}
-      </tr>
-    </thead>
-  </table>
+      </Hds::Table::Tr>
+    </:head>
+  </Hds::Table>
   <h4 class="dummy-h4">
     Static table with model defined
   </h4>

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -150,8 +150,8 @@
   {{! template-lint-enable no-unbalanced-curlies }}
   {{! prettier-ignore-end }}
   <h4 class="dummy-h4">Simple Table with model defined</h4>
-  <p class="dummy-paragraph">In the simplest invocation of the table component, you would define the data model and insert
-    your own content into the
+  <p class="dummy-paragraph">In the simplest invocation of the table component, you would define the data model and
+    insert your own content into the
     <code class="dummy-code">:head</code>
     and
     <code class="dummy-code">:body</code>
@@ -529,20 +529,18 @@ export default class ComponentsTableRoute extends Route {
     <a href="#showcase" class="dummy-link-section">§</a>
     Showcase
   </h3>
-  <h4 class="dummy-h4">States</h4> <!-- TODO add states -->
-  <div class="dummy-tag-states-grid">
-    {{#each @model.STATES as |state|}}
-      <div>
-        <span class="dummy-text-small">{{capitalize state}}:</span>
-        <br />
-        <div class="hds-table">
-          <div class="dummy-tag-states-subgrid">
-            <Hds::Table::ThSort mock-state-value={{state}} mock-state-selector="button">Artist</Hds::Table::ThSort>
-          </div>
-        </div>
-      </div>
-    {{/each}}
-  </div>
+  <h4 class="dummy-h4">States of the sortable table header (buttons)</h4>
+  <table class="hds-table">
+    <thead class="hds-table__thead">
+      <tr class="hds-table__tr">
+        {{#each @model.STATES as |state|}}
+          <Hds::Table::ThSort mock-state-value={{state}} mock-state-selector="button">
+            {{capitalize state}}
+          </Hds::Table::ThSort>
+        {{/each}}
+      </tr>
+    </thead>
+  </table>
   <h4 class="dummy-h4">
     Static table with model defined
   </h4>

--- a/packages/components/tests/integration/components/hds/table/th-sort-test.js
+++ b/packages/components/tests/integration/components/hds/table/th-sort-test.js
@@ -17,9 +17,11 @@ module('Integration | Component | hds/table/th-sort', function (hooks) {
   });
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Table::ThSort>Artist</Hds::Table::ThSort>`);
+    await render(
+      hbs`<Hds::Table::ThSort id="data-test-table-th-sort">Artist</Hds::Table::ThSort>`
+    );
 
-    assert.dom('[data-test-table-th-sort]').hasClass('hds-table__th-sort');
+    assert.dom('#data-test-table-th-sort').hasClass('hds-table__th-sort');
   });
 
   test('if @sortOrder is not defined, the swap-vertical icon should be displayed', async function (assert) {
@@ -32,13 +34,13 @@ module('Integration | Component | hds/table/th-sort', function (hooks) {
 
   test('if sorted and `@sortOrder` is set the correct icon should be displayed', async function (assert) {
     await render(
-      hbs`<Hds::Table::ThSort @isSorted={{true}} @sortOrder='asc' id="data-test-table-th-sort">Artist</Hds::Table::ThSort>`
+      hbs`<Hds::Table::ThSort @isSorted={{true}} @sortOrder='asc'>Artist</Hds::Table::ThSort>`
     );
 
     assert.dom('[data-test-icon="arrow-up"]').exists();
 
     await render(
-      hbs`<Hds::Table::ThSort @isSorted={{true}} @sortOrder='desc' id="data-test-table-th-sort">Artist</Hds::Table::ThSort>`
+      hbs`<Hds::Table::ThSort @isSorted={{true}} @sortOrder='desc'>Artist</Hds::Table::ThSort>`
     );
 
     assert.dom('[data-test-icon="arrow-down"]').exists();


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a state sample to the table showcase

### :hammer_and_wrench: Detailed description

This sample also meant it was necessary to add `...attribute` support to the `th-sort` component. Went ahead and updated the test file for the component as well. 

### :camera_flash: Screenshots

![CleanShot 2022-11-14 at 11 18 02](https://user-images.githubusercontent.com/4587451/201724399-f12ffd98-7033-4a5d-8fd9-c0ac28cbded6.png)

### :link: External links

<!-- Issues, RFC, etc. -->

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
