### PR TITLE
Fix "About" page links

### DIFF
--- a/website/app/styles/global/link.scss
+++ b/website/app/styles/global/link.scss
@@ -2,9 +2,9 @@
   color: var(--doc-color-link-on-white);
 
   // TODO check with Heather and Melanie if this is what we want
-  :hover,
-  :visited,
-  :active {
+  &:hover,
+  &:visited,
+  &:active {
     color: var(--doc-color-link-on-white);
   }
 }

--- a/website/app/templates/about.hbs
+++ b/website/app/templates/about.hbs
@@ -8,38 +8,42 @@
     <h2 class="doc-text-h2">Overview</h2>
     <p class="doc-text-body">The Design Systems Team creates and maintains the Helios Design System. This includes the
       Figma components, web components, documentation, and more. Read through our
-      <a href="/about/overview/">overview</a>
+      <a class="doc-link-generic" href="/about/overview/">overview</a>
       for more details, and to see why adopting the HashiCorp Design System is the future for product teams.</p>
 
     <h2 class="doc-text-h2">Principles</h2>
     <p class="doc-text-body">It’s important that we stay focused and grounded as a team. Setting clear expectations for
       both ourselves and our consumers by defining our philosophy and values through our
-      <a href="/about/principles/">principles</a>
+      <a class="doc-link-generic" href="/about/principles/">principles</a>
       help us do just that.</p>
 
     <h2 class="doc-text-h2">Accessibility statement</h2>
     <p class="doc-text-body">Accessibility is not just a requirement, it is a part of our company culture, grounded in
-      <a href="https://www.hashicorp.com/our-principles" target="_blank" rel="noopener noreferrer">our company
-        principles</a>
+      <a
+        class="doc-link-generic"
+        href="https://www.hashicorp.com/our-principles"
+        target="_blank"
+        rel="noopener noreferrer"
+      >our company principles</a>
       such as integrity, communication, and kindness. Read more about our intentions for an accessible design system in
       our
-      <a href="/about/accessibility-statement/">accessibility statement</a>.</p>
+      <a class="doc-link-generic" href="/about/accessibility-statement/">accessibility statement</a>.</p>
 
     <h2 class="doc-text-h2">Getting started for designers</h2>
     <p class="doc-text-body">Learn how to use our components and other resources by reading our guide to
-      <a href="/getting-started/for-designers/">getting started for designers</a>.</p>
+      <a class="doc-link-generic" href="/getting-started/for-designers/">getting started for designers</a>.</p>
 
     <h2 class="doc-text-h2">Getting started for engineers</h2>
     <p class="doc-text-body">While the design system components are conveniently packaged in a standard Ember addon, we
       still recommend reading through our guide to
-      <a href="/getting-started/for-engineers/">getting started for engineers</a>
+      <a class="doc-link-generic" href="/getting-started/for-engineers/">getting started for engineers</a>
       to better understand some specific conventions we have put in place to help engineers focus on what is really
       important in their application, instead of thinking about component APIs.</p>
 
     <h2 class="doc-text-h2">Contributions</h2>
     <p class="doc-text-body">As an open-source project, we think a lot about how people can contribute—and there are
       quite a few ways our consumers are encouraged to participate! Read our
-      <a href="/getting-started/contribution/">contribution</a>
+      <a class="doc-link-generic" href="/getting-started/contribution/">contribution</a>
       documentation to find the different ways anyone can contribute to Helios.</p>
   </Doc::Page::Content>
 </Doc::Page::Stage>

--- a/website/app/templates/about.hbs
+++ b/website/app/templates/about.hbs
@@ -8,38 +8,38 @@
     <h2 class="doc-text-h2">Overview</h2>
     <p class="doc-text-body">The Design Systems Team creates and maintains the Helios Design System. This includes the
       Figma components, web components, documentation, and more. Read through our
-      <a href="/about/overview/" target="_blank" rel="noopener noreferrer">overview</a>
+      <a href="/about/overview/">overview</a>
       for more details, and to see why adopting the HashiCorp Design System is the future for product teams.</p>
 
     <h2 class="doc-text-h2">Principles</h2>
     <p class="doc-text-body">It’s important that we stay focused and grounded as a team. Setting clear expectations for
       both ourselves and our consumers by defining our philosophy and values through our
-      <a href="/about/principles/" target="_blank" rel="noopener noreferrer">principles</a>
+      <a href="/about/principles/">principles</a>
       help us do just that.</p>
 
     <h2 class="doc-text-h2">Accessibility statement</h2>
     <p class="doc-text-body">Accessibility is not just a requirement, it is a part of our company culture, grounded in
-      <a href="https://www.hashicorp.com/our-principles" rel="noopener noreferrer" target="_blank">our company
+      <a href="https://www.hashicorp.com/our-principles" target="_blank" rel="noopener noreferrer">our company
         principles</a>
       such as integrity, communication, and kindness. Read more about our intentions for an accessible design system in
       our
-      <a href="/about/accessibility-statement/" target="_blank" rel="noopener noreferrer">accessibility statement</a>.</p>
+      <a href="/about/accessibility-statement/">accessibility statement</a>.</p>
 
     <h2 class="doc-text-h2">Getting started for designers</h2>
     <p class="doc-text-body">Learn how to use our components and other resources by reading our guide to
-      <a href="/getting-started/for-designers/" target="_blank" rel="noopener noreferrer">getting started for designers</a>.</p>
+      <a href="/getting-started/for-designers/">getting started for designers</a>.</p>
 
     <h2 class="doc-text-h2">Getting started for engineers</h2>
     <p class="doc-text-body">While the design system components are conveniently packaged in a standard Ember addon, we
       still recommend reading through our guide to
-      <a href="/getting-started/for-engineers/" target="_blank" rel="noopener noreferrer">getting started for engineers</a>
+      <a href="/getting-started/for-engineers/">getting started for engineers</a>
       to better understand some specific conventions we have put in place to help engineers focus on what is really
       important in their application, instead of thinking about component APIs.</p>
 
     <h2 class="doc-text-h2">Contributions</h2>
     <p class="doc-text-body">As an open-source project, we think a lot about how people can contribute—and there are
       quite a few ways our consumers are encouraged to participate! Read our
-      <a href="/getting-started/contribution/" target="_blank" rel="noopener noreferrer">contribution</a>
+      <a href="/getting-started/contribution/">contribution</a>
       documentation to find the different ways anyone can contribute to Helios.</p>
   </Doc::Page::Content>
 </Doc::Page::Stage>


### PR DESCRIPTION
### :pushpin: Summary

Small fix for the links in the "About" page.

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed `target="_blank" rel="noopener noreferrer”` from the links in the `About` page (they're internal)
- added `doc-link-generic` class to the links 
  - had to fix the mixin for `doc-link-generic` styles to have it work correctly

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
