### PR TITLE
New docs website / Implement "Foundations" and "Components" landing pages (with automatic list generation)

### DIFF
--- a/addons/field-guide/addon/routes/application.js
+++ b/addons/field-guide/addon/routes/application.js
@@ -6,6 +6,7 @@ import config from 'ember-get-config';
 export default Route.extend({
   model() {
     return fetch(`${config.rootURL}toc.json`)
-      .then(res => res.json())
+    // TODO! important: instead of spreading the content all over the model, group the TOC under a specific "key"!
+    .then(res => res.json())
   }
 })

--- a/website/app/components/doc/cards/card.hbs
+++ b/website/app/components/doc/cards/card.hbs
@@ -1,0 +1,20 @@
+<div class={{this.classNames}} ...attributes>
+  {{#if @route}}
+  <LinkTo class="doc-cards-card__link" @route={{@route}} @model={{@model}}>
+    <img class="doc-cards-card__image" src={{@image}} alt="" role="presentation" />
+    <div class="doc-cards-card__details">
+      <p class="doc-cards-card__title">{{capitalize @title}}</p>
+      <p class="doc-cards-card_description">{{capitalize @description}}</p>
+    </div>
+  </LinkTo>
+  {{/if}}
+  {{#if @href}}
+  <a class="doc-cards-card__link" href={{@href}}>
+    <img class="doc-cards-card__image" src={{@image}} alt="" role="presentation" />
+    <div class="doc-cards-card__details">
+      <p class="doc-cards-card__title">{{capitalize @title}}</p>
+      <p class="doc-cards-card_description">{{capitalize @description}}</p>
+    </div>
+  </a>
+  {{/if}}
+</div>

--- a/website/app/components/doc/cards/card.js
+++ b/website/app/components/doc/cards/card.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+export default class DocCardsCardComponent extends Component {
+  get classNames() {
+    let classes = ['doc-cards-card'];
+
+    // add a class based on the @xxx argument
+    // classes.push(`doc-cards-card--xxx-${this.xxx}`);
+
+    return classes.join(' ');
+  }
+}

--- a/website/app/components/doc/cards/deck.hbs
+++ b/website/app/components/doc/cards/deck.hbs
@@ -1,0 +1,16 @@
+<ul class={{this.classNames}} ...attributes>
+  {{#if @cards}}
+    {{#each @cards as |card|}}
+      <Doc::Cards::Card
+        @image={{card.image}}
+        @title={{card.title}}
+        @description={{card.description}}
+        @route={{card.route}}
+        @model={{card.model}}
+        @href={{card.href}}
+      />
+    {{/each}}
+  {{else}}
+    {{yield}}
+  {{/if}}
+</ul>

--- a/website/app/components/doc/cards/deck.js
+++ b/website/app/components/doc/cards/deck.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+
+export default class DocCardsDeckComponent extends Component {
+  get cols() {
+    return this.args.cols ?? '2';
+  }
+  get classNames() {
+    let classes = ['doc-cards-deck'];
+
+    // add a class based on the @color argument
+    classes.push(`doc-cards-deck--layout-${this.cols}cols`);
+
+    return classes.join(' ');
+  }
+}

--- a/website/app/components/doc/page/content.hbs
+++ b/website/app/components/doc/page/content.hbs
@@ -1,3 +1,3 @@
-<div class="doc-page-content" ...attributes>
+<div class={{this.classNames}} ...attributes>
   {{yield}}
 </div>

--- a/website/app/components/doc/page/content.js
+++ b/website/app/components/doc/page/content.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+export default class DocPageContentComponent extends Component {
+  get classNames() {
+    let classes = ['doc-page-content'];
+
+    // add a class based on the @breakthrough argument
+    if (this.args.breakthrough) {
+      classes.push(`doc-page-content--breakthrough`);
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/website/app/controllers/components.js
+++ b/website/app/controllers/components.js
@@ -1,0 +1,55 @@
+import Controller from '@ember/controller';
+
+export default class ComponentsController extends Controller {
+  get subTOC() {
+    // NOTICE: the TOC comes direclty from the application "model" (see addons/field-guide/addon/routes/application.js)
+    // TODO! important: instead of spreading the content all over the model, group the TOC under a specific "key"!
+
+    // hacky way to have the subTOC items in the right order
+    const subIDs = ['components', 'overrides', 'utilities'];
+    const subTOC = {};
+
+    // TODO! convert this to a recursive function shared with the "Foundations page"
+    this.model
+      .filter((item) => subIDs.includes(item.id))
+      .forEach((item) => {
+        const { id, title, pages } = item;
+        const cards = [];
+        pages.forEach((page) => {
+          if (page.pages && page.pages.length > 0) {
+            if (page.pages[0].pages) {
+              // TODO recursive
+              page.pages.forEach((subpage) => {
+                cards.push({
+                  image: `https://picsum.photos/seed/s${encodeURI(
+                    page.subtitle
+                  )}/232/124`,
+                  title: subpage.title,
+                  description:
+                    'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+                  route: 'show',
+                  // model: `${subpage.id}/${subpage.pages[0].id}`,
+                  model: subpage.pages[0].id,
+                });
+              });
+            } else {
+              cards.push({
+                image: `https://picsum.photos/seed/s${encodeURI(
+                  page.title
+                )}/232/124`,
+                title: page.title,
+                description:
+                  'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+                route: 'show',
+                model: page.pages[0].id,
+              });
+            }
+          } else {
+            console.log('????????????');
+          }
+        });
+        subTOC[id] = { title, cards };
+      });
+    return subTOC;
+  }
+}

--- a/website/app/controllers/foundations.js
+++ b/website/app/controllers/foundations.js
@@ -1,30 +1,54 @@
 import Controller from '@ember/controller';
 
 export default class FoundationsController extends Controller {
-  items = [
+  cards = [
     {
-      text: 'Tokens',
-      url: 'tokens/03--how-to-use/',
+      image: 'https://picsum.photos/seed/s{{1}}/232/124',
+      title: 'Tokens',
+      description:
+        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+      route: 'show',
+      model: 'foundations/tokens/03--how-to-use/',
     },
     {
-      text: 'Colors',
-      url: 'colors/03--how-to-use/',
+      image: 'https://picsum.photos/seed/s{{2}}/232/124',
+      title: 'Colors',
+      description:
+        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+      route: 'show',
+      model: 'foundations/colors/03--how-to-use/',
     },
     {
-      text: 'Typography',
-      url: 'typography/03--how-to-use/',
+      image: 'https://picsum.photos/seed/s{{3}}/232/124',
+      title: 'Typography',
+      description:
+        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+      route: 'show',
+      model: 'foundations/typography/03--how-to-use/',
     },
     {
-      text: 'Icons ⛔️',
-      url: 'icons',
+      image: 'https://picsum.photos/seed/s{{4}}/232/124',
+      title: 'Icons ⛔️',
+      description:
+        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+      route: 'show',
+      model: 'foundations/icons',
     },
     {
-      text: 'Elevation',
-      url: 'elevation/03--how-to-use/',
+      image: 'https://picsum.photos/seed/s{{5}}/232/124',
+      title: 'Elevation',
+      description:
+        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+      route: 'show',
+      model: 'foundations/elevation/03--how-to-use/',
     },
     {
-      text: 'Focus Ring',
-      url: 'focus-ring/03--how-to-use/',
+      image: 'https://picsum.photos/seed/s{{6}}/232/124',
+      title: 'Focus Ring',
+      description:
+        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+      route: 'show',
+      model: 'foundations/focus-ring/03--how-to-use/',
     },
   ];
 }

--- a/website/app/controllers/foundations.js
+++ b/website/app/controllers/foundations.js
@@ -1,54 +1,38 @@
 import Controller from '@ember/controller';
 
 export default class FoundationsController extends Controller {
-  cards = [
-    {
-      image: 'https://picsum.photos/seed/s{{1}}/232/124',
-      title: 'Tokens',
-      description:
-        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
-      route: 'show',
-      model: 'foundations/tokens/03--how-to-use/',
-    },
-    {
-      image: 'https://picsum.photos/seed/s{{2}}/232/124',
-      title: 'Colors',
-      description:
-        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
-      route: 'show',
-      model: 'foundations/colors/03--how-to-use/',
-    },
-    {
-      image: 'https://picsum.photos/seed/s{{3}}/232/124',
-      title: 'Typography',
-      description:
-        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
-      route: 'show',
-      model: 'foundations/typography/03--how-to-use/',
-    },
-    {
-      image: 'https://picsum.photos/seed/s{{4}}/232/124',
-      title: 'Icons ⛔️',
-      description:
-        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
-      route: 'show',
-      model: 'foundations/icons',
-    },
-    {
-      image: 'https://picsum.photos/seed/s{{5}}/232/124',
-      title: 'Elevation',
-      description:
-        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
-      route: 'show',
-      model: 'foundations/elevation/03--how-to-use/',
-    },
-    {
-      image: 'https://picsum.photos/seed/s{{6}}/232/124',
-      title: 'Focus Ring',
-      description:
-        'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
-      route: 'show',
-      model: 'foundations/focus-ring/03--how-to-use/',
-    },
-  ];
+  get subTOC() {
+    // NOTICE: the TOC comes direclty from the application "model" (see addons/field-guide/addon/routes/application.js)
+    // TODO! important: instead of spreading the content all over the model, group the TOC under a specific "key"!
+
+    // hacky way to have the subTOC items in the right order
+    const subIDs = ['foundations'];
+    const subTOC = [];
+
+    // TODO! convert this to a recursive function shared with the "Foundations page"
+    this.model
+      .filter((item) => subIDs.includes(item.id))
+      .forEach((item) => {
+        const { id, title, pages } = item;
+        const cards = [];
+        pages.forEach((page) => {
+          if (page.pages && page.pages.length > 0) {
+            cards.push({
+              image: `https://picsum.photos/seed/s${encodeURI(
+                page.title
+              )}/232/124`,
+              title: page.title,
+              description:
+                'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+              route: 'show',
+              model: page.pages[0].id,
+            });
+          } else {
+            console.log('????????????');
+          }
+        });
+        subTOC[id] = { title, cards };
+      });
+    return subTOC;
+  }
 }

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -12,6 +12,7 @@
 
 // "Doc" components
 @import "components/badge";
+@import "components/cards";
 @import "components/doc-landing-callout-blocks";
 @import "components/doc-table-of-contents";
 

--- a/website/app/styles/components/cards/card.scss
+++ b/website/app/styles/components/cards/card.scss
@@ -1,0 +1,49 @@
+// CARDS > CARD
+
+@use "../../typography/mixins" as *;
+
+
+.doc-cards-card {
+  list-style: none;
+  background-color: #fff;
+  border-radius: 10px; // this may depend on the card "size" (as in text size, border radius, etc)
+}
+
+.doc-cards-card__link {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  text-decoration: none;
+  border-radius: inherit; // needed to propagate down
+}
+
+.doc-cards-card__image {
+  display: block;
+  width: 100%;
+  height: auto;
+  background-color: #727374; // TODO is this really neaded?
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+
+.doc-cards-card__details {
+  padding: 24px 24px 32px 24px;
+  border: 1px solid #dbdbdc; // TODO convert to token
+  border-top: none;
+  border-bottom-right-radius: inherit;
+  border-bottom-left-radius: inherit;
+}
+
+.doc-cards-card__title {
+  @include doc-font-style-body();
+  margin: 0;
+  color: #000; // TODO convert to token
+  font-weight: 700;
+}
+
+.doc-cards-card_description {
+  @include doc-font-style-body-small();
+  margin: 0;
+  color: #343536; // TODO convert to token
+}
+

--- a/website/app/styles/components/cards/deck.scss
+++ b/website/app/styles/components/cards/deck.scss
@@ -1,0 +1,44 @@
+// CARDS > DECK
+
+@use "../../breakpoints" as breakpoint;
+
+
+.doc-cards-deck {
+  display: grid;
+  gap: 32px; // TODO maybe different gaps via a prop?
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.doc-cards-deck--layout-2cols {
+  grid-template-columns: 1fr;
+
+  @include breakpoint.medium () {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.doc-cards-deck--layout-3cols {
+  grid-template-columns: 1fr;
+
+  @include breakpoint.medium () {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include breakpoint.large () {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.doc-cards-deck--layout-4cols {
+  grid-template-columns: 1fr;
+
+  @include breakpoint.medium () {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include breakpoint.large () {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}

--- a/website/app/styles/components/cards/index.scss
+++ b/website/app/styles/components/cards/index.scss
@@ -1,0 +1,2 @@
+@import "./deck";
+@import "./card";

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -19,3 +19,13 @@
     padding: 0 var(--doc-page-stage-gutter-large);
   }
 }
+
+
+// in case we need it to "breakthrough" and occupy also the "sidecar" area
+.doc-page-content--breakthrough {
+  grid-area: content / content / sidecar / sidecar;
+  // notice: since the sidebar doesn't have a fixed size, we need to force the max-width on the content in this case
+  // TODO! - IMPORTANT: since now we have the `@breakthrough` argument to control the use case when we don't have the sidecar
+  // potentially we could add again the fixed size to the "sidecar" grid area and remove this max-width (to be tested)
+  max-width: calc(var(--doc-page-content-max-width) + 2 * var(--doc-page-stage-gutter-large) + var(--doc-page-sidebar-width));
+}

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -8,6 +8,15 @@
   min-width: 0; // needed to avoid that the element blows out if the content is too wide (see: https://css-tricks.com/preventing-a-grid-blowout/)
   padding: 0 var(--doc-page-stage-gutter-small);
 
+  // TODO! temp until we decide with Heather the correct vertical padding of the "content" area
+  > :first-child {
+    margin-top: 48px;
+  }
+
+  > :last-child {
+    margin-bottom: 48px;
+  }
+
   @include breakpoint.medium () {
     padding: 0 var(--doc-page-stage-gutter-medium);
   }

--- a/website/app/templates/components.hbs
+++ b/website/app/templates/components.hbs
@@ -1,11 +1,12 @@
-{{page-title 'HDS Components'}}
+{{page-title "Components"}}
 
 <Doc::Page::Stage>
-  <Doc::Page::Content>
-    <h1>HDS Components</h1>
-    <p>Here we may want to show a list of callout blocks linking to "components"
-      sub-pages like in Atlassian or Evergreen</p>
-    <pre>How do we generate dynamically the list, without having to edit it
-      manually?</pre>
+  <Doc::Page::Cover @title="Components" />
+  <Doc::Page::Content @breakthrough={{true}}>
+    <Doc::Cards::Deck @cols="4" @cards={{this.subTOC.components.cards}} />
+    <h2 class="doc-text-h2">{{capitalize this.subTOC.overrides.title}}</h2>
+    <Doc::Cards::Deck @cols="4" @cards={{this.subTOC.overrides.cards}} />
+    <h2 class="doc-text-h2">{{capitalize this.subTOC.utilities.title}}</h2>
+    <Doc::Cards::Deck @cols="4" @cards={{this.subTOC.utilities.cards}} />
   </Doc::Page::Content>
 </Doc::Page::Stage>

--- a/website/app/templates/foundations.hbs
+++ b/website/app/templates/foundations.hbs
@@ -3,6 +3,6 @@
 <Doc::Page::Stage>
   <Doc::Page::Cover @title="Foundations" />
   <Doc::Page::Content @breakthrough={{true}}>
-    <Doc::Cards::Deck @cols='4' @cards={{this.cards}} />
+    <Doc::Cards::Deck @cols="4" @cards={{this.subTOC.foundations.cards}} />
   </Doc::Page::Content>
 </Doc::Page::Stage>

--- a/website/app/templates/foundations.hbs
+++ b/website/app/templates/foundations.hbs
@@ -1,8 +1,8 @@
 {{page-title 'Foundations'}}
 
 <Doc::Page::Stage>
-  <Doc::Page::Content>
-    <h1>Foundations</h1>
-    <DocLandingCalloutBlocks @cols='4' @items={{this.items}} />
+  <Doc::Page::Cover @title="Foundations" />
+  <Doc::Page::Content @breakthrough={{true}}>
+    <Doc::Cards::Deck @cols='4' @cards={{this.cards}} />
   </Doc::Page::Content>
 </Doc::Page::Stage>


### PR DESCRIPTION
### :pushpin: Summary

This PR is to start to have the "Foundations" and "Components" landing pages look more like the current design (still not final)

Previews:
- [Foundations](https://hds-website-git-new-docs-website-components-la-e008ee-hashicorp.vercel.app/foundations/)
- [Components](https://hds-website-git-new-docs-website-components-la-e008ee-hashicorp.vercel.app/components/)
  - Notice: the links to the `form` components don't work because of a bug in `field-guide` (see [HDS-774](https://hashicorp.atlassian.net/browse/HDS-774))

### :hammer_and_wrench: Detailed description

See commits.

### :camera_flash: Screenshots

**Current designs** (⚠️ STILL IN PROGRESS ⚠️):

<img width="797" alt="screenshot_2084" src="https://user-images.githubusercontent.com/686239/202717712-570a2ef7-c393-4cac-9989-bc66cca38b2b.png">


### :link: External links

JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-1102

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
