### PR TITLE
Dropdown Docs: adds `description` and `caption` for `Dropdown` component

### DIFF
--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -1,5 +1,7 @@
 ---
 title: Dropdown
+description: Displays a list (typically of actions or links) through a toggle and is identifiable by the chevron icon in the button.
+caption: Hide/Show a list of actions or links with a toggle button.
 ---
 
 <section data-tab="Other">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the `Dropdown` component documentation. 

### :hammer_and_wrench: Detailed description

- description: Displays a list (typically of actions or links) through a toggle and is identifiable by the chevron icon in the button.
- caption: Hide/Show a list of actions or links with a toggle button.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
