### PR TITLE
New Docs Website / Show captions for component page

### DIFF
--- a/website/app/components/doc/cards/deck.hbs
+++ b/website/app/components/doc/cards/deck.hbs
@@ -4,7 +4,7 @@
       <Doc::Cards::Card
         @image={{card.image}}
         @title={{card.title}}
-        @description={{card.description}}
+        @description={{if card.caption card.caption card.description}}
         @route={{card.route}}
         @model={{card.model}}
         @href={{card.href}}

--- a/website/app/controllers/components.js
+++ b/website/app/controllers/components.js
@@ -15,9 +15,7 @@ export default class ComponentsController extends Controller {
               page.pageURL.replaceAll('/', '-')
             )}/232/124`,
             title: page.pageAttributes.title,
-            description:
-              page.pageAttributes.description ||
-              'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+            description: page.pageAttributes.description,
             route: 'show',
             model: page.pageURL,
           };

--- a/website/app/controllers/components.js
+++ b/website/app/controllers/components.js
@@ -16,8 +16,10 @@ export default class ComponentsController extends Controller {
             )}/232/124`,
             title: page.pageAttributes.title,
             description:
-              page.pageAttributes.description || 'description placeholder',
-            caption: page.pageAttributes.caption || 'caption placeholder',
+              page.pageAttributes.description ||
+              'The description should be here',
+            caption:
+              page.pageAttributes.caption || 'The caption should be here',
             route: 'show',
             model: page.pageURL,
           };

--- a/website/app/controllers/components.js
+++ b/website/app/controllers/components.js
@@ -15,7 +15,9 @@ export default class ComponentsController extends Controller {
               page.pageURL.replaceAll('/', '-')
             )}/232/124`,
             title: page.pageAttributes.title,
-            description: page.pageAttributes.description,
+            description:
+              page.pageAttributes.description || 'description placeholder',
+            caption: page.pageAttributes.caption || 'caption placeholder',
             route: 'show',
             model: page.pageURL,
           };

--- a/website/docs/components/avatar/index.md
+++ b/website/docs/components/avatar/index.md
@@ -1,5 +1,7 @@
 ---
 title: Avatar
+description: Description placeholder content
+caption: Caption placeholder content
 hidden: true
 ---
 

--- a/website/docs/components/badge-count/index.md
+++ b/website/docs/components/badge-count/index.md
@@ -1,5 +1,8 @@
 ---
 title: BadgeCount
+description: A numeric label used to display things like version number and collection enumeration 
+caption: A numeric label used to display things like version number and collection enumeration
+
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -1,5 +1,7 @@
 ---
 title: Badge
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -1,7 +1,7 @@
 ---
 title: Badge
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -1,7 +1,7 @@
 ---
 title: Breadcrumb
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -1,5 +1,7 @@
 ---
 title: Breadcrumb
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/button-set/index.md
+++ b/website/docs/components/button-set/index.md
@@ -1,5 +1,7 @@
 ---
 title: ButtonSet
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/button-set/index.md
+++ b/website/docs/components/button-set/index.md
@@ -1,7 +1,7 @@
 ---
 title: ButtonSet
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/button/index.md
+++ b/website/docs/components/button/index.md
@@ -1,7 +1,7 @@
 ---
 title: Button
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/button/index.md
+++ b/website/docs/components/button/index.md
@@ -1,5 +1,7 @@
 ---
 title: Button
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/card/index.md
+++ b/website/docs/components/card/index.md
@@ -1,7 +1,7 @@
 ---
 title: Card
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/card/index.md
+++ b/website/docs/components/card/index.md
@@ -1,5 +1,7 @@
 ---
 title: Card
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -1,5 +1,7 @@
 ---
 title: Dropdown
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Other">

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -1,7 +1,7 @@
 ---
 title: Dropdown
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Other">

--- a/website/docs/components/empty-state/index.md
+++ b/website/docs/components/empty-state/index.md
@@ -1,6 +1,8 @@
 ---
 title: EmptyState
 hidden: true
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/empty-state/index.md
+++ b/website/docs/components/empty-state/index.md
@@ -1,8 +1,8 @@
 ---
 title: EmptyState
 hidden: true
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/form/base-elements/index.md
+++ b/website/docs/components/form/base-elements/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form / Base elements
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/base-elements/index.md
+++ b/website/docs/components/form/base-elements/index.md
@@ -1,7 +1,7 @@
 ---
 title: Form / Base elements
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/checkbox/index.md
+++ b/website/docs/components/form/checkbox/index.md
@@ -1,7 +1,7 @@
 ---
 title: Form::Checkbox
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/checkbox/index.md
+++ b/website/docs/components/form/checkbox/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::Checkbox
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/radio-card/index.md
+++ b/website/docs/components/form/radio-card/index.md
@@ -1,7 +1,7 @@
 ---
 title: Form::RadioCard
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/radio-card/index.md
+++ b/website/docs/components/form/radio-card/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::RadioCard
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/radio/index.md
+++ b/website/docs/components/form/radio/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::Radio
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/radio/index.md
+++ b/website/docs/components/form/radio/index.md
@@ -1,7 +1,7 @@
 ---
 title: Form::Radio
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/select/index.md
+++ b/website/docs/components/form/select/index.md
@@ -1,7 +1,7 @@
 ---
 title: Form::Select
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Other">

--- a/website/docs/components/form/select/index.md
+++ b/website/docs/components/form/select/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::Select
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Other">

--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -1,7 +1,7 @@
 ---
 title: Form::TextInput
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::TextInput
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/textarea/index.md
+++ b/website/docs/components/form/textarea/index.md
@@ -1,7 +1,7 @@
 ---
 title: Form::Textarea
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/textarea/index.md
+++ b/website/docs/components/form/textarea/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::Textarea
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/toggle/index.md
+++ b/website/docs/components/form/toggle/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::Toggle
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/toggle/index.md
+++ b/website/docs/components/form/toggle/index.md
@@ -1,7 +1,7 @@
 ---
 title: Form::Toggle
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -1,7 +1,7 @@
 ---
 title: IconTile
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -1,5 +1,7 @@
 ---
 title: IconTile
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/link/inline/index.md
+++ b/website/docs/components/link/inline/index.md
@@ -1,7 +1,7 @@
 ---
 title: Link::Inline
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Other">

--- a/website/docs/components/link/inline/index.md
+++ b/website/docs/components/link/inline/index.md
@@ -1,5 +1,7 @@
 ---
 title: Link::Inline
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Other">

--- a/website/docs/components/link/standalone/index.md
+++ b/website/docs/components/link/standalone/index.md
@@ -1,5 +1,7 @@
 ---
 title: Link::Standalone
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/link/standalone/index.md
+++ b/website/docs/components/link/standalone/index.md
@@ -1,7 +1,7 @@
 ---
 title: Link::Standalone
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -1,7 +1,7 @@
 ---
 title: Modal
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -1,5 +1,7 @@
 ---
 title: Modal
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/stepper/index.md
+++ b/website/docs/components/stepper/index.md
@@ -1,7 +1,7 @@
 ---
 title: Stepper Indicator
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/stepper/index.md
+++ b/website/docs/components/stepper/index.md
@@ -1,5 +1,7 @@
 ---
 title: Stepper Indicator
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/table/index.md
+++ b/website/docs/components/table/index.md
@@ -1,7 +1,7 @@
 ---
 title: Table
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Other">

--- a/website/docs/components/table/index.md
+++ b/website/docs/components/table/index.md
@@ -1,5 +1,7 @@
 ---
 title: Table
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Other">

--- a/website/docs/components/tabs/index.md
+++ b/website/docs/components/tabs/index.md
@@ -1,5 +1,7 @@
 ---
 title: Tabs
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/tabs/index.md
+++ b/website/docs/components/tabs/index.md
@@ -1,7 +1,7 @@
 ---
 title: Tabs
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -1,5 +1,7 @@
 ---
 title: Tag
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -1,7 +1,7 @@
 ---
 title: Tag
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/toast/index.md
+++ b/website/docs/components/toast/index.md
@@ -1,5 +1,7 @@
 ---
 title: Toast
+description: aaa
+caption: bbb
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/toast/index.md
+++ b/website/docs/components/toast/index.md
@@ -1,7 +1,7 @@
 ---
 title: Toast
-description: aaa
-caption: bbb
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/overrides/power-select/index.md
+++ b/website/docs/overrides/power-select/index.md
@@ -1,5 +1,7 @@
 ---
 title: PowerSelect
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/utilities/disclosure/index.md
+++ b/website/docs/utilities/disclosure/index.md
@@ -1,5 +1,7 @@
 ---
 title: Disclosure
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Other">

--- a/website/docs/utilities/dismiss-button/index.md
+++ b/website/docs/utilities/dismiss-button/index.md
@@ -1,5 +1,7 @@
 ---
 title: DismissButton
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Other">

--- a/website/docs/utilities/interactive/index.md
+++ b/website/docs/utilities/interactive/index.md
@@ -1,5 +1,7 @@
 ---
 title: Interactive
+description: Description placeholder content
+caption: Caption placeholder content
 ---
 
 <section data-tab="Other">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR should show a brief description for the component in each card.

### :hammer_and_wrench: Detailed description

- updated controller to remove _lorem ipsum_ `OR` statement from `description`
- added `caption` support with description as fallback
- FOR NOW added description/caption placeholders so every component/index.md page has one

### :camera_flash: Screenshots

Before:
<img width="1327" alt="CleanShot 2022-12-14 at 14 12 48@2x" src="https://user-images.githubusercontent.com/4587451/207704387-221d2998-f41c-48b1-8977-28c538b57448.png">

After:
(coming soon!)

### :link: External links

Jira ticket: [HDS-1225](https://hashicorp.atlassian.net/browse/HDS-1225)


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
