### PR TITLE
New docs website / Content blocks / "Do/Dont"

### DIFF
--- a/website/app/components/doc/banner/index.hbs
+++ b/website/app/components/doc/banner/index.hbs
@@ -1,0 +1,3 @@
+<div class={{this.classNames}} ...attributes>
+  {{yield}}
+</div>

--- a/website/app/components/doc/banner/index.js
+++ b/website/app/components/doc/banner/index.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+
+export default class DocBannerComponent extends Component {
+  get classNames() {
+    let classes = ['doc-banner'];
+    return classes.join(' ');
+  }
+}

--- a/website/app/components/doc/do-dont/index.hbs
+++ b/website/app/components/doc/do-dont/index.hbs
@@ -1,0 +1,7 @@
+<div class={{this.classNames}} ...attributes>
+  {{! TODO decide if this one is actually a `Doc::Badge` component }}
+  <div class="doc-do-dont__badge">{{this.label}}</div>
+  <div class="doc-do-dont__content">
+    {{yield}}
+  </div>
+</div>

--- a/website/app/components/doc/do-dont/index.js
+++ b/website/app/components/doc/do-dont/index.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+
+export default class DocDoDontComponent extends Component {
+  get label() {
+    let label;
+    switch (this.args.type) {
+      case 'do':
+        label = 'Do';
+        break;
+      case 'dont':
+        label = 'Dont';
+        break;
+      default:
+        break;
+    }
+    return label;
+  }
+
+  get classNames() {
+    let classes = ['doc-do-dont'];
+
+    // add a class based on the @type argument
+    classes.push(`doc-do-dont--type-${this.args.type}`);
+
+    return classes.join(' ');
+  }
+}

--- a/website/app/shared/showdown-config.js
+++ b/website/app/shared/showdown-config.js
@@ -1,4 +1,5 @@
 import { elementsToClassNames } from './showdown-extensions/elements-to-classnames';
+import { contentBlocks } from './showdown-extensions/content-blocks';
 
 // SET SHOWDOWN SETTINGS HERE:
 // https://showdownjs.com/docs/available-options/
@@ -23,5 +24,5 @@ export const showdownConfig = {
   ghCompatibleHeaderId: true,
   // add default class for each HTML element generated
   // see: https://github.com/showdownjs/showdown/wiki/Extensions + https://showdownjs.com/docs/tutorials/add-default-class-to-html/
-  extensions: [...elementsToClassNames],
+  extensions: [...elementsToClassNames, contentBlocks],
 };

--- a/website/app/shared/showdown-extensions/content-blocks.js
+++ b/website/app/shared/showdown-extensions/content-blocks.js
@@ -1,0 +1,52 @@
+// inspiration for this approach: https://github.com/showdownjs/showdown/wiki/Cookbook:-Using-language-and-output-extensions-on-the-same-block
+export const contentBlocks = function () {
+  var langExtension = {
+    // we use the "lang" here because we want to replace the `!!!` delimitiers before everything else
+    // so that the contained markdown is normally interpreted, parsed and converted
+    // see: https://github.com/showdownjs/showdown/wiki/Extensions#type-propertyrequired
+    type: 'lang',
+    filter: function (text) {
+      // console.log('langExtension1 text', '\n', text, '\n\n');
+      // https://regex101.com/r/j4PHPo/1
+      const langRegex = new RegExp(/^!!! (\w+)[\n\s]((.|\n)*?)!!!$/, 'gm');
+      text = text.replace(langRegex, function (_match, type, content) {
+        // we use the PHP tag as passthrough "tag" because is simply ignored by the `hashHTMLBlocks` function in Showdown
+        // see: https://github.com/showdownjs/showdown/blob/master/src/subParsers/makehtml/hashHTMLBlocks.js#L93-L95
+        return `\n<?php start="content-block" type="${type.toLowerCase()}" ?>\n<div data-markdown="1">\n${content}\n</div>\n<?php end="content-block" type="${type.toLowerCase()}" ?>\n`;
+      });
+      // console.log('langExtension2 text', '\n', text, '\n\n');
+      return text;
+    },
+  };
+  var outputExtension = {
+    type: 'output',
+    filter: function (text) {
+      // console.log('outputExtension1 text', '\n', text, '\n\n');
+      // https://regex101.com/r/DebuYI/1
+      const outputRegex = new RegExp(
+        /<\?php start="content-block" type="(.*?)" \?>\n?<div data-markdown="1">\n?/,
+        'g'
+      );
+      text = text.replace(outputRegex, function (_match, type) {
+        if (type === 'do' || type === 'dont') {
+          return `<Doc::DoDont @type="${type}">\n`;
+        } else {
+          return `<Doc::Banner @type="${type}">\n`;
+        }
+      });
+      text = text.replace(
+        /\n?<\/div>\n?<\?php end="content-block" type="(.*?)" \?>/g,
+        function (_match, type) {
+          if (type === 'do' || type === 'dont') {
+            return '</Doc::DoDont>';
+          } else {
+            return '</Doc::Banner>';
+          }
+        }
+      );
+      // console.log('outputExtension2 text', '\n', text, '\n\n');
+      return text;
+    },
+  };
+  return [langExtension, outputExtension];
+};

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -12,6 +12,7 @@
 
 // "Doc" components
 @import "components/badge";
+@import "components/banner";
 @import "components/cards";
 @import "components/color-card";
 @import "components/code-block";

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -16,6 +16,7 @@
 @import "components/cards";
 @import "components/color-card";
 @import "components/code-block";
+@import "components/do-dont";
 @import "components/placeholder";
 @import "components/token-card";
 @import "components/vars-list";

--- a/website/app/styles/components/banner.scss
+++ b/website/app/styles/components/banner.scss
@@ -1,0 +1,6 @@
+// BANNER
+
+.doc-banner {
+  background-color: red;
+  border: 2px solid green;
+}

--- a/website/app/styles/components/do-dont.scss
+++ b/website/app/styles/components/do-dont.scss
@@ -1,0 +1,40 @@
+// DO-DONT
+
+@use "../typography/mixins" as *;
+
+.doc-do-dont {
+  margin: 16px 0;
+}
+
+.doc-do-dont__badge {
+  @include doc-font-style-body-small();
+  width: min-content;
+  margin-bottom: 8px;
+  padding: 3px 12px 4px;
+  color: white; // TODO transform to token
+  font-weight: 600;
+  border-radius: 100px;
+
+  .doc-do-dont--type-do & {
+    background-color: #007854;
+  }
+
+  .doc-do-dont--type-dont & {
+    background-color: #ba2226;
+  }
+}
+
+.doc-do-dont__content {
+  padding: 24px;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 3px;
+
+  .doc-do-dont--type-do & {
+    border-color: #007854;
+  }
+
+  .doc-do-dont--type-dont & {
+    border-color: #ba2226;
+  }
+}

--- a/website/docs/testing/07-test-content-blocks/do-dont.md
+++ b/website/docs/testing/07-test-content-blocks/do-dont.md
@@ -1,0 +1,37 @@
+---
+title: Test with "Do/Dont" content blocks
+---
+
+## Do/Dont blocks
+
+Lorem ipsum dolor
+
+!!! Do
+This is a paragraph
+- This is
+- A list
+!!!
+
+Lorem ipsum dolor
+
+!!! Dont
+This is a paragraph
+- This is
+- A list
+!!!
+
+With a normal code "snippet" inside
+
+!!! Do
+```
+var foo = "bar";
+```
+!!!
+
+With a normal code "block" inside
+
+!!! Dont
+```handlebars
+<Hds::Button @text="Hello world!" />
+```
+!!!

--- a/website/docs/testing/07-test-content-blocks/generic.md
+++ b/website/docs/testing/07-test-content-blocks/generic.md
@@ -1,0 +1,46 @@
+---
+title: Test with "content blocks" in markdown / HTML / Ember
+---
+
+Simple content block
+
+!!! Alert
+
+This is a paragraph
+
+This is a test
+
+> This is a blockquote
+
+- This is
+- A list
+
+!!!
+
+Lorem ipsum dolor
+
+!!! Alert
+This is another content block
+!!!
+
+Lorem ipsum dolor
+
+------
+
+With mixed content (markdown + HTML + Ember component)
+
+!!! Alert
+
+This is a badge
+
+<Doc::Badge>Hello!</Doc::Badge>
+
+This is an inline badge <Doc::Badge>Hello!</Doc::Badge>
+
+> This is a blockquote
+
+- This is
+- A list
+- With some <code>inline code</code>
+
+!!!


### PR DESCRIPTION
### :pushpin: Summary

This PR builds on top of #761 and introduces a custom block for "Do/Dont" containers.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a testing page for `Do` and `Dont` content blocks
- added the `Doc::DoDont` component
  - notice: final style will be agreed with our designers

Preview: 

### :camera_flash: Screenshots

<img width="705" alt="screenshot_2135" src="https://user-images.githubusercontent.com/686239/206191443-7c28fdfb-3858-47cc-974f-954729a2dff1.png">

### :link: External links

JIRA Ticket: https://hashicorp.atlassian.net/browse/HDS-939

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
