### PR TITLE
New docs website / First pass at fixing "doc" pages for component - Part 2 (backing classes)

### DIFF
--- a/website-html-to-markdown/moveover/components/alert/index.js
+++ b/website-html-to-markdown/moveover/components/alert/index.js
@@ -1,7 +1,22 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+import {
+  TYPES,
+  COLORS,
+} from '@hashicorp/design-system-components/components/hds/alert';
 
 export default class Index extends Component {
-  get noop() {
-    return () => {};
+  get TYPES() {
+    return TYPES;
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+
+  @action
+  noop() {
+    //
   }
 }

--- a/website-html-to-markdown/moveover/components/badge-count/index.js
+++ b/website-html-to-markdown/moveover/components/badge-count/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import {
+  SIZES as BADGE_COUNT_SIZES,
+  TYPES as BADGE_COUNT_TYPES,
+  COLORS as BADGE_COUNT_COLORS,
+} from '@hashicorp/design-system-components/components/hds/badge-count';
+
+export default class Index extends Component {
+  get BADGE_COUNT_SIZES() {
+    return BADGE_COUNT_SIZES;
+  }
+
+  get BADGE_COUNT_TYPES() {
+    return BADGE_COUNT_TYPES;
+  }
+
+  get BADGE_COUNT_COLORS() {
+    return BADGE_COUNT_COLORS;
+  }
+}

--- a/website-html-to-markdown/moveover/components/badge/index.js
+++ b/website-html-to-markdown/moveover/components/badge/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import {
+  SIZES as BADGE_SIZES,
+  TYPES as BADGE_TYPES,
+  COLORS as BADGE_COLORS,
+} from '@hashicorp/design-system-components/components/hds/badge';
+
+export default class Index extends Component {
+  get BADGE_SIZES() {
+    return BADGE_SIZES;
+  }
+
+  get BADGE_TYPES() {
+    return BADGE_TYPES;
+  }
+
+  get BADGE_COLORS() {
+    return BADGE_COLORS;
+  }
+}

--- a/website-html-to-markdown/moveover/components/button/index.js
+++ b/website-html-to-markdown/moveover/components/button/index.js
@@ -1,20 +1,27 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-import { COLORS } from '@hashicorp/design-system-components/components/hds/tag';
+import {
+  SIZES,
+  COLORS,
+} from '@hashicorp/design-system-components/components/hds/button';
 
 export default class Index extends Component {
   get STATES() {
     // these are used only for presentation purpose in the showcase
-    return ['default', 'hover', 'active', 'focus'];
+    return ['default', 'hover', 'active', 'focus', 'disabled'];
+  }
+
+  get SIZES() {
+    return SIZES;
   }
 
   get COLORS() {
     return COLORS;
   }
 
-  get copyToClipboard() {
-    return () => {
-      console.log('Clicked "Copy to clipboard" button!');
-    };
+  @action
+  copyToClipboard() {
+    console.log('Clicked "Copy to clipboard" button!');
   }
 }

--- a/website-html-to-markdown/moveover/components/card/index.js
+++ b/website-html-to-markdown/moveover/components/card/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import {
+  DEFAULT_LEVEL as CONTAINER_DEFAULT_LEVEL,
+  LEVELS as CONTAINER_LEVELS,
+  BACKGROUNDS as CONTAINER_BACKGROUNDS,
+} from '@hashicorp/design-system-components/components/hds/card/container';
+
+export default class Index extends Component {
+  get CONTAINER_DEFAULT_LEVEL() {
+    return CONTAINER_DEFAULT_LEVEL;
+  }
+
+  get CONTAINER_LEVELS() {
+    return CONTAINER_LEVELS;
+  }
+
+  get CONTAINER_BACKGROUNDS() {
+    return CONTAINER_BACKGROUNDS;
+  }
+}

--- a/website-html-to-markdown/moveover/components/dropdown/index.js
+++ b/website-html-to-markdown/moveover/components/dropdown/index.js
@@ -21,5 +21,4 @@ export default class Index extends Component {
   get ITEM_INTERACTIVE_COLORS() {
     return ITEM_INTERACTIVE_COLORS;
   }
-
 }

--- a/website-html-to-markdown/moveover/components/dropdown/index.js
+++ b/website-html-to-markdown/moveover/components/dropdown/index.js
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+
+import { COLORS as TOGGLE_BUTTON_COLORS } from '@hashicorp/design-system-components/components/hds/dropdown/toggle/button';
+import { COLORS as ITEM_INTERACTIVE_COLORS } from '@hashicorp/design-system-components/components/hds/dropdown/list-item/interactive';
+
+export default class Index extends Component {
+  get TOGGLE_STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  get TOGGLE_BUTTON_COLORS() {
+    return TOGGLE_BUTTON_COLORS;
+  }
+
+  get ITEM_STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  get ITEM_INTERACTIVE_COLORS() {
+    return ITEM_INTERACTIVE_COLORS;
+  }
+
+}

--- a/website-html-to-markdown/moveover/components/form/base-elements/index.js
+++ b/website-html-to-markdown/moveover/components/form/base-elements/index.js
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class Index extends Component {
+  @tracked showHighlight = false;
+
+  get SAMPLE_ERROR_MESSAGES() {
+    return ['First error message', 'Second error message'];
+  }
+
+  @action
+  toggleHighlight() {
+    this.showHighlight = !this.showHighlight;
+  }
+}

--- a/website-html-to-markdown/moveover/components/form/checkbox/index.js
+++ b/website-html-to-markdown/moveover/components/form/checkbox/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  @action
+  yourOnChangeFunction() {
+    console.log('Invoked "yourOnChangeFunction"');
+  }
+}

--- a/website-html-to-markdown/moveover/components/form/radio-card/index.js
+++ b/website-html-to-markdown/moveover/components/form/radio-card/index.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-
+import { action } from '@ember/object';
 export default class Index extends Component {
   get STATES() {
     // these are used only for presentation purpose in the showcase

--- a/website-html-to-markdown/moveover/components/form/radio-card/index.js
+++ b/website-html-to-markdown/moveover/components/form/radio-card/index.js
@@ -1,0 +1,48 @@
+import Component from '@glimmer/component';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus', 'disabled'];
+  }
+
+  get RADIOCARDS() {
+    return [
+      {
+        value: '1',
+        label: 'Radio card label 1',
+        badge: 'Badge',
+        checked: true,
+        description: 'Radio card description 1',
+        generic: 'Radio card custom content 1',
+      },
+      {
+        value: '2',
+        label: 'Radio card label 2',
+        badge: 'Badge',
+        description: 'Radio card description 2',
+        generic: 'Radio card custom content 2',
+      },
+      {
+        value: '3',
+        label: 'Radio card label 3',
+        badge: 'Badge',
+        description: 'Radio card description 3',
+        generic: 'Radio card custom content 3',
+      },
+    ];
+  }
+
+  // TODO this is used by us; but there should be also one with `yourOnChangeFunction` for the "how to use" section
+  @action
+  onChange(event) {
+    const control = event.target;
+    const group = control.closest('.hds-form-group__control-fields-wrapper');
+    group.querySelectorAll('.hds-form-radio-card').forEach((radioCard) => {
+      radioCard.classList.remove('hds-form-radio-card--checked');
+    });
+    control
+      .closest('.hds-form-radio-card')
+      .classList.add('hds-form-radio-card--checked');
+  }
+}

--- a/website-html-to-markdown/moveover/components/form/radio/index.js
+++ b/website-html-to-markdown/moveover/components/form/radio/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  @action
+  yourOnChangeFunction() {
+    console.log('Invoked "yourOnChangeFunction"');
+  }
+}

--- a/website-html-to-markdown/moveover/components/form/select/index.js
+++ b/website-html-to-markdown/moveover/components/form/select/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  @action
+  yourOnBlurFunction() {
+    console.log('Invoked "yourOnBlurFunction"');
+  }
+}

--- a/website-html-to-markdown/moveover/components/form/text-input/index.js
+++ b/website-html-to-markdown/moveover/components/form/text-input/index.js
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+import { TYPES } from '@hashicorp/design-system-components/components/hds/form/text-input/base';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  get TYPES() {
+    return TYPES;
+  }
+
+  @action
+  yourOnBlurFunction() {
+    console.log('Invoked "yourOnBlurFunction"');
+  }
+}

--- a/website-html-to-markdown/moveover/components/form/textarea/index.js
+++ b/website-html-to-markdown/moveover/components/form/textarea/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  @action
+  yourOnBlurFunction() {
+    console.log('Invoked "yourOnBlurFunction"');
+  }
+}

--- a/website-html-to-markdown/moveover/components/form/toggle/index.js
+++ b/website-html-to-markdown/moveover/components/form/toggle/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  @action
+  yourOnChangeFunction() {
+    console.log('Invoked "yourOnChangeFunction"');
+  }
+}

--- a/website-html-to-markdown/moveover/components/icon-tile/index.js
+++ b/website-html-to-markdown/moveover/components/icon-tile/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import {
+  SIZES,
+  COLORS,
+  PRODUCTS,
+} from '@hashicorp/design-system-components/components/hds/icon-tile';
+
+export default class Index extends Component {
+  get SIZES() {
+    return SIZES;
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+
+  get PRODUCTS() {
+    return PRODUCTS;
+  }
+}

--- a/website-html-to-markdown/moveover/components/link/inline/index.js
+++ b/website-html-to-markdown/moveover/components/link/inline/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+import { COLORS } from '@hashicorp/design-system-components/components/hds/link/inline';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+}

--- a/website-html-to-markdown/moveover/components/link/standalone/index.js
+++ b/website-html-to-markdown/moveover/components/link/standalone/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import {
+  COLORS,
+  SIZES,
+} from '@hashicorp/design-system-components/components/hds/link/standalone';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+
+  get SIZES() {
+    return SIZES;
+  }
+}

--- a/website-html-to-markdown/moveover/components/modal/index.js
+++ b/website-html-to-markdown/moveover/components/modal/index.js
@@ -1,0 +1,55 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import {
+  COLORS,
+  SIZES,
+} from '@hashicorp/design-system-components/components/hds/modal';
+
+export default class Index extends Component {
+  @tracked basicModalActive = false;
+  @tracked formModalActive = false;
+  @tracked isModalDismissDisabled = false;
+
+  get SIZES() {
+    return SIZES;
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+
+  @action
+  activateModal(modal) {
+    this.isModalDismissDisabled = false;
+    this[modal] = true;
+    document.body.style.overflow = 'hidden';
+  }
+
+  @action
+  deactivateModal(modal) {
+    this.isModalDismissDisabled = false;
+    this[modal] = false;
+    document.body.style.overflow = 'auto';
+  }
+
+  @action markFormAsChanged() {
+    this.isModalDismissDisabled = true;
+  }
+
+  @action saveFormAndClose(modal) {
+    this.isModalDismissDisabled = false;
+    this.deactivateModal(modal);
+  }
+
+  @action checkBeforeDeactivate(modal) {
+    if (this.isModalDismissDisabled) {
+      if (window.confirm('Changes that you made may not be saved')) {
+        this.deactivateModal(modal);
+      }
+    } else {
+      this.deactivateModal(modal);
+    }
+  }
+}

--- a/website-html-to-markdown/moveover/components/stepper/index.js
+++ b/website-html-to-markdown/moveover/components/stepper/index.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+import { STATUSES as STEP_STATUSES } from '@hashicorp/design-system-components/components/hds/stepper/step/indicator';
+import { STATUSES as TASK_STATUSES } from '@hashicorp/design-system-components/components/hds/stepper/task/indicator';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active'];
+  }
+
+  get STEP_STATUSES() {
+    return STEP_STATUSES;
+  }
+
+  get TASK_STATUSES() {
+    return TASK_STATUSES;
+  }
+}

--- a/website-html-to-markdown/moveover/components/table/index.js
+++ b/website-html-to-markdown/moveover/components/table/index.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['active', 'default', 'hover', 'focus'];
+  }
+  //
+  // TODO! move also the data fetching here
+  //
+}

--- a/website-html-to-markdown/moveover/components/tabs/index.js
+++ b/website-html-to-markdown/moveover/components/tabs/index.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 
 import { COLORS } from '@hashicorp/design-system-components/components/hds/tag';
 

--- a/website-html-to-markdown/moveover/components/tabs/index.js
+++ b/website-html-to-markdown/moveover/components/tabs/index.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import { COLORS } from '@hashicorp/design-system-components/components/hds/tag';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+
+  @action
+  toggleHighlight() {
+    this.showHighlight = !this.showHighlight;
+  }
+
+  @action
+  logClickedTab(event) {
+    const tabId = event.target.id;
+    console.log(`Tab with ID "${tabId}" clicked!`);
+  }
+}

--- a/website-html-to-markdown/moveover/components/tag/index.js
+++ b/website-html-to-markdown/moveover/components/tag/index.js
@@ -1,9 +1,14 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class Index extends Component {
-  get yourOnDismissFunction() {
-    return () => {
-      console.log('Clicked the "dismiss" button in the "tag"!');
-    };
+  @action
+  noop() {
+    //
+  }
+
+  @action
+  yourOnDismissFunction() {
+    console.log('Clicked the "dismiss" button in the "toast"!');
   }
 }

--- a/website-html-to-markdown/moveover/components/toast/index.js
+++ b/website-html-to-markdown/moveover/components/toast/index.js
@@ -1,19 +1,26 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+// the "Toast" is built on top of the "Alert" so it shares the same colors
+import { COLORS } from '@hashicorp/design-system-components/components/hds/alert';
 
 export default class Index extends Component {
-  get noop() {
-    return () => {};
+  get COLORS() {
+    return COLORS;
   }
 
-  get yourOnDismissFunction() {
-    return () => {
-      console.log('Clicked the "dismiss" button in the "toast"!');
-    };
+  @action
+  noop() {
+    //
   }
 
-  get yourOnClickFunction() {
-    return () => {
-      console.log('Clicked the button in the "tag"!');
-    };
+  @action
+  yourOnDismissFunction() {
+    console.log('Clicked the "dismiss" button in the "toast"!');
+  }
+
+  @action
+  yourOnClickFunction() {
+    console.log('Clicked the button in the "tag"!');
   }
 }

--- a/website-html-to-markdown/moveover/components/toast/partials/specifications/design-guidelines.js
+++ b/website-html-to-markdown/moveover/components/toast/partials/specifications/design-guidelines.js
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class DesignGuidelines extends Component {
-  get noop() {
-    return () => {};
+  @action
+  noop() {
+    //
   }
 }

--- a/website-html-to-markdown/moveover/foundations/colors/index.js
+++ b/website-html-to-markdown/moveover/foundations/colors/index.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
-import TOKENS_RAW from '../../../../packages/tokens/dist/docs/products/tokens.json';
+import TOKENS_RAW from '@hashicorp/design-system-tokens/dist/docs/products/tokens.json';
 
 export default class Colors extends Component {
   get colors() {

--- a/website-html-to-markdown/moveover/foundations/elevation/index.js
+++ b/website-html-to-markdown/moveover/foundations/elevation/index.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+
+const ELEVATIONS = ['inset', 'low', 'mid', 'high', 'higher', 'overlay'];
+const SURFACES = ['inset', 'base', 'low', 'mid', 'high', 'higher', 'overlay'];
+
+export default class Index extends Component {
+  get cssVariables() {
+    const cssVariables = { elevations: [], surfaces: [] };
+    ELEVATIONS.forEach((elevation) => {
+      cssVariables.elevations.push(`--hds-elevation-${elevation}-box-shadow`);
+    });
+    SURFACES.forEach((surface) => {
+      cssVariables.surfaces.push(`--hds-surface-${surface}-box-shadow`);
+    });
+    return cssVariables;
+  }
+  get cssHelpers() {
+    const cssHelpers = { elevations: [], surfaces: [] };
+    ELEVATIONS.forEach((elevation) => {
+      cssHelpers.elevations.push(`.hds-elevation-${elevation}`);
+    });
+    SURFACES.forEach((surface) => {
+      cssHelpers.surfaces.push(`.hds-surface-${surface}`);
+    });
+    return cssHelpers;
+  }
+}

--- a/website-html-to-markdown/moveover/foundations/tokens/index.js
+++ b/website-html-to-markdown/moveover/foundations/tokens/index.js
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+
+import TOKENS_RAW from '@hashicorp/design-system-tokens/dist/docs/products/tokens.json';
+
+export default class Index extends Component {
+  get groupedTokens() {
+    const groupedTokens = {};
+
+    TOKENS_RAW.forEach((token) => {
+      const category = token.attributes.category;
+      if (!groupedTokens[category]) {
+        groupedTokens[category] = [];
+      }
+
+      groupedTokens[category].push(token);
+    });
+
+    return groupedTokens;
+  }
+}

--- a/website-html-to-markdown/moveover/foundations/typography/index.js
+++ b/website-html-to-markdown/moveover/foundations/typography/index.js
@@ -1,0 +1,59 @@
+import Component from '@glimmer/component';
+
+const FONT_FAMILIES = ['sans-display', 'sans-text', 'mono-code'];
+const FONT_WEIGHTS = ['regular', 'medium', 'semibold', 'bold'];
+const DISPLAY_STYLES = [
+  'display-500',
+  'display-400',
+  'display-300',
+  'display-200',
+  'display-100',
+];
+const BODY_STYLES = ['body-300', 'body-200', 'body-100'];
+const CODE_STYLES = ['code-300', 'code-200', 'code-100'];
+// we add all the allowed combinations here, per design specs
+const STYLES_COMBINATIONS = {
+  'display-500': ['bold'],
+  'display-400': ['medium', 'semibold', 'bold'],
+  'display-300': ['medium', 'semibold', 'bold'],
+  'display-200': ['semibold'],
+  'display-100': ['medium'],
+  'body-300': ['regular', 'medium', 'semibold'],
+  'body-200': ['regular', 'medium', 'semibold'],
+  'body-100': ['regular', 'medium', 'semibold'],
+  'code-300': ['regular', 'bold'],
+  'code-200': ['regular', 'bold'],
+  'code-100': ['regular', 'bold'],
+};
+
+export default class Index extends Component {
+  get families() {
+    return [...FONT_FAMILIES];
+  }
+  get weights() {
+    return [...FONT_WEIGHTS];
+  }
+  get styles() {
+    return [...DISPLAY_STYLES, ...BODY_STYLES, ...CODE_STYLES];
+  }
+  get stylesCombinations() {
+    return STYLES_COMBINATIONS;
+  }
+  get cssHelpers() {
+    const cssHelpers = {
+      families: [],
+      weights: [],
+      styles: [],
+    };
+    this.families.forEach((family) => {
+      cssHelpers.families.push(`.hds-font-family-${family}`);
+    });
+    this.weights.forEach((weight) => {
+      cssHelpers.weights.push(`.hds-font-weight-${weight}`);
+    });
+    this.styles.forEach((style) => {
+      cssHelpers.styles.push(`.hds-typography-${style}`);
+    });
+    return cssHelpers;
+  }
+}

--- a/website-html-to-markdown/moveover/overrides/power-select/index.js
+++ b/website-html-to-markdown/moveover/overrides/power-select/index.js
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get OPTIONS() {
+    return [
+      'Oregon (us-west-2)',
+      'N. Virginia (us-east-1)',
+      'Ireland (eu-west-1)',
+      'London (eu-west-2)',
+      'Frankfurt (eu-central-1)',
+    ];
+  }
+
+  get SELECTED() {
+    return ['Oregon (us-west-2)'];
+  }
+
+  get SELECTEDMULTIPLE() {
+    return [
+      'Oregon (us-west-2)',
+      'N. Virginia (us-east-1)',
+      'Ireland (eu-west-1)',
+    ];
+  }
+
+  // notice: this is used as "noop" function for the onDismiss callback of the PowerSelect component
+  @action
+  noop() {
+    //
+  }
+}

--- a/website-html-to-markdown/moveover/utilities/dismiss-button/index.js
+++ b/website-html-to-markdown/moveover/utilities/dismiss-button/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  @action
+  onClickDismissButton() {
+    console.log('`Hds::DismissButton` clicked');
+  }
+}

--- a/website-html-to-markdown/scripts/preprocess-files.ts
+++ b/website-html-to-markdown/scripts/preprocess-files.ts
@@ -40,6 +40,12 @@ async function preprocess() {
       // we read the handlebars source (made of HTML + Handlebars code) to process it
       let hbsSource = await fs.readFile(filePath, 'utf8');
 
+      // GENERAL CHANGES
+      // ----------------------------
+      if (fileRelativePath.match(/showcase.hbs$/)) {
+        hbsSource = hbsSource.replace('@model.', 'this.');
+      }
+
       // FILE SPECIFIC CHANGES
       // ----------------------------
 

--- a/website/docs/components/alert/index.js
+++ b/website/docs/components/alert/index.js
@@ -1,7 +1,22 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+import {
+  TYPES,
+  COLORS,
+} from '@hashicorp/design-system-components/components/hds/alert';
 
 export default class Index extends Component {
-  get noop() {
-    return () => {};
+  get TYPES() {
+    return TYPES;
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+
+  @action
+  noop() {
+    //
   }
 }

--- a/website/docs/components/alert/partials/code/how-to-use.md
+++ b/website/docs/components/alert/partials/code/how-to-use.md
@@ -116,7 +116,7 @@ Actions can optionally be passed to component using one of the suggested `Button
   <A.Title>Title here</A.Title>
   <A.Description>Description here</A.Description>
   <A.Button @text="Your action" @color="secondary" @onClick={{this.noop}} />
-  <A.Link::Standalone @color="secondary" @icon="plus" @text="Another action" @route="..." />
+  <A.Link::Standalone @color="secondary" @icon="plus" @text="Another action" @route="components" />
   <A.Link::Standalone @icon="arrow-right" @iconPosition="leading" @text="Another action" @href="#" />
 </Hds::Alert>
 ```

--- a/website/docs/components/alert/partials/code/showcase.md
+++ b/website/docs/components/alert/partials/code/showcase.md
@@ -5,7 +5,7 @@
     "Showcase" for clarity.</p>
 
   <h4 class="dummy-h4">Type</h4>
-  {{#each @model.TYPES as |type|}}
+  {{#each this.TYPES as |type|}}
     <p class="dummy-paragraph">{{capitalize type}}</p>
     <br />
     <div class="dummy-alert-sample-item--type-{{type}}">

--- a/website/docs/components/badge-count/index.js
+++ b/website/docs/components/badge-count/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import {
+  SIZES as BADGE_COUNT_SIZES,
+  TYPES as BADGE_COUNT_TYPES,
+  COLORS as BADGE_COUNT_COLORS,
+} from '@hashicorp/design-system-components/components/hds/badge-count';
+
+export default class Index extends Component {
+  get BADGE_COUNT_SIZES() {
+    return BADGE_COUNT_SIZES;
+  }
+
+  get BADGE_COUNT_TYPES() {
+    return BADGE_COUNT_TYPES;
+  }
+
+  get BADGE_COUNT_COLORS() {
+    return BADGE_COUNT_COLORS;
+  }
+}

--- a/website/docs/components/badge-count/partials/code/showcase.md
+++ b/website/docs/components/badge-count/partials/code/showcase.md
@@ -13,7 +13,7 @@
 
   <h4 class="dummy-h4">Size</h4>
   <div class="dummy-badge-base-sample">
-    {{#each @model.BADGE_COUNT_SIZES as |size|}}
+    {{#each this.BADGE_COUNT_SIZES as |size|}}
       <Hds::BadgeCount @text={{capitalize size}} @size={{size}} />
     {{/each}}
   </div>

--- a/website/docs/components/badge/index.js
+++ b/website/docs/components/badge/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import {
+  SIZES as BADGE_SIZES,
+  TYPES as BADGE_TYPES,
+  COLORS as BADGE_COLORS,
+} from '@hashicorp/design-system-components/components/hds/badge';
+
+export default class Index extends Component {
+  get BADGE_SIZES() {
+    return BADGE_SIZES;
+  }
+
+  get BADGE_TYPES() {
+    return BADGE_TYPES;
+  }
+
+  get BADGE_COLORS() {
+    return BADGE_COLORS;
+  }
+}

--- a/website/docs/components/badge/partials/code/showcase.md
+++ b/website/docs/components/badge/partials/code/showcase.md
@@ -35,7 +35,7 @@
 
   <h4 class="dummy-h4">Size</h4>
   <div class="dummy-badge-base-sample">
-    {{#each @model.BADGE_SIZES as |size|}}
+    {{#each this.BADGE_SIZES as |size|}}
       <Hds::Badge @icon="activity" @text={{capitalize size}} @size={{size}} />
     {{/each}}
   </div>

--- a/website/docs/components/breadcrumb/partials/code/how-to-use.md
+++ b/website/docs/components/breadcrumb/partials/code/how-to-use.md
@@ -43,11 +43,11 @@ It is also possible to collect and hide part of the breadcrumb tree under a "tru
 ```handlebars
 <Hds::Breadcrumb>
   <Hds::Breadcrumb::Truncation>
-    <Hds::Breadcrumb::Item @text="My org" @icon="org" @route="..." />
-    <Hds::Breadcrumb::Item @text="Consul" @icon="consul" @route="..." />
-    <Hds::Breadcrumb::Item @text="my-consul-cluster" @route="..." />
+    <Hds::Breadcrumb::Item @text="My org" @icon="org" @route="components" />
+    <Hds::Breadcrumb::Item @text="Consul" @icon="consul" @route="components" />
+    <Hds::Breadcrumb::Item @text="my-consul-cluster" @route="components" />
   </Hds::Breadcrumb::Truncation>
-  <Hds::Breadcrumb::Item @text="Cluster details" @route="..." />
+  <Hds::Breadcrumb::Item @text="Cluster details" @route="components" />
   <Hds::Breadcrumb::Item @text="Cluster sub-details" @current={{true}} />
 </Hds::Breadcrumb>
 ```

--- a/website/docs/components/button/index.js
+++ b/website/docs/components/button/index.js
@@ -1,20 +1,27 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-import { COLORS } from '@hashicorp/design-system-components/components/hds/tag';
+import {
+  SIZES,
+  COLORS,
+} from '@hashicorp/design-system-components/components/hds/button';
 
 export default class Index extends Component {
   get STATES() {
     // these are used only for presentation purpose in the showcase
-    return ['default', 'hover', 'active', 'focus'];
+    return ['default', 'hover', 'active', 'focus', 'disabled'];
+  }
+
+  get SIZES() {
+    return SIZES;
   }
 
   get COLORS() {
     return COLORS;
   }
 
-  get copyToClipboard() {
-    return () => {
-      console.log('Clicked "Copy to clipboard" button!');
-    };
+  @action
+  copyToClipboard() {
+    console.log('Clicked "Copy to clipboard" button!');
   }
 }

--- a/website/docs/components/button/partials/code/showcase.md
+++ b/website/docs/components/button/partials/code/showcase.md
@@ -43,7 +43,7 @@
 
   <h4 class="dummy-h4">Sizes</h4>
   <div class="dummy-button-base-sample">
-    {{#each @model.SIZES as |size|}}
+    {{#each this.SIZES as |size|}}
       <Hds::Button @icon="plus" @text={{capitalize size}} @size={{size}} />
     {{/each}}
     <div class="dummy-button-full-width-container">

--- a/website/docs/components/card/index.js
+++ b/website/docs/components/card/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import {
+  DEFAULT_LEVEL as CONTAINER_DEFAULT_LEVEL,
+  LEVELS as CONTAINER_LEVELS,
+  BACKGROUNDS as CONTAINER_BACKGROUNDS,
+} from '@hashicorp/design-system-components/components/hds/card/container';
+
+export default class Index extends Component {
+  get CONTAINER_DEFAULT_LEVEL() {
+    return CONTAINER_DEFAULT_LEVEL;
+  }
+
+  get CONTAINER_LEVELS() {
+    return CONTAINER_LEVELS;
+  }
+
+  get CONTAINER_BACKGROUNDS() {
+    return CONTAINER_BACKGROUNDS;
+  }
+}

--- a/website/docs/components/card/partials/code/showcase.md
+++ b/website/docs/components/card/partials/code/showcase.md
@@ -3,7 +3,7 @@
   <h4 class="dummy-h4">Elevation:</h4>
   <div class="dummy-card-sample-grid">
     <p class="dummy-paragraph dummy-card-sample-grid__title">"level"</p>
-    {{#each @model.CONTAINER_LEVELS as |level|}}
+    {{#each this.CONTAINER_LEVELS as |level|}}
       <Hds::Card::Container @level={{level}}>
         <Doc::Placeholder @text={{level}} @width="200" @height="200" @background="transparent" />
       </Hds::Card::Container>

--- a/website/docs/components/dropdown/index.js
+++ b/website/docs/components/dropdown/index.js
@@ -21,5 +21,4 @@ export default class Index extends Component {
   get ITEM_INTERACTIVE_COLORS() {
     return ITEM_INTERACTIVE_COLORS;
   }
-
 }

--- a/website/docs/components/dropdown/index.js
+++ b/website/docs/components/dropdown/index.js
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+
+import { COLORS as TOGGLE_BUTTON_COLORS } from '@hashicorp/design-system-components/components/hds/dropdown/toggle/button';
+import { COLORS as ITEM_INTERACTIVE_COLORS } from '@hashicorp/design-system-components/components/hds/dropdown/list-item/interactive';
+
+export default class Index extends Component {
+  get TOGGLE_STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  get TOGGLE_BUTTON_COLORS() {
+    return TOGGLE_BUTTON_COLORS;
+  }
+
+  get ITEM_STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  get ITEM_INTERACTIVE_COLORS() {
+    return ITEM_INTERACTIVE_COLORS;
+  }
+
+}

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -9,7 +9,7 @@ To make the invocation more intuitive for developers, we've provided contextual 
   &lt;dd.Description @text="Lorem ipsum dolor sine qua non est." /&gt;
   &lt;dd.Interactive @href="..." @text="Add" /&gt;
   &lt;dd.Separator /&gt;
-  &lt;dd.Interactive @route="..." @icon="trash" @text="Delete" @color="critical" /&gt;
+  &lt;dd.Interactive @route="components" @icon="trash" @text="Delete" @color="critical" /&gt;
 &lt;/Hds::Dropdown&gt;
 ```
 
@@ -69,12 +69,12 @@ This example demonstrates the use of a dropdown with a toggle-button, links, a s
 ```handlebars
 &lt;Hds::Dropdown as |dd|&gt;
   &lt;dd.ToggleButton @text="Text Toggle" /&gt;
-  &lt;dd.Interactive @route="..." @text="Item One" /&gt;
-  &lt;dd.Interactive @route="..." @text="Item Two" /&gt;
-  &lt;dd.Interactive @route="..." @text="Item Three" /&gt;
+  &lt;dd.Interactive @route="components" @text="Item One" /&gt;
+  &lt;dd.Interactive @route="components" @text="Item Two" /&gt;
+  &lt;dd.Interactive @route="components" @text="Item Three" /&gt;
   &lt;dd.Interactive @text="Item Four (closes on click)" {{on "click" dd.close}} /&gt;
   &lt;dd.Separator /&gt;
-  &lt;dd.Interactive @route="..." @text="Delete" @color="critical" @icon="trash" /&gt;
+  &lt;dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" /&gt;
 &lt;/Hds::Dropdown&gt;
 ```
 
@@ -114,11 +114,11 @@ Note that `toggleText` is still required, because it supplies the `aria-label` f
 ```handlebars
 &lt;Hds::Dropdown as |dd|&gt;
   &lt;dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} /&gt;
-  &lt;dd.Interactive @route="..." @text="Create" /&gt;
-  &lt;dd.Interactive @route="..." @text="Read" /&gt;
-  &lt;dd.Interactive @route="..." @text="Update" /&gt;
+  &lt;dd.Interactive @route="components" @text="Create" /&gt;
+  &lt;dd.Interactive @route="components" @text="Read" /&gt;
+  &lt;dd.Interactive @route="components" @text="Update" /&gt;
   &lt;dd.Separator /&gt;
-  &lt;dd.Interactive @route="..." @text="Delete" @color="critical" @icon="trash" /&gt;
+  &lt;dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" /&gt;
 &lt;/Hds::Dropdown&gt;
 ```
 
@@ -155,8 +155,8 @@ In that case the argument `@isLoading={{true}}` can be passed to the item: this 
 ```handlebars
 &lt;Hds::Dropdown as |dd|&gt;
   &lt;dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} /&gt;
-  &lt;dd.Interactive @route="..." @isLoading={{true}} @text="Edit cluster" @color="action" @icon="edit" /&gt;
-  &lt;dd.Interactive @route="..." @text="Delete" @color="critical" @icon="trash" /&gt;
+  &lt;dd.Interactive @route="components" @isLoading={{true}} @text="Edit cluster" @color="action" @icon="edit" /&gt;
+  &lt;dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" /&gt;
 &lt;/Hds::Dropdown&gt;
 ```
 
@@ -186,8 +186,8 @@ Note that `toggleText` is still required, because it supplies the `aria-label` f
   &lt;dd.Title @text="Signed In" /&gt;
   &lt;dd.Description @text="design-systems@hashicorp.com" /&gt;
   &lt;dd.Separator /&gt;
-  &lt;dd.Interactive @route="..." @text="Settings and Preferences" /&gt;
-  &lt;dd.Interactive @route="..." @text="Delete" @color="critical" @icon="trash" /&gt;
+  &lt;dd.Interactive @route="components" @text="Settings and Preferences" /&gt;
+  &lt;dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" /&gt;
 &lt;/Hds::Dropdown&gt;
 ```
 
@@ -207,8 +207,8 @@ Note that `toggleText` is still required, because it supplies the `aria-label` f
   &lt;dd.Title @text="Signed In" /&gt;
   &lt;dd.Description @text="design-systems@hashicorp.com" /&gt;
   &lt;dd.Separator /&gt;
-  &lt;dd.Interactive @route="..." @text="Settings and Preferences" /&gt;
-  &lt;dd.Interactive @route="..." @text="Delete" @color="critical" @icon="trash" /&gt;
+  &lt;dd.Interactive @route="components" @text="Settings and Preferences" /&gt;
+  &lt;dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" /&gt;
 &lt;/Hds::Dropdown&gt;
 ```
 

--- a/website/docs/components/dropdown/partials/code/showcase.md
+++ b/website/docs/components/dropdown/partials/code/showcase.md
@@ -41,7 +41,7 @@
   </div>
   <h5 class="dummy-h5">States</h5>
   <div class="dummy-dropdown-toggle-states-grid">
-    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
+    {{#each this.TOGGLE_BUTTON_COLORS as |color|}}
       {{#each @model.TOGGLE_STATES as |state|}}
         <div>
           <span class="dummy-text-small">{{color}}/{{state}}:</span>

--- a/website/docs/components/form/base-elements/index.js
+++ b/website/docs/components/form/base-elements/index.js
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class Index extends Component {
+  @tracked showHighlight = false;
+
+  get SAMPLE_ERROR_MESSAGES() {
+    return ['First error message', 'Second error message'];
+  }
+
+  @action
+  toggleHighlight() {
+    this.showHighlight = !this.showHighlight;
+  }
+}

--- a/website/docs/components/form/base-elements/partials/code/how-to-use.md
+++ b/website/docs/components/form/base-elements/partials/code/how-to-use.md
@@ -70,7 +70,7 @@ To implement additional nested components within the helper text, use the block 
 ```handlebars
 <Hds::Form::HelperText @controlId="control-ID">
   Some text with a
-  <Hds::Link::Inline @route="components.link.inline">Hds::Link::Inline</Hds::Link::Inline>,
+  <Hds::Link::Inline @route="show" @model="components/link/inline">Hds::Link::Inline</Hds::Link::Inline>,
   or <code>some formatted code</code> or a <strong>strong message</strong>.
 </Hds::Form::HelperText>
 ```

--- a/website/docs/components/form/base-elements/partials/code/showcase.md
+++ b/website/docs/components/form/base-elements/partials/code/showcase.md
@@ -141,7 +141,7 @@
   <br />
   <span class="dummy-text-small">With multiple error messages</span>
   <Hds::Form::Error as |Error|>
-    {{#each @model.SAMPLE_ERROR_MESSAGES as |message|}}
+    {{#each this.SAMPLE_ERROR_MESSAGES as |message|}}
       <Error.Message>{{message}}</Error.Message>
     {{/each}}
   </Hds::Form::Error>

--- a/website/docs/components/form/checkbox/index.js
+++ b/website/docs/components/form/checkbox/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  @action
+  yourOnChangeFunction() {
+    console.log('Invoked "yourOnChangeFunction"');
+  }
+}

--- a/website/docs/components/form/checkbox/partials/code/how-to-use.md
+++ b/website/docs/components/form/checkbox/partials/code/how-to-use.md
@@ -155,7 +155,7 @@ This can be useful in case you want to add specific native behaviors to the fiel
 Thanks to the `...attributes` spreading over the `<input type="checkbox">` element, you can use as well all the usual Ember techniques for event handling, validation, etc.
 
 ```handlebars
-<Hds::Form::Checkbox::Field {{on "change" myAction}} as |F|>
+<Hds::Form::Checkbox::Field {{on "change" this.yourOnChangeFunction}} as |F|>
   <F.Label>Enable cost estimation</F.Label>
 </Hds::Form::Checkbox::Field>
 ```
@@ -380,19 +380,19 @@ As explained above, a "group" of checkboxes is made of one or more "field" check
 ```handlebars
 <Hds::Form::Checkbox::Group @layout="vertical" as |G|>
   <G.Legend>Valid datacenters</G.Legend>
-  <G.Checkbox::Field name="datacenter1" @id="datacenter-NYC1" @value="NYC1" {{on "change" myAction}} as |F|>
+  <G.Checkbox::Field name="datacenter1" @id="datacenter-NYC1" @value="NYC1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>NYC1</F.Label>
     <F.HelperText>CoreSite- 32 Avenue of the Americas</F.HelperText>
   </G.Checkbox::Field>
-  <G.Checkbox::Field name="datacenter2" @id="datacenter-DC1" checked @value="DC1" {{on "change" myAction}} as |F|>
+  <G.Checkbox::Field name="datacenter2" @id="datacenter-DC1" checked @value="DC1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>DC1</F.Label>
     <F.HelperText>CoreSite- K Street</F.HelperText>
   </G.Checkbox::Field>
-  <G.Checkbox::Field name="datacenter3" @id="datacenter-NYC2" checked @value="NYC2" {{on "change" myAction}} as |F|>
+  <G.Checkbox::Field name="datacenter3" @id="datacenter-NYC2" checked @value="NYC2" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>NYC2</F.Label>
     <F.HelperText>H5 Data Center - 325 Hudson Street</F.HelperText>
   </G.Checkbox::Field>
-  <G.Checkbox::Field name="datacenter4" @id="datacenter-SF1" @value="SF1" {{on "change" myAction}} as |F|>
+  <G.Checkbox::Field name="datacenter4" @id="datacenter-SF1" @value="SF1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>SF1</F.Label>
     <F.HelperText>INAP - 650 Townsend Street</F.HelperText>
   </G.Checkbox::Field>
@@ -434,7 +434,7 @@ To give just an example, this could be an invocation of the "base" component you
   name="enable-cost-estimation"
   aria-label="Enable cost estimation"
   @value="enable"
-  {{on "change" myAction}}
+  {{on "change" this.yourOnChangeFunction}}
 />
 ```
 

--- a/website/docs/components/form/checkbox/partials/code/showcase.md
+++ b/website/docs/components/form/checkbox/partials/code/showcase.md
@@ -17,7 +17,7 @@
   </div>
   <h5 class="dummy-h6">States (Base / Disabled)</h5>
   <div class="dummy-form-checkbox-states-grid">
-    {{#each @model.STATES as |state|}}
+    {{#each this.STATES as |state|}}
       <div>
         <span class="dummy-text-small">{{capitalize state}}:</span>
         <br />

--- a/website/docs/components/form/radio-card/index.js
+++ b/website/docs/components/form/radio-card/index.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-
+import { action } from '@ember/object';
 export default class Index extends Component {
   get STATES() {
     // these are used only for presentation purpose in the showcase

--- a/website/docs/components/form/radio-card/index.js
+++ b/website/docs/components/form/radio-card/index.js
@@ -1,0 +1,48 @@
+import Component from '@glimmer/component';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus', 'disabled'];
+  }
+
+  get RADIOCARDS() {
+    return [
+      {
+        value: '1',
+        label: 'Radio card label 1',
+        badge: 'Badge',
+        checked: true,
+        description: 'Radio card description 1',
+        generic: 'Radio card custom content 1',
+      },
+      {
+        value: '2',
+        label: 'Radio card label 2',
+        badge: 'Badge',
+        description: 'Radio card description 2',
+        generic: 'Radio card custom content 2',
+      },
+      {
+        value: '3',
+        label: 'Radio card label 3',
+        badge: 'Badge',
+        description: 'Radio card description 3',
+        generic: 'Radio card custom content 3',
+      },
+    ];
+  }
+
+  // TODO this is used by us; but there should be also one with `yourOnChangeFunction` for the "how to use" section
+  @action
+  onChange(event) {
+    const control = event.target;
+    const group = control.closest('.hds-form-group__control-fields-wrapper');
+    group.querySelectorAll('.hds-form-radio-card').forEach((radioCard) => {
+      radioCard.classList.remove('hds-form-radio-card--checked');
+    });
+    control
+      .closest('.hds-form-radio-card')
+      .classList.add('hds-form-radio-card--checked');
+  }
+}

--- a/website/docs/components/form/radio-card/partials/code/showcase.md
+++ b/website/docs/components/form/radio-card/partials/code/showcase.md
@@ -3,7 +3,7 @@
 
   <h4 class="dummy-h4">States</h4>
   <div class="dummy-form-radio-card-states-grid">
-    {{#each @model.STATES as |state|}}
+    {{#each this.STATES as |state|}}
       <div>
         <span class="dummy-text-small">{{capitalize state}}</span>
         <br />

--- a/website/docs/components/form/radio/index.js
+++ b/website/docs/components/form/radio/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  @action
+  yourOnChangeFunction() {
+    console.log('Invoked "yourOnChangeFunction"');
+  }
+}

--- a/website/docs/components/form/radio/partials/code/how-to-use.md
+++ b/website/docs/components/form/radio/partials/code/how-to-use.md
@@ -193,19 +193,19 @@ As explained above, a "group" of radios is made of one or more "field" radio com
 ```handlebars
 <Hds::Form::Radio::Group @layout="vertical" @name="datacenter-demo5" as |G|>
   <G.Legend>Choose datacenter</G.Legend>
-  <G.Radio::Field @id="datacenter-NYC1" checked @value="NYC1" {{on "change" myAction}} as |F|>
+  <G.Radio::Field @id="datacenter-NYC1" checked @value="NYC1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>NYC1</F.Label>
     <F.HelperText>CoreSite- 32 Avenue of the Americas</F.HelperText>
   </G.Radio::Field>
-  <G.Radio::Field @id="datacenter-DC1" @value="DC1" {{on "change" myAction}} as |F|>
+  <G.Radio::Field @id="datacenter-DC1" @value="DC1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>DC1</F.Label>
     <F.HelperText>CoreSite- K Street</F.HelperText>
   </G.Radio::Field>
-  <G.Radio::Field @id="datacenter-NYC2" @value="NYC2" {{on "change" myAction}} as |F|>
+  <G.Radio::Field @id="datacenter-NYC2" @value="NYC2" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>NYC1</F.Label>
     <F.HelperText>H5 Data Center - 325 Hudson Street</F.HelperText>
   </G.Radio::Field>
-  <G.Radio::Field @id="datacenter-SF1" @value="SF1" {{on "change" myAction}} as |F|>
+  <G.Radio::Field @id="datacenter-SF1" @value="SF1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>SF1</F.Label>
     <F.HelperText>INAP - 650 Townsend Street</F.HelperText>
   </G.Radio::Field>
@@ -229,7 +229,7 @@ To give just an example, this could be an invocation of the "base" component you
   name="data-center"
   aria-label="San Francisco datacenter number 1"
   @value="SF1"
-  {{on "change" myAction}}
+  {{on "change" this.yourOnChangeFunction}}
 />
 ```
 
@@ -240,7 +240,7 @@ This "base" component creates just the `<input type="radio">` control with an au
 Similarly, this could be an invocation of the "field" component:
 
 ```handlebars
-<Hds::Form::Radio::Field name="data-center" @value="SF1" {{on "change" myAction}} as |F|>
+<Hds::Form::Radio::Field name="data-center" @value="SF1" {{on "change" this.yourOnChangeFunction}} as |F|>
   <F.Label>SF1</F.Label>
 </Hds::Form::Radio::Field>
 ```

--- a/website/docs/components/form/radio/partials/code/showcase.md
+++ b/website/docs/components/form/radio/partials/code/showcase.md
@@ -17,7 +17,7 @@
   </div>
   <h5 class="dummy-h6">States (Base / Disabled)</h5>
   <div class="dummy-form-radio-states-grid">
-    {{#each @model.STATES as |state|}}
+    {{#each this.STATES as |state|}}
       <div>
         <span class="dummy-text-small">{{capitalize state}}:</span>
         <br />

--- a/website/docs/components/form/select/index.js
+++ b/website/docs/components/form/select/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  @action
+  yourOnBlurFunction() {
+    console.log('Invoked "yourOnBlurFunction"');
+  }
+}

--- a/website/docs/components/form/select/partials/code/how-to-use.md
+++ b/website/docs/components/form/select/partials/code/how-to-use.md
@@ -240,7 +240,7 @@ This can be useful in case you want to add specific native behaviors to the fiel
 Thanks to the `...attributes` spreading over the `<select>` element, you can use as well all the usual Ember techniques for event handling, validation, etc.
 
 ```handlebars
-<Hds::Form::Select::Field {{on "blur" myAction}} as |F|>
+<Hds::Form::Select::Field {{on "blur" this.yourOnBlurFunction}} as |F|>
   <F.Label>Target infrastructure</F.Label>
   <F.Options>
     <option value=""></option>
@@ -283,7 +283,7 @@ Note: when the "base" select is used, the developer is completely responsible fo
 To give just an example, this could be an invocation of the "base" component you would use:
 
 ```handlebars
-<Hds::Form::Select::Base aria-label="Target infrastructure" @isRequired={{true}} {{on "blur" myAction}} as |S|>
+<Hds::Form::Select::Base aria-label="Target infrastructure" @isRequired={{true}} {{on "blur" this.yourOnBlurFunction}} as |S|>
   <S.Options>
     <option value="Kubernetes">Kubernetes</option>
     <option value="Other">Other</option>

--- a/website/docs/components/form/select/partials/code/showcase.md
+++ b/website/docs/components/form/select/partials/code/showcase.md
@@ -19,7 +19,7 @@
   <div class="dummy-form-select-grid-sample">
     {{#let (array "base" "invalid" "disabled") as |variants|}}
       {{#each variants as |variant|}}
-        {{#each @model.STATES as |state|}}
+        {{#each this.STATES as |state|}}
           {{! template-lint-disable simple-unless }}
           {{#unless (and (eq variant "disabled") (eq state "focus"))}}
             <div>

--- a/website/docs/components/form/text-input/index.js
+++ b/website/docs/components/form/text-input/index.js
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+import { TYPES } from '@hashicorp/design-system-components/components/hds/form/text-input/base';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  get TYPES() {
+    return TYPES;
+  }
+
+  @action
+  yourOnBlurFunction() {
+    console.log('Invoked "yourOnBlurFunction"');
+  }
+}

--- a/website/docs/components/form/text-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/text-input/partials/code/how-to-use.md
@@ -197,7 +197,7 @@ This can be useful in case you want to add specific native behaviors to the fiel
 Thanks to the `...attributes` spreading over the `<input>` element, you can use as well all the usual Ember techniques for event handling, validation, etc.
 
 ```handlebars
-<Hds::Form::TextInput::Field @type="email" placeholder="eg. name.surname@email.com" {{on "blur" myAction}} as |F|>
+<Hds::Form::TextInput::Field @type="email" placeholder="eg. name.surname@email.com" {{on "blur" this.yourOnBlurFunction}} as |F|>
   <F.Label>Email</F.Label>
 </Hds::Form::TextInput::Field>
 ```
@@ -237,7 +237,7 @@ To give just an example, this could be an invocation of the "base" component you
   aria-label="User email"
   placeholder="eg. name.surname@email.com"
   @isRequired={{true}}
-  {{on "blur" myAction}}
+  {{on "blur" this.yourOnBlurFunction}}
 />
 ```
 

--- a/website/docs/components/form/text-input/partials/code/showcase.md
+++ b/website/docs/components/form/text-input/partials/code/showcase.md
@@ -22,7 +22,7 @@
   </div>
   <h5 class="dummy-h5">Types (native)</h5>
   <div class="dummy-form-text-input-types-grid">
-    {{#each @model.TYPES as |type|}}
+    {{#each this.TYPES as |type|}}
       <div>
         <span class="dummy-text-small">{{capitalize type}}:</span>
         <br />

--- a/website/docs/components/form/textarea/index.js
+++ b/website/docs/components/form/textarea/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  @action
+  yourOnBlurFunction() {
+    console.log('Invoked "yourOnBlurFunction"');
+  }
+}

--- a/website/docs/components/form/textarea/partials/code/how-to-use.md
+++ b/website/docs/components/form/textarea/partials/code/how-to-use.md
@@ -177,7 +177,7 @@ This can be useful in case you want to add specific native behaviors to the fiel
 Thanks to the `...attributes` spreading over the `<textarea>` element, you can use as well all the usual Ember techniques for event handling, validation, etc.
 
 ```handlebars
-<Hds::Form::Textarea::Field placeholder="Workspace description" {{on "blur" myAction}} as |F|>
+<Hds::Form::Textarea::Field placeholder="Workspace description" {{on "blur" this.yourOnBlurFunction}} as |F|>
   <F.Label>Email</F.Label>
 </Hds::Form::Textarea::Field>
 ```
@@ -216,7 +216,7 @@ To give just an example, this could be an invocation of the "base" component you
   aria-label="Short description"
   placeholder="Workspace description"
   @isRequired={{true}}
-  {{on "blur" myAction}}
+  {{on "blur" this.yourOnBlurFunction}}
 />
 ```
 

--- a/website/docs/components/form/textarea/partials/code/showcase.md
+++ b/website/docs/components/form/textarea/partials/code/showcase.md
@@ -24,7 +24,7 @@
   <div class="dummy-form-textarea-grid-sample">
     {{#let (array "base" "invalid" "readonly" "disabled") as |variants|}}
       {{#each variants as |variant|}}
-        {{#each @model.STATES as |state|}}
+        {{#each this.STATES as |state|}}
           {{! template-lint-disable simple-unless }}
           {{#unless (and (eq variant "disabled") (eq state "focus"))}}
             <div>

--- a/website/docs/components/form/toggle/index.js
+++ b/website/docs/components/form/toggle/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'focus'];
+  }
+
+  @action
+  yourOnChangeFunction() {
+    console.log('Invoked "yourOnChangeFunction"');
+  }
+}

--- a/website/docs/components/form/toggle/partials/code/how-to-use.md
+++ b/website/docs/components/form/toggle/partials/code/how-to-use.md
@@ -155,7 +155,7 @@ This can be useful in case you want to add specific native behaviors to the fiel
 Thanks to the `...attributes` spreading over the `<input type="checkbox">` element, you can use as well all the usual Ember techniques for event handling, validation, etc.
 
 ```handlebars
-<Hds::Form::Toggle::Field {{on "change" myAction}} as |F|>
+<Hds::Form::Toggle::Field {{on "change" this.yourOnChangeFunction}} as |F|>
   <F.Label>Enable cost estimation</F.Label>
 </Hds::Form::Toggle::Field>
 ```
@@ -205,7 +205,7 @@ To give just an example, this could be an invocation of the "base" component you
   name="enable-cost-estimation"
   aria-label="Enable cost estimation"
   @value="enable"
-  {{on "change" myAction}}
+  {{on "change" this.yourOnChangeFunction}}
 />
 ```
 

--- a/website/docs/components/form/toggle/partials/code/showcase.md
+++ b/website/docs/components/form/toggle/partials/code/showcase.md
@@ -17,7 +17,7 @@
   </div>
   <h5 class="dummy-h6">States (Base / Disabled)</h5>
   <div class="dummy-form-toggle-states-grid">
-    {{#each @model.STATES as |state|}}
+    {{#each this.STATES as |state|}}
       <div>
         <span class="dummy-text-small">{{capitalize state}}:</span>
         <br />

--- a/website/docs/components/icon-tile/index.js
+++ b/website/docs/components/icon-tile/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import {
+  SIZES,
+  COLORS,
+  PRODUCTS,
+} from '@hashicorp/design-system-components/components/hds/icon-tile';
+
+export default class Index extends Component {
+  get SIZES() {
+    return SIZES;
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+
+  get PRODUCTS() {
+    return PRODUCTS;
+  }
+}

--- a/website/docs/components/icon-tile/partials/code/showcase.md
+++ b/website/docs/components/icon-tile/partials/code/showcase.md
@@ -5,7 +5,7 @@
     <li>
       <p class="dummy-paragraph">With logo</p>
       <div class="dummy-icon-tile-base-sample">
-        {{#each @model.SIZES as |size|}}
+        {{#each this.SIZES as |size|}}
           <Hds::IconTile @logo="boundary" @size={{size}} />
         {{/each}}
       </div>

--- a/website/docs/components/link/inline/index.js
+++ b/website/docs/components/link/inline/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+import { COLORS } from '@hashicorp/design-system-components/components/hds/link/inline';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+}

--- a/website/docs/components/link/inline/partials/code/showcase.md
+++ b/website/docs/components/link/inline/partials/code/showcase.md
@@ -23,7 +23,7 @@
         <code class="dummy-code">&lt;a&gt;</code></span>
       <br />
       <div class="hds-typography-body-300">
-        <Hds::Link::Inline @color="primary" @route="index">Lorem ipsum dolor</Hds::Link::Inline>
+        <Hds::Link::Inline @color="primary" @route="components">Lorem ipsum dolor</Hds::Link::Inline>
       </div>
     </div>
   </div>
@@ -101,7 +101,7 @@
     States
   </h4>
   <div class="dummy-link-inline-states-grid">
-    {{#each @model.COLORS as |color|}}
+    {{#each this.COLORS as |color|}}
       <h5 class="dummy-h5 dummy-link-inline-states-grid__title">{{capitalize color}}</h5>
       {{#each @model.STATES as |state|}}
         <div>

--- a/website/docs/components/link/standalone/index.js
+++ b/website/docs/components/link/standalone/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import {
+  COLORS,
+  SIZES,
+} from '@hashicorp/design-system-components/components/hds/link/standalone';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+
+  get SIZES() {
+    return SIZES;
+  }
+}

--- a/website/docs/components/link/standalone/partials/code/showcase.md
+++ b/website/docs/components/link/standalone/partials/code/showcase.md
@@ -20,7 +20,7 @@
         ⇒
         <code class="dummy-code">&lt;a&gt;</code></span>
       <br />
-      <Hds::Link::Standalone @icon="plus" @text="Lorem ipsum dolor" @color="primary" @route="index" />
+      <Hds::Link::Standalone @icon="plus" @text="Lorem ipsum dolor" @color="primary" @route="components" />
     </div>
   </div>
 
@@ -45,8 +45,8 @@
     Sizes
   </h4>
   <div class="dummy-link-standalone-base-sample">
-    {{#each @model.SIZES as |size|}}
-      <Hds::Link::Standalone @icon="plus" @text={{capitalize size}} @size={{size}} @route="components.link" />
+    {{#each this.SIZES as |size|}}
+      <Hds::Link::Standalone @icon="plus" @text={{capitalize size}} @size={{size}} @route="components" />
     {{/each}}
   </div>
   <h4 class="dummy-h4">

--- a/website/docs/components/modal/index.js
+++ b/website/docs/components/modal/index.js
@@ -1,0 +1,55 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import {
+  COLORS,
+  SIZES,
+} from '@hashicorp/design-system-components/components/hds/modal';
+
+export default class Index extends Component {
+  @tracked basicModalActive = false;
+  @tracked formModalActive = false;
+  @tracked isModalDismissDisabled = false;
+
+  get SIZES() {
+    return SIZES;
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
+
+  @action
+  activateModal(modal) {
+    this.isModalDismissDisabled = false;
+    this[modal] = true;
+    document.body.style.overflow = 'hidden';
+  }
+
+  @action
+  deactivateModal(modal) {
+    this.isModalDismissDisabled = false;
+    this[modal] = false;
+    document.body.style.overflow = 'auto';
+  }
+
+  @action markFormAsChanged() {
+    this.isModalDismissDisabled = true;
+  }
+
+  @action saveFormAndClose(modal) {
+    this.isModalDismissDisabled = false;
+    this.deactivateModal(modal);
+  }
+
+  @action checkBeforeDeactivate(modal) {
+    if (this.isModalDismissDisabled) {
+      if (window.confirm('Changes that you made may not be saved')) {
+        this.deactivateModal(modal);
+      }
+    } else {
+      this.deactivateModal(modal);
+    }
+  }
+}

--- a/website/docs/components/modal/partials/code/showcase.md
+++ b/website/docs/components/modal/partials/code/showcase.md
@@ -2,7 +2,7 @@
   
 
   <h4 class="dummy-h4">Size</h4>
-  {{#each @model.SIZES as |size|}}
+  {{#each this.SIZES as |size|}}
     <p class="dummy-paragraph">{{capitalize size}}</p>
     <br />
     <div class="dummy-modal-sample-item">

--- a/website/docs/components/stepper/index.js
+++ b/website/docs/components/stepper/index.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+import { STATUSES as STEP_STATUSES } from '@hashicorp/design-system-components/components/hds/stepper/step/indicator';
+import { STATUSES as TASK_STATUSES } from '@hashicorp/design-system-components/components/hds/stepper/task/indicator';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active'];
+  }
+
+  get STEP_STATUSES() {
+    return STEP_STATUSES;
+  }
+
+  get TASK_STATUSES() {
+    return TASK_STATUSES;
+  }
+}

--- a/website/docs/components/stepper/partials/code/showcase.md
+++ b/website/docs/components/stepper/partials/code/showcase.md
@@ -3,7 +3,7 @@
   <h4 class="dummy-h4">Status</h4>
   <h5 class="dummy-h5">Default</h5>
   <div class="dummy-stepper-indicator-grid">
-    {{#each @model.STEP_STATUSES as |status|}}
+    {{#each this.STEP_STATUSES as |status|}}
       <div>
         <span class="dummy-text-small">{{capitalize status}}</span>
         <br />

--- a/website/docs/components/table/index.js
+++ b/website/docs/components/table/index.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['active', 'default', 'hover', 'focus'];
+  }
+  //
+  // TODO! move also the data fetching here
+  //
+}

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -182,3 +182,48 @@ You can also indicate that a specific column should be pre-sorted in a specific 
   </:body>
 </Hds::Table>
 ```
+
+Here's a table implementation that uses an array hash with localized strings for the column headers, indicates which columns should be sortable, and adds an overflow menu.
+
+```handlebars
+<!-- app/templates/components/table.hbs -->
+
+<Hds::Table
+  @model={{this.model.data}}
+  @columns={{array
+      (hash key='artist' label=(t 'components.table.headers.artist'))
+      (hash key='album' label=(t 'components.table.headers.album'))
+      (hash key='year' label=(t 'components.table.headers.year'))
+      (hash key='other' label=(t 'global.titles.other'))
+    }}
+  @sortingKeys={{array 'artist' 'album' 'year'}}
+>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
+      <B.Td>
+          <Hds::Dropdown as |dd|>
+            <dd.ToggleIcon
+              @icon='more-horizontal'
+              @text='Overflow Options'
+              @hasChevron={{false}}
+              @size='small'
+            />
+            <dd.Interactive @route='components.table' @text='Create' />
+            <dd.Interactive @route='components.table' @text='Read' />
+            <dd.Interactive @route='components.table' @text='Update' />
+            <dd.Separator />
+            <dd.Interactive
+              @route='components.table'
+              @text='Delete'
+              @color='critical'
+              @icon='trash'
+            />
+          </Hds::Dropdown>
+        </B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>
+```

--- a/website/docs/components/table/partials/code/showcase.md
+++ b/website/docs/components/table/partials/code/showcase.md
@@ -4,7 +4,7 @@
   <Hds::Table>
     <:head>
       <Hds::Table::Tr>
-        {{#each @model.STATES as |state|}}
+        {{#each this.STATES as |state|}}
           <Hds::Table::ThSort mock-state-value={{state}} mock-state-selector="button">
             {{capitalize state}}
           </Hds::Table::ThSort>

--- a/website/docs/components/tabs/index.js
+++ b/website/docs/components/tabs/index.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 
 import { COLORS } from '@hashicorp/design-system-components/components/hds/tag';
 

--- a/website/docs/components/tabs/index.js
+++ b/website/docs/components/tabs/index.js
@@ -2,8 +2,17 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+import { COLORS } from '@hashicorp/design-system-components/components/hds/tag';
+
 export default class Index extends Component {
-  @tracked showHighlight = false;
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  get COLORS() {
+    return COLORS;
+  }
 
   @action
   toggleHighlight() {

--- a/website/docs/components/tabs/index.js
+++ b/website/docs/components/tabs/index.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class Index extends Component {
+  @tracked showHighlight = false;
+
+  @action
+  toggleHighlight() {
+    this.showHighlight = !this.showHighlight;
+  }
+
+  @action
+  logClickedTab(event) {
+    const tabId = event.target.id;
+    console.log(`Tab with ID "${tabId}" clicked!`);
+  }
+}

--- a/website/docs/components/tag/index.js
+++ b/website/docs/components/tag/index.js
@@ -1,9 +1,14 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class Index extends Component {
-  get yourOnDismissFunction() {
-    return () => {
-      console.log('Clicked the "dismiss" button in the "tag"!');
-    };
+  @action
+  noop() {
+    //
+  }
+
+  @action
+  yourOnDismissFunction() {
+    console.log('Clicked the "dismiss" button in the "toast"!');
   }
 }

--- a/website/docs/components/tag/partials/code/how-to-use.md
+++ b/website/docs/components/tag/partials/code/how-to-use.md
@@ -17,7 +17,7 @@ Renders to:
 There are two available colors for a link: `primary` and `secondary`. The default is `primary`.
 
 ```handlebars
-<Hds::Tag @color="primary" @text="My link tag" @href="#" @onDismiss={{this.yourOnDismissFunction}} />
+<Hds::Tag @color="primary" @text="My link tag" @route="show" @model="components/tag" @onDismiss={{this.yourOnDismissFunction}} />
 ```
 
 Renders to:
@@ -27,7 +27,7 @@ Renders to:
 In most cases the tag needs to be dismissable. If you don't provide a callback function to the `onDismiss` argument the "dismiss/remove" button will not be rendered.
 
 ```handlebars
-<Hds::Tag @color="primary" @text="My link tag" @href="#" />
+<Hds::Tag @color="primary" @text="My link tag" @route="show" @model="components/tag" />
 ```
 
 Renders to:

--- a/website/docs/components/tag/partials/code/showcase.md
+++ b/website/docs/components/tag/partials/code/showcase.md
@@ -4,8 +4,8 @@
   <div class="dummy-tag-base-sample">
     <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
     <Hds::Tag @text="My text tag" />
-    <Hds::Tag @text="My link tag" @onDismiss={{this.noop}} @route="components.tag" />
-    <Hds::Tag @text="My link tag" @route="components.tag" />
+    <Hds::Tag @text="My link tag" @onDismiss={{this.noop}} @route="show" @model="components/tag" />
+    <Hds::Tag @text="My link tag" @route="show" @model="components/tag" />
   </div>
   <div class="dummy-tag-base-sample">
     <p>This is a paragraph: <Hds::Tag @text="My text tag" /></p>
@@ -13,7 +13,7 @@
 
   <h4 class="dummy-h4">States</h4>
   <div class="dummy-tag-states-grid">
-    {{#each @model.STATES as |state|}}
+    {{#each this.STATES as |state|}}
       <div>
         <span class="dummy-text-small">{{capitalize state}}:</span>
         <br />
@@ -34,7 +34,7 @@
               @color={{color}}
               @text="My link tag"
               @onDismiss={{this.noop}}
-              @route="components.tag"
+              @route="show" @model="components/tag"
               mock-state-value={{state}}
               mock-state-selector="button"
             />
@@ -42,14 +42,14 @@
               @color={{color}}
               @text="My link tag"
               @onDismiss={{this.noop}}
-              @route="components.tag"
+              @route="show" @model="components/tag"
               mock-state-value={{state}}
               mock-state-selector="a"
             />
             <Hds::Tag
               @color={{color}}
               @text="My link tag"
-              @route="components.tag"
+              @route="show" @model="components/tag"
               mock-state-value={{state}}
               mock-state-selector="a"
             />

--- a/website/docs/components/toast/index.js
+++ b/website/docs/components/toast/index.js
@@ -1,19 +1,26 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+// the "Toast" is built on top of the "Alert" so it shares the same colors
+import { COLORS } from '@hashicorp/design-system-components/components/hds/alert';
 
 export default class Index extends Component {
-  get noop() {
-    return () => {};
+  get COLORS() {
+    return COLORS;
   }
 
-  get yourOnDismissFunction() {
-    return () => {
-      console.log('Clicked the "dismiss" button in the "toast"!');
-    };
+  @action
+  noop() {
+    //
   }
 
-  get yourOnClickFunction() {
-    return () => {
-      console.log('Clicked the button in the "tag"!');
-    };
+  @action
+  yourOnDismissFunction() {
+    console.log('Clicked the "dismiss" button in the "toast"!');
+  }
+
+  @action
+  yourOnClickFunction() {
+    console.log('Clicked the button in the "tag"!');
   }
 }

--- a/website/docs/components/toast/partials/code/how-to-use.md
+++ b/website/docs/components/toast/partials/code/how-to-use.md
@@ -3,7 +3,7 @@
 The most basic invocation requires the `type` arguments to be passed, and an `onDismiss` callback function, along with the `title` and/or `description` content. By default a `neutral` toast is generated (with a neutral color applied and a specific icon visible).
 
 ```handlebars
-<Hds::Toast @onDismiss={{ your function here }} as |T|>
+<Hds::Toast @onDismiss={{this.yourOnDismissFunction}} as |T|>
   <T.Title>Title here</T.Title>
   <T.Description>Description here</T.Description>
 </Hds::Toast>
@@ -87,7 +87,7 @@ Actions can optionally be passed into the component using one of the suggested `
   <T.Title>Title here</T.Title>
   <T.Description>Description here</T.Description>
   <T.Button @text="Your action" @color="secondary" @onClick={{this.yourOnClickFunction}} />
-  <T.Link::Standalone @color="secondary" @icon="plus" @text="Another action" @route="..." @color="secondary" />
+  <T.Link::Standalone @color="secondary" @icon="plus" @text="Another action" @route="components" @color="secondary" />
 </Hds::Toast>
 ```
 

--- a/website/docs/components/toast/partials/code/showcase.md
+++ b/website/docs/components/toast/partials/code/showcase.md
@@ -3,7 +3,7 @@
 
   <h4 class="dummy-h4">Color</h4>
   <div class="dummy-toast-base-sample">
-    {{#each @model.COLORS as |color|}}
+    {{#each this.COLORS as |color|}}
       <Hds::Toast @color={{color}} @onDismiss={{this.noop}} as |T|>
         <T.Title>{{capitalize color}}</T.Title>
         <T.Description>This is the toast with <em>{{color}}</em> color.</T.Description>

--- a/website/docs/components/toast/partials/specifications/design-guidelines.js
+++ b/website/docs/components/toast/partials/specifications/design-guidelines.js
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class DesignGuidelines extends Component {
-  get noop() {
-    return () => {};
+  @action
+  noop() {
+    //
   }
 }

--- a/website/docs/foundations/colors/index.js
+++ b/website/docs/foundations/colors/index.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
-import TOKENS_RAW from '../../../../packages/tokens/dist/docs/products/tokens.json';
+import TOKENS_RAW from '@hashicorp/design-system-tokens/dist/docs/products/tokens.json';
 
 export default class Colors extends Component {
   get colors() {

--- a/website/docs/foundations/colors/partials/other/generic-2.md
+++ b/website/docs/foundations/colors/partials/other/generic-2.md
@@ -6,7 +6,7 @@
   <p class="dummy-paragraph">Use for text and icons.</p>
   <div class="dummy-colors-list">
     {{#each this.colors.semantic.foreground as |color|}}
-      <DummyColorCard @color={{color}} />
+      <Doc::ColorCard @color={{color}} />
     {{else}}
       <p class="dummy-paragraph">No tokens found for "semantic/foreground" colors 🤷‍♀️</p>
     {{/each}}
@@ -16,7 +16,7 @@
   <p class="dummy-paragraph">Use for container and component backgrounds.</p>
   <div class="dummy-colors-list">
     {{#each this.colors.semantic.surface as |color|}}
-      <DummyColorCard @color={{color}} />
+      <Doc::ColorCard @color={{color}} />
     {{else}}
       <p class="dummy-paragraph">No tokens found for "semantic/surface" colors 🤷‍♀️</p>
     {{/each}}
@@ -27,7 +27,7 @@
     rules.</p>
   <div class="dummy-colors-list">
     {{#each this.colors.semantic.border as |color|}}
-      <DummyColorCard @color={{color}} />
+      <Doc::ColorCard @color={{color}} />
     {{else}}
       <p class="dummy-paragraph">No tokens found for "semantic/border" colors 🤷‍♀️</p>
     {{/each}}
@@ -39,7 +39,7 @@
     <em>Notice: they're used internally by the design system to define focus states</em>.</p>
   <div class="dummy-colors-list">
     {{#each this.colors.semantic.focus as |color|}}
-      <DummyColorCard @color={{color}} />
+      <Doc::ColorCard @color={{color}} />
     {{else}}
       <p class="dummy-paragraph">No tokens found for "semantic/focus" colors 🤷‍♀️</p>
     {{/each}}
@@ -49,7 +49,7 @@
   <p class="dummy-paragraph">Use for page backgrounds.</p>
   <div class="dummy-colors-list">
     {{#each this.colors.semantic.page as |color|}}
-      <DummyColorCard @color={{color}} />
+      <Doc::ColorCard @color={{color}} />
     {{else}}
       <p class="dummy-paragraph">No tokens found for "semantic/page" colors 🤷‍♀️</p>
     {{/each}}
@@ -60,7 +60,7 @@
     <h4 class="dummy-h4">{{capitalize brand}}</h4>
     <div class="dummy-colors-list">
       {{#each colorsList as |color|}}
-        <DummyColorCard @color={{color}} />
+        <Doc::ColorCard @color={{color}} />
       {{/each}}
     </div>
   {{else}}
@@ -74,7 +74,7 @@
     <h4 class="dummy-h4">{{capitalize tone}}</h4>
     <div class="dummy-colors-list">
       {{#each colorsList as |color|}}
-        <DummyColorCard @color={{color}} />
+        <Doc::ColorCard @color={{color}} />
       {{/each}}
     </div>
   {{else}}

--- a/website/docs/foundations/elevation/index.js
+++ b/website/docs/foundations/elevation/index.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+
+const ELEVATIONS = ['inset', 'low', 'mid', 'high', 'higher', 'overlay'];
+const SURFACES = ['inset', 'base', 'low', 'mid', 'high', 'higher', 'overlay'];
+
+export default class Index extends Component {
+  get cssVariables() {
+    const cssVariables = { elevations: [], surfaces: [] };
+    ELEVATIONS.forEach((elevation) => {
+      cssVariables.elevations.push(`--hds-elevation-${elevation}-box-shadow`);
+    });
+    SURFACES.forEach((surface) => {
+      cssVariables.surfaces.push(`--hds-surface-${surface}-box-shadow`);
+    });
+    return cssVariables;
+  }
+  get cssHelpers() {
+    const cssHelpers = { elevations: [], surfaces: [] };
+    ELEVATIONS.forEach((elevation) => {
+      cssHelpers.elevations.push(`.hds-elevation-${elevation}`);
+    });
+    SURFACES.forEach((surface) => {
+      cssHelpers.surfaces.push(`.hds-surface-${surface}`);
+    });
+    return cssHelpers;
+  }
+}

--- a/website/docs/foundations/elevation/partials/code/showcase.md
+++ b/website/docs/foundations/elevation/partials/code/showcase.md
@@ -3,7 +3,7 @@
   <h4 class="dummy-h4">Elevation:</h4>
   <p class="dummy-paragraph">Standalone shadow effects</p>
   <div class="dummy-elevation-sample">
-    {{#each @model.ELEVATIONS as |elevation|}}
+    {{#each this.ELEVATIONS as |elevation|}}
       <div class="hds-elevation-{{elevation}}">
         <Doc::Placeholder @text={{elevation}} @width="100" @height="100" @background="transparent" />
       </div>

--- a/website/docs/foundations/tokens/index.js
+++ b/website/docs/foundations/tokens/index.js
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+
+import TOKENS_RAW from '@hashicorp/design-system-tokens/dist/docs/products/tokens.json';
+
+export default class Index extends Component {
+  get groupedTokens() {
+    const groupedTokens = {};
+
+    TOKENS_RAW.forEach((token) => {
+      const category = token.attributes.category;
+      if (!groupedTokens[category]) {
+        groupedTokens[category] = [];
+      }
+
+      groupedTokens[category].push(token);
+    });
+
+    return groupedTokens;
+  }
+}

--- a/website/docs/foundations/tokens/partials/other/generic-2.md
+++ b/website/docs/foundations/tokens/partials/other/generic-2.md
@@ -6,7 +6,7 @@
     <h4 class="dummy-h4">{{capitalize category}}</h4>
     <div class="dummy-tokens-list">
       {{#each categoryList as |token|}}
-        <DummyToken @token={{token}} />
+        <Doc::TokenCard @token={{token}} />
       {{/each}}
     </div>
   {{else}}

--- a/website/docs/foundations/typography/index.js
+++ b/website/docs/foundations/typography/index.js
@@ -1,0 +1,59 @@
+import Component from '@glimmer/component';
+
+const FONT_FAMILIES = ['sans-display', 'sans-text', 'mono-code'];
+const FONT_WEIGHTS = ['regular', 'medium', 'semibold', 'bold'];
+const DISPLAY_STYLES = [
+  'display-500',
+  'display-400',
+  'display-300',
+  'display-200',
+  'display-100',
+];
+const BODY_STYLES = ['body-300', 'body-200', 'body-100'];
+const CODE_STYLES = ['code-300', 'code-200', 'code-100'];
+// we add all the allowed combinations here, per design specs
+const STYLES_COMBINATIONS = {
+  'display-500': ['bold'],
+  'display-400': ['medium', 'semibold', 'bold'],
+  'display-300': ['medium', 'semibold', 'bold'],
+  'display-200': ['semibold'],
+  'display-100': ['medium'],
+  'body-300': ['regular', 'medium', 'semibold'],
+  'body-200': ['regular', 'medium', 'semibold'],
+  'body-100': ['regular', 'medium', 'semibold'],
+  'code-300': ['regular', 'bold'],
+  'code-200': ['regular', 'bold'],
+  'code-100': ['regular', 'bold'],
+};
+
+export default class Index extends Component {
+  get families() {
+    return [...FONT_FAMILIES];
+  }
+  get weights() {
+    return [...FONT_WEIGHTS];
+  }
+  get styles() {
+    return [...DISPLAY_STYLES, ...BODY_STYLES, ...CODE_STYLES];
+  }
+  get stylesCombinations() {
+    return STYLES_COMBINATIONS;
+  }
+  get cssHelpers() {
+    const cssHelpers = {
+      families: [],
+      weights: [],
+      styles: [],
+    };
+    this.families.forEach((family) => {
+      cssHelpers.families.push(`.hds-font-family-${family}`);
+    });
+    this.weights.forEach((weight) => {
+      cssHelpers.weights.push(`.hds-font-weight-${weight}`);
+    });
+    this.styles.forEach((style) => {
+      cssHelpers.styles.push(`.hds-typography-${style}`);
+    });
+    return cssHelpers;
+  }
+}

--- a/website/docs/overrides/power-select/index.js
+++ b/website/docs/overrides/power-select/index.js
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get OPTIONS() {
+    return [
+      'Oregon (us-west-2)',
+      'N. Virginia (us-east-1)',
+      'Ireland (eu-west-1)',
+      'London (eu-west-2)',
+      'Frankfurt (eu-central-1)',
+    ];
+  }
+
+  get SELECTED() {
+    return ['Oregon (us-west-2)'];
+  }
+
+  get SELECTEDMULTIPLE() {
+    return [
+      'Oregon (us-west-2)',
+      'N. Virginia (us-east-1)',
+      'Ireland (eu-west-1)',
+    ];
+  }
+
+  // notice: this is used as "noop" function for the onDismiss callback of the PowerSelect component
+  @action
+  noop() {
+    //
+  }
+}

--- a/website/docs/overrides/power-select/partials/code/showcase.md
+++ b/website/docs/overrides/power-select/partials/code/showcase.md
@@ -7,7 +7,7 @@
   <div class="dummy-power-select-container">
     <div class="hds-power-select">
       <PowerSelect
-        @options={{@model.OPTIONS}}
+        @options={{this.OPTIONS}}
         @selected={{@model.SELECTED}}
         @onChange={{this.noop}}
         @renderInPlace={{true}}

--- a/website/docs/utilities/dismiss-button/index.js
+++ b/website/docs/utilities/dismiss-button/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  get STATES() {
+    // these are used only for presentation purpose in the showcase
+    return ['default', 'hover', 'active', 'focus'];
+  }
+
+  @action
+  onClickDismissButton() {
+    console.log('`Hds::DismissButton` clicked');
+  }
+}

--- a/website/docs/utilities/dismiss-button/partials/code/showcase.md
+++ b/website/docs/utilities/dismiss-button/partials/code/showcase.md
@@ -2,7 +2,7 @@
   
   <h4 class="dummy-h4">States</h4>
   <div class="dummy-dismiss-button-states-grid">
-    {{#each @model.STATES as |state|}}
+    {{#each this.STATES as |state|}}
       <div>
         <span class="dummy-text-small">{{capitalize state}}:</span>
         <br />

--- a/website/package.json
+++ b/website/package.json
@@ -34,6 +34,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@hashicorp/design-system-components": "workspace:^",
+    "@hashicorp/design-system-tokens": "workspace:^",
     "@hashicorp/ember-flight-icons": "workspace:^",
     "@hashicorp/field-guide": "*",
     "babel-eslint": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3083,7 +3083,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hashicorp/design-system-tokens@^1.2.0, @hashicorp/design-system-tokens@workspace:packages/tokens":
+"@hashicorp/design-system-tokens@^1.2.0, @hashicorp/design-system-tokens@workspace:^, @hashicorp/design-system-tokens@workspace:packages/tokens":
   version: 0.0.0-use.local
   resolution: "@hashicorp/design-system-tokens@workspace:packages/tokens"
   dependencies:
@@ -24170,6 +24170,7 @@ __metadata:
     "@glimmer/component": ^1.1.2
     "@glimmer/tracking": ^1.1.2
     "@hashicorp/design-system-components": "workspace:^"
+    "@hashicorp/design-system-tokens": "workspace:^"
     "@hashicorp/ember-flight-icons": "workspace:^"
     "@hashicorp/field-guide": "*"
     babel-eslint: ^10.1.0


### PR DESCRIPTION
### :pushpin: Summary

This if the second part of a series of tasks that intend to fix most of the obvious JS errors in the documentation pages (mainly due to the conversion from the old "how to" and "showcase" pages, to the new markdown-like format.

👉 Not all the component pages have been fixed, see the list here: https://hashicorp.atlassian.net/browse/HDS-1171

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a "preprocess" rule rule to replace `@model` with `this`
  - with the new architecture based on `field-guide` the markdown files have backing classes as “components” not “controllers”, so there’s no model
- added or updated all the markdown backing classes (in the “moveover” folder)

_⚠️ Notice: I have not regenerated the docs in output, to avoid noise in the PR. I'll regenerate them before merging, once the PR i approved. If you want to test I suggest to get the branch up and running in your local environment and test the website there._

### :link: External links

Main JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-1171
Jira task: https://hashicorp.atlassian.net/browse/HDS-1173

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
