### PR TITLE
New docs website / Updated WCAG list processing + regenerated docs in output

### DIFF
--- a/website-html-to-markdown/codemods/transforms/enrich-wcag-lists.js
+++ b/website-html-to-markdown/codemods/transforms/enrich-wcag-lists.js
@@ -102,17 +102,13 @@ module.exports = function ({ source /*, path */ }, { parse, visit }) {
               criteria.push({ href, id});
             }
           });
-          // console.log('\nAAA\n', criteria.map(item => item.id).join('|'), '\n');
-
-          // update the class name of the `<ul>` element (this also prevents an infinite loop)
-          node.attributes[0].value.chars = 'dummy-wcag-success-criteria-list';
 
           const nl = build.text('\n');
 
           const customComponentNode = build.element(
-            { name: 'Dummy-Wcag-Success-Criteria-List', selfClosing: false },
+            { name: 'dummywcagsuccesscriterialist', selfClosing: false },
             {
-              children: [ build.text('Placeholder for the WCAG Success Criteria List component - Don\'t delete!') ],
+              children: [ build.text('WCAG') ],
               attrs: [
                 // use this one if we need just the ID of the criteria
                 build.attr('data-list', build.text(`${criteria.map(item => item.id).join('|')}`)),
@@ -126,7 +122,7 @@ module.exports = function ({ source /*, path */ }, { parse, visit }) {
             build.element(
               { name: 'div', selfClosing: false },
               {
-                children: [nl, nl, customComponentNode, nl, nl, node, nl],
+                children: [nl, nl, customComponentNode, nl],
               }
             ),
           ];

--- a/website-html-to-markdown/scripts/convert-to-markdown.ts
+++ b/website-html-to-markdown/scripts/convert-to-markdown.ts
@@ -103,7 +103,7 @@ async function convert() {
           break;
         // ACCESSIBILITY
         case 'accessibility.hbs':
-          turndownService.keep(['dummy-wcag-success-criteria-list']);
+          turndownService.keep(['dummywcagsuccesscriterialist']);
           markdownContent = turndownService.turndown(hbsSource);
           break;
         // SHOWCASE

--- a/website-html-to-markdown/scripts/postprocess-files.ts
+++ b/website-html-to-markdown/scripts/postprocess-files.ts
@@ -33,8 +33,14 @@ async function postprocess() {
       // GLOBAL CHANGES
       // ----------------------------
 
+      // <DummyPlaceholder> → <Doc::Placeholder>
       markdownSource = markdownSource.replace(/<DummyPlaceholder/g, '<Doc::Placeholder');
       markdownSource = markdownSource.replace(/<\/DummyPlaceholder/g, '</Doc::Placeholder');
+
+      // <dummywcagsuccesscriterialist> → <Doc::WcagList>
+      markdownSource = markdownSource.replace(/<dummywcagsuccesscriterialist data-list="(.*)">WCAG<\/dummywcagsuccesscriterialist>/g, (_match, list) => {
+        return `<Doc::WcagList @criteriaList={{array "${list.split('|').join('" "')}" }} />\n`;
+      });
 
       await fs.writeFile(filePath, markdownSource);
     }

--- a/website/docs/components/alert/partials/accessibility/accessibility.md
+++ b/website/docs/components/alert/partials/accessibility/accessibility.md
@@ -2,6 +2,6 @@ This component is conditionally conformant. That is, it is conformant when there
 
 #### Applicable WCAG Success Criteria (Reference)
 
-This section is for education and reference. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG success criteria:
 
-<Doc::WcagList @criteriaList={{array '1.3.1' '1.3.2' '1.4.1' '1.4.3' '1.4.10' '1.4.11' '1.4.12' '2.1.1' '2.1.2' '2.2.1' '2.5.3' '4.1.1' '4.1.2' '4.1.3' }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />

--- a/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
@@ -6,4 +6,4 @@
 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG success criteria:
 
-<Doc::WcagList @criteriaList={{array 1.3.1|1.3.2|1.3.4|1.3.5|1.4.1|1.4.3|1.4.4|1.4.10|1.4.11|1.4.12|2.4.6|2.4.7|3.2.1|3.2.2|3.2.4|3.3.2|4.1.1|4.1.2 }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />


### PR DESCRIPTION
### :pushpin: Summary

Follow up of #724, to avoid the `docs` file being overwritten by the automated processing of the existing documentation.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the automated pipeline for WCAG list processing (pre and post markdown generation)
  - @alex-ju in case you want to use a similar approach (see my commit)
- regenerated docs in output (this fixed a couple of issues too)

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
