### PR TITLE
Table / Use standard mixin for focus ring of `ThSort` button element

### DIFF
--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -2,6 +2,9 @@
 // TABLE
 //
 //
+
+@use "../mixins/focus-ring" as *;
+
 $hds-table-border-radius: 6px;
 $hds-table-border-width: 1px;
 $hds-table-inner-border-radius: $hds-table-border-radius - $hds-table-border-width;
@@ -71,14 +74,7 @@ $hds-table-cell-padding-tall: 20px 16px;
           cursor: pointer;
         }
 
-        &:focus,
-        &:focus-visible,
-        &.mock-focus,
-        &.mock-focus-visible { // using the mixin doesn't work for this one, so we copy the styles
-          border: 1px solid var(--token-color-focus-action-external);
-          outline: 0;
-          box-shadow: inset 0 0 0 1px var(--token-color-focus-action-internal), 0 0 0 3px var(--token-color-focus-action-external);
-        }
+        @include hds-focus-ring-with-pseudo-element($radius: inherit);
 
         &:active,
         &.mock-active {


### PR DESCRIPTION
### :pushpin: Summary

A small PR to remove the custom code and use the standard `focus-ring` mixing to handle focus for the `ThSort` button element

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
