### PR TITLE
Add meta for `robots/noindex` to the website `<head>`

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- TODO! remember to remove this once we're ready to launch -->
+    <meta name="robots" content="noindex">
 
     {{content-for "head"}}
 


### PR DESCRIPTION
### :pushpin: Summary

Following this conversation: https://hashicorp.slack.com/archives/C0436UKEQR1/p1670500121766149 I've added a `<meta name="robots" content="noindex">` tag to the `<head>` of the website pages (to be removed before launch).

@alex-ju @heatherlarsen @MelSumner I suspect you all had previous SEO experience, so would like your thought if it's a good precaution, or unnecessary.

