### PR TITLE
use current-when to set active class in sidebar

### DIFF
--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -9,6 +9,7 @@
           @route="show"
           @model={{item.pageURL}}
           @query={{hash tab=null}}
+          @current-when={{"show"}}
         >
           {{item.pageAttributes.title}}
         </LinkTo>

--- a/website/tests/acceptance/component-query-test.js
+++ b/website/tests/acceptance/component-query-test.js
@@ -15,6 +15,10 @@ module('Acceptance | Component Tabs', function (hooks) {
       .dom('.doc-page-tabs__tab:nth-child(1)')
       .hasClass('doc-page-tabs__tab--is-current');
 
+    // Sidebar should show this component as the active "link"
+    assert.dom('.doc-table-of-contents__link.active').hasText('Alert');
+    assert.dom('.doc-table-of-contents__link.active').exists({ count: 1 });
+
     await click('#tab-code');
 
     assert
@@ -22,6 +26,10 @@ module('Acceptance | Component Tabs', function (hooks) {
       .doesNotHaveClass('doc-page-tabs__tab--is-current');
 
     assert.strictEqual(currentURL(), '/components/alert?tab=code');
+
+    // Sidebar should show this component as the active "link"
+    assert.dom('.doc-table-of-contents__link.active').hasText('Alert');
+    assert.dom('.doc-table-of-contents__link.active').exists({ count: 1 });
   });
 
   test('visiting a tabbed component page and interacting with tabs by specific tab', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

Fixes an issue where the sidebar did not indicate which item was currently actively being viewed.

### :hammer_and_wrench: Detailed description

[Per the ember docs](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)

> A link will be active if current-when is true **or the current route is the route this link would transition to**.

I'm honestly not 100% sure why this fixes the issue, but in my testing it seems like it does what we want.

#### How to test

* go to the website [preview](https://hds-website-git-br-current-hashicorp.vercel.app/)

* go to a component page (eg. [components/badge-count](https://hds-website-git-br-current-hashicorp.vercel.app//components/badge-count)) using the normal navigation

* see that Badge Count item is active (bolder) in the sidebar

* click on a tab of the page (eg. “Accessibility”) - the Badge Count item in the sidebar **should be active**


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1345](https://hashicorp.atlassian.net/browse/HDS-1345)


[HDS-1345]: https://hashicorp.atlassian.net/browse/HDS-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-1345]: https://hashicorp.atlassian.net/browse/HDS-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ