### PR TITLE
Add "try the beta" banner to old websites

### DIFF
--- a/flight-website/app/styles/app.css
+++ b/flight-website/app/styles/app.css
@@ -24,7 +24,7 @@
 * 1. extra specificity: because it's the docs site, we don't want naming collisions
 *    so there's a little extra specificity
 * 2. if it makes sense to extract a portion into a separate file, do that
-* 3. properties within classes are alphabetically sorted 
+* 3. properties within classes are alphabetically sorted
 * 4. custom CSS comes first, then Tailwind's `@apply`
 * 5. variables are stored in ./root
 */
@@ -74,6 +74,23 @@ main.ds-main {
 
   @apply
   font-bold;
+}
+
+.ds-beta-banner {
+  display: block;
+  max-width: fit-content;
+  margin: 1.25rem auto;
+  padding: 0.75rem 1.25rem;
+  color: #911ced;
+  font-family: var(--font-body);
+  font-size: 1rem;
+  line-height: 1.2;
+  background-color: #f9f2ff;
+  border-radius: 0.25rem;
+}
+
+.ds-beta-banner a {
+  color: inherit;
 }
 
 .ds-info {

--- a/flight-website/app/styles/app.css
+++ b/flight-website/app/styles/app.css
@@ -77,7 +77,6 @@ main.ds-main {
 }
 
 .ds-beta-banner {
-  display: block;
   max-width: fit-content;
   margin: 1.25rem auto;
   padding: 0.75rem 1.25rem;

--- a/flight-website/app/styles/app.css
+++ b/flight-website/app/styles/app.css
@@ -91,6 +91,7 @@ main.ds-main {
 
 .ds-beta-banner a {
   color: inherit;
+  text-decoration: underline;
 }
 
 .ds-info {

--- a/flight-website/app/templates/application.hbs
+++ b/flight-website/app/templates/application.hbs
@@ -5,7 +5,7 @@
   there is a new "beta" version of this website:
   <a href="https://hds-website-hashicorp.vercel.app/icons/library" target="_blank" rel="noopener noreferrer">do you want
     to try it?</a>
-  &nbsp; → &nbsp; Share your feedback in
+  → Share your feedback in
   <a
     href="https://hashicorp.slack.com/archives/C04F7TH6A8P "
     target="_blank"

--- a/flight-website/app/templates/application.hbs
+++ b/flight-website/app/templates/application.hbs
@@ -1,5 +1,8 @@
 {{page-title "Flight icons"}}
 <DsHeader />
+<div class="ds-beta-banner">
+  <strong>Notice</strong>: there is a new "beta" version of this website:
+  <a href="https://hds-website-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">do you want to try it?</a></div>
 <main class="ds-main">
   {{outlet}}
 </main>

--- a/flight-website/app/templates/application.hbs
+++ b/flight-website/app/templates/application.hbs
@@ -1,8 +1,10 @@
 {{page-title "Flight icons"}}
 <DsHeader />
 <div class="ds-beta-banner">
-  <strong>Notice</strong>: there is a new "beta" version of this website:
-  <a href="https://hds-website-hashicorp.vercel.app/icons/library" target="_blank" rel="noopener noreferrer">do you want to try it?</a>
+  <strong>Notice:</strong>
+  there is a new "beta" version of this website:
+  <a href="https://hds-website-hashicorp.vercel.app/icons/library" target="_blank" rel="noopener noreferrer">do you want
+    to try it?</a>
   &nbsp; → &nbsp; Share your feedback in
   <a
     href="https://hashicorp.slack.com/archives/C04F7TH6A8P "

--- a/flight-website/app/templates/application.hbs
+++ b/flight-website/app/templates/application.hbs
@@ -2,7 +2,13 @@
 <DsHeader />
 <div class="ds-beta-banner">
   <strong>Notice</strong>: there is a new "beta" version of this website:
-  <a href="https://hds-website-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">do you want to try it?</a></div>
+  <a href="https://hds-website-hashicorp.vercel.app/icons/library" target="_blank" rel="noopener noreferrer">do you want to try it?</a>
+  &nbsp; → &nbsp; Share your feedback in
+  <a
+    href="https://hashicorp.slack.com/archives/C04F7TH6A8P "
+    target="_blank"
+    rel="noopener noreferrer"
+  >#proj-ds-launch-feedback</a></div>
 <main class="ds-main">
   {{outlet}}
 </main>

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -67,6 +67,9 @@ body.dummy-app {
   background-color: #d9d9d9;
 
   .dummy-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     padding: 0.75rem;
     color: white;
     text-align: center;
@@ -75,6 +78,23 @@ body.dummy-app {
     .dummy-h1 {
       margin: 0 auto;
       padding: 0.5rem 1rem;
+    }
+
+    .dummy-beta-banner {
+      @include dummyFontFamily();
+      display: inline-block;
+      margin: 1.25rem auto;
+      padding: 0.75rem 1.25rem;
+      color: #911ced;
+      font-size: 1rem;
+      line-height: 1.2;
+      background-color: #f9f2ff;
+      // border: 1px solid #ead2fe;
+      border-radius: 0.25rem;
+
+      a {
+        color: inherit;
+      }
     }
   }
 

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -9,7 +9,7 @@
     <strong>Notice:</strong>
     there is a new "beta" version of this website:
     <a href="https://hds-website-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">do you want to try it?</a>
-    &nbsp; → &nbsp; Share your feedback in
+    → Share your feedback in
     <a
       href="https://hashicorp.slack.com/archives/C04F7TH6A8P "
       target="_blank"

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -5,6 +5,9 @@
     HashiCorp Design System (HDS)
   </h1>
   <DummyNpmVersion />
+  <div class="dummy-beta-banner">
+    <strong>Notice</strong>: there is a new "beta" version of this website:
+    <a href="https://hds-website-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">do you want to try it?</a></div>
 </header>
 
 {{outlet}}

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -6,7 +6,8 @@
   </h1>
   <DummyNpmVersion />
   <div class="dummy-beta-banner">
-    <strong>Notice</strong>: there is a new "beta" version of this website:
+    <strong>Notice:</strong>
+    there is a new "beta" version of this website:
     <a href="https://hds-website-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">do you want to try it?</a>
     &nbsp; → &nbsp; Share your feedback in
     <a

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -7,7 +7,13 @@
   <DummyNpmVersion />
   <div class="dummy-beta-banner">
     <strong>Notice</strong>: there is a new "beta" version of this website:
-    <a href="https://hds-website-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">do you want to try it?</a></div>
+    <a href="https://hds-website-hashicorp.vercel.app/" target="_blank" rel="noopener noreferrer">do you want to try it?</a>
+    &nbsp; → &nbsp; Share your feedback in
+    <a
+      href="https://hashicorp.slack.com/archives/C04F7TH6A8P "
+      target="_blank"
+      rel="noopener noreferrer"
+    >#proj-ds-launch-feedback</a></div>
 </header>
 
 {{outlet}}


### PR DESCRIPTION
### :pushpin: Summary

This PR adds a "try the beta" banner to the old websites ("scrappy" and "flight icons").

It's ready to be merged, when it's the right time.

Preview: 
- scrappy website: https://hds-components-git-old-websites-beta-banner-hashicorp.vercel.app/
- flight website: https://hds-flight-website-git-old-websites-beta-banner-hashicorp.vercel.app/

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1343

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1343]: https://hashicorp.atlassian.net/browse/HDS-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ