### PR TITLE
Link/Inline Docs: Add `description` and `caption`

### DIFF
--- a/website/docs/components/link/inline/index.md
+++ b/website/docs/components/link/inline/index.md
@@ -1,5 +1,7 @@
 ---
 title: Link::Inline
+description: A link that is used within a body of text.
+caption: A link that is used within a body of text.
 ---
 
 <section data-tab="Other">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the Link/Inline component documentation. 

### :hammer_and_wrench: Detailed description

- description: A link that is used within a body of text.
- caption: A link that is used within a body of text.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
