### PR TITLE
New docs website / Add support for "content block" syntax and parsing to `showdown`

### DIFF
--- a/website/app/components/doc/banner/index.hbs
+++ b/website/app/components/doc/banner/index.hbs
@@ -1,0 +1,3 @@
+<div class={{this.classNames}} ...attributes>
+  {{yield}}
+</div>

--- a/website/app/components/doc/banner/index.js
+++ b/website/app/components/doc/banner/index.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+
+export default class DocBannerComponent extends Component {
+  get classNames() {
+    let classes = ['doc-banner'];
+    return classes.join(' ');
+  }
+}

--- a/website/app/shared/showdown-config.js
+++ b/website/app/shared/showdown-config.js
@@ -1,4 +1,5 @@
 import { elementsToClassNames } from './showdown-extensions/elements-to-classnames';
+import { contentBlocks } from './showdown-extensions/content-blocks';
 
 // SET SHOWDOWN SETTINGS HERE:
 // https://showdownjs.com/docs/available-options/
@@ -23,5 +24,5 @@ export const showdownConfig = {
   ghCompatibleHeaderId: true,
   // add default class for each HTML element generated
   // see: https://github.com/showdownjs/showdown/wiki/Extensions + https://showdownjs.com/docs/tutorials/add-default-class-to-html/
-  extensions: [...elementsToClassNames],
+  extensions: [...elementsToClassNames, contentBlocks],
 };

--- a/website/app/shared/showdown-extensions/content-blocks.js
+++ b/website/app/shared/showdown-extensions/content-blocks.js
@@ -1,0 +1,52 @@
+// inspiration for this approach: https://github.com/showdownjs/showdown/wiki/Cookbook:-Using-language-and-output-extensions-on-the-same-block
+export const contentBlocks = function () {
+  var langExtension = {
+    // we use the "lang" here because we want to replace the `!!!` delimitiers before everything else
+    // so that the contained markdown is normally interpreted, parsed and converted
+    // see: https://github.com/showdownjs/showdown/wiki/Extensions#type-propertyrequired
+    type: 'lang',
+    filter: function (text) {
+      // console.log('langExtension1 text', '\n', text, '\n\n');
+      // https://regex101.com/r/j4PHPo/1
+      const langRegex = new RegExp(/^!!! (\w+)[\n\s]((.|\n)*?)!!!$/, 'gm');
+      text = text.replace(langRegex, function (_match, type, content) {
+        // we use the PHP tag as passthrough "tag" because is simply ignored by the `hashHTMLBlocks` function in Showdown
+        // see: https://github.com/showdownjs/showdown/blob/master/src/subParsers/makehtml/hashHTMLBlocks.js#L93-L95
+        return `\n<?php start="content-block" type="${type.toLowerCase()}" ?>\n<div data-markdown="1">\n${content}\n</div>\n<?php end="content-block" type="${type.toLowerCase()}" ?>\n`;
+      });
+      // console.log('langExtension2 text', '\n', text, '\n\n');
+      return text;
+    },
+  };
+  var outputExtension = {
+    type: 'output',
+    filter: function (text) {
+      // console.log('outputExtension1 text', '\n', text, '\n\n');
+      // https://regex101.com/r/DebuYI/1
+      const outputRegex = new RegExp(
+        /<\?php start="content-block" type="(.*?)" \?>\n?<div data-markdown="1">\n?/,
+        'g'
+      );
+      text = text.replace(outputRegex, function (_match, type) {
+        if (type === 'do' || type === 'dont') {
+          return `<Doc::DoDont @type="${type}">\n`;
+        } else {
+          return `<Doc::Banner @type="${type}">\n`;
+        }
+      });
+      text = text.replace(
+        /\n?<\/div>\n?<\?php end="content-block" type="(.*?)" \?>/g,
+        function (_match, type) {
+          if (type === 'do' || type === 'dont') {
+            return '</Doc::DoDont>';
+          } else {
+            return '</Doc::Banner>';
+          }
+        }
+      );
+      // console.log('outputExtension2 text', '\n', text, '\n\n');
+      return text;
+    },
+  };
+  return [langExtension, outputExtension];
+};

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -12,6 +12,7 @@
 
 // "Doc" components
 @import "components/badge";
+@import "components/banner";
 @import "components/cards";
 @import "components/color-card";
 @import "components/code-block";

--- a/website/app/styles/components/banner.scss
+++ b/website/app/styles/components/banner.scss
@@ -1,0 +1,6 @@
+// BANNER
+
+.doc-banner {
+  background-color: red;
+  border: 2px solid green;
+}

--- a/website/docs/testing/07-test-content-blocks/generic.md
+++ b/website/docs/testing/07-test-content-blocks/generic.md
@@ -1,0 +1,46 @@
+---
+title: Test with "content blocks" in markdown / HTML / Ember
+---
+
+Simple content block
+
+!!! Alert
+
+This is a paragraph
+
+This is a test
+
+> This is a blockquote
+
+- This is
+- A list
+
+!!!
+
+Lorem ipsum dolor
+
+!!! Alert
+This is another content block
+!!!
+
+Lorem ipsum dolor
+
+------
+
+With mixed content (markdown + HTML + Ember component)
+
+!!! Alert
+
+This is a badge
+
+<Doc::Badge>Hello!</Doc::Badge>
+
+This is an inline badge <Doc::Badge>Hello!</Doc::Badge>
+
+> This is a blockquote
+
+- This is
+- A list
+- With some <code>inline code</code>
+
+!!!


### PR DESCRIPTION
### :pushpin: Summary

This is the first PR that adds generic support for "content block" syntax to Showdown. 
I will do the actual implementation of the `Banner` and `Do/Dont` components in follow-up PRs.

_Notice: the final syntax may change depending on the results of [an internal poll](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1670413705286489)._

_Notice: this branch is squashed and cleaned up, if you want to see the history of this experimentation see this draft PR: https://github.com/hashicorp/design-system/pull/762_

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a temporary `Doc::Banner` component
  - still barebone, no styling (this will be done in a follow-up PR)
- added a page in markdown for testing different cases and variants of content blocks
- added `contentBlocks` extension to `showdown`

The inspiration for this approach comes from this "recipe" found on the official showdown documentation https://github.com/showdownjs/showdown/wiki/Cookbook:-Using-language-and-output-extensions-on-the-same-block and the observation (looking at the Showdown source code) that PHP (`<?...?>`) and ASP (`<%...%>`) tags are simply ignored by Showdown: https://github.com/showdownjs/showdown/blob/master/src/subParsers/makehtml/hashHTMLBlocks.js#L93-L95

Preview: https://hds-website-git-new-docs-website-content-block-0fbd3f-hashicorp.vercel.app/testing/07-test-content-blocks/generic/

### :camera_flash: Screenshots

<img width="812" alt="screenshot_2129" src="https://user-images.githubusercontent.com/686239/206170067-640b62b8-d671-42c7-8b63-69352ffbdfe1.png">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1029?filter=10826

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
