### PR TITLE
New docs website / Existing code block basic styling

### DIFF
--- a/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-code.js
+++ b/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-code.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  // notice: this is used as "noop" function for the onDismiss callback of the PowerSelect component
+  @action
+  noop() {
+    //
+  }
+}

--- a/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-code.md
+++ b/website-html-to-markdown/moveover/testing/00-testing-markdown-formatting/more-complex-code.md
@@ -30,3 +30,18 @@ Long, single-line code blocks should not wrap. They should horizontally scroll i
 ```javascript
 var foo = "The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.";
 ```
+
+---
+
+GitHub code block with <code>handlebars</code> syntax attribute.
+
+```handlebars
+<Hds::Button @text="Hello world!" {{on "click" this.noop }} />
+```
+
+GitHub code block with <code>handlebars</code> + <code>data-execute=false</code> attributes.
+
+```handlebars{data-execute=false}
+<Hds::Button @text="Hello world!" {{on "click" this.noop }} />
+```
+

--- a/website/app/initializers/showdown-extensions.js
+++ b/website/app/initializers/showdown-extensions.js
@@ -52,16 +52,17 @@ export function initialize(/* application */) {
         // escape { and } for the code sample
         highlightedCodeBlock = highlightedCodeBlock.replace(/{/g, '&#123;').replace(/}/g, '&#125;')
 
-        let preBlock = `<pre class="language-${language}"><code ${language ? `class="${language} language-${language}"` : ''}>${highlightedCodeBlock}</code></pre>`;
+        let preBlock = `<pre class="doc-code-block__code-snippet language-${language}"><code ${language ? `class="${language} language-${language}"` : ''}>${highlightedCodeBlock}</code></pre>`;
 
         let autoExecuteLanguages = ['html', 'handlebars', 'hbs'];
 
-        let selfExecutingBlock = `<div class="self-executing-code-block">
-  <div class="example">
-    ${inputCodeblock}
-  </div>
-  ${preBlock}
-</div>`;
+        let selfExecutingBlock = "";
+        selfExecutingBlock += '<div class="doc-code-block doc-code-block--self-executing">';
+        selfExecutingBlock += '  <div class="doc-code-block__code-rendered">';
+        selfExecutingBlock += `    ${inputCodeblock}`;
+        selfExecutingBlock += '  </div>';
+        selfExecutingBlock += `  ${preBlock}`;
+        selfExecutingBlock += '</div>';
 
         if(attributeString.includes('data-execute=false')) {
           codeblock = preBlock;

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -14,6 +14,7 @@
 @import "components/badge";
 @import "components/cards";
 @import "components/color-card";
+@import "components/code-block";
 @import "components/placeholder";
 @import "components/token-card";
 @import "components/vars-list";
@@ -42,25 +43,6 @@ body {
   min-height: 100vh;
   margin: 0;
   padding: 0;
-}
-
-// TODO! move to another file once we have converted this to a "doc" custom component
-
-// stylelint-disable-next-line selector-class-pattern
-.self-executing-code-block {
-  border-color: #ccc;
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 3px;
-}
-
-// stylelint-disable-next-line selector-class-pattern
-.self-executing-code-block pre {
-  margin: 0;
-  padding: 10px;
-  border-color: #ccc;
-  border-width: 1px;
-  border-top-style: solid;
 }
 
 

--- a/website/app/styles/components/code-block.scss
+++ b/website/app/styles/components/code-block.scss
@@ -1,0 +1,54 @@
+// CODE BLOCK
+
+// Notice: this is temporary! The actual styling work will be done in https://hashicorp.atlassian.net/browse/HDS-938
+
+// TODO check how this overlaps with the other similar classes (`.doc-markdown-pre`, `.doc-markdown-code`) and the syntax highlighting too, and what we need to override here
+
+@use "../breakpoints" as breakpoint;
+@use "../typography/mixins";
+
+
+.doc-code-block {
+  margin: 24px 0;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}
+
+// TODO do we need this?
+// .doc-code-block--self-executing {}
+
+.doc-code-block__code-rendered {
+  padding: 12px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 2'%3E%3Cpath d='M1 2V0h1v1H0v1z' fill-opacity='.05'/%3E%3C/svg%3E");
+  // use this to fine tune the size of the checkered pattern
+  background-size: 16px 16px;
+
+  @include breakpoint.medium () {
+    padding: 18px;
+  }
+
+  @include breakpoint.large () {
+    padding: 24px;
+  }
+}
+
+// notice: in some cases it's rendered as standalone element, so we have to have
+.doc-code-block__code-snippet {
+  border: 1px solid #ccc;
+  border-radius: 3px;
+
+  // artificial specificity to override the syntax highligter
+  &#{&}#{&} {
+    @include doc-font-style-code ();
+    margin: 24px 0;
+    padding: 10px;
+  }
+
+  .doc-code-block & {
+    margin: 0 !important; // sorry, temporary
+    border: none;
+    border-top: 1px solid #ccc;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+}

--- a/website/docs/testing/00-testing-markdown-formatting/more-complex-code.js
+++ b/website/docs/testing/00-testing-markdown-formatting/more-complex-code.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Index extends Component {
+  // notice: this is used as "noop" function for the onDismiss callback of the PowerSelect component
+  @action
+  noop() {
+    //
+  }
+}

--- a/website/docs/testing/00-testing-markdown-formatting/more-complex-code.md
+++ b/website/docs/testing/00-testing-markdown-formatting/more-complex-code.md
@@ -30,3 +30,18 @@ Long, single-line code blocks should not wrap. They should horizontally scroll i
 ```javascript
 var foo = "The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.";
 ```
+
+---
+
+GitHub code block with <code>handlebars</code> syntax attribute.
+
+```handlebars
+<Hds::Button @text="Hello world!" {{on "click" this.noop }} />
+```
+
+GitHub code block with <code>handlebars</code> + <code>data-execute=false</code> attributes.
+
+```handlebars{data-execute=false}
+<Hds::Button @text="Hello world!" {{on "click" this.noop }} />
+```
+


### PR DESCRIPTION
### :pushpin: Summary

This is  small MVP to provide a "code block" sample that has better styling, and is inline with the current designs.
The actual work for the "code block" implementation will be done in https://hashicorp.atlassian.net/browse/HDS-938 but in the meantime designers can have a preview of how it would work in practice, and see it in the context of a browser.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated `showdown-extension` code to use `doc` prefixed class names (so they’re easier to target/consume)
- added custom styling for `code-block` (MVP)
- added code samples for code blocks with preview

Preview: https://hds-website-git-new-docs-website-code-snippet-340b4d-hashicorp.vercel.app/testing/00-testing-markdown-formatting/more-complex-code/

### :camera_flash: Screenshots

<img width="626" alt="screenshot_2118" src="https://user-images.githubusercontent.com/686239/205339170-a10167fc-6e5e-4cdf-abe7-3bb76c571085.png">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1181

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
