### PR TITLE
remove `ember-test-selectors` peerDependency from ember-flight-icons

### DIFF
--- a/.changeset/witty-stingrays-visit.md
+++ b/.changeset/witty-stingrays-visit.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/ember-flight-icons": patch
+---
+
+remove `ember-test-selectors` peerDependency

--- a/flight-website/app/templates/engineering.hbs
+++ b/flight-website/app/templates/engineering.hbs
@@ -77,9 +77,10 @@
     <CodeBlock @code="yarn add @hashicorp/ember-flight-icons" @language="bash" />
     {{! prettier-ignore-end }}
   </p>
-  <p>Note:
-    <code class="ds-code">ember-test-selectors</code>
-    is a dependency added for the author's convenience.
+  <p>Note: Because this addon exposes a
+    <code class="ds-code">data-test-icon</code>
+    helper it is suggested consumers install
+    <code class="ds-code">ember-test-selectors</code>.
     <a
       href="https://github.com/simplabs/ember-test-selectors"
       class="ds-a"

--- a/packages/ember-flight-icons/package.json
+++ b/packages/ember-flight-icons/package.json
@@ -78,9 +78,6 @@
     "qunit-dom": "^2.0.0",
     "webpack": "^5.74.0"
   },
-  "peerDependencies": {
-    "ember-test-selectors": "^6.0.0"
-  },
   "engines": {
     "node": "12.* || 14.* || >= 16"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3145,8 +3145,6 @@ __metadata:
     qunit: ^2.19.1
     qunit-dom: ^2.0.0
     webpack: ^5.74.0
-  peerDependencies:
-    ember-test-selectors: ^6.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### :pushpin: Summary

removes `ember-test-selectors` peerDependency from ember-flight-icons

### :hammer_and_wrench: Detailed description

This PR addresses some confusion that was raised by a consuming team who didn't understand why we exposed this dependency as a `peerDependency`. In retrospect the documentation we provided for this was not entirely clear, and in practice this was not a situation where a peerDependency made a lot of sense.  _We_ were even confused about this [at the time we did this initially](https://github.com/hashicorp/flight/pull/306).

Per [the NPM Docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#peerdependencies) these are often used when you "want to express the compatibility of your package with a host tool or library". In practice we don't actually care what version of this addon a consumer has installed and in fact don't need it to be installed at all for the addon to work correctly.

Given this, this PR removes the peerDep and adjusts the documentation to recommend consumers install the addon if they so desire.

A future effort could be made to remove the `data-test-icon` selector as we do not expose them in the rest of the design system, but since that is a larger, breaking, effort this seems like a pragmatic step to take.

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review by files changed

Reviewer's checklist:

- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
