### PR TITLE
New docs website / Freeze automatic generation of docs in markdown

### DIFF
--- a/website-html-to-markdown/.gitignore
+++ b/website-html-to-markdown/.gitignore
@@ -1,0 +1,1 @@
+generated-output

--- a/website-html-to-markdown/package.json
+++ b/website-html-to-markdown/package.json
@@ -11,7 +11,7 @@
   "license": "MPL-2.0",
   "author": "HashiCorp Design Systems <design-systems@hashicorp.com>",
   "scripts": {
-    "generate": "yarn prepare-temp-folder && yarn copy-source-files && yarn identify-sections && yarn split-files && yarn replace-linkto-with-a && yarn refactor-codeblocks && yarn refactor-properties && yarn enrich-wcag-lists && yarn preprocess-files && yarn convert-to-markdown && yarn prettify-files && yarn prepare-dest-folder && yarn copy-markdown-files && yarn copy-assets-folder && yarn copy-moveover-files && yarn postprocess-files && yarn cleanup-temp-folder",
+    "generate": "yarn prepare-temp-folder && yarn copy-source-files && yarn identify-sections && yarn split-files && yarn replace-linkto-with-a && yarn refactor-codeblocks && yarn refactor-properties && yarn enrich-wcag-lists && yarn preprocess-files && yarn convert-to-markdown && yarn prettify-files && yarn prepare-dest-folder && yarn copy-markdown-files && yarn copy-moveover-files && yarn postprocess-files && yarn cleanup-temp-folder",
     "prepare-temp-folder": "rm -fr temp && mkdir temp && mkdir temp/original",
     "copy-source-files": "cp -r ../packages/components/tests/dummy/app/templates/* temp/original",
     "identify-sections": "echo '\n==========\nIdentifying <section> blocks...\n' && node codemods/bin/cli.js identify-sections ./temp/original/**/*.hbs",
@@ -23,10 +23,9 @@
     "preprocess-files": "ts-node --transpile-only ./scripts/preprocess-files",
     "convert-to-markdown": "ts-node --transpile-only ./scripts/convert-to-markdown",
     "prettify-files": "echo '\n==========\nPrettifying markdown files...\n' && npx prettier --loglevel warn --write temp/split-files",
-    "prepare-dest-folder": "rm -fr ../website/docs/components && mkdir ../website/docs/components && rm -fr ../website/docs/content && mkdir ../website/docs/content && rm -fr ../website/docs/foundations && mkdir ../website/docs/foundations && rm -fr ../website/docs/overrides && mkdir ../website/docs/overrides && rm -fr ../website/docs/utilities && mkdir ../website/docs/utilities && rm -fr ../website/docs/testing && mkdir ../website/docs/testing",
-    "copy-markdown-files": "echo '\n==========\nCopying markdown files to `docs` folder...\n' && cp -r ./temp/markdown/* ../website/docs/",
-    "copy-assets-folder": "rm -fr ../website/public/assets/images && cp -r ../packages/components/tests/dummy/public/assets/images ../website/public/assets/",
-    "copy-moveover-files": "cp -r ./moveover/* ../website/docs/",
+    "prepare-dest-folder": "rm -fr ./generated-output && mkdir ./generated-output",
+    "copy-markdown-files": "echo '\n==========\nCopying markdown files to `docs` folder...\n' && cp -r ./temp/markdown/* ./generated-output/",
+    "copy-moveover-files": "cp -r ./moveover/* ./generated-output/",
     "postprocess-files": "ts-node --transpile-only ./scripts/postprocess-files",
     "cleanup-temp-folder": "rm -fr temp"
   },

--- a/website-html-to-markdown/scripts/postprocess-files.ts
+++ b/website-html-to-markdown/scripts/postprocess-files.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import chalk from 'chalk';
 
-const docsFolder = path.resolve(__dirname, '../../website/docs');
+const docsFolder = path.resolve(__dirname, './generated-output');
 
 (async () => {
   try {


### PR DESCRIPTION
### :pushpin: Summary

Once this PR is merge, we will be able to make any change to the markdown files (and retain the changes via PRs) and move towards the "final content" for all the documentation pages.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the documentation conversion/migration scripts to point to a local `generated-output` folder instead of the main `docs` website, so we don't overwrite anymore the markdown files (which become the "source of truth" from now on)
  - I still generate the files in a local folder in case we need the automation for automatic conversion of documentation files of new components.

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
