### PR TITLE
[DON'T MERGE] Spacing adjustment examples

### DIFF
--- a/website/app/styles/doc-components/banner.scss
+++ b/website/app/styles/doc-components/banner.scss
@@ -7,7 +7,7 @@
   display: flex;
   gap: 16px;
   align-items: flex-start;
-  margin: 16px 0;
+  margin: 16px 0 24px;
   padding: 12px;
   border: 1px solid var(--doc-banner-border-color);
   border-left-width: 4px;
@@ -30,21 +30,21 @@
 .doc-banner__content {
 
   // we need to override the margin of the children in some cases
-  > *:first-child {
+  >*:first-child {
     margin-top: 0;
   }
 
-  > *:last-child {
+  >*:last-child {
     margin-bottom: 0;
   }
 
   // this is the title, and it's based on convention (it's supposed to be the first "strong" element inside the paragraph)
-  > p:first-child strong {
+  >p:first-child strong {
     @include doc-font-style-h6();
     color: var(--doc-banner-title-color);
   }
 
-  > p:first-child:has(strong) {
+  >p:first-child:has(strong) {
     margin: 0 0 6px 0;
   }
 

--- a/website/app/styles/doc-components/do-dont.scss
+++ b/website/app/styles/doc-components/do-dont.scss
@@ -6,7 +6,7 @@
 .doc-do-dont {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.25rem;
   margin: 16px 0;
 }
 
@@ -51,11 +51,11 @@
 
   // we need to override the margin of the children in some cases
 
-  > *:first-child {
+  >*:first-child {
     margin-top: 0;
   }
 
-  > *:last-child {
+  >*:last-child {
     margin-bottom: 0;
   }
 

--- a/website/app/styles/spacing/index.scss
+++ b/website/app/styles/spacing/index.scss
@@ -43,7 +43,7 @@
 }
 
 .doc-markdown-hr {
-  margin: 16px 0;
+  margin: 48px 0 0;
 }
 
 // LISTS
@@ -54,11 +54,11 @@
   margin-top: 16px;
   margin-bottom: 24px;
 
-  > li > p {
+  >li>p {
     margin-top: 12px;
   }
 
-  > li + li {
+  >li+li {
     margin-top: 12px;
   }
 }
@@ -78,12 +78,18 @@ pre[class*="language-"].doc-markdown-pre.doc-code-block__code-snippet {
   margin: 16px 0 32px;
 }
 
-.doc-code-block + .doc-code-block,
-.doc-code-block + pre[class*="language-"].doc-markdown-pre.doc-code-block__code-snippet,
-pre[class*="language-"].doc-markdown-pre.doc-code-block__code-snippet + .doc-code-block,
-pre[class*="language-"].doc-markdown-pre.doc-code-block__code-snippet + pre[class*="language-"].doc-markdown-pre.doc-code-block__code-snippet {
+.doc-code-block+.doc-code-block,
+.doc-code-block+pre[class*="language-"].doc-markdown-pre.doc-code-block__code-snippet,
+pre[class*="language-"].doc-markdown-pre.doc-code-block__code-snippet+.doc-code-block,
+pre[class*="language-"].doc-markdown-pre.doc-code-block__code-snippet+pre[class*="language-"].doc-markdown-pre.doc-code-block__code-snippet {
   // we want to reduce the spacing between to consecutive code blocks
   margin-top: -16px;
+}
+
+// TABLES
+
+.doc-markdown-table {
+  margin-top: 32px;
 }
 
 
@@ -93,16 +99,24 @@ pre[class*="language-"].doc-markdown-pre.doc-code-block__code-snippet + pre[clas
 
 .doc-banner,
 .doc-do-dont {
-  & + .doc-markdown-h2,
-  & + .doc-markdown-h3,
-  & + .doc-markdown-h4,
-  & + .doc-markdown-h5,
-  & + .doc-markdown-h6,
-  & + .doc-text-h2,
-  & + .doc-text-h3,
-  & + .doc-text-h4,
-  & + .doc-text-h6,
-  & + .doc-text-h5 {
+
+  &+.doc-markdown-h2,
+  &+.doc-markdown-h3,
+  &+.doc-markdown-h4,
+  &+.doc-markdown-h5,
+  &+.doc-markdown-h6,
+  &+.doc-text-h2,
+  &+.doc-text-h3,
+  &+.doc-text-h4,
+  &+.doc-text-h6,
+  &+.doc-text-h5 {
     margin-top: 32px;
   }
+}
+
+// Hack for adding spacing to HDS components within a paragraph tag
+// PLEASE REMOVE THIS, IT'S TERRIBLE
+
+.doc-markdown-p>*[class*="hds-"] {
+  margin-top: 24px;
 }


### PR DESCRIPTION
### :pushpin: Summary

This is purely an illustrative example of some of the slight spacing tweaks referenced HDS-1031 based off of @didoo 's testing branch.

### :hammer_and_wrench: Detailed description

Elements that changed:
- Do/don't block spacing between badge
- Hacked spacing between markdown elements and `hds-` components (don't @ me)
- Adjusted spacing of `hr`
- Adjusted spacing of `table`
- Adjusted spacing of Banner components

### :camera_flash: Screenshots

Do/don't block
<img width="905" alt="Screen Shot 2023-01-06 at 12 13 24 PM" src="https://user-images.githubusercontent.com/2200899/211092005-204ccb3b-d928-4b4a-9ae3-8c2332a7c06e.png">

Nested HDS components
<img width="771" alt="Screen Shot 2023-01-06 at 12 14 10 PM" src="https://user-images.githubusercontent.com/2200899/211092114-79bea6ca-4961-4e4b-a7e4-a1fa81d3c29d.png">

Horiztontal rule
<img width="928" alt="Screen Shot 2023-01-06 at 12 14 46 PM" src="https://user-images.githubusercontent.com/2200899/211092187-413b1a25-5daa-4808-b3e2-608f15fac407.png">

Table
<img width="937" alt="Screen Shot 2023-01-06 at 12 15 03 PM" src="https://user-images.githubusercontent.com/2200899/211092219-0b28d728-2b86-4296-8ea4-db391616dafd.png">

Banner
<img width="922" alt="Screen Shot 2023-01-06 at 12 15 29 PM" src="https://user-images.githubusercontent.com/2200899/211092298-47ed4cb1-5494-483e-a6f2-13504d806ec4.png">

<img width="913" alt="Screen Shot 2023-01-06 at 12 16 33 PM" src="https://user-images.githubusercontent.com/2200899/211092465-4c3760e9-6404-4b8a-b134-6629263e7c67.png">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1031](https://hashicorp.atlassian.net/browse/HDS-1031) and [HDS-1081](https://hashicorp.atlassian.net/browse/HDS-1081)

***


[HDS-1031]: https://hashicorp.atlassian.net/browse/HDS-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ