### PR TITLE
Badge Docs: Adds `description` and `caption` for badge component.

### DIFF
--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -1,5 +1,7 @@
 ---
 title: Badge
+description: Concise, non-interactive labels that represent metadata.
+caption: Concise, non-interactive labels that represent metadata.
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/badge/partials/guidelines/overview.md
+++ b/website/docs/components/badge/partials/guidelines/overview.md
@@ -1,8 +1,8 @@
-`Badge` are concise, non-interactive labels that represent metadata. It should be used:
+Badges are concise, non-interactive labels that represent metadata. It should be used:
 
-*   to indicate status, such as “Running”, “Applied”, “Errored”, etc
-*   as feature flags, such as “In Preview”, “Beta”, “New”, etc
-*   for categorizations, such as Product Lines and Account Levels
-*   for keyboard shortcut hints, such as “Esc”
+- to indicate status, such as “Running”, “Applied”, “Errored”, etc
+- as feature flags, such as “In Preview”, “Beta”, “New”, etc
+- for categorizations, such as Product Lines and Account Levels
+- for keyboard shortcut hints, such as “Esc”
 
 _Notice: for collection enumeration or version number, use [BadgeCount](/components/badge-count/)._


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to badge component documentation. It also updates the markdown for the badge/overview documentation.

### :hammer_and_wrench: Detailed description

- description: Concise, non-interactive labels that represent metadata.
- caption: Concise, non-interactive labels that represent metadata.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
