### PR TITLE
New docs website / Sidebar TOC sorting

### DIFF
--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -78,6 +78,7 @@ export default class ShowRoute extends Route {
           'links',
           'layout',
           'hidden',
+          'weight',
         ];
         frontmatterAttributes.forEach((attribute) => {
           if (attribute in res.data.attributes) {

--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -78,7 +78,7 @@ export default class ShowRoute extends Route {
           'links',
           'layout',
           'hidden',
-          'weight',
+          'order',
         ];
         frontmatterAttributes.forEach((attribute) => {
           if (attribute in res.data.attributes) {

--- a/website/docs/about/hds-principles.md
+++ b/website/docs/about/hds-principles.md
@@ -1,6 +1,7 @@
 ---
 title: HDS principles
 description: Consider the whole when creating the parts.
+weight: 102
 ---
 
 <!-- TO EDIT THESE PRINCIPLES LOOK AT THE COMPONENT IN `website/app/components/doc/content/hds-principles/` -->

--- a/website/docs/about/hds-principles.md
+++ b/website/docs/about/hds-principles.md
@@ -1,7 +1,7 @@
 ---
 title: HDS principles
 description: Consider the whole when creating the parts.
-weight: 102
+order: 102
 ---
 
 <!-- TO EDIT THESE PRINCIPLES LOOK AT THE COMPONENT IN `website/app/components/doc/content/hds-principles/` -->

--- a/website/docs/about/overview.md
+++ b/website/docs/about/overview.md
@@ -1,6 +1,7 @@
 ---
-title: For designers
+title: Overview
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+weight: 101
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/about/overview.md
+++ b/website/docs/about/overview.md
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-weight: 101
+order: 101
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/getting-started/adoption.md
+++ b/website/docs/getting-started/adoption.md
@@ -1,6 +1,7 @@
 ---
-title: Release notes
+title: Adoption
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+weight: 103
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/getting-started/adoption.md
+++ b/website/docs/getting-started/adoption.md
@@ -1,7 +1,7 @@
 ---
 title: Adoption
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-weight: 103
+order: 103
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/getting-started/contribution/index.md
+++ b/website/docs/getting-started/contribution/index.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution
+weight: 104
 ---
 
 ## Types of contribution
@@ -14,7 +15,7 @@ While we don't accept direct contributions of new components or patterns, we do 
 
 We continue to listen to feedback as we consider the best way to open contributions further.
 
-## Code contributions 
+## Code contributions
 
 For contributions to the individual code packages, consult the `CONTRIBUTING.md` files.
 * [Tokens](https://github.com/hashicorp/design-system/blob/main/packages/tokens/CONTRIBUTING.md)

--- a/website/docs/getting-started/contribution/index.md
+++ b/website/docs/getting-started/contribution/index.md
@@ -1,6 +1,6 @@
 ---
 title: Contribution
-weight: 104
+order: 104
 ---
 
 ## Types of contribution

--- a/website/docs/getting-started/for-designers.md
+++ b/website/docs/getting-started/for-designers.md
@@ -1,7 +1,7 @@
 ---
 title: For designers
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-weight: 101
+order: 101
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/getting-started/for-designers.md
+++ b/website/docs/getting-started/for-designers.md
@@ -1,6 +1,7 @@
 ---
-title: Tutorials
+title: For designers
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+weight: 101
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -1,6 +1,7 @@
 ---
-title: Overview
+title: For engineers
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+weight: 102
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -1,7 +1,7 @@
 ---
 title: For engineers
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-weight: 102
+order: 102
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/getting-started/tutorials.md
+++ b/website/docs/getting-started/tutorials.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorials
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-weight: 105
+order: 105
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/getting-started/tutorials.md
+++ b/website/docs/getting-started/tutorials.md
@@ -1,6 +1,7 @@
 ---
-title: Roadmap
+title: Tutorials
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+weight: 105
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/updates/newsletter.md
+++ b/website/docs/updates/newsletter.md
@@ -1,6 +1,7 @@
 ---
 title: Newsletter
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+weight: 103
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/updates/newsletter.md
+++ b/website/docs/updates/newsletter.md
@@ -1,7 +1,7 @@
 ---
 title: Newsletter
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-weight: 103
+order: 103
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/updates/release-notes.md
+++ b/website/docs/updates/release-notes.md
@@ -1,6 +1,7 @@
 ---
-title: Adoption
+title: Release notes
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+weight: 101
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/updates/release-notes.md
+++ b/website/docs/updates/release-notes.md
@@ -1,7 +1,7 @@
 ---
 title: Release notes
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-weight: 101
+order: 101
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/updates/roadmap.md
+++ b/website/docs/updates/roadmap.md
@@ -1,6 +1,7 @@
 ---
-title: For engineers
+title: Roadmap
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+weight: 102
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/updates/roadmap.md
+++ b/website/docs/updates/roadmap.md
@@ -1,7 +1,7 @@
 ---
 title: Roadmap
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-weight: 102
+order: 102
 ---
 
 ## Lorem ipsum dolor

--- a/website/lib/markdown/markdown-to-jsonapi.js
+++ b/website/lib/markdown/markdown-to-jsonapi.js
@@ -27,7 +27,7 @@ class MarkdownToJsonApi extends PersistentFilter {
         'links',
         'layout',
         'hidden',
-        'weight',
+        'order',
       ],
     };
 

--- a/website/lib/markdown/markdown-to-jsonapi.js
+++ b/website/lib/markdown/markdown-to-jsonapi.js
@@ -27,6 +27,7 @@ class MarkdownToJsonApi extends PersistentFilter {
         'links',
         'layout',
         'hidden',
+        'weight',
       ],
     };
 

--- a/website/lib/markdown/table-of-contents.js
+++ b/website/lib/markdown/table-of-contents.js
@@ -6,20 +6,70 @@
 const walkSync = require('walk-sync');
 const Plugin = require('broccoli-plugin');
 const fs = require('fs-extra');
-const _ = require('lodash');
+const { pick, set, isEqual } = require('lodash');
 
-// const CATEGORIES = [
-//   'about',
-//   'overview',
-//   'getting-started',
-//   'updates',
-//   'foundations',
-//   'components',
-//   'overrides',
-//   'utilities',
-//   'patterns',
-//   'testing',
-// ];
+const CATEGORIES = [
+  'about',
+  'getting-started',
+  'updates',
+  'foundations',
+  'components',
+  'overrides',
+  'utilities',
+  'patterns',
+  'testing',
+];
+
+const sortPages = (s1, s2) => {
+  if (
+    s1.filePath === 'components/form/checkbox/index' &&
+    s2.filePath === 'components/badge/index'
+  ) {
+    console.log('s1-s2 (form/checkbox vs badge)', s1, s2);
+  }
+  // if they are siblings...
+  if (isEqual(s1.pageParents, s2.pageParents)) {
+    //  we use the weight first...
+    if (s1.pageAttributes.weight < s2.pageAttributes.weight) {
+      return -1;
+    } else if (s1.pageAttributes.weight > s2.pageAttributes.weight) {
+      return 1;
+    } else {
+      // or we fallback to sort alphabethically
+      const p1 = s1.pageName.toLowerCase;
+      const p2 = s2.pageName.toLowerCase;
+      if (p1 < p2) {
+        return 1;
+      } else if (p1 > p2) {
+        return -1;
+      } else {
+        return 0;
+      }
+    }
+  } else {
+    // we try to use the top-level category
+    const c1 = CATEGORIES.indexOf(s1.pageParents[0].toLowerCase());
+    const c2 = CATEGORIES.indexOf(s2.pageParents[0].toLowerCase());
+    if (c1 < c2) {
+      return -1;
+    } else if (c1 > c2) {
+      return 1;
+    } else {
+      // the natural "file system" order works here
+      return 0;
+      // or if it doesn't try to tweak this logic
+      // const p1 = s1.filePath;
+      // const p2 = s2.filePath;
+      // if (p1 < p2) {
+      //   return -1;
+      // } else if (p1 > p2) {
+      //   return 1;
+      // } else {
+      //   return 0;
+      // }
+    }
+  }
+};
 
 class TableOfContents extends Plugin {
   constructor(inputNodes, folder) {
@@ -58,7 +108,7 @@ class TableOfContents extends Plugin {
       if (fs.existsSync(fullFilePath)) {
         const jsonData = fs.readJSONSync(fullFilePath);
         // notice: the page attributes are quite verbose, so we select only a subset (what we really need for the TOC generation)
-        pageAttributes = _.pick(jsonData.data.attributes, [
+        pageAttributes = pick(jsonData.data.attributes, [
           'title',
           'caption',
           'weight',
@@ -85,11 +135,12 @@ class TableOfContents extends Plugin {
     });
 
     // notice: we pre-sort the list so we don't need to do it in the structured tree (much harder!)
-    // flatPageList = flatPageList.sort(sortPages);
+    // const flatSortedPageList = [...flatPageList].sort(sortPages); // use this if you want to maintain the
+    flatPageList.sort(sortPages);
 
     flatPageList.forEach((page) => {
       // we have to rebuild the full structure here
-      _.set(structuredPageTree, [...page.pageParents, page.pageName], page);
+      set(structuredPageTree, [...page.pageParents, page.pageName], page);
     });
 
     const toc = { flat: flatPageList, tree: structuredPageTree };

--- a/website/lib/markdown/table-of-contents.js
+++ b/website/lib/markdown/table-of-contents.js
@@ -29,10 +29,10 @@ const sortPages = (s1, s2) => {
   }
   // if they are siblings...
   if (isEqual(s1.pageParents, s2.pageParents)) {
-    //  we use the weight first...
-    if (s1.pageAttributes.weight < s2.pageAttributes.weight) {
+    //  we use the order first...
+    if (s1.pageAttributes.order < s2.pageAttributes.order) {
       return -1;
-    } else if (s1.pageAttributes.weight > s2.pageAttributes.weight) {
+    } else if (s1.pageAttributes.order > s2.pageAttributes.order) {
       return 1;
     } else {
       // or we fallback to sort alphabethically
@@ -111,7 +111,7 @@ class TableOfContents extends Plugin {
         pageAttributes = pick(jsonData.data.attributes, [
           'title',
           'caption',
-          'weight',
+          'order',
           'hidden',
         ]);
       } else {
@@ -119,9 +119,9 @@ class TableOfContents extends Plugin {
         pageAttributes = {};
       }
 
-      // assign a "weight" using the frontmatter value (or a default)
+      // assign an "order" using the frontmatter value (or a default)
       // notice: it's used for sorting criteria in the navigation
-      pageAttributes.weight = pageAttributes.weight ?? 100;
+      pageAttributes.order = pageAttributes.order ?? 100;
 
       if (!pageAttributes.hidden) {
         flatPageList.push({


### PR DESCRIPTION
### :pushpin: Summary

This PR introduces sorting for the TOC of the application (used by the sidebar and the cards lists)

### :hammer_and_wrench: Detailed description

In this PR I have:
- added the missing `weight` to the list of attributes parsed by showdown
- added a custom sorting function to the TOC generation
- removed the numbered prefix from the “docs” markdown files and set correct ordering via “weight” attribute
- renamed `weight` “frontmatter” attribute to `order` per team decision (see screenshot below)

**Preview**: https://hds-website-git-new-docs-website-toc-sorting-hashicorp.vercel.app/about/

Notice: the sorting "algorithm" is covering our most common needs; if special needs will arise, we will consider possible improvements (but they're not straightforward as one may think: how do you rank/order a folder that doesn't contain just an index but multiple pages? do we need to add a specific file - eg. `meta.md/yaml` or `frontmatter.md/yaml` - just to specify its order?)

### :camera_flash: Screenshots

<img width="452" alt="screenshot_2198" src="https://user-images.githubusercontent.com/686239/207834375-b10631d1-743a-4c87-b2a4-7b79652963ae.png">
([poll](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1671039421969139))

### :link: External links

Jira tickets:
- https://hashicorp.atlassian.net/browse/HDS-934 (main ticket)
- https://hashicorp.atlassian.net/browse/HDS-1252 (sorting)

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
