### PR TITLE
Link/Standalone Docs: Add `description` and `caption`

### DIFF
--- a/website/docs/components/link/standalone/index.md
+++ b/website/docs/components/link/standalone/index.md
@@ -1,5 +1,7 @@
 ---
 title: Link::Standalone
+description: A link used in isolation and not as a part of surrounding body text. 
+caption: A link used in isolation and not as a part of surrounding body text.
 ---
 
 <section data-tab="Guidelines">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the Link/Standalone component documentation. 

### :hammer_and_wrench: Detailed description

- description: A link used in isolation and not as a part of surrounding body text. 
- caption: A link used in isolation and not as a part of surrounding body text.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
