### PR TITLE
[Docs] adds some style for `wcag-list` component

### DIFF
--- a/website/app/components/doc/wcag-list/index.hbs
+++ b/website/app/components/doc/wcag-list/index.hbs
@@ -4,6 +4,7 @@
         <li class="doc-wcag-list__li">
           <a href={{criterion.url}} class="doc-wcag-list__link">
           {{criterion.number}} {{criterion.title}}:</a>
+          <br/>
           {{criterion.description}}
         </li>
     {{/each}}

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -23,6 +23,7 @@
 @import "components/placeholder";
 @import "components/token-card";
 @import "components/vars-list";
+@import "components/wcag-list";
 @import "components/doc-table-of-contents";
 @import "components/content/hds-principles";
 

--- a/website/app/styles/components/wcag-list.scss
+++ b/website/app/styles/components/wcag-list.scss
@@ -1,0 +1,3 @@
+.doc-wcag-list__li {
+  margin-bottom: 1.1875rem;
+}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR makes 2 small changes to the `wcag-list` component per design request.

### :hammer_and_wrench: Detailed description

- adds a bottom margin to the list items
- adds a line break after the link and before the description text

### 👀 How to review

👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
