### PR TITLE
New docs website / Responsive page "sidebar" (and "burger" menu)

### DIFF
--- a/website/app/components/doc/page/header/index.hbs
+++ b/website/app/components/doc/page/header/index.hbs
@@ -16,5 +16,11 @@
         ><FlightIcon @name="github" @size="24" @isInlineBlock={{false}} /><span class="sr-only">GitHub</span></a></li>
     </ul>
   </nav>
-  <button type="button" class="doc-page-header__burger-menu" {{on "click" this.toggleBurgerMenu}}><FlightIcon @name={{if this.burgerMenuOpen "x" "menu"}} /> <span class="doc-text-navigation">Menu</span></button>
+  <button type="button" class="doc-page-header__burger-menu" {{on "click" this.onToggleBurgerMenu}}>
+    {{#if this.burgerMenuOpen}}
+      <FlightIcon @name="x" /> <span class="doc-text-navigation">Close</span>
+    {{else}}
+      <FlightIcon @name="menu" /> <span class="doc-text-navigation">Menu</span>
+    {{/if}}
+  </button>
 </header>

--- a/website/app/components/doc/page/header/index.js
+++ b/website/app/components/doc/page/header/index.js
@@ -12,7 +12,12 @@ export default class DocPageHeaderComponent extends Component {
   }
 
   @action
-  toggleBurgerMenu() {
+  onToggleBurgerMenu() {
     this.burgerMenuOpen = !this.burgerMenuOpen;
+    let { onToggleBurgerMenu } = this.args;
+
+    if (typeof onToggleBurgerMenu === 'function') {
+      onToggleBurgerMenu(this.burgerMenuOpen);
+    }
   }
 }

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -1,5 +1,19 @@
 <aside class={{this.classNames}} ...attributes>
   <div class="doc-page-sidebar__inner-wrapper">
+    <nav class="doc-page-sidebar__top-routes" aria-label="primary page navigation">
+      <ul>
+        <li><LinkTo @route="about">About</LinkTo></li>
+        <li><LinkTo @route="foundations">Foundations</LinkTo></li>
+        <li><LinkTo @route="components">Components</LinkTo></li>
+        <li><LinkTo @route="patterns">Patterns</LinkTo></li>
+        <li><LinkTo @route="support">Support</LinkTo></li>
+        <li class="doc-page-header__nav-item-generic"><a
+            href="https://github.com/hashicorp/design-system"
+            target="_blank"
+            rel="noopener noreferrer"
+          ><FlightIcon @name="github" @size="24" @isInlineBlock={{false}} /><span class="sr-only">GitHub</span></a></li>
+      </ul>
+    </nav>
     {{#if this.structuredPageTree}}
       <nav class="doc-page-sidebar__table-of-contents" aria-label="secondary page navigation">
         <Doc::TableOfContents @structuredPageTree={{this.structuredPageTree}} @level={{1}} />

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -1,9 +1,9 @@
-{{#if this.structuredPageTree}}
-  <aside class="doc-page-sidebar" ...attributes>
-    <div class="doc-page-sidebar__inner-wrapper">
+<aside class={{this.classNames}} ...attributes>
+  <div class="doc-page-sidebar__inner-wrapper">
+    {{#if this.structuredPageTree}}
       <nav class="doc-page-sidebar__table-of-contents" aria-label="secondary page navigation">
         <Doc::TableOfContents @structuredPageTree={{this.structuredPageTree}} @level={{1}} />
       </nav>
-    </div>
-  </aside>
-{{/if}}
+    {{/if}}
+  </div>
+</aside>

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -1,7 +1,7 @@
 <aside class={{this.classNames}} ...attributes>
   <div class="doc-page-sidebar__inner-wrapper">
     <nav class="doc-page-sidebar__top-routes" aria-label="primary page navigation">
-      <ul>
+      <ul role="list">
         <li><LinkTo @route="about">About</LinkTo></li>
         <li><LinkTo @route="foundations">Foundations</LinkTo></li>
         <li><LinkTo @route="components">Components</LinkTo></li>

--- a/website/app/components/doc/page/sidebar.js
+++ b/website/app/components/doc/page/sidebar.js
@@ -79,4 +79,15 @@ export default class DocPageSidebarComponent extends Component {
 
     return Object.keys(subSectionTree).length > 0 ? subSectionTree : false;
   }
+
+  get classNames() {
+    let classes = ['doc-page-sidebar'];
+
+    // add a class based on the @showSidebarOnSmallViewport argument
+    if (this.args.showSidebarOnSmallViewport) {
+      classes.push(`doc-page-sidebar--show-sidebar-on-small-viewport`);
+    }
+
+    return classes.join(' ');
+  }
 }

--- a/website/app/controllers/application.js
+++ b/website/app/controllers/application.js
@@ -1,0 +1,16 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ApplicationController extends Controller {
+  @tracked showSidebarOnSmallViewport = false;
+
+  // TODO add a reset for the `showSidebarOnSmallViewport` on route change
+
+  @action
+  onToggleBurgerMenu(isOpen) {
+    console.log('onToggleBurgerMenu', isOpen);
+    this.showSidebarOnSmallViewport = isOpen;
+    document.body.style.overflow = isOpen ? 'hidden' : 'auto';
+  }
+}

--- a/website/app/styles/breakpoints/index.scss
+++ b/website/app/styles/breakpoints/index.scss
@@ -1,31 +1,33 @@
 // BREAKPOINTS
 
 // general breakdpoints
-$small-upper-breakpoint: 767px;
-$medium-lower-breakpoint: 768px;
-$medium-upper-breakpoint: 1279px;
-$large-lower-breakpoint: 1280px;
+$doc-breakpoint-medium: 768px;
+$doc-breakpoint-large: 1280px;
 
 // we have a special breakpoint for when we show the sidebar
-$with-sidedar-breakpoint: 1000px;
+$doc-breakpoint-for-sidebar: 1000px;
 
 
 @mixin small {
-  @media (max-width: $small-upper-breakpoint) { @content; }
+  @media (max-width: calc(#{$doc-breakpoint-medium} - 1px)) { @content; }
 }
 
 @mixin medium {
-  @media (min-width: $medium-lower-breakpoint) and (max-width: $medium-upper-breakpoint) { @content; }
+  @media (min-width: $doc-breakpoint-medium) and (max-width: calc(#{$doc-breakpoint-large} - 1px)) { @content; }
 }
 
 @mixin medium-and-above {
-  @media (min-width: $medium-lower-breakpoint) { @content; }
+  @media (min-width: $doc-breakpoint-medium) { @content; }
 }
 
 @mixin large {
-  @media (min-width: $large-lower-breakpoint) { @content; }
+  @media (min-width: $doc-breakpoint-large) { @content; }
 }
 
-@mixin with-sidebar {
-  @media (min-width: $with-sidedar-breakpoint) { @content; }
+@mixin with-mobile-sidebar {
+  @media (max-width: calc(#{$doc-breakpoint-for-sidebar} - 1px)) { @content; }
+}
+
+@mixin with-fixed-sidebar {
+  @media (min-width: $doc-breakpoint-for-sidebar) { @content; }
 }

--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -4,6 +4,7 @@
 @use "../../typography/mixins" as *;
 
 .doc-page-footer {
+  // z-index: var(--doc-z-index-footer);
   display: flex;
   flex-direction: column;
   grid-area: footer;

--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -17,7 +17,6 @@
     justify-content: space-between;
   }
 
-  // `ember-body-class` sets specific classes on the `<body>` element and we use this to have a full black background even in case of overscrolling
   body.application.index & {
     flex-direction: column-reverse;
     color: var(--doc-color-white);
@@ -55,7 +54,6 @@
       text-decoration: underline;
     }
 
-    // `ember-body-class` sets specific classes on the `<body>` element and we use this to have a full black background even in case of overscrolling
     body.application.index & {
       color: var(--doc-color-gray-400);
     }

--- a/website/app/styles/pages/application/header.scss
+++ b/website/app/styles/pages/application/header.scss
@@ -44,7 +44,6 @@
   }
 
   // we add a bit of "responsiveness" to the logo too, to gain some extra space :)
-
   .doc-logo-hds__hashicorp {
     @include breakpoint.with-mobile-sidebar() {
       display: none;
@@ -143,15 +142,14 @@
     color: var(--doc-color-white);
   }
 
-  // `ember-body-class` sets specific classes on the `<body>` element and we use this to have a full black background even in case of overscrolling
+  @include breakpoint.with-fixed-sidebar () {
+    display: none;
+  }
+
   body.application.index & {
-    // in homepage the top-level links in the header are still accessible, so no need to show the menu
+    // this is a special case: in homepage the top-level links in the header are still accessible at the "medium" viewport, so no need to show the burger menu
     @include breakpoint.medium () {
       display: none;
     }
-  }
-
-  @include breakpoint.large () {
-    display: none;
   }
 }

--- a/website/app/styles/pages/application/header.scss
+++ b/website/app/styles/pages/application/header.scss
@@ -3,9 +3,6 @@
 @use "../../breakpoints" as breakpoint;
 @use "../../typography/mixins" as *;
 
-// notice: we use an ad-hoc breakpoint here to avoid overlapping of content
-$header-custom-breakpoint: 1000px;
-
 .doc-page-header {
   position: sticky;
   top: 0;
@@ -22,7 +19,7 @@ $header-custom-breakpoint: 1000px;
   color: var(--doc-color-white);
   background: var(--doc-color-black);
 
-  @media (min-width: $header-custom-breakpoint) {
+  @include breakpoint.with-fixed-sidebar() {
     gap: 32px;
   }
 }
@@ -50,7 +47,7 @@ $header-custom-breakpoint: 1000px;
   // we add a bit of "responsiveness" to the logo too, to gain some extra space :)
 
   .doc-logo-hds__hashicorp {
-    @media (max-width: calc($header-custom-breakpoint - 1px)) {
+    @include breakpoint.with-mobile-sidebar() {
       display: none;
     }
   }
@@ -76,7 +73,7 @@ $header-custom-breakpoint: 1000px;
     padding: 0;
     list-style: none;
 
-    @media (min-width: $header-custom-breakpoint) {
+    @include breakpoint.with-fixed-sidebar() {
       gap: 12px;
     }
   }

--- a/website/app/styles/pages/application/header.scss
+++ b/website/app/styles/pages/application/header.scss
@@ -6,8 +6,7 @@
 .doc-page-header {
   position: sticky;
   top: 0;
-  // TODO review all the z-index stacking once the navigation has been finalized
-  z-index: 2; // needs to be above the sidebar (when the content scrolls)
+  z-index: var(--doc-z-index-header);
   display: flex;
   flex-direction: row;
   grid-area: header;

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -1,15 +1,34 @@
 // SIDE NAVIGATION
 
-.doc-page-sidebar {
-  display: none; // TODO! - We have to implement the whole "mobile" experience, for now we simply hide it
+@use "../../breakpoints" as breakpoint;
 
-  @media (min-width: 1000px) {
-    display: flex;
-    flex-direction: column;
+.doc-page-sidebar {
+  z-index: var(--doc-z-index-sidebar);
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--doc-page-header-height));
+  background: var(--doc-color-white);
+  box-shadow: 0 8px 12px rgba(37, 38, 45, 8%);
+
+  @include breakpoint.with-mobile-sidebar() {
+    position: fixed;
+    top: var(--doc-page-header-height);
+    right: 0;
+    left: 0;
+    transform: translate3d(-100%, 0, 0);
+    // transition: transform 0.25s ease-in;
+
+    &.doc-page-sidebar--show-sidebar-on-small-viewport {
+      transform: translate3d(0, 0, 0);
+      transition-timing-function: ease-out;
+    }
+  }
+
+  @include breakpoint.with-fixed-sidebar() {
+    position: sticky;
+    top: var(--doc-page-header-height);
     grid-area: sidebar;
     width: var(--doc-page-sidebar-width); // TODO discuss with Heather if we want to reduce this width when the viewport is "medium"
-    background: white;
-    border-right: 1px solid #ddd;
   }
 }
 
@@ -19,6 +38,8 @@
   min-height: 0;
   padding: 2rem 0.5rem;
   overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .doc-page-sidebar__top-routes {

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -20,3 +20,13 @@
   padding: 2rem 0.5rem;
   overflow-y: auto;
 }
+
+.doc-page-sidebar__top-routes {
+  // TODO style the items
+  display: none;
+
+  // `ember-body-class` sets specific classes on the `<body>` element and we use this to have a full black background even in case of overscrolling
+  body.application.index & {
+    display: block;
+  }
+}

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -10,7 +10,9 @@
   background: var(--doc-color-white);
   box-shadow: 0 8px 12px rgba(37, 38, 45, 8%);
 
-  @include breakpoint.with-mobile-sidebar() {
+  // home page (special case)
+
+  body.application.index & {
     position: fixed;
     top: var(--doc-page-header-height);
     right: 0;
@@ -24,11 +26,29 @@
     }
   }
 
-  @include breakpoint.with-fixed-sidebar() {
-    position: sticky;
-    top: var(--doc-page-header-height);
-    grid-area: sidebar;
-    width: var(--doc-page-sidebar-width); // TODO discuss with Heather if we want to reduce this width when the viewport is "medium"
+  // all the other pages
+
+  body.application:not(.index) & {
+    @include breakpoint.with-mobile-sidebar() {
+      position: fixed;
+      top: var(--doc-page-header-height);
+      right: 0;
+      left: 0;
+      transform: translate3d(-100%, 0, 0);
+      // transition: transform 0.25s ease-in;
+
+      &.doc-page-sidebar--show-sidebar-on-small-viewport {
+        transform: translate3d(0, 0, 0);
+        transition-timing-function: ease-out;
+      }
+    }
+
+    @include breakpoint.with-fixed-sidebar() {
+      position: sticky;
+      top: var(--doc-page-header-height);
+      grid-area: sidebar;
+      width: var(--doc-page-sidebar-width);
+    }
   }
 }
 
@@ -46,7 +66,6 @@
   // TODO style the items
   display: none;
 
-  // `ember-body-class` sets specific classes on the `<body>` element and we use this to have a full black background even in case of overscrolling
   body.application.index & {
     display: block;
   }

--- a/website/app/styles/pages/application/stage.scss
+++ b/website/app/styles/pages/application/stage.scss
@@ -13,10 +13,6 @@
   grid-template-columns: 1fr;
   width: 100%; // needed (otherwise it collapses, because is in a grid)
 
-  // @include breakpoint.with-sidebar () {
-  //   background-color: cyan;
-  // }
-
   @include breakpoint.large () {
     --max-content-width: calc(var(--doc-page-content-max-width) + 2 * var(--doc-page-stage-gutter-large));
     grid-template-areas:
@@ -26,13 +22,9 @@
       // content
       minmax(auto, var(--max-content-width))
       // sidecar
-      // var(--doc-page-sidecar-width)
       auto
       // extra space
       auto;
     margin: 0 auto 0 0;
-    // TODO! padding should be refactored, now is full-width!
-    // padding-right: var(--doc-page-stage-gutter-large);
-    // padding-left: var(--doc-page-stage-gutter-large);
   }
 }

--- a/website/app/styles/tokens.scss
+++ b/website/app/styles/tokens.scss
@@ -1,6 +1,7 @@
 // TOKENS (CSS PROPS)
 
 :root {
+  // COLORS
   --doc-color-white: #fff;
   --doc-color-gray-600: #f2f2f3;
   --doc-color-gray-500: #dbdbdc;
@@ -27,13 +28,8 @@
   --doc-color-feedback-critical-200: #f25054;
   --doc-color-feedback-critical-300: #ffd4d6;
   --doc-color-feedback-critical-400: #fcf0f2;
-  // --color-code-dark: #252937;
-  // --color-code-light: #f8f8f2;
-  // --color-code-light-transparent: #1d1e23;
-  // --color-code-comments: #75715e;
-  // --color-code-strings: #e6db74;
-  // --color-code-numbers: #ae81ff;
-  // --color-code-operators: #f92672;
-  // --color-code-properties: #a6e22e;
-  // --color-code-control: #66d9ef;
+  // Z-INDEXES
+  --doc-z-index-header: 200;
+  --doc-z-index-sidebar: 150;
+  --doc-z-index-footer: 100;
 }

--- a/website/app/templates/application.hbs
+++ b/website/app/templates/application.hbs
@@ -1,7 +1,12 @@
 <div class="doc-page-wrapper">
-  <Doc::Page::Header />
-  {{! `this.model.toc` comes from `routes/application.js` }}
-  <Doc::Page::Sidebar @toc={{this.model.toc}} @currentPath={{this.target.currentPath}} @currentRoute={{this.target.currentRoute}} />
+  <Doc::Page::Header @onToggleBurgerMenu={{this.onToggleBurgerMenu}} />
+  <Doc::Page::Sidebar
+    {{! `this.model.toc` comes from `routes/application.js` }}
+    @toc={{this.model.toc}}
+    @currentPath={{this.target.currentPath}}
+    @currentRoute={{this.target.currentRoute}}
+    @showSidebarOnSmallViewport={{this.showSidebarOnSmallViewport}}
+  />
   {{outlet}}
   <Doc::Page::Footer />
 </div>


### PR DESCRIPTION
### :pushpin: Summary

This is the second PR for the finalization of the page "sidebar" (the first one is #840).

This involves adding a responsive behaviour for the "sidebar" (controlled by a "burger" menu) and decouple the scrolling of the sidebar from the scrolling of the content.

_Notice: I am going to have a session with @heatherlarsen in which I'll go through the behaviour with her and see if we need to do some changes to the current implementation._

### :hammer_and_wrench: Detailed description

In this PR I have:
- added event handling logic between “burger” menu in the header, the main “application” controller, and the “sidebar”
- refactored breakpoints mixins to simplify their definitions and make them more easy to use
- added `z-index` scale as CSS tokens
- added links to “top level” routes in the sidebar navigation (only for small viewports)
- updated page “header” to use the updated breakpoint mixins
- added responsive behaviour to the “sidebar” (differentiated between homepage an other pages)
  - show/hide via "burger" menu on small viewports
  - fixed on medium/large viewports
  - for the homepage, always show/hide via "burger" menu
  - allowed the sidebar to scroll independently from the content

**Notice**: the actual styling of the sidebar content is done in #845.

👉 👉 👉 **Previews**:
- homepage: https://hds-website-git-new-docs-website-responsive-sidebar-hashicorp.vercel.app/
- details page: https://hds-website-git-new-docs-website-responsive-sidebar-hashicorp.vercel.app/components/alert/

### 🚧 TODOs

- ~~add a reset for the `showSidebarOnSmallViewport` on route change~~
  - tracked here: https://hashicorp.atlassian.net/browse/HDS-1258

### :link: External links

Jira tickets:
- https://hashicorp.atlassian.net/browse/HDS-934 (main ticket)
- https://hashicorp.atlassian.net/browse/HDS-1253 (behaviour)

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
