### PR TITLE
New docs website / Fix caption in cards

### DIFF
--- a/website/app/components/doc/cards/card.hbs
+++ b/website/app/components/doc/cards/card.hbs
@@ -3,8 +3,8 @@
   <LinkTo class="doc-cards-card__link" @route={{@route}} @model={{@model}}>
     <img class="doc-cards-card__image" src={{@image}} alt="" role="presentation" />
     <div class="doc-cards-card__details">
-      <p class="doc-cards-card__title">{{capitalize @title}}</p>
-      <p class="doc-cards-card_description">{{capitalize @description}}</p>
+      <p class="doc-cards-card__title">{{@title}}</p>
+      <p class="doc-cards-card_description">{{@caption}}</p>
     </div>
   </LinkTo>
   {{/if}}
@@ -12,8 +12,8 @@
   <a class="doc-cards-card__link" href={{@href}}>
     <img class="doc-cards-card__image" src={{@image}} alt="" role="presentation" />
     <div class="doc-cards-card__details">
-      <p class="doc-cards-card__title">{{capitalize @title}}</p>
-      <p class="doc-cards-card_description">{{capitalize @description}}</p>
+      <p class="doc-cards-card__title">{{@title}}</p>
+      <p class="doc-cards-card_description">{{@caption}}</p>
     </div>
   </a>
   {{/if}}

--- a/website/app/components/doc/cards/deck.hbs
+++ b/website/app/components/doc/cards/deck.hbs
@@ -4,7 +4,7 @@
       <Doc::Cards::Card
         @image={{card.image}}
         @title={{card.title}}
-        @description={{card.description}}
+        @caption={{card.caption}}
         @route={{card.route}}
         @model={{card.model}}
         @href={{card.href}}

--- a/website/app/controllers/components.js
+++ b/website/app/controllers/components.js
@@ -15,9 +15,9 @@ export default class ComponentsController extends Controller {
               page.pageURL.replaceAll('/', '-')
             )}/232/124`,
             title: page.pageAttributes.title,
-            description:
-              page.pageAttributes.description ||
-              'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+            caption:
+              page.pageAttributes.caption ||
+              'Don\'t forget to add the "caption" to the frontmatter for this page',
             route: 'show',
             model: page.pageURL,
           };

--- a/website/app/controllers/foundations.js
+++ b/website/app/controllers/foundations.js
@@ -15,9 +15,9 @@ export default class FoundationsController extends Controller {
               page.pageURL.replaceAll('/', '-')
             )}/232/124`,
             title: page.pageAttributes.title,
-            description:
-              page.pageAttributes.description ||
-              'Excepteur sint occaecat cupidatat non proident, sunt in culpa.',
+            caption:
+              page.pageAttributes.caption ||
+              'Don\'t forget to add the "caption" to the frontmatter for this page',
             route: 'show',
             model: page.pageURL,
           };

--- a/website/docs/foundations/colors/index.md
+++ b/website/docs/foundations/colors/index.md
@@ -1,5 +1,7 @@
 ---
 title: Colors
+description: This is the description of the colors that will appear in the page cover
+caption: This is the caption of the colors page that will appear in the cards lists
 ---
 
 <section data-tab="Code">

--- a/website/lib/markdown/table-of-contents.js
+++ b/website/lib/markdown/table-of-contents.js
@@ -60,6 +60,7 @@ class TableOfContents extends Plugin {
         // notice: the page attributes are quite verbose, so we select only a subset (what we really need for the TOC generation)
         pageAttributes = _.pick(jsonData.data.attributes, [
           'title',
+          'caption',
           'weight',
           'hidden',
         ]);


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes how the `caption` frontmatter value is passed to the "cards" in the "Foundations" and "Components" landing pages.

### :hammer_and_wrench: Detailed description

In this PR I have:
- fixed TOC generation to add `caption` to the attributes stored in the JSON file
- updated “Foundations” and “Components” controllers to pass down the “caption” to the cards
- updated the `Doc::Cards` component to use the `caption` value
- added `description` and `value` to the “colors” page for testing