### PR TITLE
Form/Toggle Docs: Add `description` and `caption`

### DIFF
--- a/website/docs/components/form/toggle/index.md
+++ b/website/docs/components/form/toggle/index.md
@@ -1,5 +1,7 @@
 ---
 title: Form::Toggle
+description: A form element that allows users to select between two mutually exclusive states.
+caption: A form element that allows users to select between two mutually exclusive states.
 ---
 
 <section data-tab="Guidelines">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the Form/Toggle component documentation. 

### :hammer_and_wrench: Detailed description

- description: A form element that allows users to select between two mutually exclusive states.
- caption: A form element that allows users to select between two mutually exclusive states.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
