### PR TITLE
Fixes a11y issue where empty tablist was being rendered

### DIFF
--- a/website/app/components/doc/page/tabs.hbs
+++ b/website/app/components/doc/page/tabs.hbs
@@ -1,4 +1,5 @@
 {{! template-lint-disable no-invalid-role require-context-role }}
+{{#if @tabs}}
 <ul class='doc-page-tabs' role='tablist' ...attributes>
   {{#each @tabs as |tab|}}
     <li
@@ -18,3 +19,4 @@
     </li>
   {{/each}}
 </ul>
+{{/if}}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes the accessibility issue where an empty tablist was being rendered.

### :hammer_and_wrench: Detailed description

- wrapped the list element in a conditional on content existing.

### :camera_flash: Screenshots

Issue: 
<img width="1261" alt="CleanShot 2022-12-19 at 16 35 36@2x" src="https://user-images.githubusercontent.com/4587451/208540073-dd3eaa41-10bf-46af-95e6-54abc8c42a1e.png">


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
