### PR TITLE
New docs website / fix console errors

### DIFF
--- a/website/app/components/power-select/after-options.hbs
+++ b/website/app/components/power-select/after-options.hbs
@@ -1,0 +1,4 @@
+{{! This is not an HDS component, but a supporting file for `overrides/power-select.hbs` which requires a component to be passed in for the showcase }}
+<div class="hds-power-select__after-options">
+  5 results
+</div>

--- a/website/docs/components/power-select/after-options/index.md
+++ b/website/docs/components/power-select/after-options/index.md
@@ -1,4 +1,0 @@
----
-title: Missing component title
----
-

--- a/website/docs/components/table/index.js
+++ b/website/docs/components/table/index.js
@@ -1,11 +1,116 @@
 import Component from '@glimmer/component';
+import { capitalize } from '@ember/string';
 
 export default class Index extends Component {
   get STATES() {
     // these are used only for presentation purpose in the showcase
     return ['active', 'default', 'hover', 'focus'];
   }
-  //
-  // TODO! move also the data fetching here
-  //
+
+  get model() {
+    let data = [
+      {
+        id: '1',
+        type: 'folk',
+        attributes: {
+          artist: 'Nick Drake',
+          album: 'Pink Moon',
+          year: '1972',
+          quote:
+            "The song is very special. It's an old song by a guy named Nick Drake. It's called 'Pink Moon' and is actually a very good introduction to Nick Drake if you're not familiar with him. It's very transporting. And to us seemed very fitting for a beautiful drive in the country on a very special night.",
+          'vinyl-cost': '29.27',
+          icon: 'boundary-color',
+          'badge-type': 'filled',
+          'badge-color': 'neutral',
+        },
+      },
+      {
+        id: '2',
+        type: 'folk',
+        attributes: {
+          artist: 'The Beatles',
+          album: 'Abbey Road',
+          year: '1969',
+          quote:
+            "it was the Beatles' last love letter to the world...lush, rich, smooth, epic, emotional and utterly gorgeous",
+          'vinyl-cost': '25.99',
+          icon: 'consul-color',
+          'badge-type': 'outlined',
+          'badge-color': 'neutral',
+        },
+      },
+      {
+        id: '3',
+        type: 'folk',
+        attributes: {
+          artist: 'Melanie',
+          album: 'Candles in the Rain',
+          year: '1971',
+          quote:
+            'Candles in the Rain matched material and interpretation with greater skill than she had in the past, and it ranks with her finest work',
+          'vinyl-cost': '46.49',
+          icon: 'terraform-color',
+          'badge-type': 'filled',
+          'badge-color': 'highlight',
+        },
+      },
+      {
+        id: '4',
+        type: 'folk',
+        attributes: {
+          artist: 'Bob Dylan',
+          album: 'Bringing It All Back Home',
+          year: '1965',
+          quote:
+            'By fusing the Chuck Berry beat of the Rolling Stones and the Beatles with the leftist, folk tradition of the folk revival, Dylan really had brought it back home, creating a new kind of rock & roll that made every type of artistic tradition available to rock.',
+          'vinyl-cost': '229.00',
+          icon: 'nomad-color',
+          'badge-type': 'outlined',
+          'badge-color': 'success',
+        },
+      },
+      {
+        id: '5',
+        type: 'folk',
+        attributes: {
+          artist: 'James Taylor',
+          album: 'Sweet Baby James',
+          year: '1970',
+          quote:
+            '(It) struck a chord with music fans, especially because of its attractive mixture of folk, country, gospel, and blues elements, all of them carefully understated and distanced.',
+          'vinyl-cost': '16.00',
+          icon: 'waypoint-color',
+          'badge-type': 'filled',
+          'badge-color': 'warning',
+        },
+      },
+      {
+        id: '6',
+        type: 'folk',
+        attributes: {
+          artist: 'Simon and Garfunkel',
+          album: 'Bridge Over Troubled Waters',
+          year: '1970',
+          quote:
+            'Perhaps the most delicately textured album to close out the 1960s from any major rock act.',
+          'vinyl-cost': '20.49',
+          icon: 'vagrant-color',
+          'badge-type': 'outlined',
+          'badge-color': 'critical',
+        },
+      },
+    ];
+
+    // make sure the variable is declared outside of the loop
+    // so we can return it in the model response
+    let dataResponse = data.map((record) => {
+      let { id, attributes } = record;
+      return { id, ...attributes };
+    });
+    const keys = Object.keys(data[0].attributes);
+    const columns = keys.map((key) => {
+      return { key, label: capitalize(key) };
+    });
+    return { data: dataResponse, columns };
+  }
 }

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -4,7 +4,7 @@ There are several ways to implement the table component. These examples will be 
 
 If you have your own content and don't want to use a model, you can still benefit from the components themselves. Here is an example of such an invocation in a template:
 
-```handlebars
+```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
 
 <Hds::Table>
@@ -29,7 +29,7 @@ If you have your own content and don't want to use a model, you can still benefi
 
 In this invocation of the table component, you would define the data model and insert your own content into the `:head` and `:body` blocks. Here is an example of such an invocation in a template:
 
-```handlebars
+```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
 
 <Hds::Table @model={{this.model}}>
@@ -103,7 +103,7 @@ export default class ComponentsTableRoute extends Route {
 
 2\. Invoke the Hds::Table component in your template file.
 
-```handlebars
+```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
 
 <Hds::Table
@@ -122,7 +122,7 @@ export default class ComponentsTableRoute extends Route {
 
 If you want, you can indicate that only specific columns should be sortable.
 
-```handlebars
+```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
 
 <Hds::Table
@@ -142,7 +142,7 @@ If you want, you can indicate that only specific columns should be sortable.
 
 You can also indicate that a specific column should be pre-sorted.
 
-```handlebars
+```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
 
 <Hds::Table
@@ -163,7 +163,7 @@ You can also indicate that a specific column should be pre-sorted.
 
 You can also indicate that a specific column should be pre-sorted in a specific direction.
 
-```handlebars
+```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
 
 <Hds::Table
@@ -185,7 +185,7 @@ You can also indicate that a specific column should be pre-sorted in a specific 
 
 Here's a table implementation that uses an array hash with localized strings for the column headers, indicates which columns should be sortable, and adds an overflow menu.
 
-```handlebars
+```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
 
 <Hds::Table

--- a/website/docs/components/tabs/partials/code/component-api.md
+++ b/website/docs/components/tabs/partials/code/component-api.md
@@ -30,7 +30,7 @@ Here is the API for the “Tab” component:
     Sets a custom initial tab to display when the page is loaded. (The first tab is selected on page load by default.)
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside a `<button>` element.
+    Elements passed as children of this component are yielded inside a `button` element.
   </C.Property>
   <C.Property @name="...attributes">
     `...attributes` spreading is supported on this component.
@@ -43,7 +43,7 @@ Here is the API for the “Panel” component:
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside a `<section>` element.
+    Elements passed as children of this component are yielded inside a `section` element.
   </C.Property>
   <C.Property @name="...attributes">
     `...attributes` spreading is supported on this component.

--- a/website/docs/overrides/power-select/partials/code/how-to-use.md
+++ b/website/docs/overrides/power-select/partials/code/how-to-use.md
@@ -20,8 +20,8 @@ Invocation of the component with overrides would look something like this:
 ```handlebars
 <div class="hds-power-select">
   <PowerSelect
-    @options={{@model.OPTIONS}}
-    @selected={{@model.SELECTED}}
+    @options={{this.OPTIONS}}
+    @selected={{this.SELECTED}}
     @onChange={{this.noop}}
     @renderInPlace={{true}}
     as |option|
@@ -42,8 +42,8 @@ When used with the `@searchEnabled` argument, the input is automatically styled 
 ```handlebars
 <div class="hds-power-select">
   <PowerSelect
-    @options={{@model.OPTIONS}}
-    @selected={{@model.SELECTED}}
+    @options={{this.OPTIONS}}
+    @selected={{this.SELECTED}}
     @onChange={{this.noop}}
     @renderInPlace={{true}}
     @searchEnabled={{true}}
@@ -54,10 +54,6 @@ When used with the `@searchEnabled` argument, the input is automatically styled 
 </div>
 ```
 
-Renders to:
-
-{{option}}
-
 #### After options block
 
 To consistently style the `@afterOptionsComponent` use the `hds-power-select__after-options` class on the outermost element of the after options component.
@@ -65,8 +61,8 @@ To consistently style the `@afterOptionsComponent` use the `hds-power-select__af
 ```handlebars
 <div class="hds-power-select">
   <PowerSelect
-    @options={{@model.OPTIONS}}
-    @selected={{@model.SELECTED}}
+    @options={{this.OPTIONS}}
+    @selected={{this.SELECTED}}
     @afterOptionsComponent={{"power-select/after-options"}}
     @onChange={{this.noop}}
     @renderInPlace={{true}}
@@ -85,10 +81,6 @@ Where `power-select/after-options.hbs` would look like this:
 </div>
 ```
 
-Renders to:
-
-{{option}}
-
 #### Multiple selection
 
 When multiple options are allowed the selected items are automatically styled to resemble the [`Tag`](/components/tag/) component.
@@ -96,8 +88,8 @@ When multiple options are allowed the selected items are automatically styled to
 ```handlebars
 <div class="hds-power-select">
   <PowerSelectMultiple
-    @options={{@model.OPTIONS}}
-    @selected={{@model.SELECTEDMULTIPLE}}
+    @options={{this.OPTIONS}}
+    @selected={{this.SELECTEDMULTIPLE}}
     @onChange={{this.noop}}
     @renderInPlace={{true}}
     as |option|

--- a/website/docs/utilities/interactive/partials/code/how-to-use.md
+++ b/website/docs/utilities/interactive/partials/code/how-to-use.md
@@ -2,7 +2,7 @@
 
 Invocation of the component would look something like this:
 
-```handlebars
+```handlebars{data-execute=false}
 <Hds::Interactive>
     your content here (will be yielded)
 </Hds::Interactive>
@@ -18,7 +18,7 @@ _Notice: a `type="button"` HTML attribute is applied by default to the element, 
 
 If an `@href` argument is provided:
 
-```handlebars
+```handlebars{data-execute=false}
 <Hds::Interactive @href="https://google.com">
     your content here
 </Hds::Interactive>
@@ -30,7 +30,7 @@ _We add these attributes by default because this is the most common case (intern
 
 If an `@isHrefExternal` argument is provided with `false` value:
 
-```handlebars
+```handlebars{data-execute=false}
 <Hds::Interactive @href="#your-local-anchor-id" @isHrefExternal={{false}}>
     your content here
 </Hds::Interactive>
@@ -42,7 +42,7 @@ it will generate in output an HTML `<a>` link element **without** the HTML `targ
 
 If a `@route` argument is provided:
 
-```handlebars
+```handlebars{data-execute=false}
 <Hds::Interactive @route="components" >
     your content here
 </Hds::Interactive>
@@ -52,7 +52,7 @@ it will generate in output a `<LinkTo>` component.
 
 If the `@route` is external to the current engine ([more details here](https://ember-engines.com/docs/link-to-external)), you need to provide an extra `@isRouteExternal` parameter:
 
-```handlebars
+```handlebars{data-execute=false}
 <Hds::Interactive @route="components" @isRouteExternal={{true}} >
     your content here
 </Hds::Interactive>

--- a/website/package.json
+++ b/website/package.json
@@ -61,6 +61,7 @@
     "ember-math-helpers": "^2.18.2",
     "ember-meta": "^2.0.0",
     "ember-page-title": "^7.0.0",
+    "ember-power-select": "^6.0.0",
     "ember-prism": "^0.10.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23136,6 +23136,7 @@ __metadata:
     ember-math-helpers: ^2.18.2
     ember-meta: ^2.0.0
     ember-page-title: ^7.0.0
+    ember-power-select: ^6.0.0
     ember-prism: ^0.10.0
     ember-qunit: ^5.1.5
     ember-resolver: ^8.0.3


### PR DESCRIPTION
### :pushpin: Summary

This PR is a follow-up on #750 and attempts to fix page errors for the following pages:
 - [PowerSelect](https://hds-website-git-alex-ju-new-website-error-fixes-hashicorp.vercel.app/overrides/power-select/)
   - added `ember-power-select` dependency
   - ported the `after-options.hbs` template
   - removes the unnecessary file from automated conversion)
 - [Tabs](https://hds-website-git-alex-ju-new-website-error-fixes-hashicorp.vercel.app/components/tabs/)
   - unable to escape HTML tags within property definitions – will look into this limitation more in-depth, but to be able to see the page I removed the angle brackets, for now
 - [Table](https://hds-website-git-alex-ju-new-website-error-fixes-hashicorp.vercel.app/components/table/)
   - mark non-executable examples under 'How to use' as such
   - ported the async data fetch
 - [Interactive](https://hds-website-git-alex-ju-new-website-error-fixes-hashicorp.vercel.app/utilities/interactive/)
   - mark non-executable examples as such

Follow-up work:
 - The `PowerSelect` override requires some additional resilience as it seems to rely on a few `ul`/`li` resets
 - Investigate the use of HTML tags inside component property blocks

### :link: External links

[Jira issue](https://hashicorp.atlassian.net/browse/HDS-1171)

***

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
