### PR TITLE
Form/TextInput Docs: Add `description` and `caption`

### DIFF
--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::TextInput
+description: A form element that provides users with a way to read, input, or edit data.
+caption: A form element that provides users with a way to read, input, or edit data.
 ---
 
 <section data-tab="Guidelines">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the Form/TextInput component documentation. 

### :hammer_and_wrench: Detailed description

- description: A form element that provides users with a way to read, input, or edit data.
- caption: A form element that provides users with a way to read, input, or edit data.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
