### PR TITLE
[docs] adds `aria-label` to sidebar nav

### DIFF
--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -1,7 +1,7 @@
 {{#if this.structuredPageTree}}
   <aside class="doc-page-sidebar" ...attributes>
     <div class="doc-page-sidebar__inner-wrapper">
-      <nav class="doc-page-sidebar__table-of-contents">
+      <nav class="doc-page-sidebar__table-of-contents" aria-label="secondary page navigation">
         <DocTableOfContents @structuredPageTree={{this.structuredPageTree}} @level={{1}} />
       </nav>
     </div>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds an `aria-label` to the sidebar navigation element.

### :hammer_and_wrench: Detailed description

Because we (correctly) have multiple nav elements, each require a unique `aria-label` attribute. 

### 👀 How to review
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
