### PR TITLE
[Table] Integration tests changes - Alternative 2

### DIFF
--- a/packages/components/tests/integration/components/hds/table/index-test.js
+++ b/packages/components/tests/integration/components/hds/table/index-test.js
@@ -4,7 +4,7 @@ import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 // we're using this for multiple tests so we'll declare context once and use it when we need it.
-const setData = (context) => {
+const renderSortableTable = async (context) => {
   context.set('model', [
     {
       id: '1',
@@ -35,8 +35,7 @@ const setData = (context) => {
   ]);
   context.set('sortBy', 'artist');
   context.set('sortOrder', 'asc');
-};
-const renderSortableTable = async () => {
+
   await render(hbs`
   <Hds::Table
         @model={{this.model}}
@@ -188,9 +187,7 @@ module('Integration | Component | hds/table/index', function (hooks) {
   });
 
   test('it should render a sortable table when appropriate', async function (assert) {
-    setData(this);
-
-    await renderSortableTable();
+    await renderSortableTable(this);
 
     assert
       .dom('#data-test-table th:first-of-type')
@@ -199,9 +196,7 @@ module('Integration | Component | hds/table/index', function (hooks) {
   });
 
   test('it should render a sortable table with an empty caption if no caption is provided and table is unsorted', async function (assert) {
-    setData(this);
-
-    await renderSortableTable();
+    await renderSortableTable(this);
 
     assert
       .dom('#data-test-table th:first-of-type')
@@ -210,9 +205,7 @@ module('Integration | Component | hds/table/index', function (hooks) {
   });
 
   test('it sorts the rows asc by default when the sort button is clicked on an unsorted column', async function (assert) {
-    setData(this);
-
-    await renderSortableTable();
+    await renderSortableTable(this);
 
     assert.dom('#data-test-table td:nth-of-type(1)').hasText('Melanie');
 
@@ -221,9 +214,7 @@ module('Integration | Component | hds/table/index', function (hooks) {
   });
 
   test('it updates the caption correctly after a sort has been performed', async function (assert) {
-    setData(this);
-
-    await renderSortableTable();
+    await renderSortableTable(this);
 
     assert.dom('#data-test-table td:nth-of-type(1)').hasText('Melanie');
 
@@ -237,9 +228,7 @@ module('Integration | Component | hds/table/index', function (hooks) {
   });
 
   test('it updates the `aria-sort` attribute value when a sort is performed', async function (assert) {
-    setData(this);
-
-    await renderSortableTable();
+    await renderSortableTable(this);
 
     await click('#data-test-table .hds-table__th-sort:nth-of-type(1) button');
     assert


### PR DESCRIPTION
### :pushpin: Summary

This is the second of two alternative ways to simplify (a little) the integration tests for the `Table` component.

(context: https://github.com/hashicorp/design-system/pull/542#discussion_r1019016532)

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
