### PR TITLE
Bugfix: Resolve issue where extra spacing before `required` badges in form labels was not being applied consistently

### DIFF
--- a/.changeset/honest-lemons-dream.md
+++ b/.changeset/honest-lemons-dream.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Bugfix: removed extra space in label that was causing label and legend to be inconsistent

--- a/.changeset/honest-lemons-dream.md
+++ b/.changeset/honest-lemons-dream.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Bugfix: removed extra space in label that was causing label and legend to be inconsistent
+Bugfix: removed extra space in label that was causing label and legend to be inconsistent. Moved the `&nbsp;` to the `required` indicator instead for consistency.

--- a/packages/components/addon/components/hds/form/indicator/index.hbs
+++ b/packages/components/addon/components/hds/form/indicator/index.hbs
@@ -2,5 +2,5 @@
   <span class={{this.classNames}}>(Optional)</span>
 {{/if}}
 {{#if @isRequired}}
-  <Hds::Badge class={{this.classNames}} @size="small" @color="neutral" @text="Required" />
+  &nbsp;<Hds::Badge class={{this.classNames}} @size="small" @color="neutral" @text="Required" />
 {{/if}}

--- a/packages/components/addon/components/hds/form/label/index.hbs
+++ b/packages/components/addon/components/hds/form/label/index.hbs
@@ -1,4 +1,4 @@
 <label class={{this.classNames}} for={{@controlId}} ...attributes>
-  {{yield}}{{#if (or @isRequired @isOptional)}}&nbsp;{{/if}}
+  {{yield}}{{#if (or @isRequired @isOptional)}}{{/if}}
   <Hds::Form::Indicator @isRequired={{@isRequired}} @isOptional={{@isOptional}} />
 </label>

--- a/packages/components/addon/components/hds/form/label/index.hbs
+++ b/packages/components/addon/components/hds/form/label/index.hbs
@@ -1,4 +1,4 @@
 <label class={{this.classNames}} for={{@controlId}} ...attributes>
-  {{yield}}{{#if (or @isRequired @isOptional)}}{{/if}}
+  {{yield}}
   <Hds::Form::Indicator @isRequired={{@isRequired}} @isOptional={{@isOptional}} />
 </label>


### PR DESCRIPTION
### :pushpin: Summary

 If merged, this PR provides a bugfix that removes the extra space between the label and the required badge that wasn't present in the legend, causing an inconsistency.  Instead, the non-breaking space has been added to the `required` indicator, so it's consistently applied to both.

Adds patch changeset.

### :hammer_and_wrench: Detailed description

Reported issue: 
<img width="648" alt="CleanShot 2022-12-15 at 13 56 41@2x" src="https://user-images.githubusercontent.com/4587451/207954939-c562f22c-b162-4fb3-9e43-1f7d96a3da83.png">


### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
