### PR TITLE
Updates sub-component language

### DIFF
--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -86,7 +86,7 @@ The `Hds::Dropdown` component is composed of different child components, each wi
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements passed as children of this sub-component are yielded inside the list item. _Note: when using the "generic" list item the developer is completely responsible for any element yielded, including the accessibility of that element, as well as the layout of the content (we provide only the horizontal padding for consistency with the other items)._
+    Elements nested within this child component are yielded inside the list item. _Note: when using the "generic" list item the developer is completely responsible for any element yielded, including the accessibility of that element, as well as the layout of the content (we provide only the horizontal padding for consistency with the other items)._
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/tabs/partials/code/component-api.md
+++ b/website/docs/components/tabs/partials/code/component-api.md
@@ -2,9 +2,9 @@
 
 The `Tabs` component is composed of different parts, with their own APIs:
 
-*  `Tabs` “container”
-*  multiple `Tab` sub-components
-*  multiple `Panel` sub-components (corresponding to each Tab)
+- `Tabs` “container”
+- multiple `Tab` child components
+- multiple `Panel` child components (corresponding to each Tab)
 
 ### Tabs API
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR replaces "sub-component" with the more correct term "child component" in the documentation.
