### PR TITLE
Fix power select styles

### DIFF
--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -26,7 +26,7 @@
 
 // Third-party declarations
 @import "prism-dracula";
-
+@import "ember-power-select";
 
 // GLOBALS
 

--- a/website/docs/overrides/power-select/partials/code/how-to-use.md
+++ b/website/docs/overrides/power-select/partials/code/how-to-use.md
@@ -78,7 +78,7 @@ To consistently style the `@afterOptionsComponent` use the `hds-power-select__af
 
 Where `power-select/after-options.hbs` would look like this:
 
-```handlebars
+```handlebars{data-execute=false}
 <div class="hds-power-select__after-options">
   5 results
 </div>

--- a/website/docs/overrides/power-select/partials/code/showcase.md
+++ b/website/docs/overrides/power-select/partials/code/showcase.md
@@ -10,7 +10,7 @@
     <div class="hds-power-select">
       <PowerSelect
         @options={{this.OPTIONS}}
-        @selected={{@model.SELECTED}}
+        @selected={{this.SELECTED}}
         @onChange={{this.noop}}
         @renderInPlace={{true}}
         as |option|
@@ -25,8 +25,8 @@
     <div class="hds-power-select">
       <PowerSelect
         class="mock-focus"
-        @options={{@model.OPTIONS}}
-        @selected={{@model.SELECTED}}
+        @options={{this.OPTIONS}}
+        @selected={{this.SELECTED}}
         @onChange={{this.noop}}
         @renderInPlace={{true}}
         as |option|
@@ -40,8 +40,8 @@
   <div class="dummy-power-select-container">
     <div class="hds-power-select">
       <PowerSelect
-        @options={{@model.OPTIONS}}
-        @selected={{@model.SELECTED}}
+        @options={{this.OPTIONS}}
+        @selected={{this.SELECTED}}
         @onChange={{this.noop}}
         @disabled={{true}}
         @renderInPlace={{true}}


### PR DESCRIPTION
### :pushpin: Summary

This PR brings the `<PowerSelect>` style overrides to work on the [new website](https://hds-website-hashicorp.vercel.app/overrides/power-select) as they did on the [old one](https://design-system-components-hashicorp.vercel.app/overrides/power-select).

### :hammer_and_wrench: Detailed description

For an unknown reason, on the old website, we were benefitting from a series of styles that are no longer applied to the new website. I have checked the configuration and the only difference between the two is the following (extract from `ember-cli-build`)

```
    'ember-power-select': {
      theme: false,
    },
```

Applying the same configuration to the new website doesn't change anything visually, hence the only option I could see was to port the missing CSS declarations into the override to make the overrides more resilient.

I'm still scratching my head around this, but not sure spending more time on would be of help.

### :camera_flash: Screenshots

There are many subtle changes, but the most obvious one is in the multiselect version.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![hds-website-hashicorp vercel app_overrides_power-select](https://user-images.githubusercontent.com/788096/211341856-c0473422-a64b-4704-a2c3-d196cab92fce.png)


</td><td>

![localhost_4200_overrides_power-select](https://user-images.githubusercontent.com/788096/211341875-371dfc39-1eae-4218-9734-6bdf1de9744a.png)


</td></tr>
</table>

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
