### PR TITLE
Form/Select Doc: Add `description` and `caption`

### DIFF
--- a/website/docs/components/form/select/index.md
+++ b/website/docs/components/form/select/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::Select
+description: A form element that allows users to choose one option from a list.
+caption: A form element that allows users to choose one option from a list.
 ---
 
 <section data-tab="Other">
@@ -23,4 +25,3 @@ title: Form::Select
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the Form/Select component documentation. 

### :hammer_and_wrench: Detailed description

- description: A form element that allows users to choose one option from a list.
- caption: A form element that allows users to choose one option from a list.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
