### PR TITLE
Website: Add missing link classes (HDS-1365)

### DIFF
--- a/website/app/templates/about.hbs
+++ b/website/app/templates/about.hbs
@@ -8,35 +8,35 @@
     <h2 class="doc-text-h2">Overview</h2>
     <p class="doc-text-body">The Design Systems Team creates and maintains the Helios Design System. This includes the
       Figma components, web components, documentation, and more. Read through our
-      <a href="/about/overview/" target="_blank" rel="noopener noreferrer">overview</a>
+      <a class="doc-link-generic" href="/about/overview/" target="_blank" rel="noopener noreferrer">overview</a>
       for more details, and to see why adopting the design system is the future for product teams.
     </p>
 
     <h2 class="doc-text-h2">Principles</h2>
     <p class="doc-text-body">It’s important that we stay focused and grounded as a team. Setting clear expectations for
       both ourselves and our consumers by defining our philosophy and values through our
-      <a href="/about/principles/" target="_blank" rel="noopener noreferrer">principles</a>
+      <a class="doc-link-generic" href="/about/principles/" target="_blank" rel="noopener noreferrer">principles</a>
       help us do just that.
     </p>
 
     <h2 class="doc-text-h2">Accessibility statement</h2>
     <p class="doc-text-body">Accessibility is not just a requirement, it is a part of our company culture, grounded in
-      <a href="https://www.hashicorp.com/our-principles" rel="noopener noreferrer" target="_blank">our company
+      <a class="doc-link-generic" href="https://www.hashicorp.com/our-principles" rel="noopener noreferrer" target="_blank">our company
         principles</a>
       such as integrity, communication, and kindness. Read more about our intentions for an accessible design system in
       our
-      <a href="/about/accessibility-statement/" target="_blank" rel="noopener noreferrer">accessibility statement</a>.
+      <a class="doc-link-generic" href="/about/accessibility-statement/" target="_blank" rel="noopener noreferrer">accessibility statement</a>.
     </p>
 
     <h2 class="doc-text-h2">Getting started for designers</h2>
     <p class="doc-text-body">Learn how to use our components and other resources by reading our guide to
-      <a href="/getting-started/for-designers/" target="_blank" rel="noopener noreferrer">getting started for designers</a>.
+      <a class="doc-link-generic" href="/getting-started/for-designers/" target="_blank" rel="noopener noreferrer">getting started for designers</a>.
     </p>
 
     <h2 class="doc-text-h2">Getting started for engineers</h2>
     <p class="doc-text-body">While the design system components are conveniently packaged in a standard Ember addon, we
       still recommend reading through our guide to
-      <a href="/getting-started/for-engineers/" target="_blank" rel="noopener noreferrer">getting started for engineers</a>
+      <a class="doc-link-generic" href="/getting-started/for-engineers/" target="_blank" rel="noopener noreferrer">getting started for engineers</a>
       to better understand some specific conventions we have put in place to help engineers focus on what is really
       important in their application, instead of thinking about component APIs.
     </p>
@@ -44,7 +44,7 @@
     <h2 class="doc-text-h2">Contributions</h2>
     <p class="doc-text-body">As an open-source project, we think a lot about how people can contribute—and there are
       quite a few ways our consumers are encouraged to participate! Read our
-      <a href="/getting-started/contribution/" target="_blank" rel="noopener noreferrer">contribution</a>
+      <a class="doc-link-generic" href="/getting-started/contribution/" target="_blank" rel="noopener noreferrer">contribution</a>
       documentation to find the different ways anyone can contribute to Helios.
     </p>
   </Doc::Page::Content>

--- a/website/app/templates/about.hbs
+++ b/website/app/templates/about.hbs
@@ -21,22 +21,41 @@
 
     <h2 class="doc-text-h2">Accessibility statement</h2>
     <p class="doc-text-body">Accessibility is not just a requirement, it is a part of our company culture, grounded in
-      <a class="doc-link-generic" href="https://www.hashicorp.com/our-principles" rel="noopener noreferrer" target="_blank">our company
-        principles</a>
+      <a
+        class="doc-link-generic"
+        href="https://www.hashicorp.com/our-principles"
+        rel="noopener noreferrer"
+        target="_blank"
+      >our company principles</a>
       such as integrity, communication, and kindness. Read more about our intentions for an accessible design system in
       our
-      <a class="doc-link-generic" href="/about/accessibility-statement/" target="_blank" rel="noopener noreferrer">accessibility statement</a>.
+      <a
+        class="doc-link-generic"
+        href="/about/accessibility-statement/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >accessibility statement</a>.
     </p>
 
     <h2 class="doc-text-h2">Getting started for designers</h2>
     <p class="doc-text-body">Learn how to use our components and other resources by reading our guide to
-      <a class="doc-link-generic" href="/getting-started/for-designers/" target="_blank" rel="noopener noreferrer">getting started for designers</a>.
+      <a
+        class="doc-link-generic"
+        href="/getting-started/for-designers/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >getting started for designers</a>.
     </p>
 
     <h2 class="doc-text-h2">Getting started for engineers</h2>
     <p class="doc-text-body">While the design system components are conveniently packaged in a standard Ember addon, we
       still recommend reading through our guide to
-      <a class="doc-link-generic" href="/getting-started/for-engineers/" target="_blank" rel="noopener noreferrer">getting started for engineers</a>
+      <a
+        class="doc-link-generic"
+        href="/getting-started/for-engineers/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >getting started for engineers</a>
       to better understand some specific conventions we have put in place to help engineers focus on what is really
       important in their application, instead of thinking about component APIs.
     </p>
@@ -44,7 +63,12 @@
     <h2 class="doc-text-h2">Contributions</h2>
     <p class="doc-text-body">As an open-source project, we think a lot about how people can contribute—and there are
       quite a few ways our consumers are encouraged to participate! Read our
-      <a class="doc-link-generic" href="/getting-started/contribution/" target="_blank" rel="noopener noreferrer">contribution</a>
+      <a
+        class="doc-link-generic"
+        href="/getting-started/contribution/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >contribution</a>
       documentation to find the different ways anyone can contribute to Helios.
     </p>
   </Doc::Page::Content>


### PR DESCRIPTION
### :pushpin: Summary

Add missing "doc-link-generic" classes to non-markdown links.

**Preview (fixed):** https://hds-website-git-hds-1365-website-link-classes-hashicorp.vercel.app/about

**Before (not fixed):** https://hds-website.vercel.app/about

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1365](https://hashicorp.atlassian.net/browse/HDS-1365)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1365]: https://hashicorp.atlassian.net/browse/HDS-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ