### PR TITLE
New docs website / Update component api sections

### DIFF
--- a/website/app/components/doc/component-api/index.hbs
+++ b/website/app/components/doc/component-api/index.hbs
@@ -1,13 +1,3 @@
-<table class="doc-markdown-table doc-component-api" ...attributes>
-  <thead class="doc-markdown-thead">
-    <tr class="doc-markdown-tr">
-      <th class="doc-markdown-th">Name</th>
-      <th class="doc-markdown-th">Type</th>
-      <th class="doc-markdown-th">Value</th>
-      <th class="doc-markdown-th">Notes</th>
-    </tr>
-  </thead>
-  <tbody class="doc-markdown-tbody">
-    {{yield (hash Property=(component "doc/component-api/property"))}}
-  </tbody>
-</table>
+<div class="doc-component-api" ...attributes>
+  {{yield (hash Property=(component "doc/component-api/property"))}}
+</div>

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -22,7 +22,7 @@
       <ul class="doc-component-api__property-values">
         {{#each @values as |value|}}
           <li class="doc-component-api__property-value{{if (eq @default value) "--default"}}">
-            {{value}}
+            {{value}}{{#if (eq @default value)}} <span class="doc-sr-only">(default)</span>{{/if}}
           </li>
         {{/each}}
       </ul>

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -15,9 +15,10 @@
         <span class="doc-component-api__property-required">Required</span>
     </dd>
   {{/if}}
-  {{#if @values}}
+  {{#if (or @values @valueNote)}}
     <dt class="doc-component-api__term doc-component-api__term--values">Values</dt> 
     <dd class="doc-component-api__description doc-component-api__description--values">
+      {{#if @values}}
       <ul class="doc-component-api__property-values">
         {{#each @values as |value|}}
           <li class="doc-component-api__property-value{{if (eq @default value) "--default"}}">
@@ -25,6 +26,9 @@
           </li>
         {{/each}}
       </ul>
+      {{else if @valueNote}}
+        {{@valueNote}}
+      {{/if}}
     </dd>
   {{/if}}
   {{#if (has-block)}}

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -12,7 +12,7 @@
   {{#if @required}}
     <dt class="doc-component-api__term doc-component-api__term--required">Required</dt>
     <dd class="doc-component-api__description doc-component-api__description--required">
-        <span class="doc-component-api__property-required">Required</span>
+      <Doc::Badge @type="outlined">Required</Doc::Badge>
     </dd>
   {{/if}}
   {{#if (or @values @valueNote)}}

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -1,8 +1,36 @@
-<tr class="doc-markdown-tr" ...attributes>
-  <td class="doc-markdown-td">{{@name}}</td>
-  <td class="doc-markdown-td">{{@type}}</td>
-  <td class="doc-markdown-td">{{@value}}</td>
-  <td class="doc-markdown-td">
-    {{yield}}
-  </td>
-</tr>
+<dl class="doc-component-api__property">
+  <dt class="doc-component-api__term doc-component-api__term--name">Name</dt>
+  <dd class="doc-component-api__description doc-component-api__description--name">
+    <code class="doc-component-api__property-name">{{@name}}</code>
+  </dd>
+  {{#if @type}}
+    <dt class="doc-component-api__term doc-component-api__term--type">Type</dt>
+    <dd class="doc-component-api__description doc-component-api__description--type">
+      <code class="doc-component-api__property-type">{{@type}}</code>
+    </dd>
+  {{/if}}
+  {{#if @required}}
+    <dt class="doc-component-api__term doc-component-api__term--required">Required</dt>
+    <dd class="doc-component-api__description doc-component-api__description--required">
+        <span class="doc-component-api__property-required">Required</span>
+    </dd>
+  {{/if}}
+  {{#if @values}}
+    <dt class="doc-component-api__term doc-component-api__term--values">Values</dt> 
+    <dd class="doc-component-api__description doc-component-api__description--values">
+      <ul class="doc-component-api__property-values">
+        {{#each @values as |value|}}
+          <li class="doc-component-api__property-value{{if (eq @default value) "--default"}}">
+            {{value}}
+          </li>
+        {{/each}}
+      </ul>
+    </dd>
+  {{/if}}
+  {{#if (has-block)}}
+    <dt class="doc-component-api__term doc-component-api__term--description">Description</dt>
+    <dd class="doc-component-api__description doc-component-api__description--description">
+      {{yield}}
+    </dd>
+  {{/if}}
+</dl>

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -54,6 +54,18 @@ body {
   padding: 0;
 }
 
+.doc-sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  clip-path: inset(50%) !important;
+}
 
 // PERCY
 

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -20,6 +20,7 @@
 @import "components/cards";
 @import "components/code-block";
 @import "components/color-card";
+@import "components/component-api";
 @import "components/copy-button";
 @import "components/do-dont";
 @import "components/placeholder";

--- a/website/app/styles/components/badge.scss
+++ b/website/app/styles/components/badge.scss
@@ -43,3 +43,7 @@
   background-color: var(--doc-color-feedback-critical-100);
 }
 
+.doc-badge--type-outlined {
+  color: var(--doc-color-gray-300);
+  border: 1px solid var(--doc-color-gray-400);
+}

--- a/website/app/styles/components/component-api.scss
+++ b/website/app/styles/components/component-api.scss
@@ -31,14 +31,11 @@
 }
 
 .doc-component-api__term {
-  @include doc-font-family("gilmer");
+  @include doc-font-style-label();
   margin: 0;
   margin-bottom: 8px;
   padding: 0;
   color: var(--doc-color-gray-300);
-  font-weight: 700;
-  font-size: 0.75rem;
-  line-height: 1.5;
 
   &--name {
     grid-area: 1 / 1 / 2 / 2;

--- a/website/app/styles/components/component-api.scss
+++ b/website/app/styles/components/component-api.scss
@@ -121,17 +121,6 @@
   color: var(--doc-color-gray-100);
 }
 
-.doc-component-api__property-required {
-  @include doc-font-family("sans");
-  padding: 3px 12px 4px;
-  color: var(--doc-color-gray-300);
-  font-weight: 700;
-  font-size: 0.875rem;
-  line-height: 1.357;
-  border: 1px solid var(--doc-color-gray-400);
-  border-radius: 24px;
-}
-
 .doc-component-api__property-values {
   @include doc-font-style-code ();
   margin: 0;

--- a/website/app/styles/components/component-api.scss
+++ b/website/app/styles/components/component-api.scss
@@ -1,0 +1,160 @@
+// COMPONENT API
+
+// Property grid areas
+// | 1 | 3 | 5 |
+// | 2 | 4 | 5 |
+// | 6 | 6 | 6 |
+// | 7 | 7 | 7 |
+// | 8 | 8 | 8 |
+// | 9 | 9 | 9 |
+
+@use "../breakpoints" as breakpoint;
+@use "../typography/mixins";
+
+
+.doc-component-api {
+  margin-bottom: 24px;
+}
+
+.doc-component-api__property {
+  position: relative;
+  display: grid;
+  grid-template-rows: repeat(6, auto);
+  grid-template-columns: repeat(3, 1fr);
+  margin: 0;
+  padding: 24px 16px;
+  border-bottom: 1px solid var(--doc-color-gray-500);
+
+  @include breakpoint.small () {
+    display: block;
+  }
+}
+
+.doc-component-api__term {
+  @include doc-font-family("gilmer");
+  margin: 0;
+  margin-bottom: 8px;
+  padding: 0;
+  color: var(--doc-color-gray-300);
+  font-weight: 700;
+  font-size: 0.75rem;
+  line-height: 1.5;
+
+  &--name {
+    grid-area: 1 / 1 / 2 / 2;
+  }
+
+  &--type {
+    grid-area: 1 / 2 / 2 / 3;
+    padding-left: 8px;
+
+    @include breakpoint.small () {
+      padding-left: 0;
+    }
+  }
+
+  &--required {
+    display: none;
+  }
+
+  &--values {
+    grid-area: 3 / 1 / 4 / 4;
+  }
+
+  &--description {
+    grid-area: 5 / 1 / 6 / 4;
+  }
+}
+
+.doc-component-api__description {
+  @include doc-font-style-body-small ();
+  margin: 0 0 16px;
+  padding: 0;
+
+  &--name {
+    grid-area: 2 / 1 / 3 / 2;
+  }
+
+  &--type {
+    grid-area: 2 / 2 / 3 / 3;
+    padding-left: 8px;
+
+    @include breakpoint.small () {
+      padding-left: 0;
+    }
+  }
+
+  &--required {
+    grid-area: 1 / 3 / 3 / 4;
+    text-align: right;
+
+    @include breakpoint.small () {
+      position: absolute;
+      top: 24px;
+      right: 16px;
+    }
+  }
+
+  &--values {
+    grid-area: 4 / 1 / 5 / 4;
+  }
+
+  &--description {
+    grid-area: 6 / 1 / 7 / 4;
+  }
+
+  &:last-child {
+    margin: 0;
+  }
+}
+
+.doc-component-api__property-name {
+  @include doc-font-style-code ();
+  display: inline-block;
+  padding: 0 7px;
+  color: var(--doc-color-white);
+  font-weight: 700;
+  background-color: var(--doc-color-gray-200);
+  border-radius: 3px;
+}
+
+.doc-component-api__property-type {
+  @include doc-font-style-code ();
+  display: inline-block;
+  color: var(--doc-color-gray-100);
+}
+
+.doc-component-api__property-required {
+  @include doc-font-family("sans");
+  padding: 3px 12px 4px;
+  color: var(--doc-color-gray-300);
+  font-weight: 700;
+  font-size: 0.875rem;
+  line-height: 1.357;
+  border: 1px solid var(--doc-color-gray-400);
+  border-radius: 24px;
+}
+
+.doc-component-api__property-values {
+  @include doc-font-style-code ();
+  margin: 0;
+  padding: 0;
+}
+
+.doc-component-api__property-value {
+  display: inline-block;
+  margin-bottom: 8px;
+  padding: 0 7px;
+  color: var(--doc-color-feedback-information-200);
+  background-color: var(--doc-color-feedback-information-400);
+  border-radius: 3px;
+}
+
+.doc-component-api__property-value--default {
+  display: inline-block;
+  padding: 0 7px;
+  color: var(--doc-color-white);
+  font-weight: 700;
+  background-color: var(--doc-color-feedback-information-200);
+  border-radius: 3px;
+}

--- a/website/docs/components/alert/partials/code/component-api.md
+++ b/website/docs/components/alert/partials/code/component-api.md
@@ -1,10 +1,10 @@
 Here is the API for the component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @required="true" @type="enum" @value="page, inline, compact">
+  <C.Property @name="type" @required="true" @type="enum" @values={{array "page" "inline" "compact" }}>
     Sets the type of alert.
   </C.Property>
-  <C.Property @name="color" @type="enum" @value="neutral, highlight, success, warning, critical" @default="neutral">
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "highlight" "success" "warning" "critical" }} @default="neutral">
     Sets the color scheme for `background`, `border`, `title`, and `description`, which **cannot** be overridden. `color` results in a default `icon`, which **can** be overridden.
   </C.Property>
   <C.Property @name="icon" @type="string | false">

--- a/website/docs/components/badge-count/partials/code/component-api.md
+++ b/website/docs/components/badge-count/partials/code/component-api.md
@@ -1,9 +1,9 @@
 Here is the API for the component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="size" @type="enum" @value="small, medium, large" @default="medium"/>
-  <C.Property @name="type" @type="enum" @value="filled, inverted, outlined" @default="filled"/>
-  <C.Property @name="color" @type="enum" @value="neutral, neutral-dark-mode" @default="neutral"/>
+  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
+  <C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" }} @default="neutral"/>
   <C.Property @name="text" @type="string">
     The text value that should go in the badge counter.
   </C.Property>

--- a/website/docs/components/badge/partials/code/component-api.md
+++ b/website/docs/components/badge/partials/code/component-api.md
@@ -1,9 +1,9 @@
 Here is the API for the component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="size" @type="enum" @value="small, medium, large" @default="medium"/>
-  <C.Property @name="type" @type="enum" @value="filled, inverted, outlined" @default="filled"/>
-  <C.Property @name="color" @type="enum" @value="neutral, neutral-dark-mode, highlight, critical, success, warning" @default="neutral"/>
+  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
+  <C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" "highlight" "critical" "success" "warning" }} @default="neutral"/>
   <C.Property @name="text" @type="string">
     The text of the badge or value of the screen-reader only element if `isIconOnly` is set to `true`. _If no text value is defined an error will be thrown._
   </C.Property>

--- a/website/docs/components/button/partials/code/component-api.md
+++ b/website/docs/components/button/partials/code/component-api.md
@@ -1,15 +1,15 @@
 Here is the API for the component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="size" @type="enum" @value="small, medium, large" @default="medium"/>
-  <C.Property @name="color" @type="enum" @value="primary, secondary, tertiary, critical" @default="primary"/>
+  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
+  <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" "tertiary" "critical" }} @default="primary"/>
   <C.Property @name="text" @required="true" @type="string">
     The text of the button or value of `aria-label` if `isIconOnly` is set to `true`. _If no text value is defined an error will be thrown._
   </C.Property>
   <C.Property @name="icon" @type="string">
     Use this parameter to show an icon. Acceptable value: any Flight icon name. **Important**: `tertiary` buttons have transparent backgrounds, and interactive elements must communicate interactivity with more than just color. Therefore, a leading or trailing icon is required when using the `tertiary` color. [WCAG 2.1 Criterion 1.4.1: Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=141#use-of-color)
   </C.Property>
-  <C.Property @name="iconPosition" @type="enum" @value="leading, trailing" @default="leading">
+  <C.Property @name="iconPosition" @type="enum" @values={{array "leading" "trailing" }} @default="leading">
     Positions the icon before or after the text.
   </C.Property>
   <C.Property @name="isIconOnly" @type="boolean">

--- a/website/docs/components/card/partials/code/component-api.md
+++ b/website/docs/components/card/partials/code/component-api.md
@@ -10,13 +10,13 @@ Here is the API for the component:
   <C.Property @name="levelActive" @type="enum">
     This controls the level of elevation on `:active` state.
   </C.Property>
-  <C.Property @name="background" @type="enum" @value="neutral-primary, neutral-secondary" @default="neutral-primary">
+  <C.Property @name="background" @type="enum" @values={{array "neutral-primary" "neutral-secondary" }} @default="neutral-primary">
     This controls the background color. _Notice: later we may decide/need to add more colors, but for now we have found only these two use cases._
   </C.Property>
   <C.Property @name="hasBorder" @type="boolean">
     This controls if the card has a visual "edge", an external border (technically is an extra 1px shadow on top of the other drop shadows). _Notice: the color of the border is pre-defined. If you need a custom border you have to wrap your content in an element and assign the border to it (in that case, remember to inherit the border radius)._
   </C.Property>
-  <C.Property @name="overflow" @type="enum" @value="hidden, visible" @default="hidden">
+  <C.Property @name="overflow" @type="enum" @values={{array "hidden" "visible" }} @default="hidden">
     This controls if the main wrapper (who has a border-radius applied) has overflow = visible or hidden. We expect that this is needed in case part of the content (eg. a tooltip) needs to go beyond the bounding box of the card itself.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -20,8 +20,8 @@ _Notice: to make the invocation more intuitive for developers, all the sub-compo
 Here is the API for the main ("container") component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="listPosition" @type="string" @value="left, right" @default="right"/>
-  <C.Property @name="width" @type="string" @value="any valid CSS width (px, rem, etc)">
+  <C.Property @name="listPosition" @type="string" @values={{array "left" "right" }} @default="right"/>
+  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
     _Notice: by default the dropdown list has a `min-width` of `200px` and a `max-width` of `400px` applied to it, so it adapts to the content size. If a `@width` parameter is provided then the list will have a fixed width._
   </C.Property>
   <C.Property @name="close" @type="function">
@@ -43,8 +43,8 @@ Here is the API for the "button-like" toggle component (yielded in a hash under 
   <C.Property @name="text" @required="true" @type="string">
     The text of the toggle button. _If no text value is defined an error will be thrown._
   </C.Property>
-  <C.Property @name="color" @type="enum" @value="primary, secondary" @default="primary"/>
-  <C.Property @name="size" @type="enum" @value="medium, small" @default="medium"/>
+  <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
+  <C.Property @name="size" @type="enum" @values={{array "medium" "small" }} @default="medium"/>
   <C.Property @name="...attributes">
     `...attributes` spreading is supported on this component.
   </C.Property>
@@ -113,7 +113,7 @@ Here is the API for the "interactive" list item component (yielded in a hash und
   <C.Property @name="text" @required="true" @type="string">
     The text to be used in the item. _If no text value is defined an error will be thrown._
   </C.Property>
-  <C.Property @name="color" @type="enum" @value="action, critical" @default="action">
+  <C.Property @name="color" @type="enum" @values={{array "action" "critical" }} @default="action">
     Acceptabe values:
   </C.Property>
   <C.Property @name="icon" @type="string">

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -21,7 +21,7 @@ Here is the API for the main ("container") component:
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="listPosition" @type="string" @values={{array "left" "right" }} @default="right"/>
-  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
+  <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     _Notice: by default the dropdown list has a `min-width` of `200px` and a `max-width` of `400px` applied to it, so it adapts to the content size. If a `@width` parameter is provided then the list will have a fixed width._
   </C.Property>
   <C.Property @name="close" @type="function">

--- a/website/docs/components/form/base-elements/partials/code/component-api.md
+++ b/website/docs/components/form/base-elements/partials/code/component-api.md
@@ -89,7 +89,7 @@ Here is the API for the component:
 Here is the API for the component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="layout" @type="enum" @value="vertical, flag">
+  <C.Property @name="layout" @type="enum" @values={{array "vertical" "flag" }}>
     Sets the layout of the component. "Vertical" layout is used for `TextInput`, `Textarea` and `Select` fields. "Flag" layout is used for `Checkbox`, `Radio` and `Toggle` fields.
   </C.Property>
   <C.Property @name="id" @type="string">
@@ -142,7 +142,7 @@ Control, label, helper text and error content are passed to the field as yielded
 Here is the API for the component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="layout" @type="enum" @value="vertical, horizontal" @default="vertical">
+  <C.Property @name="layout" @type="enum" @values={{array "vertical" "horizontal" }} @default="vertical">
     Sets the layout of the field controls in the component.
   </C.Property>
   <C.Property @name="id" @type="string">

--- a/website/docs/components/form/checkbox/partials/code/component-api.md
+++ b/website/docs/components/form/checkbox/partials/code/component-api.md
@@ -54,7 +54,7 @@ Label, helper text and error content are passed to the field as yielded componen
 Here is the API for the "group" component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="layout" @type="enum" @value="vertical, horizontal" @default="vertical">
+  <C.Property @name="layout" @type="enum" @values={{array "vertical" "horizontal" }} @default="vertical">
     Sets the layout of group.
   </C.Property>
   <C.Property @name="name" @type="string">

--- a/website/docs/components/form/radio-card/partials/code/component-api.md
+++ b/website/docs/components/form/radio-card/partials/code/component-api.md
@@ -24,7 +24,7 @@ Here is the API for the `RadioCard` component:
   <C.Property @name="layout" @type="string" @values={{array "fluid" "fixed" }} @default="fluid">
     _Notice: by default the card will expand to fit the parent container. When used in a group the cards will equally share the width to fit the available space. If the `@layout` parameter is set to `fixed` a `@maxWidth` value must be specified to constrain the card._
   </C.Property>
-  <C.Property @name="maxWidth" @type="string" @values={{array "any valid CSS width (%, vw, etc)" }}>
+  <C.Property @name="maxWidth" @type="string" @valueNote="any valid CSS width (%, vw, etc)">
     When used with a `fluid` layout, this parameter will determine the number of cards shown per row (for example `25%` will result in 4 cards). When used with a `fixed` layout, this parameter will preserve the width of the card and wrap cards on multiple rows if necessary.
   </C.Property>
   <C.Property @name="extraAriaDescribedBy" @type="string">

--- a/website/docs/components/form/radio-card/partials/code/component-api.md
+++ b/website/docs/components/form/radio-card/partials/code/component-api.md
@@ -15,16 +15,16 @@ Here is the API for the `RadioCard` component:
   <C.Property @name="disabled" @type="boolean">
     The input control's disabled attribute
   </C.Property>
-  <C.Property @name="controlPosition" @type="enum" @value="bottom, left" @default="bottom">
+  <C.Property @name="controlPosition" @type="enum" @values={{array "bottom" "left" }} @default="bottom">
     Sets the position of the form control in relation to the card content.
   </C.Property>
-  <C.Property @name="alignment" @type="enum" @value="left, center" @default="left">
+  <C.Property @name="alignment" @type="enum" @values={{array "left" "center" }} @default="left">
     Sets the alignment of the card content.
   </C.Property>
-  <C.Property @name="layout" @type="string" @value="fluid, fixed" @default="fluid">
+  <C.Property @name="layout" @type="string" @values={{array "fluid" "fixed" }} @default="fluid">
     _Notice: by default the card will expand to fit the parent container. When used in a group the cards will equally share the width to fit the available space. If the `@layout` parameter is set to `fixed` a `@maxWidth` value must be specified to constrain the card._
   </C.Property>
-  <C.Property @name="maxWidth" @type="string" @value="any valid CSS width (%, vw, etc)">
+  <C.Property @name="maxWidth" @type="string" @values={{array "any valid CSS width (%, vw, etc)" }}>
     When used with a `fluid` layout, this parameter will determine the number of cards shown per row (for example `25%` will result in 4 cards). When used with a `fixed` layout, this parameter will preserve the width of the card and wrap cards on multiple rows if necessary.
   </C.Property>
   <C.Property @name="extraAriaDescribedBy" @type="string">
@@ -62,10 +62,10 @@ Here is the API for the `RadioCard` component:
 Here is the API for the "group" component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="controlPosition" @type="enum" @value="bottom, left" @default="bottom">
+  <C.Property @name="controlPosition" @type="enum" @values={{array "bottom" "left" }} @default="bottom">
     Sets the position of the form control in relation to the card content.
   </C.Property>
-  <C.Property @name="alignment" @type="enum" @value="left, center" @default="left">
+  <C.Property @name="alignment" @type="enum" @values={{array "left" "center" }} @default="left">
     Sets the alignment of the card content.
   </C.Property>
   <C.Property @name="name" @type="string">
@@ -74,7 +74,7 @@ Here is the API for the "group" component:
   <C.Property @name="isRequired" @type="boolean">
     Appends a `Required` indicator next to the legend text and sets the `required` attribute on the controls when user input is required.
   </C.Property>
-  <C.Property @name="layout" @type="string" @value="fluid, fixed" @default="fluid">
+  <C.Property @name="layout" @type="string" @values={{array "fluid" "fixed" }} @default="fluid">
     _Notice: by default the cards will expand to fit the parent container and will equally share the width to fit the available space. If the `@layout` parameter is set to `fixed` a `@maxWidth` value must be specified for each `RadioCard` to constrain them._
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/form/radio/partials/code/component-api.md
+++ b/website/docs/components/form/radio/partials/code/component-api.md
@@ -56,7 +56,7 @@ Label, helper text and error content are passed to the field as yielded componen
 Here is the API for the "group" component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="layout" @type="enum" @value="vertical, horizontal" @default="vertical">
+  <C.Property @name="layout" @type="enum" @values={{array "vertical" "horizontal" }} @default="vertical">
     Sets the layout of group.
   </C.Property>
   <C.Property @name="name" @type="string">

--- a/website/docs/components/form/select/partials/code/component-api.md
+++ b/website/docs/components/form/select/partials/code/component-api.md
@@ -11,7 +11,7 @@ Here is the API for the "base" component:
   <C.Property @name="isInvalid" @type="boolean">
     It applies an "invalid" appearance to the control (_notice: this does \_not\_ modify its logical validity_).
   </C.Property>
-  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
+  <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     _Notice: by default the `<select>` has an intrinsic width based on its content. If a `@width` parameter is provided then the control will have a fixed width._
   </C.Property>
   <C.Property @name="...attributes">
@@ -37,7 +37,7 @@ Here is the API for the "field" component:
   <C.Property @name="isInvalid" @type="boolean">
     It applies an "invalid" appearance to the control (_notice: this does \_not\_ modify its logical validity_).
   </C.Property>
-  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
+  <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     _Notice: by default the `<select>` has an intrinsic width based on its content. If a `@width` parameter is provided then the control will have a fixed width. This width will be applied **only** to the control, not the other elements of the field._
   </C.Property>
   <C.Property @name="id" @type="string">

--- a/website/docs/components/form/select/partials/code/component-api.md
+++ b/website/docs/components/form/select/partials/code/component-api.md
@@ -11,7 +11,7 @@ Here is the API for the "base" component:
   <C.Property @name="isInvalid" @type="boolean">
     It applies an "invalid" appearance to the control (_notice: this does \_not\_ modify its logical validity_).
   </C.Property>
-  <C.Property @name="width" @type="string" @value="any valid CSS width (px, rem, etc)">
+  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
     _Notice: by default the `<select>` has an intrinsic width based on its content. If a `@width` parameter is provided then the control will have a fixed width._
   </C.Property>
   <C.Property @name="...attributes">
@@ -37,7 +37,7 @@ Here is the API for the "field" component:
   <C.Property @name="isInvalid" @type="boolean">
     It applies an "invalid" appearance to the control (_notice: this does \_not\_ modify its logical validity_).
   </C.Property>
-  <C.Property @name="width" @type="string" @value="any valid CSS width (px, rem, etc)">
+  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
     _Notice: by default the `<select>` has an intrinsic width based on its content. If a `@width` parameter is provided then the control will have a fixed width. This width will be applied **only** to the control, not the other elements of the field._
   </C.Property>
   <C.Property @name="id" @type="string">

--- a/website/docs/components/form/text-input/partials/code/component-api.md
+++ b/website/docs/components/form/text-input/partials/code/component-api.md
@@ -17,7 +17,7 @@ Here is the API for the "base" component:
   <C.Property @name="isInvalid" @type="boolean">
     It applies an "invalid" appearance to the control (_notice: this does \_not\_ modify its logical validity_).
   </C.Property>
-  <C.Property @name="width" @type="string" @value="any valid CSS width (px, rem, etc)">
+  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
     _Notice: by default the `<input>` has a `width` of `100%` applied to it, so it fills the parent container. If a `@width` parameter is provided then the control will have a fixed width._
   </C.Property>
   <C.Property @name="...attributes">
@@ -45,7 +45,7 @@ Here is the API for the "field" component:
   <C.Property @name="isOptional" @type="boolean">
     Appends an `Optional` indicator next to the label text when user input is optional.
   </C.Property>
-  <C.Property @name="width" @type="string" @value="any valid CSS width (px, rem, etc)">
+  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
     _Notice: by default the `<input>` has a `width` of `100%` applied to it, so it fills the parent container. If a `@width` parameter is provided then the control will have a fixed width. This width will be applied **only** to the control, not the other elements of the field._
   </C.Property>
   <C.Property @name="id" @type="string">

--- a/website/docs/components/form/text-input/partials/code/component-api.md
+++ b/website/docs/components/form/text-input/partials/code/component-api.md
@@ -17,7 +17,7 @@ Here is the API for the "base" component:
   <C.Property @name="isInvalid" @type="boolean">
     It applies an "invalid" appearance to the control (_notice: this does \_not\_ modify its logical validity_).
   </C.Property>
-  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
+  <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     _Notice: by default the `<input>` has a `width` of `100%` applied to it, so it fills the parent container. If a `@width` parameter is provided then the control will have a fixed width._
   </C.Property>
   <C.Property @name="...attributes">
@@ -45,7 +45,7 @@ Here is the API for the "field" component:
   <C.Property @name="isOptional" @type="boolean">
     Appends an `Optional` indicator next to the label text when user input is optional.
   </C.Property>
-  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
+  <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     _Notice: by default the `<input>` has a `width` of `100%` applied to it, so it fills the parent container. If a `@width` parameter is provided then the control will have a fixed width. This width will be applied **only** to the control, not the other elements of the field._
   </C.Property>
   <C.Property @name="id" @type="string">

--- a/website/docs/components/form/textarea/partials/code/component-api.md
+++ b/website/docs/components/form/textarea/partials/code/component-api.md
@@ -15,10 +15,10 @@ In addition this component provides this extra API:
   <C.Property @name="isInvalid" @type="boolean">
     It applies an "invalid" appearance to the control (_notice: this does \_not\_ modify its logical validity_).
   </C.Property>
-  <C.Property @name="width" @type="string" @value="any valid CSS width (px, rem, etc)">
+  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
     _Notice: by default the `<textarea>` has a `width` of `100%` applied to it, so it fills the parent container. If a `@width` parameter is provided then the control will have a fixed width._
   </C.Property>
-  <C.Property @name="height" @type="string" @value="any valid CSS height (px, rem, etc)">
+  <C.Property @name="height" @type="string" @values={{array "any valid CSS height (px, rem, etc)" }}>
     _Notice: by default the `<textarea>` has a `height` determined by the browser to accommodate 4 lines of text. If a `@height` parameter is provided then the control will have a fixed height._
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/form/textarea/partials/code/component-api.md
+++ b/website/docs/components/form/textarea/partials/code/component-api.md
@@ -15,10 +15,10 @@ In addition this component provides this extra API:
   <C.Property @name="isInvalid" @type="boolean">
     It applies an "invalid" appearance to the control (_notice: this does \_not\_ modify its logical validity_).
   </C.Property>
-  <C.Property @name="width" @type="string" @values={{array "any valid CSS width (px, rem, etc)" }}>
+  <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     _Notice: by default the `<textarea>` has a `width` of `100%` applied to it, so it fills the parent container. If a `@width` parameter is provided then the control will have a fixed width._
   </C.Property>
-  <C.Property @name="height" @type="string" @values={{array "any valid CSS height (px, rem, etc)" }}>
+  <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
     _Notice: by default the `<textarea>` has a `height` determined by the browser to accommodate 4 lines of text. If a `@height` parameter is provided then the control will have a fixed height._
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/form/toggle/partials/code/component-api.md
+++ b/website/docs/components/form/toggle/partials/code/component-api.md
@@ -55,7 +55,7 @@ Label, helper text and error content are passed to the field as yielded componen
 Here is the API for the "group" component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="layout" @type="enum" @value="vertical, horizontal" @default="vertical">
+  <C.Property @name="layout" @type="enum" @values={{array "vertical" "horizontal" }} @default="vertical">
     Sets the layout of group.
   </C.Property>
   <C.Property @name="isRequired" @type="boolean">

--- a/website/docs/components/icon-tile/partials/code/component-api.md
+++ b/website/docs/components/icon-tile/partials/code/component-api.md
@@ -1,8 +1,8 @@
 Here is the API for the component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="size" @type="enum" @value="small, medium, large" @default="medium"/>
-  <C.Property @name="logo" @type="enum" @value="hcp, boundary, consul, nomad, packer, terraform, vagrant, vault, waypoint">
+  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
+  <C.Property @name="logo" @type="enum" @values={{array "hcp" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "waypoint" }}>
     Use this parameter to show a product logo.
   </C.Property>
   <C.Property @name="icon" @type="string">
@@ -11,7 +11,7 @@ Here is the API for the component:
   <C.Property @name="iconSecondary" @type="string">
     Use this parameter to show an extra "badge" with icon on top of the tile. Acceptable value: any Flight icon name. _Notice: the color of the secondary icon is predefined and can't be changed._
   </C.Property>
-  <C.Property @name="color" @type="enum" @value="neutral, boundary, consul, nomad, packer, terraform, vagrant, vault, waypoint" @default="neutral">
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "waypoint" }} @default="neutral">
     _Notice: if it's a "logo" then we overwrite any @color parameter passed and just use the product "brand" color._
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/link/inline/partials/code/component-api.md
+++ b/website/docs/components/link/inline/partials/code/component-api.md
@@ -1,14 +1,14 @@
 Here is the API for the component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="color" @type="enum" @value="primary, secondary" @default="primary"/>
+  <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
   <C.Property @name="yield">
     Elements passed as children are yielded to the content of the `<a>` HTML element.
   </C.Property>
   <C.Property @name="icon" @type="string">
     Use this parameter to show an icon. Acceptable value: any Flight icon name.
   </C.Property>
-  <C.Property @name="iconPosition" @type="enum" @value="leading, trailing" @default="trailing">
+  <C.Property @name="iconPosition" @type="enum" @values={{array "leading" "trailing" }} @default="trailing">
     Positions the icon before or after the text.
   </C.Property>
   <C.Property @name="href">

--- a/website/docs/components/link/standalone/partials/code/component-api.md
+++ b/website/docs/components/link/standalone/partials/code/component-api.md
@@ -1,15 +1,15 @@
 Here is the API for the component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="size" @type="enum" @value="small, medium, large" @default="medium"/>
-  <C.Property @name="color" @type="enum" @value="primary, secondary" @default="primary"/>
+  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
+  <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
   <C.Property @name="text" @required="true" @type="string">
     The text of the link. _If no text value is defined an error will be thrown._
   </C.Property>
   <C.Property @name="icon" @required="true" @type="string">
     Use this parameter to show an icon. Acceptable value: any Flight icon name. **Important:** the `icon` is required to make the component accessible.
   </C.Property>
-  <C.Property @name="iconPosition" @type="enum" @value="leading, trailing" @default="leading">
+  <C.Property @name="iconPosition" @type="enum" @values={{array "leading" "trailing" }} @default="leading">
     Positions the icon before or after the text.
   </C.Property>
   <C.Property @name="href">

--- a/website/docs/components/modal/partials/code/component-api.md
+++ b/website/docs/components/modal/partials/code/component-api.md
@@ -1,10 +1,10 @@
 Here is the API for the component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="size" @type="enum" @value="small, medium, large" @default="medium">
+  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium">
     Sets the width of the modal.
   </C.Property>
-  <C.Property @name="color" @type="enum" @value="neutral, warning, critical" @default="neutral">
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "warning" "critical" }} @default="neutral">
     Sets the color scheme for the modal header elements: icon, tagline and title.
   </C.Property>
   <C.Property @name="onOpen" @type="function">

--- a/website/docs/components/stepper/partials/code/component-api.md
+++ b/website/docs/components/stepper/partials/code/component-api.md
@@ -5,7 +5,7 @@ Note: Since the `indicator` components are meant to be assembled into larger ste
 Here is the API for the `Step::Indicator` component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="status" @type="enum" @value="incomplete, progress, processing, complete" @default="incomplete"/>
+  <C.Property @name="status" @type="enum" @values={{array "incomplete" "progress" "processing" "complete" }} @default="incomplete"/>
   <C.Property @name="isInteractive" @type="boolean">
     By default the `Indicator::Step` is not interactive and has no hover state. Usage for this variant is generally recommended for onboarding-type sequences or list-item steps.
   </C.Property>
@@ -19,6 +19,6 @@ Here is the API for the `Step::Indicator` component:
 Here is the API for the `Task::Indicator` component:
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="status" @type="enum" @value="incomplete, progress, processing, complete" @default="incomplete"/>
+  <C.Property @name="status" @type="enum" @values={{array "incomplete" "progress" "processing" "complete" }} @default="incomplete"/>
   <C.Property @name="isInteractive" @type="boolean"/>
 </Doc::ComponentApi>

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -25,16 +25,16 @@ Additionally, there are child components that can also be used to provide custom
   <C.Property @name="sortBy" @type="string">
     If defined, indicates which column should be pre-sorted when the table is rendered. For more information about how this value, look at the code examples in the "How to Use" section.
   </C.Property>
-  <C.Property @name="sortOrder" @type="string" @value="asc, desc" @default="asc">
+  <C.Property @name="sortOrder" @type="string" @values={{array "asc" "desc" }} @default="asc">
     Use in conjunction with `sortBy`. If defined, indicates which direction the column should be pre-sorted in. All columns are unsorted by default.
   </C.Property>
   <C.Property @name="isStriped" @type="boolean">
     If set to `false`, zebra striping on the table will not be applied.
   </C.Property>
-  <C.Property @name="density" @type="enum" @value="short, medium, tall" @default="medium">
+  <C.Property @name="density" @type="enum" @values={{array "short" "medium" "tall" }} @default="medium">
     If set, determines the density, or height, of the row.
   </C.Property>
-  <C.Property @name="valign" @type="enum" @value="top, middle, bottom, baseline, sub, text-top" @default="top">
+  <C.Property @name="valign" @type="enum" @values={{array "top" "middle" "bottom" "baseline" "sub" "text-top" }} @default="top">
     If set, determines the vertical alignment of table's cell (td) content. While the acceptable values contain all of the values that the CSS property accepts, the default (top) and middle are the values most likely to be used.
   </C.Property>
   <C.Property @name="caption" @type="string">

--- a/website/docs/components/tag/partials/code/component-api.md
+++ b/website/docs/components/tag/partials/code/component-api.md
@@ -16,7 +16,7 @@ Here is the API for the component:
   <C.Property @name="isRouteExternal" @type="boolean">
     This controls if the "LinkTo" is external to the Ember engine ([more details here](https://ember-engines.com/docs/link-to-external)) in which case it will use a `<LinkToExternal>` instead of a simple `<LinkTo>` for the @route.
   </C.Property>
-  <C.Property @name="color" @type="enum" @value="primary, secondary" @default="primary">
+  <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary">
     Sets the color of a link and it is allowed only when `@route` or `@href` are set.
   </C.Property>
   <C.Property @name="onDismiss" @type="function">

--- a/website/docs/testing/components/badge.md
+++ b/website/docs/testing/components/badge.md
@@ -17,7 +17,7 @@ layout:
 <Doc::Badge @type="success">success</Doc::Badge>
 <Doc::Badge @type="warning">warning</Doc::Badge>
 <Doc::Badge @type="critical">critical</Doc::Badge>
-
+<Doc::Badge @type="outlined">outlined</Doc::Badge>
 
 ------
 


### PR DESCRIPTION
### :pushpin: Summary

Update `Doc::ComponentApi` to match design.

### :hammer_and_wrench: Detailed description

We update the `@value` argument to take an array instead of a comma-separated string (aligning it with the `Doc::WcagList` component and the HTML structure and CSS to match the new design.

[👉 Preview link](https://hds-website-749oxj13j-hashicorp.vercel.app/components/alert/)

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![component-api-before](https://user-images.githubusercontent.com/788096/207033056-70e6936b-cd44-40af-932d-8500144c178f.png)

</td><td>

![component-api-after](https://user-images.githubusercontent.com/788096/207033072-3a0b82d6-382c-449c-a904-104d17c9a39c.png)


</td></tr>
</table>


### :link: External links

[Jira issue](https://hashicorp.atlassian.net/browse/HDS-1056)
[Design reference](https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=1364%3A85506&t=kdnlBGICNMkMM1GC-1)

***

### 👀 How to review

<!-- Suggest how it's best for the reviewer to review the code (choose one, or remove) -->
👉 Review commit-by-commit

Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
