### PR TITLE
New docs website / Add a 🌈 button to the top navigation header to toggle "debugging" colors visibility

### DIFF
--- a/website/app/components/doc/page/header.hbs
+++ b/website/app/components/doc/page/header.hbs
@@ -14,4 +14,5 @@
       <li><a href="/patterns">Patterns</a></li>
     </ul>
   </nav>
+  <button type="button" class="doc-page-header__🌈" {{on "click" this.toggleLayoutColors}}>🌈</button>
 </header>

--- a/website/app/components/doc/page/header.js
+++ b/website/app/components/doc/page/header.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class DocPageHeaderComponent extends Component {
+  @tracked showLayoutColors = false;
+
+  @action
+  toggleLayoutColors() {
+    if (this.showLayoutColors) {
+      this.showLayoutColors = false;
+      document.body.classList.remove('🌈');
+    } else {
+      this.showLayoutColors = true;
+      document.body.classList.add('🌈');
+    }
+  }
+}

--- a/website/app/components/doc/page/sidecar.hbs
+++ b/website/app/components/doc/page/sidecar.hbs
@@ -1,3 +1,3 @@
 <div class="doc-page-sidecar" ...attributes>
-  this is the doc-page-sidecar
+  <p>[this is the page "sidecar"]</p>
 </div>

--- a/website/app/styles/pages/application/_debug.scss
+++ b/website/app/styles/pages/application/_debug.scss
@@ -1,28 +1,50 @@
-.doc-page-header {
-  background-color: red;
+// stylelint-disable selector-class-pattern
+
+.🌈 {
+  background-color: pink;
+
+  .doc-page-hero {
+    background-color: cyan;
+  }
+
+  .doc-page-header {
+    background-color: red;
+  }
+
+  .doc-page-sidebar {
+    background-color: #0c56e9;
+  }
+
+  .doc-page-stage {
+    background-color: #edf7fc;
+  }
+
+  .doc-page-cover {
+    background-color: #feff38;
+  }
+
+  .doc-page-content {
+    background-color: #a737ff;
+    background-clip: content-box;
+  }
+
+  .doc-page-sidecar {
+    background-color: #008a22;
+  }
+
+  .doc-page-footer {
+    background-color: #111f5d;
+  }
 }
 
-.doc-page-sidebar {
-  background-color: #0c56e9;
+.doc-page-header__🌈 {
+  justify-self: flex-end;
+  margin: auto 0 auto auto;
+  padding: 1px 3px;
+  font-size: 20px;
+  background-color: #fff;
+  border-color: transparent;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
-.doc-page-stage {
-  background-color: #edf7fc;
-}
-
-.doc-page-cover {
-  background-color: #feff38;
-}
-
-.doc-page-content {
-  background-color: #a737ff;
-  background-clip: content-box;
-}
-
-.doc-page-sidecar {
-  background-color: #008a22;
-}
-
-.doc-page-footer {
-  background-color: #111f5d;
-}

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -8,6 +8,15 @@
   min-width: 0; // needed to avoid that the element blows out if the content is too wide (see: https://css-tricks.com/preventing-a-grid-blowout/)
   padding: 0 var(--doc-page-stage-gutter-small);
 
+  // TODO! temp until we decide with Heather the correct vertical padding of the "content" area
+  > :first-child {
+    margin-top: 48px;
+  }
+
+  > :last-child {
+    margin-bottom: 48px;
+  }
+
   @include breakpoint.medium () {
     padding: 0 var(--doc-page-stage-gutter-medium);
   }

--- a/website/app/styles/pages/application/sidecar.scss
+++ b/website/app/styles/pages/application/sidecar.scss
@@ -11,6 +11,10 @@
     grid-area: sidecar;
     width: var(--doc-page-sidecar-width);
     margin-right: calc(var(--doc-page-stage-gutter-large) / 2);
+
+    > :first-child {
+      margin-top: 48px;
+    }
   }
 }
 

--- a/website/app/styles/pages/application/stage.scss
+++ b/website/app/styles/pages/application/stage.scss
@@ -13,9 +13,9 @@
   grid-template-columns: 1fr;
   width: 100%; // needed (otherwise it collapses, because is in a grid)
 
-  @include breakpoint.with-sidebar () {
-    background-color: cyan;
-  }
+  // @include breakpoint.with-sidebar () {
+  //   background-color: cyan;
+  // }
 
   @include breakpoint.large () {
     --max-content-width: calc(var(--doc-page-content-max-width) + 2 * var(--doc-page-stage-gutter-large));


### PR DESCRIPTION
### :pushpin: Summary

Just added a "🌈" button to the top navigation header to toggle colors visibility for the layout "debugging".

### :camera_flash: Screenshots

https://user-images.githubusercontent.com/686239/202770814-296b10dd-1b49-4e78-a28b-6819f1355ca6.mov

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
