### PR TITLE
New docs website / Finalize `Page:Cover` element (component)

### DIFF
--- a/website/app/components/doc/page/cover.hbs
+++ b/website/app/components/doc/page/cover.hbs
@@ -1,6 +1,28 @@
 <div class="doc-page-cover" ...attributes>
-  <h1 class="doc-page-cover__title doc-text-h1">{{@title}}</h1>
-  <pre>{{@extra}}</pre>
+  <div class="doc-page-cover__title-extra-wrapper">
+    <h1 class="doc-page-cover__title doc-text-h1">{{@title}}</h1>
+    <div class="doc-page-cover__extra">
+      {{#if this.status}}
+        <Doc::Badge @type={{this.status.badgeType}}>{{this.status.badgeText}}</Doc::Badge>
+      {{/if}}
+      {{#if this.links}}
+        {{#each-in this.links as |service url|}}
+          {{#if (eq service 'figma')}}
+            <a class="doc-page-cover__link doc-link-generic" href={{url}} target="_blank" rel="noopener noreferrer">
+              <FlightIcon @name="figma-color" />
+              Figma
+            </a>
+          {{/if}}
+          {{#if (eq service 'github')}}
+            <a class="doc-page-cover__link doc-link-generic" href={{url}} target="_blank" rel="noopener noreferrer">
+              <FlightIcon @name="github-color" />
+              GitHub
+            </a>
+          {{/if}}
+        {{/each-in}}
+      {{/if}}
+    </div>
+  </div>
   {{#if @description}}
     <p class="doc-page-cover__description doc-text-body">{{@description}}</p>
   {{/if}}

--- a/website/app/components/doc/page/cover.js
+++ b/website/app/components/doc/page/cover.js
@@ -1,0 +1,39 @@
+import Component from '@glimmer/component';
+
+const STATUSES = {
+  released: {
+    badgeType: 'success',
+    badgeText: 'Released',
+  },
+};
+
+export default class DocPageContentComponent extends Component {
+  get status() {
+    let { extra } = this.args;
+
+    if (extra?.status) {
+      if (extra.status in STATUSES) {
+        return STATUSES[extra.status];
+      } else {
+        console.error(
+          `Error: you have provided an unexpected status for the page cover element (${
+            extra.status
+          }) - Possible values: "${Object.keys(STATUSES).join('", "')}".`
+        );
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+
+  get links() {
+    let { extra } = this.args;
+
+    if (extra?.links) {
+      return extra?.links;
+    } else {
+      return false;
+    }
+  }
+}

--- a/website/app/components/doc/page/tabs.hbs
+++ b/website/app/components/doc/page/tabs.hbs
@@ -13,7 +13,6 @@
         role='tab'
         aria-controls={{tab.target}}
         aria-selected={{tab.isCurrent}}
-        tabindex='-1'
         {{on 'click' (fn tab.onClickTab tab)}}
       >{{capitalize tab.label}}</button>
     </li>

--- a/website/app/components/doc/page/tabs.hbs
+++ b/website/app/components/doc/page/tabs.hbs
@@ -8,7 +8,7 @@
     >
       <button
         id={{tab.id}}
-        class='doc-text-body-small'
+        class='doc-text-navigation'
         type='button'
         role='tab'
         aria-controls={{tab.target}}

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -7,6 +7,7 @@
 @import "tokens";
 
 // Global declarations
+@import "global";
 @import "typography";
 
 // Pages declarations

--- a/website/app/styles/breakpoints/index.scss
+++ b/website/app/styles/breakpoints/index.scss
@@ -18,6 +18,10 @@ $with-sidedar-breakpoint: 1000px;
   @media (min-width: $medium-lower-breakpoint) and (max-width: $medium-upper-breakpoint) { @content; }
 }
 
+@mixin medium-and-above {
+  @media (min-width: $medium-lower-breakpoint) { @content; }
+}
+
 @mixin large {
   @media (min-width: $large-lower-breakpoint) { @content; }
 }

--- a/website/app/styles/global/index.scss
+++ b/website/app/styles/global/index.scss
@@ -1,0 +1,3 @@
+// GLOBAL STYLES
+
+@import "./link";

--- a/website/app/styles/global/link.scss
+++ b/website/app/styles/global/link.scss
@@ -1,0 +1,14 @@
+@mixin doc-link-generic-styles() {
+  color: var(--doc-color-link-on-white);
+
+  // TODO check with Heather and Melanie if this is what we want
+  :hover,
+  :visited,
+  :active {
+    color: var(--doc-color-link-on-white);
+  }
+}
+
+.doc-link-generic {
+  @include doc-link-generic-styles();
+}

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -9,11 +9,13 @@
   padding: 0 var(--doc-page-stage-gutter-small);
 
   // TODO! temp until we decide with Heather the correct vertical padding of the "content" area
-  > :first-child {
+  > :first-child,
+  > section {
     margin-top: 48px;
   }
 
-  > :last-child {
+  > :last-child,
+  > section {
     margin-bottom: 48px;
   }
 

--- a/website/app/styles/pages/application/cover.scss
+++ b/website/app/styles/pages/application/cover.scss
@@ -1,22 +1,30 @@
 // COVER
 
 @use "../../breakpoints" as breakpoint;
+@use "../../typography/mixins" as *;
 
 .doc-page-cover {
   position: relative;
   grid-area: cover;
-  // TODO check with heather what she wants to do with the vertical padding (responsive)
-  padding: 16px var(--doc-page-stage-gutter-small);
+  min-width: 0; // This is needed to allow the scrolling of the tabs
+  padding: 16px var(--doc-page-stage-gutter-small) 0;
   background-color: var(--doc-color-white);
   border-bottom: 1px solid var(--doc-color-gray-500);
 
   @include breakpoint.medium () {
-    padding: 32px var(--doc-page-stage-gutter-medium);
+    padding: 64px var(--doc-page-stage-gutter-medium) 68px;
   }
 
   @include breakpoint.large () {
-    padding: 64px var(--doc-page-stage-gutter-large);
+    padding: 64px var(--doc-page-stage-gutter-large) 68px;
   }
+}
+
+.doc-page-cover__title-extra-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  align-items: center;
 }
 
 .doc-page-cover__title {
@@ -24,8 +32,38 @@
   color: var(--doc-color-gray-100);
 }
 
+
+.doc-page-cover__extra {
+  display: flex;
+  gap: 12px;
+}
+
+.doc-page-cover__link {
+  @include doc-font-style-body-small();
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
 .doc-page-cover__description {
   max-width: var(--doc-page-content-max-width);
   margin: 16px 0 0 0;
   color: var(--doc-color-gray-300);
+}
+
+.doc-page-cover__tabs {
+  display: flex;
+  flex-wrap: nowrap;
+  height: min-content;
+  margin-top: 24px;
+  overflow-x: auto;
+  overflow-y: visible; // needed or it will show a small vertical scrollbar
+  -webkit-overflow-scrolling: touch;
+
+  @include breakpoint.medium-and-above () {
+    position: absolute;
+    bottom: 0;
+    display: block;
+    overflow: visible;
+  }
 }

--- a/website/app/styles/pages/application/tabs.scss
+++ b/website/app/styles/pages/application/tabs.scss
@@ -1,8 +1,6 @@
 // TABS
 
 .doc-page-tabs {
-  position: absolute;
-  bottom: 0;
   display: flex;
   gap: 16px;
   margin: 0;
@@ -23,7 +21,7 @@
     cursor: pointer;
 
     &:hover {
-      color: #2264d6;
+      color: var(--doc-color-black);
     }
   }
 
@@ -34,12 +32,12 @@
       bottom: -1px;
       left: 0;
       height: 3px;
-      background-color: #2264d6;
+      background-color: var(--doc-color-black);
       content: "";
     }
 
     button {
-      color: #2264d6;
+      color: var(--doc-color-black);
     }
   }
 }

--- a/website/app/styles/pages/application/tabs.scss
+++ b/website/app/styles/pages/application/tabs.scss
@@ -13,11 +13,11 @@
 
   button {
     position: relative;
-    padding: 4px 12px;
+    padding: 3px 11px; // we need to take in account the transparent border
     color: var(--doc-color-gray-300);
     font-weight: 600;
     background-color: transparent;
-    border: none;
+    border: 1px solid transparent;
     cursor: pointer;
 
     &:hover {


### PR DESCRIPTION
### :pushpin: Summary

This PR builds on top of another PR (will open soon) that refactors how the "frontmatter" attributes (and which ones) are provided to the `show` template/controller. This has allowed me to finalize the `Page::Cover` component (page _"cover"_ element) in terms visual design (according to the [latest design specs](https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=1345%3A79255&t=YNJcoWCVScYCh1p5-1)).

### :hammer_and_wrench: Detailed description

In this PR I have:
- added global styling for generic links (added both a mixin and a CSS class, will be used also in other places)
- finalized the `cover` (with responsiveness and correct spacing) including `tabs` (colors, scrolling)

👉 👉 👉 **Preview**: https://hds-website-git-new-docs-website-page-cover-extra-hashicorp.vercel.app/components/alert/ (Notice: only the `Alert` doc page has the proper "frontmatter" attributes).

@heatherlarsen can you check and see if it adheres to the current specifications?
@KristinLBradley @alex-ju can you check and see if you see something off in terms of code?

### :camera_flash: Screenshots

<img width="1468" alt="screenshot_2150" src="https://user-images.githubusercontent.com/686239/206471949-e740893d-af46-4970-9804-c28589d59098.png">

### :link: External links

JIRA ticket: https://hashicorp.atlassian.net/browse/HDS-1202

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
