### PR TITLE
New docs website / Add possibility to control rendering of "cover" and "sidecar" elements via "frontmatter"

### DIFF
--- a/addons/field-guide/addon/routes/show.js
+++ b/addons/field-guide/addon/routes/show.js
@@ -36,6 +36,7 @@ export default class ShowRoute extends Route {
           'group',
           'component',
           'section',
+          'layout',
           'title',
           'description',
           'caption',
@@ -48,13 +49,17 @@ export default class ShowRoute extends Route {
           }
         });
 
+        // check if there are special needs for the page layout
+        const hasCover = frontmatter?.layout.cover ?? true;
+        // TODO! probably we should also check if we have TOC data for the sidecar
+        const hasSidecar = frontmatter?.layout.sidecar ?? true;
+
         return {
           id: res.data.id,
           ...res.data.attributes,
           frontmatter,
-          // TODO! TEMPORARY, FOR TESTING!
-          hasCover: true,
-          hasSidecar: true,
+          hasCover,
+          hasSidecar,
         };
       });
   }

--- a/addons/field-guide/addon/templates/show.hbs
+++ b/addons/field-guide/addon/templates/show.hbs
@@ -3,7 +3,7 @@
   {{#if this.model.hasCover}}
     <Doc::Page::Cover @title={{this.title}} @description={{this.description}} />
   {{/if}}
-  <Doc::Page::Content>
+  <Doc::Page::Content @breakthrough={{not this.model.hasSidecar}}>
     {{!-- Leave it here for debugging purpose (will be removed later!) --}}
     <!--
     {{#if this.model.id}}

--- a/addons/field-guide/index.js
+++ b/addons/field-guide/index.js
@@ -91,10 +91,11 @@ module.exports = {
         'group',
         'component',
         'section',
+        'layout',
         'title',
         'description',
         'caption',
-        'status'
+        'status',
       ],
     });
 

--- a/website-html-to-markdown/moveover/testing/05-test-frontmatter/no-cover-no-sidecar.md
+++ b/website-html-to-markdown/moveover/testing/05-test-frontmatter/no-cover-no-sidecar.md
@@ -1,0 +1,18 @@
+---
+order: 1
+title: Page with no sidecar and no cover
+category: testing
+layout:
+  cover: false
+  sidecar: false
+---
+
+# Page with no sidecar and no cover
+
+Using "frontmatter" properties it's possible to remove the generation of the "cover" and "sidecar" elements in a "doc" page:
+
+```
+layout:
+  cover: false
+  sidecar: false
+```

--- a/website-html-to-markdown/moveover/testing/05-test-frontmatter/no-sidecar.md
+++ b/website-html-to-markdown/moveover/testing/05-test-frontmatter/no-sidecar.md
@@ -1,0 +1,14 @@
+---
+order: 1
+title: Page with no sidecar
+category: testing
+layout:
+  sidecar: false
+---
+
+Using "frontmatter" properties it's possible to remove the generation of the "sidecar" element in a "doc" page:
+
+```
+layout:
+  sidecar: false
+```

--- a/website/docs/testing/05-test-frontmatter/no-cover-no-sidecar.md
+++ b/website/docs/testing/05-test-frontmatter/no-cover-no-sidecar.md
@@ -1,0 +1,18 @@
+---
+order: 1
+title: Page with no sidecar and no cover
+category: testing
+layout:
+  cover: false
+  sidecar: false
+---
+
+# Page with no sidecar and no cover
+
+Using "frontmatter" properties it's possible to remove the generation of the "cover" and "sidecar" elements in a "doc" page:
+
+```
+layout:
+  cover: false
+  sidecar: false
+```

--- a/website/docs/testing/05-test-frontmatter/no-sidecar.md
+++ b/website/docs/testing/05-test-frontmatter/no-sidecar.md
@@ -1,0 +1,14 @@
+---
+order: 1
+title: Page with no sidecar
+category: testing
+layout:
+  sidecar: false
+---
+
+Using "frontmatter" properties it's possible to remove the generation of the "sidecar" element in a "doc" page:
+
+```
+layout:
+  sidecar: false
+```


### PR DESCRIPTION
### :pushpin: Summary

In this PR I have used the recently added support for "frontmatter" attributes in markdown, to control the hiding of the "cover" and "sidecar" elements.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added possibility to remove “cover” and “sidecar” rendering for “docs” pages via “frontmatter”
- added a couple of “testing” examples

Preview:
- [no sidecar](https://hds-website-git-page-layout-frontmatter-hashicorp.vercel.app/testing/05-test-frontmatter/no-sidecar/)
- [no cover + no sidecar](https://hds-website-git-page-layout-frontmatter-hashicorp.vercel.app/testing/05-test-frontmatter/no-cover-no-sidecar/)

@heatherlarsen @jorytindall let's use this sparingly plz :)

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
