### PR TITLE
New docs website / Fix `Page::Sidecar`

### DIFF
--- a/website/app/components/doc/page/sidecar.hbs
+++ b/website/app/components/doc/page/sidecar.hbs
@@ -1,7 +1,7 @@
 <div class='doc-page-sidecar'>
-  <p class='doc-page-sidecar__on-this-page doc-text-label'>On this page:</p>
+  <p class='doc-page-sidecar__on-this-page doc-text-label' id="nav-sidecar">On this page:</p>
   {{#each @tocs as |toc|}}
-    <ul class='doc-page-sidecar__list' id={{toc.id}} hidden={{not toc.isCurrent}}>
+    <ul class='doc-page-sidecar__list' id={{toc.id}} hidden={{not toc.isCurrent}} aria-labelledby="nav-sidecar">
       {{#each toc.list as |item|}}
         <li
           class='doc-page-sidecar__item doc-page-sidecar__item--depth-{{item.depth}}'

--- a/website/app/components/doc/page/sidecar.hbs
+++ b/website/app/components/doc/page/sidecar.hbs
@@ -1,12 +1,12 @@
 <div class='doc-page-sidecar'>
-  <p class='doc-page-sidecar__on-this-page doc-text-h6'>On this page:</p>
+  <p class='doc-page-sidecar__on-this-page doc-text-label'>On this page:</p>
   {{#each @tocs as |toc|}}
     <ul class='doc-page-sidecar__list' id={{toc.id}} hidden={{not toc.isCurrent}}>
       {{#each toc.list as |item|}}
         <li
           class='doc-page-sidecar__item doc-page-sidecar__item--depth-{{item.depth}}'
         >
-          <a href='#{{item.target}}'>{{item.text}}</a>
+          <a class="doc-text-navigation" href='#{{item.target}}'>{{item.text}}</a>
         </li>
       {{/each}}
     </ul>

--- a/website/app/styles/pages/application/sidecar.scss
+++ b/website/app/styles/pages/application/sidecar.scss
@@ -19,20 +19,15 @@
 }
 
 .doc-page-sidecar__on-this-page {
-  @include doc-font-family("gilmer");
-  color: var(--doc-color-gray-100);
-  font-weight: 600;
-  font-size: 13px;
-  line-height: 1;
-  text-transform: uppercase;
+  margin: 0 0 16px 0;
+  color: var(--doc-color-black);
 }
 
 .doc-page-sidecar__list {
-  @include doc-font-style-body-small();
   margin: 0;
   padding: 0;
   list-style: none;
-  border-left: 1px solid #dbdbdc;
+  border-left: 1px solid var(--doc-color-gray-500);
 }
 
 .doc-page-sidecar__item {
@@ -43,12 +38,11 @@
   a {
     position: relative;
     padding: 0 0 0 var(--padding-left);
-    color: #727374;
-    font-weight: var(--font-weight);
+    color: var(--doc-color-gray-300);
     text-decoration: none;
 
     &:hover {
-      color: #2264d6;
+      color: var(--doc-color-black);
 
       &::after {
         position: absolute;
@@ -56,26 +50,24 @@
         bottom: 0;
         left: -1px;
         width: 3px;
-        background-color: #2264d6;
+        background-color: var(--doc-color-black);
         content: "";
       }
     }
 
     &:active,
     &:visited {
-      color: #727374;
+      color: var(--doc-color-gray-300);
     }
   }
 }
 
 .doc-page-sidecar__item--depth-2 {
   --padding-left: 12px;
-  --font-weight: bold;
 }
 
 .doc-page-sidecar__item--depth-3 {
   --padding-left: 24px;
-  --font-weight: medium;
 }
 
 


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes a couple of things in the `Page::Sidecar` component.

### :hammer_and_wrench: Detailed description

In this PR I have:
- changed logic in `show` so that the sidecar gets populated also when there are no `<section data-tab="">` containers
- updated styling for sidecar according to latest designs

The selection of the "active" item according to the URL is something still to do (low priority)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1218
Figma file: https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=1315%3A84058&t=lSi4bFHEq0ZWgvSk-1]
