### PR TITLE
Tag Docs: Add `description` and `caption`

### DIFF
--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -1,5 +1,7 @@
 ---
 title: Tag
+description: Used to indicate an object's categorization.
+caption: Used to indicate an object's categorization.
 ---
 
 <section data-tab="Code">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the `Tag` component documentation. 

### :hammer_and_wrench: Detailed description

- description: Used to indicate an object's categorization.
- caption: Used to indicate an object's categorization.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
