### PR TITLE
IconTile Docs: Add `description` and `caption`

### DIFF
--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -1,5 +1,7 @@
 ---
 title: IconTile
+description: Used to display an an icon in a tile-like object.
+caption: Used to display an an icon in a tile-like object.
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -1,7 +1,7 @@
 ---
 title: IconTile
-description: Used to display an an icon in a tile-like object.
-caption: Used to display an an icon in a tile-like object.
+description: Used to display an icon in a tile-like object.
+caption: Used to display an icon in a tile-like object.
 ---
 
 <section data-tab="Code">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the `IconTile` component documentation. 

### :hammer_and_wrench: Detailed description

- description: Used to display an an icon in a tile-like object.
- caption: Used to display an an icon in a tile-like object.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
