### PR TITLE
New docs website / Add proper style for links in markdown

### DIFF
--- a/website/app/styles/markdown/other-elements.scss
+++ b/website/app/styles/markdown/other-elements.scss
@@ -1,9 +1,10 @@
 @use "../typography/mixins";
+@use "../global/link";
 
 // LINKS
 
 .doc-markdown-a {
-  color: teal;
+  @include doc-link-generic-styles();
 }
 
 // IMAGES


### PR DESCRIPTION
### :pushpin: Summary

Tiny PR to add proper styling to the markdown links (`doc-markdown-a`) now that we have finally a mixin available for it.