### PR TITLE
New docs website / Fix color on `<code>` elements

### DIFF
--- a/website/app/styles/markdown/other-elements.scss
+++ b/website/app/styles/markdown/other-elements.scss
@@ -16,11 +16,9 @@
 
 // CODE SNIPPETS
 
-// TBD if we need a more specific selector to target only the "inline code" elements and not overlap with the other types of code snippets
 .doc-markdown-code {
   @include doc-font-family("mono");
   padding: 0.25em 0.5em;
-  color: var(--doc-color-black);
   font-weight: inherit;
   font-size: 0.8em; // no need to set the line-height, it's an inline element!
   background-color: var(--doc-color-gray-600);

--- a/website/docs/testing/markdown/basic-styling.md
+++ b/website/docs/testing/markdown/basic-styling.md
@@ -46,6 +46,10 @@ A simple image
 
 A simple inline code snippet `var foo = "bar";` like this.
 
+Code snippet with link [`var foo = "bar";`](https://github.com)
+
+Code snippet bold **`var foo = "bar";`** and italic _`var foo = "bar";`_
+
 A simple code block.
 
 ```


### PR DESCRIPTION
### :pushpin: Summary

Remove the explicit `color` declaration for `doc-markdown-code` to allow a code element to inherit the color from the parent (be that a paragraph, a link, a code block, etc), following the [design reference](https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=1368%3A86135&t=63HZQcd219hu6fi4-1).

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![localhost_5000_components_alert_tab=code_ copy](https://user-images.githubusercontent.com/788096/208419693-e614fa80-b747-49fe-a915-a7a4435cc577.png)


</td><td>

![localhost_5000_components_alert_tab=code_](https://user-images.githubusercontent.com/788096/208419711-fbe29d9e-d2e6-46db-ad13-bca018fd4a69.png)


</td></tr>
</table>


***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
