### PR TITLE
New docs website / "Icons" page tweaks

### DIFF
--- a/website/app/components/doc/icons-list/index.hbs
+++ b/website/app/components/doc/icons-list/index.hbs
@@ -1,5 +1,5 @@
 <div class="doc-icons-list-filter">
-  <Doc::IconsList::Select @onSelect={{@onSelect}} />
+  <Doc::IconsList::Select @onSelect={{@onSelect}} @selectedIconSize={{@selectedIconSize}}/>
   <Doc::IconsList::Search @searchQuery={{@searchQuery}} @onInput={{@searchIcons}} />
 </div>
 

--- a/website/app/components/doc/icons-list/search.hbs
+++ b/website/app/components/doc/icons-list/search.hbs
@@ -1,5 +1,5 @@
 <div class="doc-icons-list-filter__search">
-  <label class="doc-icons-list-filter__label" for="doc-foundations-icons-filter-search">Filter results</label>
+  <label class="doc-icons-list-filter__label" for="doc-foundations-icons-filter-search">Filter</label>
   <input
     type="search"
     name="search"

--- a/website/app/components/doc/icons-list/select.hbs
+++ b/website/app/components/doc/icons-list/select.hbs
@@ -5,7 +5,7 @@
     id="doc-foundations-icons-filter-select"
     {{on "change" @onSelect}}
   >
-    <option value="16">16px</option>
-    <option value="24">24px</option>
+    <option value="16" selected={{eq @selectedIconSize "16"}}>16px</option>
+    <option value="24" selected={{eq @selectedIconSize "24"}}>24px</option>
   </select>
 </div>

--- a/website/app/styles/components/icons-list/filter.scss
+++ b/website/app/styles/components/icons-list/filter.scss
@@ -18,7 +18,7 @@
   @include doc-font-family("sans");
   display: block;
   width: min-content;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
   color: var(--doc-color-gray-200);
   font-weight: 600;
   font-size: 15px;

--- a/website/docs/foundations/icons/index.js
+++ b/website/docs/foundations/icons/index.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 
@@ -9,6 +10,9 @@ const DEBOUNCE_MS = 250;
 
 export default class Index extends Component {
   @service router;
+
+  @tracked selectedIconSize =
+    this.router.currentRoute.queryParams['selectedIconSize'] || '24';
 
   allIcons = catalog.assets.map(({ iconName, fileName, size, description }) => {
     return {
@@ -24,16 +28,14 @@ export default class Index extends Component {
     // query params come from `controllers/show.js` and we access them here because there
     // is no "controller" for individual component documentation routes
     const searchQuery = this.router.currentRoute.queryParams['searchQuery'];
-    const selectedIconSize =
-      this.router.currentRoute.queryParams['selectedIconSize'] || '16';
     if (searchQuery) {
       return this.allIcons.filter(
         (i) =>
-          i.size === selectedIconSize &&
+          i.size === this.selectedIconSize &&
           i.searchable.indexOf(searchQuery) !== -1
       );
     } else {
-      return this.allIcons.filter((i) => i.size === selectedIconSize);
+      return this.allIcons.filter((i) => i.size === this.selectedIconSize);
     }
   }
 

--- a/website/docs/foundations/icons/index.md
+++ b/website/docs/foundations/icons/index.md
@@ -8,6 +8,7 @@ layout:
   <Doc::IconsList
     @icons={{this.filteredIcons}}
     @onSelect={{this.selectIconSize}}
+    @selectedIconSize={{this.selectedIconSize}}
     @searchQuery={{this.searchQuery}}
     @searchIcons={{this.searchIcons}}
   />

--- a/website/tests/acceptance/icon-query-test.js
+++ b/website/tests/acceptance/icon-query-test.js
@@ -11,7 +11,7 @@ module('Acceptance | Icon Search', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      '/foundations/icons?searchQuery=loading&tab=library'
+      '/foundations/icons?searchQuery=loading&selectedIconSize=24&tab=library'
     );
 
     assert.dom('.doc-icons-list-grid-item').exists({ count: 1 });


### PR DESCRIPTION
### :pushpin: Summary

Follow up of conversation with @cveigt, here's some updates requested for the "Icons" page:
- change "Filter records" to "Filter"
- reduce space below the filters' labels
- have `24px` as default selected size for the filter instead of `16px`

👉 👉 👉 **Preview**: https://hds-website-git-new-docs-website-icons-tweaks-hashicorp.vercel.app/foundations/icons?tab=library/

@Dhaulagiri can you check that the changes I made to the way the query params are consumed in the page works for you?