### PR TITLE
Enable proper page titles

### DIFF
--- a/website/app/templates/application.hbs
+++ b/website/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{page-title "HDS - HashiCorp Design System"}}
+
 <div class="doc-page-wrapper">
   <Doc::Page::Header />
   {{! `this.model.toc` comes from `routes/application.js` }}

--- a/website/app/templates/index.hbs
+++ b/website/app/templates/index.hbs
@@ -1,5 +1,3 @@
-{{page-title "HDS - HashiCorp Design System"}}
-
 <main class="doc-page-home">
   <div class="doc-page-home__content">
     <div class="doc-page-home__hero">

--- a/website/app/templates/show.hbs
+++ b/website/app/templates/show.hbs
@@ -1,4 +1,7 @@
 <HeadLayout />
+
+{{page-title this.title}}
+
 <Doc::Page::Stage>
   {{#if this.model.hasCover}}
     <Doc::Page::Cover @title={{this.title}} @description={{this.description}} @tabs={{this.tabs}} @extra={{this.extra}} />


### PR DESCRIPTION
### :pushpin: Summary

Fixes a minor issue preventing page titles from updating as expected to the following format

`Page Title | DS Name`

I can't find the thread we had on this from this week, so if there is another desired format we can see how to make that happen.  I think something like `Page Title | Category | DS Name` was the other option.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1237](https://hashicorp.atlassian.net/browse/HDS-1237)

***

