### PR TITLE
New docs website / Basic styling for tables in markdown

### DIFF
--- a/website/app/styles/markdown/tables.scss
+++ b/website/app/styles/markdown/tables.scss
@@ -1,33 +1,36 @@
 // TABLES
 
+@use "../typography/mixins" as *;
+
+$doc-markdown-table-border-color: rgba(101, 106, 118, 20%);
+
 .doc-markdown-table {
-  display: block;
   width: 100%;
-  width: max-content;
   max-width: 100%;
   overflow: auto;
-
-  // TODO why is needed?
-  .doc-markdown-img {
-    background-color: transparent;
-  }
-}
-
-.doc-markdown-tr {
-  background-color: pink; // TODO
-  border-top: 1px solid coral; // TODO
-
-  &:nth-child(2n) {
-    background-color: maroon; // TODO
-  }
+  table-layout: fixed;
+  border: 1px solid $doc-markdown-table-border-color;
+  border-radius: 4px;
+  border-spacing: 0;
 }
 
 .doc-markdown-th {
-  font-weight: bold; // TODO
+  @include doc-font-style-body-small();
+  padding: 12px 16px;
+  color: #0c0c0e;  // TODO convert to design token
+  font-weight: bold;
+  text-align: left;
+  text-transform: uppercase;
+  background-color: #f1f2f3; // TODO convert to design token
 }
 
-.doc-markdown-th,
 .doc-markdown-td {
-  padding: 6px 12px;
-  border: 1px solid olivedrab; // TODO
+  @include doc-font-style-body-small();
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid $doc-markdown-table-border-color;
+
+  .doc-markdown-tr:last-child & {
+    border-bottom: none;
+  }
 }


### PR DESCRIPTION
### :pushpin: Summary

A simple basic styling for tables (instead of the pink/maroon temporary styles 🤢) so @alex-ju can work on #726 more easily.

Preview: https://hds-website-git-new-docs-website-basic-table-styling-hashicorp.vercel.app/testing/00-testing-markdown-formatting/more-complex-tables/

_Notice: the final styling will be applied once the designs are confirmed/approved._

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
