### PR TITLE
Revised modal border radius and documentation

### DIFF
--- a/.changeset/dull-cameras-retire.md
+++ b/.changeset/dull-cameras-retire.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Updated the modal border radius based on revised design guidelines.

--- a/packages/components/app/styles/components/modal.scss
+++ b/packages/components/app/styles/components/modal.scss
@@ -8,7 +8,7 @@
   padding: 0;
   background: var(--token-color-surface-primary);
   border: none;
-  border-radius: 10px;
+  border-radius: 8px;
   box-shadow: var(--token-surface-overlay-box-shadow);
 
   &[open] {

--- a/website/docs/foundations/border/index.md
+++ b/website/docs/foundations/border/index.md
@@ -2,6 +2,6 @@
 title: Border
 ---
 
-<section id="section-specs" data-markdown="1">
+<section data-tab="Guidelines">
   @include "partials/border-radius.md"
 </section>

--- a/website/docs/foundations/border/index.md
+++ b/website/docs/foundations/border/index.md
@@ -1,0 +1,7 @@
+---
+title: Border
+---
+
+<section id="section-specs" data-markdown="1">
+  @include "partials/border-radius.md"
+</section>

--- a/website/docs/foundations/border/partials/border-radius.md
+++ b/website/docs/foundations/border/partials/border-radius.md
@@ -1,0 +1,11 @@
+## Border radius
+
+Figma doesn't currently support border radius as a style and the HashiCorp Design System doesn't yet publish tokens for border radius. These are a set of high-level guidelines for how border-radius is used in components of various types.
+
+| Type                           | Value | Examples                       |
+| ------------------------------ | ----- | ------------------------------ |
+| Small bass components          | 3px   | Checkbox                       |
+| In-page/inline components      | 5px   | Badge, Button, Form Components |
+| In-page containers             | 6px   | Card, RadioCard                |
+| Elevated components/containers | 6px   | Alert, Toast                   |
+| Overlaid components/containers | 8px   | Modal                          |

--- a/website/docs/foundations/border/partials/border-radius.md
+++ b/website/docs/foundations/border/partials/border-radius.md
@@ -2,10 +2,11 @@
 
 Figma doesn't currently support border radius as a style and the HashiCorp Design System doesn't yet publish tokens for border radius. These are a set of high-level guidelines for how border-radius is used in components of various types.
 
-| Type                           | Value | Examples                       |
-| ------------------------------ | ----- | ------------------------------ |
-| Small bass components          | 3px   | Checkbox                       |
-| In-page/inline components      | 5px   | Badge, Button, Form Components |
-| In-page containers             | 6px   | Card, RadioCard                |
-| Elevated components/containers | 6px   | Alert, Toast                   |
-| Overlaid components/containers | 8px   | Modal                          |
+At this time the strategy for applying border radius is determined by the size of the component.
+
+| Size        | Value | Examples                       |
+| ----------- | ----- | ------------------------------ |
+| Extra small | 3px   | Checkbox                       |
+| Small       | 5px   | Badge, Button, Form Components |
+| Medium      | 6px   | Card, RadioCard, Alert, Toast  |
+| Large       | 8px   | Modal                          |

--- a/website/docs/foundations/border/partials/border-radius.md
+++ b/website/docs/foundations/border/partials/border-radius.md
@@ -1,8 +1,8 @@
 ## Border radius
 
-Figma doesn't currently support border radius as a style and the HashiCorp Design System doesn't yet publish tokens for border radius. These are a set of high-level guidelines for how border-radius is used in components of various types.
+We don't currently offer border radius tokens or Figma styles.
 
-At this time the strategy for applying border radius is determined by the size of the component.
+The size of the component determines the border radius. These are high-level guidelines for how border radius is used in our components.
 
 | Size        | Value | Examples                       |
 | ----------- | ----- | ------------------------------ |


### PR DESCRIPTION
### :pushpin: Summary

This is a pretty small PR of related items so I decided to roll both of these together (LMK if you'd like me to break them up):

1. @hashicorp/hds-design established a more consistent strategy for applying border radius, this specifically impacts the `modal`. The change is slight but adjusts the border radius from 10px to 8px.
2. I've added brief documentation on this strategy to the foundations docs under `foundations/border`.

Further down the road I think we can address tokens for this style. As a note: Figma doesn't support border radius as a style yet.

### :camera_flash: Screenshots

The difference is very slight.

Before:
<img width="664" alt="modal-before" src="https://user-images.githubusercontent.com/2200899/207464216-a238be6d-3ac6-4c2c-b59b-21b303b48e3a.png">

After:
<img width="719" alt="modal-after" src="https://user-images.githubusercontent.com/2200899/207464231-21380206-e552-4565-84ed-1cb5557bb144.png">

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

Preview the documentation [here](https://hds-website-7kedt356g-hashicorp.vercel.app/foundations/border/)

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1140](https://hashicorp.atlassian.net/browse/HDS-1140?atlOrigin=eyJpIjoiYzIxNDY0ZjlkYjNjNDJjOGI2MmZhMWE0NGIxYWJkMGYiLCJwIjoiaiJ9)
Figma file: [Add border radius docs (branch)](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/branch/EZebOkZBJMd16IFcKHMnEl/HDS-Product---Foundations?node-id=6024%3A2082&t=XWY1X1DpfHZOjWxJ-1)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
