### PR TITLE
[docs] Adds component metadata for multiple components

### DIFF
--- a/website/docs/components/badge-count/index.md
+++ b/website/docs/components/badge-count/index.md
@@ -2,6 +2,7 @@
 title: BadgeCount
 description: A numeric label used to display things like version number or collection enumerations.
 caption: A non-interactive numeric label.
+status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A20946&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/badge-count

--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -2,6 +2,10 @@
 title: Badge
 description: Concise, non-interactive labels that represent metadata.
 caption: Concise, non-interactive labels that represent metadata.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2337%3A20761&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/badge
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: Concise, non-interactive labels that represent metadata.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -2,6 +2,9 @@
 title: Breadcrumb
 description: A breadcrumb is a type of secondary navigation that reveals the user's location in an application.
 caption: A secondary navigation that shows the user's current location.
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=3073%3A11771&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/breadcrumb
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +24,3 @@ caption: A secondary navigation that shows the user's current location.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -2,6 +2,7 @@
 title: Breadcrumb
 description: A breadcrumb is a type of secondary navigation that reveals the user's location in an application.
 caption: A secondary navigation that shows the user's current location.
+status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=3073%3A11771&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/breadcrumb

--- a/website/docs/components/button-set/index.md
+++ b/website/docs/components/button-set/index.md
@@ -2,6 +2,7 @@
 title: ButtonSet
 description: Provides consistent layout and spacing for a set of buttons.
 caption: A set of buttons.
+status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A21001&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button-set

--- a/website/docs/components/button-set/index.md
+++ b/website/docs/components/button-set/index.md
@@ -2,6 +2,9 @@
 title: ButtonSet
 description: Provides consistent layout and spacing for a set of buttons.
 caption: A set of buttons.
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A21001&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button-set
 ---
 
 <section data-tab="Guidelines">
@@ -17,4 +20,3 @@ caption: A set of buttons.
 <section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
-

--- a/website/docs/components/button/index.md
+++ b/website/docs/components/button/index.md
@@ -2,6 +2,7 @@
 title: Button
 description: An interactive element that initiates an action or event, such as a form submission.
 caption: An interactive element that initiates an action.
+status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A21001&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button

--- a/website/docs/components/button/index.md
+++ b/website/docs/components/button/index.md
@@ -2,6 +2,9 @@
 title: Button
 description: An interactive element that initiates an action or event, such as a form submission.
 caption: An interactive element that initiates an action.
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A21001&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button
 ---
 
 <section data-tab="Code">
@@ -17,4 +20,3 @@ caption: An interactive element that initiates an action.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/card/index.md
+++ b/website/docs/components/card/index.md
@@ -2,6 +2,10 @@
 title: Card
 description: A block container that provides styling for elevation, border, and background.
 caption: A block container that provides styling for elevation, border, and background.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2359%3A19245&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/card
 ---
 
 <section data-tab="Code">
@@ -17,4 +21,3 @@ caption: A block container that provides styling for elevation, border, and back
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -2,6 +2,10 @@
 title: Dropdown
 description: Displays a list (typically of actions or links) revealed by a toggle button. Identifiable by the chevron icon in the button.
 caption: Hide/Show a list of actions or links with a toggle button.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=5633%3A16319&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/dropdown
 ---
 
 <section data-tab="Other">
@@ -22,4 +26,3 @@ caption: Hide/Show a list of actions or links with a toggle button.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -2,6 +2,10 @@
 title: IconTile
 description: Used to display an icon in a tile-like object.
 caption: Used to display an icon in a tile-like object.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2632%3A8072&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/icon-tile
 ---
 
 <section data-tab="Code">
@@ -17,4 +21,3 @@ caption: Used to display an icon in a tile-like object.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/link/inline/index.md
+++ b/website/docs/components/link/inline/index.md
@@ -2,6 +2,10 @@
 title: Link::Inline
 description: A link that is used within a body of text.
 caption: A link that is used within a body of text.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2365%3A21590&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/link
 ---
 
 <section data-tab="Other">
@@ -21,4 +25,3 @@ caption: A link that is used within a body of text.
 <section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
-

--- a/website/docs/components/link/standalone/index.md
+++ b/website/docs/components/link/standalone/index.md
@@ -1,7 +1,11 @@
 ---
 title: Link::Standalone
-description: A link used in isolation and not as a part of surrounding body text. 
+description: A link used in isolation and not as a part of surrounding body text.
 caption: A link used in isolation and not as a part of surrounding body text.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2365%3A21590&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/link
 ---
 
 <section data-tab="Guidelines">
@@ -17,4 +21,3 @@ caption: A link used in isolation and not as a part of surrounding body text.
 <section data-tab="Specifications">
   @include "partials/specifications/design-guidelines.md"
 </section>
-

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -2,6 +2,10 @@
 title: Modal
 description: A pop-up window used to request information or feedback from the user, confirm a decision, or provide additional context about a function or feature.
 caption: A pop-up window used to request information, confirm a decision, or provide additional context.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=22928%3A43284&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/modal
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: A pop-up window used to request information, confirm a decision, or pro
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -4,7 +4,7 @@ description: A pop-up window used to request information or feedback from the us
 caption: A pop-up window used to request information, confirm a decision, or provide additional context.
 status: released
 links:
-  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=22928%3A43284&t=XC8SUxxJOFHgqYzK-1
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=22928%3A56204&t=pDgL7LJUJXZUN7Xq-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/modal
 ---
 

--- a/website/docs/components/stepper/index.md
+++ b/website/docs/components/stepper/index.md
@@ -2,6 +2,10 @@
 title: Stepper Indicator
 description: Helps the user maintain context and directionality when advancing through a multi-step flow or feature; generally assembled as part of a larger stepper pattern.
 caption: Helps the user maintain context and directionality when advancing through a multi-step flow or feature.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=15313%3A50538&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/stepper
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: Helps the user maintain context and directionality when advancing throu
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/table/index.md
+++ b/website/docs/components/table/index.md
@@ -2,6 +2,10 @@
 title: Table
 description: Used to display organized, two-dimensional tabular data.
 caption: Used to display organized, two-dimensional tabular data.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=18814%3A54972&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/table
 ---
 
 <section data-tab="Other">
@@ -25,4 +29,3 @@ caption: Used to display organized, two-dimensional tabular data.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/tabs/index.md
+++ b/website/docs/components/tabs/index.md
@@ -2,6 +2,10 @@
 title: Tabs
 description: Allows users to move among different views within the same context and at the same level of hierarchy.
 caption: Allows users to move among different views within the same context.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=16384%3A46484&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/tabs
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: Allows users to move among different views within the same context.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -2,6 +2,10 @@
 title: Tag
 description: Used to indicate an object's categorization.
 caption: Used to indicate an object's categorization.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13720%3A34360&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/tag
 ---
 
 <section data-tab="Code">
@@ -17,4 +21,3 @@ caption: Used to indicate an object's categorization.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/toast/index.md
+++ b/website/docs/components/toast/index.md
@@ -2,6 +2,10 @@
 title: Toast
 description: Used to display messages that are the result of a user's actions.
 caption: Used to display messages that are the result of a user's actions.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=7636%3A30467&t=XC8SUxxJOFHgqYzK-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/toast
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: Used to display messages that are the result of a user's actions.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR will add metadata (Figma link, GitHub link, and status) to multiple components:

- Alert
- Badge
- BadgeCount
- Breadcrumb
- Button
- ButtonSet
- Card
- Dropdown
- IconTile
- Links (standalone and inline)
- Modal
- Stepper Indicator
- Table
- Tabs
- Tag
- Toast

This is a pretty straightforward content change and addition of links so I decided to combine them into one PR. Form controls are larger and will come in a follow-up PR

