### PR TITLE
Update wiki docs and add component template

### DIFF
--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -11,7 +11,6 @@ links:
 <section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
   @include "partials/guidelines/guidelines.md"
-  @include "partials/guidelines/related.md"
 </section>
 
 <section data-tab="Code">

--- a/website/docs/components/alert/partials/guidelines/guidelines.md
+++ b/website/docs/components/alert/partials/guidelines/guidelines.md
@@ -192,3 +192,8 @@ Compact alerts can be wrapped with a section or component of the page or inline 
 - For warning and critical alerts, guide the users on how to prevent or fix the issue.
 - We support basic text formatting capabilities, such as inline links, bold, italic, code, and bulleted lists.
 - For actions, refer to [Button](/components/button) and [Link](/components/link/standalone) content guidelines.
+
+## Related
+
+- [Toast](/components/toast)
+- [Modal](/components/modal)

--- a/website/docs/components/alert/partials/guidelines/related.md
+++ b/website/docs/components/alert/partials/guidelines/related.md
@@ -1,4 +1,0 @@
-## Related
-
-- [Toast](/components/toast)
-- [Modal](/components/modal)

--- a/website/docs/components/template/index.md
+++ b/website/docs/components/template/index.md
@@ -1,6 +1,6 @@
 ---
 title: Template
-hidden: true
+hidden: false
 description: {Optional long description that appears in the cover}
 caption: {Short description that appears in the cards}
 status: released
@@ -12,7 +12,6 @@ links:
 <section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
   @include "partials/guidelines/guidelines.md"
-  @include "partials/guidelines/related.md"
 </section>
 
 <section data-tab="Code">

--- a/website/docs/components/template/index.md
+++ b/website/docs/components/template/index.md
@@ -1,0 +1,32 @@
+---
+title: Template
+hidden: true
+description: {Optional long description that appears in the cover}
+caption: {Short description that appears in the cards}
+status: released
+links:
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?t=nsKJzzKtdX5A7zpz-7
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds
+---
+
+<section data-tab="Guidelines">
+  @include "partials/guidelines/overview.md"
+  @include "partials/guidelines/guidelines.md"
+  @include "partials/guidelines/related.md"
+</section>
+
+<section data-tab="Code">
+  @include "partials/code/how-to-use.md"
+  @include "partials/code/component-api.md"
+  @include "partials/code/showcase.md"
+</section>
+
+<section data-tab="Specifications">
+  @include "partials/specifications/anatomy.md"
+  @include "partials/specifications/states.md"
+</section>
+
+<section data-tab="Accessibility">
+  @include "partials/accessibility/accessibility.md"
+  @include "partials/accessibility/support.md"
+</section>

--- a/website/docs/components/template/partials/accessibility/accessibility.md
+++ b/website/docs/components/template/partials/accessibility/accessibility.md
@@ -1,0 +1,20 @@
+## Conformance rating
+
+<!-- Update conformance rating badge with correct status -->
+<Doc::Badge @type="warning">Conditionally conformant</Doc::Badge>
+
+Alerts are conformant when there are no interactive elements present inside of the alert. There is future work planned to make this component WCAG conformant by adding support for the correct ARIA roles when interactive elements are contained within the alert.
+
+## Best practices
+
+### Heading 3
+{description of best practice}
+
+### Heading 3
+{description of best practice}
+
+## Applicable WCAG Success Criteria
+
+This section is for reference only. This component intends to conform to the following WCAG success criteria:
+
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />

--- a/website/docs/components/template/partials/accessibility/support.md
+++ b/website/docs/components/template/partials/accessibility/support.md
@@ -1,0 +1,4 @@
+---
+
+## Support
+If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/template/partials/code/component-api.md
+++ b/website/docs/components/template/partials/code/component-api.md
@@ -1,0 +1,20 @@
+## Component API
+
+<!-- fill this out based on the API found in the scrappy site -->
+<Doc::ComponentApi as |C|>
+  <C.Property @name="type" @required="true" @type="enum" @values={{array "page" "inline" "compact"}}>
+    Sets the type of alert.
+  </C.Property>
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "highlight" "success" "warning" "critical"}} @default="neutral">
+    Sets the color scheme for `background`, `border`, `title`, and `description`, which **cannot** be overridden.<br/><br/>`color` results in a default `icon`, which **can** be overridden.
+  </C.Property>
+  <C.Property @name="icon" @type="string | false">
+    Override the default `icon` name, which is determined by the `color` argument.<br/><br/>Accepts any [icon](/foundations/icons) name, or `false`, for no icon.
+  </C.Property>
+  <C.Property @name="onDismiss" @type="function">
+    The alert can be dismissed by the user. When a function is passed, the "dismiss" button is displayed.
+  </C.Property>
+  <C.Property @name="...attributes">
+    `...attributes` spreading is supported.
+  </C.Property>
+</Doc::ComponentApi>

--- a/website/docs/components/template/partials/code/how-to-use.md
+++ b/website/docs/components/template/partials/code/how-to-use.md
@@ -1,0 +1,21 @@
+## How to use this component
+
+<!-- use the same heading order from Guidelines -->
+{basic invocation details}
+
+```handlebars
+<Hds::Alert @type="inline" as |A|>
+  <A.Title>Title here</A.Title>
+  <A.Description>Description here</A.Description>
+</Hds::Alert>
+```
+
+### Variant/property name
+{description}
+
+```handlebars
+<Hds::Alert @type="page" as |A|>
+  <A.Title>Title here</A.Title>
+  <A.Description>Description here</A.Description>
+</Hds::Alert>
+```

--- a/website/docs/components/template/partials/code/showcase.md
+++ b/website/docs/components/template/partials/code/showcase.md
@@ -1,1 +1,3 @@
+## Showcase
+
 <!-- copy existing showcase over; do not change it for now (unless broken). -->

--- a/website/docs/components/template/partials/code/showcase.md
+++ b/website/docs/components/template/partials/code/showcase.md
@@ -1,0 +1,1 @@
+<!-- copy existing showcase over; do not change it for now (unless broken). -->

--- a/website/docs/components/template/partials/guidelines/guidelines.md
+++ b/website/docs/components/template/partials/guidelines/guidelines.md
@@ -1,0 +1,28 @@
+## Usage
+### When to use
+
+- {description}
+
+### When not to use
+
+- {description}, consider {[component](#)}.
+- {description}, consider {[component](#)}.
+- {description}, consider {[component](#)}.
+
+### Variant/property name
+
+<!-- don't forget to include real examples and do/don't blocks, as necessary -->
+{description}
+
+### Variant/property name
+
+<!-- don't forget to include real examples and do/don't blocks, as necessary -->
+{description}
+
+## Content
+
+- {description}
+- {description}
+- {description}
+- {description}
+- {description}

--- a/website/docs/components/template/partials/guidelines/guidelines.md
+++ b/website/docs/components/template/partials/guidelines/guidelines.md
@@ -26,3 +26,9 @@
 - {description}
 - {description}
 - {description}
+
+## Related
+
+<!-- only include the 2 most similar/related components -->
+- {[component name](#)}
+- {[component name](#)}

--- a/website/docs/components/template/partials/guidelines/overview.md
+++ b/website/docs/components/template/partials/guidelines/overview.md
@@ -1,0 +1,1 @@
+{description}

--- a/website/docs/components/template/partials/guidelines/related.md
+++ b/website/docs/components/template/partials/guidelines/related.md
@@ -1,0 +1,5 @@
+## Related
+
+<!-- only include the 2 most similar/related components -->
+- {[component name](#)}
+- {[component name](#)}

--- a/website/docs/components/template/partials/guidelines/related.md
+++ b/website/docs/components/template/partials/guidelines/related.md
@@ -1,5 +1,0 @@
-## Related
-
-<!-- only include the 2 most similar/related components -->
-- {[component name](#)}
-- {[component name](#)}

--- a/website/docs/components/template/partials/specifications/anatomy.md
+++ b/website/docs/components/template/partials/specifications/anatomy.md
@@ -1,0 +1,14 @@
+## Anatomy
+
+<!-- image then table -->
+![Anatomy of the page alert](/assets/components/alert/alert-anatomy-inline.png)
+
+| Element          | Usage                                           |
+|------------------|-------------------------------------------------|
+| Icon             | Optional, but recommended                       |
+| Title            | Required, if no description Optional, otherwise |
+| Description      | Required, if no title Optional, otherwise       |
+| Actions          | Optional                                        |
+| Dismiss button   | Optional                                        |
+| Content          | Required                                        |
+| Container        | Required                                        |

--- a/website/docs/components/template/partials/specifications/states.md
+++ b/website/docs/components/template/partials/specifications/states.md
@@ -1,0 +1,2 @@
+<!-- populate with examples and documentation of interactive states -->
+<!-- this can usually be found in the design guidelines -->

--- a/wiki/Website-Editing-existing-content.md
+++ b/wiki/Website-Editing-existing-content.md
@@ -60,16 +60,23 @@ A large portion of the content in the new documentation website has been ported 
 To see how to write markdown and which syntax to use, refer to [the specific Markdown documentation](./Website-Markdown.md).
 
 ## Steps to getting started
+At any time, you can check out the `components/template` folder to get an idea of how the sections and files should be structured, but here's a list of specific steps to take when updating the documentation for an existing component. 
+
 1. Rename `design-guidelines.md` to `guidelines.md` and move it to `/guidelines`. 
-2. Within `guidelines.md`, find the "Anatomy" section and move that into a new file called `anatomy.md`. This new file should live in `/specifications`.
-3. Update `index.md` accordingly.
-4. Remove content related to the old `design guidelines` (preview image + link to Figma file), if it still exists.
-    1. Make sure the associated images are removed from the `public` folder.
-5. Replace temporary `Do/Dont` blocks in the design guidelines with [the new "Do/Dont" syntax](./Website-Markdown.md#dodont).
-6. Replace content that needs to go in a `Banner` block using [the new specific "Banner" syntax](./Website-Markdown.md#banner).
-7. Update the anatomy assets to use the new website colors. This can be done in the [Website Assets file](https://www.figma.com/file/42LK10XbP5IERhzzgMOiI2/Website-assets?node-id=66%3A6622&t=WpqvfoziubA4azgP-0), see [the "Media" documentation](./Website-Media.md) for more details on exporting assets.
-8. Check that code snippets work as expected. Speak with Alex Jurubita, if something looks incorrect.
-9. Check and update links, as necessary.
+2. Within `guidelines.md`, find the "Anatomy" section and move that into a new file called `anatomy.md`. This new file should live in `/specifications`. Remove that content from `guidelines.md`.
+3. Within `guidelines.md`, find the "Accessibility" section (if available) and move that into `/accessibility/accessibility.md`. Remove that content from `guidelines.md`.
+4. Update `index.md` according to the change above.
+5. Within `index.md`, update the order of content for the "Code" section to be: 
+    - how-to-use.md
+    - component-api.md
+    - showcase.md
+6. Remove the old `design guidelines` image and Figma link, if they still exist.
+    1. Make sure the associated images are also removed from the `public` folder.
+7. Replace temporary `Do/Dont` blocks in the design guidelines with [the new "Do/Dont" syntax](./Website-Markdown.md#dodont).
+8. Replace content that needs to go in a `Banner` block using [the new specific "Banner" syntax](./Website-Markdown.md#banner).
+9. Update the anatomy assets to use the new website colors. This can be done in the [Website Assets file](https://www.figma.com/file/42LK10XbP5IERhzzgMOiI2/Website-assets?node-id=66%3A6622&t=WpqvfoziubA4azgP-0), see [the "Media" documentation](./Website-Media.md) for more details on exporting assets.
+10. Check that code snippets work as expected. Speak with Alex Jurubita, if something looks incorrect.
+11. Check and update links, as necessary.
     1. If they are **internal/cross-page** links (eg. `/components/alert/`) fix them with the correct route/model.
     2. If they are **external** links (eg. `https://hashicorp.com`) make sure they have `target="blank" rel="noopener noreferrer"`.
     3. If you are not sure what to do, speak with Brian Runnells.
@@ -88,6 +95,8 @@ To see how to write markdown and which syntax to use, refer to [the specific Mar
 - Remove directionality language, such as "see below". This is not inclusive language, nor is it very scalable.
 - Check that assets represent what they're meant to.
     - If you need to add/remove assets, see [the "Media" documentation](./Website-Media.md).
+
+For more information and best practices around content writing, see [the HDS Writing Guidelines](https://docs.google.com/document/d/1WyoJVpWFVgWbCnZ28WW0gRJwJlj-qV5oY0ExhDR2obs/edit?usp=sharing).
 
 ## Terminology cheat sheet
 - Avoid overusing "the HashiCorp Design System" and "the design system", consider "we" or "our" instead (eg. "the design system components" to "our components").

--- a/wiki/Website-Editing-existing-content.md
+++ b/wiki/Website-Editing-existing-content.md
@@ -21,7 +21,7 @@ Below you can find a list of things to do when working on the content of an exis
 Check that the correct frontmatter attributes are in place. Technically, only the `title` is required, but depending on the page other attributes may be needed as well. Please refer to [the "Frontmatter" documentation](./Website-Doc-folder.md#frontmatter) for details about what attributes are recognized and how to use them, or check in similar pages what attributes are used.
 
 ## Sections/tabs
-Ensure consistent tab names and order. For components, we use: **Guidelines**, **Code**, **Specifications**, and **Accessibility**. If needing to add a section that is not listed above, speak with the HDS team.
+Ensure consistent tab names and order. For components, we use: **Guidelines**, **Code**, **Specifications**, and **Accessibility**. If needing to add a section that is not listed above, speak with the HDS team. Note that not all sections may be necessary for all components. In that case, remove the section from `index.md`.
 
 ### Guidelines
 Guidelines are used for design guidelines and general best practices for usage. Content should generally follow this order: 
@@ -102,9 +102,10 @@ For more information and best practices around content writing, see [the HDS Wri
 - Avoid overusing "the HashiCorp Design System" and "the design system", consider "we" or "our" instead (eg. "the design system components" to "our components").
 - Never use "a design system", use "the design system", as "a" is impersonal.
 - "Use" instead of "utilize" (and other large word swaps in favor of more simple terms). 
-- Use contractions when it feels natural. If you'd say "don't" out loud in a conversationm use "don't" in the documentation instead of "do not".
+- Use contractions when it feels natural. If you'd say "don't" in a conversation use "don't" instead of "do not" in the documentation.
 - Use "application" instead of "website".
 - Use "product team" when referring to an entire consuming team, instead of "application team".
+- Use "consumer" when referring to folks who use the design system.
 
 ---
 

--- a/wiki/Website-Editing-existing-content.md
+++ b/wiki/Website-Editing-existing-content.md
@@ -7,35 +7,107 @@
 
 ---
 
-🚨 To be extended/integrated with the work @Heather Larsen is doing. 🚨
-
-Below you can find a ;ist of things to do when working on the content of an existing documentation page.
+Below you can find a list of things to do when working on the content of an existing documentation page.
 
 ## Frontmatter
 Check that the correct frontmatter attributes are in place. Technically, only the `title` is required, but depending on the page other attributes may be needed as well. Please refer to [the "Frontmatter" documentation](./Website-Doc-folder.md#frontmatter) for details about what attributes are recognized and how to use them, or check in similar pages what attributes are used.
 
-## Markdown content
-Large portion of the content in the new documentation website has been ported or automatically, from the old "scrappy" documentation website, or manually from the design guidelines in Figma. This means that, unless it's already been reviewed an updated, it will require **a lot** of love and editing.
+## Sections/tabs
+Ensure consistent tab names and order. For components, we use: Guidelines, Code, Specifications, and Accessibility.
 
-🚧 Heather not sure how to fit your content in this section or otherwise how to reorganize the entire content of this document file. I'll leave it to you to figure out 😀
+As a general rule of thumb, 
+- **Guidelines** are used for design guidelines and general best practices for usage.
+- **Code** houses all engineering documentation.
+- **Specifications** are used for more tactical, technical details about the structure of the component (eg. anatomy, token specs, interactive states, etc).
+- **Accessibility** houses content related to the built-in accessibility features we provide, gotchas and best practices for implementing the component, compliance ratings, and known issues.
+
+If needing to add a section that is not listed above, speak with the HDS team.
+
+### Guidelines
+Content should generally follow this order: 
+
+- Overview description (no heading)
+- Type (if multiple exists, see `Alert`)
+- Usage
+    - When to use
+    - When not to use
+    - Variant/property sections (in the order of likely use)
+- Content
+- Related
+
+### Code
+Content should generally follow this order: 
+
+- How to use this component
+- Component API
+- Showcase
+
+### Specifications
+Content should generally follow this order: 
+
+- Anatomy (image, then table)
+- Interactive states
+- Any token-related content (this likely doesn't exist yet)
+
+### Accessibility
+Content should generally follow this order: 
+
+- Conformance rating
+    - Rating badge
+    - Details
+- Best practices
+- WCAG Success Criteria
+
+## Markdown content
+Large portion of the content in the new documentation website has been ported over automatically, from the old "scrappy" documentation website, or manually from the design guidelines in Figma. This means that, unless it's already been reviewed and updated, it will require **a lot** of love and editing.
 
 To see how to write markdown and which syntax to use, refer to [the specific Markdown documentation](./Website-Markdown.md).
 
-## Things to check/fix:
+## Steps to getting started
+1. Rename `design-guidelines.md` to `guidelines.md` and move it to `/guidelines`. 
+2. Within `guidelines.md`, find the "Anatomy" section and move that into a new file called `anatomy.md`. This new file should live in `/specifications`.
+3. Update `index.md` accordingly.
+4. Remove content related to the old `design guidelines` (preview image + link to Figma file), if it still exists.
+    1. Make sure the associated images are removed from the `public` folder.
+5. Replace temporary `Do/Dont` blocks in the design guidelines with [the new "Do/Dont" syntax](./Website-Markdown.md#dodont)
+6. Replace content that needs to go in a `Banner` block using [the new specific "Banner" syntax](./Website-Markdown.md#banner)
+7. Update the anatomy assets to use the new website colors. This can be done in the [Website Assets file](https://www.figma.com/file/42LK10XbP5IERhzzgMOiI2/Website-assets?node-id=66%3A6622&t=WpqvfoziubA4azgP-0), see [the "Media" documentation](./Website-Media.md) for more details on exporting assets.
+8. Check that code snippets work as expected. Speak with Alex Jurubita, if something looks incorrect.
+9. Check and update links, as necessary.
+    1. If they are **internal/cross-page** links (eg. `/components/alert/`) fix them with the correct route/model
+    2. If they are **external** links (eg. `https://hashicorp.com`) make sure they have `target="blank" rel="noopener noreferrer"`
+    3. If you are not sure what to do, speak with Brian Runnells
 
-- Check all the headings in the page (titles and levels)
-- Replace temporary `Do/Dont` blocks in the design guidelines with [the new "Do/Dont" syntax](./Website-Markdown.md#dodont)
-- Replace content that needs to go in a `Banner` block using [the new specific "Banner" syntax](./Website-Markdown.md#banner)
-- Check that code snippets work as expected (if not, speak with Alex Jurubita)
-- Remove content related to the old `design guidelines` (preview image + link to Figma file) if still exist
-    - Make sure the associated images are removed from the `public` folder too
-- Check all the links
-    - If they are **internal/cross-page** links (eg. `/components/alert/`) fix them with the correct route/model
-    - If they are **external** links (eg. `https://hashicorp.com`) make sure they have `target="blank" rel="noopener noreferrer"`
-    - If you are not sure what to do, speak with Brian Runnells
-- Assets
-    - Check that what they represent is still correct
+⚠️ **Important**: Leave the **Showcase** section as is, for now. If it breaks the page, try to resolve the issue. We will reconsider this section more holistically in January.
+
+
+## Content improvement tips
+- Check that all headings are in sequential order and that they accurately represent the content within the paragraph.
+- Check for and remove extra filler language.
+- Look for inaccuracies and misused terminology (eg. if we use the word "description" for the main body text of the `alert`, update "alert message" to "alert description").
+- Consider if all banners in the current documentation should really be housed in an alert or if it can be a normal paragraph. 
+- Re-organize content into logical chunks. 
+    - If it feels like a new topic has started but is a continuation of a paragraph, consider creating a new paragraph for that topic. Bonus points if you can add a meaningful heading above it. 
+    - Conversely, if a topic feels related to a prior topic, consider merging them into one section.
+- Remove directionality language, such as "see below". This is not inclusive language, nor is it very scalable.
+- Check that assets represent what they're meant to.
     - If you need to add/remove assets, see [the "Media" documentation](./Website-Media.md).
-- "Showcase" section
-    - Leave it as is for now, (unless it breaks the page) as we will re-consider the "Showcase" holistically in January (we have to understand how to use it in the context of the new documentation format).
 
+## Terminology cheat sheet
+- Avoid overusing "the HashiCorp Design System" and "the design system", consider "we" or "our" instead (eg. "the design system components" to "our components").
+- Never use "a design system", use "the design system", as "a" is impersonal.
+- "Use" instead of "utilize" (and other large word swaps in favor of more simple terms). 
+- Use contractions when it feels natural. If you'd say "don't" out loud in a conversationm use "don't" in the documentation instead of "do not".
+- Use "application" instead of "website".
+- Use "product team" when referring to an entire consuming team, instead of "application team".
+
+---
+
+## Reviews (What to expect)
+When reviewing documentation, we check for: 
+- accuracy
+- spelling and grammar
+- consistency in voice, tone, and terminology
+- instructional design (content hierarchy, how the content flows, can it be easily scanned)
+
+You can expect a few to a few dozen copy edits to update grammar and spelling. It is completely normal to have dozens of copy edit suggestions. You may also receive instructional design recommendations, such as reordering content or adding additional explanations.

--- a/wiki/Website-Editing-existing-content.md
+++ b/wiki/Website-Editing-existing-content.md
@@ -72,11 +72,12 @@ At any time, you can check out the `components/template` folder to get an idea o
     - showcase.md
 6. Remove the old `design guidelines` image and Figma link, if they still exist.
     1. Make sure the associated images are also removed from the `public` folder.
-7. Replace temporary `Do/Dont` blocks in the design guidelines with [the new "Do/Dont" syntax](./Website-Markdown.md#dodont).
-8. Replace content that needs to go in a `Banner` block using [the new specific "Banner" syntax](./Website-Markdown.md#banner).
-9. Update the anatomy assets to use the new website colors. This can be done in the [Website Assets file](https://www.figma.com/file/42LK10XbP5IERhzzgMOiI2/Website-assets?node-id=66%3A6622&t=WpqvfoziubA4azgP-0), see [the "Media" documentation](./Website-Media.md) for more details on exporting assets.
-10. Check that code snippets work as expected. Speak with Alex Jurubita, if something looks incorrect.
-11. Check and update links, as necessary.
+7. Update mentions of "HashiCorp Design System" to "Helios" (in rare cases "Helios Design System") and "the design systems team" to "Helios team". 
+8. Replace temporary `Do/Dont` blocks in the design guidelines with [the new "Do/Dont" syntax](./Website-Markdown.md#dodont).
+9. Replace content that needs to go in a `Banner` block using [the new specific "Banner" syntax](./Website-Markdown.md#banner).
+10. Update the anatomy assets to use the new website colors. This can be done in the [Website Assets file](https://www.figma.com/file/42LK10XbP5IERhzzgMOiI2/Website-assets?node-id=66%3A6622&t=WpqvfoziubA4azgP-0), see [the "Media" documentation](./Website-Media.md) for more details on exporting assets.
+11. Check that code snippets work as expected. Speak with Alex Jurubita, if something looks incorrect.
+12. Check and update links, as necessary.
     1. If they are **internal/cross-page** links (eg. `/components/alert/`) fix them with the correct route/model.
     2. If they are **external** links (eg. `https://hashicorp.com`) make sure they have `target="blank" rel="noopener noreferrer"`.
     3. If you are not sure what to do, speak with Brian Runnells.
@@ -102,7 +103,7 @@ At any time, you can check out the `components/template` folder to get an idea o
 For more information and best practices around content writing, see [the HDS Writing Guidelines](https://docs.google.com/document/d/1WyoJVpWFVgWbCnZ28WW0gRJwJlj-qV5oY0ExhDR2obs/edit?usp=sharing).
 
 ## Terminology cheat sheet
-- Avoid overusing "the HashiCorp Design System" and "the design system", consider "we" or "our" instead (eg. "the design system components" to "our components").
+- Avoid overusing "Helios Design System" and "the design system", consider "we" or "our" instead (eg. "the design system components" to "our components").
 - Never use "a design system", use "the design system", as "a" is impersonal.
 - "Use" instead of "utilize" (and other large word swaps in favor of more simple terms). 
 - Use contractions when it feels natural. If you'd say "don't" in a conversation use "don't" instead of "do not" in the documentation.

--- a/wiki/Website-Editing-existing-content.md
+++ b/wiki/Website-Editing-existing-content.md
@@ -95,6 +95,9 @@ At any time, you can check out the `components/template` folder to get an idea o
 - Remove directionality language, such as "see below". This is not inclusive language, nor is it very scalable.
 - Check that assets represent what they're meant to.
     - If you need to add/remove assets, see [the "Media" documentation](./Website-Media.md).
+- Ensure complete sentences and periods are on the `caption` and `description`.
+- Include "(Internal only)" on links that go to internal resources.
+- Remove any reference to "Flight" when talking about Icons.
 
 For more information and best practices around content writing, see [the HDS Writing Guidelines](https://docs.google.com/document/d/1WyoJVpWFVgWbCnZ28WW0gRJwJlj-qV5oY0ExhDR2obs/edit?usp=sharing).
 

--- a/wiki/Website-Editing-existing-content.md
+++ b/wiki/Website-Editing-existing-content.md
@@ -2,8 +2,16 @@
 
 - [Website / Editing existing content (playbook)](#website--editing-existing-content-playbook)
   - [Frontmatter](#frontmatter)
+  - [Sections/tabs](#sections-tabs)
+    - [Guidelines](#guidelines)
+    - [Code](#code)
+    - [Specifications](#specifications)
+    - [Accessibility](#accessibility)
   - [Markdown content](#markdown-content)
-  - [Things to check/fix:](#things-to-checkfix)
+  - [Steps to getting started](#steps-to-getting-started)
+  - [Content improvement tips](#content-improvement-tips)
+  - [Terminology cheat sheet](#terminology-cheat-sheet)
+  - [Review (What to expect)](#reviews-what-to-expect)
 
 ---
 
@@ -13,19 +21,10 @@ Below you can find a list of things to do when working on the content of an exis
 Check that the correct frontmatter attributes are in place. Technically, only the `title` is required, but depending on the page other attributes may be needed as well. Please refer to [the "Frontmatter" documentation](./Website-Doc-folder.md#frontmatter) for details about what attributes are recognized and how to use them, or check in similar pages what attributes are used.
 
 ## Sections/tabs
-Ensure consistent tab names and order. For components, we use: Guidelines, Code, Specifications, and Accessibility.
-
-As a general rule of thumb, 
-- **Guidelines** are used for design guidelines and general best practices for usage.
-- **Code** houses all engineering documentation.
-- **Specifications** are used for more tactical, technical details about the structure of the component (eg. anatomy, token specs, interactive states, etc).
-- **Accessibility** houses content related to the built-in accessibility features we provide, gotchas and best practices for implementing the component, compliance ratings, and known issues.
-
-If needing to add a section that is not listed above, speak with the HDS team.
+Ensure consistent tab names and order. For components, we use: **Guidelines**, **Code**, **Specifications**, and **Accessibility**. If needing to add a section that is not listed above, speak with the HDS team.
 
 ### Guidelines
-Content should generally follow this order: 
-
+Guidelines are used for design guidelines and general best practices for usage. Content should generally follow this order: 
 - Overview description (no heading)
 - Type (if multiple exists, see `Alert`)
 - Usage
@@ -36,30 +35,27 @@ Content should generally follow this order:
 - Related
 
 ### Code
-Content should generally follow this order: 
-
+Code houses all engineering documentation. Content should generally follow this order: 
 - How to use this component
 - Component API
 - Showcase
 
 ### Specifications
-Content should generally follow this order: 
-
+Specifications are used for more tactical, technical details about the structure of the component (eg. anatomy, token specs, interactive states, etc). Content should generally follow this order: 
 - Anatomy (image, then table)
 - Interactive states
 - Any token-related content (this likely doesn't exist yet)
 
 ### Accessibility
-Content should generally follow this order: 
-
+Accessibility houses content related to the built-in accessibility features we provide, gotchas, and best practices for implementing the component, compliance ratings, and known issues. Content should generally follow this order: 
 - Conformance rating
     - Rating badge
     - Details
-- Best practices
+- Best practices (typically found throughout the docs)
 - WCAG Success Criteria
 
 ## Markdown content
-Large portion of the content in the new documentation website has been ported over automatically, from the old "scrappy" documentation website, or manually from the design guidelines in Figma. This means that, unless it's already been reviewed and updated, it will require **a lot** of love and editing.
+A large portion of the content in the new documentation website has been ported over automatically, from the old "scrappy" documentation website, or manually from the design guidelines in Figma. This means that, unless it's already been reviewed and updated, it will require **a lot** of love and editing.
 
 To see how to write markdown and which syntax to use, refer to [the specific Markdown documentation](./Website-Markdown.md).
 
@@ -69,14 +65,14 @@ To see how to write markdown and which syntax to use, refer to [the specific Mar
 3. Update `index.md` accordingly.
 4. Remove content related to the old `design guidelines` (preview image + link to Figma file), if it still exists.
     1. Make sure the associated images are removed from the `public` folder.
-5. Replace temporary `Do/Dont` blocks in the design guidelines with [the new "Do/Dont" syntax](./Website-Markdown.md#dodont)
-6. Replace content that needs to go in a `Banner` block using [the new specific "Banner" syntax](./Website-Markdown.md#banner)
+5. Replace temporary `Do/Dont` blocks in the design guidelines with [the new "Do/Dont" syntax](./Website-Markdown.md#dodont).
+6. Replace content that needs to go in a `Banner` block using [the new specific "Banner" syntax](./Website-Markdown.md#banner).
 7. Update the anatomy assets to use the new website colors. This can be done in the [Website Assets file](https://www.figma.com/file/42LK10XbP5IERhzzgMOiI2/Website-assets?node-id=66%3A6622&t=WpqvfoziubA4azgP-0), see [the "Media" documentation](./Website-Media.md) for more details on exporting assets.
 8. Check that code snippets work as expected. Speak with Alex Jurubita, if something looks incorrect.
 9. Check and update links, as necessary.
-    1. If they are **internal/cross-page** links (eg. `/components/alert/`) fix them with the correct route/model
-    2. If they are **external** links (eg. `https://hashicorp.com`) make sure they have `target="blank" rel="noopener noreferrer"`
-    3. If you are not sure what to do, speak with Brian Runnells
+    1. If they are **internal/cross-page** links (eg. `/components/alert/`) fix them with the correct route/model.
+    2. If they are **external** links (eg. `https://hashicorp.com`) make sure they have `target="blank" rel="noopener noreferrer"`.
+    3. If you are not sure what to do, speak with Brian Runnells.
 
 ⚠️ **Important**: Leave the **Showcase** section as is, for now. If it breaks the page, try to resolve the issue. We will reconsider this section more holistically in January.
 

--- a/wiki/Website-Media.md
+++ b/wiki/Website-Media.md
@@ -22,7 +22,7 @@ Please add the original source of every image or illustration that you add to th
 
 As mentioned above, the generated files should be exported in the `website/public` folder.
 
-Regading the format and settings of the "Export" panel in Figma, please follow these guidelines:
+Regarding the format and settings of the "Export" panel in Figma, please follow these guidelines:
 
 - assets should be ready to be exported as they are, without the need for someone to do something
   - give them frame the exact name that will be used in the code
@@ -32,7 +32,7 @@ Regading the format and settings of the "Export" panel in Figma, please follow t
         - it’s just vectors, with normal paths? probably an `SVG` is best
         - it’s vectors, but with thousands of points? export in `SVG` and `PNG` and compare the size, then choose
         - it’s both vectors and bitmap (eg. the new illustrations)? then `JPG` is the one that compress better
-  - decide if the frame should be clipped or not (generally is not necessary if it’s `SVG`, but if it’s `JPG` is better because in some cases it may create visual artefacts on the borders)
+  - decide if the frame should be clipped or not (generally is not necessary if it’s `SVG`, but if it’s `JPG` is better because in some cases it may create visual artifacts on the borders)
     - ![The "Frame" panel in Figma with the "Clip content" option selected](images/doc-figma-clip-content.png)
   - decide if the background color applied to the frame should be exported or not (if it’s `SVG` almost certainly not, if it’s `PNG` or `JPG` almost certainly yes)
     - ![The "Fill" panel in Figma with the "Show in exports" option selected](images/doc-figma-show-in-exports.png)
@@ -40,4 +40,4 @@ Regading the format and settings of the "Export" panel in Figma, please follow t
   - is it a fixed size in the page? use the exact same size (and export at `@2x`)
   - is it an image that resize when the viewport changes? speak with the developer and decide what is the right size to use
 
-If you have any doubts or problems expoerting the files, speak with one of the designers of the HDS team.
+If you have any doubts or problems exporting the files, speak with one of the designers of the HDS team.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR.... 
- Updates the content in `wiki/Website-Editing-existing-content.md` to include more detailed instructions for editing existing component documentation
- Adds a "template" folder with corresponding files in `/components` to aid in the component authoring experience
  - This is hidden in the website UI

**Preview of wiki doc**: https://github.com/hashicorp/design-system/blob/d8f11da4d0e67e2a023e6ccc333180e6a41a0113/wiki/Website-Editing-existing-content.md

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1205](https://hashicorp.atlassian.net/browse/HDS-1205)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
