### PR TITLE
Fix tabs error when no tabs are present

### DIFF
--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -39,6 +39,7 @@ export default class ShowController extends Controller {
   @tracked tocs = A([]);
 
   get selectedTabIndex() {
+    // if no query param is set then default to the first tab
     if (!this.selectedTab) {
       return 0;
     }

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -152,8 +152,13 @@ export default class ShowController extends Controller {
       set(toc, 'isCurrent', toc.index === current);
     });
 
-    // for consistency we always set the query param tab to a lowercase version of the tab label
-    set(this, 'selectedTab', this.tabs[current].label.toLowerCase());
+    // only attempt to update the query params if tabs exist
+    if (this.tabs.length > 1) {
+      // for consistency we always set the query param tab to a lowercase version of the tab label
+      set(this, 'selectedTab', this.tabs[current].label.toLowerCase());
+    } else {
+      set(this, 'selectedTab', null);
+    }
 
     // leave for debugging
     // console.log('show setCurrent', this.sections, this.tabs, this.tocs);


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
Fixes issues with tab logic on pages where there aren't any tabs

### :hammer_and_wrench: Detailed description

Visiting a page like `about/02--hds-principles/` in prod you'll see a console error because we're trying to set the query param for a tab that doesn't exist. You'd also see that query params from pages with tabs persist to pages without tabs. This should help with that.