### PR TITLE
Update do-don't styling to match current design

### DIFF
--- a/website/app/styles/components/do-dont.scss
+++ b/website/app/styles/components/do-dont.scss
@@ -30,7 +30,7 @@
 .doc-do-dont__content {
   padding: 16px;
   border-style: solid;
-  border-width: 3px 1px 1px 1px;
+  border-width: 4px 1px 1px 1px;
   border-radius: 3px;
 
   @include breakpoint.medium () {

--- a/website/app/styles/components/do-dont.scss
+++ b/website/app/styles/components/do-dont.scss
@@ -4,10 +4,10 @@
 @use "../typography/mixins" as *;
 
 .doc-do-dont {
-  margin: 16px 0;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  margin: 16px 0;
 }
 
 .doc-do-dont__badge {

--- a/website/app/styles/components/do-dont.scss
+++ b/website/app/styles/components/do-dont.scss
@@ -5,12 +5,14 @@
 
 .doc-do-dont {
   margin: 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .doc-do-dont__badge {
   @include doc-font-style-body-small();
   width: min-content;
-  margin-bottom: 8px;
   padding: 3px 12px 4px;
   color: white; // TODO transform to token
   font-weight: 600;
@@ -26,17 +28,17 @@
 }
 
 .doc-do-dont__content {
-  padding: 12px;
+  padding: 16px;
   border-style: solid;
-  border-width: 1px;
+  border-width: 3px 1px 1px 1px;
   border-radius: 3px;
 
   @include breakpoint.medium () {
-    padding: 18px;
+    padding: 24px;
   }
 
   @include breakpoint.large () {
-    padding: 24px;
+    padding: 32px;
   }
 
   .doc-do-dont--type-do & {


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR will bring the styling for the do-don't block up to date with the current design.

### :camera_flash: Screenshots

<img width="787" alt="Screen Shot 2022-12-08 at 6 46 13 PM" src="https://user-images.githubusercontent.com/2200899/206612699-f1b9616f-fea7-44a1-a7d9-03ecda4da3b1.png">

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit
👉 Review by files changed

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
