### PR TITLE
disable fingerprinting by default so it's only on in production

### DIFF
--- a/website/ember-cli-build.js
+++ b/website/ember-cli-build.js
@@ -28,7 +28,6 @@ module.exports = function (defaults) {
         'illustrations/overrides',
         'illustrations/utilities',
       ],
-      enabled: true,
     },
     'ember-prism': {
       components: [


### PR DESCRIPTION
### :pushpin: Summary

I accidentally left this in from some debugging. This will be enabled by default in production.