### PR TITLE
Setup meta tags

### DIFF
--- a/website/app/services/head-data.js
+++ b/website/app/services/head-data.js
@@ -1,24 +1,19 @@
 import HeadDataService from 'ember-meta/services/head-data';
+import config from 'ember-get-config';
 
 export default class CustomHeadDataService extends HeadDataService {
-  // this is needed or `head-data.js` will crush
-  get config() {
-    return {};
-  }
-
   get title() {
     return (
       this.currentRouteMeta?.title ??
       this.currentRouteMeta?.frontmatter?.title ??
-      'Helios Design System'
+      config['ember-meta'].title
     );
   }
 
-  get siteName() {
-    return 'Helios Design System';
-  }
-
   get description() {
-    return this.currentRouteMeta?.frontmatter?.description ?? null;
+    return (
+      this.currentRouteMeta?.frontmatter?.description ??
+      config['ember-meta'].description
+    );
   }
 }

--- a/website/app/services/head-data.js
+++ b/website/app/services/head-data.js
@@ -16,4 +16,13 @@ export default class CustomHeadDataService extends HeadDataService {
       config['ember-meta'].description
     );
   }
+
+  get imgSrc() {
+    return this.currentRouteMeta?.id
+      ? `/assets/illustrations/${this.currentRouteMeta?.id.replace(
+          /\/index$/,
+          ''
+        )}.jpg`
+      : config['ember-meta'].imgSrc;
+  }
 }

--- a/website/app/templates/application.hbs
+++ b/website/app/templates/application.hbs
@@ -1,3 +1,5 @@
+<HeadLayout />
+
 {{page-title "Helios Design System"}}
 
 <div class="doc-page-wrapper">

--- a/website/app/templates/head.hbs
+++ b/website/app/templates/head.hbs
@@ -6,12 +6,7 @@ We've made some small customizations to simplify this compared to the default te
 
 }}
 
-{{! Begin General }}
-
-{{! TODO: Determine how to avoid this conflict between ember-meta and ember-page-title where they both set a <title> which causes the latter addon to throw an exception }}
-{{!-- {{#if this.model.title}}
-  <title>{{this.model.title}}</title>
-{{/if}} --}}
+{{! BEGIN GENERAL }}
 
 {{#if this.model.description}}
   <meta name="description" content={{this.model.description}} />
@@ -19,43 +14,26 @@ We've made some small customizations to simplify this compared to the default te
 
 <meta name="referrer" content="unsafe-url" />
 
-{{#if this.model.canonical}}
-  <link rel="canonical" href={{this.model.canonical}} />
-{{else if this.model.url}}
+{{#if this.model.url}}
   <link rel="canonical" href={{this.model.url}} />
-{{/if}}
-{{! End General }}
-
-{{! Begin Article }}
-{{!-- {{#if this.model.date}}
-  <meta property="article:published_time" content={{this.model.date}} />
+  <meta property="og:url" content={{this.model.url}} />
 {{/if}}
 
-{{#each this.model.tags as |tag|}}
-  <meta property="article:tag" content={{tag}} />
-{{/each}} --}}
-{{! End Article }}
+{{! END GENERAL }}
 
-{{! Begin opengraph (Facebook, Slack, etc) }}
+{{! BEGIN OPENGRAPH }}
+
 {{#if this.model.siteName}}
   <meta property="og:site_name" content={{this.model.siteName}} />
 {{/if}}
 
-{{#if (or this.model.articleTitle this.model.title)}}
-  <meta property="og:title" content={{if this.model.articleTitle this.model.articleTitle this.model.title}} />
-{{/if}}
-
-{{#if this.model.url}}
-  <meta property="og:url" content={{this.model.url}} />
+{{#if this.model.title}}
+  <meta property="og:title" content={{this.model.title}} />
 {{/if}}
 
 {{#if this.model.description}}
   <meta property="og:description" content={{this.model.description}} />
 {{/if}}
-
-{{!-- {{#if this.model.type}}
-  <meta property="og:type" content={{this.model.type}} />
-{{/if}} --}}
 
 {{#if this.model.imgSrc}}
   <meta property="og:image" content={{this.model.imgSrc}} />
@@ -63,22 +41,19 @@ We've made some small customizations to simplify this compared to the default te
   <meta property="og:image:width" content="256" />
   <meta property="og:image:height" content="256" />
 {{/if}}
-{{! End opengraph }}
 
-{{! Begin Twitter }}
+{{! END OPENGRAPH }}
+
+{{! BEGIN TWITTER }}
+
 <meta name="twitter:card" content="summary" />
-
-{{!-- {{#if this.model.twitterUsername}}
-  <meta name="twitter:site" content={{this.model.twitterUsername}} />
-  <meta name="twitter:creator" content={{this.model.twitterUsername}} />
-{{/if}} --}}
 
 {{#if this.model.imgSrc}}
   <meta name="twitter:image" content={{this.model.imgSrc}} />
 {{/if}}
 
-{{#if (or this.model.articleTitle this.model.title)}}
-  <meta name="twitter:title" content={{if this.model.articleTitle this.model.articleTitle this.model.title}} />
+{{#if this.model.title}}
+  <meta name="twitter:title" content={{this.model.title}} />
 {{/if}}
 
 {{#if this.model.url}}
@@ -88,3 +63,5 @@ We've made some small customizations to simplify this compared to the default te
 {{#if this.model.description}}
   <meta name="twitter:description" content={{this.model.description}} />
 {{/if}}
+
+{{! END TWITTER }}

--- a/website/app/templates/head.hbs
+++ b/website/app/templates/head.hbs
@@ -1,0 +1,90 @@
+{{!
+
+Per https://github.com/shipshapecode/ember-meta#defining-your-own-headhbs this is a place where we can customize what information is injected by the ember-meta addon
+
+We've made some small customizations to simplify this compared to the default template
+
+}}
+
+{{! Begin General }}
+
+{{! TODO: Determine how to avoid this conflict between ember-meta and ember-page-title where they both set a <title> which causes the latter addon to throw an exception }}
+{{!-- {{#if this.model.title}}
+  <title>{{this.model.title}}</title>
+{{/if}} --}}
+
+{{#if this.model.description}}
+  <meta name="description" content={{this.model.description}} />
+{{/if}}
+
+<meta name="referrer" content="unsafe-url" />
+
+{{#if this.model.canonical}}
+  <link rel="canonical" href={{this.model.canonical}} />
+{{else if this.model.url}}
+  <link rel="canonical" href={{this.model.url}} />
+{{/if}}
+{{! End General }}
+
+{{! Begin Article }}
+{{!-- {{#if this.model.date}}
+  <meta property="article:published_time" content={{this.model.date}} />
+{{/if}}
+
+{{#each this.model.tags as |tag|}}
+  <meta property="article:tag" content={{tag}} />
+{{/each}} --}}
+{{! End Article }}
+
+{{! Begin opengraph (Facebook, Slack, etc) }}
+{{#if this.model.siteName}}
+  <meta property="og:site_name" content={{this.model.siteName}} />
+{{/if}}
+
+{{#if (or this.model.articleTitle this.model.title)}}
+  <meta property="og:title" content={{if this.model.articleTitle this.model.articleTitle this.model.title}} />
+{{/if}}
+
+{{#if this.model.url}}
+  <meta property="og:url" content={{this.model.url}} />
+{{/if}}
+
+{{#if this.model.description}}
+  <meta property="og:description" content={{this.model.description}} />
+{{/if}}
+
+{{!-- {{#if this.model.type}}
+  <meta property="og:type" content={{this.model.type}} />
+{{/if}} --}}
+
+{{#if this.model.imgSrc}}
+  <meta property="og:image" content={{this.model.imgSrc}} />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:width" content="256" />
+  <meta property="og:image:height" content="256" />
+{{/if}}
+{{! End opengraph }}
+
+{{! Begin Twitter }}
+<meta name="twitter:card" content="summary" />
+
+{{!-- {{#if this.model.twitterUsername}}
+  <meta name="twitter:site" content={{this.model.twitterUsername}} />
+  <meta name="twitter:creator" content={{this.model.twitterUsername}} />
+{{/if}} --}}
+
+{{#if this.model.imgSrc}}
+  <meta name="twitter:image" content={{this.model.imgSrc}} />
+{{/if}}
+
+{{#if (or this.model.articleTitle this.model.title)}}
+  <meta name="twitter:title" content={{if this.model.articleTitle this.model.articleTitle this.model.title}} />
+{{/if}}
+
+{{#if this.model.url}}
+  <meta name="twitter:url" content={{this.model.url}} />
+{{/if}}
+
+{{#if this.model.description}}
+  <meta name="twitter:description" content={{this.model.description}} />
+{{/if}}

--- a/website/app/templates/show.hbs
+++ b/website/app/templates/show.hbs
@@ -1,5 +1,3 @@
-<HeadLayout />
-
 {{page-title this.title}}
 
 <Doc::Page::Stage>

--- a/website/config/environment.js
+++ b/website/config/environment.js
@@ -24,6 +24,13 @@ module.exports = function (environment) {
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],
     },
+
+    'ember-meta': {
+      description:
+        'Helios Design System provides the building blocks to design and implement consistent, accessible, and delightful product experiences across HashiCorp.',
+      siteName: 'Helios Design System',
+      title: 'Helios Design System',
+    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
### :pushpin: Summary

Configures some basic meta tags for use in SEO and social media

### :hammer_and_wrench: Detailed description
Sets up meta tags for the followin

* Description: Caption from frontmatter where it exists otherwise generic blurbe
* Images
  * Caveat: we don't currently have an image for pages without an illustration, but once we have our logos sorted out we can add one
 * Title
   * This is _complicated_. We use ember-page-title for the `<title>` title as it does a better job building up the titles as we traverse route.  This PR we use the `title` defined by ember-meta for the title used in the `og` attributes but **not** the `<title>`. It's definitely possible there's a better way to do this, but it's a solution I was able to make work.

One can use a site like https://www.opengraph.xyz/ to test this out


#### Note

I copied in the `head.hbs` template from the addon and commented out the aspects of I didn't think applied for our use case. If you think otherwise leave a comment and we can sort it out.

### :camera_flash: Screenshots
<img width="1170" alt="Screen Shot 2023-01-04 at 14 25 19" src="https://user-images.githubusercontent.com/1672302/210643471-397065f5-dc1b-4847-b609-e384a3774f84.png">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1114](https://hashicorp.atlassian.net/browse/HDS-1114)




[HDS-1114]: https://hashicorp.atlassian.net/browse/HDS-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ