### PR TITLE
New docs website / Finalize typography

### DIFF
--- a/website/app/components/doc/page/cover.hbs
+++ b/website/app/components/doc/page/cover.hbs
@@ -1,7 +1,7 @@
 <div class="doc-page-cover" ...attributes>
   <h1 class="doc-page-cover__title doc-text-h1">{{@title}}</h1>
   {{#if @description}}
-    <p class="doc-page-cover__description doc-text-body-large">{{@description}}</p>
+    <p class="doc-page-cover__description doc-text-body">{{@description}}</p>
   {{/if}}
   <div class="doc-page-cover__tabs">
     <Doc::Page::Tabs @tabs={{@tabs}} />

--- a/website/app/styles/typography/index.scss
+++ b/website/app/styles/typography/index.scss
@@ -1,10 +1,10 @@
+// TYPOGRAPHIC STYLES
+
 @import "./font-faces";
 @import "./mixins";
 
-// TYPOGRAPHIC STYLES
 
 // HEADERS
-// TODO! discuss with Heather if we use `docs-text-h1` or `docs-text-display1`
 
 .doc-text-h1 {
   @include doc-font-style-h1 ();
@@ -38,14 +38,6 @@
 
 .doc-text-body-small {
   @include doc-font-style-body-small ();
-}
-
-.doc-text-body-large {
-  @include doc-font-style-body-large();
-}
-
-.doc-text-body-long {
-  @include doc-font-style-body-long();
 }
 
 // CODE

--- a/website/app/styles/typography/index.scss
+++ b/website/app/styles/typography/index.scss
@@ -46,3 +46,12 @@
   @include doc-font-style-code();
 }
 
+// SUPPORTING STYLES
+
+.doc-text-navigation {
+  @include doc-font-style-navigation();
+}
+
+.doc-text-label {
+  @include doc-font-style-label();
+}

--- a/website/app/styles/typography/mixins.scss
+++ b/website/app/styles/typography/mixins.scss
@@ -161,3 +161,20 @@
   line-height: 1.714; // 24px
 }
 
+
+// ---------
+// SUPPORTING STYLES
+// ---------
+
+@mixin doc-font-style-navigation { // same as body-small but different weight
+  @include doc-font-style-body-small();
+  font-weight: 500;
+}
+
+@mixin doc-font-style-label {
+  @include doc-font-family("gilmer");
+  font-weight: 700;
+  font-size: 0.75rem; // 12px
+  line-height: 1.5;
+}
+

--- a/website/app/styles/typography/mixins.scss
+++ b/website/app/styles/typography/mixins.scss
@@ -30,26 +30,22 @@
 
   @if $responsive {
     @include breakpoint.small () {
-      font-size: 2.125rem;
-      line-height: 1.265;
-      letter-spacing: -0.008em;
+      font-size: 2.125rem; // 34px
+      line-height: 1.265; // 43px
     }
 
     @include breakpoint.medium () {
-      font-size: 2.625rem;
-      line-height: 1.19;
-      letter-spacing: -0.01em;
+      font-size: 2.625rem; // 42px
+      line-height: 1.19; // 50px
     }
 
     @include breakpoint.large () {
-      font-size: 3.125rem;
-      line-height: 1.2;
-      letter-spacing: -0.01em;
+      font-size: 3.125rem; // 50px
+      line-height: 1.2; // 60px
     }
   } @else {
-    font-size: 3.125rem;
-    line-height: 1.2;
-    letter-spacing: -0.01em;
+    font-size: 3.125rem; // 50px
+    line-height: 1.2; // 60px
   }
 }
 
@@ -61,26 +57,22 @@
 
   @if $responsive {
     @include breakpoint.small () {
-      font-size: 1.75rem;
-      line-height: 1.286;
-      letter-spacing: -0.004em;
+      font-size: 1.5rem; // 24px
+      line-height: 2.063; // 33px
     }
 
     @include breakpoint.medium () {
-      font-size: 2.125rem;
-      line-height: 1.265;
-      letter-spacing: -0.008em;
+      font-size: 28px; // 28px
+      line-height: 1.321; // 37px
     }
 
     @include breakpoint.large () {
-      font-size: 2.5rem;
-      line-height: 1.25;
-      letter-spacing: -0.01em;
+      font-size: 32px; // 32px
+      line-height: 1.3125; // 42px
     }
   } @else {
-    font-size: 2.5rem;
-    line-height: 1.25;
-    letter-spacing: -0.01em;
+    font-size: 32px; // 32px
+    line-height: 1.3125; // 42px
   }
 }
 
@@ -92,26 +84,22 @@
 
   @if $responsive {
     @include breakpoint.small () {
-      font-size: 1.5rem;
-      line-height: 1.375;
-      letter-spacing: -0.004em;
+      font-size: 1.313rem; // 21px
+      line-height: 1.429; // 30px
     }
 
     @include breakpoint.medium () {
-      font-size: 1.75rem;
-      line-height: 1.321;
-      letter-spacing: -0.004em;
+      font-size: 1.438rem; // 23px
+      line-height: 1.391; // 32px
     }
 
     @include breakpoint.large () {
-      font-size: 2rem;
-      line-height: 1.313;
-      letter-spacing: -0.006em;
+      font-size: 24px; // 24px
+      line-height: 1.417; // 34px
     }
   } @else {
-    font-size: 2rem;
-    line-height: 1.313;
-    letter-spacing: -0.006em;
+    font-size: 24px; // 24px
+    line-height: 1.417; // 34px
   }
 }
 
@@ -120,29 +108,8 @@
 @mixin doc-font-style-h4($responsive: true) {
   @include doc-font-family("gilmer");
   font-weight: 700;
-
-  @if $responsive {
-    @include breakpoint.small () {
-      font-size: 1.313rem;
-      line-height: 1.429;
-    }
-
-    @include breakpoint.medium () {
-      font-size: 1.438rem;
-      line-height: 1.391;
-      letter-spacing: -0.004em;
-    }
-
-    @include breakpoint.large () {
-      font-size: 1.5rem;
-      line-height: 1.417;
-      letter-spacing: -0.004em;
-    }
-  } @else {
-    font-size: 1.5rem;
-    line-height: 1.417;
-    letter-spacing: -0.004em;
-  }
+  font-size: 1.125rem; // 18px
+  line-height: 1.556; // 28px
 }
 
 // H5
@@ -150,8 +117,8 @@
 @mixin doc-font-style-h5 {
   @include doc-font-family("gilmer");
   font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.556;
+  font-size: 1rem; // 16px
+  line-height: 1.5; // 24px
 }
 
 // H6
@@ -159,8 +126,8 @@
 @mixin doc-font-style-h6 {
   @include doc-font-family("gilmer");
   font-weight: 700;
-  font-size: 1rem;
-  line-height: 1.5;
+  font-size: 0.938rem; // 15px
+  line-height: 1.25; // 20px
 }
 
 
@@ -172,59 +139,17 @@
 
 @mixin doc-font-style-body {
   @include doc-font-family("sans");
-  font-size: 1.063rem;
-  line-height: 1.647;
-  letter-spacing: 0.01em;
+  font-size: 1.063rem; // 17px;
+  line-height: 1.765; // 30px
 }
 
 // SMALL
 
 @mixin doc-font-style-body-small {
   @include doc-font-family("sans");
-  font-size: 0.938rem;
-  line-height: 1.667;
-  letter-spacing: 0.01em;
+  font-size: 0.938rem; // 15px
+  line-height: 1.667; // 25px
 }
-
-// LARGE
-
-@mixin doc-font-style-body-large($responsive: true) {
-  @include doc-font-family("sans");
-
-  @if $responsive {
-    @include breakpoint.small () {
-      font-size: 1.188rem;
-      line-height: 1.579;
-      letter-spacing: 0.01em;
-    }
-
-    @include breakpoint.medium () {
-      font-size: 1.188rem;
-      line-height: 1.579;
-      letter-spacing: 0.01em;
-    }
-
-    @include breakpoint.large () {
-      font-size: 1.25rem;
-      line-height: 1.55;
-      letter-spacing: 0.01em;
-    }
-  } @else {
-    font-size: 1.25rem;
-    line-height: 1.55;
-    letter-spacing: 0.01em;
-  }
-}
-
-// LONG
-
-@mixin doc-font-style-body-long {
-  @include doc-font-family("sans");
-  font-size: 1.063rem;
-  line-height: 1.765;
-  letter-spacing: 0.01em;
-}
-
 
 // ---------
 // CODE
@@ -232,7 +157,7 @@
 
 @mixin doc-font-style-code {
   @include doc-font-family("mono");
-  font-size: 0.875rem;
-  line-height: 1.714;
+  font-size: 0.875rem; // 14px
+  line-height: 1.714; // 24px
 }
 

--- a/website/docs/testing/components/badge.md
+++ b/website/docs/testing/components/badge.md
@@ -1,5 +1,7 @@
 ---
 title: Doc::Badge
+layout:
+  sidecar: false
 ---
 
 **Basic badge**

--- a/website/docs/testing/components/typography.md
+++ b/website/docs/testing/components/typography.md
@@ -1,0 +1,50 @@
+---
+title: Typography
+layout:
+  sidecar: false
+---
+
+
+## Classnames styling
+
+Styling applied to HTML elements using the `doc-text-***` CSS class names
+
+<h1 class="doc-text-h1">H1 - Lorem ipsum dolor sit amet</h1>
+<h2 class="doc-text-h2">H2 - Lorem ipsum dolor sit amet</h2>
+<h3 class="doc-text-h3">H3 - Lorem ipsum dolor sit amet</h3>
+<h4 class="doc-text-h4">H4 - Lorem ipsum dolor sit amet</h4>
+<h5 class="doc-text-h5">H5 - Lorem ipsum dolor sit amet</h5>
+<h6 class="doc-text-h6">H6 - Lorem ipsum dolor sit amet</h6>
+
+---
+
+<p class="doc-text-body">This is the "base" body copy (<code>doc-text-body</code>) - lorem ipsum dolor praesent dapibus vitae velit non aliquet aenean feugiat hendrerit nibh quis placerat. in finibus ultricies risus, a sodales velit maximus et aenean commodo.</p>
+<p class="doc-text-body">This is the "base" body copy with <strong>strong text</strong> / <em>emphasized text</em> / <code>inline code</code></p>
+
+<p class="doc-text-body-small">This is the "small" body copy (<code>doc-text-body-small</code>) - lorem ipsum dolor praesent dapibus vitae velit non aliquet aenean feugiat hendrerit nibh quis placerat. in finibus ultricies risus, a sodales velit maximus et aenean commodo</p>
+<p class="doc-text-body-small">This is the "base" body copy with <strong>strong text</strong> / <em>emphasized text</em> / <code>inline code</code></p>
+
+---
+
+<kbd class="doc-text-code">This is the "code" text (diffent from the "inline code" which has a specific styling)</kbd>
+
+<code class="doc-text-code">This is the inline "code" text</code>
+
+---
+
+## Markdown styling
+
+# This is markdown text level 1
+## This is markdown text level 2
+### This is markdown text level 3
+#### This is markdown text level 4
+##### This is markdown text level 5
+###### This is markdown text level 6
+
+This is markdown text as body copy with **strong** _emphasis_ and `inline code`
+
+> This is markdown text as blockquote
+
+- This is markdown text in a list
+- And other markdown text too
+


### PR DESCRIPTION
### :pushpin: Summary

This aligns the typographic definitions to the latest design specs.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the typographic definitions in CSS (font sizes and line heights) and aligned mixins and class names to match the latest design specs
- added markdown page for testing typography

👉 👉 👉 [Preview](https://hds-website-git-new-docs-website-typography-hashicorp.vercel.app/testing/components/typography/): https://hds-website-git-new-docs-website-typography-hashicorp.vercel.app/testing/components/typography/

### :camera_flash: Screenshots

**In code:**
<img width="888" alt="screenshot_2170" src="https://user-images.githubusercontent.com/686239/206713467-6452a642-d64f-465d-9e2c-0680825bad29.png">

**In design:** 

See [Figma file](https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=181%3A23422).

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1030
Figma file: https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=181%3A23422

***

### 👀 How to review

👉 Review commit-by-commit or by files changed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
