### PR TITLE
Adds accessible routing to docs site

### DIFF
--- a/website/app/components/doc/page/header/index.hbs
+++ b/website/app/components/doc/page/header/index.hbs
@@ -1,4 +1,5 @@
 <header class="doc-page-header" ...attributes>
+  <NavigationNarrator />
   <LinkTo @route="index" class="doc-page-header__logo" aria-label="home page">
     <Doc::Logo::DesignSystem />
   </LinkTo>

--- a/website/app/components/doc/page/stage.hbs
+++ b/website/app/components/doc/page/stage.hbs
@@ -1,3 +1,3 @@
-<main class="doc-page-stage" ...attributes>
+<main class="doc-page-stage" ...attributes id="main">
   {{yield}}
 </main>

--- a/website/app/templates/error.hbs
+++ b/website/app/templates/error.hbs
@@ -11,7 +11,7 @@
       <h1 class="doc-text-h1">Well shoot...</h1>
       <p class="doc-text-body">We can't seem to find what you're looking for, or an error occurred. Head back to the
         <LinkTo class="doc-link-generic" @route="index">homepage</LinkTo>.</p>
-      <h4 class="doc-text-h4">Other helpful resources</h4>
+      <h2 class="doc-text-h4">Other helpful resources</h2>
       <ul class="doc-list-generic doc-text-body">
         <li><LinkTo class="doc-link-generic" @route="about">About</LinkTo></li>
         <li><LinkTo class="doc-link-generic" @route="support">Support</LinkTo></li>

--- a/website/app/templates/index.hbs
+++ b/website/app/templates/index.hbs
@@ -1,4 +1,4 @@
-<main class="doc-page-home">
+<main class="doc-page-home" id="main">
   <div class="doc-page-home__content">
     <div class="doc-page-home__hero">
       <h1>HashiCorp<br />Design System</h1>

--- a/website/package.json
+++ b/website/package.json
@@ -43,6 +43,7 @@
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",
     "broccoli-multifilter": "^2.0.0",
+    "ember-a11y-refocus": "^3.0.2",
     "ember-auto-import": "^2.4.2",
     "ember-body-class": "^3.0.0",
     "ember-cli": "~4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9839,6 +9839,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ember-a11y-refocus@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "ember-a11y-refocus@npm:3.0.2"
+  dependencies:
+    ember-cli-babel: ^7.26.11
+    ember-cli-htmlbars: ^6.0.1
+  checksum: c192e80514adad4928207f4025975f225fde0b135a9156f257999dc49a8eb16b84d6f7a8c489b33a87a17c5b6325e48fc152055e6d4ecee45cdddfd2cd4d2c0a
+  languageName: node
+  linkType: hard
+
 "ember-a11y-testing@npm:^5.0.0":
   version: 5.0.0
   resolution: "ember-a11y-testing@npm:5.0.0"
@@ -23178,6 +23188,7 @@ __metadata:
     broccoli-funnel: ^3.0.3
     broccoli-merge-trees: ^4.2.0
     broccoli-multifilter: ^2.0.0
+    ember-a11y-refocus: ^3.0.2
     ember-auto-import: ^2.4.2
     ember-body-class: ^3.0.0
     ember-cli: ~4.7.0


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR adds `ember-a11y-routing` for an accessible routing solution and bypass block (skip link) implementation.

It mostly works as intended, but...those pesky query param tabs. 🥹

**Issue**:

- URL and query params aren't playing nicely

**Steps to reproduce:** 

- turn VoiceOver on
- load website
- use TAB key to navigate to "Components"
- after page loads, use TAB key and "skip to main"
- then use TAB and navigate to any component
- after component page loads, use TAB key and "skip to main"
- use TAB key to navigate to any of the tabs
- after page loads, use "skip to main"
- note the url:  (e.g., `/components/badge-count?tab=code#main`)

Potentially, we could [customize the definition of a route change](https://github.com/ember-a11y/ember-a11y-refocus#customizing-the-definition-of-a-route-change), and set up the tabs so that if one is activated, the focus is automatically moved to the first heading within the content.

