### PR TITLE
Adds the role of list to stylized list elements

### DIFF
--- a/website/app/components/doc/cards/deck.hbs
+++ b/website/app/components/doc/cards/deck.hbs
@@ -1,4 +1,4 @@
-<ul class={{this.classNames}} ...attributes>
+<ul class={{this.classNames}} ...attributes role="list">
   {{#if @cards}}
     {{#each @cards as |card|}}
       <Doc::Cards::Card

--- a/website/app/components/doc/color-card/index.hbs
+++ b/website/app/components/doc/color-card/index.hbs
@@ -1,7 +1,7 @@
 <div class="doc-color-card" style={{this.cardStyle}}>
   <div class="doc-color-card__color-preview"></div>
   <div class="doc-color-card__color-name">{{this.colorName}}</div>
-  <ul class="doc-color-card__color-vars">
+  <ul class="doc-color-card__color-vars" role="list">
     <li>
       <span>CSS variable: </span>
       <code>--{{this.cssVariable}}</code>

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -19,7 +19,7 @@
     <dt class="doc-component-api__term doc-component-api__term--values">Values</dt> 
     <dd class="doc-component-api__description doc-component-api__description--values">
       {{#if @values}}
-      <ul class="doc-component-api__property-values">
+      <ul class="doc-component-api__property-values" role="list">
         {{#each @values as |value|}}
           <li class="doc-component-api__property-value{{if (eq @default value) "--default"}}">
             {{value}}{{#if (eq @default value)}} <span class="doc-sr-only">(default)</span>{{/if}}

--- a/website/app/components/doc/content/hds-principles/index.hbs
+++ b/website/app/components/doc/content/hds-principles/index.hbs
@@ -1,4 +1,4 @@
-<ul class="doc-content-principles">
+<ul class="doc-content-principles" role="list">
   {{#each this.principles as |principle index|}}
   <li class="doc-text-body-small">
     <img class="doc-content-principles__image" src="https://picsum.photos/seed/s{{index}}/456/124" alt="" role="presentation" />

--- a/website/app/components/doc/font-helpers-list/index.hbs
+++ b/website/app/components/doc/font-helpers-list/index.hbs
@@ -1,4 +1,4 @@
-<ul class="doc-font-helpers-list">
+<ul class="doc-font-helpers-list" role="list">
   {{#each @items as |item|}}
     <li class="doc-font-helpers-list__item">
       <div class="doc-font-helpers-list__preview {{item.previewClass}}">{{item.previewText}}</div>

--- a/website/app/components/doc/icons-list/grid.hbs
+++ b/website/app/components/doc/icons-list/grid.hbs
@@ -1,4 +1,4 @@
-<ul class="doc-icons-list-grid">
+<ul class="doc-icons-list-grid" role="list">
   {{#each @icons as |meta|}}
     <Doc::IconsList::Item @meta={{meta}} />
   {{else}}

--- a/website/app/components/doc/page/header/index.hbs
+++ b/website/app/components/doc/page/header/index.hbs
@@ -3,7 +3,7 @@
     <Doc::Logo::DesignSystem />
   </LinkTo>
   <nav class="doc-page-header__nav-menu" aria-label="primary navigation">
-    <ul>
+    <ul role="list">
       <Doc::Page::Header::NavItem @label="About" @route="about" @currentTopRoute={{this.currentTopRoute}} />
       <Doc::Page::Header::NavItem @label="Foundations" @route="foundations" @currentTopRoute={{this.currentTopRoute}} />
       <Doc::Page::Header::NavItem @label="Components" @route="components" @currentTopRoute={{this.currentTopRoute}} />

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-configure no-inline-styles {"allowDynamicStyles": true} }}
 
-<ul class="doc-table-of-contents">
+<ul class="doc-table-of-contents" role="list">
   {{#each-in @structuredPageTree as |key item|}}
     <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-{{@depth}}">
       {{#if item.pageURL}}

--- a/website/app/components/doc/tokens-list/grid.hbs
+++ b/website/app/components/doc/tokens-list/grid.hbs
@@ -1,6 +1,6 @@
 {{#if @categoryTokens}}
   <h2 class="doc-text-h2">{{capitalize @category}}</h2>
-  <ul class="doc-tokens-list">
+  <ul class="doc-tokens-list" role="list">
     {{#each @categoryTokens as |token|}}
       <Doc::TokensList::Item @token={{token}} />
     {{/each}}

--- a/website/app/components/doc/vars-list/index.hbs
+++ b/website/app/components/doc/vars-list/index.hbs
@@ -1,4 +1,4 @@
-<ul class="doc-vars-list">
+<ul class="doc-vars-list" role="list">
   {{#each @items as |item|}}
     <li class="doc-vars-list__item">
       <code>{{item}}</code>

--- a/website/app/templates/index.hbs
+++ b/website/app/templates/index.hbs
@@ -9,7 +9,7 @@
         <Doc::LinkWithIcon @route="show" @model="getting-started/02--for-engineers" @label="Install HDS in your project" @icon="arrow-right" @isAnimated={{true}} />
       </div>
     </div>
-    <ul class="doc-page-home__cards">
+    <ul class="doc-page-home__cards" role="list">
       {{#each this.cards as |card|}}
         <li class="doc-page-home__card">
           <p class="doc-page-home__card-title">{{capitalize card.title}}</p>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `role="list"` to `<ul>` elements that have had their styles changed from the default. The redundant role is necessary to present the information correctly to users with assistive tech, since some browsers have chosen to remove the implicit role of list from the `ul` element if the `display` style has been altered.


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
