### PR TITLE
New docs website / Fix bug `elements-to-classnames` Showdown modifier

### DIFF
--- a/website/app/shared/showdown-extensions/elements-to-classnames.js
+++ b/website/app/shared/showdown-extensions/elements-to-classnames.js
@@ -31,7 +31,6 @@ export const elementsToClassNames = Object.keys(mapElementsToClassNames).map(
     // IMPORTANT: we NEED to set the "g" global option here!
     regex: new RegExp(`<${element}>|<${element} ([^>]*)>`, 'g'),
     replace: function (text) {
-      console.log('text', text);
       // IMPORTANT: we DO NOT NEED to set the "g" global option here!
       const regexBasic = new RegExp(`<${element}>`);
       const matchBasic = text.match(regexBasic);

--- a/website/app/shared/showdown-extensions/elements-to-classnames.js
+++ b/website/app/shared/showdown-extensions/elements-to-classnames.js
@@ -29,12 +29,13 @@ export const elementsToClassNames = Object.keys(mapElementsToClassNames).map(
     // this is a custom regex, modified from the one found in the original tutolrial, to make it more solid and encompass more use cases
     // for testing see: https://regex101.com/r/jLk7wN/2 + https://regex101.com/r/jLk7wN/5
     // IMPORTANT: we NEED to set the "g" global option here!
-    regex: new RegExp(`<${element}>|<${element} (.*)>`, 'g'),
+    regex: new RegExp(`<${element}>|<${element} ([^>]*)>`, 'g'),
     replace: function (text) {
+      console.log('text', text);
       // IMPORTANT: we DO NOT NEED to set the "g" global option here!
       const regexBasic = new RegExp(`<${element}>`);
       const matchBasic = text.match(regexBasic);
-      const regexWithAttrs = new RegExp(`<${element} (.*)>`);
+      const regexWithAttrs = new RegExp(`<${element} ([^>]*)>`);
       const matchWithAttrs = text.match(regexWithAttrs);
 
       let attrs;


### PR DESCRIPTION
### :pushpin: Summary

While reviewing #804 I noticed that the content was not formatted correctly (the `doc-markdown-***` class names were all over the place). After some testing, I realized that the issue was in the excessive "greadyness" of the regex for tags with attributes in the `elements-to-classnames` Showdown modifier.

This small PR fixes the issue.

### :camera_flash: Screenshots

**Before:**
<img width="780" alt="screenshot_2191" src="https://user-images.githubusercontent.com/686239/207580241-35d86bad-b01c-4836-9018-bc7406d67afa.png">

**After:**
<img width="786" alt="screenshot_2190" src="https://user-images.githubusercontent.com/686239/207580247-20ca4bf5-fce7-4053-8362-415c06f1bff5.png">

