### PR TITLE
Fixes aria-selected tab issue

### DIFF
--- a/website/app/components/doc/page/tabs.hbs
+++ b/website/app/components/doc/page/tabs.hbs
@@ -12,7 +12,7 @@
         type='button'
         role='tab'
         aria-controls={{tab.target}}
-        aria-selected={{tab.isCurrent}}
+        aria-selected={{if tab.isCurrent "true" "false"}}
         {{on 'click' (fn tab.onClickTab tab)}}
       >{{capitalize tab.label}}</button>
     </li>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves the issue where the tab's `aria-selected` value wasn't being rendered correctly.

### :hammer_and_wrench: Detailed description

- changed the `aria-selected` value to a conditional

### :camera_flash: Screenshots

<img width="1267" alt="bug-aria-selected@2x" src="https://user-images.githubusercontent.com/4587451/208545186-0d466eeb-eac1-4ee5-aaaa-54d3e2407da7.png">


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
