### PR TITLE
Documentation tweaks for component API refactor

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -133,12 +133,15 @@
         name, which is determined by the
         <code class="dummy-code">color</code>
         argument.</p>
-      <p>Acceptable values: any
-        <a href="https://flight-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">
-          Flight</a>
-        icon name or pass
-        <code class="dummy-code">false</code>
-        for no icon.</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li>any
+          <a href="https://flight-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">
+            Flight</a>
+          icon name or pass
+          <code class="dummy-code">false</code>
+          for no icon.</li>
+      </ol>
     </dd>
     <dt>onDismiss <code>function</code></dt>
     <dd>

--- a/packages/components/tests/dummy/app/templates/components/badge.hbs
+++ b/packages/components/tests/dummy/app/templates/components/badge.hbs
@@ -52,12 +52,11 @@
     </dd>
     <dt>text <code>string</code></dt>
     <dd>
-      <p>The text of the badge or value of the
-        <em>screen-reader only</em>
+      <p>The text of the badge or value of the screen-reader only
         element if
-        <em>isIconOnly</em>
+        <code>isIconOnly</code>
         is set to
-        <em>true</em>.</p>
+        <code>true</code>.</p>
       <p><em>If no text value is defined an error will be thrown.</em></p>
     </dd>
     <dt>icon <code>string</code></dt>

--- a/packages/components/tests/dummy/app/templates/components/badge.hbs
+++ b/packages/components/tests/dummy/app/templates/components/badge.hbs
@@ -52,8 +52,7 @@
     </dd>
     <dt>text <code>string</code></dt>
     <dd>
-      <p>The text of the badge or value of the screen-reader only
-        element if
+      <p>The text of the badge or value of the screen-reader only element if
         <code>isIconOnly</code>
         is set to
         <code>true</code>.</p>

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -33,7 +33,12 @@
       <strong class="required">required</strong>
     </dt>
     <dd>
-      <p>The text of the button or value of <code>aria-label</code> if <code>isIconOnly</code> is set to <code>true</code>.</p>
+      <p>The text of the button or value of
+        <code>aria-label</code>
+        if
+        <code>isIconOnly</code>
+        is set to
+        <code>true</code>.</p>
       <p><em>If no text value is defined an error will be thrown.</em></p>
     </dd>
     <dt>icon <code>string</code></dt>
@@ -56,7 +61,8 @@
     </dd>
     <dt>iconPosition <code>enum</code></dt>
     <dd>
-      <p>Positions the icon before or after the text. Acceptable values:</p>
+      <p>Positions the icon before or after the text.</p>
+      <p>Acceptable values:</p>
       <ol>
         <li class="default">leading</li>
         <li>trailing</li>

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -33,7 +33,7 @@
       <strong class="required">required</strong>
     </dt>
     <dd>
-      <p>The text of the button or value of <em>aria-label</em> if <em>isIconOnly</em> is set to <em>true</em>.</p>
+      <p>The text of the button or value of <code>aria-label</code> if <code>isIconOnly</code> is set to <code>true</code>.</p>
       <p><em>If no text value is defined an error will be thrown.</em></p>
     </dd>
     <dt>icon <code>string</code></dt>

--- a/packages/components/tests/dummy/app/templates/components/card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/card.hbs
@@ -8,7 +8,8 @@
   <dl class="dummy-component-props" aria-labelledby="component-api-card">
     <dt>level <code>enum</code></dt>
     <dd>
-      <p>This controls the level of elevation ("shadow" visual effect). Acceptable values:</p>
+      <p>This controls the level of elevation ("shadow" visual effect).</p>
+      <p>Acceptable values:</p>
       <ol>
         {{#each @model.CONTAINER_LEVELS as |level|}}
           <li class={{if (eq level @model.CONTAINER_DEFAULT_LEVEL) "default"}}>{{level}}</li>
@@ -22,7 +23,8 @@
     </dd>
     <dt>levelHover <code>enum</code></dt>
     <dd>
-      <p>This controls the level of elevation on <code class="dummy-code">:hover</code> state. Acceptable values:</p>
+      <p>This controls the level of elevation on <code class="dummy-code">:hover</code> state.</p>
+      <p>Acceptable values:</p>
       <ol>
         {{#each @model.CONTAINER_HOVER_LEVELS as |level|}}
           <li>{{level}}</li>
@@ -31,7 +33,8 @@
     </dd>
     <dt>levelActive <code>enum</code></dt>
     <dd>
-      <p>This controls the level of elevation on <code class="dummy-code">:active</code> state. Acceptable values:</p>
+      <p>This controls the level of elevation on <code class="dummy-code">:active</code> state.</p>
+      <p>Acceptable values:</p>
       <ol>
         {{#each @model.CONTAINER_ACTIVE_LEVELS as |level|}}
           <li>{{level}}</li>
@@ -40,7 +43,8 @@
     </dd>
     <dt>background <code>enum</code></dt>
     <dd>
-      <p>This controls the background color. Acceptable values:</p>
+      <p>This controls the background color.</p>
+      <p>Acceptable values:</p>
       <ol>
         <li class="default">neutral-primary</li>
         <li>neutral-secondary</li>
@@ -58,7 +62,8 @@
     <dd>
       <p>This controls if the main wrapper (who has a border-radius applied) has overflow = visible or hidden. We expect
         that this is needed in case part of the content (eg. a tooltip) needs to go beyond the bounding box of the card
-        itself. Acceptable values:</p>
+        itself.</p>
+      <p>Acceptable values:</p>
       <ol>
         <li class="default">hidden</li>
         <li>visible</li>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -88,7 +88,10 @@
     </dd>
     <dt>width <code>string</code></dt>
     <dd>
-      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li>any valid CSS width (px, rem, etc)</li>
+      </ol>
       <p><em>Notice: by default the dropdown list has a
           <code class="dummy-code">min-width</code>
           of

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -287,48 +287,43 @@
       <p>The
         <code class="dummy-code">Control</code>
         yielded component exposes two hashed arguments:</p>
-      <dl class="dummy-component-props">
-        <dt>[C].id <code>string</code></dt>
-        <dd>
-          <p>returns the unique "id" attribute for the control element (generated automatically, unless provided using
-            the
-            <code class="dummy-code">@id</code>
-            argument described above).
-          </p>
-        </dd>
-        <dt>[C].ariaDescribedBy <code>string</code></dt>
-        <dd>
-          <p>returns the "aria-describedby" attribute for the control element (generated automatically, based on the
-            presence of the
-            <code class="dummy-code">HelperText</code>
-            an/or the
-            <code class="dummy-code">Error</code>
-            elements in the field, plus the optional
-            <code class="dummy-code">@extraAriaDescribedBy</code>
-            argument described above).</p>
-        </dd>
-      </dl>
+    </dd>
+    <dt>[C].id <code>string</code></dt>
+    <dd>
+      <p>returns the unique "id" attribute for the control element (generated automatically, unless provided using the
+        <code class="dummy-code">@id</code>
+        argument described above).
+      </p>
+    </dd>
+    <dt>[C].ariaDescribedBy <code>string</code></dt>
+    <dd>
+      <p>returns the "aria-describedby" attribute for the control element (generated automatically, based on the
+        presence of the
+        <code class="dummy-code">HelperText</code>
+        an/or the
+        <code class="dummy-code">Error</code>
+        elements in the field, plus the optional
+        <code class="dummy-code">@extraAriaDescribedBy</code>
+        argument described above).</p>
     </dd>
     <dt>&lt;[F].Error&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the "error" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the <code class="dummy-code">Form::Error</code> component.</p>
       <p><em>Notice: the
           <code class="dummy-code">id</code>
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
 
@@ -337,8 +332,7 @@
   <dl class="dummy-component-props" aria-labelledby="component-api-form-field">
     <dt>layout <code>enum</code></dt>
     <dd>
-      <p>
-        Sets the layout of the field controls in the component.</p>
+      <p>Sets the layout of the field controls in the component.</p>
       <p>Acceptable values:</p>
       <ol>
         <li class="default">vertical</li>
@@ -416,37 +410,14 @@
           <code class="dummy-code">&lt;Control&gt;</code>
           container, or you can have one control per container.</em></p>
     </dd>
-    <dt>&lt;[F].Error&gt; <code>yielded component</code></dt>
-    <dd>
-      <p>It is a container that yields its content inside the "error" block (at group level).</p>
-      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
-        style).</p>
-
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.</p>
-          <p>For details about its API check the <code class="dummy-code">Form::Error</code> component.</p>
-          <p><em>Note:</em>
-            the
-            <code class="dummy-code">id</code>
-            attribute of the
-            <code class="dummy-code">Error</code>
-            element is automatically generated.</p>
-        </dd>
-      </dl>
-    </dd>
-
-    <dt>[F].id <code>function</code></dt>
+    <dt>[C].id <code>function</code></dt>
     <dd>
       <p>returns the unique "id" attribute for the control element (generated automatically, unless provided using the
         <code class="dummy-code">@id</code>
         argument described above).
       </p>
     </dd>
-    <dt>[F].ariaDescribedBy <code>function</code></dt>
+    <dt>[C].ariaDescribedBy <code>function</code></dt>
     <dd>
       <p>returns the "aria-describedby" attribute for the control element (generated automatically, based on the
         presence of the
@@ -456,6 +427,25 @@
         elements in the field, plus the optional
         <code class="dummy-code">@extraAriaDescribedBy</code>
         argument described above).</p>
+    </dd>
+    <dt>&lt;[F].Error&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>It is a container that yields its content inside the "error" block (at group level).</p>
+      <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
+        style).</p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.</p>
+      <p>For details about its API check the <code class="dummy-code">Form::Error</code> component.</p>
+      <p><em>Note:</em>
+        the
+        <code class="dummy-code">id</code>
+        attribute of the
+        <code class="dummy-code">Error</code>
+        element is automatically generated.</p>
     </dd>
   </dl>
 

--- a/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
@@ -140,15 +140,6 @@
       <p>It is a container that yields its content inside the "error" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the
         <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
         component.</p>
@@ -157,6 +148,13 @@
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
   <h4 class="dummy-h4">Form::Checkbox::Group</h4>
@@ -246,15 +244,6 @@
       <p>It is a container that yields its content inside the "error" block (at group level).</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the
         <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
         component.</p>
@@ -263,6 +252,13 @@
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -150,12 +150,7 @@
     <dt>&lt;[R].Label&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content emphasized inside the card.</p>
-      <dl class="dummy-component-props">
-        <dt>...attributes</dt>
-        <dd>
-          <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
-        </dd>
-      </dl>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
     </dd>
     <dt>&lt;[R].Badge&gt;</dt>
     <dd>
@@ -168,23 +163,13 @@
     <dd>
       <p>It is a container that yields its content inside the card.</p>
       <p>The content can be a simple string or a more complex/structured one, in which case it inherits the text style.</p>
-      <dl class="dummy-component-props">
-        <dt>...attributes</dt>
-        <dd>
-          <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
-        </dd>
-      </dl>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
     </dd>
     <dt>&lt;[R].Generic&gt; <code>yielded component</code></dt>
     <dd>
       <p>It is a container that yields its content inside the card.</p>
       <p>The content does not inherit any styles and can be customized as desired.</p>
-      <dl class="dummy-component-props">
-        <dt>...attributes</dt>
-        <dd>
-          <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
-        </dd>
-      </dl>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
     </dd>
   </dl>
 
@@ -301,15 +286,6 @@
       <p>It is a container that yields its content inside the "error" block (at group level).</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the
         <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
         component.</p>
@@ -318,6 +294,13 @@
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -82,7 +82,10 @@
     </dd>
     <dt>maxWidth <code>string</code></dt>
     <dd>
-      <p>Acceptable values: any valid CSS width (%, vw, etc)</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li>any valid CSS width (%, vw, etc)</li>
+      </ol>
       <p>When used with a
         <code class="dummy-code">fluid</code>
         layout, this parameter will determine the number of cards shown per row (for example

--- a/packages/components/tests/dummy/app/templates/components/form/radio.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio.hbs
@@ -145,15 +145,6 @@
       <p>It is a container that yields its content inside the "error" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the
         <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
         component.</p>
@@ -162,6 +153,13 @@
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
   <h4 class="dummy-h4">Form::Radio::Group</h4>
@@ -251,15 +249,6 @@
       <p>It is a container that yields its content inside the "error" block (at group level).</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the
         <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
         component.</p>
@@ -268,6 +257,13 @@
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -236,15 +236,6 @@
       <p>It is a container that yields its content inside the "error" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the
         <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
         component.</p>
@@ -253,6 +244,13 @@
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
 

--- a/packages/components/tests/dummy/app/templates/components/form/select.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/select.hbs
@@ -52,7 +52,10 @@
     </dd>
     <dt>width <code>string</code></dt>
     <dd>
-      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li>any valid CSS width (px, rem, etc)</li>
+      </ol>
       <p><em>Notice: by default the
           <code class="dummy-code">&lt;select&gt;</code>
           has an intrinsic width based on its content. If a
@@ -111,7 +114,10 @@
     </dd>
     <dt>width <code>string</code></dt>
     <dd>
-      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li>any valid CSS width (px, rem, etc)</li>
+      </ol>
       <p><em>Notice: by default the
           <code class="dummy-code">&lt;select&gt;</code>
           has an intrinsic width based on its content. If a

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -60,7 +60,10 @@
     </dd>
     <dt>width <code>string</code></dt>
     <dd>
-      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li>any valid CSS width (px, rem, etc)</li>
+      </ol>
       <p><em>Notice: by default the
           <code class="dummy-code">&lt;input&gt;</code>
           has a
@@ -149,7 +152,10 @@
     </dd>
     <dt>width <code>string</code></dt>
     <dd>
-      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li>any valid CSS width (px, rem, etc)</li>
+      </ol>
       <p><em>Notice: by default the
           <code class="dummy-code">&lt;input&gt;</code>
           has a

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -249,15 +249,6 @@
       <p>It is a container that yields its content inside the "error" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the
         <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
         component.</p>
@@ -266,6 +257,13 @@
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
 

--- a/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
@@ -51,7 +51,10 @@
     </dd>
     <dt>width <code>string</code></dt>
     <dd>
-      <p>Acceptable values: any valid CSS width (px, rem, etc)</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li>any valid CSS width (px, rem, etc)</li>
+      </ol>
       <p><em>Notice: by default the
           <code class="dummy-code">&lt;textarea&gt;</code>
           has a
@@ -64,7 +67,10 @@
     </dd>
     <dt>height <code>string</code></dt>
     <dd>
-      <p>Acceptable values: any valid CSS height (px, rem, etc)</p>
+      <p>Acceptable values:</p>
+      <ol>
+        <li>any valid CSS height (px, rem, etc)</li>
+      </ol>
       <p><em>Notice: by default the
           <code class="dummy-code">&lt;textarea&gt;</code>
           has a

--- a/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
@@ -209,15 +209,6 @@
       <p>It is a container that yields its content inside the "error" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the
         <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
         component.</p>
@@ -226,6 +217,13 @@
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
 

--- a/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
@@ -134,15 +134,6 @@
       <p>It is a container that yields its content inside the "error" block.</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the
         <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
         component.</p>
@@ -151,6 +142,13 @@
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
   <h4 class="dummy-h4">Form::Toggle::Group</h4>
@@ -233,15 +231,6 @@
       <p>It is a container that yields its content inside the "error" block (at group level).</p>
       <p>The content can be a simple string, or a more complex/structured one (in which case it inherits the text
         style).</p>
-      <dl class="dummy-component-props">
-        <dt>[E].Message <code>yielded component</code></dt>
-        <dd>
-          <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
-            individual items using
-            <code class="dummy-code">Error.Message</code>.
-          </p>
-        </dd>
-      </dl>
       <p>For details about its API check the
         <LinkTo @route="components.form.base-elements"><code class="dummy-code">Form::Error</code></LinkTo>
         component.</p>
@@ -250,6 +239,13 @@
           attribute of the
           <code class="dummy-code">Error</code>
           element is automatically generated.</em></p>
+    </dd>
+    <dt>&lt;[E].Message&gt; <code>yielded component</code></dt>
+    <dd>
+      <p>If the error is made of multiple messages, you can iterate over a collection of error messages yielding
+        individual items using
+        <code class="dummy-code">Error.Message</code>.
+      </p>
     </dd>
   </dl>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/icon-tile.hbs
+++ b/packages/components/tests/dummy/app/templates/components/icon-tile.hbs
@@ -17,7 +17,8 @@
     </dd>
     <dt>logo <code>enum</code></dt>
     <dd>
-      <p>Use this parameter to show a product logo. Acceptable values:</p>
+      <p>Use this parameter to show a product logo.</p>
+      <p>Acceptable values:</p>
       <ol>
         <li>hcp</li>
         <li>boundary</li>

--- a/packages/components/tests/dummy/app/templates/components/link/inline.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/inline.hbs
@@ -86,7 +86,8 @@
     </dd>
     <dt>iconPosition <code>enum</code></dt>
     <dd>
-      <p>Positions the icon before or after the text. Acceptable values:</p>
+      <p>Positions the icon before or after the text.</p>
+      <p>Acceptable values:</p>
       <ol>
         <li>leading</li>
         <li class="default">trailing</li>

--- a/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/standalone.hbs
@@ -64,19 +64,11 @@
   <dl class="dummy-component-props" aria-labelledby="component-api-link-standalone">
     <dt>size <code>enum</code></dt>
     <dd>
-      <p>
-        Acceptable values:
-      </p>
+      <p>Acceptable values:</p>
       <ol>
-        <li>
-          small
-        </li>
-        <li class="default">
-          medium
-        </li>
-        <li>
-          large
-        </li>
+        <li>small</li>
+        <li class="default">medium</li>
+        <li>large</li>
       </ol>
     </dd>
     <dt>color <code>enum</code></dt>
@@ -112,7 +104,8 @@
     </dd>
     <dt>iconPosition <code>enum</code></dt>
     <dd>
-      <p>Positions the icon before or after the text. Acceptable values:</p>
+      <p>Positions the icon before or after the text.</p>
+      <p>Acceptable values:</p>
       <ol>
         <li class="default">leading</li>
         <li>trailing</li>

--- a/packages/components/tests/dummy/app/templates/components/modal.hbs
+++ b/packages/components/tests/dummy/app/templates/components/modal.hbs
@@ -82,56 +82,46 @@
     <code class="dummy-code">Body</code>,
     <code class="dummy-code">Footer</code>
     keys.</p>
+
+  <h5 class="dummy-h5">Modal::Header</h5>
+  <p class="dummy-paragraph">It is a container that yields its content as the title of the modal dialog.</p>
   <dl class="dummy-component-props" aria-labelledby="contextual-components-modal">
-    <dt>&lt;[M].Header&gt; <code>yielded component</code></dt>
+    <dt>icon <code>string</code></dt>
     <dd>
-      <p>It is a container that yields its content as the title of the modal dialog.</p>
-      <dl class="dummy-component-props">
-        <dt>icon <code>string</code></dt>
-        <dd>
-          <p>Acceptable values: any
-            <a href="https://flight-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">
-              Flight</a>
-            icon name.</p>
-        </dd>
-        <dt>tagline <code>string</code></dt>
-        <dd>
-          <p>A string that helps the user maintain context when a modal dialog is open. (Note: this is NOT the title
-            text, but a small piece of text above the title text.)</p>
-        </dd>
-        <dt>...attributes</dt>
-        <dd>
-          <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
-        </dd>
-      </dl>
+      <p>Acceptable values: any
+        <a href="https://flight-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">
+          Flight</a>
+        icon name.</p>
     </dd>
-    <dt>&lt;[M].Body&gt; <code>yielded component</code></dt>
+    <dt>tagline <code>string</code></dt>
     <dd>
-      <p>It is an unstyled, generic container that yields as the main content of the modal dialog.</p>
-      <p>This container gets a scrollbar when the yielded content exceeds the available space.</p>
-      <dl class="dummy-component-props">
-        <dt>...attributes</dt>
-        <dd>
-          <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
-        </dd>
-      </dl>
+      <p>A string that helps the user maintain context when a modal dialog is open. (Note: this is NOT the title text,
+        but a small piece of text above the title text.)</p>
     </dd>
-    <dt>&lt;[M].Footer&gt; <code>yielded component</code></dt>
+    <dt>...attributes</dt>
     <dd>
-      <p>It is a container that yields its content as the footer of the modal dialog.</p>
-      <p>We recommend using it exclusively for actions using the
-        <LinkTo @route="components.button-set"><code class="dummy-code">ButtonSet</code></LinkTo>
-        component. If a tertiary action is presented, it will always be aligned at the end of the row.</p>
-      <dl class="dummy-component-props">
-        <dt>close <code>function</code></dt>
-        <dd>
-          A function that can be called to close the modal programmatically. This call will have the same effect as the
-          dismiss button in the modal header.</dd>
-        <dt>...attributes</dt>
-        <dd>
-          <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
-        </dd>
-      </dl>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+    </dd>
+  </dl>
+
+  <h5 class="dummy-h5">Modal::Body</h5>
+  <p class="dummy-paragraph">It is an unstyled, generic container that yields as the main content of the modal dialog.</p>
+  <p class="dummy-paragraph">This container gets a scrollbar when the yielded content exceeds the available space.</p>
+  <p class="dummy-paragraph"><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
+
+  <h5 class="dummy-h5">Modal::Footer</h5>
+  <p class="dummy-paragraph">It is a container that yields its content as the footer of the modal dialog.</p>
+  <p class="dummy-paragraph">We recommend using it exclusively for actions using the
+    <LinkTo @route="components.button-set"><code class="dummy-code">ButtonSet</code></LinkTo>
+    component. If a tertiary action is presented, it will always be aligned at the end of the row.</p>
+  <dl class="dummy-component-props">
+    <dt>close <code>function</code></dt>
+    <dd>
+      A function that can be called to close the modal programmatically. This call will have the same effect as the
+      dismiss button in the modal header.</dd>
+    <dt>...attributes</dt>
+    <dd>
+      <p><code class="dummy-code">...attributes</code> spreading is supported on this component.</p>
     </dd>
   </dl>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/tag.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tag.hbs
@@ -9,9 +9,9 @@
     <dt>text <code>string</code></dt>
     <dd>
       <p>The text of the tag; or link text when the
-        <em>@route</em>
+        <code>@route</code>
         or
-        <em>@href</em>
+        <code>@href</code>
         are set.</p>
       <p><em>If no text value is defined an error will be thrown.</em></p>
     </dd>
@@ -56,9 +56,9 @@
     <dt>color <code>enum</code></dt>
     <dd>
       <p>Sets the color of a link and it is allowed only when
-        <em>@route</em>
+        <code>@route</code>
         or
-        <em>@href</em>
+        <code>@href</code>
         are set.</p>
       <p>Acceptable values:</p>
       <ol>


### PR DESCRIPTION
### :pushpin: Summary


### :hammer_and_wrench: Detailed description

 - Use `<code>` elements for technical notations (instead of `<em>`)
 - Align acceptable values definitions (even when there's only one item, we place it in a list so we can extract it easier)
 - Flatten `<dl>` definitions to avoid nested properties (for form controls, where we already have subcomponents – `::Base`, `::Field`, `::Group` I sticked to the current pattern; for the modal I split it into 3 subtitles as we do with other components)

Supports the work in #726

### :link: External links

[Jira issue](https://hashicorp.atlassian.net/browse/HDS-1056)

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
