### PR TITLE
New docs website / Fix markdown processing

### DIFF
--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -44,19 +44,20 @@ export default class ShowController extends Controller {
     let tabs = [];
     let tocs = [];
     document
-      .querySelectorAll(`.doc-page-content section[id^=section-]`)
+      .querySelectorAll(`.doc-page-content section[data-tab]`)
       .forEach((section, index) => {
         // SECTIONS
-        const name = section.id.replace(/^section-/, '');
+        const id = section.id;
+        const name = section.getAttribute('data-tab');
         section.setAttribute('role', 'tabpanel');
         section.setAttribute('tabindex', '0');
-        section.setAttribute('aria-labelledby', `tab-${name}`);
+        section.setAttribute('aria-labelledby', `tab-${id}`);
         section.setAttribute('hidden', true);
         sections.push(section);
         // TABS
         tabs.push({
           index,
-          id: `tab-${name}`,
+          id: `tab-${id}`,
           label: name,
           target: section.id,
           onClickTab: this.onClickTab,

--- a/website/app/shared/showdown-config.js
+++ b/website/app/shared/showdown-config.js
@@ -1,4 +1,5 @@
 import { elementsToClassNames } from './showdown-extensions/elements-to-classnames';
+import { pageSections } from './showdown-extensions/page-sections';
 import { contentBlocks } from './showdown-extensions/content-blocks';
 
 // SET SHOWDOWN SETTINGS HERE:
@@ -24,5 +25,5 @@ export const showdownConfig = {
   ghCompatibleHeaderId: true,
   // add default class for each HTML element generated
   // see: https://github.com/showdownjs/showdown/wiki/Extensions + https://showdownjs.com/docs/tutorials/add-default-class-to-html/
-  extensions: [...elementsToClassNames, contentBlocks],
+  extensions: [pageSections, ...elementsToClassNames, contentBlocks],
 };

--- a/website/app/shared/showdown-extensions/content-blocks.js
+++ b/website/app/shared/showdown-extensions/content-blocks.js
@@ -12,7 +12,7 @@ export const contentBlocks = function () {
       text = text.replace(langRegex, function (_match, type, content) {
         // we use the PHP tag as passthrough "tag" because is simply ignored by the `hashHTMLBlocks` function in Showdown
         // see: https://github.com/showdownjs/showdown/blob/master/src/subParsers/makehtml/hashHTMLBlocks.js#L93-L95
-        return `\n<?php start="content-block" type="${type.toLowerCase()}" ?>\n<div data-markdown="1">\n${content}\n</div>\n<?php end="content-block" type="${type.toLowerCase()}" ?>\n`;
+        return `\n<?php start="content-block" type="${type.toLowerCase()}" ?>\n${content}\n<?php end="content-block" type="${type.toLowerCase()}" ?>\n`;
       });
       // console.log('langExtension2 text', '\n', text, '\n\n');
       return text;
@@ -24,7 +24,7 @@ export const contentBlocks = function () {
       // console.log('outputExtension1 text', '\n', text, '\n\n');
       // https://regex101.com/r/DebuYI/1
       const outputRegex = new RegExp(
-        /<\?php start="content-block" type="(.*?)" \?>\n?<div data-markdown="1">\n?/,
+        /<\?php start="content-block" type="(.*?)" \?>\n?/,
         'g'
       );
       text = text.replace(outputRegex, function (_match, type) {
@@ -35,7 +35,7 @@ export const contentBlocks = function () {
         }
       });
       text = text.replace(
-        /\n?<\/div>\n?<\?php end="content-block" type="(.*?)" \?>/g,
+        /\n?<\?php end="content-block" type="(.*?)" \?>/g,
         function (_match, type) {
           if (type === 'do' || type === 'dont') {
             return '</Doc::DoDont>';

--- a/website/app/shared/showdown-extensions/page-sections.js
+++ b/website/app/shared/showdown-extensions/page-sections.js
@@ -1,0 +1,45 @@
+// inspiration for this approach: https://github.com/showdownjs/showdown/wiki/Cookbook:-Using-language-and-output-extensions-on-the-same-block
+export const pageSections = function () {
+  var langExtension = {
+    // we use the "lang" here because we want to replace the `!!!` delimitiers before everything else
+    // so that the contained markdown is normally interpreted, parsed and converted
+    // see: https://github.com/showdownjs/showdown/wiki/Extensions#type-propertyrequired
+    type: 'lang',
+    filter: function (text) {
+      console.log('langExtension1 text', '\n', text, '\n\n');
+      // https://regex101.com/r/ZMRcG9/1
+      const langRegex = new RegExp(
+        /^<section data-tab="([^>]*)">((.|\n)*?)<\/section>$/,
+        'gm'
+      );
+      text = text.replace(langRegex, function (_match, tab, content) {
+        // we use the ASP tag as passthrough "tag" because is simply ignored by the `hashHTMLBlocks` function in Showdown
+        // see: https://github.com/showdownjs/showdown/blob/master/src/subParsers/makehtml/hashHTMLBlocks.js#L93-L95
+        return `\n<%asp start="page-section" tab="${tab}" %>\n<div data-markdown="1">\n${content}\n</div>\n<%asp end="page-section" %>\n`;
+      });
+      console.log('langExtension2 text', '\n', text, '\n\n');
+      return text;
+    },
+  };
+  var outputExtension = {
+    type: 'output',
+    filter: function (text) {
+      console.log('outputExtension1 text', '\n', text, '\n\n');
+      text = text.replace(
+        /<%asp start="page-section" tab="(.*)" %>\n?<div data-markdown="1">\n?/g,
+        function (_match, tab) {
+          // TODO understand if this is enough or we need something more solid
+          const id = tab.toLowerCase().replace(' ', '-');
+          return `<section id="${id}" data-tab="${tab}">\n`;
+        }
+      );
+      text = text.replace(
+        /\n?<\/div>\n?<%asp end="page-section" %>/g,
+        '</section>'
+      );
+      console.log('outputExtension2 text', '\n', text, '\n\n');
+      return text;
+    },
+  };
+  return [langExtension, outputExtension];
+};

--- a/website/app/shared/showdown-extensions/page-sections.js
+++ b/website/app/shared/showdown-extensions/page-sections.js
@@ -6,7 +6,7 @@ export const pageSections = function () {
     // see: https://github.com/showdownjs/showdown/wiki/Extensions#type-propertyrequired
     type: 'lang',
     filter: function (text) {
-      console.log('langExtension1 text', '\n', text, '\n\n');
+      // console.log('langExtension1 text', '\n', text, '\n\n');
       // https://regex101.com/r/ZMRcG9/1
       const langRegex = new RegExp(
         /^<section data-tab="([^>]*)">((.|\n)*?)<\/section>$/,
@@ -17,14 +17,14 @@ export const pageSections = function () {
         // see: https://github.com/showdownjs/showdown/blob/master/src/subParsers/makehtml/hashHTMLBlocks.js#L93-L95
         return `\n<%asp start="page-section" tab="${tab}" %>\n${content}\n<%asp end="page-section" %>\n`;
       });
-      console.log('langExtension2 text', '\n', text, '\n\n');
+      // console.log('langExtension2 text', '\n', text, '\n\n');
       return text;
     },
   };
   var outputExtension = {
     type: 'output',
     filter: function (text) {
-      console.log('outputExtension1 text', '\n', text, '\n\n');
+      // console.log('outputExtension1 text', '\n', text, '\n\n');
       text = text.replace(
         /<%asp start="page-section" tab="(.*)" %>\n?/g,
         function (_match, tab) {
@@ -34,7 +34,7 @@ export const pageSections = function () {
         }
       );
       text = text.replace(/\n?<%asp end="page-section" %>/g, '</section>');
-      console.log('outputExtension2 text', '\n', text, '\n\n');
+      // console.log('outputExtension2 text', '\n', text, '\n\n');
       return text;
     },
   };

--- a/website/app/shared/showdown-extensions/page-sections.js
+++ b/website/app/shared/showdown-extensions/page-sections.js
@@ -15,7 +15,7 @@ export const pageSections = function () {
       text = text.replace(langRegex, function (_match, tab, content) {
         // we use the ASP tag as passthrough "tag" because is simply ignored by the `hashHTMLBlocks` function in Showdown
         // see: https://github.com/showdownjs/showdown/blob/master/src/subParsers/makehtml/hashHTMLBlocks.js#L93-L95
-        return `\n<%asp start="page-section" tab="${tab}" %>\n<div data-markdown="1">\n${content}\n</div>\n<%asp end="page-section" %>\n`;
+        return `\n<%asp start="page-section" tab="${tab}" %>\n${content}\n<%asp end="page-section" %>\n`;
       });
       console.log('langExtension2 text', '\n', text, '\n\n');
       return text;
@@ -26,17 +26,14 @@ export const pageSections = function () {
     filter: function (text) {
       console.log('outputExtension1 text', '\n', text, '\n\n');
       text = text.replace(
-        /<%asp start="page-section" tab="(.*)" %>\n?<div data-markdown="1">\n?/g,
+        /<%asp start="page-section" tab="(.*)" %>\n?/g,
         function (_match, tab) {
           // TODO understand if this is enough or we need something more solid
           const id = tab.toLowerCase().replace(' ', '-');
           return `<section id="${id}" data-tab="${tab}">\n`;
         }
       );
-      text = text.replace(
-        /\n?<\/div>\n?<%asp end="page-section" %>/g,
-        '</section>'
-      );
+      text = text.replace(/\n?<%asp end="page-section" %>/g, '</section>');
       console.log('outputExtension2 text', '\n', text, '\n\n');
       return text;
     },

--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -8,21 +8,21 @@ links:
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/alert
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/avatar/index.md
+++ b/website/docs/components/avatar/index.md
@@ -3,21 +3,21 @@ title: Avatar
 hidden: true
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/badge-count/index.md
+++ b/website/docs/components/badge-count/index.md
@@ -2,17 +2,17 @@
 title: BadgeCount
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -2,21 +2,21 @@
 title: Badge
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -2,21 +2,21 @@
 title: Breadcrumb
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/button-set/index.md
+++ b/website/docs/components/button-set/index.md
@@ -2,17 +2,17 @@
 title: ButtonSet
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 

--- a/website/docs/components/button/index.md
+++ b/website/docs/components/button/index.md
@@ -2,17 +2,17 @@
 title: Button
 ---
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/card/index.md
+++ b/website/docs/components/card/index.md
@@ -2,17 +2,17 @@
 title: Card
 ---
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -2,22 +2,22 @@
 title: Dropdown
 ---
 
-<section id="section-other" data-markdown="1">
+<section data-tab="Other">
   @include "partials/other/generic-1.md"
   @include "partials/other/generic-2.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/empty-state/index.md
+++ b/website/docs/components/empty-state/index.md
@@ -3,17 +3,17 @@ title: EmptyState
 hidden: true
 ---
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/form/base-elements/index.md
+++ b/website/docs/components/form/base-elements/index.md
@@ -2,21 +2,21 @@
 title: Form / Base elements
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/form/checkbox/index.md
+++ b/website/docs/components/form/checkbox/index.md
@@ -2,21 +2,21 @@
 title: Form::Checkbox
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/form/radio-card/index.md
+++ b/website/docs/components/form/radio-card/index.md
@@ -2,21 +2,21 @@
 title: Form::RadioCard
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/form/radio/index.md
+++ b/website/docs/components/form/radio/index.md
@@ -2,21 +2,21 @@
 title: Form::Radio
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/form/select/index.md
+++ b/website/docs/components/form/select/index.md
@@ -2,25 +2,25 @@
 title: Form::Select
 ---
 
-<section id="section-other" data-markdown="1">
+<section data-tab="Other">
   @include "partials/other/generic-1.md"
 </section>
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -2,21 +2,21 @@
 title: Form::TextInput
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/form/textarea/index.md
+++ b/website/docs/components/form/textarea/index.md
@@ -2,21 +2,21 @@
 title: Form::Textarea
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/form/toggle/index.md
+++ b/website/docs/components/form/toggle/index.md
@@ -2,21 +2,21 @@
 title: Form::Toggle
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -2,17 +2,17 @@
 title: IconTile
 ---
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/link/inline/index.md
+++ b/website/docs/components/link/inline/index.md
@@ -2,21 +2,21 @@
 title: Link::Inline
 ---
 
-<section id="section-other" data-markdown="1">
+<section data-tab="Other">
   @include "partials/other/generic-1.md"
 </section>
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 

--- a/website/docs/components/link/standalone/index.md
+++ b/website/docs/components/link/standalone/index.md
@@ -2,17 +2,17 @@
 title: Link::Standalone
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -2,21 +2,21 @@
 title: Modal
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/stepper/index.md
+++ b/website/docs/components/stepper/index.md
@@ -2,21 +2,21 @@
 title: Stepper Indicator
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/table/index.md
+++ b/website/docs/components/table/index.md
@@ -2,25 +2,25 @@
 title: Table
 ---
 
-<section id="section-other" data-markdown="1">
+<section data-tab="Other">
   @include "partials/other/generic-1.md"
 </section>
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/tabs/index.md
+++ b/website/docs/components/tabs/index.md
@@ -2,21 +2,21 @@
 title: Tabs
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -2,17 +2,17 @@
 title: Tag
 ---
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/components/toast/index.md
+++ b/website/docs/components/toast/index.md
@@ -2,21 +2,21 @@
 title: Toast
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 
-<section id="section-accessibility" data-markdown="1">
+<section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
 

--- a/website/docs/foundations/colors/index.md
+++ b/website/docs/foundations/colors/index.md
@@ -2,11 +2,11 @@
 title: Colors
 ---
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/how-to-use.md"
 </section>
 
-<section id="section-other" data-markdown="1">
+<section data-tab="Other">
   @include "partials/other/generic-2.md"
 </section>
 

--- a/website/docs/foundations/elevation/index.md
+++ b/website/docs/foundations/elevation/index.md
@@ -2,12 +2,12 @@
 title: Elevation
 ---
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>
 
-<section id="section-specifications" data-markdown="1">
+<section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
 

--- a/website/docs/foundations/focus-ring/index.md
+++ b/website/docs/foundations/focus-ring/index.md
@@ -2,7 +2,7 @@
 title: Focus ring
 ---
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>

--- a/website/docs/foundations/icons/index.md
+++ b/website/docs/foundations/icons/index.md
@@ -4,7 +4,7 @@ layout:
   sidecar: false
 ---
 
-<section id="section-library">
+<section data-tab="Library">
   <Doc::IconsList
     @icons={{this.filteredIcons}}
     @onSelect={{this.selectIconSize}}
@@ -13,14 +13,14 @@ layout:
   />
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/engineering-guidelines.md"
 </section>
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/design-guidelines.md"
 </section>
 
-<section id="section-contributing" data-markdown="1">
+<section data-tab="Contributing">
   @include "partials/contributing.md"
 </section>

--- a/website/docs/foundations/tokens/index.md
+++ b/website/docs/foundations/tokens/index.md
@@ -2,11 +2,11 @@
 title: Design tokens
 ---
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/how-to-use.md"
 </section>
 
-<section id="section-other" data-markdown="1">
+<section data-tab="Other">
   @include "partials/other/generic-2.md"
 </section>
 

--- a/website/docs/foundations/typography/index.md
+++ b/website/docs/foundations/typography/index.md
@@ -2,12 +2,12 @@
 title: Typography
 ---
 
-<section id="section-other" data-markdown="1">
+<section data-tab="Other">
   @include "partials/other/generic-1.md"
   @include "partials/other/generic-3.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>

--- a/website/docs/foundations/typography/partials/code/how-to-use.md
+++ b/website/docs/foundations/typography/partials/code/how-to-use.md
@@ -49,6 +49,10 @@ These are the **CSS helper classes** that you can use:
 
 To use this classes you have to import the CSS file `[products|devdot]/css/helpers/typography.css` from the `@hashicorp/design-system-tokens` package.
 
-**🚨 IMPORTANT: 🚨**
+!!! info
 
-*   while the _font-family/font-weight/typography_ helpers can be combined together in code, in reality not all the combinations are valid from the design perspective: please refer to the design documentation to see which styles combinations are allowed.
+**Important**
+
+While the _font-family/font-weight/typography_ helpers can be combined together in code, in reality not all the combinations are valid from the design perspective: please refer to the design documentation to see which styles combinations are allowed.
+
+!!!

--- a/website/docs/overrides/power-select/index.md
+++ b/website/docs/overrides/power-select/index.md
@@ -2,11 +2,11 @@
 title: PowerSelect
 ---
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"
 </section>

--- a/website/docs/testing/components/banner/index.md
+++ b/website/docs/testing/components/banner/index.md
@@ -58,3 +58,12 @@ This is a paragraph
 - This is
 - A list
 !!!
+
+-----
+
+## Imported banners
+
+
+Banner included directly via `partial`
+
+@include "partials/simple-banner.md"

--- a/website/docs/testing/components/banner/index.md
+++ b/website/docs/testing/components/banner/index.md
@@ -67,3 +67,9 @@ This is a paragraph
 Banner included directly via `partial`
 
 @include "partials/simple-banner.md"
+
+Banner included via `partial` inside a `&lt;section&gt;`
+
+<section id="section-guidelines" data-markdown="1">
+    @include "partials/simple-banner.md"
+</section>

--- a/website/docs/testing/components/banner/index.md
+++ b/website/docs/testing/components/banner/index.md
@@ -68,8 +68,8 @@ Banner included directly via `partial`
 
 @include "partials/simple-banner.md"
 
-Banner included via `partial` inside a `&lt;section&gt;`
+Banner included via `partial` inside a `<section>`
 
-<section id="section-guidelines" data-markdown="1">
+<section data-tab="Guidelines">
     @include "partials/simple-banner.md"
 </section>

--- a/website/docs/testing/components/banner/partials/simple-banner.md
+++ b/website/docs/testing/components/banner/partials/simple-banner.md
@@ -1,0 +1,8 @@
+!!! Info
+
+**This is the title**
+
+This is a paragraph
+- This is
+- A list
+!!!

--- a/website/docs/utilities/disclosure/index.md
+++ b/website/docs/utilities/disclosure/index.md
@@ -2,11 +2,11 @@
 title: Disclosure
 ---
 
-<section id="section-other" data-markdown="1">
+<section data-tab="Other">
   @include "partials/other/generic-1.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"

--- a/website/docs/utilities/dismiss-button/index.md
+++ b/website/docs/utilities/dismiss-button/index.md
@@ -2,11 +2,11 @@
 title: DismissButton
 ---
 
-<section id="section-other" data-markdown="1">
+<section data-tab="Other">
   @include "partials/other/generic-1.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"

--- a/website/docs/utilities/interactive/index.md
+++ b/website/docs/utilities/interactive/index.md
@@ -2,11 +2,11 @@
 title: Interactive
 ---
 
-<section id="section-other" data-markdown="1">
+<section data-tab="Other">
   @include "partials/other/generic-1.md"
 </section>
 
-<section id="section-code" data-markdown="1">
+<section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"


### PR DESCRIPTION
### :pushpin: Summary

While working on #809 I realized that the `Banner` syntax added in #791 worked in the test page/example, but actually didn't work **at all** when used in an imported file (via custom `@import` markdown syntax).

After a few experimentations trying to fix the problem, I started to fear that the root cause what that `data-markdown="1"` attribute applied to the main `<section>` containers (the banner blocks worked perfectly well in an imported file, without a section with that attribute). So I decided to bite the bullet and try to fix the problem at the root: use the same technique used in #791 and apply it for the `<section>` main containers elements (that generate the tabs).

At the end the effort paid out, and seems we solved two problems with one change: now I don't see anymore duplicated CSS class names assigned to the elements (🎉).

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the “Banner” test examples to use includes, in different ways, to cover all the use cases
- fixed the crashing of the app introducing a new `page-sections` extension for `Showdown`
  - it was working but elements still had too many identical classes applied to them
- fixed the multiple classes problem by removing the `<div data-markdown="1">` wrapper for the content of both `page-sections` and `content-blocks
- updated the "typography" doc page, using a `Banner`, to make sure everything was working as expected
- replaced all the `<section>` declarations in the `docs` using the new syntax
- updated the "tabs" logic in the `show` controller to target new sections format

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1191

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
