### PR TITLE
Adds correct CSS class to link

### DIFF
--- a/website/app/components/doc/wcag-list/index.hbs
+++ b/website/app/components/doc/wcag-list/index.hbs
@@ -1,8 +1,8 @@
 <div class={{this.classNames}}>
-  <ul class="doc-wcag-list__ul">
+  <ul class="doc-wcag-list__list">
     {{#each this.filteredCriteria as |criterion|}}
-      <li class="doc-wcag-list__li">
-        <a href={{criterion.url}} class="doc-wcag-list__link">
+      <li class="doc-wcag-list__listitem">
+        <a href={{criterion.url}} class="doc-wcag-listitem__link doc-link-generic">
           {{criterion.number}}
           {{criterion.title}}:</a>
         <br />

--- a/website/app/styles/doc-components/wcag-list.scss
+++ b/website/app/styles/doc-components/wcag-list.scss
@@ -1,3 +1,3 @@
-.doc-wcag-list__li {
+.doc-wcag-list__listitem {
   margin-bottom: 1.1875rem;
 }


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds the correct CSS class to the link in the WCAG component. It also makes a few naming changes for future flexibility.


### :link: External links

Jira ticket: [HDS-1303](https://hashicorp.atlassian.net/browse/HDS-1303)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1303]: https://hashicorp.atlassian.net/browse/HDS-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ