### PR TITLE
Remove `unhashHTMLSpans ` subparser override

### DIFF
--- a/website/app/initializers/showdown-extensions.js
+++ b/website/app/initializers/showdown-extensions.js
@@ -4,43 +4,6 @@
 import showdown from 'showdown';
 
 export function initialize(/* application */) {
-  // Overriding `unhashHTMLSpans` subparser to overcome the 10 levels of nesting limit
-  showdown.subParser('unhashHTMLSpans', function (text, options, globals) {
-    'use strict';
-
-    text = globals.converter._dispatch(
-      'unhashHTMLSpans.before',
-      text,
-      options,
-      globals
-    );
-  
-    for (var i = 0; i < globals.gHtmlSpans.length; ++i) {
-      var repText = globals.gHtmlSpans[i],
-        // limiter to prevent infinite loop (assume 50 as limit for recurse)
-        limit = 0;
-  
-      while (/¨C(\d+)C/.test(repText)) {
-        var num = RegExp.$1;
-        repText = repText.replace('¨C' + num + 'C', globals.gHtmlSpans[num]);
-        if (limit === 50) {
-          console.error('maximum nesting of 50 spans reached!!!');
-          break;
-        }
-        ++limit;
-      }
-      text = text.replace('¨C' + i + 'C', repText);
-    }
-  
-    text = globals.converter._dispatch(
-      'unhashHTMLSpans.after',
-      text,
-      options,
-      globals
-    );
-    return text;
-  });
-
   showdown.subParser('githubCodeBlocks', function (text, options, globals) {
     'use strict';
 


### PR DESCRIPTION
### :pushpin: Summary

Remove `unhashHTMLSpans ` subparser override

### :hammer_and_wrench: Detailed description

The excessive or infinite loop causing the `unhashHTMLSpans` to throw the 'maximum nesting of 50 spans reached!!!' error was fixed in #810 so we can safely remove the subparser override (which only worked at runtime, but not on build, anyway).

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
