### PR TITLE
New docs website / Add support to `showdown` for "frontmatter" in markdown

### DIFF
--- a/addons/field-guide/addon/routes/show.js
+++ b/addons/field-guide/addon/routes/show.js
@@ -26,9 +26,28 @@ export default class ShowRoute extends Route {
         return res.json();
       })
       .then((res) => {
+        // want to group all the "frontmatter" attributes under the same object
+        // instead of having them spread across the whole model
+        // (super-hacky for now, we will find a better way later)
+        const frontmatter = {};
+        // NOTICE: this list for now needs to be _manually_ aligned with a similar one found in `addons/field-guide/index.js`
+        const frontmatterAttributes = [
+          'category',
+          'group',
+          'component',
+          'section',
+        ];
+        frontmatterAttributes.forEach((attribute) => {
+          if (attribute in res.data.attributes) {
+            frontmatter[attribute] = res.data.attributes[attribute];
+            delete res.data.attributes[attribute];
+          }
+        });
+
         return {
           id: res.data.id,
           ...res.data.attributes,
+          frontmatter,
         };
       });
   }

--- a/addons/field-guide/addon/templates/show.hbs
+++ b/addons/field-guide/addon/templates/show.hbs
@@ -1,2 +1,20 @@
 <HeadLayout />
+{{!-- Leave it here for debugging purpose (will be removed later!) --}}
+<!--
+{{#if this.model.id}}
+    <pre>this.model.id = {{this.model.id}}</pre>
+{{/if}}
+{{#if this.model.frontmatter.category}}
+    <pre>this.model.frontmatter.category = {{this.model.frontmatter.category}}</pre>
+{{/if}}
+{{#if this.model.frontmatter.group}}
+    <pre>this.model.frontmatter.group = {{this.model.frontmatter.group}}</pre>
+{{/if}}
+{{#if this.model.frontmatter.component}}
+    <pre>this.model.frontmatter.component = {{this.model.frontmatter.component}}</pre>
+{{/if}}
+{{#if this.model.frontmatter.section}}
+    <pre>this.model.frontmatter.section = {{this.model.frontmatter.section}}</pre>
+{{/if}}
+-->
 <DynamicTemplate @templateString={{this.renderedContent}} @componentId={{this.model.id}}/>

--- a/addons/field-guide/index.js
+++ b/addons/field-guide/index.js
@@ -86,7 +86,7 @@ module.exports = {
       contentTypes: ['content', 'html', 'toc'],
       // IMPORTANT: according to the documentation, the frontmatter attributes that we want to include need to be explicitly declared ¯\_(ツ)_/¯
       // see: https://github.com/empress/broccoli-static-site-json#attributes
-      attributes: ['category', 'group', 'component', 'section']
+      attributes: ['category', 'group', 'component', 'section'], // NOTICE: this list for now needs to be _manually_ aligned with a similar one found in `addons/field-guide/addon/routes/show.js`
     });
 
     let toc = new TableOfContents(docs, {

--- a/addons/field-guide/index.js
+++ b/addons/field-guide/index.js
@@ -84,6 +84,9 @@ module.exports = {
       contentFolder: 'docs',
       collate: true,
       contentTypes: ['content', 'html', 'toc'],
+      // IMPORTANT: according to the documentation, the frontmatter attributes that we want to include need to be explicitly declared ¯\_(ツ)_/¯
+      // see: https://github.com/empress/broccoli-static-site-json#attributes
+      attributes: ['category', 'group', 'component', 'section']
     });
 
     let toc = new TableOfContents(docs, {

--- a/website-html-to-markdown/moveover/components/alert/04--design-guidelines.md
+++ b/website-html-to-markdown/moveover/components/alert/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: alert
+section: design-guidelines
+---
+
 # Alert
 
 ## When to use

--- a/website-html-to-markdown/moveover/components/badge/04--design-guidelines.md
+++ b/website-html-to-markdown/moveover/components/badge/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge
+section: design-guidelines
+---
+
 # Badge
 
 ## When to use

--- a/website-html-to-markdown/moveover/components/breadcrumb/04--design-guidelines.md
+++ b/website-html-to-markdown/moveover/components/breadcrumb/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: breadcrumb
+section: design-guidelines
+---
+
 # Breadcrumb
 
 ## When to use

--- a/website-html-to-markdown/moveover/components/button/04--design-guidelines.md
+++ b/website-html-to-markdown/moveover/components/button/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button
+section: design-guidelines
+---
+
 # Button - Design Guidelines
 
 ## When to use

--- a/website-html-to-markdown/moveover/components/dropdown/04--design-guidelines.md
+++ b/website-html-to-markdown/moveover/components/dropdown/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: dropdown
+section: design-guidelines
+---
+
 # Dropdown - Design Guidelines
 
 ## When to use

--- a/website-html-to-markdown/moveover/components/form/select/04--design-guidelines.md
+++ b/website-html-to-markdown/moveover/components/form/select/04--design-guidelines.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: select
+section: design-guidelines
+---
+
 # Select
 
 ## When to use

--- a/website-html-to-markdown/moveover/components/toast/04--design-guidelines.md
+++ b/website-html-to-markdown/moveover/components/toast/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: toast
+section: design-guidelines
+---
+
 # Toast
 
 ## When to use

--- a/website-html-to-markdown/package.json
+++ b/website-html-to-markdown/package.json
@@ -11,7 +11,7 @@
   "license": "MPL-2.0",
   "author": "HashiCorp Design Systems <design-systems@hashicorp.com>",
   "scripts": {
-    "generate": "yarn prepare-temp-folder && yarn copy-source-files && yarn identify-sections && yarn split-files && yarn replace-linkto-with-a && yarn refactor-codeblocks && yarn enrich-wcag-lists && yarn preprocess-files && yarn convert-to-markdown && yarn prettify-files && yarn prepare-dest-folder && yarn copy-markdown-files && yarn copy-assets-folder && yarn copy-moveover-files && yarn cleanup-temp-folder",
+    "generate": "yarn prepare-temp-folder && yarn copy-source-files && yarn identify-sections && yarn split-files && yarn replace-linkto-with-a && yarn refactor-codeblocks && yarn enrich-wcag-lists && yarn preprocess-files && yarn convert-to-markdown && yarn prettify-files && yarn add-frontmatter && yarn prepare-dest-folder && yarn copy-markdown-files && yarn copy-assets-folder && yarn copy-moveover-files && yarn cleanup-temp-folder",
     "prepare-temp-folder": "rm -fr temp && mkdir temp && mkdir temp/original",
     "copy-source-files": "cp -r ../packages/components/tests/dummy/app/templates/* temp/original",
     "identify-sections": "echo '\n==========\nIdentifying <section> blocks...\n' && node codemods/bin/cli.js identify-sections ./temp/original/**/*.hbs",
@@ -22,6 +22,7 @@
     "preprocess-files": "ts-node --transpile-only ./scripts/preprocess-files",
     "convert-to-markdown": "ts-node --transpile-only ./scripts/convert-to-markdown",
     "prettify-files": "echo '\n==========\nPrettifying markdown files...\n' && npx prettier --loglevel warn --write temp/split-files",
+    "add-frontmatter": "ts-node --transpile-only ./scripts/add-frontmatter",
     "prepare-dest-folder": "rm -fr ../website/docs/components && mkdir ../website/docs/components && rm -fr ../website/docs/content && mkdir ../website/docs/content && rm -fr ../website/docs/foundations && mkdir ../website/docs/foundations && rm -fr ../website/docs/overrides && mkdir ../website/docs/overrides && rm -fr ../website/docs/utilities && mkdir ../website/docs/utilities && rm -fr ../website/docs/testing && mkdir ../website/docs/testing",
     "copy-markdown-files": "echo '\n==========\nCopying markdown files to `docs` folder...\n' && cp -r ./temp/markdown/* ../website/docs/",
     "copy-assets-folder": "rm -fr ../website/public/assets/images && cp -r ../packages/components/tests/dummy/public/assets/images ../website/public/assets/",

--- a/website-html-to-markdown/scripts/add-frontmatter.ts
+++ b/website-html-to-markdown/scripts/add-frontmatter.ts
@@ -1,0 +1,60 @@
+import { glob } from 'glob';
+import fs from 'fs-extra';
+import path from 'path';
+import chalk from 'chalk';
+
+const sourceFolder = path.resolve(__dirname, '../temp/markdown');
+
+(async () => {
+  try {
+    console.log(
+      `\n==========\n${chalk.cyan(
+        'Adding frontmatter...'
+      )}\n`
+    );
+
+    await addFrontmatter();
+
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();
+
+async function addFrontmatter() {
+  glob(sourceFolder + '/**/*.md', {}, async function (_error, files) {
+    for (const filePath of files) {
+      // get the relative path of the file, in relation to the "source" folder
+      const fileRelativePath = path.relative(sourceFolder, filePath);
+
+      let category;
+      let group;
+      let component;
+      let file;
+
+      const fileParts = fileRelativePath.split('/');
+      if (fileParts.length === 3) {
+        [category, component, file] = fileParts;
+      } else if (fileParts.length === 4) {
+        [category, group, component, file] = fileParts;
+      }
+      const section = file?.replace(/\d+--(.*)\.md/, '$1');
+
+      // we read the markdown source
+      const mdSource = await fs.readFile(filePath, 'utf8');
+
+      // prepare the frontmatter block
+      let frontmatter = '';
+      frontmatter += '---\n';
+      frontmatter += `category: ${category}\n`;
+      if (group) {
+        frontmatter += `group: ${group}\n`;
+      }
+      frontmatter += `component: ${component}\n`;
+      frontmatter += `section: ${section}\n`;
+      frontmatter += '---\n';
+
+      await fs.writeFile(filePath, `${frontmatter}\n${mdSource}`);
+    }
+  });
+}

--- a/website-html-to-markdown/scripts/convert-to-markdown.ts
+++ b/website-html-to-markdown/scripts/convert-to-markdown.ts
@@ -17,6 +17,7 @@ const destFolder = path.resolve(__dirname, '../temp/markdown');
     );
 
     await convert();
+
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/website-html-to-markdown/scripts/rename-files-as-markdown.ts
+++ b/website-html-to-markdown/scripts/rename-files-as-markdown.ts
@@ -14,6 +14,7 @@ const sourceFolder = path.resolve(__dirname, '../temp/split-files');
     );
 
     await renameFiles();
+
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/website/docs/components/alert/01--overview.md
+++ b/website/docs/components/alert/01--overview.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: alert
+section: overview
+---
+
 # Alert component - Overview
 
 An Alert is an element intended for **system-generated messages**. It is a live region with important, usually time-sensitive information. The use of this alert component will cause immediate notifications for users with assistive technology. Since alerts are not required to receive focus, it should not be required that the user close the alert.

--- a/website/docs/components/alert/02--component-api.md
+++ b/website/docs/components/alert/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: alert
+section: component-api
+---
+
 # Alert component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/alert/03--how-to-use.md
+++ b/website/docs/components/alert/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: alert
+section: how-to-use
+---
+
 # Alert component - How to use
 
 #### Basic use

--- a/website/docs/components/alert/04--design-guidelines.md
+++ b/website/docs/components/alert/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: alert
+section: design-guidelines
+---
+
 # Alert
 
 ## When to use

--- a/website/docs/components/alert/05--accessibility.md
+++ b/website/docs/components/alert/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: alert
+section: accessibility
+---
+
 # Alert component - Accessibility
 
 This component is conditionally conformant. That is, it is conformant when there are no interactive elements present inside of the alert. There is future work planned to make this component WCAG conformant by adding support for the correct ARIA roles when interactive elements are contained within the alert.

--- a/website/docs/components/alert/06--showcase.md
+++ b/website/docs/components/alert/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: alert
+section: showcase
+---
+
 <h1>Alert component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/avatar/01--overview.md
+++ b/website/docs/components/avatar/01--overview.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: avatar
+section: overview
+---
+
 # Avatar Component - Overview
 
 Renders an avatar; a user image if provided, otherwise a user icon by default.

--- a/website/docs/components/avatar/02--component-api.md
+++ b/website/docs/components/avatar/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: avatar
+section: component-api
+---
+
 # Avatar Component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/avatar/03--how-to-use.md
+++ b/website/docs/components/avatar/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: avatar
+section: how-to-use
+---
+
 # Avatar Component - How to use
 
 Default invocation:

--- a/website/docs/components/avatar/04--design-guidelines.md
+++ b/website/docs/components/avatar/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: avatar
+section: design-guidelines
+---
+
 <h1>Avatar Component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/avatar/05--accessibility.md
+++ b/website/docs/components/avatar/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: avatar
+section: accessibility
+---
+
 # Avatar Component - Accessibility
 
 The avatar is hidden from assistive technology. The accessible name should be provided by the containing element, if needed (e.g., if used within a button, use the aria-label attribute on the button).

--- a/website/docs/components/avatar/06--showcase.md
+++ b/website/docs/components/avatar/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: avatar
+section: showcase
+---
+
 <h1>Avatar Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/badge-count/01--overview.md
+++ b/website/docs/components/badge-count/01--overview.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge-count
+section: overview
+---
+
 # BadgeCount component - Overview
 
 `BadgeCount` is a numeric label used to display things like version number and collection enumeration in tabs.

--- a/website/docs/components/badge-count/02--component-api.md
+++ b/website/docs/components/badge-count/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge-count
+section: component-api
+---
+
 # BadgeCount component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/badge-count/03--how-to-use.md
+++ b/website/docs/components/badge-count/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge-count
+section: how-to-use
+---
+
 # BadgeCount component - How to use
 
 Invocation of the component would look something like this:

--- a/website/docs/components/badge-count/05--accessibility.md
+++ b/website/docs/components/badge-count/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge-count
+section: accessibility
+---
+
 # BadgeCount component - Accessibility
 
 This component has been designed and implemented with accessibility in mind. When used as recommended, there should not be any accessibility issues with this component.

--- a/website/docs/components/badge-count/06--showcase.md
+++ b/website/docs/components/badge-count/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge-count
+section: showcase
+---
+
 <h1>BadgeCount component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/badge/01--overview.md
+++ b/website/docs/components/badge/01--overview.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge
+section: overview
+---
+
 # Badge component - Overview
 
 `Badge` are concise, non-interactive labels that represent metadata. It should be used:

--- a/website/docs/components/badge/02--component-api.md
+++ b/website/docs/components/badge/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge
+section: component-api
+---
+
 # Badge component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/badge/03--how-to-use.md
+++ b/website/docs/components/badge/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge
+section: how-to-use
+---
+
 # Badge component - How to use
 
 Invocation of the component would look something like this:

--- a/website/docs/components/badge/04--design-guidelines.md
+++ b/website/docs/components/badge/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge
+section: design-guidelines
+---
+
 # Badge
 
 ## When to use

--- a/website/docs/components/badge/05--accessibility.md
+++ b/website/docs/components/badge/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge
+section: accessibility
+---
+
 # Badge component - Accessibility
 
 This component has been designed and implemented with accessibility in mind. When used as recommended, there should not be any accessibility issues with this component.

--- a/website/docs/components/badge/06--showcase.md
+++ b/website/docs/components/badge/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: badge
+section: showcase
+---
+
 <h1>Badge component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/breadcrumb/01--overview.md
+++ b/website/docs/components/breadcrumb/01--overview.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: breadcrumb
+section: overview
+---
+
 # Breadcrumb - Overview
 
 A “breadcrumb” (or “breadcrumb trail”) is a type of secondary navigation that reveals the user's location in a website or Web application.

--- a/website/docs/components/breadcrumb/02--component-api.md
+++ b/website/docs/components/breadcrumb/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: breadcrumb
+section: component-api
+---
+
 # Breadcrumb - Component API
 
 The `Breadcrumb` component is composed by different parts, with their own APIs:

--- a/website/docs/components/breadcrumb/03--how-to-use.md
+++ b/website/docs/components/breadcrumb/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: breadcrumb
+section: how-to-use
+---
+
 # Breadcrumb - How to use
 
 The breadcrumb is a high-level UI element, so it's likely that it will be implemented once per application, and then never changed (apart from follow-up redesigns/improvements). Below we give a couple of examples to give a general overview and show how it works.

--- a/website/docs/components/breadcrumb/04--design-guidelines.md
+++ b/website/docs/components/breadcrumb/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: breadcrumb
+section: design-guidelines
+---
+
 # Breadcrumb
 
 ## When to use

--- a/website/docs/components/breadcrumb/05--accessibility.md
+++ b/website/docs/components/breadcrumb/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: breadcrumb
+section: accessibility
+---
+
 # Breadcrumb - Accessibility
 
 This component has been designed and implemented with accessibility in mind. However, if the truncation feature is used, this component would not pass a WCAG conformance audit.

--- a/website/docs/components/breadcrumb/06--showcase.md
+++ b/website/docs/components/breadcrumb/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: breadcrumb
+section: showcase
+---
+
 <h1>Breadcrumb - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/button-set/01--overview.md
+++ b/website/docs/components/button-set/01--overview.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button-set
+section: overview
+---
+
 # ButtonSet Component - Overview
 
 Provides consistent layout and spacing of buttons.

--- a/website/docs/components/button-set/02--component-api.md
+++ b/website/docs/components/button-set/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button-set
+section: component-api
+---
+
 # ButtonSet Component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/button-set/03--how-to-use.md
+++ b/website/docs/components/button-set/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button-set
+section: how-to-use
+---
+
 # ButtonSet Component - How to use
 
 ```handlebars

--- a/website/docs/components/button-set/04--design-guidelines.md
+++ b/website/docs/components/button-set/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button-set
+section: design-guidelines
+---
+
 <h1>ButtonSet Component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/button-set/06--showcase.md
+++ b/website/docs/components/button-set/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button-set
+section: showcase
+---
+
 <h1>ButtonSet Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/button/02--component-api.md
+++ b/website/docs/components/button/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button
+section: component-api
+---
+
 # Button component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/button/03--how-to-use.md
+++ b/website/docs/components/button/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button
+section: how-to-use
+---
+
 # Button component - How to use
 
 The button component is used to trigger an action or event. For accessibility, buttons should not be used to route to a URL.

--- a/website/docs/components/button/04--design-guidelines.md
+++ b/website/docs/components/button/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button
+section: design-guidelines
+---
+
 # Button - Design Guidelines
 
 ## When to use

--- a/website/docs/components/button/05--accessibility.md
+++ b/website/docs/components/button/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button
+section: accessibility
+---
+
 # Button component - Accessibility
 
 This component has been designed and implemented with accessibility in mind. When used as recommended, there should not be any WCAG conformance issues with this component.

--- a/website/docs/components/button/06--showcase.md
+++ b/website/docs/components/button/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: button
+section: showcase
+---
+
 <h1>Button component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/card/02--component-api.md
+++ b/website/docs/components/card/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: card
+section: component-api
+---
+
 # Card component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/card/03--how-to-use.md
+++ b/website/docs/components/card/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: card
+section: how-to-use
+---
+
 # Card component - How to use
 
 #### Basic use

--- a/website/docs/components/card/04--design-guidelines.md
+++ b/website/docs/components/card/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: card
+section: design-guidelines
+---
+
 <h1>Card component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/card/05--accessibility.md
+++ b/website/docs/components/card/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: card
+section: accessibility
+---
+
 # Card component - Accessibility
 
 By default, the _Card Container_ component has `@overflow="hidden"` applied to it. This means you may need to handle the case in which text is truncated, to make it accessible (even though, this is a very unlikely situation).

--- a/website/docs/components/card/06--showcase.md
+++ b/website/docs/components/card/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: card
+section: showcase
+---
+
 <h1>Card component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/dropdown/02--component-api.md
+++ b/website/docs/components/dropdown/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: dropdown
+section: component-api
+---
+
 # Dropdown Component - Component API
 
 The `Dropdown` component is composed of different child components, each with their own APIs:

--- a/website/docs/components/dropdown/03--how-to-use.md
+++ b/website/docs/components/dropdown/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: dropdown
+section: how-to-use
+---
+
 # Dropdown Component - How to use
 
 #### Invocation

--- a/website/docs/components/dropdown/04--design-guidelines.md
+++ b/website/docs/components/dropdown/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: dropdown
+section: design-guidelines
+---
+
 # Dropdown - Design Guidelines
 
 ## When to use

--- a/website/docs/components/dropdown/05--accessibility.md
+++ b/website/docs/components/dropdown/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: dropdown
+section: accessibility
+---
+
 # Dropdown Component - Accessibility
 
 This component has been designed and implemented with accessibility in mind. When used as recommended, there should not be any accessibility issues with this component.

--- a/website/docs/components/dropdown/06--showcase.md
+++ b/website/docs/components/dropdown/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: dropdown
+section: showcase
+---
+
 <h1>Dropdown Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/dropdown/11--generic.md
+++ b/website/docs/components/dropdown/11--generic.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: dropdown
+section: generic
+---
+
 <h1>Dropdown Component - Generic #1</h1>
 
 <section class="dummy-link-cta-button-banner" data-section="generic">

--- a/website/docs/components/dropdown/12--generic.md
+++ b/website/docs/components/dropdown/12--generic.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: dropdown
+section: generic
+---
+
 <h1>Dropdown Component - Generic #2</h1>
 
 <section data-section="generic">

--- a/website/docs/components/empty-state/02--component-api.md
+++ b/website/docs/components/empty-state/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: empty-state
+section: component-api
+---
+
 # Card component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/empty-state/03--how-to-use.md
+++ b/website/docs/components/empty-state/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: empty-state
+section: how-to-use
+---
+
 # Card component - How to use
 
 The EmptyState component is a block-yielding component that contains three child components: a header, body and footer. Each child component is also a block yield. While none of the child components are explicitly required, use of at least the header or body components are recommended.

--- a/website/docs/components/empty-state/04--design-guidelines.md
+++ b/website/docs/components/empty-state/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: empty-state
+section: design-guidelines
+---
+
 <h1>Card component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/empty-state/05--accessibility.md
+++ b/website/docs/components/empty-state/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: empty-state
+section: accessibility
+---
+
 # Card component - Accessibility
 
 This component and its child components are rendered as blocks for developers to place content into. Developers should ensure that the content is conformant with WCAG 2.1 AA Success Criteria.

--- a/website/docs/components/empty-state/06--showcase.md
+++ b/website/docs/components/empty-state/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: empty-state
+section: showcase
+---
+
 <h1>Card component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/form/base-elements/01--overview.md
+++ b/website/docs/components/form/base-elements/01--overview.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: base-elements
+section: overview
+---
+
 # Form / Base elements - Overview
 
 In this page we collect a few "base" elements that are used to build/compose the "form" fields. They can also be used to build custom fields (in very specific cases).

--- a/website/docs/components/form/base-elements/02--component-api.md
+++ b/website/docs/components/form/base-elements/02--component-api.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: base-elements
+section: component-api
+---
+
 # Form / Base elements - Component API
 
 #### Form::Label

--- a/website/docs/components/form/base-elements/03--how-to-use.md
+++ b/website/docs/components/form/base-elements/03--how-to-use.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: base-elements
+section: how-to-use
+---
+
 # Form / Base elements - How to use
 
 The base form elements collected in this page are used internally as building blocks for the "field" and "group" controls, but can also be used in special cases when you need to implement custom layouts or controls in forms. Unless strictly needed, we **strongly** suggest to use the pre-defined "field" and "group" controls provided by the system (you can find them in the other "form" documentation pages).

--- a/website/docs/components/form/base-elements/04--design-guidelines.md
+++ b/website/docs/components/form/base-elements/04--design-guidelines.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: base-elements
+section: design-guidelines
+---
+
 <h1>Form / Base elements - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/form/base-elements/05--accessibility.md
+++ b/website/docs/components/form/base-elements/05--accessibility.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: base-elements
+section: accessibility
+---
+
 # Form / Base elements - Accessibility
 
 Since these are the base elements, they are conditionally conformant; that is, they are not conformant until used in conjunction with the other components/elements that will make them conformant.

--- a/website/docs/components/form/base-elements/06--showcase.md
+++ b/website/docs/components/form/base-elements/06--showcase.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: base-elements
+section: showcase
+---
+
 <h1>Form / Base elements - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/form/checkbox/01--overview.md
+++ b/website/docs/components/form/checkbox/01--overview.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: checkbox
+section: overview
+---
+
 # Form::Checkbox Component - Overview
 
 An input of type "checkbox" is a form element that allows users to select one or more items from a list of individual items.

--- a/website/docs/components/form/checkbox/02--component-api.md
+++ b/website/docs/components/form/checkbox/02--component-api.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: checkbox
+section: component-api
+---
+
 # Form::Checkbox Component - Component API
 
 The `Form::Checkbox` component has three different variants, with their own APIs:

--- a/website/docs/components/form/checkbox/03--how-to-use.md
+++ b/website/docs/components/form/checkbox/03--how-to-use.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: checkbox
+section: how-to-use
+---
+
 # Form::Checkbox Component - How to use
 
 Note: depending on how you're going to process the user input upon submission (eg. server-side via form `POST` or client-side using JavaScript) you will need to provide a `name` attribute or a custom `ID` attribute to the field. Since the decision on how to process the input data is left to the consumers, in the examples provided we will omit these specific arguments, for sake of simplicity.

--- a/website/docs/components/form/checkbox/04--design-guidelines.md
+++ b/website/docs/components/form/checkbox/04--design-guidelines.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: checkbox
+section: design-guidelines
+---
+
 <h1>Form::Checkbox Component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/form/checkbox/05--accessibility.md
+++ b/website/docs/components/form/checkbox/05--accessibility.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: checkbox
+section: accessibility
+---
+
 # Form::Checkbox Component - Accessibility
 
 #### Known Issues

--- a/website/docs/components/form/checkbox/06--showcase.md
+++ b/website/docs/components/form/checkbox/06--showcase.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: checkbox
+section: showcase
+---
+
 <h1>Form::Checkbox Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/form/radio-card/01--overview.md
+++ b/website/docs/components/form/radio-card/01--overview.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio-card
+section: overview
+---
+
 # Form::RadioCard Component - Overview
 
 The `RadioCard` is an input of type "radio" with a bigger target area represented by a card container. Same as the [`Form::Radio`](/components/form/radio/01_overview/) component, the `RadioCard` ​​ is a form element that allows users to select a single item from a list of related options.

--- a/website/docs/components/form/radio-card/02--component-api.md
+++ b/website/docs/components/form/radio-card/02--component-api.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio-card
+section: component-api
+---
+
 # Form::RadioCard Component - Component API
 
 #### Form::RadioCard

--- a/website/docs/components/form/radio-card/03--how-to-use.md
+++ b/website/docs/components/form/radio-card/03--how-to-use.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio-card
+section: how-to-use
+---
+
 # Form::RadioCard Component - How to use
 
 #### Form::Radio::Group

--- a/website/docs/components/form/radio-card/04--design-guidelines.md
+++ b/website/docs/components/form/radio-card/04--design-guidelines.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio-card
+section: design-guidelines
+---
+
 <h1>Form::RadioCard Component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/form/radio-card/05--accessibility.md
+++ b/website/docs/components/form/radio-card/05--accessibility.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio-card
+section: accessibility
+---
+
 # Form::RadioCard Component - Accessibility
 
 #### Known Issues

--- a/website/docs/components/form/radio-card/06--showcase.md
+++ b/website/docs/components/form/radio-card/06--showcase.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio-card
+section: showcase
+---
+
 <h1>Form::RadioCard Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/form/radio/01--overview.md
+++ b/website/docs/components/form/radio/01--overview.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio
+section: overview
+---
+
 # Form::Radio Component - Overview
 
 An input of type "radio" is a form element that allows users to select a single item from a list of related options.

--- a/website/docs/components/form/radio/02--component-api.md
+++ b/website/docs/components/form/radio/02--component-api.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio
+section: component-api
+---
+
 # Form::Radio Component - Component API
 
 The `Form::Radio` component has three different variants, with their own APIs:

--- a/website/docs/components/form/radio/03--how-to-use.md
+++ b/website/docs/components/form/radio/03--how-to-use.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio
+section: how-to-use
+---
+
 # Form::Radio Component - How to use
 
 Note: depending on how you're going to process the user input upon submission (eg. server-side via form `POST` or client-side using JavaScript) you will need to provide a `name` attribute or a custom `ID` attribute to the field. Since the decision on how to process the input data is left to the consumers, in the examples provided we will omit these specific arguments, for sake of simplicity.

--- a/website/docs/components/form/radio/04--design-guidelines.md
+++ b/website/docs/components/form/radio/04--design-guidelines.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio
+section: design-guidelines
+---
+
 <h1>Form::Radio Component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/form/radio/05--accessibility.md
+++ b/website/docs/components/form/radio/05--accessibility.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio
+section: accessibility
+---
+
 # Form::Radio Component - Accessibility
 
 #### Known Issues

--- a/website/docs/components/form/radio/06--showcase.md
+++ b/website/docs/components/form/radio/06--showcase.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: radio
+section: showcase
+---
+
 <h1>Form::Radio Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/form/select/01--overview.md
+++ b/website/docs/components/form/select/01--overview.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: select
+section: overview
+---
+
 # Form::Select Component - Overview
 
 A select is a form element that provides users with a way to select amongst a set of options.

--- a/website/docs/components/form/select/02--component-api.md
+++ b/website/docs/components/form/select/02--component-api.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: select
+section: component-api
+---
+
 # Form::Select Component - Component API
 
 The `Form::Select` component has two different variants, with their own APIs:

--- a/website/docs/components/form/select/03--how-to-use.md
+++ b/website/docs/components/form/select/03--how-to-use.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: select
+section: how-to-use
+---
+
 # Form::Select Component - How to use
 
 Note: depending on how you're going to process the user input upon submission (eg. server-side via form `POST` or client-side using JavaScript) you will need to provide a `name` attribute or a custom `ID` attribute to the field. Since the decision on how to process the input data is left to the consumers, in the examples provided we will omit these specific arguments, for sake of simplicity.

--- a/website/docs/components/form/select/04--design-guidelines.md
+++ b/website/docs/components/form/select/04--design-guidelines.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: select
+section: design-guidelines
+---
+
 # Select
 
 ## When to use

--- a/website/docs/components/form/select/05--accessibility.md
+++ b/website/docs/components/form/select/05--accessibility.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: select
+section: accessibility
+---
+
 # Form::Select Component - Accessibility
 
 #### Known Issues

--- a/website/docs/components/form/select/06--showcase.md
+++ b/website/docs/components/form/select/06--showcase.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: select
+section: showcase
+---
+
 <h1>Form::Select Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/form/select/11--generic.md
+++ b/website/docs/components/form/select/11--generic.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: select
+section: generic
+---
+
 <h1>Form::Select Component - Generic #1</h1>
 
 <section class="dummy-link-cta-button-banner" data-section="generic">

--- a/website/docs/components/form/text-input/01--overview.md
+++ b/website/docs/components/form/text-input/01--overview.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: text-input
+section: overview
+---
+
 # Form::TextInput Component - Overview
 
 A text input is a form element that provides users with a way to read, input, or edit data.

--- a/website/docs/components/form/text-input/02--component-api.md
+++ b/website/docs/components/form/text-input/02--component-api.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: text-input
+section: component-api
+---
+
 # Form::TextInput Component - Component API
 
 The `Form::TextInput` component has two different variants, with their own APIs:

--- a/website/docs/components/form/text-input/03--how-to-use.md
+++ b/website/docs/components/form/text-input/03--how-to-use.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: text-input
+section: how-to-use
+---
+
 # Form::TextInput Component - How to use
 
 Note: depending on how you're going to process the user input upon submission (eg. server-side via form `POST` or client-side using JavaScript) you will need to provide a `name` attribute or a custom `ID` attribute to the field. Since the decision on how to process the input data is left to the consumers, in the examples provided we will omit these specific arguments, for sake of simplicity.

--- a/website/docs/components/form/text-input/04--design-guidelines.md
+++ b/website/docs/components/form/text-input/04--design-guidelines.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: text-input
+section: design-guidelines
+---
+
 <h1>Form::TextInput Component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/form/text-input/05--accessibility.md
+++ b/website/docs/components/form/text-input/05--accessibility.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: text-input
+section: accessibility
+---
+
 # Form::TextInput Component - Accessibility
 
 This component was designed with WCAG conformance as a requirement. As such, the `Form::TextInput::Base` is conditionally conformant; that is, it is not conformant until it has an accessible name. However, the `Form::TextInput::Field` component is the one that developers should use in most cases, and it is conformant when used as directed. Please report any conformance issues that you find.

--- a/website/docs/components/form/text-input/06--showcase.md
+++ b/website/docs/components/form/text-input/06--showcase.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: text-input
+section: showcase
+---
+
 <h1>Form::TextInput Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/form/textarea/01--overview.md
+++ b/website/docs/components/form/textarea/01--overview.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: textarea
+section: overview
+---
+
 # Form::Textarea Component - Overview
 
 A textarea input provides all the same features as the [text input](/components/form/text-input/01_overview/), with the difference that it accepts a multi-line text.

--- a/website/docs/components/form/textarea/02--component-api.md
+++ b/website/docs/components/form/textarea/02--component-api.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: textarea
+section: component-api
+---
+
 # Form::Textarea Component - Component API
 
 The `Form::Textarea` component is based on the Ember [`Textarea` built-in component](https://guides.emberjs.com/release/components/built-in-components/).

--- a/website/docs/components/form/textarea/03--how-to-use.md
+++ b/website/docs/components/form/textarea/03--how-to-use.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: textarea
+section: how-to-use
+---
+
 # Form::Textarea Component - How to use
 
 Note: depending on how you're going to process the user input upon submission (eg. server-side via form `POST` or client-side using JavaScript) you will need to provide a `name` attribute or a custom `ID` attribute to the field. Since the decision on how to process the input data is left to the consumers, in the examples provided we will omit these specific arguments, for sake of simplicity.

--- a/website/docs/components/form/textarea/04--design-guidelines.md
+++ b/website/docs/components/form/textarea/04--design-guidelines.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: textarea
+section: design-guidelines
+---
+
 <h1>Form::Textarea Component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/form/textarea/05--accessibility.md
+++ b/website/docs/components/form/textarea/05--accessibility.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: textarea
+section: accessibility
+---
+
 # Form::Textarea Component - Accessibility
 
 #### Known Issues

--- a/website/docs/components/form/textarea/06--showcase.md
+++ b/website/docs/components/form/textarea/06--showcase.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: textarea
+section: showcase
+---
+
 <h1>Form::Textarea Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/form/toggle/01--overview.md
+++ b/website/docs/components/form/toggle/01--overview.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: toggle
+section: overview
+---
+
 # Form::Toggle Component - Overview
 
 A toggle is a form element that allows users to select between two mutually exclusive states.

--- a/website/docs/components/form/toggle/02--component-api.md
+++ b/website/docs/components/form/toggle/02--component-api.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: toggle
+section: component-api
+---
+
 # Form::Toggle Component - Component API
 
 The `Form::Toggle` component has two different variants, with their own APIs:

--- a/website/docs/components/form/toggle/03--how-to-use.md
+++ b/website/docs/components/form/toggle/03--how-to-use.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: toggle
+section: how-to-use
+---
+
 # Form::Toggle Component - How to use
 
 Note: depending on how you're going to process the user input upon submission (eg. server-side via form `POST` or client-side using JavaScript) you will need to provide a `name` attribute or a custom `ID` attribute to the field. Since the decision on how to process the input data is left to the consumers, in the examples provided we will omit these specific arguments, for sake of simplicity.

--- a/website/docs/components/form/toggle/04--design-guidelines.md
+++ b/website/docs/components/form/toggle/04--design-guidelines.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: toggle
+section: design-guidelines
+---
+
 <h1>Form::Toggle Component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/form/toggle/05--accessibility.md
+++ b/website/docs/components/form/toggle/05--accessibility.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: toggle
+section: accessibility
+---
+
 # Form::Toggle Component - Accessibility
 
 #### Known Issues

--- a/website/docs/components/form/toggle/06--showcase.md
+++ b/website/docs/components/form/toggle/06--showcase.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: form
+component: toggle
+section: showcase
+---
+
 <h1>Form::Toggle Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/icon-tile/02--component-api.md
+++ b/website/docs/components/icon-tile/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: icon-tile
+section: component-api
+---
+
 # IconTile - Component API
 
 Here is the API for the component:

--- a/website/docs/components/icon-tile/03--how-to-use.md
+++ b/website/docs/components/icon-tile/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: icon-tile
+section: how-to-use
+---
+
 # IconTile - How to use
 
 Invocation of the component would look something like this:

--- a/website/docs/components/icon-tile/05--accessibility.md
+++ b/website/docs/components/icon-tile/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: icon-tile
+section: accessibility
+---
+
 # IconTile - Accessibility
 
 This component has been designed and implemented with accessibility in mind. When used as recommended, there should not be any accessibility issues with this component.

--- a/website/docs/components/icon-tile/06--showcase.md
+++ b/website/docs/components/icon-tile/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: icon-tile
+section: showcase
+---
+
 <h1>IconTile - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/link/inline/01--overview.md
+++ b/website/docs/components/link/inline/01--overview.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: link
+component: inline
+section: overview
+---
+
 # Link::Inline component - Overview
 
 The `Link::Inline` component handles the generation of:

--- a/website/docs/components/link/inline/02--component-api.md
+++ b/website/docs/components/link/inline/02--component-api.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: link
+component: inline
+section: component-api
+---
+
 # Link::Inline component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/link/inline/03--how-to-use.md
+++ b/website/docs/components/link/inline/03--how-to-use.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: link
+component: inline
+section: how-to-use
+---
+
 # Link::Inline component - How to use
 
 #### Basic use

--- a/website/docs/components/link/inline/04--design-guidelines.md
+++ b/website/docs/components/link/inline/04--design-guidelines.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: link
+component: inline
+section: design-guidelines
+---
+
 <h1>Link::Inline component - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/components/link/inline/06--showcase.md
+++ b/website/docs/components/link/inline/06--showcase.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: link
+component: inline
+section: showcase
+---
+
 <h1>Link::Inline component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/link/inline/11--generic.md
+++ b/website/docs/components/link/inline/11--generic.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: link
+component: inline
+section: generic
+---
+
 <h1>Link::Inline component - Generic #1</h1>
 
 <section data-section="generic">

--- a/website/docs/components/link/standalone/01--overview.md
+++ b/website/docs/components/link/standalone/01--overview.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: link
+component: standalone
+section: overview
+---
+
 # Link::Standalone component - Overview
 
 The `Link::Standalone` component handles the generation of:

--- a/website/docs/components/link/standalone/02--component-api.md
+++ b/website/docs/components/link/standalone/02--component-api.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: link
+component: standalone
+section: component-api
+---
+
 # Link::Standalone component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/link/standalone/03--how-to-use.md
+++ b/website/docs/components/link/standalone/03--how-to-use.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: link
+component: standalone
+section: how-to-use
+---
+
 # Link::Standalone component - How to use
 
 #### Basic use

--- a/website/docs/components/link/standalone/06--showcase.md
+++ b/website/docs/components/link/standalone/06--showcase.md
@@ -1,3 +1,10 @@
+---
+category: components
+group: link
+component: standalone
+section: showcase
+---
+
 <h1>Link::Standalone component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/stepper/01--overview.md
+++ b/website/docs/components/stepper/01--overview.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: stepper
+section: overview
+---
+
 # Stepper Indicator Component - Overview
 
 A stepper indicator helps the user maintain context and directionality when advancing through a multi-step flow or feature, and in certain circumstances, could act as a navigational device between steps. It is generally assembled as part of a larger stepper pattern.

--- a/website/docs/components/stepper/02--component-api.md
+++ b/website/docs/components/stepper/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: stepper
+section: component-api
+---
+
 # Stepper Indicator Component - Component API
 
 **Note:** Since the `indicator` components are meant to be assembled into larger stepper item patterns, the component's interactive states should be tied to the larger pattern. This includes `hover`, `active`, and `focus`.

--- a/website/docs/components/stepper/03--how-to-use.md
+++ b/website/docs/components/stepper/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: stepper
+section: how-to-use
+---
+
 # Stepper Indicator Component - How to use
 
 The stepper indicator is used to indicate the relational step number or value, helping the user maintain context in a multi-step flow or sequence. It should be used in larger stepper item patterns with an appropriate label, description, and visual language indicating directionality.

--- a/website/docs/components/stepper/05--accessibility.md
+++ b/website/docs/components/stepper/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: stepper
+section: accessibility
+---
+
 # Stepper Indicator Component - Accessibility
 
 The `Stepper Indicator` components are not WCAG-conformant on their own.

--- a/website/docs/components/stepper/06--showcase.md
+++ b/website/docs/components/stepper/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: stepper
+section: showcase
+---
+
 <h1>Stepper Indicator Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/tabs/01--overview.md
+++ b/website/docs/components/tabs/01--overview.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: tabs
+section: overview
+---
+
 # Tabs Component - Overview
 
 Tabs allow users to move between different views within the same context and at the same level of hierarchy, ie. UI vs CLI, macOS vs Windows vs Linux, etc.

--- a/website/docs/components/tabs/02--component-api.md
+++ b/website/docs/components/tabs/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: tabs
+section: component-api
+---
+
 # Tabs Component - Component API
 
 The `Tabs` component is composed of different parts, with their own APIs:

--- a/website/docs/components/tabs/03--how-to-use.md
+++ b/website/docs/components/tabs/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: tabs
+section: how-to-use
+---
+
 # Tabs Component - How to use
 
 #### Basic use

--- a/website/docs/components/tabs/05--accessibility.md
+++ b/website/docs/components/tabs/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: tabs
+section: accessibility
+---
+
 # Tabs Component - Accessibility
 
 #### Relevant WCAG

--- a/website/docs/components/tabs/06--showcase.md
+++ b/website/docs/components/tabs/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: tabs
+section: showcase
+---
+
 <h1>Tabs Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/tag/02--component-api.md
+++ b/website/docs/components/tag/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: tag
+section: component-api
+---
+
 # Tag component - Component API
 
 Here is the API for the component:

--- a/website/docs/components/tag/03--how-to-use.md
+++ b/website/docs/components/tag/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: tag
+section: how-to-use
+---
+
 # Tag component - How to use
 
 Use tags to indicate an object's categorization, i.e., for filtering. Use a [badge](/components/badge/01_overview/) instead for static metadata, status, or to indicate a new feature.

--- a/website/docs/components/tag/05--accessibility.md
+++ b/website/docs/components/tag/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: tag
+section: accessibility
+---
+
 # Tag component - Accessibility
 
 #### Applicable WCAG Success Criteria (Reference)

--- a/website/docs/components/tag/06--showcase.md
+++ b/website/docs/components/tag/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: tag
+section: showcase
+---
+
 <h1>Tag component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/components/toast/01--overview.md
+++ b/website/docs/components/toast/01--overview.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: toast
+section: overview
+---
+
 # Toast component - Overview
 
 A Toast is an element intended for **messages that are the result of a user's actions**.

--- a/website/docs/components/toast/02--component-api.md
+++ b/website/docs/components/toast/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: toast
+section: component-api
+---
+
 # Toast component - Component API
 
 **Notice**: the `Hds::Toast` component is built out of the `Hds::Alert(Inline)` component, so it shares the same API. Please refer to [the Alert Component API documentation](/components/alert/01_overview/) to know more.

--- a/website/docs/components/toast/03--how-to-use.md
+++ b/website/docs/components/toast/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: toast
+section: how-to-use
+---
+
 # Toast component - How to use
 
 #### Basic use

--- a/website/docs/components/toast/04--design-guidelines.md
+++ b/website/docs/components/toast/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: toast
+section: design-guidelines
+---
+
 # Toast
 
 ## When to use

--- a/website/docs/components/toast/05--accessibility.md
+++ b/website/docs/components/toast/05--accessibility.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: toast
+section: accessibility
+---
+
 # Toast component - Accessibility
 
 This component has been designed and implemented with accessibility in mind. When used as designed, there should not be any accessibility issues with this component.

--- a/website/docs/components/toast/06--showcase.md
+++ b/website/docs/components/toast/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: components
+component: toast
+section: showcase
+---
+
 <h1>Toast component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/foundations/colors/03--how-to-use.md
+++ b/website/docs/foundations/colors/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: colors
+section: how-to-use
+---
+
 # Colors - How to use
 
 There are two different ways to apply a color to a UI element, via **design tokens** or via **CSS helper classes**.

--- a/website/docs/foundations/colors/12--generic.md
+++ b/website/docs/foundations/colors/12--generic.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: colors
+section: generic
+---
+
 <h1>Colors - Generic #2</h1>
 
 <section data-test-percy data-section="colors-semantic">

--- a/website/docs/foundations/elevation/03--how-to-use.md
+++ b/website/docs/foundations/elevation/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: elevation
+section: how-to-use
+---
+
 # Elevation - How to use
 
 There are two different ways to apply an "elevation" or "surface" effect to a UI element, via **design tokens** or via **CSS helper classes**.

--- a/website/docs/foundations/elevation/04--design-guidelines.md
+++ b/website/docs/foundations/elevation/04--design-guidelines.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: elevation
+section: design-guidelines
+---
+
 <h1>Elevation - Design Guidelines</h1>
 
 <section data-section="design-guidelines">

--- a/website/docs/foundations/elevation/06--showcase.md
+++ b/website/docs/foundations/elevation/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: elevation
+section: showcase
+---
+
 <h1>Elevation - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/foundations/focus-ring/03--how-to-use.md
+++ b/website/docs/foundations/focus-ring/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: focus-ring
+section: how-to-use
+---
+
 # Focus ring - How to use
 
 The suggested way to apply a "focus-ring" style to an UI element is using the specific **design token** provided as CSS custom property.

--- a/website/docs/foundations/focus-ring/06--showcase.md
+++ b/website/docs/foundations/focus-ring/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: focus-ring
+section: showcase
+---
+
 <h1>Focus ring - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/foundations/tokens/03--how-to-use.md
+++ b/website/docs/foundations/tokens/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: tokens
+section: how-to-use
+---
+
 # Design tokens - How to use
 
 You can use the design tokens in your CSS code as CSS custom properties:

--- a/website/docs/foundations/tokens/12--generic.md
+++ b/website/docs/foundations/tokens/12--generic.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: tokens
+section: generic
+---
+
 <h1>Design tokens - Generic #2</h1>
 
 <section data-section="css-custom-properties">

--- a/website/docs/foundations/typography/03--how-to-use.md
+++ b/website/docs/foundations/typography/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: typography
+section: how-to-use
+---
+
 # Typography - How to use
 
 The suggested way to apply the typographic definitions to a UI element is using the **predefined CSS helper classes** provided.

--- a/website/docs/foundations/typography/06--showcase.md
+++ b/website/docs/foundations/typography/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: typography
+section: showcase
+---
+
 <h1>Typography - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/foundations/typography/11--generic.md
+++ b/website/docs/foundations/typography/11--generic.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: typography
+section: generic
+---
+
 <h1>Typography - Generic #1</h1>
 
 <section class="dummy-link-cta-button-banner" data-section="generic">

--- a/website/docs/foundations/typography/13--generic.md
+++ b/website/docs/foundations/typography/13--generic.md
@@ -1,3 +1,9 @@
+---
+category: foundations
+component: typography
+section: generic
+---
+
 <h1>Typography - Generic #3</h1>
 
 <section data-section="writing-guidelines">

--- a/website/docs/overrides/power-select/01--overview.md
+++ b/website/docs/overrides/power-select/01--overview.md
@@ -1,3 +1,9 @@
+---
+category: overrides
+component: power-select
+section: overview
+---
+
 # PowerSelect Component - Overview
 
 [PowerSelect](https://ember-power-select.com/) is a popular Ember add-on aiming to overcome some limitations of the `<select>` tag. HashiCorp Design System only provides style overrides for this add-on to keep it in line with other form components.

--- a/website/docs/overrides/power-select/03--how-to-use.md
+++ b/website/docs/overrides/power-select/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: overrides
+component: power-select
+section: how-to-use
+---
+
 # PowerSelect Component - How to use
 
 To use this component in your application follow [the getting started guide on the add-on website](https://ember-power-select.com) then add the PowerSelect overrides as shown below.

--- a/website/docs/overrides/power-select/06--showcase.md
+++ b/website/docs/overrides/power-select/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: overrides
+component: power-select
+section: showcase
+---
+
 <h1>PowerSelect Component - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/utilities/disclosure/02--component-api.md
+++ b/website/docs/utilities/disclosure/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: utilities
+component: disclosure
+section: component-api
+---
+
 # Disclosure - Component API
 
 Here is the API for the component:

--- a/website/docs/utilities/disclosure/03--how-to-use.md
+++ b/website/docs/utilities/disclosure/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: utilities
+component: disclosure
+section: how-to-use
+---
+
 # Disclosure - How to use
 
 Invocation of the component would look something like this:

--- a/website/docs/utilities/disclosure/06--showcase.md
+++ b/website/docs/utilities/disclosure/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: utilities
+component: disclosure
+section: showcase
+---
+
 <h1>Disclosure - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/utilities/disclosure/11--generic.md
+++ b/website/docs/utilities/disclosure/11--generic.md
@@ -1,3 +1,9 @@
+---
+category: utilities
+component: disclosure
+section: generic
+---
+
 <h1>Disclosure - Generic #1</h1>
 
 <section data-section="generic">

--- a/website/docs/utilities/interactive/02--component-api.md
+++ b/website/docs/utilities/interactive/02--component-api.md
@@ -1,3 +1,9 @@
+---
+category: utilities
+component: interactive
+section: component-api
+---
+
 # Interactive - Component API
 
 Here is the API for the component:

--- a/website/docs/utilities/interactive/03--how-to-use.md
+++ b/website/docs/utilities/interactive/03--how-to-use.md
@@ -1,3 +1,9 @@
+---
+category: utilities
+component: interactive
+section: how-to-use
+---
+
 # Interactive - How to use
 
 #### Basic use (<button>)

--- a/website/docs/utilities/interactive/06--showcase.md
+++ b/website/docs/utilities/interactive/06--showcase.md
@@ -1,3 +1,9 @@
+---
+category: utilities
+component: interactive
+section: showcase
+---
+
 <h1>Interactive - Showcase</h1>
 
 <section data-test-percy data-section="showcase">

--- a/website/docs/utilities/interactive/11--generic.md
+++ b/website/docs/utilities/interactive/11--generic.md
@@ -1,3 +1,9 @@
+---
+category: utilities
+component: interactive
+section: generic
+---
+
 <h1>Interactive - Generic #1</h1>
 
 <section data-section="generic">


### PR DESCRIPTION
### :pushpin: Summary

We want to make sure that the frontmatter content added to the markdown files is correctly parsed, interpreted, and provided in the pages' model. 

### :hammer_and_wrench: Detailed description

In this PR I have:
- created a script that adds "frontmatter" to the automatically generated markdown files
- re-generated markdown files
- added missing frontmatter to moveover “design-guidelines” files previously converted by @jorytindall (^1)
- configured `broccoli-static-site-json` in `field-guide` to interpret custom attributes in frontmatter markdown

(^1) @jorytindall for the new files you're going to add, please use one of the files that you have already created as an example of the frontmatter block you need to add on top of your markdown files.

### :camera_flash: Screenshots

It works! 🎉

<img width="1040" alt="screenshot_2063" src="https://user-images.githubusercontent.com/686239/202047413-d0e324fb-2c63-41e5-b287-0eaae18ebaa1.png">

### :link: External links

JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-1032

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
