### PR TITLE
Resolves accessibility issues with toggle button in token list

### DIFF
--- a/website/app/components/doc/tokens-list/item.hbs
+++ b/website/app/components/doc/tokens-list/item.hbs
@@ -18,7 +18,7 @@
     {{! template-lint-enable no-inline-styles }}
   </div>
   <div class="doc-tokens-list__content">
-    <button type="button" class="doc-tokens-list__toggle" {{on "click" this.toggle}}><FlightIcon @name={{if this.isExpanded "chevron-up" "chevron-down"}} /><span class="doc-sr-only">{{this.isExpanded 'Collapse' 'Expand'}}</span></button>
+    <button type="button" class="doc-tokens-list__toggle" {{on "click" this.toggle}} aria-label={{(concat this.token.name " information list")}}><FlightIcon @name={{if this.isExpanded "chevron-up" "chevron-down"}} /><span class="doc-sr-only">{{this.isExpanded 'Collapse' 'Expand'}}</span></button>
     {{#if this.token.deprecated}}
       <Doc::MetaRow @label="Don't use" @valueToShow="This token is now deprecated" />
       <Doc::MetaRow class="doc-tokens-list__item--is-deprecated" @label="CSS var" @valueToShow={{this.token.name}}  />

--- a/website/app/components/doc/tokens-list/item.hbs
+++ b/website/app/components/doc/tokens-list/item.hbs
@@ -18,7 +18,7 @@
     {{! template-lint-enable no-inline-styles }}
   </div>
   <div class="doc-tokens-list__content">
-    <button type="button" class="doc-tokens-list__toggle" {{on "click" this.toggle}} aria-label={{(concat this.token.name " information list")}}><FlightIcon @name={{if this.isExpanded "chevron-up" "chevron-down"}} /><span class="doc-sr-only">{{this.isExpanded 'Collapse' 'Expand'}}</span></button>
+    <button type="button" class="doc-tokens-list__toggle" {{on "click" this.toggle}} aria-label={{(concat this.token.name " information list")}} aria-expanded={{if this.isExpanded "true" "false"}}><FlightIcon @name={{if this.isExpanded "chevron-up" "chevron-down"}} /></button>
     {{#if this.token.deprecated}}
       <Doc::MetaRow @label="Don't use" @valueToShow="This token is now deprecated" />
       <Doc::MetaRow class="doc-tokens-list__item--is-deprecated" @label="CSS var" @valueToShow={{this.token.name}}  />


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR:

- adds a unique accessible name via `aria-label` to the toggle buttons in the token list.
- removes the `sr-only` span and adds `aria-expanded` to the button element itself

Note: FWIW, I don't think we need to include the toggle or the `type`, not really sure why those are there. Also, we could work some more on how the list content is present to the AOM. Right now it just says "generic." 😬 

### :camera_flash: Screenshots

Screenshot of Issue: 
![CleanShot 2022-12-20 at 09 45 50](https://user-images.githubusercontent.com/4587451/208707789-d6edfd5e-a012-45ae-8cef-6007daa357c6.png)

After fix: 

`aria-label`:
![CleanShot 2022-12-20 at 09 48 47](https://user-images.githubusercontent.com/4587451/208708310-3cb44f25-599e-44b3-902b-80e9a3f633de.png)

`aria-expanded`: 
![CleanShot 2022-12-20 at 10 00 34](https://user-images.githubusercontent.com/4587451/208711020-c0a8b07e-cd39-494f-8f3b-dc44eac7991d.png)
![CleanShot 2022-12-20 at 10 02 15](https://user-images.githubusercontent.com/4587451/208711237-ce75604f-3808-48d4-8089-23d30e1a9ebf.png)



:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
