### PR TITLE
Fix repetitive required field indicator for screen readers

### DIFF
--- a/.changeset/orange-suits-guess.md
+++ b/.changeset/orange-suits-guess.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix repetitive required field indicator for screen readers

--- a/packages/components/addon/components/hds/form/indicator/index.hbs
+++ b/packages/components/addon/components/hds/form/indicator/index.hbs
@@ -1,6 +1,6 @@
 {{#if @isOptional}}
-  <span class={{this.classNames}}>(Optional)</span>
+  <span aria-hidden="true" class={{this.classNames}}>(Optional)</span>
 {{/if}}
 {{#if @isRequired}}
-  &nbsp;<Hds::Badge class={{this.classNames}} @size="small" @color="neutral" @text="Required" />
+  &nbsp;<Hds::Badge aria-hidden="true" class={{this.classNames}} @size="small" @color="neutral" @text="Required" />
 {{/if}}


### PR DESCRIPTION
### :pushpin: Summary

Fix repetitive required field indicator for screen readers.

### :hammer_and_wrench: Detailed description

`@isRequired` applies both a visual indicator (a badge) and the `required` attribute on the associated form field, causing a repetitive 'required' when a screen reader user reaches the form element. We set `aria-hidden="true"` to remove the indicator from the a11y tree and rely on the native HTML attribute to communicate this to users.

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
