### PR TITLE
More tab query param fixes

### DIFF
--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -4,7 +4,7 @@
   {{#each-in @structuredPageTree as |key item|}}
     <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-{{@depth}}">
       {{#if item.pageURL}}
-        <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="show" @model={{item.pageURL}}>
+        <LinkTo class="doc-table-of-contents__link doc-text-navigation" @route="show" @model={{item.pageURL}} @query={{hash tab=null}}>
           {{item.pageAttributes.title}}
         </LinkTo>
       {{else}}

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -50,7 +50,7 @@ export default class ShowController extends Controller {
 
     let tab = this.tabs.find((el) => {
       // for consistency we always compare the query param tab to a lowercase version of the tab label
-      return el.label.toLowerCase() === this.selectedTab;
+      return el.label.toLowerCase() === this.selectedTab.replace(/\/+$/, '');
     });
     return tab ? tab.index : 0;
   }
@@ -66,6 +66,13 @@ export default class ShowController extends Controller {
   get extra() {
     let { status, links } = this.model.frontmatter;
     return { status, links };
+  }
+
+  get currentActiveTabIndex() {
+    const tab = this.tabs.find((tab) => {
+      return tab.isCurrent;
+    });
+    return tab.index;
   }
 
   get renderedContent() {
@@ -157,7 +164,7 @@ export default class ShowController extends Controller {
     });
 
     // only attempt to update the query params if tabs exist
-    if (this.tabs.length > 1) {
+    if (this.tabs.length > 1 && this.currentActiveTabIndex != 0) {
       // for consistency we always set the query param tab to a lowercase version of the tab label
       set(this, 'selectedTab', this.tabs[current].label.toLowerCase());
     } else {

--- a/website/tests/acceptance/component-query-test.js
+++ b/website/tests/acceptance/component-query-test.js
@@ -8,7 +8,7 @@ module('Acceptance | Component Tabs', function (hooks) {
   test('visiting a tabbed component page and interacting with tabs by default', async function (assert) {
     await visit('/components/alert');
 
-    assert.strictEqual(currentURL(), '/components/alert?tab=guidelines');
+    assert.strictEqual(currentURL(), '/components/alert');
 
     assert.dom('.doc-page-tabs__tab--is-current').exists({ count: 1 });
     assert
@@ -38,7 +38,7 @@ module('Acceptance | Component Tabs', function (hooks) {
   test('specifying a component tab that does not exist defaults to the first tab', async function (assert) {
     await visit('/components/alert?tab=wubalubadubdub');
 
-    assert.strictEqual(currentURL(), '/components/alert?tab=guidelines');
+    assert.strictEqual(currentURL(), '/components/alert');
 
     assert.dom('.doc-page-tabs__tab--is-current').exists({ count: 1 });
     assert

--- a/website/tests/acceptance/icon-query-test.js
+++ b/website/tests/acceptance/icon-query-test.js
@@ -11,7 +11,7 @@ module('Acceptance | Icon Search', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      '/foundations/icons?searchQuery=loading&selectedIconSize=24&tab=library'
+      '/foundations/icons?searchQuery=loading&selectedIconSize=24'
     );
 
     assert.dom('.doc-icons-list-grid-item').exists({ count: 1 });
@@ -22,7 +22,7 @@ module('Acceptance | Icon Search', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      '/foundations/icons?searchQuery=loading&selectedIconSize=16&tab=library'
+      '/foundations/icons?searchQuery=loading&selectedIconSize=16'
     );
 
     assert.dom('.doc-icons-list-grid-item').exists({ count: 1 });


### PR DESCRIPTION
### :pushpin: Summary

This fixes a couple of small issues:
* Navigating back from a component page required hitting the back button multiple times
* Once you navigated to the non-default tab for a component, the link in the sidebar would then include that tab in the link when we would want that to take someone to the default tab
* If you're on the default tab, we don't need to have that in the query params

Does not fix
* Hitting the back button from the non-default tab doesn't update which tab you're on 😢 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1251](https://hashicorp.atlassian.net/browse/HDS-1251)

