### PR TITLE
Improve fix for text in "CopyButton"

### DIFF
--- a/website/app/components/doc/color-swatch/index.hbs
+++ b/website/app/components/doc/color-swatch/index.hbs
@@ -8,15 +8,15 @@
         <Doc::CopyButton @textToCopy={{this.cssVariable}} @type="ghost" />
 
       </li>
-      <li class="doc-color-swatch__listitem">
-        <span class="doc-color-swatch__listitem--context">CSS Helper</span>
-        <Doc::CopyButton @textToCopy={{this.cssHelper}} @textToShow=".{{this.cssHelper}}" @type="ghost" />
-
-      </li>
+      {{#if this.cssHelper}}
+        <li class="doc-color-swatch__listitem">
+          <span class="doc-color-swatch__listitem--context">CSS Helper</span>
+          <Doc::CopyButton @textToCopy={{this.cssHelper}} @textToShow=".{{this.cssHelper}}" @type="ghost" />
+        </li>
+      {{/if}}
       <li class="doc-color-swatch__listitem">
         <span class="doc-color-swatch__listitem--context">HEX</span>
         <Doc::CopyButton @textToCopy={{this.hexValue}} @type="ghost" />
-
       </li>
     </ul>
   </div>

--- a/website/app/components/doc/copy-button/index.hbs
+++ b/website/app/components/doc/copy-button/index.hbs
@@ -1,9 +1,4 @@
-<CopyButton
-  class={{this.classNames}}
-  @text="{{this.textToCopy}}"
-  @onSuccess={{this.onSuccess}}
-  @onError={{this.onError}}
->
+<CopyButton class={{this.classNames}} @text={{this.textToCopy}} @onSuccess={{this.onSuccess}} @onError={{this.onError}}>
   {{#if this.textToShow}}
     <span class="doc-copy-button__visible-value doc-text-code">{{this.textToShow}}</span>
   {{/if}}


### PR DESCRIPTION
### :pushpin: Summary

This reverts #961 and applies a fix at template level.

The fix done in #961 worked because was converting this condition:
https://github.com/hashicorp/design-system/blob/main/website/app/components/doc/color-swatch/index.js#L14
to a string (`"false"`) so the `CopyButton` component would not complain, but the user would copy `"false"` as CSS helper (exists only for the 'foreground', 'page', 'surface', 'border' groups, see: https://github.com/hashicorp/design-system/blob/85055c0be427826cae79f231d9758296f20439d4/website/docs/foundations/colors/index.js#L37-L40)

### :hammer_and_wrench: Detailed description

In this PR I have:
- reverted the #961 fix
- added a conditional check around the "css helper" block of code

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
