### PR TITLE
Adds aria-hidden attribute to svgs in logo

### DIFF
--- a/website/app/components/doc/logo/design-system.hbs
+++ b/website/app/components/doc/logo/design-system.hbs
@@ -5,6 +5,7 @@
   viewBox="0 0 42 42"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
 >
   <defs>
     <linearGradient
@@ -34,6 +35,7 @@
   viewBox="0 0 90 42"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
 >
   <path d="M25.21 31.58V22.31H16.66V31.58H12.9V10H16.66V19.04H25.21V10H28.97V31.58H25.21Z" fill="currentColor"></path>
   <path
@@ -57,6 +59,7 @@
   viewBox="0 0 183 42"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
 >
   <path
     d="M16.82 10.47C22 10.47 23.48 13.16 23.48 16.77V25.47C23.48 29.09 22.01 31.77 16.82 31.77H9.78003V10.47H16.82ZM11.67 30.08H16.85C20.43 30.08 21.59 28.61 21.59 25.57V16.67C21.59 13.63 20.44 12.16 16.85 12.16H11.67V30.08V30.08Z"


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds the `aria-hidden` attribute to the svg elements in the site logo. The link already has an aria-label.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
