### PR TITLE
Updates to docs templates

### DIFF
--- a/website/docs/components/template/index.md
+++ b/website/docs/components/template/index.md
@@ -1,6 +1,6 @@
 ---
 title: Template
-hidden: false
+hidden: true
 description: {Optional long description that appears in the cover}
 caption: {Short description that appears in the cards}
 status: released

--- a/website/docs/components/template/index.md
+++ b/website/docs/components/template/index.md
@@ -1,6 +1,6 @@
 ---
 title: Template
-hidden: true
+hidden: false
 description: {Optional long description that appears in the cover}
 caption: {Short description that appears in the cards}
 status: released

--- a/website/docs/components/template/partials/accessibility/accessibility.md
+++ b/website/docs/components/template/partials/accessibility/accessibility.md
@@ -8,9 +8,11 @@ Alerts are conformant when there are no interactive elements present inside of t
 ## Best practices
 
 ### Heading 3
+
 {description of best practice}
 
 ### Heading 3
+
 {description of best practice}
 
 ## Applicable WCAG Success Criteria

--- a/website/docs/components/template/partials/accessibility/support.md
+++ b/website/docs/components/template/partials/accessibility/support.md
@@ -1,4 +1,3 @@
----
-
 ## Support
+
 If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/template/partials/code/component-api.md
+++ b/website/docs/components/template/partials/code/component-api.md
@@ -15,6 +15,6 @@
     The alert can be dismissed by the user. When a function is passed, the "dismiss" button is displayed.
   </C.Property>
   <C.Property @name="...attributes">
-    `...attributes` spreading is supported.
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/template/partials/code/how-to-use.md
+++ b/website/docs/components/template/partials/code/how-to-use.md
@@ -11,6 +11,7 @@
 ```
 
 ### Variant/property name
+
 {description}
 
 ```handlebars

--- a/website/docs/components/template/partials/guidelines/guidelines.md
+++ b/website/docs/components/template/partials/guidelines/guidelines.md
@@ -1,4 +1,5 @@
 ## Usage
+
 ### When to use
 
 - {description}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves issues in the docs component templates. 

### :hammer_and_wrench: Detailed description

- headings should be preceded and followed by blank lines
- blank lines should surround lists
- an .md file should end with a blank line
- frontmatter change: set `hidden` to true since we don't want it to show up in the component list
- updated sample language used for `...attributes`

