### PR TITLE
New docs website / Update markup in page "Footer"

### DIFF
--- a/website/app/components/doc/page/footer.hbs
+++ b/website/app/components/doc/page/footer.hbs
@@ -1,26 +1,42 @@
 <footer class="doc-page-footer" ...attributes>
-  <div class="doc-page-footer__links doc-text-body-small">
-    <LinkTo @route="show" @model="about/accessibility-statement">Accessibility</LinkTo>
-    <a href="https://hashicorp.com/careers" target="_blank" rel="noopener noreferrer">Careers</a>
-    <a href="https://www.hashicorp.com/terms-of-service" target="_blank" rel="noopener noreferrer">Terms of Use</a>
-    <a href="https://www.hashicorp.com/security" target="_blank" rel="noopener noreferrer">Security</a>
-    <a href="https://www.hashicorp.com/privacy" target="_blank" rel="noopener noreferrer">Privacy</a>
-    <span role="presentation">–</span>
-    <LinkTo @route="testing">Testing</LinkTo>
-    <button
-      type="button"
-      class="doc-page-footer__🌈"
-      {{on "click" this.toggleLayoutColors}}
-      aria-label="toggle layout colors"
-    >🌈</button>
-  </div>
-  <a
-    class="doc-page-footer__logo"
-    href="https://www.hashicorp.com/"
-    target="_blank"
-    rel="noopener noreferrer"
-    aria-label="hashicorp dot com"
-  >
-    <Doc::Logo::HashiCorp />
-  </a>
+  <nav class="doc-page-footer__nav-menu" aria-label="footer navigation">
+    <ul class="doc-page-footer__nav-list doc-text-body-small" role="list">
+      <li class="doc-page-footer__nav-item">
+        <LinkTo @route="show" @model="about/accessibility-statement">Accessibility</LinkTo>
+      </li>
+      <li class="doc-page-footer__nav-item">
+        <a href="https://hashicorp.com/careers" target="_blank" rel="noopener noreferrer">Careers</a>
+      </li>
+      <li class="doc-page-footer__nav-item">
+        <a href="https://www.hashicorp.com/terms-of-service" target="_blank" rel="noopener noreferrer">Terms of Use</a>
+      </li>
+      <li class="doc-page-footer__nav-item">
+        <a href="https://www.hashicorp.com/security" target="_blank" rel="noopener noreferrer">Security</a>
+      </li>
+      <li class="doc-page-footer__nav-item">
+        <a href="https://www.hashicorp.com/privacy" target="_blank" rel="noopener noreferrer">Privacy</a>
+      </li>
+      <li class="doc-page-footer__nav-item" role="separator"><span aria-hidden="true">–</span></li>
+      <li class="doc-page-footer__nav-item">
+        <LinkTo @route="testing">Testing</LinkTo>
+      </li>
+      <li class="doc-page-footer__nav-item">
+        <button
+          type="button"
+          class="doc-page-footer__🌈"
+          {{on "click" this.toggleLayoutColors}}
+          aria-label="toggle layout colors"
+        >🌈</button>
+      </li>
+    </ul>
+    <a
+      class="doc-page-footer__logo"
+      href="https://www.hashicorp.com/"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="hashicorp dot com"
+    >
+      <Doc::Logo::HashiCorp />
+    </a>
+  </nav>
 </footer>

--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -5,14 +5,17 @@
 
 .doc-page-footer {
   // z-index: var(--doc-z-index-footer);
+  grid-area: footer;
+}
+
+.doc-page-footer__nav-menu {
   display: flex;
   flex-direction: column;
-  grid-area: footer;
   gap: 16px;
   padding: 16px 24px;
   color: var(--doc-color-black);
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium-and-above() {
     flex-direction: row;
     justify-content: space-between;
   }
@@ -21,8 +24,32 @@
     flex-direction: column-reverse;
     color: var(--doc-color-white);
 
-    @include breakpoint.medium-and-above () {
+    @include breakpoint.medium-and-above() {
       flex-direction: row-reverse;
+    }
+  }
+}
+
+.doc-page-footer__nav-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.doc-page-footer__nav-item {
+  a {
+    color: var(--doc-color-gray-300);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    body.application.index & {
+      color: var(--doc-color-gray-400);
     }
   }
 }
@@ -38,24 +65,5 @@
   svg {
     width: auto;
     height: 100%;
-  }
-}
-
-.doc-page-footer__links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 16px;
-
-  a {
-    color: var(--doc-color-gray-300);
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-
-    body.application.index & {
-      color: var(--doc-color-gray-400);
-    }
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

This PR updates the markup in the footer, based on #931.

### :hammer_and_wrench: Detailed description

In this PR I have:
- update markup (and associated class names and styles) in the page `footer`

Preview:
- homepage: https://hds-website-git-new-docs-website-footer-markup-137bd6-hashicorp.vercel.app/
- component page: https://hds-website-git-new-docs-website-footer-markup-137bd6-hashicorp.vercel.app/components/alert

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1324
Figma file: https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=1345%3A80286&t=hzq1cpxx9nwpnf1v-1

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
