### PR TITLE
New docs website / First pass at fixing "doc" pages for component - Part 1 (preprocessing)

### DIFF
--- a/website-html-to-markdown/scripts/preprocess-files.ts
+++ b/website-html-to-markdown/scripts/preprocess-files.ts
@@ -30,7 +30,7 @@ async function preprocess() {
       const fileRelativePath = path.relative(sourceFolder, filePath);
 
       // DEBUG - let's use a single file for testing
-      // if (fileRelativePath !== 'components/alert/03_how-to-use.hbs') {
+      // if (fileRelativePath !== 'components/alert/partials/code/showcase.hbs') {
       //   continue;
       // }
 
@@ -43,14 +43,70 @@ async function preprocess() {
       // FILE SPECIFIC CHANGES
       // ----------------------------
 
-      if (fileRelativePath === 'components/tag/partials/code/how-to-use.hbs') {
+      if (fileRelativePath === 'foundations/tokens/partials/other/generic-2.hbs') {
+        hbsSource = hbsSource.replace(/DummyToken/g, 'Doc::TokenCard');
+      }
+      if (fileRelativePath === 'foundations/colors/partials/other/generic-2.hbs') {
+        hbsSource = hbsSource.replace(/DummyColorCard/g, 'Doc::ColorCard');
+      }
+      if (fileRelativePath === 'components/alert/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/@route="\.\.\."/g, '@route="components"');
+      }
+      if (fileRelativePath === 'components/breadcrumb/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/@route="\.\.\."/g, '@route="components"');
+        // TODO add more fixes for other routes (`list`, `detail`, etc)
+      }
+      if (fileRelativePath === 'components/dropdown/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/@route="\.\.\."/g, '@route="components"');
+      }
+      if (fileRelativePath === 'components/form/base-elements/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/@route="components.link.inline"/g, '@route="show" @model="components/link/inline"');
+      }
+      if (fileRelativePath === 'components/form/checkbox/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/myAction/g, 'this.yourOnChangeFunction');
+      }
+      if (fileRelativePath === 'components/form/radio/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/myAction/g, 'this.yourOnChangeFunction');
+      }
+      if (fileRelativePath === 'components/form/radio-card/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/myAction/g, 'this.yourOnChangeFunction');
+      }
+      if (fileRelativePath === 'components/form/select/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/myAction/g, 'this.yourOnBlurFunction');
+      }
+      if (fileRelativePath === 'components/form/text-input/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/myAction/g, 'this.yourOnBlurFunction');
+      }
+      if (fileRelativePath === 'components/form/textarea/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/myAction/g, 'this.yourOnBlurFunction');
+      }
+      if (fileRelativePath === 'components/form/toggle/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/myAction/g, 'this.yourOnChangeFunction');
+      }
+      //
+      // TODO - fix `Dropdown` errors
+      //
+      if (fileRelativePath === 'components/link/inline/partials/code/showcase.hbs') {
+        hbsSource = hbsSource.replace(/@route="index"/g, '@route="components"');
+      }
+      if (fileRelativePath === 'components/link/standalone/partials/code/showcase.hbs') {
+        hbsSource = hbsSource.replace(/@route="(index|components.link)"/g, '@route="components"');
+      }
+      if (fileRelativePath === 'components/link/inline/partials/code/showcase.hbs') {
+        hbsSource = hbsSource.replace(/@route="index"/g, '@route="components"');
+      }
+      if (fileRelativePath === 'components/tag/partials/code/how-to-use.hbs' || fileRelativePath === 'components/tag/partials/code/showcase.hbs') {
         hbsSource = hbsSource.replace(/ your function here /g, 'this.yourOnDismissFunction');
-        hbsSource = hbsSource.replace(/@route="components.tag"/g, '@href="#"');
+        hbsSource = hbsSource.replace(/@route="components.tag"/g, '@route="show" @model="components/tag"');
+      }
+      if (fileRelativePath === 'components/power-select/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/@route="components.tag"/g, '@route="components"');
       }
       if (fileRelativePath === 'components/toast/partials/code/how-to-use.hbs') {
-        hbsSource = hbsSource.replace('<Hds::Toast @onDismiss={{ your function here }} as |T|>', '<Hds::Toast @onDismiss={{this.yourOnDismissFunction}} as |T|>');
+        hbsSource = hbsSource.replace(/Hds::Toast @onDismiss=\{\{ your function here \}\} as \|T\|/g, 'Hds::Toast @onDismiss={{this.yourOnDismissFunction}} as |T|');
         hbsSource = hbsSource.replace(/@onDismiss=\{\{\.\.\.\}\}/g, '@onDismiss={{this.yourOnDismissFunction}}');
-        hbsSource = hbsSource.replace('@onClick={{ your function here }}', '@onClick={{this.yourOnClickFunction}}');
+        hbsSource = hbsSource.replace(/@onClick=\{\{ your function here \}\}/g, '@onClick={{this.yourOnClickFunction}}');
+        hbsSource = hbsSource.replace(/@route="\.\.\."/g, '@route="components"');
       }
 
       await fs.writeFile(filePath, hbsSource);

--- a/website/app/router.js
+++ b/website/app/router.js
@@ -13,6 +13,8 @@ Router.map(function () {
   this.route('patterns');
   // this will be removed later
   this.route('testing');
+  // this is a fake route that we use for the "how to use" and "showcase" sections
+  this.route('my.page.route', { path: 'my/*path' });
   // this is a catch-all route that points any path not matched above to the "show" route
   this.route('show', { path: '*path' });
 });


### PR DESCRIPTION
### :pushpin: Summary

This if the first part of a series of tasks that intend to fix most of the obvious JS errors in the documentation pages (mainly due to the conversion from the old "how to" and "showcase" pages, to the new markdown-like format.

👉 Not all the component pages have been fixed, see the list here: https://hashicorp.atlassian.net/browse/HDS-1171

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the "pre-process" script to fix some of the “docs” pages
- added fake `my.page.route` (to be used in code demos)
  - later we will implement a more systematic approach to the problem of having fake routes for demo purpose

_⚠️ Notice: I have not regenerated the docs in output, to avoid noise in the PR. I'll regenerate them before merging, once the PR i approved. If you want to test I suggest to get the branch up and running in your local environment and test the website there._

### :link: External links

Main JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-1171
Jira task: https://hashicorp.atlassian.net/browse/HDS-1172

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
