### PR TITLE
Error page fixes part 1/n

### DIFF
--- a/website/app/styles/pages/application/error.scss
+++ b/website/app/styles/pages/application/error.scss
@@ -3,6 +3,16 @@
 @use "../../breakpoints" as breakpoint;
 @use "../../typography/mixins";
 
+// temporary fix - see:
+// - https://github.com/hashicorp/design-system/pull/1021
+// - https://hashicorp.atlassian.net/browse/HDS-1309?focusedCommentId=178673
+
+// `ember-body-class` sets specific classes on the `<body>` element
+body.application.error {
+  background-color: var(--doc-color-white) !important;
+}
+
+
 .doc-page-error {
   display: flex;
   grid-area: sidebar / sidebar / stage / stage;

--- a/website/app/styles/pages/application/error.scss
+++ b/website/app/styles/pages/application/error.scss
@@ -10,6 +10,12 @@
 // `ember-body-class` sets specific classes on the `<body>` element
 body.application.error {
   background-color: var(--doc-color-white) !important;
+
+  @include breakpoint.with-fixed-sidebar() {
+    .doc-page-sidebar {
+      display: none;
+    }
+  }
 }
 
 

--- a/website/app/templates/error.hbs
+++ b/website/app/templates/error.hbs
@@ -6,6 +6,8 @@
       class="doc-page-error__image"
       src="/assets/other/jory-travolta.gif"
       alt="Animated gif created by Jory Tindall, showing a classic John Travolta meme on top of a composition of Helios components"
+      height="258"
+      width="320"
     />
     <div class="doc-page-error__content">
       <h1 class="doc-text-h1">Well shoot...</h1>

--- a/website/lib/markdown/index.js
+++ b/website/lib/markdown/index.js
@@ -65,7 +65,14 @@ module.exports = {
   urlsForPrember(distDir) {
     const flatPageListJson = fs.readJsonSync(`${distDir}/toc.json`);
     // TODO is there a way to have this list generated automatically (or exported) from the routes (`website/app/router.js`)?
-    const staticURLs = ['/', 'about', 'foundations', 'components', 'patterns'];
+    const staticURLs = [
+      '/',
+      'about',
+      'foundations',
+      'components',
+      'patterns',
+      'error',
+    ];
     const docsURLs = flatPageListJson.flat.map((page) => page.pageURL);
 
     return [...staticURLs, ...docsURLs];


### PR DESCRIPTION
### :pushpin: Summary

* [x] pre-render the error route (missed this before)
* [x] add some dimensions to the image
* [x] adjust styles to account for sidebar
* [ ] Probably in a followup PR - figure out why vercel is going index -> error page instead of directly to it

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1309](https://hashicorp.atlassian.net/browse/HDS-1309)



[HDS-1309]: https://hashicorp.atlassian.net/browse/HDS-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ