### PR TITLE
New docs website / Finalize styling for `blockquote`

### DIFF
--- a/website/app/styles/markdown/typography.scss
+++ b/website/app/styles/markdown/typography.scss
@@ -61,11 +61,11 @@
 }
 
 .doc-markdown-blockquote {
+  @include doc-font-style-body();
   margin: 0 0 12px 0;
   padding: 0 0 0 16px;
-  border-left: 2px solid lightgray;
-
-  @include doc-font-style-body();
+  color: var(--doc-color-gray-200);
+  border-left: 6px solid var(--doc-color-gray-400);
 
   > :first-child {
     margin-top: 0;


### PR DESCRIPTION
### :pushpin: Summary

This small PR aligns the styling of the `blockquote` in markdown to the design specs.

### :camera_flash: Screenshots

**In code:**
<img width="659" alt="screenshot_2160" src="https://user-images.githubusercontent.com/686239/206675271-8c594b2a-4a06-41e5-aee8-e1bc756e6e22.png">

**In design** ([Figma file](https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=810%3A63785&t=SG6x8piu4ObfVyAR-1))
<img width="866" alt="screenshot_2161" src="https://user-images.githubusercontent.com/686239/206675402-8dfe4e64-1541-4785-9863-eb759d9e3e86.png">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1214

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
