### PR TITLE
refactor how illustrations are referenced

### DIFF
--- a/website/app/controllers/components.js
+++ b/website/app/controllers/components.js
@@ -11,10 +11,7 @@ export default class ComponentsController extends Controller {
         .filter((page) => page.pageParents[0] === section)
         .map((page) => {
           return {
-            image: `/assets/illustrations/${page.filePath.replace(
-              /\/index$/,
-              ''
-            )}.jpg`,
+            image: `assets/${page.pageAttributes.previewImage}`,
             title: page.pageAttributes.title,
             caption:
               page.pageAttributes.caption ||

--- a/website/app/controllers/components.js
+++ b/website/app/controllers/components.js
@@ -11,7 +11,7 @@ export default class ComponentsController extends Controller {
         .filter((page) => page.pageParents[0] === section)
         .map((page) => {
           return {
-            image: `assets/${page.pageAttributes.previewImage}`,
+            image: page.pageAttributes.previewImage,
             title: page.pageAttributes.title,
             caption:
               page.pageAttributes.caption ||

--- a/website/app/controllers/foundations.js
+++ b/website/app/controllers/foundations.js
@@ -11,10 +11,7 @@ export default class FoundationsController extends Controller {
         .filter((page) => page.pageParents[0] === section)
         .map((page) => {
           return {
-            image: `/assets/illustrations/${page.filePath.replace(
-              /\/index$/,
-              ''
-            )}.jpg`,
+            image: page.pageAttributes.previewImage,
             title: page.pageAttributes.title,
             caption:
               page.pageAttributes.caption ||

--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -85,6 +85,7 @@ export default class ShowRoute extends Route {
           'layout',
           'hidden',
           'order',
+          'previewImage',
         ];
         frontmatterAttributes.forEach((attribute) => {
           if (attribute in res.data.attributes) {

--- a/website/app/services/head-data.js
+++ b/website/app/services/head-data.js
@@ -18,11 +18,8 @@ export default class CustomHeadDataService extends HeadDataService {
   }
 
   get imgSrc() {
-    return this.currentRouteMeta?.id
-      ? `/assets/illustrations/${this.currentRouteMeta?.id.replace(
-          /\/index$/,
-          ''
-        )}.jpg`
+    return this.currentRouteMeta?.frontmatter?.previewImage
+      ? this.currentRouteMeta.frontmatter.previewImage
       : config['ember-meta'].imgSrc;
   }
 }

--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -6,7 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=1377%3A11987
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/alert
-previewImage: illustrations/components/alert.jpg
+previewImage: assets/illustrations/components/alert.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=1377%3A11987
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/alert
+previewImage: illustrations/components/alert.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/avatar/index.md
+++ b/website/docs/components/avatar/index.md
@@ -3,6 +3,7 @@ title: Avatar
 description: An avatar
 caption: An avatar
 hidden: true
+previewImage: assets/illustrations/components/avatar.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/badge-count/index.md
+++ b/website/docs/components/badge-count/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A20946&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/badge-count
+previewImage: assets/illustrations/components/badge-count.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2337%3A20761&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/badge
+previewImage: assets/illustrations/components/badge.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=3073%3A11771&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/breadcrumb
+previewImage: assets/illustrations/components/breadcrumb.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/button-set/index.md
+++ b/website/docs/components/button-set/index.md
@@ -5,6 +5,7 @@ caption: A set of buttons.
 status: code-only
 links:
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button-set
+previewImage: assets/illustrations/components/button-set.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/button/index.md
+++ b/website/docs/components/button/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A21001&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button
+previewImage: assets/illustrations/components/button.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/card/index.md
+++ b/website/docs/components/card/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2359%3A19245&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/card
+previewImage: assets/illustrations/components/card.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=5633%3A16319&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/dropdown
+previewImage: assets/illustrations/components/dropdown.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/checkbox/index.md
+++ b/website/docs/components/form/checkbox/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=9120%3A23132&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/checkbox
+previewImage: assets/illustrations/components/form/checkbox.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/primitives/index.md
+++ b/website/docs/components/form/primitives/index.md
@@ -6,6 +6,7 @@ status: released
 order: 99
 links:
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form
+previewImage: assets/illustrations/components/form/primitives.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/radio-card/index.md
+++ b/website/docs/components/form/radio-card/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=17482%3A56258&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/radio-card
+previewImage: assets/illustrations/components/form/radio-card.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/radio/index.md
+++ b/website/docs/components/form/radio/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13181%3A36977&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/radio
+previewImage: assets/illustrations/components/form/radio.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/select/index.md
+++ b/website/docs/components/form/select/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=14283%3A34475&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/select
+previewImage: assets/illustrations/components/form/select.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=11530%3A28348&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/text-input
+previewImage: assets/illustrations/components/form/text-input.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/textarea/index.md
+++ b/website/docs/components/form/textarea/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13343%3A31585&t=pDgL7LJUJXZUN7Xq-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/textarea
+previewImage: assets/illustrations/components/form/textarea.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/toggle/index.md
+++ b/website/docs/components/form/toggle/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13181%3A36435&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/toggle
+previewImage: assets/illustrations/components/form/toggle.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2632%3A8072&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/icon-tile
+previewImage: assets/illustrations/components/icon-tile.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/link/inline/index.md
+++ b/website/docs/components/link/inline/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2365%3A21590&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/link
+previewImage: assets/illustrations/components/link/inline.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/link/standalone/index.md
+++ b/website/docs/components/link/standalone/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2365%3A21590&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/link
+previewImage: assets/illustrations/components/link/standalone.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=22928%3A56204&t=pDgL7LJUJXZUN7Xq-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/modal
+previewImage: assets/illustrations/components/modal.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/stepper/index.md
+++ b/website/docs/components/stepper/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=15313%3A50538&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/stepper
+previewImage: assets/illustrations/components/stepper.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/table/index.md
+++ b/website/docs/components/table/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=18814%3A54972&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/table
+previewImage: assets/illustrations/components/table.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/tabs/index.md
+++ b/website/docs/components/tabs/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=16384%3A46484&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/tabs
+previewImage: assets/illustrations/components/tabs.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13720%3A34360&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/tag
+previewImage: assets/illustrations/components/tag.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/toast/index.md
+++ b/website/docs/components/toast/index.md
@@ -6,6 +6,7 @@ status: released
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=7636%3A30467&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/toast
+previewImage: assets/illustrations/components/toast.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/foundations/accessibility/index.md
+++ b/website/docs/foundations/accessibility/index.md
@@ -2,6 +2,7 @@
 title: Accessibility
 caption: Content should be usable and accessible for all users of differing abilities.
 description: Content should be usable and accessible for all users of differing abilities.
+previewImage: assets/illustrations/foundations/accessibility.jpg
 ---
 
 While our components are designed and developed with accessibility as a core requirement, they can still be implemented in a way that results in an application that is not conformant with WCAG Guidelines. To that end, we provide some considerations for application-level concerns.

--- a/website/docs/foundations/border/index.md
+++ b/website/docs/foundations/border/index.md
@@ -2,6 +2,7 @@
 title: Border
 caption: Borders define and separate content visually. They can be used alone or in combination with elevation.
 description: Borders define and separate content visually. They can be used alone or in combination with elevation.
+previewImage: assets/illustrations/foundations/border.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/foundations/colors/index.md
+++ b/website/docs/foundations/colors/index.md
@@ -2,6 +2,7 @@
 title: Colors
 caption: Color and contrast are used to convey information, highlight content, and communicate intent.
 description: Color and contrast are used to convey information, highlight content, and communicate intent.
+previewImage: assets/illustrations/foundations/colors.jpg
 ---
 
 <section data-tab="Code">

--- a/website/docs/foundations/elevation/index.md
+++ b/website/docs/foundations/elevation/index.md
@@ -2,6 +2,7 @@
 title: Elevation
 caption: Elevation can be used to offset and draw attention to content or indicate interactivity.
 description: Elevation can be used to offset and draw attention to content or indicate interactivity.
+previewImage: assets/illustrations/foundations/elevation.jpg
 ---
 
 <section data-tab="Code">

--- a/website/docs/foundations/focus-ring/index.md
+++ b/website/docs/foundations/focus-ring/index.md
@@ -2,6 +2,7 @@
 title: Focus ring
 caption: Focus rings are a vital tool in communicating interactivity.
 description: Focus rings display when interactive components including links and buttons are focused by the user. They are a vital tool in communicating interactivity.
+previewImage: assets/illustrations/foundations/focus-ring.jpg
 ---
 
 ## How to use this style

--- a/website/docs/foundations/tokens/index.md
+++ b/website/docs/foundations/tokens/index.md
@@ -2,6 +2,7 @@
 title: Tokens
 caption: Design tokens are provided as CSS custom properties and used to share and standardize foundation styles.
 description: Design tokens are provided as CSS custom properties and used to share and standardize foundation styles.
+previewImage: assets/illustrations/foundations/tokens.jpg
 ---
 
 <section data-tab="Library">

--- a/website/docs/foundations/typography/index.md
+++ b/website/docs/foundations/typography/index.md
@@ -2,6 +2,7 @@
 title: Typography
 caption: Typography relates to the style and appearance of textual information.
 description: Typography relates to the structure and appearance of textual information. It relates to visual hierarchy, letterforms, and punctuation.
+previewImage: assets/illustrations/foundations/typography.jpg
 ---
 
 ## Font stack

--- a/website/docs/icons/library/index.md
+++ b/website/docs/icons/library/index.md
@@ -6,6 +6,7 @@ caption: Icons can be used to support and enhance meaning and can help call out 
 links:
   figma: https://www.figma.com/file/TLnoT5AYQfy3tZ0H68BgOr/Flight-Icons?node-id=164%3A0
   github: https://github.com/hashicorp/design-system/tree/main/packages/flight-icons
+previewImage: assets/illustrations/icons/library.jpg
 ---
 
 <Doc::IconsList

--- a/website/docs/icons/usage-guidelines/index.md
+++ b/website/docs/icons/usage-guidelines/index.md
@@ -1,6 +1,7 @@
 ---
 title: Usage Guidelines
 caption: Guidelines for using and implementing icons consistently.
+previewImage: assets/illustrations/icons/usage-guidelines.jpg
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/overrides/power-select/index.md
+++ b/website/docs/overrides/power-select/index.md
@@ -2,6 +2,7 @@
 title: PowerSelect
 description: Style overrides for the ember-power-select addon.
 caption: Style overrides for the ember-power-select addon.
+previewImage: assets/illustrations/overrides/power-select.jpg
 ---
 
 <section data-tab="Code">

--- a/website/docs/utilities/disclosure/index.md
+++ b/website/docs/utilities/disclosure/index.md
@@ -2,6 +2,7 @@
 title: Disclosure
 description: An internal utility that provides hide/show functionality.
 caption: An internal utility that provides hide/show functionality.
+previewImage: assets/illustrations/utilities/disclosure.jpg
 ---
 
 <section data-tab="Code">

--- a/website/docs/utilities/dismiss-button/index.md
+++ b/website/docs/utilities/dismiss-button/index.md
@@ -2,6 +2,7 @@
 title: Dismiss Button
 description: An internal utility component used to provide "dismiss" functionality in other components.
 caption: An internal utility component used to provide "dismiss" functionality in other components.
+previewImage: assets/illustrations/utilities/dismiss-button.jpg
 ---
 
 <section data-tab="Code">

--- a/website/docs/utilities/interactive/index.md
+++ b/website/docs/utilities/interactive/index.md
@@ -2,6 +2,7 @@
 title: Interactive
 description: An internal utility component used to provide interactivity to other components.
 caption: An internal utility component used to provide interactivity to other components.
+previewImage: assets/illustrations/utilities/interactive.jpg
 ---
 
 <section data-tab="Code">

--- a/website/ember-cli-build.js
+++ b/website/ember-cli-build.js
@@ -21,13 +21,6 @@ module.exports = function (defaults) {
     fingerprint: {
       // override defaults to also include json files which our markdown is compiled to. without this images don't render properly.
       replaceExtensions: ['html', 'css', 'js', 'json'],
-      exclude: [
-        'illustrations/foundations',
-        'illustrations/icons',
-        'illustrations/components',
-        'illustrations/overrides',
-        'illustrations/utilities',
-      ],
     },
     'ember-prism': {
       components: [

--- a/website/lib/markdown/markdown-to-jsonapi.js
+++ b/website/lib/markdown/markdown-to-jsonapi.js
@@ -26,6 +26,7 @@ class MarkdownToJsonApi extends PersistentFilter {
         'layout',
         'hidden',
         'order',
+        'previewImage',
       ],
     };
 

--- a/website/lib/markdown/table-of-contents.js
+++ b/website/lib/markdown/table-of-contents.js
@@ -107,6 +107,7 @@ class TableOfContents extends Plugin {
           'caption',
           'order',
           'hidden',
+          'previewImage',
         ]);
       } else {
         console.log('File NOT found!', fullFilePath);

--- a/wiki/Website-Doc-folder.md
+++ b/wiki/Website-Doc-folder.md
@@ -109,6 +109,7 @@ layout:
   sidecar: false
 order: 101
 hidden: false
+previewImage: assets/illustrations/components/alert.jpg
 ---
 ```
 
@@ -137,6 +138,8 @@ The "frontmatter" attributes that we support are the following:
     Used to control the order of the pages in navigational lists (lower value moves up the page, higher value moves it down) - default is `100`
 *   `hidden`
     Used to hide the page from the sidebar navigation and the lists on the landing pages - default is `false`
+*   `previewImage`
+  An optional full path to an image used when listing the page as "card" (eg. in landing pages). The path refers to the `dist` folder generated at build time, so is relative to the content of the `/website/public` folder.
 
 
 Only the `title` attribute is technically required, all the others are optional (even though some of them like `description` and `caption` are necessary for component pages).


### PR DESCRIPTION
### :pushpin: Summary

This PR refactors how we reference illustrations, changing from an file name inference to an explicit reference in the frontmatter.

### :hammer_and_wrench: Detailed description

The main reasons for this change are twofold
* Makes these reference more resilient by not having them depend on the name of a component which _could_ change
* By explicitly referencing the files like this we can reenable their fingerprinting

Test this works by checking  these links for correct illustrations
* [Components](https://hds-website-git-br-preview-hashicorp.vercel.app/components)
* [Foundations](https://hds-website-git-br-preview-hashicorp.vercel.app/foundations)
* Inspect the source of an [individual component](https://hds-website-git-br-preview-hashicorp.vercel.app/components/alert) and confirm you see a value like `<meta property="og:image" content="assets/illustrations/components/alert-dc12b37ebbc20cfbc2a1ff618c20e1c4.jpg">`

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1367](https://hashicorp.atlassian.net/browse/HDS-1367)


[HDS-1367]: https://hashicorp.atlassian.net/browse/HDS-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ