### PR TITLE
refactor tab parsing logic to run every time model changes

### DIFF
--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -3,10 +3,14 @@ import showdown from 'showdown';
 import { set, action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
+import { schedule } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 
 import { showdownConfig } from '../shared/showdown-config';
 
 export default class ShowController extends Controller {
+  @service fastboot;
+
   @tracked sections = A([]);
   @tracked tabs = A([]);
   @tracked tocs = A([]);
@@ -20,16 +24,21 @@ export default class ShowController extends Controller {
   }
 
   get renderedContent() {
+    // schedule tabs logic for after this content is rendered
+    if (!this.fastboot.isFastBoot) {
+      schedule('afterRender', () => {
+        this.didInsertContent();
+      });
+    }
     const converter = new showdown.Converter(showdownConfig);
     return converter.makeHtml(this.model.content);
   }
 
-  @action
-  didInsertContent(docPageContentElement) {
+  didInsertContent = () => {
     let sections = [];
     let tabs = [];
     let tocs = [];
-    docPageContentElement
+    document
       .querySelectorAll(`section[id^=section-]`)
       .forEach((section, index) => {
         // SECTIONS
@@ -75,7 +84,7 @@ export default class ShowController extends Controller {
     this.setCurrent(0);
     // leave for debugging
     // console.log('show didInsert', this.sections, this.tabs, this.tocs);
-  }
+  };
 
   @action
   onClickTab(tab) {

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -39,7 +39,7 @@ export default class ShowController extends Controller {
     let tabs = [];
     let tocs = [];
     document
-      .querySelectorAll(`section[id^=section-]`)
+      .querySelectorAll(`.doc-page-content section[id^=section-]`)
       .forEach((section, index) => {
         // SECTIONS
         const name = section.id.replace(/^section-/, '');

--- a/website/app/templates/show.hbs
+++ b/website/app/templates/show.hbs
@@ -1,13 +1,10 @@
 <HeadLayout />
 <Doc::Page::Stage>
   {{#if this.model.hasCover}}
-    <Doc::Page::Cover @title={{this.title}} @description={{this.description}} @tabs={{this.tabs}}/>
+    <Doc::Page::Cover @title={{this.title}} @description={{this.description}} @tabs={{this.tabs}} />
   {{/if}}
-  <Doc::Page::Content @breakthrough={{not this.model.hasSidecar}} {{did-insert this.didInsertContent}}>
-    <DynamicTemplate
-      @templateString={{this.renderedContent}}
-      @componentId={{this.model.id}}
-    />
+  <Doc::Page::Content @breakthrough={{not this.model.hasSidecar}}>
+    <DynamicTemplate @templateString={{this.renderedContent}} @componentId={{this.model.id}} />
   </Doc::Page::Content>
   {{#if this.model.hasSidecar}}
     <Doc::Page::Sidecar @tocs={{this.tocs}} />

--- a/website/package.json
+++ b/website/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/render-modifiers": "^2.0.4",
     "@ember/test-helpers": "^2.8.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23106,7 +23106,6 @@ __metadata:
   resolution: "website@workspace:website"
   dependencies:
     "@ember/optional-features": ^2.0.0
-    "@ember/render-modifiers": ^2.0.4
     "@ember/test-helpers": ^2.8.1
     "@glimmer/component": ^1.1.2
     "@glimmer/tracking": ^1.1.2


### PR DESCRIPTION
### :pushpin: Summary

refactor tab parsing logic to run every time model changes so that navigation routing shows correct component pages

### :hammer_and_wrench: Detailed description
A side effect of https://github.com/hashicorp/design-system/pull/779 is that because we are routing via Ember, when you're on a component page and use the navigation to route to another a full transition does not occur and the `did-insert` helper we rely on to parse the tabs doesn't actually run past the initial page load.

This PR refactors the logic to schedule this for after the `renderedContent` function does it's thing which is triggered on each transition because the underlying model is changing (which is what we want).

~~The main drawback is that this is slightly slower on initial render leading to the content jumping a bit once the tabs logic happens, but this does happen with the previous method as well.~~ I think it's the same actually, but please test me on this.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
