### PR TITLE
Form/Base Elements Docs: Add `description` and `caption`

### DIFF
--- a/website/docs/components/form/base-elements/index.md
+++ b/website/docs/components/form/base-elements/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form / Base elements
+description: Elements used to compose form fields.
+caption: Elements used to compose form fields.
 ---
 
 <section data-tab="Guidelines">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the Form/Base Elements component documentation. 

### :hammer_and_wrench: Detailed description

- description: Elements used to compose form fields.
- caption: Elements used to compose form fields.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.