### PR TITLE
Adds missing apostrophe in `dont` associated `label`

### DIFF
--- a/website/app/components/doc/do-dont/index.js
+++ b/website/app/components/doc/do-dont/index.js
@@ -8,7 +8,7 @@ export default class DocDoDontComponent extends Component {
         label = 'Do';
         break;
       case 'dont':
-        label = 'Dont';
+        label = 'Don’t';
         break;
       default:
         break;


### PR DESCRIPTION
### :pushpin: Summary

Updates the label for the `dont` case from `Dont` to `Don’t`.

### :camera_flash: Screenshots

<img width="957" alt="CleanShot 2022-12-21 at 10 20 01@2x" src="https://user-images.githubusercontent.com/4587451/208953543-7f845d69-87b1-4c4c-a03f-a3a352a8a5e6.png">
