### PR TITLE
Form/Radio Docs: Add `description` and `caption`

### DIFF
--- a/website/docs/components/form/radio/index.md
+++ b/website/docs/components/form/radio/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::Radio
+description: A form element that allows users to select a single item from group of items.
+caption: A form element that allows users to select a single item from group of items.
 ---
 
 <section data-tab="Guidelines">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the Form/Radio component documentation. 

### :hammer_and_wrench: Detailed description

- description: A form element that allows users to select a single item from group of items.
- caption: A form element that allows users to select a single item from group of items.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
