### PR TITLE
Updating CopyButton interactive state and fixing width bug.

### DIFF
--- a/website/app/styles/components/copy-button.scss
+++ b/website/app/styles/components/copy-button.scss
@@ -5,9 +5,13 @@
 .doc-copy-button {
   display: inline-flex;
   align-items: center;
-  max-width: 100%;
+  max-width: fit-content;
   border: 1px solid transparent;
   border-radius: 4px;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .doc-copy-button--type-solid {


### PR DESCRIPTION
### :pushpin: Summary

This PR solves a small bug that was occurring in the `ColorSwatch` component in which the `CopyButton` was filling the rest of the grid container and looked strange on hover interaction.

Also updated the hover interaction to cursor on hover.

### :camera_flash: Screenshots

Before:
_GitHub is preventing me from uploading images for some reason_

### :link: External links

[HDS-1058](https://hashicorp.atlassian.net/browse/HDS-1058?atlOrigin=eyJpIjoiNTNiYTcyODUyZmYzNDhiMWI4MWY0YzAzNDljNTA3ZGEiLCJwIjoiaiJ9)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
