### PR TITLE
Utils/Disclosure Docs: Add `description` and `caption`

### DIFF
--- a/website/docs/utilities/disclosure/index.md
+++ b/website/docs/utilities/disclosure/index.md
@@ -1,5 +1,7 @@
 ---
 title: Disclosure
+description: An internal utility that provides hide/show functionality.
+caption: An internal utility that provides hide/show functionality.
 ---
 
 <section data-tab="Other">

--- a/website/docs/utilities/dismiss-button/index.md
+++ b/website/docs/utilities/dismiss-button/index.md
@@ -1,5 +1,7 @@
 ---
 title: DismissButton
+description: An internal utility component used to provide "dismiss" functionality in other components.
+caption: An internal utility component used to provide "dismiss" functionality in other components.
 ---
 
 <section data-tab="Other">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `description` and `caption` to the Utilities/Disclosure component documentation. 

### :hammer_and_wrench: Detailed description

- description: An internal utility that provides hide/show functionality.
- caption: An internal utility that provides hide/show functionality.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
