### PR TITLE
Form/RadioCard Doc: Adds `description` and `caption`

### DIFF
--- a/website/docs/components/form/radio-card/index.md
+++ b/website/docs/components/form/radio-card/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::RadioCard
+description: A type of radio input represented as a card.
+caption: A type of radio input represented as a card.
 ---
 
 <section data-tab="Guidelines">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the Form/RadioCard component documentation. 

### :hammer_and_wrench: Detailed description

- description: A type of radio input represented as a card.
- caption: A type of radio input represented as a card.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
