### PR TITLE
New docs website / First pass at fixing "doc" pages for component - Part 3 (foundations)

### DIFF
--- a/website-html-to-markdown/scripts/convert-to-markdown.ts
+++ b/website-html-to-markdown/scripts/convert-to-markdown.ts
@@ -94,6 +94,7 @@ async function convert() {
           break;
         // HOW TO USE
         case 'how-to-use.hbs':
+          turndownService.keep(['dummyvarslist']);
           markdownContent = turndownService.turndown(hbsSource);
           break;
         // DESIGN GUIDELINES

--- a/website-html-to-markdown/scripts/postprocess-files.ts
+++ b/website-html-to-markdown/scripts/postprocess-files.ts
@@ -42,6 +42,11 @@ async function postprocess() {
         return `<Doc::WcagList @criteriaList={{array "${list.split('|').join('" "')}" }} />\n`;
       });
 
+      // <dummyvarslist> → <Doc::VarsList>
+      markdownSource = markdownSource.replace(/<dummyvarslist data-items="(.*?)">TEMP<\/dummyvarslist>/g, (_match, items) => {
+        return `<Doc::VarsList @items={{${items}}} />\n`;
+      });
+
       await fs.writeFile(filePath, markdownSource);
     }
   });

--- a/website-html-to-markdown/scripts/preprocess-files.ts
+++ b/website-html-to-markdown/scripts/preprocess-files.ts
@@ -55,6 +55,12 @@ async function preprocess() {
       if (fileRelativePath === 'foundations/colors/partials/other/generic-2.hbs') {
         hbsSource = hbsSource.replace(/DummyColorCard/g, 'Doc::ColorCard');
       }
+      if (fileRelativePath === 'foundations/elevation/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/<DummyVarsList @items=\{\{(.*)\}\} \/>/g, '<dummyvarslist data-items="$1">TEMP</dummyvarslist>');
+      }
+      if (fileRelativePath === 'foundations/typography/partials/code/how-to-use.hbs') {
+        hbsSource = hbsSource.replace(/<DummyVarsList @items=\{\{(.*)\}\} \/>/g, '<dummyvarslist data-items="$1">TEMP</dummyvarslist>');
+      }
       if (fileRelativePath === 'components/alert/partials/code/how-to-use.hbs') {
         hbsSource = hbsSource.replace(/@route="\.\.\."/g, '@route="components"');
       }

--- a/website/app/components/doc/color-card/index.hbs
+++ b/website/app/components/doc/color-card/index.hbs
@@ -1,0 +1,20 @@
+<div class="doc-color-card" style={{this.cardStyle}}>
+  <div class="doc-color-card__color-preview"></div>
+  <div class="doc-color-card__color-name">{{this.colorName}}</div>
+  <ul class="doc-color-card__color-vars">
+    <li>
+      <span>CSS variable: </span>
+      <code>--{{this.cssVariable}}</code>
+    </li>
+    {{#if this.cssHelper}}
+      <li>
+        <span>CSS helper:</span>
+        <code>.{{this.cssHelper}}</code>
+      </li>
+    {{/if}}
+    <li>
+      <span>HEX value:</span>
+      <code>{{this.hexValue}}</code>
+    </li>
+  </ul>
+</div>

--- a/website/app/components/doc/color-card/index.js
+++ b/website/app/components/doc/color-card/index.js
@@ -1,0 +1,26 @@
+import Component from '@glimmer/component';
+import { htmlSafe } from '@ember/template';
+
+export default class DummyColorCardIndexComponent extends Component {
+  get colorName() {
+    return this.args.color.colorName;
+  }
+
+  get cssVariable() {
+    return this.args.color.cssVariable;
+  }
+
+  get cssHelper() {
+    return this.args.color.cssHelper ?? false;
+  }
+
+  get hexValue() {
+    return this.args.color.value;
+  }
+
+  get cardStyle() {
+    let style = '';
+    style += `color: ${this.hexValue};`;
+    return htmlSafe(style);
+  }
+}

--- a/website/app/components/doc/token-card/index.hbs
+++ b/website/app/components/doc/token-card/index.hbs
@@ -1,0 +1,57 @@
+<div
+  class="doc-token-card
+    {{if this.isExpanded 'doc-token-card--is-expanded' ''}}
+    {{if this.isDeprecated 'doc-token-card--is-deprecated' ''}}"
+>
+  <button class="doc-token-card__summary" type="button" {{on "click" this.toggle}}>
+    <span class="doc-token-card__name">
+      {{this.token.name}}
+      {{#if this.isAlias}}
+        <span class="doc-token-card__asterisk">*</span>
+      {{/if}}
+    </span>
+    <code class="doc-token-card__value">
+      {{#if this.isColor}}
+        {{! template-lint-disable no-inline-styles }}
+        <span class="doc-token-card__color" style={{this.colorPreviewStyle}}></span>
+      {{/if}}
+      {{this.token.value}}
+    </code>
+  </button>
+  <div class="doc-token-card__details">
+    <table class="doc-token-card__details-table">
+      <tbody>
+        <tr>
+          <th>CSS variable:</th>
+          <td>--{{this.token.name}}</td>
+          <td>
+            <CopyButton @text="var(--{{this.token.name}})">Copy</CopyButton>
+          </td>
+        </tr>
+        {{#if this.isAlias}}
+          <tr>
+            <th>Value/Computed:</th>
+            {{! we don't want developers to use directly HEX values, so we don't add a "copy" button on purpose }}
+            <td colspan="2">{{this.token.value}}</td>
+          </tr>
+          <tr>
+            <th>Value/Original:</th>
+            <td colspan="2">{{this.token.original_value}}</td>
+          </tr>
+        {{else}}
+          <tr>
+            <th>Value:</th>
+            {{! we don't want developers to use directly HEX values, so we don't add a "copy" button on purpose }}
+            <td colspan="2">{{this.token.value}}</td>
+          </tr>
+        {{/if}}
+        {{#if this.token.comment}}
+          <tr>
+            <th>Comment:</th>
+            <td colspan="2"><span class="doc-token-card__comment">{{this.token.comment}}</span></td>
+          </tr>
+        {{/if}}
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/website/app/components/doc/token-card/index.js
+++ b/website/app/components/doc/token-card/index.js
@@ -1,0 +1,46 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { htmlSafe } from '@ember/template';
+
+export default class DocTokenCardIndexComponent extends Component {
+  @tracked isExpanded = false;
+
+  get token() {
+    let { token } = this.args;
+    return {
+      name: token.name,
+      value: token.value,
+      category: token.attributes.category,
+      original_value: token.original.value,
+      deprecated: token.deprecated,
+      comment: token?.documentation?.comment ?? token?.comment ?? undefined,
+    };
+  }
+
+  get isAlias() {
+    return (
+      this.token.original_value !== this.token.value &&
+      this.token.original_value.includes('{')
+    );
+  }
+
+  get isDeprecated() {
+    return this.token.deprecated;
+  }
+
+  get isColor() {
+    return (
+      this.token.value.startsWith('#') || this.token.value.startsWith('rgb')
+    );
+  }
+
+  get colorPreviewStyle() {
+    return this.isColor ? htmlSafe(`color: ${this.token.value}`) : undefined;
+  }
+
+  @action
+  toggle() {
+    this.isExpanded = !this.isExpanded;
+  }
+}

--- a/website/app/components/doc/vars-list/index.hbs
+++ b/website/app/components/doc/vars-list/index.hbs
@@ -1,0 +1,8 @@
+<ul class="doc-vars-list">
+  {{#each @items as |item|}}
+    <li class="doc-vars-list__item">
+      <code>{{item}}</code>
+      <CopyButton @text="{{item}}">Copy</CopyButton>
+    </li>
+  {{/each}}
+</ul>

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -15,6 +15,7 @@
 @import "components/cards";
 @import "components/color-card";
 @import "components/placeholder";
+@import "components/token-card";
 @import "components/doc-table-of-contents";
 @import "components/content/hds-principles";
 

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -13,6 +13,7 @@
 // "Doc" components
 @import "components/badge";
 @import "components/cards";
+@import "components/color-card";
 @import "components/placeholder";
 @import "components/doc-table-of-contents";
 @import "components/content/hds-principles";

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -16,6 +16,7 @@
 @import "components/color-card";
 @import "components/placeholder";
 @import "components/token-card";
+@import "components/vars-list";
 @import "components/doc-table-of-contents";
 @import "components/content/hds-principles";
 

--- a/website/app/styles/components/color-card.scss
+++ b/website/app/styles/components/color-card.scss
@@ -19,7 +19,7 @@
   width: 140px;
   background-color: currentColor;
   border-radius: 10px;
-  box-shadow: rgb(0 0 0 / 50%) 0 0 1px inset;
+  box-shadow: rgba(0, 0, 0, 50%) 0 0 1px inset;
 }
 
 .doc-color-card__color-name {

--- a/website/app/styles/components/color-card.scss
+++ b/website/app/styles/components/color-card.scss
@@ -1,0 +1,51 @@
+// DOC COLOR CARD
+
+@use "../typography/mixins" as *;
+
+.doc-color-card {
+  position: relative;
+  width: 100%;
+  max-width: 740px;
+  padding: 20px 20px 20px 160px;
+
+  & + & { margin-top: 0.5rem; }
+}
+
+.doc-color-card__color-preview {
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  left: 5px;
+  width: 140px;
+  background-color: currentColor;
+  border-radius: 10px;
+  box-shadow: rgb(0 0 0 / 50%) 0 0 1px inset;
+}
+
+.doc-color-card__color-name {
+  @include doc-font-family("sans");
+  color: #000;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.doc-color-card__color-vars {
+  margin: 1rem 0 0 0;
+  padding: 0;
+  color: #000;
+  font-size: 0.8rem;
+  line-height: 1;
+  list-style: none;
+
+  li {
+    margin: 0.5rem 0 0 0;
+    padding: 0;
+  }
+
+  span {
+    @include doc-font-family("sans");
+    display: inline-block;
+    width: 85px;
+    opacity: 0.5;
+  }
+}

--- a/website/app/styles/components/token-card.scss
+++ b/website/app/styles/components/token-card.scss
@@ -1,0 +1,118 @@
+// DOC TOKEN CARD
+
+@use "../typography/mixins" as *;
+
+.doc-token-card {
+  @include doc-font-family("sans");
+  font-size: 1rem;
+  line-height: 1;
+  border-top: 1px dotted #ccc;
+
+  &:last-child {
+    border-bottom: 1px dotted #ccc;
+  }
+
+  &.doc-token-card--is-expanded {
+    background-color: #fafafa;
+  }
+}
+
+.doc-token-card__summary { // it's a button
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  padding: 10px 30px 10px 10px;
+  font-size: inherit;
+  font-family: inherit;
+  text-align: left;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  appearance: none;
+
+  &::after {
+    position: absolute;
+    right: 0;
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
+    text-align: center;
+    transform: rotate(180deg);
+    opacity: 0.3;
+    content: "▲";
+  }
+
+  .doc-token-card--is-expanded & {
+    background-color: #eceff1;
+
+    &::after {
+      transform: none;
+    }
+  }
+}
+
+.doc-token-card__name {
+  flex: 1 0 60%;
+  min-width: 0;
+  margin: 0;
+  padding: 5px 20px 5px 0;
+  color: #000;
+
+  .doc-token-card--is-deprecated & {
+    color: #ccc;
+    text-decoration: line-through;
+  }
+}
+
+.doc-token-card__asterisk {
+  font-size: 0.8125rem;
+  opacity: 0.5;
+}
+
+.doc-token-card__value {
+  display: flex;
+  color: #666;
+}
+
+.doc-token-card__color {
+  width: 20px;
+  height: 20px;
+  margin-right: 10px;
+  background-color: currentColor;
+  box-shadow: inset 0 0 1px 0 rgb(0, 0, 0, 25%);
+}
+
+.doc-token-card__details {
+  display: none;
+
+  .doc-token-card--is-expanded & {
+    display: block;
+  }
+}
+
+.doc-token-card__details-table {
+  width: 100%;
+  padding: 10px 10px 10px 15px;
+  font-size: 0.9rem;
+  font-family: monospace;
+  text-align: left;
+
+  th {
+    width: 150px;
+    padding: 5px 0 5px 0;
+    color: #666;
+    font-weight: 500;
+    font-style: italic;
+  }
+
+  td {
+    padding: 5px 0 5px 0;
+  }
+}
+
+.doc-token-card__comment {
+  @include doc-font-family("sans");
+  font-size: 0.9em;
+}

--- a/website/app/styles/components/vars-list.scss
+++ b/website/app/styles/components/vars-list.scss
@@ -1,0 +1,38 @@
+// DOC VARS LIST
+
+@use "../typography/mixins" as *;
+
+.doc-vars-list {
+  margin: 1.5rem 0;
+  padding: 1rem;
+  list-style: none;
+  // background: var(--background);
+  background: #f5f5f5;
+  border-radius: 0.5rem;
+}
+
+.doc-vars-list__item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
+  & + & {
+    margin-top: 0.5rem;
+  }
+
+  code {
+    @include doc-font-family("mono");
+    font-weight: 700;
+    font-size: 0.9rem;
+    line-height: 24px;
+  }
+
+  button {
+    visibility: hidden;
+    cursor: pointer;
+  }
+
+  &:hover button {
+    visibility: visible;
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -43,6 +43,7 @@
     "ember-cli": "~4.7.0",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
+    "ember-cli-clipboard": "^1.0.0",
     "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-deprecation-workflow": "^2.1.0",
     "ember-cli-fastboot": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2544,6 +2544,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@embroider/macros@npm:^1.8.1":
+  version: 1.10.0
+  resolution: "@embroider/macros@npm:1.10.0"
+  dependencies:
+    "@embroider/shared-internals": 2.0.0
+    assert-never: ^1.2.1
+    babel-import-util: ^1.1.0
+    ember-cli-babel: ^7.26.6
+    find-up: ^5.0.0
+    lodash: ^4.17.21
+    resolve: ^1.20.0
+    semver: ^7.3.2
+  checksum: 31ef88fbfd786fd066eb5c351a621ca4810e3ca57ab8cff3e360c116f1d16477ddecf98fc1fcfea363f6631fb5693a443586f122b35389f839e5b894a86a963c
+  languageName: node
+  linkType: hard
+
 "@embroider/shared-internals@npm:0.43.5":
   version: 0.43.5
   resolution: "@embroider/shared-internals@npm:0.43.5"
@@ -2587,6 +2603,22 @@ __metadata:
     semver: ^7.3.5
     typescript-memoize: ^1.0.1
   checksum: de636225b3e85379caad5bf4cb3c4f8cc8d95d1c9fab05668faf55654ae2cfe1ca2632c5cc4b81f0b52781d4fc5b80879e6cd143801976de46c591430957040f
+  languageName: node
+  linkType: hard
+
+"@embroider/shared-internals@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@embroider/shared-internals@npm:2.0.0"
+  dependencies:
+    babel-import-util: ^1.1.0
+    ember-rfc176-data: ^0.3.17
+    fs-extra: ^9.1.0
+    js-string-escape: ^1.0.1
+    lodash: ^4.17.21
+    resolve-package-path: ^4.0.1
+    semver: ^7.3.5
+    typescript-memoize: ^1.0.1
+  checksum: 19d2754182b9e1373177843a354852c82b35d71af66edcdf0662597442062e5f5f51adbdf7a63a263ee0052064c222ff33ddb983ec3f17b68b7275de8de3680e
   languageName: node
   linkType: hard
 
@@ -8283,7 +8315,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clipboard@npm:^2.0.6":
+"clipboard@npm:^2.0.11, clipboard@npm:^2.0.6":
   version: 2.0.11
   resolution: "clipboard@npm:2.0.11"
   dependencies:
@@ -9895,6 +9927,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ember-arg-types@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "ember-arg-types@npm:1.0.0"
+  dependencies:
+    "@embroider/macros": ^1.8.1
+    ember-auto-import: ^2.4.2
+    ember-cli-babel: ^7.26.11
+    ember-cli-typescript: ^5.1.1
+    ember-get-config: ^2.1.1
+    prop-types: ^15.7.2
+  checksum: 8313a4a2644daeedcbd6d097b9cbd1d19045117b76814d33552f207d33111454379c38cdcfc478cdca85c0b956727371ba4bee83cc89cdb438463a0b2f5e72bd
+  languageName: node
+  linkType: hard
+
 "ember-assign-helper@npm:^0.4.0":
   version: 0.4.0
   resolution: "ember-assign-helper@npm:0.4.0"
@@ -10129,6 +10175,21 @@ __metadata:
     ember-cli-babel: ^7.26.6
     ember-cli-htmlbars: ^5.7.1
   checksum: dea292fb8116d657cc2ac00695c7cdfc6fd71db3ff444b8418a3bdb641165d632e4281e06eb6fabfb82a58eb3a3ed5ea3e861539961501bb141725df7dc75604
+  languageName: node
+  linkType: hard
+
+"ember-cli-clipboard@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "ember-cli-clipboard@npm:1.0.0"
+  dependencies:
+    clipboard: ^2.0.11
+    ember-arg-types: ^1.0.0
+    ember-auto-import: ^2.4.2
+    ember-cli-babel: ^7.26.11
+    ember-cli-htmlbars: ^6.1.0
+    ember-modifier: ^3.2.7
+    prop-types: ^15.8.1
+  checksum: 448891dcd9db44dfd6621434a5158a226a7cf572fd6359b08c7f486bdeb6380dedb031e21bdad12e9db78b422a365b26e98160c472fb6605cd0efe9936cc037c
   languageName: node
   linkType: hard
 
@@ -10566,6 +10627,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ember-cli-typescript@npm:^5.1.1":
+  version: 5.2.1
+  resolution: "ember-cli-typescript@npm:5.2.1"
+  dependencies:
+    ansi-to-html: ^0.6.15
+    broccoli-stew: ^3.0.0
+    debug: ^4.0.0
+    execa: ^4.0.0
+    fs-extra: ^9.0.1
+    resolve: ^1.5.0
+    rsvp: ^4.8.1
+    semver: ^7.3.2
+    stagehand: ^1.0.0
+    walk-sync: ^2.2.0
+  checksum: b4306b37e9a9e070cc61a67acf404b30636ad2681379589fbc349c7e83158a7b634d792ab5af4cd4dd0770eecb8a901fa84d29a15167826db9c97b664a115df0
+  languageName: node
+  linkType: hard
+
 "ember-cli-version-checker@npm:^2.1.0, ember-cli-version-checker@npm:^2.1.2":
   version: 2.2.0
   resolution: "ember-cli-version-checker@npm:2.2.0"
@@ -10953,7 +11032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-get-config@npm:^1.0.2 || ^2.0.0":
+"ember-get-config@npm:^1.0.2 || ^2.0.0, ember-get-config@npm:^2.1.1":
   version: 2.1.1
   resolution: "ember-get-config@npm:2.1.1"
   dependencies:
@@ -16674,7 +16753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -19517,6 +19596,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+  version: 15.8.1
+  resolution: "prop-types@npm:15.8.1"
+  dependencies:
+    loose-envify: ^1.4.0
+    object-assign: ^4.1.1
+    react-is: ^16.13.1
+  checksum: c056d3f1c057cb7ff8344c645450e14f088a915d078dcda795041765047fa080d38e5d626560ccaac94a4e16e3aa15f3557c1a9a8d1174530955e992c675e459
+  languageName: node
+  linkType: hard
+
 "proper-lockfile@npm:^4.1.2":
   version: 4.1.2
   resolution: "proper-lockfile@npm:4.1.2"
@@ -19862,6 +19952,13 @@ __metadata:
   bin:
     rc: ./cli.js
   checksum: 2e26e052f8be2abd64e6d1dabfbd7be03f80ec18ccbc49562d31f617d0015fbdbcf0f9eed30346ea6ab789e0fdfe4337f033f8016efdbee0df5354751842080e
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^16.13.1":
+  version: 16.13.1
+  resolution: "react-is@npm:16.13.1"
+  checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
   languageName: node
   linkType: hard
 
@@ -24179,6 +24276,7 @@ __metadata:
     ember-cli: ~4.7.0
     ember-cli-app-version: ^5.0.0
     ember-cli-babel: ^7.26.11
+    ember-cli-clipboard: ^1.0.0
     ember-cli-dependency-checker: ^3.3.1
     ember-cli-deprecation-workflow: ^2.1.0
     ember-cli-fastboot: ^3.3.2


### PR DESCRIPTION
### :pushpin: Summary

For the Colors and Tokens documentation pages to work, and not crash, we need to port the old Dummy components that generate small “cards” with information about the colors and tokens.

These will be completely reviewed/redesigned in other parallel tasks, but for the time being the pages will work and will be available to designers to see as reference (and the components can be used as starting point by the developers)

### :hammer_and_wrench: Detailed description

In this PR I have:
- added `ember-cli-clipboard` as dependency
- added `Doc::ColorCard` component (temporary)
- added `Doc::TokenCard` component (temporary)
- added `Doc::VarsList` component (temporary)
- updated the preprocess/convert/postprocess scripts to handle `VarsList` component

_⚠️ Notice: I have not regenerated the docs in output, to avoid noise in the PR. I'll regenerate them before merging, once the PR i approved. If you want to test I suggest to get the branch up and running in your local environment and test the website there._


### :link: External links

JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-1180

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
