### PR TITLE
Update docs / Designer Best Practices

### DIFF
--- a/website/docs/getting-started/for-designers/index.md
+++ b/website/docs/getting-started/for-designers/index.md
@@ -6,10 +6,6 @@ title: Getting started for designers
     @include "partials/overview.md"
 </section>
 
-<section data-tab="Design language">
-    @include "partials/design-language.md"
-</section>
-
 <section data-tab="Setup guide">
     @include "partials/setup-guide.md"
 </section>

--- a/website/docs/getting-started/for-designers/index.md
+++ b/website/docs/getting-started/for-designers/index.md
@@ -1,5 +1,5 @@
 ---
-title: For designers
+title: Getting started for designers
 ---
 
 <section data-tab="Overview">

--- a/website/docs/getting-started/for-designers/index.md
+++ b/website/docs/getting-started/for-designers/index.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started for designers
+title: For designers
 ---
 
 <section data-tab="Overview">

--- a/website/docs/getting-started/for-designers/partials/best-practices.md
+++ b/website/docs/getting-started/for-designers/partials/best-practices.md
@@ -8,7 +8,7 @@ For documentation around broader Figma best practices within HashiCorp design te
 
 **What is structure?**
 
-Structure is the legacy design system used primarily by Cloud UI. It is no longer supported and being sunset.
+Structure is the legacy design system used primarily by Cloud UI. It is no longer supported and is being sunset.
 !!!
 
 Use this decision tree to understand when to use a component from Helios, from Structure, or when to create your own local component or pattern.
@@ -21,14 +21,14 @@ If the component or pattern exists in Helios, use it. This ensures it will be su
 
 ### Element exists in Structure
 
-If the component or pattern doesn't exist in Helios, but does exist in Structure, use the Structure version, but do so sparingly and with caution because:
+If the component or pattern doesn’t exist in Helios, but does exist in Structure, use the Structure version, but do so sparingly and with caution because:
 
 - Structure is no longer supported and is being sunset
 - Some Figma components are not built in code
 
-### Element doesn't exist in Helios or Structure
+### Element doesn’t exist in Helios or Structure
 
-If the component or pattern doesn't exist in Helios or in Structure, design and build your own local element using Helios foundations (color, typography, elevation, etc) as a starting point.
+If the component or pattern doesn’t exist in Helios or in Structure, design and build your own local element using Helios foundations (color, typography, elevation, etc) as a starting point.
 
 ## Working with Components
 
@@ -49,14 +49,14 @@ If you find that a component doesn’t meet your needs, reach out to us for [sup
 
 ### Overriding component styles
 
-While styles in Helios Figma components can technically be overwritten without detaching the component, we recommend against doing this prior to consulting the Design System Team. It may seem simple to change the color or the font size within a Figma component, but this can have trickle-down effects in code.
+While styles in Helios Figma components can technically be overwritten without detaching the component, we recommend against doing this prior to consulting the Design Systems Team. It may seem simple to change the color or the font size within a Figma component, but this can have trickle-down effects in code.
 
 - It forces engineers to create custom classes and styles to override Helios styles. This can have unexpected long-term effects within the [CSS cascade](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#:~:text=The%20cascade%20is%20an%20algorithm,a%20property%20on%20an%20element).
 - In addition to being difficult to scale, overrides nudge the visual language of your product out of sync with Helios and with the rest of the HashiCorp product line.
 
 ### Resizing components
 
-Helios components are designed and built to layout-agnostic, meaning the task of laying out components in a design is left to the consumer.
+Helios components are designed and built to be layout-agnostic, meaning the task of laying out components in a design is left to the consumer.
 
 Unless specifically mentioned in the documentation, the component in code will fill the parent container it is used in. For designers, it's helpful to use [auto layout](https://help.figma.com/hc/en-us/articles/5731482952599-Using-auto-layout#:~:text=You%20can%20add%20auto%20layout%20to%20a%20selected%20frame%2C%20component,and%20select%20Add%20Auto%20layout) wherever possible which closely mimics [CSS Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) and other layout mechanisms in the browser. Helios Figma components are flexible and can be set to `fill container` within an auto layout container, which replicates the experience of a development environment.
 
@@ -67,9 +67,9 @@ Unless specifically mentioned in the documentation, the component in code will f
 Setting a component to a fixed width in Figma is akin to setting an explicit `width` value on a component or element in code. This generally goes against fluid and responsive best practices and should be avoided in Figma. Instead, use auto layout wherever possible.
 !!!
 
-## Working with foundations (styles)
+## Working with foundations
 
-Similar to components, using styles defined in the Helios [Product Foundations](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?t=4kdgl88SMIiEYhbA-1) reinforces consistency and can help to resolve problems with style usage and implementation. Detaching from Helios styles is not recommended in most circumstances.
+Similar to components, using the foundational styles defined in the Helios [Product Foundations](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?t=4kdgl88SMIiEYhbA-1) library reinforces consistency and can help to resolve problems with style usage and implementation. We don't recommend detaching from Helios styles in most circumstances.
 
 Helios publishes a set of **semantic** styles and tokens that are labeled with their intended usage. For example:
 
@@ -81,7 +81,7 @@ At this time, color styles are the only category for which semantic tokens are a
 
 ### Palette color styles
 
-When choosing what color style to use in your design, we recommend starting with semantic styles as their usage is clearly defined and common color pairings are accessible out of the box. If you don't find a semantic style that meets your needs, a set of base `Palette` styles that are labeled with a numerical scale are also available. These styles are usage agnostic which can introduce challenges in consistently scaling a complex design, but allow more freedom and flexibility in color pairing.
+When choosing what color style to use in your design, we recommend starting with semantic styles as their usage is clearly defined and common color pairings are accessible out of the box. If you don’t find a semantic style that meets your needs, a set of base `Palette` styles that are labeled with a numerical scale are also available. These styles are usage agnostic which can introduce challenges in consistently scaling a complex design, but allow more freedom and flexibility in color pairing.
 
 For more information and details on styles and their intended usage, visit [foundations](/foundations).
 
@@ -91,11 +91,11 @@ Components and patterns that are unique to your product should be designed and b
 
 ![Local component patterns](/assets/getting-started/designers/local-component-patterns.png)
 
-When creating your own library of local components to use in your projects, it's helpful to separate components from your main design work in their own Figma file. This simplifies library publishing and creates a single consistent dependency for your design files. For more information on creating and publishing libraries, visit [Figma's official documentation.](https://www.figma.com/best-practices/components-styles-and-shared-libraries/organizing-and-creating-libraries/)
+When creating your own library of local components to use in your projects, it’s helpful to separate components from your main design work in their own Figma file. This simplifies library publishing and creates a single consistent dependency for your design files. For more information on creating and publishing libraries, visit [Figma’s official documentation.](https://www.figma.com/best-practices/components-styles-and-shared-libraries/organizing-and-creating-libraries/)
 
 !!! Info
 
 When designing and building local components, consider [Atomic Design](https://bradfrost.com/blog/post/atomic-web-design/) methods whenever possible. Helios components generally correspond with the `atom` and `molecule` levels, with some more complex components being considered `organisms`.
 !!!
 
-We've spent much of the past year building lower level components, and therefore, don't yet offer <LinkTo class="doc-link-generic" @route="patterns">patterns</LinkTo>. See which patterns we plan to work on in the [Helios roadmap](https://go.hashi.co/hds-rollout).
+We’ve spent much of the past year building lower level components, and therefore, don't yet offer <LinkTo class="doc-link-generic" @route="patterns">patterns</LinkTo>. See which patterns we plan to work on in the [Helios roadmap](https://go.hashi.co/hds-rollout).

--- a/website/docs/getting-started/for-designers/partials/best-practices.md
+++ b/website/docs/getting-started/for-designers/partials/best-practices.md
@@ -1,40 +1,15 @@
-Figma is an incredibly versatile tool, but this versatility can sometimes backfire leading to disorganization, inconsistency, and difficulty in handoffs and collaboration. Use these best practices to better organize your designs and use the components and styles provided by the design system effectively.
-
-!!! Info
-
-These best practices have been curated by the Design Systems Team, Figma has its own set of [best practices](https://www.figma.com/best-practices/) for using the tool effectively.
-
-!!!
-
-**Note:** Much of this already exists from Design Ops, waiting to collaborate with them on the content.
-
-## File hygiene
-
-- Use a cover photo
-- Differentiate between delivered work, and work in progress
-
-### Naming conventions
-
-Naming things is hard, and while naming components and elements within a design system is often different from naming elements further down the UX funnel, the same best practices can be applied.
-
-!!! Insight
-
-Whatever method you choose to use, the most important thing is maintaining a consistent naming strategy across projects, files, and components.
-
-!!!
-
-#### Teams, projects, files, and pages
-
-- Figma **teams** should match the product name or where the team sits in the larger corporate organizational structure (i.e. Waypoint, or HCP Waypoint).
-- **Projects**, since they act as a sort of folder structure within Figma, should be named in an organizational/directory manner. For example: "Work in progress", "Delivered", "Library" (for local components and patterns).
-- **File** names should match the epic or project name used in Jira, or as specific sub-categories within a local library or template.
-- **Pages** should be named after specific flows or features, as core deliverables, or as specific components or patterns.
-
-#### Components, variants, and styles
+Figma is an incredibly versatile tool, but this versatility can sometimes backfire leading to disorganization, inconsistency, and difficulty in handoffs and collaboration. These best practices are geared towards using Helios components and foundations effectively, for documentation around broader Figma best practices within HashiCorp design teams, reach out to the HashiCorp [Design Ops team](https://sites.google.com/hashicorp.com/designknowledgehub/design-system) or visit the [#design-ops slack channel](https://hashicorp.slack.com/archives/C029GL8GJDV).
 
 ## Component availability
 
-We are in the process of sunsetting [Structure](https://github.com/hashicorp/structure). As we work to achieve parity between Structure and the Helios Design System, use this decision tree to understand how to move forward within your project:
+!!! Info
+
+**Structure** is the legacy set of components and foundations used to connect HashiCorp products. It is no longer supported and is in the process of deprecation and sunsetting.
+!!!
+
+[Structure](https://github.com/hashicorp/structure) consists of a package of Ember components and foundational styles paired with a limited set of Figma counterparts.
+
+As we work to achieve parity between Structure and Helios, use this decision tree to understand how to move forward within your project:
 
 ![Decision tree flow chart](/assets/getting-started/designers/hds-decision-tree.png)
 
@@ -60,12 +35,56 @@ Functions and experiences that are unique to your product should be designed and
 
 <LinkTo class="doc-link-generic" @route="patterns">Patterns</LinkTo> and guidance around combining and extending Helios components are not currently supported, but are on our [roadmap](https://go.hashi.co/hds-rollout)
 
+!!! Insight
+
+When creating your own library of local components to use in your projects, it's helpful to separate the components from the main design file in their own Figma file. This simplifies publishing and creates a single consistent dependency for your design files. For more information on creating and publishing libraries, visit [Figma's official documentation.](https://www.figma.com/best-practices/components-styles-and-shared-libraries/organizing-and-creating-libraries/)
+!!!
+
 ## Component instances & detaching
 
-A component inserted from a library into a project is referred to as an **instance**. Instances maintain a link to the main component in the library, which has significant benefits for deploying components and iterating quickly.
+A component inserted from a library into a project is referred to as an **instance**. Instances maintain a link to the main component in the library, which has significant benefits for deploying updates and iterating quickly on components.
 
 Our Figma components are coupled closely with their code counterparts to maintain consistency in the API and design language. In most scenarios, we don’t recommend detaching a component or foundation from the library. If you find that a component doesn’t meet your needs, reach out to us for [support](/support) or [submit a request](https://docs.google.com/forms/d/e/1FAIpQLScpMXgrUTVT5fYriu4Pp48r4Nl_eCPluVnJLg0Yg3NXsRWvIA/viewform) for a new component, foundation, or feature.
 
 ### Why to avoid detaching components
 
 When you detach a component, that component will no longer receive updates when new features or changes are published in the library. This can cause Figma projects and production applications to drift out of sync quickly. This can introduce tech debt and complex updates in the future. It can be avoided by working closely with the Design Systems Team and learning how to extend components as necessary.
+
+### Overriding component styles
+
+While styles in Helios Figma components can technically be overwritten without detaching the component, we recommend against doing this prior to consulting the Design System Team. It may seem simple to change the color or the font size within a Figma component, but this can have drastic trickle-down effects in code.
+
+- It forces engineers to create custom classes and styles to override Helios styles. This can have unexpected long-term effects within the [CSS cascade](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#:~:text=The%20cascade%20is%20an%20algorithm,a%20property%20on%20an%20element).
+- While difficult to scale in the long-term, overrides nudge the visual language of your product out of sync with Helios and with the rest of the HashiCorp product line.
+
+### Resizing components
+
+Helios components are designed and build to be as layout-agnostic as possible, meaning the task of laying out components is left to the consumer.
+
+Unless specifically mentioned in the documentation, the component in code will fill the parent container it is used in. For designers, it's useful to use [auto layout](https://help.figma.com/hc/en-us/articles/5731482952599-Using-auto-layout#:~:text=You%20can%20add%20auto%20layout%20to%20a%20selected%20frame%2C%20component,and%20select%20Add%20Auto%20layout) wherever possible, Helios Figma components are flexible and can be set to `fill container` within an auto layout container, which will closely replicate the experience in a development environment.
+
+!!! Warning
+
+**Fixed width components:** Setting a component to a fixed width in Figma is akin to setting an explicit `width` value on a component or element in code. This generally goes against fluid and responsive development best practices and should therefore be avoided in Figma. Instead, use auto layout wherever possible.
+!!!
+
+## Figma styles
+
+Similar to components, using styles defined in the Helios [Product Foundations](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?t=4kdgl88SMIiEYhbA-1) reinforces consistency and can help to resolve problems with style usage and implementation. Detatching from Helios styles is not recommended in most circumstances.
+
+To assist in usage and implementation of Helios styles we publish a set of **semantic** styles and tokens that are labeled with their intended usage. For example:
+
+- `Surface / Primary` would be used as the main (or surface) background color of a component.
+- `Foreground / Primary` would be used for primary text elements with a component or page.
+- `Foreground / Action` would be used for an actionable or interactive element within a component or page (i.e. a [Link](/components/link/standalone), or primary [Button](/components/button))
+
+!!! Info
+
+At this time color styles are the only category in which semantic tokens are available. Semantic styles and tokens have yet to be defined for typography and border.
+!!!
+
+### Palette color styles
+
+When choosing what color style to use in your design, we recommend starting with semantic styles as their usage is clearly defined. If you don't find a semantic style that meets your needs, we make available a set of base `Palette` styles that are labeled with a numerical scale. While these styles are more usage agnostic, this can introduce challenges in consistently scaling a complex design.
+
+For more information and details on styles and their intended usage visit [foundations](/foundations).

--- a/website/docs/getting-started/for-designers/partials/best-practices.md
+++ b/website/docs/getting-started/for-designers/partials/best-practices.md
@@ -1,6 +1,6 @@
-Effectively use Helios components and foundations with these best practices.
+Effectively use Helios components and foundations by following these best practices.
 
-For documentation around & broader Figma best practices within HashiCorp design teams, reach out to the HashiCorp [Design Ops team](https://sites.google.com/hashicorp.com/designknowledgehub/design-system) or visit the [#design-ops slack channel](https://hashicorp.slack.com/archives/C029GL8GJDV).
+For documentation around broader Figma best practices within HashiCorp design teams, reach out to the HashiCorp [Design Ops team](https://sites.google.com/hashicorp.com/designknowledgehub/design-system) or visit the [#design-ops slack channel](https://hashicorp.slack.com/archives/C029GL8GJDV).
 
 ## When to use Helios
 
@@ -8,7 +8,7 @@ For documentation around & broader Figma best practices within HashiCorp design 
 
 **What is structure?**
 
-Structure is the legacy design system used primarily by Cloud UI. Structure is no longer supported and we're in the process of sunsetting it.
+Structure is the legacy design system used primarily by Cloud UI. It is no longer supported and being sunset.
 !!!
 
 Use this decision tree to understand when to use a component from Helios, from Structure, or when to create your own local component or pattern.
@@ -17,11 +17,11 @@ Use this decision tree to understand when to use a component from Helios, from S
 
 ### Element exists in Helios
 
-If the component or pattern exists in Helios, use it. This ensures it will be supported in future versions of Helios and that it shares a common visiual language with the rest of the elements.
+If the component or pattern exists in Helios, use it. This ensures it will be supported in future versions of Helios and that it shares a common visual language with the rest of the elements.
 
 ### Element exists in Structure
 
-If the component or pattern doesn't exist in Helios, but does exist in Structure, use the Structure version. Use Structure sparingly and with caution because:
+If the component or pattern doesn't exist in Helios, but does exist in Structure, use the Structure version, but do so sparingly and with caution because:
 
 - Structure is no longer supported and is being sunset
 - Some Figma components are not built in code
@@ -32,17 +32,17 @@ If the component or pattern doesn't exist in Helios or in Structure, design and 
 
 ## Working with Components
 
-A component inserted from a library into a project is referred to as an **instance**. Instances maintain a link to the main component in the library, which has significant benefits for deploying updates and iterating quickly on components.
+A component inserted from a library into a project is referred to as an [instance](https://help.figma.com/hc/en-us/articles/360039150173-Create-and-insert-component-instances). Instances maintain a link to the main component in the library, which has significant benefits for deploying updates and iterating quickly on components.
 
 ### Detaching components
 
-Our Figma components are coupled closely with their code counterparts to maintain consistency in the API and design language, so in most scenarios, we don’t recommend detaching a component or foundation from the library.
+Our Figma components are coupled tightly with their code counterparts to maintain consistency in the API and design language, so in most scenarios, we don’t recommend detaching a component or foundation from the library.
 
 !!! Info
 
 **Why to avoid detaching components**
 
-When you detach a component, it no longer receives updates from the library. This can cause designs production applications to drift out of sync quickly.
+When you detach a component, it no longer receives updates from the library. This can cause designs and production applications to drift out of sync quickly.
 !!!
 
 If you find that a component doesn’t meet your needs, reach out to us for [support](/support) or [submit a request](https://docs.google.com/forms/d/e/1FAIpQLScpMXgrUTVT5fYriu4Pp48r4Nl_eCPluVnJLg0Yg3NXsRWvIA/viewform) for a new component, foundation, or feature.
@@ -52,17 +52,19 @@ If you find that a component doesn’t meet your needs, reach out to us for [sup
 While styles in Helios Figma components can technically be overwritten without detaching the component, we recommend against doing this prior to consulting the Design System Team. It may seem simple to change the color or the font size within a Figma component, but this can have trickle-down effects in code.
 
 - It forces engineers to create custom classes and styles to override Helios styles. This can have unexpected long-term effects within the [CSS cascade](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#:~:text=The%20cascade%20is%20an%20algorithm,a%20property%20on%20an%20element).
-- While being difficult to scale, overrides nudge the visual language of your product out of sync with Helios and with the rest of the HashiCorp product line.
+- In addition to being difficult to scale, overrides nudge the visual language of your product out of sync with Helios and with the rest of the HashiCorp product line.
 
 ### Resizing components
 
-Helios components are designed and built to be as layout-agnostic as possible, meaning the task of laying out components is left to the consumer.
+Helios components are designed and built to layout-agnostic, meaning the task of laying out components in a design is left to the consumer.
 
-Unless specifically mentioned in the documentation, the component in code will fill the parent container it is used in. For designers, it's helpful to use [auto layout](https://help.figma.com/hc/en-us/articles/5731482952599-Using-auto-layout#:~:text=You%20can%20add%20auto%20layout%20to%20a%20selected%20frame%2C%20component,and%20select%20Add%20Auto%20layout) wherever possible which closely mimics [CSS Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/). Helios Figma components are flexible and can be set to `fill container` within an auto layout container, which will closely replicate the experience in a development environment.
+Unless specifically mentioned in the documentation, the component in code will fill the parent container it is used in. For designers, it's helpful to use [auto layout](https://help.figma.com/hc/en-us/articles/5731482952599-Using-auto-layout#:~:text=You%20can%20add%20auto%20layout%20to%20a%20selected%20frame%2C%20component,and%20select%20Add%20Auto%20layout) wherever possible which closely mimics [CSS Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) and other layout mechanisms in the browser. Helios Figma components are flexible and can be set to `fill container` within an auto layout container, which replicates the experience of a development environment.
 
 !!! Warning
 
-**Fixed width components:** Setting a component to a fixed width in Figma is akin to setting an explicit `width` value on a component or element in code. This generally goes against fluid and responsive development best practices and should be avoided in Figma. Instead, use auto layout wherever possible.
+**Fixed width components**
+
+Setting a component to a fixed width in Figma is akin to setting an explicit `width` value on a component or element in code. This generally goes against fluid and responsive best practices and should be avoided in Figma. Instead, use auto layout wherever possible.
 !!!
 
 ## Working with foundations (styles)
@@ -73,13 +75,13 @@ Helios publishes a set of **semantic** styles and tokens that are labeled with t
 
 - `Surface / Primary` would be used as the main (or surface) background color of a component.
 - `Foreground / Primary` would be used for primary text elements or elements that sit on top of a surface background.
-- `Foreground / Action` would be used for an actionable or interactive element within a component or page (i.e. a [Link](/components/link/standalone), or primary [Button](/components/button))
+- `Foreground / Action` would be used for an actionable or interactive element within a component or page (i.e. a [Link](/components/link/standalone))
 
 At this time, color styles are the only category for which semantic tokens are available. Semantic styles and tokens have yet to be defined for typography and borders.
 
 ### Palette color styles
 
-When choosing what color style to use in your design, we recommend starting with semantic styles as their usage is clearly defined. If you don't find a semantic style that meets your needs, a set of base `Palette` styles that are labeled with a numerical scale are also available. These styles are more usage agnostic which can introduce challenges in consistently scaling a complex design.
+When choosing what color style to use in your design, we recommend starting with semantic styles as their usage is clearly defined and common color pairings are accessible out of the box. If you don't find a semantic style that meets your needs, a set of base `Palette` styles that are labeled with a numerical scale are also available. These styles are usage agnostic which can introduce challenges in consistently scaling a complex design, but allow more freedom and flexibility in color pairing.
 
 For more information and details on styles and their intended usage, visit [foundations](/foundations).
 
@@ -89,7 +91,7 @@ Components and patterns that are unique to your product should be designed and b
 
 ![Local component patterns](/assets/getting-started/designers/local-component-patterns.png)
 
-When creating your own library of local components to use in your projects, it's helpful to separate components from your main design work in their own Figma file. This simplifies publishing and creates a single consistent dependency for your design files. For more information on creating and publishing libraries, visit [Figma's official documentation.](https://www.figma.com/best-practices/components-styles-and-shared-libraries/organizing-and-creating-libraries/)
+When creating your own library of local components to use in your projects, it's helpful to separate components from your main design work in their own Figma file. This simplifies library publishing and creates a single consistent dependency for your design files. For more information on creating and publishing libraries, visit [Figma's official documentation.](https://www.figma.com/best-practices/components-styles-and-shared-libraries/organizing-and-creating-libraries/)
 
 !!! Info
 

--- a/website/docs/getting-started/for-designers/partials/best-practices.md
+++ b/website/docs/getting-started/for-designers/partials/best-practices.md
@@ -1,6 +1,6 @@
 Below are best practices for using Helios components and foundations effectively.
 
-For documentation around broader Figma best practices within HashiCorp design teams, reach out to the HashiCorp [Design Ops team](https://sites.google.com/hashicorp.com/designknowledgehub/design-system) or visit the [#design-ops slack channel](https://hashicorp.slack.com/archives/C029GL8GJDV).
+For documentation around & broader Figma best practices within HashiCorp design teams, reach out to the HashiCorp [Design Ops team](https://sites.google.com/hashicorp.com/designknowledgehub/design-system) or visit the [#design-ops slack channel](https://hashicorp.slack.com/archives/C029GL8GJDV).
 
 ## When to use Helios
 
@@ -34,7 +34,7 @@ If the component or pattern doesn't exist in Helios or in Structure, design and 
 
 A component inserted from a library into a project is referred to as an **instance**. Instances maintain a link to the main component in the library, which has significant benefits for deploying updates and iterating quickly on components.
 
-## Detaching components
+### Detaching components
 
 Our Figma components are coupled closely with their code counterparts to maintain consistency in the API and design language, so in most scenarios, we don’t recommend detaching a component or foundation from the library.
 
@@ -75,15 +75,15 @@ Helios publishes a set of **semantic** styles and tokens that are labeled with t
 - `Foreground / Primary` would be used for primary text elements or elements that sit on top of a surface background.
 - `Foreground / Action` would be used for an actionable or interactive element within a component or page (i.e. a [Link](/components/link/standalone), or primary [Button](/components/button))
 
-At this time color styles are the only category for which semantic tokens are available. Semantic styles and tokens have yet to be defined for typography and border.
+At this time, color styles are the only category for which semantic tokens are available. Semantic styles and tokens have yet to be defined for typography and borders.
 
 ### Palette color styles
 
 When choosing what color style to use in your design, we recommend starting with semantic styles as their usage is clearly defined. If you don't find a semantic style that meets your needs, a set of base `Palette` styles that are labeled with a numerical scale are also available. These styles are more usage agnostic which can introduce challenges in consistently scaling a complex design.
 
-For more information and details on styles and their intended usage visit [foundations](/foundations).
+For more information and details on styles and their intended usage, visit [foundations](/foundations).
 
-### Designing local components
+## Designing local components
 
 Components and patterns that are unique to your product should be designed and built locally, extending Helios components and foundations.
 
@@ -93,7 +93,7 @@ When creating your own library of local components to use in your projects, it's
 
 !!! Info
 
-When design and building local components, consider [Atomic Design](https://bradfrost.com/blog/post/atomic-web-design/) methods whenever possible. Helios components generally correspond with the `atom` and `molecule` levels, with some more complex components being considered `organisms`.
+When designing and building local components, consider [Atomic Design](https://bradfrost.com/blog/post/atomic-web-design/) methods whenever possible. Helios components generally correspond with the `atom` and `molecule` levels, with some more complex components being considered `organisms`.
 !!!
 
-<LinkTo class="doc-link-generic" @route="patterns">Patterns</LinkTo> and guidance around combining and extending Helios components are not currently supported, but are on our [roadmap](https://go.hashi.co/hds-rollout).
+We've spent much of the past year building lower level components, and therefore, don't yet offer <LinkTo class="doc-link-generic" @route="patterns">patterns</LinkTo>. See which patterns we plan to work on in the [Helios roadmap](https://go.hashi.co/hds-rollout).

--- a/website/docs/getting-started/for-designers/partials/best-practices.md
+++ b/website/docs/getting-started/for-designers/partials/best-practices.md
@@ -1,4 +1,4 @@
-Below are best practices for using Helios components and foundations effectively.
+Effectively use Helios components and foundations with these best practices.
 
 For documentation around & broader Figma best practices within HashiCorp design teams, reach out to the HashiCorp [Design Ops team](https://sites.google.com/hashicorp.com/designknowledgehub/design-system) or visit the [#design-ops slack channel](https://hashicorp.slack.com/archives/C029GL8GJDV).
 

--- a/website/docs/getting-started/for-designers/partials/best-practices.md
+++ b/website/docs/getting-started/for-designers/partials/best-practices.md
@@ -29,16 +29,18 @@ If no, or having future support is a must: design and build your own local eleme
 
 ### Local components
 
-Functions and experiences that are unique to your product should be designed and built locally, extending Helios components and foundations.
+Compoents and patterns that are unique to your product should be designed and built locally, extending Helios components and foundations.
 
 ![Local component patterns](/assets/getting-started/designers/local-component-patterns.png)
 
-<LinkTo class="doc-link-generic" @route="patterns">Patterns</LinkTo> and guidance around combining and extending Helios components are not currently supported, but are on our [roadmap](https://go.hashi.co/hds-rollout)
+<LinkTo class="doc-link-generic" @route="patterns">Patterns</LinkTo> and guidance around combining and extending Helios components are not currently supported, but are on our [roadmap](https://go.hashi.co/hds-rollout).
 
 !!! Insight
 
 When creating your own library of local components to use in your projects, it's helpful to separate the components from the main design file in their own Figma file. This simplifies publishing and creates a single consistent dependency for your design files. For more information on creating and publishing libraries, visit [Figma's official documentation.](https://www.figma.com/best-practices/components-styles-and-shared-libraries/organizing-and-creating-libraries/)
 !!!
+
+When design and building local components, consider [Atomic Design](https://bradfrost.com/blog/post/atomic-web-design/) methods whenever possible. Helios components generally correspond with the `atom` and `molecule` levels, with some more complex components being considered `organisms`.
 
 ## Component instances & detaching
 

--- a/website/docs/getting-started/for-designers/partials/best-practices.md
+++ b/website/docs/getting-started/for-designers/partials/best-practices.md
@@ -1,23 +1,18 @@
-Figma is an incredibly versatile tool, but this versatility can sometimes backfire leading to disorganization, inconsistency, and difficulty in handoffs and collaboration. These best practices are geared towards using Helios components and foundations effectively, for documentation around broader Figma best practices within HashiCorp design teams, reach out to the HashiCorp [Design Ops team](https://sites.google.com/hashicorp.com/designknowledgehub/design-system) or visit the [#design-ops slack channel](https://hashicorp.slack.com/archives/C029GL8GJDV).
+Figma is an incredibly versatile tool, but this versatility can sometimes backfire leading to disorganization, inconsistency, and difficulty in handoffs and collaboration. These best practices are geared towards using Helios components and foundations effectively to alleviate some of these challenges. For documentation around broader Figma best practices within HashiCorp design teams, reach out to the HashiCorp [Design Ops team](https://sites.google.com/hashicorp.com/designknowledgehub/design-system) or visit the [#design-ops slack channel](https://hashicorp.slack.com/archives/C029GL8GJDV).
 
 ## Component availability
 
-!!! Info
-
-**Structure** is the legacy set of components and foundations used to connect HashiCorp products. It is no longer supported and is in the process of deprecation and sunsetting.
-!!!
-
-[Structure](https://github.com/hashicorp/structure) consists of a package of Ember components and foundational styles paired with a limited set of Figma counterparts.
+**Structure** is the legacy set of components and foundations used to connect HashiCorp products and consists Ember components and foundational styles paired with a limited set of Figma counterparts. **Structure is no longer supported and is in the process of deprecation and sunsetting.**
 
 As we work to achieve parity between Structure and Helios, use this decision tree to understand how to move forward within your project:
 
 ![Decision tree flow chart](/assets/getting-started/designers/hds-decision-tree.png)
 
-**Does the element (or a comparible alternative) exist in Helios?**
+**Does the element (or a comparable alternative) exist in Helios?**
 
 If so, great! Using this element ensures it will be supported in future versions of Helios and that it shares a common visual language with the rest of the elements.
 
-**If no, does the element (or a comparible alternative) exist in Structure?**
+**If no, does the element (or a comparable alternative) exist in Structure?**
 
 If yes, use this component with the understanding that:
 
@@ -29,7 +24,7 @@ If no, or having future support is a must: design and build your own local eleme
 
 ### Local components
 
-Compoents and patterns that are unique to your product should be designed and built locally, extending Helios components and foundations.
+Components and patterns that are unique to your product should be designed and built locally, extending Helios components and foundations.
 
 ![Local component patterns](/assets/getting-started/designers/local-component-patterns.png)
 
@@ -37,7 +32,7 @@ Compoents and patterns that are unique to your product should be designed and bu
 
 !!! Insight
 
-When creating your own library of local components to use in your projects, it's helpful to separate the components from the main design file in their own Figma file. This simplifies publishing and creates a single consistent dependency for your design files. For more information on creating and publishing libraries, visit [Figma's official documentation.](https://www.figma.com/best-practices/components-styles-and-shared-libraries/organizing-and-creating-libraries/)
+When creating your own library of local components to use in your projects, it's helpful to separate components from your main design work in their own Figma file. This simplifies publishing and creates a single consistent dependency for your design files. For more information on creating and publishing libraries, visit [Figma's official documentation.](https://www.figma.com/best-practices/components-styles-and-shared-libraries/organizing-and-creating-libraries/)
 !!!
 
 When design and building local components, consider [Atomic Design](https://bradfrost.com/blog/post/atomic-web-design/) methods whenever possible. Helios components generally correspond with the `atom` and `molecule` levels, with some more complex components being considered `organisms`.
@@ -50,43 +45,43 @@ Our Figma components are coupled closely with their code counterparts to maintai
 
 ### Why to avoid detaching components
 
-When you detach a component, that component will no longer receive updates when new features or changes are published in the library. This can cause Figma projects and production applications to drift out of sync quickly. This can introduce tech debt and complex updates in the future. It can be avoided by working closely with the Design Systems Team and learning how to extend components as necessary.
+When you detach a component, that component will no longer receive updates when new features or changes are published in the library. This can cause Figma projects and production applications to drift out of sync quickly and introduce tech debt in the future. This can be avoided by working closely with the Design Systems Team and learning how to extend components as necessary to meet your needs.
 
 ### Overriding component styles
 
 While styles in Helios Figma components can technically be overwritten without detaching the component, we recommend against doing this prior to consulting the Design System Team. It may seem simple to change the color or the font size within a Figma component, but this can have drastic trickle-down effects in code.
 
 - It forces engineers to create custom classes and styles to override Helios styles. This can have unexpected long-term effects within the [CSS cascade](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#:~:text=The%20cascade%20is%20an%20algorithm,a%20property%20on%20an%20element).
-- While difficult to scale in the long-term, overrides nudge the visual language of your product out of sync with Helios and with the rest of the HashiCorp product line.
+- While being difficult to scale, overrides nudge the visual language of your product out of sync with Helios and with the rest of the HashiCorp product line.
 
 ### Resizing components
 
-Helios components are designed and build to be as layout-agnostic as possible, meaning the task of laying out components is left to the consumer.
+Helios components are designed and built to be as layout-agnostic as possible, meaning the task of laying out components is left to the consumer.
 
-Unless specifically mentioned in the documentation, the component in code will fill the parent container it is used in. For designers, it's useful to use [auto layout](https://help.figma.com/hc/en-us/articles/5731482952599-Using-auto-layout#:~:text=You%20can%20add%20auto%20layout%20to%20a%20selected%20frame%2C%20component,and%20select%20Add%20Auto%20layout) wherever possible, Helios Figma components are flexible and can be set to `fill container` within an auto layout container, which will closely replicate the experience in a development environment.
+Unless specifically mentioned in the documentation, the component in code will fill the parent container it is used in. For designers, it's helpful to use [auto layout](https://help.figma.com/hc/en-us/articles/5731482952599-Using-auto-layout#:~:text=You%20can%20add%20auto%20layout%20to%20a%20selected%20frame%2C%20component,and%20select%20Add%20Auto%20layout) wherever possible which closely mimics [CSS Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/). Helios Figma components are flexible and can be set to `fill container` within an auto layout container, which will closely replicate the experience in a development environment.
 
 !!! Warning
 
-**Fixed width components:** Setting a component to a fixed width in Figma is akin to setting an explicit `width` value on a component or element in code. This generally goes against fluid and responsive development best practices and should therefore be avoided in Figma. Instead, use auto layout wherever possible.
+**Fixed width components:** Setting a component to a fixed width in Figma is akin to setting an explicit `width` value on a component or element in code. This generally goes against fluid and responsive development best practices and should be avoided in Figma. Instead, use auto layout wherever possible.
 !!!
 
 ## Figma styles
 
-Similar to components, using styles defined in the Helios [Product Foundations](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?t=4kdgl88SMIiEYhbA-1) reinforces consistency and can help to resolve problems with style usage and implementation. Detatching from Helios styles is not recommended in most circumstances.
+Similar to components, using styles defined in the Helios [Product Foundations](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?t=4kdgl88SMIiEYhbA-1) reinforces consistency and can help to resolve problems with style usage and implementation. Detaching from Helios styles is not recommended in most circumstances.
 
-To assist in usage and implementation of Helios styles we publish a set of **semantic** styles and tokens that are labeled with their intended usage. For example:
+Helios publishes a set of **semantic** styles and tokens that are labeled with their intended usage. For example:
 
 - `Surface / Primary` would be used as the main (or surface) background color of a component.
-- `Foreground / Primary` would be used for primary text elements with a component or page.
+- `Foreground / Primary` would be used for primary text elements or elements that sit on top of a surface background.
 - `Foreground / Action` would be used for an actionable or interactive element within a component or page (i.e. a [Link](/components/link/standalone), or primary [Button](/components/button))
 
 !!! Info
 
-At this time color styles are the only category in which semantic tokens are available. Semantic styles and tokens have yet to be defined for typography and border.
+At this time color styles are the only category for which semantic tokens are available. Semantic styles and tokens have yet to be defined for typography and border.
 !!!
 
 ### Palette color styles
 
-When choosing what color style to use in your design, we recommend starting with semantic styles as their usage is clearly defined. If you don't find a semantic style that meets your needs, we make available a set of base `Palette` styles that are labeled with a numerical scale. While these styles are more usage agnostic, this can introduce challenges in consistently scaling a complex design.
+When choosing what color style to use in your design, we recommend starting with semantic styles as their usage is clearly defined. If you don't find a semantic style that meets your needs, a set of base `Palette` styles that are labeled with a numerical scale are also available. These styles are more usage agnostic which can introduce challenges in consistently scaling a complex design.
 
 For more information and details on styles and their intended usage visit [foundations](/foundations).

--- a/website/docs/getting-started/for-designers/partials/best-practices.md
+++ b/website/docs/getting-started/for-designers/partials/best-practices.md
@@ -1,55 +1,55 @@
-Figma is an incredibly versatile tool, but this versatility can sometimes backfire leading to disorganization, inconsistency, and difficulty in handoffs and collaboration. These best practices are geared towards using Helios components and foundations effectively to alleviate some of these challenges. For documentation around broader Figma best practices within HashiCorp design teams, reach out to the HashiCorp [Design Ops team](https://sites.google.com/hashicorp.com/designknowledgehub/design-system) or visit the [#design-ops slack channel](https://hashicorp.slack.com/archives/C029GL8GJDV).
+Below are best practices for using Helios components and foundations effectively.
 
-## Component availability
+For documentation around broader Figma best practices within HashiCorp design teams, reach out to the HashiCorp [Design Ops team](https://sites.google.com/hashicorp.com/designknowledgehub/design-system) or visit the [#design-ops slack channel](https://hashicorp.slack.com/archives/C029GL8GJDV).
 
-**Structure** is the legacy set of components and foundations used to connect HashiCorp products and consists Ember components and foundational styles paired with a limited set of Figma counterparts. **Structure is no longer supported and is in the process of deprecation and sunsetting.**
+## When to use Helios
 
-As we work to achieve parity between Structure and Helios, use this decision tree to understand how to move forward within your project:
+!!! Info
+
+**What is structure?**
+
+Structure is the legacy design system used primarily by Cloud UI. Structure is no longer supported and we're in the process of sunsetting it.
+!!!
+
+Use this decision tree to understand when to use a component from Helios, from Structure, or when to create your own local component or pattern.
 
 ![Decision tree flow chart](/assets/getting-started/designers/hds-decision-tree.png)
 
-**Does the element (or a comparable alternative) exist in Helios?**
+### Element exists in Helios
 
-If so, great! Using this element ensures it will be supported in future versions of Helios and that it shares a common visual language with the rest of the elements.
+If the component or pattern exists in Helios, use it. This ensures it will be supported in future versions of Helios and that it shares a common visiual language with the rest of the elements.
 
-**If no, does the element (or a comparable alternative) exist in Structure?**
+### Element exists in Structure
 
-If yes, use this component with the understanding that:
+If the component or pattern doesn't exist in Helios, but does exist in Structure, use the Structure version. Use Structure sparingly and with caution because:
 
-1. Structure will be deprecated/sunsetted in the future
-2. Not all Figma components are built in code
-3. There is no longer a support structure in place if errors/bugs arise
+- Structure is no longer supported and is being sunset
+- Some Figma components are not built in code
 
-If no, or having future support is a must: design and build your own local element using Helios foundations (color, typography, elevation, etc) as a starting point.
+### Element doesn't exist in Helios or Structure
 
-### Local components
+If the component or pattern doesn't exist in Helios or in Structure, design and build your own local element using Helios foundations (color, typography, elevation, etc) as a starting point.
 
-Components and patterns that are unique to your product should be designed and built locally, extending Helios components and foundations.
-
-![Local component patterns](/assets/getting-started/designers/local-component-patterns.png)
-
-<LinkTo class="doc-link-generic" @route="patterns">Patterns</LinkTo> and guidance around combining and extending Helios components are not currently supported, but are on our [roadmap](https://go.hashi.co/hds-rollout).
-
-!!! Insight
-
-When creating your own library of local components to use in your projects, it's helpful to separate components from your main design work in their own Figma file. This simplifies publishing and creates a single consistent dependency for your design files. For more information on creating and publishing libraries, visit [Figma's official documentation.](https://www.figma.com/best-practices/components-styles-and-shared-libraries/organizing-and-creating-libraries/)
-!!!
-
-When design and building local components, consider [Atomic Design](https://bradfrost.com/blog/post/atomic-web-design/) methods whenever possible. Helios components generally correspond with the `atom` and `molecule` levels, with some more complex components being considered `organisms`.
-
-## Component instances & detaching
+## Working with Components
 
 A component inserted from a library into a project is referred to as an **instance**. Instances maintain a link to the main component in the library, which has significant benefits for deploying updates and iterating quickly on components.
 
-Our Figma components are coupled closely with their code counterparts to maintain consistency in the API and design language. In most scenarios, we don’t recommend detaching a component or foundation from the library. If you find that a component doesn’t meet your needs, reach out to us for [support](/support) or [submit a request](https://docs.google.com/forms/d/e/1FAIpQLScpMXgrUTVT5fYriu4Pp48r4Nl_eCPluVnJLg0Yg3NXsRWvIA/viewform) for a new component, foundation, or feature.
+## Detaching components
 
-### Why to avoid detaching components
+Our Figma components are coupled closely with their code counterparts to maintain consistency in the API and design language, so in most scenarios, we don’t recommend detaching a component or foundation from the library.
 
-When you detach a component, that component will no longer receive updates when new features or changes are published in the library. This can cause Figma projects and production applications to drift out of sync quickly and introduce tech debt in the future. This can be avoided by working closely with the Design Systems Team and learning how to extend components as necessary to meet your needs.
+!!! Info
+
+**Why to avoid detaching components**
+
+When you detach a component, it no longer receives updates from the library. This can cause designs production applications to drift out of sync quickly.
+!!!
+
+If you find that a component doesn’t meet your needs, reach out to us for [support](/support) or [submit a request](https://docs.google.com/forms/d/e/1FAIpQLScpMXgrUTVT5fYriu4Pp48r4Nl_eCPluVnJLg0Yg3NXsRWvIA/viewform) for a new component, foundation, or feature.
 
 ### Overriding component styles
 
-While styles in Helios Figma components can technically be overwritten without detaching the component, we recommend against doing this prior to consulting the Design System Team. It may seem simple to change the color or the font size within a Figma component, but this can have drastic trickle-down effects in code.
+While styles in Helios Figma components can technically be overwritten without detaching the component, we recommend against doing this prior to consulting the Design System Team. It may seem simple to change the color or the font size within a Figma component, but this can have trickle-down effects in code.
 
 - It forces engineers to create custom classes and styles to override Helios styles. This can have unexpected long-term effects within the [CSS cascade](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#:~:text=The%20cascade%20is%20an%20algorithm,a%20property%20on%20an%20element).
 - While being difficult to scale, overrides nudge the visual language of your product out of sync with Helios and with the rest of the HashiCorp product line.
@@ -65,7 +65,7 @@ Unless specifically mentioned in the documentation, the component in code will f
 **Fixed width components:** Setting a component to a fixed width in Figma is akin to setting an explicit `width` value on a component or element in code. This generally goes against fluid and responsive development best practices and should be avoided in Figma. Instead, use auto layout wherever possible.
 !!!
 
-## Figma styles
+## Working with foundations (styles)
 
 Similar to components, using styles defined in the Helios [Product Foundations](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?t=4kdgl88SMIiEYhbA-1) reinforces consistency and can help to resolve problems with style usage and implementation. Detaching from Helios styles is not recommended in most circumstances.
 
@@ -75,13 +75,25 @@ Helios publishes a set of **semantic** styles and tokens that are labeled with t
 - `Foreground / Primary` would be used for primary text elements or elements that sit on top of a surface background.
 - `Foreground / Action` would be used for an actionable or interactive element within a component or page (i.e. a [Link](/components/link/standalone), or primary [Button](/components/button))
 
-!!! Info
-
 At this time color styles are the only category for which semantic tokens are available. Semantic styles and tokens have yet to be defined for typography and border.
-!!!
 
 ### Palette color styles
 
 When choosing what color style to use in your design, we recommend starting with semantic styles as their usage is clearly defined. If you don't find a semantic style that meets your needs, a set of base `Palette` styles that are labeled with a numerical scale are also available. These styles are more usage agnostic which can introduce challenges in consistently scaling a complex design.
 
 For more information and details on styles and their intended usage visit [foundations](/foundations).
+
+### Designing local components
+
+Components and patterns that are unique to your product should be designed and built locally, extending Helios components and foundations.
+
+![Local component patterns](/assets/getting-started/designers/local-component-patterns.png)
+
+When creating your own library of local components to use in your projects, it's helpful to separate components from your main design work in their own Figma file. This simplifies publishing and creates a single consistent dependency for your design files. For more information on creating and publishing libraries, visit [Figma's official documentation.](https://www.figma.com/best-practices/components-styles-and-shared-libraries/organizing-and-creating-libraries/)
+
+!!! Info
+
+When design and building local components, consider [Atomic Design](https://bradfrost.com/blog/post/atomic-web-design/) methods whenever possible. Helios components generally correspond with the `atom` and `molecule` levels, with some more complex components being considered `organisms`.
+!!!
+
+<LinkTo class="doc-link-generic" @route="patterns">Patterns</LinkTo> and guidance around combining and extending Helios components are not currently supported, but are on our [roadmap](https://go.hashi.co/hds-rollout).

--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -1,5 +1,5 @@
 ---
-title: For engineers
+title: Getting started for engineers
 order: 102
 ---
 


### PR DESCRIPTION
### :pushpin: Summary

This PR updates and adds content geared towards best practices for designers

### :hammer_and_wrench: Detailed description

In more detail, this PR:

- Removes most of the broader Figma best practices, instead directing users to content put together by the ops team.
- Cleans up the content relating to Structure
- Adds more content on detaching, overriding, and resizing components
- Adds more content on creating local components
- Adds some best practices for understanding and using Helios styles.

Broadly, this pivots this content to be less Figma-specific, and more specific for best-practices as they relate to using Helios as a designer

👉👉👉 [Preview](https://hds-website-git-jorytindall-update-docs-onboar-71093e-hashicorp.vercel.app/)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1315](https://hashicorp.atlassian.net/browse/HDS-1315)
Figma file: [if it applies]


[HDS-1315]: https://hashicorp.atlassian.net/browse/HDS-1315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-1315]: https://hashicorp.atlassian.net/browse/HDS-1315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ