### PR TITLE
New docs website / "About  - HDS principles" page

### DIFF
--- a/website-html-to-markdown/moveover/overview/02--hds-principles.md
+++ b/website-html-to-markdown/moveover/overview/02--hds-principles.md
@@ -1,9 +1,8 @@
 ---
 category: about
 title: HDS principles
-description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+description: Consider the whole when creating the parts.
 ---
 
-## Lorem ipsum dolor
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Diam diam mi etiam mollis tortor vestibulum. Felis, arcu amet, nibh eget eget etiam orci aliquet. Varius facilisis magna faucibus commodo iaculis faucibus aliquet.
+<!-- TO EDIT THESE PRINCIPLES LOOK AT THE COMPONENT IN `website/app/components/doc/content/hds-principles/` -->
+<Doc::Content::HdsPrinciples />

--- a/website/.stylelintrc.js
+++ b/website/.stylelintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     'selector-class-pattern': [
       // found this pattern here: https://github.com/humanmade/coding-standards/pull/199
       // '^(?<block>(?:[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)(?<element>(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*))?(?<modifier>(?:--[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)?$',
-      '^(hds|doc)-(?<block>(?:[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)(?<element>(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*))?(?<modifier>(?:--[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)?$|^mock-(?:[a-z][a-z0-9]*)$',
+      '^(hds|doc)-(?<block>(?:[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)(?<element>(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*))?(?<modifier>(?:--[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)?$|^mock-(?:[a-z][a-z0-9]*)$||^doc-(?:[a-z][a-z0-9]*)$',
       { resolveNestedSelectors: true },
     ],
   },

--- a/website/app/components/doc/content/hds-principles/index.hbs
+++ b/website/app/components/doc/content/hds-principles/index.hbs
@@ -1,0 +1,9 @@
+<ul class="doc-content-principles">
+  {{#each this.principles as |principle index|}}
+  <li class="doc-text-body-small">
+    <img class="doc-content-principles__image" src="https://picsum.photos/seed/s{{index}}/456/124" alt="" role="presentation" />
+    <p class="doc-content-principles__title"><strong>{{principle.title}}</strong></p>
+    <p class="doc-content-principles__description">{{principle.description}}</p>
+  </li>
+  {{/each}}
+</ul>

--- a/website/app/components/doc/content/hds-principles/index.js
+++ b/website/app/components/doc/content/hds-principles/index.js
@@ -1,0 +1,36 @@
+import Component from '@glimmer/component';
+
+export default class DocBadgeComponent extends Component {
+  principles = [
+    {
+      title: 'Rooted in reality',
+      description:
+        'We ground our work and our decisions in reality through data and observations.',
+    },
+    {
+      title: 'Guidance over control',
+      description:
+        'We provide balance between configurability and composability while driving consistency.',
+    },
+    {
+      title: 'Don’t iterate on quality',
+      description:
+        'We recognize that we are providing a service and commit to a baseline of quality to provide value.',
+    },
+    {
+      title: 'Design in context',
+      description:
+        'We meet consumers where they are and consider both the current and future context in which they use the system.',
+    },
+    {
+      title: 'Consider everyone',
+      description:
+        'We take an inclusive approach to our work from the start, considering the context and range of abilities for all customers.',
+    },
+    {
+      title: 'Invite feedback',
+      description:
+        'We take time to have the right conversations with the appropriate stakeholders, to validate and create trust in the outcome.',
+    },
+  ];
+}

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -14,6 +14,7 @@
 @import "components/badge";
 @import "components/doc-landing-callout-blocks";
 @import "components/doc-table-of-contents";
+@import "components/content/hds-principles";
 
 // Markdown
 @import "markdown";

--- a/website/app/styles/components/content/hds-principles.scss
+++ b/website/app/styles/components/content/hds-principles.scss
@@ -1,0 +1,28 @@
+.doc-content-principles {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 64px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.doc-content-principles__item {
+  // border-radius: 10px;
+}
+
+.doc-content-principles__image {
+  width: 100%;
+  height: auto;
+  border-radius: 10px;
+}
+
+.doc-content-principles__title {
+  margin: 24px 0 0 0;
+  color: #000; // TODO convert to token
+}
+
+.doc-content-principles__description {
+  margin: 4px 0 0 0;
+  color: #343536; // TODO convert to token
+}

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -8,6 +8,15 @@
   min-width: 0; // needed to avoid that the element blows out if the content is too wide (see: https://css-tricks.com/preventing-a-grid-blowout/)
   padding: 0 var(--doc-page-stage-gutter-small);
 
+  // TODO! temp until we decide with Heather the correct vertical padding of the "content" area
+  > :first-child {
+    margin-top: 48px;
+  }
+
+  > :last-child {
+    margin-bottom: 48px;
+  }
+
   @include breakpoint.medium () {
     padding: 0 var(--doc-page-stage-gutter-medium);
   }

--- a/website/docs/overview/02--hds-principles.md
+++ b/website/docs/overview/02--hds-principles.md
@@ -1,9 +1,8 @@
 ---
 category: about
 title: HDS principles
-description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+description: Consider the whole when creating the parts.
 ---
 
-## Lorem ipsum dolor
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Diam diam mi etiam mollis tortor vestibulum. Felis, arcu amet, nibh eget eget etiam orci aliquet. Varius facilisis magna faucibus commodo iaculis faucibus aliquet.
+<!-- TO EDIT THESE PRINCIPLES LOOK AT THE COMPONENT IN `website/app/components/doc/content/hds-principles/` -->
+<Doc::Content::HdsPrinciples />


### PR DESCRIPTION
### :pushpin: Summary

Following [this comment/question in Figma](https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1?node-id=514:34792#310098389) by @heatherlarsen I have quickly mocked up the page so we can see how that works in the context of the current infrastructure.

### :hammer_and_wrench: Detailed description

See commits history.

Preview: https://hds-website-git-new-docs-website-about-principles-hashicorp.vercel.app/overview/02--hds-principles/

### :camera_flash: Screenshots

Via existing markdown file:
<img width="1792" alt="screenshot_2082" src="https://user-images.githubusercontent.com/686239/202678245-1676dba0-06b1-4085-ad7f-5aa2e47223d5.png">

Via custom route/page:
<img width="1791" alt="screenshot_2083" src="https://user-images.githubusercontent.com/686239/202678316-e6e2fe29-617a-4215-80e6-d7ee34e9406d.png">

As you can see @heatherlarsen in the second case we need to:
- add the sidebar navigation (not trivial at the moment) and the content "cover" block
- add the specific route to the sidebar under the `About/Overview` block (also, not trivial at the moment)

Maybe we can do it later, after the complete revamp of the navigation logic ([HDS-1059](https://hashicorp.atlassian.net/browse/HDS-1059)) but for now we have to go with the standard one.

### :link: External links

JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-1101

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
