### PR TITLE
Updates "explore" links on home page to add description for AT

### DIFF
--- a/website/app/templates/index.hbs
+++ b/website/app/templates/index.hbs
@@ -23,21 +23,19 @@
     </div>
     <ul class="doc-page-home__cards" role="list">
       {{#each this.cards as |card|}}
-        {{#let (unique-id) as |describedbyId|}}
-          <li class="doc-page-home__card">
-            <p class="doc-page-home__card-title">{{capitalize card.title}}</p>
-            <p class="doc-page-home__card-description" id={{describedbyId}}>{{capitalize card.description}}</p>
-            <Doc::LinkWithIcon
-              class="doc-page-home__card-link"
-              @route={{card.route}}
-              @label="Explore"
-              @icon="arrow-right"
-              @fillParent={{true}}
-              @isAnimated={{true}}
-              aria-describedby={{describedbyId}}
-            />
-          </li>
-        {{/let}}
+        <li class="doc-page-home__card">
+          <p class="doc-page-home__card-title">{{capitalize card.title}}</p>
+          <p class="doc-page-home__card-description">{{capitalize card.description}}</p>
+          <Doc::LinkWithIcon
+            class="doc-page-home__card-link"
+            @route={{card.route}}
+            @label="Explore"
+            @icon="arrow-right"
+            @fillParent={{true}}
+            @isAnimated={{true}}
+            aria-label={{concat "Explore " card.title ": " card.description}}
+          />
+        </li>
       {{/each}}
     </ul>
   </div>

--- a/website/app/templates/index.hbs
+++ b/website/app/templates/index.hbs
@@ -23,18 +23,21 @@
     </div>
     <ul class="doc-page-home__cards" role="list">
       {{#each this.cards as |card|}}
-        <li class="doc-page-home__card">
-          <p class="doc-page-home__card-title">{{capitalize card.title}}</p>
-          <p class="doc-page-home__card-description">{{capitalize card.description}}</p>
-          <Doc::LinkWithIcon
-            class="doc-page-home__card-link"
-            @route={{card.route}}
-            @label="Explore"
-            @icon="arrow-right"
-            @fillParent={{true}}
-            @isAnimated={{true}}
-          />
-        </li>
+        {{#let (unique-id) as |describedbyId|}}
+          <li class="doc-page-home__card">
+            <p class="doc-page-home__card-title">{{capitalize card.title}}</p>
+            <p class="doc-page-home__card-description" id={{describedbyId}}>{{capitalize card.description}}</p>
+            <Doc::LinkWithIcon
+              class="doc-page-home__card-link"
+              @route={{card.route}}
+              @label="Explore"
+              @icon="arrow-right"
+              @fillParent={{true}}
+              @isAnimated={{true}}
+              aria-describedby={{describedbyId}}
+            />
+          </li>
+        {{/let}}
       {{/each}}
     </ul>
   </div>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `aria-label` to the "explore" links on the home page so they have **unique** accessible names for users with AT. Typically we would want the visible link name to be the same as the accessible link name, but in this case, they both start with the same word (clutch), and they provide an equivalent experience.

### :camera_flash: Screenshots

Before:
![CleanShot 2023-01-09 at 12 30 48](https://user-images.githubusercontent.com/4587451/211381503-29d294b1-cd53-470d-8439-6aece2e7ba6f.png)

After: 
![image](https://user-images.githubusercontent.com/4587451/211386916-acc4bb58-379d-4018-9a90-02eddac3b2ea.png)


***


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
