### PR TITLE
[docs] Add `FormControls` metadata

### DIFF
--- a/website/docs/components/form/base-elements/index.md
+++ b/website/docs/components/form/base-elements/index.md
@@ -2,6 +2,9 @@
 title: Form / Base elements
 description: Elements used to compose form fields.
 caption: Elements used to compose form fields.
+status: released
+links:
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +24,3 @@ caption: Elements used to compose form fields.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/form/checkbox/index.md
+++ b/website/docs/components/form/checkbox/index.md
@@ -2,6 +2,10 @@
 title: Form::Checkbox
 description: A form element that allows users to select one or more items from a group of items.
 caption: A form element that allows users to select one or more items from a group of items.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=9120%3A23132&t=pDgL7LJUJXZUN7Xq-3
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/checkbox
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: A form element that allows users to select one or more items from a gro
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/form/radio-card/index.md
+++ b/website/docs/components/form/radio-card/index.md
@@ -2,6 +2,10 @@
 title: Form::RadioCard
 description: A type of radio input represented as a card.
 caption: A type of radio input represented as a card.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=17482%3A56258&t=pDgL7LJUJXZUN7Xq-3
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/radio-card
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: A type of radio input represented as a card.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/form/radio/index.md
+++ b/website/docs/components/form/radio/index.md
@@ -2,6 +2,10 @@
 title: Form::Radio
 description: A form element that allows users to select a single item from group of items.
 caption: A form element that allows users to select a single item from group of items.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13181%3A36977&t=pDgL7LJUJXZUN7Xq-3
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/radio
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: A form element that allows users to select a single item from group of 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/form/select/index.md
+++ b/website/docs/components/form/select/index.md
@@ -2,6 +2,10 @@
 title: Form::Select
 description: A form element that allows users to choose one option from a list.
 caption: A form element that allows users to choose one option from a list.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=14283%3A34475&t=pDgL7LJUJXZUN7Xq-3
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/select
 ---
 
 <section data-tab="Other">

--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -2,6 +2,10 @@
 title: Form::TextInput
 description: A form element that provides users with a way to read, input, or edit data.
 caption: A form element that provides users with a way to read, input, or edit data.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=11530%3A28348&t=pDgL7LJUJXZUN7Xq-3
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/text-input
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: A form element that provides users with a way to read, input, or edit d
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/form/textarea/index.md
+++ b/website/docs/components/form/textarea/index.md
@@ -2,6 +2,10 @@
 title: Form::Textarea
 description: A form input that accepts multi-line text.
 caption: A form input that accepts multi-line text.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13343%3A31585&t=pDgL7LJUJXZUN7Xq-1
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/textarea
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: A form input that accepts multi-line text.
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-

--- a/website/docs/components/form/toggle/index.md
+++ b/website/docs/components/form/toggle/index.md
@@ -2,6 +2,10 @@
 title: Form::Toggle
 description: A form element that allows users to select between two mutually exclusive states.
 caption: A form element that allows users to select between two mutually exclusive states.
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13181%3A36435&t=pDgL7LJUJXZUN7Xq-3
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/toggle
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +25,3 @@ caption: A form element that allows users to select between two mutually exclusi
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
-


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR will add metadata (status, Figma link, GitHub link) to the form controls component pages:

- Base elements (not relevant for Figma, linked directly to the broader form directory in GitHub)
- Checkbox
- Radio
- RadioCard
- Select
- TextInput
- Textarea
- Toggle
