### PR TITLE
[SPIKE] Table / `Td` component

### DIFF
--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -28,14 +28,14 @@
   <tbody class="hds-table__tbody">
     {{#if this.isSortableTable}}
       {{#each (sort-by this.getSortCriteria @model) as |data|}}
-        {{yield data to="body"}}
+        {{yield (hash Tr=(component "hds/table/tr") Td=(component "hds/table/td") data=data) to="body"}}
       {{/each}}
     {{else if @model}}
-      {{#each @model as |record|}}
-        {{yield record to="body"}}
+      {{#each @model as |data|}}
+        {{yield (hash Tr=(component "hds/table/tr") Td=(component "hds/table/td") data=data) to="body"}}
       {{/each}}
     {{else}}
-      {{yield to="body"}}
+      {{yield (hash Tr=(component "hds/table/tr") Td=(component "hds/table/td")) to="body"}}
     {{/if}}
   </tbody>
 </table>

--- a/packages/components/addon/components/hds/table/td.hbs
+++ b/packages/components/addon/components/hds/table/td.hbs
@@ -1,0 +1,3 @@
+<td class="hds-table__td hds-typography-body-200 hds-font-weight-regular" ...attributes>
+  {{yield}}
+</td>

--- a/packages/components/app/components/hds/table/td.js
+++ b/packages/components/app/components/hds/table/td.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/table/td';

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -127,11 +127,7 @@ $hds-table-cell-padding-tall: 20px 16px;
     color: var(--token-color-foreground-primary);
     background-color: var(--token-color-surface-primary);
 
-
-    td { // TODO decide what to do with TD
-      font-size: var(--token-typography-body-200-font-size);
-      font-family: var(--token-typography-font-stack-text);
-      line-height: var(--token-typography-body-200-line-height);
+    td {
       vertical-align: top; // this is so the text will automatically vertically align to the top of the cell if one of the cells has multiple lines of text; otherwise everything will center align (vertically)
       border-top: none;
       border-right: none;

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -140,9 +140,9 @@
   </:head>
   <:body as |B|>
     <B.Tr>
-      <td>Custom Cell Content</td>
-      <td>\{{t 'translated-cell-content-string'}}</td>
-      <td>Some other custom cell content</td>
+      <B.Td>Custom Cell Content</B.Td>
+      <B.Td>\{{t 'translated-cell-content-string'}}</B.Td>
+      <B.Td>Some other custom cell content</B.Td>
     </B.Tr>
   </:body>
 </Hds::Table>"
@@ -163,19 +163,19 @@
     @code="<!-- app/templates/components/table.hbs -->
 
 <Hds::Table @model=\{{this.model}}>
-  <:head>
-    <Hds::Table::Tr>
-      <Hds::Table::Th>Artist</Hds::Table::Th>
-      <Hds::Table::Th>Album</Hds::Table::Th>
-      <Hds::Table::Th>Release Year</Hds::Table::Th>
-    </Hds::Table::Tr>
+  <:head as |H|>
+    <H.Tr>
+      <H.Th>Artist</H.Th>
+      <H.Th>Album</H.Th>
+      <H.Th>Release Year</H.Th>
+    </H.Tr>
   </:head>
-  <:body as |data|>
-    <Hds::Table::Tr>
-      <td>\{{data.artist}}</td>
-      <td>\{{data.album}}</td>
-      <td>\{{data.year}}</td>
-    </Hds::Table::Tr>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>\{{B.data.artist}}</B.Td>
+      <B.Td>\{{B.data.album}}</B.Td>
+      <B.Td>\{{B.data.year}}</B.Td>
+    </B.Tr>
   </:body>
 </Hds::Table>"
   />
@@ -259,12 +259,12 @@ export default class ComponentsTableRoute extends Route {
   @model=\{{this.model.data}}
   @columns=\{{this.model.columns}}
 >
-  <:body as |data|>
-    <Hds::Table::Tr>
-      <td>\{{data.artist}}</td>
-      <td>\{{data.album}}</td>
-      <td>\{{data.year}}</td>
-    </Hds::Table::Tr>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>\{{B.data.artist}}</B.Td>
+      <B.Td>\{{B.data.album}}</B.Td>
+      <B.Td>\{{B.data.year}}</B.Td>
+    </B.Tr>
   </:body>
 </Hds::Table>"
   />
@@ -282,12 +282,12 @@ export default class ComponentsTableRoute extends Route {
   @columns=\{{this.model.columns}}
   @sortingKeys=\{{array 'artist' 'album'}}
 >
-  <:body as |data|>
-    <Hds::Table::Tr>
-      <td>\{{data.artist}}</td>
-      <td>\{{data.album}}</td>
-      <td>\{{data.year}}</td>
-    </Hds::Table::Tr>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>\{{B.data.artist}}</B.Td>
+      <B.Td>\{{B.data.album}}</B.Td>
+      <B.Td>\{{B.data.year}}</B.Td>
+    </B.Tr>
   </:body>
 </Hds::Table>"
   />
@@ -306,12 +306,12 @@ export default class ComponentsTableRoute extends Route {
   @sortingKeys=\{{array 'artist' 'album'}}
   @sortBy='artist'
 >
-  <:body as |data|>
-    <Hds::Table::Tr>
-      <td>\{{data.artist}}</td>
-      <td>\{{data.album}}</td>
-      <td>\{{data.year}}</td>
-    </Hds::Table::Tr>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>\{{B.data.artist}}</B.Td>
+      <B.Td>\{{B.data.album}}</B.Td>
+      <B.Td>\{{B.data.year}}</B.Td>
+    </B.Tr>
   </:body>
 </Hds::Table>"
   />
@@ -331,12 +331,12 @@ export default class ComponentsTableRoute extends Route {
   @sortBy='artist'
   @sortOrder='desc'
 >
-  <:body as |data|>
-    <Hds::Table::Tr>
-      <td>\{{data.artist}}</td>
-      <td>\{{data.album}}</td>
-      <td>\{{data.year}}</td>
-    </Hds::Table::Tr>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>\{{B.data.artist}}</B.Td>
+      <B.Td>\{{B.data.album}}</B.Td>
+      <B.Td>\{{B.data.year}}</B.Td>
+    </B.Tr>
   </:body>
 </Hds::Table>"
   />
@@ -545,129 +545,129 @@ export default class ComponentsTableRoute extends Route {
     Static table with model defined
   </h4>
   <Hds::Table @model={{this.model.data}}>
-    <:head>
-      <Hds::Table::Tr>
-        <Hds::Table::Th>Artist</Hds::Table::Th>
-        <Hds::Table::Th>Album</Hds::Table::Th>
-        <Hds::Table::Th>Release Year</Hds::Table::Th>
-      </Hds::Table::Tr>
+    <:head as |H|>
+      <H.Tr>
+        <H.Th>Artist</H.Th>
+        <H.Th>Album</H.Th>
+        <H.Th>Release Year</H.Th>
+      </H.Tr>
     </:head>
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td>{{data.artist}}</td>
-        <td>{{data.album}}</td>
-        <td>{{data.year}}</td>
-      </Hds::Table::Tr>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td>{{B.data.year}}</B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
     Static table with density set to "short"
   </h4>
   <Hds::Table @model={{this.model.data}} @density="short">
-    <:head>
-      <Hds::Table::Tr>
-        <Hds::Table::Th>Artist</Hds::Table::Th>
-        <Hds::Table::Th>Album</Hds::Table::Th>
-        <Hds::Table::Th>Release Year</Hds::Table::Th>
-      </Hds::Table::Tr>
+    <:head as |H|>
+      <H.Tr>
+        <H.Th>Artist</H.Th>
+        <H.Th>Album</H.Th>
+        <H.Th>Release Year</H.Th>
+      </H.Tr>
     </:head>
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td>{{data.artist}}</td>
-        <td>{{data.album}}</td>
-        <td>{{data.year}}</td>
-      </Hds::Table::Tr>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td>{{B.data.year}}</B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
     Static table with density set to "tall"
   </h4>
   <Hds::Table @model={{this.model.data}} @density="tall">
-    <:head>
-      <Hds::Table::Tr>
-        <Hds::Table::Th>Artist</Hds::Table::Th>
-        <Hds::Table::Th>Album</Hds::Table::Th>
-        <Hds::Table::Th>Release Year</Hds::Table::Th>
-      </Hds::Table::Tr>
+    <:head as |H|>
+      <H.Tr>
+        <H.Th>Artist</H.Th>
+        <H.Th>Album</H.Th>
+        <H.Th>Release Year</H.Th>
+      </H.Tr>
     </:head>
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td>{{data.artist}}</td>
-        <td>{{data.album}}</td>
-        <td>{{data.year}}</td>
-      </Hds::Table::Tr>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td>{{B.data.year}}</B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
     Static table with no model defined
   </h4>
   <Hds::Table @caption="a custom table with no model defined">
-    <:head as |T|>
-      <T.Tr>
-        <T.Th>Cell Header</T.Th>
-        <T.Th>Cell Header</T.Th>
-        <T.Th>Cell Header</T.Th>
-      </T.Tr>
+    <:head as |H|>
+      <H.Tr>
+        <H.Th>Cell Header</H.Th>
+        <H.Th>Cell Header</H.Th>
+        <H.Th>Cell Header</H.Th>
+      </H.Tr>
     </:head>
-    <:body>
-      <Hds::Table::Tr>
-        <td>Cell Content</td>
-        <td>Cell Content</td>
-        <td>Cell Content</td>
-      </Hds::Table::Tr>
-      <Hds::Table::Tr>
-        <td>Cell Content</td>
-        <td>Cell Content</td>
-        <td>Cell Content</td>
-      </Hds::Table::Tr>
-      <Hds::Table::Tr>
-        <td>Cell Content</td>
-        <td>Cell Content</td>
-        <td>Cell Content</td>
-      </Hds::Table::Tr>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+      </B.Tr>
+      <B.Tr>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+      </B.Tr>
+      <B.Tr>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
     Static table with no striping
   </h4>
   <Hds::Table @model={{this.model.data}} @isStriped={{false}} @caption="Static table with no striping">
-    <:head>
-      <Hds::Table::Tr>
-        <Hds::Table::Th>Artist</Hds::Table::Th>
-        <Hds::Table::Th>Album</Hds::Table::Th>
-        <Hds::Table::Th>Release Year</Hds::Table::Th>
-      </Hds::Table::Tr>
+    <:head as |H|>
+      <H.Tr>
+        <H.Th>Artist</H.Th>
+        <H.Th>Album</H.Th>
+        <H.Th>Release Year</H.Th>
+      </H.Tr>
     </:head>
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td>{{data.artist}}</td>
-        <td>{{data.album}}</td>
-        <td>{{data.year}}</td>
-      </Hds::Table::Tr>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td>{{B.data.year}}</B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
     Sortable table (all columns sortable)
   </h4>
   <Hds::Table @model={{this.model.data}} @columns={{take 3 this.model.columns}}>
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td>{{data.artist}}</td>
-        <td>{{data.album}}</td>
-        <td>{{data.year}}</td>
-      </Hds::Table::Tr>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td>{{B.data.year}}</B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
     Sortable table (only some columns sortable)
   </h4>
   <Hds::Table @model={{this.model.data}} @columns={{take 3 this.model.columns}} @sortingKeys={{array "artist" "album"}}>
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td>{{data.artist}}</td>
-        <td>{{data.album}}</td>
-        <td>{{data.year}}</td>
-      </Hds::Table::Tr>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td>{{B.data.year}}</B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
@@ -679,12 +679,12 @@ export default class ComponentsTableRoute extends Route {
     @sortingKeys={{array "artist" "album"}}
     @sortBy="artist"
   >
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td>{{data.artist}}</td>
-        <td>{{data.album}}</td>
-        <td>{{data.year}}</td>
-      </Hds::Table::Tr>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td>{{B.data.year}}</B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">
@@ -697,12 +697,12 @@ export default class ComponentsTableRoute extends Route {
     @sortBy="artist"
     @sortOrder="desc"
   >
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td>{{data.artist}}</td>
-        <td>{{data.album}}</td>
-        <td>{{data.year}}</td>
-        <td>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td>{{B.data.year}}</B.Td>
+        <B.Td>
           <Hds::Dropdown as |dd|>
             <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
             <dd.Interactive @route="components.table" @text="Create" />
@@ -711,8 +711,8 @@ export default class ComponentsTableRoute extends Route {
             <dd.Separator />
             <dd.Interactive @route="components.table" @text="Delete" @color="critical" @icon="trash" />
           </Hds::Dropdown>
-        </td>
-      </Hds::Table::Tr>
+        </B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">Table with a custom-width column and right-aligned text column</h4>
@@ -725,13 +725,13 @@ export default class ComponentsTableRoute extends Route {
         <H.Th class="db-table-text-right">Current Vinyl Cost (USD)</H.Th>
       </H.Tr>
     </:head>
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td>{{data.artist}}</td>
-        <td>{{data.album}}</td>
-        <td class="db-table-w1-7">{{data.year}}</td>
-        <td class="db-table-text-right">{{data.vinyl-cost}}</td>
-      </Hds::Table::Tr>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td class="db-table-w1-7">{{B.data.year}}</B.Td>
+        <B.Td class="db-table-text-right">{{B.data.vinyl-cost}}</B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">Table with different types of cell content (no striping because badges are used)</h4>
@@ -744,26 +744,26 @@ export default class ComponentsTableRoute extends Route {
         <H.Th>Additional Actions As Buttons</H.Th>
       </H.Tr>
     </:head>
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td><Hds::Link::Inline @href="#showcase">{{data.artist}}</Hds::Link::Inline></td>
-        <td>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td><Hds::Link::Inline @href="#showcase">{{B.data.artist}}</Hds::Link::Inline></B.Td>
+        <B.Td>
           <div class="db-table-cell-content-div">
-            <FlightIcon @name={{data.icon}} />
-            {{data.album}}
+            <FlightIcon @name={{B.data.icon}} />
+            {{B.data.album}}
           </div>
-        </td>
-        <td>
-          <Hds::Badge @text={{data.year}} @type={{data.badge-type}} @color={{data.badge-color}} />
-        </td>
-        <td>
+        </B.Td>
+        <B.Td>
+          <Hds::Badge @text={{B.data.year}} @type={{B.data.badge-type}} @color={{B.data.badge-color}} />
+        </B.Td>
+        <B.Td>
           <Hds::ButtonSet>
             <Hds::Button @text="Add" @isIconOnly={{true}} @icon="plus" @size="small" />
             <Hds::Button @text="Edit" @isIconOnly={{true}} @icon="edit" @size="small" @color="secondary" />
             <Hds::Button @text="Delete" @isIconOnly={{true}} @icon="trash" @size="small" @color="critical" />
           </Hds::ButtonSet>
-        </td>
-      </Hds::Table::Tr>
+        </B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
   <h4 class="dummy-h4">Table with multi-line content</h4>
@@ -775,12 +775,12 @@ export default class ComponentsTableRoute extends Route {
         <H.Th>Related Quote about the artist</H.Th>
       </H.Tr>
     </:head>
-    <:body as |data|>
-      <Hds::Table::Tr>
-        <td>{{data.artist}}</td>
-        <td>{{data.album}}</td>
-        <td>&ldquo;{{data.quote}}&rdquo;</td>
-      </Hds::Table::Tr>
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td>&ldquo;{{B.data.quote}}&rdquo;</B.Td>
+      </B.Tr>
     </:body>
   </Hds::Table>
 </section>

--- a/packages/components/tests/integration/components/hds/table/index-test.js
+++ b/packages/components/tests/integration/components/hds/table/index-test.js
@@ -45,12 +45,12 @@ const hbsSortableTable = hbs`
   @columns={{this.columns}}
   id="data-test-table"
 >
-  <:body as |row|>
-    <Hds::Table::Tr>
-      <td>{{row.artist}}</td>
-      <td>{{row.album}}</td>
-      <td>{{row.year}}</td>
-    </Hds::Table::Tr>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
+    </B.Tr>
   </:body>
 </Hds::Table>
 `;
@@ -90,29 +90,29 @@ module('Integration | Component | hds/table/index', function (hooks) {
   test('it should render the table with manual data passed and no model defined', async function (assert) {
     await render(hbs`
       <Hds::Table id="data-test-table">
-        <:head>
-          <Hds::Table::Tr>
-            <Hds::Table::Th>Cell Header 1</Hds::Table::Th>
-            <Hds::Table::Th>Cell Header 2</Hds::Table::Th>
-            <Hds::Table::Th>Cell Header 3</Hds::Table::Th>
-          </Hds::Table::Tr>
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Cell Header 1</H.Th>
+            <H.Th>Cell Header 2</H.Th>
+            <H.Th>Cell Header 3</H.Th>
+          </H.Tr>
         </:head>
-        <:body>
-          <Hds::Table::Tr>
-            <td>Cell Content 1 1</td>
-            <td>Cell Content 1 2</td>
-            <td>Cell Content 1 3</td>
-          </Hds::Table::Tr>
-          <Hds::Table::Tr>
-            <td>Cell Content 2 1</td>
-            <td>Cell Content 2 2</td>
-            <td>Cell Content 2 3</td>
-          </Hds::Table::Tr>
-          <Hds::Table::Tr>
-            <td>Cell Content 3 1</td>
-            <td>Cell Content 3 2</td>
-            <td>Cell Content 3 3</td>
-          </Hds::Table::Tr>
+        <:body as |B|>
+          <B.Tr>
+            <B.Td>Cell Content 1 1</B.Td>
+            <B.Td>Cell Content 1 2</B.Td>
+            <B.Td>Cell Content 1 3</B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Td>Cell Content 2 1</B.Td>
+            <B.Td>Cell Content 2 2</B.Td>
+            <B.Td>Cell Content 2 3</B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Td>Cell Content 3 1</B.Td>
+            <B.Td>Cell Content 3 2</B.Td>
+            <B.Td>Cell Content 3 3</B.Td>
+          </B.Tr>
         </:body>
       </Hds::Table>
     `);
@@ -132,19 +132,19 @@ module('Integration | Component | hds/table/index', function (hooks) {
 
     await render(hbs`
       <Hds::Table id="data-test-table" @model={{this.model}}>
-        <:head>
-          <Hds::Table::Tr>
-            <Hds::Table::Th>Id</Hds::Table::Th>
-            <Hds::Table::Th>Name</Hds::Table::Th>
-            <Hds::Table::Th>Description</Hds::Table::Th>
-          </Hds::Table::Tr>
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Id</H.Th>
+            <H.Th>Name</H.Th>
+            <H.Th>Description</H.Th>
+          </H.Tr>
         </:head>
-        <:body as |row|>
-          <Hds::Table::Tr>
-            <td>{{row.id}}</td>
-            <td>{{row.name}}</td>
-            <td>{{row.description}}</td>
-          </Hds::Table::Tr>
+        <:body as |B|>
+          <B.Tr>
+            <B.Td>{{B.data.id}}</B.Td>
+            <B.Td>{{B.data.name}}</B.Td>
+            <B.Td>{{B.data.description}}</B.Td>
+          </B.Tr>
         </:body>
       </Hds::Table>
     `);
@@ -166,19 +166,19 @@ module('Integration | Component | hds/table/index', function (hooks) {
 
     await render(hbs`
       <Hds::Table id="data-test-table" @model={{this.model}} @caption="a test caption">
-        <:head>
-          <Hds::Table::Tr>
-            <Hds::Table::Th>Id</Hds::Table::Th>
-            <Hds::Table::Th>Name</Hds::Table::Th>
-            <Hds::Table::Th>Description</Hds::Table::Th>
-          </Hds::Table::Tr>
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Id</H.Th>
+            <H.Th>Name</H.Th>
+            <H.Th>Description</H.Th>
+          </H.Tr>
         </:head>
-        <:body as |row|>
-          <Hds::Table::Tr>
-            <td>{{row.id}}</td>
-            <td>{{row.name}}</td>
-            <td>{{row.description}}</td>
-          </Hds::Table::Tr>
+        <:body as |B|>
+          <B.Tr>
+            <B.Td>{{B.data.id}}</B.Td>
+            <B.Td>{{B.data.name}}</B.Td>
+            <B.Td>{{B.data.description}}</B.Td>
+          </B.Tr>
         </:body>
       </Hds::Table>
     `);

--- a/packages/components/tests/integration/components/hds/table/td-test.js
+++ b/packages/components/tests/integration/components/hds/table/td-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/table/td', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <Hds::Table::Td>template block text</Hds::Table::Td>
+    `);
+    assert.dom(this.element).hasText('template block text');
+  });
+
+  test('it should render with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Table::Td id="data-test-table-td"/>`);
+    assert.dom('#data-test-table-td').hasClass('hds-table__td');
+  });
+
+  test('it should support splattributes', async function (assert) {
+    await render(hbs`<Hds::Table::Td id="data-test-table-td" lang="es" />`);
+    assert.dom('#data-test-table-td').hasAttribute('lang', 'es');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

This PR is to show what the refactoring of the API of the `Table` component would require, in order to be able to use `Td` as contextual component, similar to what we already do for `Tr`, `Th` and `ThSort`.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added `Td` as sub-component for `Table`
  - added template (no backing class for now, but likely we'll need it)
  - removed typography styling for the `td` element from the `table.scss` file (we're using helper classes directly in the template
- updated the `Table` template so that `Tr` `Td` and `data` are hashed and provided to the `body` named block
- updated the `Table` documentation page to use the new API for `Table`, `:body` and `Td`
- updated integration tests for the `Table` component + added tests for `Td` sub-component

**What these changes entail**:

- we can now use `Td` as contextual component
  - this will open the doors for managing vertical and horizontal alignment in the table cells too, using Ember `@arguments` instead of client-side classes (not something we want to do)
- the way in which the children of the `Table` are declared have been standardized: 
  <img width="817" alt="screenshot_2058" src="https://user-images.githubusercontent.com/686239/201784367-090f09b5-e754-4a81-9286-e6d4aad30e0d.png">
- the "data" of the model is not accessed directly as before, but via a `data` key:
  - before: `<td>{{data.artist}}</td>` → after: `<B.Td>{{B.data.artist}}</B.Td>`
- all tests (integration + visual) passed 🎉

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
