### PR TITLE
Overrides/PowerSelect Docs: Adds `description` and `caption`

### DIFF
--- a/website/docs/components/tabs/index.md
+++ b/website/docs/components/tabs/index.md
@@ -1,5 +1,7 @@
 ---
 title: Tabs
+description: Allows users to move among different views within the same context and at the same level of hierarchy.
+caption: Allows users to move among different views within the same context.
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -1,5 +1,7 @@
 ---
 title: Tag
+description: Used to indicate an object's categorization.
+caption: Used to indicate an object's categorization.
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/toast/index.md
+++ b/website/docs/components/toast/index.md
@@ -1,5 +1,7 @@
 ---
 title: Toast
+description: Used to display messages that are the result of a user's actions.
+caption: Used to display messages that are the result of a user's actions.
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/overrides/power-select/index.md
+++ b/website/docs/overrides/power-select/index.md
@@ -1,5 +1,7 @@
 ---
 title: PowerSelect
+description: Style overrides for the ember-power-select addon.
+caption: Style overrides for the ember-power-select addon.
 ---
 
 <section data-tab="Guidelines">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the Overrides/PowerSelect component documentation. 

### :hammer_and_wrench: Detailed description

description: Style overrides for the ember-power-select addon.
caption: Style overrides for the ember-power-select addon.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
