### PR TITLE
New docs website / `Doc::Badge` component (MVP)

### DIFF
--- a/website-html-to-markdown/moveover/testing/06-test-hds-component-in-markdown/badge.md
+++ b/website-html-to-markdown/moveover/testing/06-test-hds-component-in-markdown/badge.md
@@ -1,0 +1,55 @@
+# Test with inline Ember component
+
+<DocNpmVersion class="doc-test-markdown-basic-styling" />
+
+Ember component directly declared in the markdown "root"
+
+<Doc::Badge>Hello!</Doc::Badge>
+
+Different colors:
+
+<Doc::Badge @color="neutral-light">neutral-light</Doc::Badge>
+<Doc::Badge @color="neutral-dark">neutral-dark</Doc::Badge>
+<Doc::Badge @color="highlight">highlight</Doc::Badge>
+<Doc::Badge @color="success">success</Doc::Badge>
+<Doc::Badge @color="warning">warning</Doc::Badge>
+<Doc::Badge @color="critical">critical</Doc::Badge>
+
+
+------
+
+Ember component inside a `<div>`
+
+<div>
+    <Doc::Badge @color="neutral-dark">Hello!</Doc::Badge>
+</div>
+
+------
+
+Ember component inside a markdown blockquote
+
+> <Doc::Badge @color="neutral-dark">Hello!</Doc::Badge>
+
+------
+
+Ember component inside a markdown list
+
+- <Doc::Badge @color="neutral-dark">Hello!</Doc::Badge>
+
+------
+
+Ember component inside a markdown table
+
+| Lorem ipsum                                               |
+|-----------------------------------------------------------|
+| <Doc::Badge @color="neutral-dark">Hello!</Doc::Badge>                               |
+
+Ember component inside an HTML table
+
+<table>
+    <tr>
+        <td>
+            <Doc::Badge @color="neutral-dark">Hello!</Doc::Badge>
+        </td>
+    </tr>
+</table>

--- a/website/app/components/doc/badge/index.hbs
+++ b/website/app/components/doc/badge/index.hbs
@@ -1,0 +1,3 @@
+<div class={{this.classNames}} ...attributes>
+  {{yield}}
+</div>

--- a/website/app/components/doc/badge/index.js
+++ b/website/app/components/doc/badge/index.js
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+
+// colors values taken from Boostrap for the time being...
+// (later we will update them when there are actual designs for this component)
+
+export const DEFAULT_COLOR = 'neutral-light';
+export const COLORS = [
+  'neutral-light',
+  'neutral-dark',
+  'highlight',
+  'success',
+  'warning',
+  'critical',
+];
+
+export default class DocBadgeComponent extends Component {
+  get color() {
+    return this.args.color ?? DEFAULT_COLOR;
+  }
+  get classNames() {
+    let classes = ['doc-badge'];
+
+    // add a class based on the @color argument
+    classes.push(`doc-badge--color-${this.color}`);
+
+    return classes.join(' ');
+  }
+}

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -10,6 +10,7 @@
 @import "pages/application"; // main application frame
 
 // "Doc" components
+@import "components/badge";
 @import "components/doc-landing-callout-blocks";
 @import "components/doc-table-of-contents";
 

--- a/website/app/styles/components/badge.scss
+++ b/website/app/styles/components/badge.scss
@@ -1,0 +1,49 @@
+// BADGE
+
+@use "../typography/mixins" as *;
+
+.doc-badge {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  padding: 0 8px;
+  vertical-align: middle;
+  border: 1px solid transparent;
+  border-radius: 5px;
+
+  @include doc-font-style-body-small();
+}
+
+
+// colors
+
+.doc-badge--color-neutral-light {
+  color: #212529;
+  background-color: #f8f9fa;
+}
+
+.doc-badge--color-neutral-dark {
+  color: #fff;
+  background-color: #343a40;
+}
+
+.doc-badge--color-highlight {
+  color: #fff;
+  background-color: #17a2b8;
+}
+
+.doc-badge--color-success {
+  color: #fff;
+  background-color: #28a745;
+}
+
+.doc-badge--color-warning {
+  color: #212529;
+  background-color: #ffc107;
+}
+
+.doc-badge--color-critical {
+  color: #fff;
+  background-color: #dc3545;
+}
+

--- a/website/docs/testing/06-test-hds-component-in-markdown/badge.md
+++ b/website/docs/testing/06-test-hds-component-in-markdown/badge.md
@@ -1,0 +1,55 @@
+# Test with inline Ember component
+
+<DocNpmVersion class="doc-test-markdown-basic-styling" />
+
+Ember component directly declared in the markdown "root"
+
+<Doc::Badge>Hello!</Doc::Badge>
+
+Different colors:
+
+<Doc::Badge @color="neutral-light">neutral-light</Doc::Badge>
+<Doc::Badge @color="neutral-dark">neutral-dark</Doc::Badge>
+<Doc::Badge @color="highlight">highlight</Doc::Badge>
+<Doc::Badge @color="success">success</Doc::Badge>
+<Doc::Badge @color="warning">warning</Doc::Badge>
+<Doc::Badge @color="critical">critical</Doc::Badge>
+
+
+------
+
+Ember component inside a `<div>`
+
+<div>
+    <Doc::Badge @color="neutral-dark">Hello!</Doc::Badge>
+</div>
+
+------
+
+Ember component inside a markdown blockquote
+
+> <Doc::Badge @color="neutral-dark">Hello!</Doc::Badge>
+
+------
+
+Ember component inside a markdown list
+
+- <Doc::Badge @color="neutral-dark">Hello!</Doc::Badge>
+
+------
+
+Ember component inside a markdown table
+
+| Lorem ipsum                                               |
+|-----------------------------------------------------------|
+| <Doc::Badge @color="neutral-dark">Hello!</Doc::Badge>                               |
+
+Ember component inside an HTML table
+
+<table>
+    <tr>
+        <td>
+            <Doc::Badge @color="neutral-dark">Hello!</Doc::Badge>
+        </td>
+    </tr>
+</table>


### PR DESCRIPTION
### :pushpin: Summary

Simple PR to add a temporary `Doc::Badge` component to test that works as expected when mixed within markdown content.

Preview: https://hds-website-git-new-docs-website-doc-badge-com-227d83-hashicorp.vercel.app/testing/06-test-hds-component-in-markdown/badge/

### :link: External links

JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-937

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
