### PR TITLE
HDS-1317: Remove "Guidelines" sections

### DIFF
--- a/website/docs/overrides/power-select/index.md
+++ b/website/docs/overrides/power-select/index.md
@@ -4,10 +4,6 @@ description: Style overrides for the ember-power-select addon.
 caption: Style overrides for the ember-power-select addon.
 ---
 
-<section data-tab="Guidelines">
-  @include "partials/guidelines/overview.md"
-</section>
-
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/showcase.md"

--- a/website/docs/overrides/power-select/partials/code/how-to-use.md
+++ b/website/docs/overrides/power-select/partials/code/how-to-use.md
@@ -1,3 +1,10 @@
+[PowerSelect](https://ember-power-select.com/) is a popular Ember add-on aiming to overcome some limitations of the `<select>` tag. The design system only provides style overrides for this add-on to keep it in line with other form components.
+
+!!! Info
+
+These style overrides assume the PowerSelect component is set up in your project using the default theme.
+!!!
+
 To use this component in your application follow [the getting started guide on the add-on website](https://ember-power-select.com), then add the PowerSelect overrides.
 
 ## Overrides import

--- a/website/docs/overrides/power-select/partials/guidelines/overview.md
+++ b/website/docs/overrides/power-select/partials/guidelines/overview.md
@@ -1,8 +1,0 @@
-## Usage
-
-[PowerSelect](https://ember-power-select.com/) is a popular Ember add-on aiming to overcome some limitations of the `<select>` tag. The design system only provides style overrides for this add-on to keep it in line with other form components.
-
-!!! Info
-
-These style overrides assume the PowerSelect component is set up in your project using the default theme.
-!!!

--- a/website/docs/utilities/disclosure/index.md
+++ b/website/docs/utilities/disclosure/index.md
@@ -4,10 +4,6 @@ description: An internal utility that provides hide/show functionality.
 caption: An internal utility that provides hide/show functionality.
 ---
 
-<section data-tab="Guidelines">
-  @include "partials/guidelines/guidelines.md"
-</section>
-
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"

--- a/website/docs/utilities/disclosure/partials/code/how-to-use.md
+++ b/website/docs/utilities/disclosure/partials/code/how-to-use.md
@@ -1,3 +1,8 @@
+!!! Info
+
+This component is intended only for internal use (for now). If you need to use it please speak with the HDS team.
+!!!
+
 ## How to use this component
 
 Use an interactive element that can trigger a custom event handler provided by the `:toggle` block (is passed via `hash` by Ember). This element is usually usually a button, or a component that renders a button (for accessibility reasons).

--- a/website/docs/utilities/disclosure/partials/guidelines/guidelines.md
+++ b/website/docs/utilities/disclosure/partials/guidelines/guidelines.md
@@ -1,3 +1,0 @@
-## Usage
-
-This component is intended only for internal use (for now). If you need to use it please speak with the HDS team.

--- a/website/docs/utilities/dismiss-button/index.md
+++ b/website/docs/utilities/dismiss-button/index.md
@@ -4,10 +4,6 @@ description: An internal utility component used to provide "dismiss" functionali
 caption: An internal utility component used to provide "dismiss" functionality in other components.
 ---
 
-<section data-tab="Guidelines">
-  @include "partials/guidelines/guidelines.md"
-</section>
-
 <section data-tab="Code">
   
   @include "partials/code/how-to-use.md"

--- a/website/docs/utilities/dismiss-button/partials/code/how-to-use.md
+++ b/website/docs/utilities/dismiss-button/partials/code/how-to-use.md
@@ -1,3 +1,8 @@
+!!! Info
+
+This component is intended only for internal use (for now). If you need to use it please speak with the HDS team.
+!!!
+
 ## How to use this component
 
 ```handlebars

--- a/website/docs/utilities/dismiss-button/partials/guidelines/guidelines.md
+++ b/website/docs/utilities/dismiss-button/partials/guidelines/guidelines.md
@@ -1,3 +1,0 @@
-## Usage
-
-This component is intended only for internal use (for now). If you need to use it please speak with the HDS team.

--- a/website/docs/utilities/interactive/index.md
+++ b/website/docs/utilities/interactive/index.md
@@ -4,10 +4,6 @@ description: An internal utility component used to provide interactivity to othe
 caption: An internal utility component used to provide interactivity to other components.
 ---
 
-<section data-tab="Guidelines">
-  @include "partials/guidelines/guidelines.md"
-</section>
-
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"

--- a/website/docs/utilities/interactive/partials/code/how-to-use.md
+++ b/website/docs/utilities/interactive/partials/code/how-to-use.md
@@ -1,3 +1,8 @@
+!!! Info
+
+This component is intended only for internal use (for now). If you need to use it please speak with the HDS team.
+!!!
+
 ## How to use this component
 
 ### Basic use (`<button>`)

--- a/website/docs/utilities/interactive/partials/guidelines/guidelines.md
+++ b/website/docs/utilities/interactive/partials/guidelines/guidelines.md
@@ -1,3 +1,0 @@
-## Usage 
-
-This component is intended only for internal use (for now). If you need to use it please speak with the HDS team.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR moves basic information to the "Code" section and removes the "Guidelines" section for a few code-only overrides and utilities; `PowerSelect`, `Disclosure`, `Interactive`, and `Dismiss Button`.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1317](https://hashicorp.atlassian.net/browse/HDS-1317)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1317]: https://hashicorp.atlassian.net/browse/HDS-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-1317]: https://hashicorp.atlassian.net/browse/HDS-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ