### PR TITLE
New docs website / Fix cards layout

### DIFF
--- a/website/app/styles/components/cards/card.scss
+++ b/website/app/styles/components/cards/card.scss
@@ -13,12 +13,14 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 100%;
   text-decoration: none;
   border-radius: inherit; // needed to propagate down
 }
 
 .doc-cards-card__image {
   display: block;
+  flex: none;
   width: 100%;
   height: auto;
   background-color: var(--doc-color-gray-300);
@@ -27,6 +29,7 @@
 }
 
 .doc-cards-card__details {
+  flex: 1 1 auto;
   padding: 24px 24px 32px 24px;
   border: 1px solid var(--doc-color-gray-500);
   border-top: none;


### PR DESCRIPTION
### :pushpin: Summary

Small PR to fix a layout issue I noticed only now (the card height is not uniform, when the length of the textual content is different).

### :camera_flash: Screenshots

**Before**:
<img width="1024" alt="screenshot_2194" src="https://user-images.githubusercontent.com/686239/207816710-15824dc9-e82a-437a-8695-9f1e2314ce6a.png">

**After**:
<img width="968" alt="screenshot_2195" src="https://user-images.githubusercontent.com/686239/207816698-5a144a25-2124-4ce5-9c76-61d8a7e58a69.png">
