### PR TITLE
New docs website / Page "sidebar" styling (and other polishing)

### DIFF
--- a/website/app/components/doc/page/header/index.hbs
+++ b/website/app/components/doc/page/header/index.hbs
@@ -16,5 +16,11 @@
         ><FlightIcon @name="github" @size="24" @isInlineBlock={{false}} /><span class="sr-only">GitHub</span></a></li>
     </ul>
   </nav>
-  <button type="button" class="doc-page-header__burger-menu" {{on "click" this.toggleBurgerMenu}}><FlightIcon @name={{if this.burgerMenuOpen "x" "menu"}} /> <span class="doc-text-navigation">Menu</span></button>
+  <button type="button" class="doc-page-header__burger-menu" {{on "click" this.onToggleBurgerMenu}}>
+    {{#if this.burgerMenuOpen}}
+      <FlightIcon @name="x" /> <span class="doc-text-navigation">Close</span>
+    {{else}}
+      <FlightIcon @name="menu" /> <span class="doc-text-navigation">Menu</span>
+    {{/if}}
+  </button>
 </header>

--- a/website/app/components/doc/page/header/index.js
+++ b/website/app/components/doc/page/header/index.js
@@ -12,7 +12,12 @@ export default class DocPageHeaderComponent extends Component {
   }
 
   @action
-  toggleBurgerMenu() {
+  onToggleBurgerMenu() {
     this.burgerMenuOpen = !this.burgerMenuOpen;
+    let { onToggleBurgerMenu } = this.args;
+
+    if (typeof onToggleBurgerMenu === 'function') {
+      onToggleBurgerMenu(this.burgerMenuOpen);
+    }
   }
 }

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -3,6 +3,9 @@
     <nav class="doc-page-sidebar__top-routes" aria-label="primary page navigation">
       <ul class="doc-table-of-contents">
         <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2">
+          <div class="doc-table-of-contents__heading doc-text-label">Main categories</div>
+        </li>
+        <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2">
           <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="about">About</LinkTo>
         </li>
         <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2">

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -1,5 +1,19 @@
 <aside class={{this.classNames}} ...attributes>
   <div class="doc-page-sidebar__inner-wrapper">
+    <nav class="doc-page-sidebar__top-routes" aria-label="primary page navigation">
+      <ul>
+        <li><LinkTo @route="about">About</LinkTo></li>
+        <li><LinkTo @route="foundations">Foundations</LinkTo></li>
+        <li><LinkTo @route="components">Components</LinkTo></li>
+        <li><LinkTo @route="patterns">Patterns</LinkTo></li>
+        <li><LinkTo @route="support">Support</LinkTo></li>
+        <li class="doc-page-header__nav-item-generic"><a
+            href="https://github.com/hashicorp/design-system"
+            target="_blank"
+            rel="noopener noreferrer"
+          ><FlightIcon @name="github" @size="24" @isInlineBlock={{false}} /><span class="sr-only">GitHub</span></a></li>
+      </ul>
+    </nav>
     {{#if this.structuredPageTree}}
       <nav class="doc-page-sidebar__table-of-contents" aria-label="secondary page navigation">
         <Doc::TableOfContents @structuredPageTree={{this.structuredPageTree}} @level={{1}} />

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -1,13 +1,24 @@
 <aside class={{this.classNames}} ...attributes>
   <div class="doc-page-sidebar__inner-wrapper">
     <nav class="doc-page-sidebar__top-routes" aria-label="primary page navigation">
-      <ul>
-        <li><LinkTo @route="about">About</LinkTo></li>
-        <li><LinkTo @route="foundations">Foundations</LinkTo></li>
-        <li><LinkTo @route="components">Components</LinkTo></li>
-        <li><LinkTo @route="patterns">Patterns</LinkTo></li>
-        <li><LinkTo @route="support">Support</LinkTo></li>
-        <li class="doc-page-header__nav-item-generic"><a
+      {{! TODO decide if this is the style that we really want }}
+      <ul class="doc-table-of-contents">
+        <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2">
+          <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="about">About</LinkTo>
+        </li>
+        <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2">
+          <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="foundations">Foundations</LinkTo>
+        </li>
+        <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2">
+          <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="components">Components</LinkTo>
+        </li>
+        <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2">
+          <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="patterns">Patterns</LinkTo>
+        </li>
+        <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2">
+          <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="support">Support</LinkTo>
+        </li>
+        <li class="doc-table-of-contents__item"><a
             href="https://github.com/hashicorp/design-system"
             target="_blank"
             rel="noopener noreferrer"

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -16,7 +16,7 @@
     </nav>
     {{#if this.structuredPageTree}}
       <nav class="doc-page-sidebar__table-of-contents" aria-label="secondary page navigation">
-        <Doc::TableOfContents @structuredPageTree={{this.structuredPageTree}} @level={{1}} />
+        <Doc::TableOfContents @structuredPageTree={{this.structuredPageTree}} @depth={{1}} />
       </nav>
     {{/if}}
   </div>

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -17,11 +17,9 @@
         <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2">
           <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="support">Support</LinkTo>
         </li>
-        <li class="doc-table-of-contents__item"><a
-            href="https://github.com/hashicorp/design-system"
-            target="_blank"
-            rel="noopener noreferrer"
-          ><FlightIcon @name="github" @size="24" @isInlineBlock={{false}} /><span class="sr-only">GitHub</span></a></li>
+        <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2" >
+          <a class="doc-table-of-contents__link doc-text-navigation" href="https://github.com/hashicorp/design-system" target="_blank" rel="noopener noreferrer">GitHub</a>
+        </li>
       </ul>
     </nav>
     {{#if this.structuredPageTree}}

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -1,9 +1,9 @@
-{{#if this.structuredPageTree}}
-  <aside class="doc-page-sidebar" ...attributes>
-    <div class="doc-page-sidebar__inner-wrapper">
+<aside class={{this.classNames}} ...attributes>
+  <div class="doc-page-sidebar__inner-wrapper">
+    {{#if this.structuredPageTree}}
       <nav class="doc-page-sidebar__table-of-contents" aria-label="secondary page navigation">
         <Doc::TableOfContents @structuredPageTree={{this.structuredPageTree}} @level={{1}} />
       </nav>
-    </div>
-  </aside>
-{{/if}}
+    {{/if}}
+  </div>
+</aside>

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -1,7 +1,6 @@
 <aside class={{this.classNames}} ...attributes>
   <div class="doc-page-sidebar__inner-wrapper">
     <nav class="doc-page-sidebar__top-routes" aria-label="primary page navigation">
-      {{! TODO decide if this is the style that we really want }}
       <ul class="doc-table-of-contents">
         <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-2">
           <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="about">About</LinkTo>

--- a/website/app/components/doc/page/sidebar.js
+++ b/website/app/components/doc/page/sidebar.js
@@ -33,31 +33,6 @@ export default class DocPageSidebarComponent extends Component {
   get structuredPageTree() {
     const { currentPath, currentRoute } = this.args;
 
-    // eg. currentPath = 'about'
-    // console.log('sidebar >>> currentPath', currentPath);
-
-    // eg. currentRoute = {
-    //      name: 'about',
-    //      parent: {
-    //        name: 'application',
-    //        parent: null,
-    //        ...
-    //      },
-    //      localName: 'about',
-    //      attributes: [
-    //        { id: 'components', title: 'components', pages: [Array] },
-    //        { id: 'content', title: 'content', pages: [Array] },
-    //        { id: 'foundations', title: 'foundations', pages: [Array] },
-    //        { id: 'getting-started', title: 'getting-started', pages: [Array] },
-    //        { id: 'overrides', title: 'overrides', pages: [Array] },
-    //        { id: 'overview', title: 'overview', pages: [Array] },
-    //        { id: 'testing', title: 'testing', pages: [Array] },
-    //        { id: 'updates', title: 'updates', pages: [Array] },
-    //        { id: 'utilities', title: 'utilities', pages: [Array] }
-    //      ]
-    //   }
-    // console.log('sidebar >>> currentRoute', currentRoute);
-
     let currentSection;
     if (currentRoute.localName === 'show') {
       // eg. "foundations/tokens/"
@@ -70,8 +45,7 @@ export default class DocPageSidebarComponent extends Component {
     const subSectionTree = {};
     getTocSectionBundle(currentSection).forEach((section) => {
       let subTree = this.args.toc.tree[section];
-      // the "about" section doesn't exist, it's there only to make sure the related sections appear for the "About" landing page
-      // with this check we avoid that it appears in the sidebar as empty container
+      // this check avoids that we show in the sidebar empty "containers"
       if (subTree) {
         subSectionTree[section] = subTree;
       }

--- a/website/app/components/doc/page/sidebar.js
+++ b/website/app/components/doc/page/sidebar.js
@@ -79,4 +79,15 @@ export default class DocPageSidebarComponent extends Component {
 
     return Object.keys(subSectionTree).length > 0 ? subSectionTree : false;
   }
+
+  get classNames() {
+    let classes = ['doc-page-sidebar'];
+
+    // add a class based on the @showSidebarOnSmallViewport argument
+    if (this.args.showSidebarOnSmallViewport) {
+      classes.push(`doc-page-sidebar--show-sidebar-on-small-viewport`);
+    }
+
+    return classes.join(' ');
+  }
 }

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -2,19 +2,19 @@
 
 <ul class="doc-table-of-contents">
   {{#each-in @structuredPageTree as |key item|}}
-    {{#if item.pageURL}}
-      <li class="doc-table-of-contents__item doc-table-of-contents__item--with-link" style={{this.leftPadStyle}}>
-        <LinkTo @route="show" @model={{item.pageURL}}>
-          {{capitalize item.pageAttributes.title}}
+    <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-{{@depth}}">
+      {{#if item.pageURL}}
+        <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="show" @model={{item.pageURL}}>
+          {{item.pageAttributes.title}}
         </LinkTo>
-      </li>
-    {{else}}
-      <li class="doc-table-of-contents__item">
-        <span style={{this.leftPadStyle}}>
-          {{capitalize key}}
-        </span>
-        <Doc::TableOfContents @structuredPageTree={{item}} @level={{add @level 1}} />
-      </li>
-    {{/if}}
+      {{else}}
+        {{#if (eq @depth 1)}}
+          <div class="doc-table-of-contents__heading doc-text-label">{{capitalize key}}</div>
+        {{else}}
+          <div class="doc-table-of-contents__folder doc-text-navigation">{{capitalize key}}</div>
+        {{/if}}
+        <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} />
+      {{/if}}
+    </li>
   {{/each-in}}
 </ul>

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -10,10 +10,13 @@
       {{else}}
         {{#if (eq @depth 1)}}
           <div class="doc-table-of-contents__heading doc-text-label">{{capitalize key}}</div>
+          <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} />
         {{else}}
-          <div class="doc-table-of-contents__folder doc-text-navigation">{{capitalize key}}</div>
+          <details class="doc-table-of-contents__folder" open>
+            <summary class="doc-table-of-contents__summary doc-text-navigation">{{capitalize key}}</summary>
+            <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} />
+          </details>
         {{/if}}
-        <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} />
       {{/if}}
     </li>
   {{/each-in}}

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -12,7 +12,7 @@
           <div class="doc-table-of-contents__heading doc-text-label">{{capitalize key}}</div>
           <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} />
         {{else}}
-          <details class="doc-table-of-contents__folder" open>
+          <details class="doc-table-of-contents__folder">
             <summary class="doc-table-of-contents__summary doc-text-navigation">{{capitalize key}}</summary>
             <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} />
           </details>

--- a/website/app/components/doc/table-of-contents/index.js
+++ b/website/app/components/doc/table-of-contents/index.js
@@ -1,8 +1,0 @@
-import Component from '@glimmer/component';
-import { htmlSafe } from '@ember/template';
-
-export default class DummyTableOfContentsComponent extends Component {
-  get leftPadStyle() {
-    return htmlSafe(`padding-left:${this.args.level}em;`);
-  }
-}

--- a/website/app/controllers/application.js
+++ b/website/app/controllers/application.js
@@ -1,0 +1,16 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ApplicationController extends Controller {
+  @tracked showSidebarOnSmallViewport = false;
+
+  // TODO add a reset for the `showSidebarOnSmallViewport` on route change
+
+  @action
+  onToggleBurgerMenu(isOpen) {
+    console.log('onToggleBurgerMenu', isOpen);
+    this.showSidebarOnSmallViewport = isOpen;
+    document.body.style.overflow = isOpen ? 'hidden' : 'auto';
+  }
+}

--- a/website/app/controllers/application.js
+++ b/website/app/controllers/application.js
@@ -9,7 +9,6 @@ export default class ApplicationController extends Controller {
 
   @action
   onToggleBurgerMenu(isOpen) {
-    console.log('onToggleBurgerMenu', isOpen);
     this.showSidebarOnSmallViewport = isOpen;
     document.body.style.overflow = isOpen ? 'hidden' : 'auto';
   }

--- a/website/app/styles/breakpoints/index.scss
+++ b/website/app/styles/breakpoints/index.scss
@@ -1,31 +1,33 @@
 // BREAKPOINTS
 
 // general breakdpoints
-$small-upper-breakpoint: 767px;
-$medium-lower-breakpoint: 768px;
-$medium-upper-breakpoint: 1279px;
-$large-lower-breakpoint: 1280px;
+$doc-breakpoint-medium: 768px;
+$doc-breakpoint-large: 1280px;
 
 // we have a special breakpoint for when we show the sidebar
-$with-sidedar-breakpoint: 1000px;
+$doc-breakpoint-for-sidebar: 1000px;
 
 
 @mixin small {
-  @media (max-width: $small-upper-breakpoint) { @content; }
+  @media (max-width: calc(#{$doc-breakpoint-medium} - 1px)) { @content; }
 }
 
 @mixin medium {
-  @media (min-width: $medium-lower-breakpoint) and (max-width: $medium-upper-breakpoint) { @content; }
+  @media (min-width: $doc-breakpoint-medium) and (max-width: calc(#{$doc-breakpoint-large} - 1px)) { @content; }
 }
 
 @mixin medium-and-above {
-  @media (min-width: $medium-lower-breakpoint) { @content; }
+  @media (min-width: $doc-breakpoint-medium) { @content; }
 }
 
 @mixin large {
-  @media (min-width: $large-lower-breakpoint) { @content; }
+  @media (min-width: $doc-breakpoint-large) { @content; }
 }
 
-@mixin with-sidebar {
-  @media (min-width: $with-sidedar-breakpoint) { @content; }
+@mixin with-mobile-sidebar {
+  @media (max-width: calc(#{$doc-breakpoint-for-sidebar} - 1px)) { @content; }
+}
+
+@mixin with-fixed-sidebar {
+  @media (min-width: $doc-breakpoint-for-sidebar) { @content; }
 }

--- a/website/app/styles/breakpoints/index.scss
+++ b/website/app/styles/breakpoints/index.scss
@@ -5,7 +5,7 @@ $doc-breakpoint-medium: 768px;
 $doc-breakpoint-large: 1280px;
 
 // we have a special breakpoint for when we show the sidebar
-$doc-breakpoint-for-sidebar: 1000px;
+$doc-breakpoint-for-sidebar: 880px;
 
 
 @mixin small {

--- a/website/app/styles/components/doc-table-of-contents.scss
+++ b/website/app/styles/components/doc-table-of-contents.scss
@@ -43,16 +43,15 @@ $doc-toc-item-inset: 8px;
   border-radius: 3px;
 
   &:hover {
-    color: var(--doc-color-black);
+    color: var(--doc-color-gray-100);
   }
 
   &.active {
-    color: var(--doc-color-gray-200);
-    background-color: var(--doc-color-gray-500);
+    color: var(--doc-color-black);
+    font-weight: 700;
 
     &:hover {
       color: var(--doc-color-black);
-      background-color: var(--doc-color-gray-400);
     }
   }
 

--- a/website/app/styles/components/doc-table-of-contents.scss
+++ b/website/app/styles/components/doc-table-of-contents.scss
@@ -44,6 +44,10 @@ $doc-toc-item-inset: 8px;
   border: 1px solid transparent;
   cursor: pointer;
 
+  &::-webkit-details-marker {
+    display: none;
+  }
+
   // it's using a `<detail>` HMTL tag
   [open] > & {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='%23727374' fill-rule='evenodd' d='M3.235 5.205a.75.75 0 011.06.03L8 9.158l3.705-3.923a.75.75 0 011.09 1.03l-4.25 4.5a.75.75 0 01-1.09 0l-4.25-4.5a.75.75 0 01.03-1.06z' clip-rule='evenodd'/%3E%3C/svg%3E");

--- a/website/app/styles/components/doc-table-of-contents.scss
+++ b/website/app/styles/components/doc-table-of-contents.scss
@@ -6,6 +6,8 @@ $doc-toc-item-inset: 8px;
   width: 100%;
   margin: 0;
   padding: 0;
+  // avoid accidental text selection (expecially with the `<details>` element)
+  user-select: none;
 }
 
 .doc-table-of-contents__item {
@@ -28,9 +30,24 @@ $doc-toc-item-inset: 8px;
   padding: 0 $doc-toc-item-inset 12px $doc-toc-item-inset;
 }
 
-.doc-table-of-contents__folder {
-  padding: $doc-toc-item-inset;
+.doc-table-of-contents__summary {
+  display: block;
+  width: 100%;
+  padding: $doc-toc-item-inset 32px $doc-toc-item-inset $doc-toc-item-inset;
   color: var(--doc-color-gray-300);
+  text-align: left;
+  background-color: transparent;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='%23727374' fill-rule='evenodd' d='M5.205 3.235a.75.75 0 00.03 1.06L9.158 8l-3.923 3.705a.75.75 0 001.03 1.09l4.5-4.25a.75.75 0 000-1.09l-4.5-4.25a.75.75 0 00-1.06.03z' clip-rule='evenodd'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: top 12.5px right 8px;
+  background-size: 16px 16px;
+  border: 1px solid transparent;
+  cursor: pointer;
+
+  // it's using a `<detail>` HMTL tag
+  [open] > & {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='%23727374' fill-rule='evenodd' d='M3.235 5.205a.75.75 0 011.06.03L8 9.158l3.705-3.923a.75.75 0 011.09 1.03l-4.25 4.5a.75.75 0 01-1.09 0l-4.25-4.5a.75.75 0 01.03-1.06z' clip-rule='evenodd'/%3E%3C/svg%3E");
+  }
 }
 
 .doc-table-of-contents__link {

--- a/website/app/styles/components/doc-table-of-contents.scss
+++ b/website/app/styles/components/doc-table-of-contents.scss
@@ -1,25 +1,72 @@
-/* stylelint-disable selector-class-pattern */
+// TABLE OF CONTENTS
+
+$doc-toc-item-inset: 8px;
+
 .doc-table-of-contents {
   width: 100%;
   margin: 0;
   padding: 0;
-  list-style: none;
 }
 
 .doc-table-of-contents__item {
-  padding: 0.5rem 0;
+  margin-bottom: 2px;
+  padding: 0;
+  list-style: none;
+
+  &.doc-table-of-contents__item--depth-1 {
+    &::after {
+      display: block;
+      height: 1px;
+      margin: 20px $doc-toc-item-inset;
+      background-color: var(--doc-color-gray-500);
+      content: "";
+    }
+  }
 }
 
-.doc-table-of-contents__item--with-link {
-  a {
-    color: inherit;
+.doc-table-of-contents__heading {
+  padding: 0 $doc-toc-item-inset 12px $doc-toc-item-inset;
+}
 
-    &.active {
-      font-weight: bold;
+.doc-table-of-contents__folder {
+  padding: $doc-toc-item-inset;
+  color: var(--doc-color-gray-300);
+}
+
+.doc-table-of-contents__link {
+  display: block;
+  padding-top: $doc-toc-item-inset;
+  padding-right: $doc-toc-item-inset;
+  padding-bottom: $doc-toc-item-inset;
+  color: var(--doc-color-gray-300);
+  text-decoration: none;
+  border-radius: 3px;
+
+  &:hover {
+    color: var(--doc-color-black);
+  }
+
+  &.active {
+    color: var(--doc-color-gray-200);
+    background-color: var(--doc-color-gray-500);
+
+    &:hover {
+      color: var(--doc-color-black);
+      background-color: var(--doc-color-gray-400);
     }
   }
 
-  &:hover {
-    background-color: #f0f0f0;
+  // left padding depends on the depth of nesting
+
+  .doc-table-of-contents__item--depth-2 & {
+    padding-left: 1 * $doc-toc-item-inset;
+  }
+
+  .doc-table-of-contents__item--depth-3 & {
+    padding-left: 3 * $doc-toc-item-inset;
+  }
+
+  .doc-table-of-contents__item--depth-4 & {
+    padding-left: 5 * $doc-toc-item-inset;
   }
 }

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -8,7 +8,6 @@
   min-width: 0; // needed to avoid that the element blows out if the content is too wide (see: https://css-tricks.com/preventing-a-grid-blowout/)
   padding: 0 var(--doc-page-stage-gutter-small);
 
-  // TODO! temp until we decide with Heather the correct vertical padding of the "content" area
   > :first-child,
   > section {
     margin-top: 48px;

--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -4,6 +4,7 @@
 @use "../../typography/mixins" as *;
 
 .doc-page-footer {
+  // z-index: var(--doc-z-index-footer);
   display: flex;
   flex-direction: column;
   grid-area: footer;

--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -17,7 +17,6 @@
     justify-content: space-between;
   }
 
-  // `ember-body-class` sets specific classes on the `<body>` element and we use this to have a full black background even in case of overscrolling
   body.application.index & {
     flex-direction: column-reverse;
     color: var(--doc-color-white);
@@ -55,7 +54,6 @@
       text-decoration: underline;
     }
 
-    // `ember-body-class` sets specific classes on the `<body>` element and we use this to have a full black background even in case of overscrolling
     body.application.index & {
       color: var(--doc-color-gray-400);
     }

--- a/website/app/styles/pages/application/header.scss
+++ b/website/app/styles/pages/application/header.scss
@@ -44,7 +44,6 @@
   }
 
   // we add a bit of "responsiveness" to the logo too, to gain some extra space :)
-
   .doc-logo-hds__hashicorp {
     @include breakpoint.with-mobile-sidebar() {
       display: none;
@@ -143,15 +142,14 @@
     color: var(--doc-color-white);
   }
 
-  // `ember-body-class` sets specific classes on the `<body>` element and we use this to have a full black background even in case of overscrolling
+  @include breakpoint.with-fixed-sidebar () {
+    display: none;
+  }
+
   body.application.index & {
-    // in homepage the top-level links in the header are still accessible, so no need to show the menu
+    // this is a special case: in homepage the top-level links in the header are still accessible at the "medium" viewport, so no need to show the burger menu
     @include breakpoint.medium () {
       display: none;
     }
-  }
-
-  @include breakpoint.large () {
-    display: none;
   }
 }

--- a/website/app/styles/pages/application/header.scss
+++ b/website/app/styles/pages/application/header.scss
@@ -3,9 +3,6 @@
 @use "../../breakpoints" as breakpoint;
 @use "../../typography/mixins" as *;
 
-// notice: we use an ad-hoc breakpoint here to avoid overlapping of content
-$header-custom-breakpoint: 1000px;
-
 .doc-page-header {
   position: sticky;
   top: 0;
@@ -22,7 +19,7 @@ $header-custom-breakpoint: 1000px;
   color: var(--doc-color-white);
   background: var(--doc-color-black);
 
-  @media (min-width: $header-custom-breakpoint) {
+  @include breakpoint.with-fixed-sidebar() {
     gap: 32px;
   }
 }
@@ -50,7 +47,7 @@ $header-custom-breakpoint: 1000px;
   // we add a bit of "responsiveness" to the logo too, to gain some extra space :)
 
   .doc-logo-hds__hashicorp {
-    @media (max-width: calc($header-custom-breakpoint - 1px)) {
+    @include breakpoint.with-mobile-sidebar() {
       display: none;
     }
   }
@@ -76,7 +73,7 @@ $header-custom-breakpoint: 1000px;
     padding: 0;
     list-style: none;
 
-    @media (min-width: $header-custom-breakpoint) {
+    @include breakpoint.with-fixed-sidebar() {
       gap: 12px;
     }
   }

--- a/website/app/styles/pages/application/header.scss
+++ b/website/app/styles/pages/application/header.scss
@@ -6,8 +6,7 @@
 .doc-page-header {
   position: sticky;
   top: 0;
-  // TODO review all the z-index stacking once the navigation has been finalized
-  z-index: 2; // needs to be above the sidebar (when the content scrolls)
+  z-index: var(--doc-z-index-header);
   display: flex;
   flex-direction: row;
   grid-area: header;

--- a/website/app/styles/pages/application/index.scss
+++ b/website/app/styles/pages/application/index.scss
@@ -1,5 +1,9 @@
 // "APPLICATION" PAGE
 
+@use "../../breakpoints" as breakpoint;
+
+// application parts
+
 @import "./header";
 @import "./sidebar";
 @import "./stage";
@@ -11,20 +15,22 @@
 @import "./error";
 @import "./debug";
 
-
 // globals
 
 :root {
   --doc-page-header-height: 68px;
-  --doc-page-sidebar-width: 320px;
+  --doc-page-sidebar-width: 260px;
   --doc-page-stage-gutter-small: 24px;
   --doc-page-stage-gutter-medium: 48px;
   --doc-page-stage-gutter-large: 96px;
   --doc-page-content-max-width: 900px;
   --doc-page-text-limit-width: 720px;
   --doc-page-sidecar-width: 220px;
-}
 
+  @include breakpoint.large () {
+    --doc-page-sidebar-width: 320px;
+  }
+}
 
 // "top/root" page wrapper
 

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -1,15 +1,34 @@
 // SIDE NAVIGATION
 
-.doc-page-sidebar {
-  display: none; // TODO! - We have to implement the whole "mobile" experience, for now we simply hide it
+@use "../../breakpoints" as breakpoint;
 
-  @media (min-width: 1000px) {
-    display: flex;
-    flex-direction: column;
+.doc-page-sidebar {
+  z-index: var(--doc-z-index-sidebar);
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--doc-page-header-height));
+  background: var(--doc-color-white);
+  box-shadow: 0 8px 12px rgba(37, 38, 45, 8%);
+
+  @include breakpoint.with-mobile-sidebar() {
+    position: fixed;
+    top: var(--doc-page-header-height);
+    right: 0;
+    left: 0;
+    transform: translate3d(-100%, 0, 0);
+    // transition: transform 0.25s ease-in;
+
+    &.doc-page-sidebar--show-sidebar-on-small-viewport {
+      transform: translate3d(0, 0, 0);
+      transition-timing-function: ease-out;
+    }
+  }
+
+  @include breakpoint.with-fixed-sidebar() {
+    position: sticky;
+    top: var(--doc-page-header-height);
     grid-area: sidebar;
     width: var(--doc-page-sidebar-width); // TODO discuss with Heather if we want to reduce this width when the viewport is "medium"
-    background: white;
-    border-right: 1px solid #ddd;
   }
 }
 
@@ -19,6 +38,8 @@
   min-height: 0;
   padding: 2rem 0.5rem;
   overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .doc-page-sidebar__top-routes {

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -20,3 +20,13 @@
   padding: 2rem 0.5rem;
   overflow-y: auto;
 }
+
+.doc-page-sidebar__top-routes {
+  // TODO style the items
+  display: none;
+
+  // `ember-body-class` sets specific classes on the `<body>` element and we use this to have a full black background even in case of overscrolling
+  body.application.index & {
+    display: block;
+  }
+}

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -2,23 +2,22 @@
 
 @use "../../breakpoints" as breakpoint;
 
-.doc-page-sidebar {
-  z-index: var(--doc-z-index-sidebar);
-  display: flex;
-  flex-direction: column;
-  height: calc(100vh - var(--doc-page-header-height));
-  background: var(--doc-color-white);
-  box-shadow: 0 8px 12px rgba(37, 38, 45, 8%);
 
-  // home page (special case)
+// ⚠️ ---  the sidebar "navigation" is different between the homepage and the other pages --- ⚠️
 
-  body.application.index & {
+
+// HOME PAGE (SPECIAL CASE)
+
+body.application.index {
+  .doc-page-sidebar {
     position: fixed;
     top: var(--doc-page-header-height);
     right: 0;
     left: 0;
-    transform: translate3d(-100%, 0, 0);
-    // transition: transform 0.25s ease-in;
+    z-index: var(--doc-z-index-sidebar);
+    background: linear-gradient(92.03deg, #4f53d0 -0.05%, #7545cb 100.68%);
+    transform: translate3d(0, -100%, 0);
+    transition: transform 0.25s ease-in;
 
     &.doc-page-sidebar--show-sidebar-on-small-viewport {
       transform: translate3d(0, 0, 0);
@@ -26,16 +25,56 @@
     }
   }
 
-  // all the other pages
+  // for the homepage we have a special treatment
+  // and for now we simply override the styles of the TOC
+  // when we will have the final designs we'll clean up things
+  .doc-page-sidebar__top-routes {
+    .doc-table-of-contents {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: space-evenly;
+      padding: 16px;
+    }
 
-  body.application:not(.index) & {
+    .doc-table-of-contents__item {
+      margin: 0;
+    }
+
+    .doc-table-of-contents__heading {
+      display: none;
+    }
+
+    .doc-table-of-contents__link {
+      color: var(--doc-color-white);
+
+      &:hover,
+      &:active {
+        color: var(--doc-color-white);
+      }
+    }
+  }
+}
+
+
+// ALL THE OTHER PAGES
+
+body.application:not(.index) {
+  .doc-page-sidebar {
+    top: var(--doc-page-header-height);
+    left: 0;
+    z-index: var(--doc-z-index-sidebar);
+    display: flex;
+    flex-direction: column;
+    width: var(--doc-page-sidebar-width);
+    height: calc(100vh - var(--doc-page-header-height));
+    background: var(--doc-color-white);
+    box-shadow: 0 8px 16px rgba(37, 38, 45, 20%);
+
     @include breakpoint.with-mobile-sidebar() {
       position: fixed;
-      top: var(--doc-page-header-height);
-      right: 0;
-      left: 0;
       transform: translate3d(-100%, 0, 0);
-      // transition: transform 0.25s ease-in;
+      transition: transform 0.25s ease-in;
 
       &.doc-page-sidebar--show-sidebar-on-small-viewport {
         transform: translate3d(0, 0, 0);
@@ -45,34 +84,34 @@
 
     @include breakpoint.with-fixed-sidebar() {
       position: sticky;
-      top: var(--doc-page-header-height);
       grid-area: sidebar;
-      width: var(--doc-page-sidebar-width);
+      transform: none;
+      transition: none;
     }
   }
-}
 
-.doc-page-sidebar__inner-wrapper {
-  position: relative;
-  flex: 1 0 0;
-  min-height: 0;
-  padding: 32px 24px;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-}
-
-.doc-page-sidebar__top-routes {
-  ul {
-    margin: 0;
-    padding: 0;
+  .doc-page-sidebar__inner-wrapper {
+    position: relative;
+    flex: 1 0 0;
+    min-height: 0;
+    padding: 32px 24px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
   }
 
-  @include breakpoint.with-fixed-sidebar() {
-    // display: none;
-  }
+  .doc-page-sidebar__top-routes {
+    &::after {
+      display: block;
+      height: 3px;
+      margin: 20px 0;
+      // background-color: var(--doc-color-gray-500);
+      background: linear-gradient(92.03deg, #4f53d0 -0.05%, #7545cb 100.68%);
+      content: "";
+    }
 
-  body.application.index & {
-    display: block;
+    @include breakpoint.with-fixed-sidebar() {
+      display: none;
+    }
   }
 }

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -10,7 +10,9 @@
   background: var(--doc-color-white);
   box-shadow: 0 8px 12px rgba(37, 38, 45, 8%);
 
-  @include breakpoint.with-mobile-sidebar() {
+  // home page (special case)
+
+  body.application.index & {
     position: fixed;
     top: var(--doc-page-header-height);
     right: 0;
@@ -24,11 +26,29 @@
     }
   }
 
-  @include breakpoint.with-fixed-sidebar() {
-    position: sticky;
-    top: var(--doc-page-header-height);
-    grid-area: sidebar;
-    width: var(--doc-page-sidebar-width); // TODO discuss with Heather if we want to reduce this width when the viewport is "medium"
+  // all the other pages
+
+  body.application:not(.index) & {
+    @include breakpoint.with-mobile-sidebar() {
+      position: fixed;
+      top: var(--doc-page-header-height);
+      right: 0;
+      left: 0;
+      transform: translate3d(-100%, 0, 0);
+      // transition: transform 0.25s ease-in;
+
+      &.doc-page-sidebar--show-sidebar-on-small-viewport {
+        transform: translate3d(0, 0, 0);
+        transition-timing-function: ease-out;
+      }
+    }
+
+    @include breakpoint.with-fixed-sidebar() {
+      position: sticky;
+      top: var(--doc-page-header-height);
+      grid-area: sidebar;
+      width: var(--doc-page-sidebar-width);
+    }
   }
 }
 
@@ -46,7 +66,6 @@
   // TODO style the items
   display: none;
 
-  // `ember-body-class` sets specific classes on the `<body>` element and we use this to have a full black background even in case of overscrolling
   body.application.index & {
     display: block;
   }

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -56,7 +56,7 @@
   position: relative;
   flex: 1 0 0;
   min-height: 0;
-  padding: 2rem 0.5rem;
+  padding: 32px 24px;
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -63,8 +63,14 @@
 }
 
 .doc-page-sidebar__top-routes {
-  // TODO style the items
-  display: none;
+  ul {
+    margin: 0;
+    padding: 0;
+  }
+
+  @include breakpoint.with-fixed-sidebar() {
+    // display: none;
+  }
 
   body.application.index & {
     display: block;

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -110,7 +110,7 @@ body.application:not(.index) {
       content: "";
     }
 
-    @include breakpoint.with-fixed-sidebar() {
+    @include breakpoint.medium-and-above() {
       display: none;
     }
   }

--- a/website/app/styles/pages/application/sidecar.scss
+++ b/website/app/styles/pages/application/sidecar.scss
@@ -7,14 +7,17 @@
   display: none;
 
   @include breakpoint.large () {
+    position: sticky;
+    top: var(--doc-page-header-height);
     display: block;
     grid-area: sidecar;
+    // TIL this is needed because is inside a grid, otherwise the stickyness will not work
+    // see: https://melanie-richards.com/blog/css-grid-sticky/
+    // see: https://ishadeed.com/article/position-sticky-css-grid/
+    align-self: start;
     width: var(--doc-page-sidecar-width);
     margin-right: calc(var(--doc-page-stage-gutter-large) / 2);
-
-    > :first-child {
-      margin-top: 48px;
-    }
+    padding-top: 48px;
   }
 }
 

--- a/website/app/styles/pages/application/stage.scss
+++ b/website/app/styles/pages/application/stage.scss
@@ -13,10 +13,6 @@
   grid-template-columns: 1fr;
   width: 100%; // needed (otherwise it collapses, because is in a grid)
 
-  // @include breakpoint.with-sidebar () {
-  //   background-color: cyan;
-  // }
-
   @include breakpoint.large () {
     --max-content-width: calc(var(--doc-page-content-max-width) + 2 * var(--doc-page-stage-gutter-large));
     grid-template-areas:
@@ -26,13 +22,9 @@
       // content
       minmax(auto, var(--max-content-width))
       // sidecar
-      // var(--doc-page-sidecar-width)
       auto
       // extra space
       auto;
     margin: 0 auto 0 0;
-    // TODO! padding should be refactored, now is full-width!
-    // padding-right: var(--doc-page-stage-gutter-large);
-    // padding-left: var(--doc-page-stage-gutter-large);
   }
 }

--- a/website/app/styles/pages/home.scss
+++ b/website/app/styles/pages/home.scss
@@ -30,7 +30,7 @@ body.application.index {
 
   @include breakpoint.medium-and-above() {
     height: 40vw;
-    max-height: 700px;
+    max-height: 640px;
     background-image: url("/assets/illustrations/home-abstract.jpg");
     background-size: contain;
   }

--- a/website/app/styles/tokens.scss
+++ b/website/app/styles/tokens.scss
@@ -1,6 +1,7 @@
 // TOKENS (CSS PROPS)
 
 :root {
+  // COLORS
   --doc-color-white: #fff;
   --doc-color-gray-600: #f2f2f3;
   --doc-color-gray-500: #dbdbdc;
@@ -27,13 +28,8 @@
   --doc-color-feedback-critical-200: #f25054;
   --doc-color-feedback-critical-300: #ffd4d6;
   --doc-color-feedback-critical-400: #fcf0f2;
-  // --color-code-dark: #252937;
-  // --color-code-light: #f8f8f2;
-  // --color-code-light-transparent: #1d1e23;
-  // --color-code-comments: #75715e;
-  // --color-code-strings: #e6db74;
-  // --color-code-numbers: #ae81ff;
-  // --color-code-operators: #f92672;
-  // --color-code-properties: #a6e22e;
-  // --color-code-control: #66d9ef;
+  // Z-INDEXES
+  --doc-z-index-header: 200;
+  --doc-z-index-sidebar: 150;
+  --doc-z-index-footer: 100;
 }

--- a/website/app/templates/application.hbs
+++ b/website/app/templates/application.hbs
@@ -1,7 +1,12 @@
 <div class="doc-page-wrapper">
-  <Doc::Page::Header />
-  {{! `this.model.toc` comes from `routes/application.js` }}
-  <Doc::Page::Sidebar @toc={{this.model.toc}} @currentPath={{this.target.currentPath}} @currentRoute={{this.target.currentRoute}} />
+  <Doc::Page::Header @onToggleBurgerMenu={{this.onToggleBurgerMenu}} />
+  <Doc::Page::Sidebar
+    {{! `this.model.toc` comes from `routes/application.js` }}
+    @toc={{this.model.toc}}
+    @currentPath={{this.target.currentPath}}
+    @currentRoute={{this.target.currentRoute}}
+    @showSidebarOnSmallViewport={{this.showSidebarOnSmallViewport}}
+  />
   {{outlet}}
   <Doc::Page::Footer />
 </div>


### PR DESCRIPTION
### :pushpin: Summary

This PR styles the "sidebar" elements according to the design specs. It's built on top of  #807, #840 and #844 (it's been closed in favour of a single PR, this one)

### :hammer_and_wrench: Detailed description

In #844 I have:
- added event handling logic between “burger” menu in the header, the main “application” controller, and the “sidebar”
- refactored breakpoints mixins to simplify their definitions and make them more easy to use
- added `z-index` scale as CSS tokens
- added links to “top level” routes in the sidebar navigation (only for small viewports)
- updated page “header” to use the updated breakpoint mixins
- added responsive behaviour to the “sidebar” (differentiated between homepage an other pages)
  - show/hide via "burger" menu on small viewports
  - fixed on medium/large viewports
  - for the homepage, always show/hide via "burger" menu
  - allowed the sidebar to scroll independently from the content

In this PR I have: 
- done a first pass at styling the "sidebar" elements following the current design specs
  - to be discussed/reviewed with @heatherlarsen because I am not sure what is the "final" design
- did a quick change to make the page "side**c**ar" sticky when the page is scrolled

After a review session with @heatherlarsen I have then:
- updated breakpoint for when we show/hide the sidebar in “mobile” mode
  - changed from `1000px` to `880px`, value determined testing in a browser
- made the variable `--doc-page-sidebar-width` responsive
  - at small/medium viewport the sidebar is slightly smaller to optimize the available space
- changed `max-height` value for the homepage illustration on large viewports
- removed GitHub icon from top-route link in sidebar
- refactored sidebar code to split home vs other pages + implemented home-specific animated version with gradient
- implemented collapsible “folder” in sidebar using `<details>`

👉 👉 👉 **Previews**:
- homepage: https://hds-website-git-new-docs-website-sidebar-styling-hashicorp.vercel.app/
- details page: https://hds-website-git-new-docs-website-sidebar-styling-hashicorp.vercel.app/components/alert/

### 🚧 TODOs
- ~~add a reset for the `showSidebarOnSmallViewport` on route change~~
  - tracked here: https://hashicorp.atlassian.net/browse/HDS-1258
- [ ] understand if we really need to handle overflowing of the content, or is an edge case and we can live without it for now

### :link: External links

Jira tickets::
- https://hashicorp.atlassian.net/browse/HDS-934 (main ticket)
- https://hashicorp.atlassian.net/browse/HDS-1253 (behaviour)
- https://hashicorp.atlassian.net/browse/HDS-1220 (styling)
Figma file: https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=188%3A18330

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
