### PR TITLE
one weird trick

### DIFF
--- a/website/app/components/doc/copy-button/index.hbs
+++ b/website/app/components/doc/copy-button/index.hbs
@@ -1,4 +1,9 @@
-<CopyButton class={{this.classNames}} @text="{{this.textToCopy}}" @onSuccess={{this.onSuccess}} @onError={{this.onError}}>
+<CopyButton
+  class={{this.classNames}}
+  @text="{{this.textToCopy}}"
+  @onSuccess={{this.onSuccess}}
+  @onError={{this.onError}}
+>
   {{#if this.textToShow}}
     <span class="doc-copy-button__visible-value doc-text-code">{{this.textToShow}}</span>
   {{/if}}

--- a/website/app/components/doc/copy-button/index.hbs
+++ b/website/app/components/doc/copy-button/index.hbs
@@ -1,4 +1,4 @@
-<CopyButton class={{this.classNames}} @text={{this.textToCopy}} @onSuccess={{this.onSuccess}} @onError={{this.onError}}>
+<CopyButton class={{this.classNames}} @text="{{this.textToCopy}}" @onSuccess={{this.onSuccess}} @onError={{this.onError}}>
   {{#if this.textToShow}}
     <span class="doc-copy-button__visible-value doc-text-code">{{this.textToShow}}</span>
   {{/if}}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR _really_ fixes the copybutton that we thought we already fixed. Turns out we did need the quotes around the text value (which I don't actually understand why)

Before the change: 
<img width="1704" alt="CleanShot 2022-12-22 at 17 35 55@2x" src="https://user-images.githubusercontent.com/4587451/209242916-08a63032-57ff-4d09-a1ec-a01c677b604a.png">


After the change:
<img width="1706" alt="CleanShot 2022-12-22 at 17 37 00@2x" src="https://user-images.githubusercontent.com/4587451/209242983-cb95f6ec-0b65-47e9-9603-b9986452f030.png">
