### PR TITLE
New docs website / Style `dynamic-template-error` page

### DIFF
--- a/website/app/components/dynamic-template-error.hbs
+++ b/website/app/components/dynamic-template-error.hbs
@@ -1,3 +1,6 @@
-<h1> Error Rendering your Dynamic Template </h1>
 
-<p>Check the console to see the details of the error</p>
+<Doc::Banner @type="critical">
+  <p class="doc-text-body-small"><strong>Error rendering the dynamic template</strong></p>
+  <p class="doc-text-body-small">There was an error rendering the dynamic template for this page.<br/>Check the console to see the details of the error.</p>
+  <p class="doc-text-body-small">If you need support or want to notify the design system team of this error, please <LinkTo @route="support" class="doc-link-generic">contact us</LinkTo>.</p>
+</Doc::Banner>


### PR DESCRIPTION
### :pushpin: Summary

Per discussion, here's a basic styling for the `dynamic-template-error` page (in theory, we should never see it live, but things can be broken, so… better to have one).

### :camera_flash: Screenshots

<img width="1788" alt="screenshot_2185" src="https://user-images.githubusercontent.com/686239/207443623-864cb846-c9f3-482c-8e85-90fd64bfe36d.png">

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
