### PR TITLE
Adds landing content to the about page (v1)

### DIFF
--- a/website/app/controllers/about.js
+++ b/website/app/controllers/about.js
@@ -1,0 +1,28 @@
+import Controller from '@ember/controller';
+
+export default class AboutController extends Controller {
+  get cards() {
+    // we want to use a flat tree here...
+    const tocTree = this.model.toc.flat;
+    const sections = ['about'];
+    const cards = {};
+    sections.forEach((section) => {
+      cards[section] = tocTree
+        .filter((page) => page.pageParents[0] === section)
+        .map((page) => {
+          return {
+            image: `https://picsum.photos/seed/s${encodeURI(
+              page.pageURL.replaceAll('/', '-')
+            )}/232/124`,
+            title: page.pageAttributes.title,
+            caption:
+              page.pageAttributes.caption ||
+              'Don\'t forget to add the "caption" to the frontmatter for this page',
+            route: 'show',
+            model: page.pageURL,
+          };
+        });
+    });
+    return cards;
+  }
+}

--- a/website/app/templates/about.hbs
+++ b/website/app/templates/about.hbs
@@ -2,7 +2,7 @@
 
 <Doc::Page::Stage>
   <Doc::Page::Cover @title="About" />
-  <Doc::Page::Content>
-    <p>TBD what this page will contain</p>
+  <Doc::Page::Content @breakthrough={{true}}>
+    <Doc::Cards::Deck @cols="4" @cards={{this.cards.about}} />
   </Doc::Page::Content>
 </Doc::Page::Stage>

--- a/website/docs/about/accessibility-statement.md
+++ b/website/docs/about/accessibility-statement.md
@@ -1,6 +1,7 @@
 ---
 title: Accessibility Statement
 description: This is an accessibility statement from the HashiCorp Design Systems team.
+caption: Learn more about the accessibility intentions of the design system.
 order: 103
 ---
 

--- a/website/docs/about/overview.md
+++ b/website/docs/about/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: This is the (missing) long description of the component, that will come from the frontmatter attributes
+caption: Get an overview of the design system.
 order: 101
 ---
 

--- a/website/docs/about/principles.md
+++ b/website/docs/about/principles.md
@@ -1,6 +1,7 @@
 ---
 title: Principles
 description: Consider the whole when creating the parts
+caption: Read the principles that guide the design system team.
 order: 102
 layout:
   sidecar: false


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add a landing page content for the "About" page, similarly to the Foundations and Components pages (all the same level)

### :hammer_and_wrench: Detailed description

- it implements cards with titles and captions the same way as the Foundations and Components pages. 
- since the JIRA ticket indicates a preference for content instead of cards, I'll be following up this PR but it will take me longer to write that content. So I wanted to get something in place for the time being. 

### :camera_flash: Screenshots

<img width="1501" alt="CleanShot 2022-12-19 at 10 50 02@2x" src="https://user-images.githubusercontent.com/4587451/208477678-0d4b04da-8713-462f-a042-339cc34442aa.png">


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
