### PR TITLE
implement query params

### DIFF
--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -45,7 +45,7 @@ export default class ShowController extends Controller {
 
     let tab = this.tabs.find((el) => {
       // trim trailing slashes from query param
-      return el.label === this.selectedTab.replace(/\/$/, '');
+      return el.label.toLowerCase() === this.selectedTab.replace(/\/$/, '');
     });
     return tab ? tab.index : 0;
   }
@@ -151,7 +151,7 @@ export default class ShowController extends Controller {
       set(toc, 'isCurrent', toc.index === current);
     });
 
-    set(this, 'selectedTab', this.tabs[current].label);
+    set(this, 'selectedTab', this.tabs[current].label.toLowerCase());
 
     // leave for debugging
     // console.log('show setCurrent', this.sections, this.tabs, this.tocs);

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -24,11 +24,29 @@ const getTOCs = (container) => {
 };
 
 export default class ShowController extends Controller {
+  queryParams = [
+    {
+      selectedTab: 'tab',
+    },
+  ];
+
   @service fastboot;
 
   @tracked sections = A([]);
   @tracked tabs = A([]);
   @tracked tocs = A([]);
+
+  get selectedTabIndex() {
+    if (!this.selectedTab) {
+      return 0;
+    }
+
+    let tab = this.tabs.find((el) => {
+      // trim trailing slashes from query param
+      return el.label === this.selectedTab.replace(/\/$/, '');
+    });
+    return tab ? tab.index : 0;
+  }
 
   get title() {
     return this.model.frontmatter?.title ?? '';
@@ -101,8 +119,7 @@ export default class ShowController extends Controller {
     this.sections.setObjects(sections);
     this.tabs.setObjects(tabs);
     this.tocs.setObjects(tocs);
-    // TODO handle when the page loads which one is the current, based on the URL query params
-    this.setCurrent(0);
+    this.setCurrent(this.selectedTabIndex);
     // leave for debugging
     // console.log('show didInsert', this.sections, this.tabs, this.tocs);
   };
@@ -131,6 +148,9 @@ export default class ShowController extends Controller {
     this.tocs.forEach((toc) => {
       set(toc, 'isCurrent', toc.index === current);
     });
+
+    set(this, 'selectedTab', this.tabs[current].label);
+
     // leave for debugging
     // console.log('show setCurrent', this.sections, this.tabs, this.tocs);
   }

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -28,6 +28,8 @@ export default class ShowController extends Controller {
     {
       selectedTab: 'tab',
     },
+    'searchQuery',
+    'selectedIconSize',
   ];
 
   @service fastboot;

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -44,6 +44,7 @@ export default class ShowController extends Controller {
     }
 
     let tab = this.tabs.find((el) => {
+      // for consistency we always compare the query param tab to a lowercase version of the tab label
       return el.label.toLowerCase() === this.selectedTab;
     });
     return tab ? tab.index : 0;
@@ -150,6 +151,7 @@ export default class ShowController extends Controller {
       set(toc, 'isCurrent', toc.index === current);
     });
 
+    // for consistency we always set the query param tab to a lowercase version of the tab label
     set(this, 'selectedTab', this.tabs[current].label.toLowerCase());
 
     // leave for debugging

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -44,8 +44,7 @@ export default class ShowController extends Controller {
     }
 
     let tab = this.tabs.find((el) => {
-      // trim trailing slashes from query param
-      return el.label.toLowerCase() === this.selectedTab.replace(/\/$/, '');
+      return el.label.toLowerCase() === this.selectedTab;
     });
     return tab ? tab.index : 0;
   }

--- a/website/docs/foundations/icons/index.js
+++ b/website/docs/foundations/icons/index.js
@@ -21,6 +21,8 @@ export default class Index extends Component {
   });
 
   get filteredIcons() {
+    // query params come from `controllers/show.js` and we access them here because there
+    // is no "controller" for individual component documentation routes
     const searchQuery = this.router.currentRoute.queryParams['searchQuery'];
     const selectedIconSize =
       this.router.currentRoute.queryParams['selectedIconSize'] || '16';

--- a/website/docs/foundations/icons/index.js
+++ b/website/docs/foundations/icons/index.js
@@ -21,7 +21,6 @@ export default class Index extends Component {
   });
 
   get filteredIcons() {
-    // this.router.currentRoute.queryParams['searchQuery'];
     const searchQuery = this.router.currentRoute.queryParams['searchQuery'];
     const selectedIconSize =
       this.router.currentRoute.queryParams['selectedIconSize'] || '16';

--- a/website/docs/foundations/icons/index.js
+++ b/website/docs/foundations/icons/index.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 
@@ -10,9 +9,6 @@ const DEBOUNCE_MS = 250;
 
 export default class Index extends Component {
   @service router;
-
-  @tracked searchQuery = null;
-  @tracked selectedIconSize = '16';
 
   allIcons = catalog.assets.map(({ iconName, fileName, size, description }) => {
     return {
@@ -25,14 +21,18 @@ export default class Index extends Component {
   });
 
   get filteredIcons() {
-    if (this.searchQuery) {
+    // this.router.currentRoute.queryParams['searchQuery'];
+    const searchQuery = this.router.currentRoute.queryParams['searchQuery'];
+    const selectedIconSize =
+      this.router.currentRoute.queryParams['selectedIconSize'] || '16';
+    if (searchQuery) {
       return this.allIcons.filter(
         (i) =>
-          i.size === this.selectedIconSize &&
-          i.searchable.indexOf(this.searchQuery) !== -1
+          i.size === selectedIconSize &&
+          i.searchable.indexOf(searchQuery) !== -1
       );
     } else {
-      return this.allIcons.filter((i) => i.size === this.selectedIconSize);
+      return this.allIcons.filter((i) => i.size === selectedIconSize);
     }
   }
 
@@ -45,10 +45,6 @@ export default class Index extends Component {
     if (this.selectedIconSize) {
       newQueryParams.queryParams.selectedIconSize = this.selectedIconSize;
     }
-    console.log('updateQueryParams', this.router, newQueryParams);
-    // TODO this should work but it doesn't
-    // https://api.emberjs.com/ember/4.4/classes/RouterService/methods/transitionTo?anchor=transitionTo
-    // maybe related to this? https://github.com/emberjs/ember.js/issues/18282
     this.router.transitionTo(newQueryParams);
   }
 

--- a/website/tests/acceptance/component-query-test.js
+++ b/website/tests/acceptance/component-query-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { click, visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 
-module('Acceptance | tab routing', function (hooks) {
+module('Acceptance | Component Tabs', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('visiting a tabbed page and interacting with tabs by default', async function (assert) {
+  test('visiting a tabbed component page and interacting with tabs by default', async function (assert) {
     await visit('/components/alert');
 
     assert.strictEqual(currentURL(), '/components/alert?tab=guidelines');
@@ -24,7 +24,7 @@ module('Acceptance | tab routing', function (hooks) {
     assert.strictEqual(currentURL(), '/components/alert?tab=code');
   });
 
-  test('visiting a tabbed page and interacting with tabs by specific tab', async function (assert) {
+  test('visiting a tabbed component page and interacting with tabs by specific tab', async function (assert) {
     await visit('/components/alert?tab=code');
 
     assert.strictEqual(currentURL(), '/components/alert?tab=code');
@@ -35,7 +35,7 @@ module('Acceptance | tab routing', function (hooks) {
       .hasClass('doc-page-tabs__tab--is-current');
   });
 
-  test('specifying a tab that does not exist defaults to the first tab', async function (assert) {
+  test('specifying a component tab that does not exist defaults to the first tab', async function (assert) {
     await visit('/components/alert?tab=wubalubadubdub');
 
     assert.strictEqual(currentURL(), '/components/alert?tab=guidelines');

--- a/website/tests/acceptance/icon-query-test.js
+++ b/website/tests/acceptance/icon-query-test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { fillIn, visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+
+module('Acceptance | Icon Search', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting a icons page and interacting with search by default', async function (assert) {
+    await visit('/foundations/icons');
+    await fillIn('#doc-foundations-icons-filter-search', 'loading');
+
+    assert.strictEqual(
+      currentURL(),
+      '/foundations/icons?searchQuery=loading&tab=library'
+    );
+
+    assert.dom('.doc-icons-list-grid-item').exists({ count: 1 });
+  });
+
+  test('visiting a icons page with a query param', async function (assert) {
+    await visit('/foundations/icons?searchQuery=loading&selectedIconSize=16');
+
+    assert.strictEqual(
+      currentURL(),
+      '/foundations/icons?searchQuery=loading&selectedIconSize=16&tab=library'
+    );
+
+    assert.dom('.doc-icons-list-grid-item').exists({ count: 1 });
+  });
+
+  test('visiting icons page with no results', async function (assert) {
+    await visit('/foundations/icons?searchQuery=wubalubadubdub');
+
+    assert.dom('.doc-icons-list-grid__not-found').exists();
+    assert.dom('[data-test-icon="activity"]').doesNotExist();
+  });
+});

--- a/website/tests/acceptance/tab-routing-test.js
+++ b/website/tests/acceptance/tab-routing-test.js
@@ -1,0 +1,48 @@
+import { module, test } from 'qunit';
+import { click, visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+
+module('Acceptance | tab routing', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting a tabbed page and interacting with tabs by default', async function (assert) {
+    await visit('/components/alert');
+
+    assert.strictEqual(currentURL(), '/components/alert?tab=guidelines');
+
+    assert.dom('.doc-page-tabs__tab--is-current').exists({ count: 1 });
+    assert
+      .dom('.doc-page-tabs__tab:nth-child(1)')
+      .hasClass('doc-page-tabs__tab--is-current');
+
+    await click('#tab-code');
+
+    assert
+      .dom('.doc-page-tabs__tab:nth-child(1)')
+      .doesNotHaveClass('doc-page-tabs__tab--is-current');
+
+    assert.strictEqual(currentURL(), '/components/alert?tab=code');
+  });
+
+  test('visiting a tabbed page and interacting with tabs by specific tab', async function (assert) {
+    await visit('/components/alert?tab=code');
+
+    assert.strictEqual(currentURL(), '/components/alert?tab=code');
+
+    assert.dom('.doc-page-tabs__tab--is-current').exists({ count: 1 });
+    assert
+      .dom('.doc-page-tabs__tab:nth-child(2)')
+      .hasClass('doc-page-tabs__tab--is-current');
+  });
+
+  test('specifying a tab that does not exist defaults to the first tab', async function (assert) {
+    await visit('/components/alert?tab=wubalubadubdub');
+
+    assert.strictEqual(currentURL(), '/components/alert?tab=guidelines');
+
+    assert.dom('.doc-page-tabs__tab--is-current').exists({ count: 1 });
+    assert
+      .dom('.doc-page-tabs__tab:nth-child(1)')
+      .hasClass('doc-page-tabs__tab--is-current');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
This PR creates query params to handle "routing" for:
* tabs on "show" pages
* Icon search and size

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

* [ ] Why do we lose `#` when reloading a query param'ed route (but we scroll to the right content)


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
