### PR TITLE
New docs website / Postprocess docs - Replace `DummyPlaceholder`

### DIFF
--- a/website-html-to-markdown/package.json
+++ b/website-html-to-markdown/package.json
@@ -11,7 +11,7 @@
   "license": "MPL-2.0",
   "author": "HashiCorp Design Systems <design-systems@hashicorp.com>",
   "scripts": {
-    "generate": "yarn prepare-temp-folder && yarn copy-source-files && yarn identify-sections && yarn split-files && yarn replace-linkto-with-a && yarn refactor-codeblocks && yarn refactor-properties && yarn enrich-wcag-lists && yarn preprocess-files && yarn convert-to-markdown && yarn prettify-files && yarn prepare-dest-folder && yarn copy-markdown-files && yarn copy-assets-folder && yarn copy-moveover-files && yarn cleanup-temp-folder",
+    "generate": "yarn prepare-temp-folder && yarn copy-source-files && yarn identify-sections && yarn split-files && yarn replace-linkto-with-a && yarn refactor-codeblocks && yarn refactor-properties && yarn enrich-wcag-lists && yarn preprocess-files && yarn convert-to-markdown && yarn prettify-files && yarn prepare-dest-folder && yarn copy-markdown-files && yarn copy-assets-folder && yarn copy-moveover-files && yarn postprocess-files && yarn cleanup-temp-folder",
     "prepare-temp-folder": "rm -fr temp && mkdir temp && mkdir temp/original",
     "copy-source-files": "cp -r ../packages/components/tests/dummy/app/templates/* temp/original",
     "identify-sections": "echo '\n==========\nIdentifying <section> blocks...\n' && node codemods/bin/cli.js identify-sections ./temp/original/**/*.hbs",
@@ -27,6 +27,7 @@
     "copy-markdown-files": "echo '\n==========\nCopying markdown files to `docs` folder...\n' && cp -r ./temp/markdown/* ../website/docs/",
     "copy-assets-folder": "rm -fr ../website/public/assets/images && cp -r ../packages/components/tests/dummy/public/assets/images ../website/public/assets/",
     "copy-moveover-files": "cp -r ./moveover/* ../website/docs/",
+    "postprocess-files": "ts-node --transpile-only ./scripts/postprocess-files",
     "cleanup-temp-folder": "rm -fr temp"
   },
   "devDependencies": {

--- a/website-html-to-markdown/scripts/postprocess-files.ts
+++ b/website-html-to-markdown/scripts/postprocess-files.ts
@@ -1,0 +1,42 @@
+import { glob } from 'glob';
+import fs from 'fs-extra';
+import path from 'path';
+import chalk from 'chalk';
+
+const docsFolder = path.resolve(__dirname, '../../website/docs');
+
+(async () => {
+  try {
+    console.log(
+      `\n==========\n${chalk.cyan(
+        'Postprocessing "docs" files...'
+      )}\n`
+    );
+
+    await postprocess();
+
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();
+
+async function postprocess() {
+  // process the markdown files
+  glob(docsFolder + '/**/*.md', {}, async function (_error, files) {
+    // loop on every markdown file found in the source folder
+    for (const filePath of files) {
+
+      // we read the markdown source
+      let markdownSource = await fs.readFile(filePath, 'utf8');
+
+      // GLOBAL CHANGES
+      // ----------------------------
+
+      markdownSource = markdownSource.replace(/<DummyPlaceholder/g, '<Doc::Placeholder');
+      markdownSource = markdownSource.replace(/<\/DummyPlaceholder/g, '</Doc::Placeholder');
+
+      await fs.writeFile(filePath, markdownSource);
+    }
+  });
+}


### PR DESCRIPTION
### :pushpin: Summary

In this small PR I have added a postprocess script that replaces all the `DummyPlaceholder` occurrences with `Doc::Placeholder` (so the pages don't trigger an error).

_Notice: the actual regeneration of the markdown files will be done in a follow-up PR_

@alex-ju this can be also used in your follow-up of the Component API automated conversion, in case.

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
