### PR TITLE
capitalize Success Criteria

### DIFF
--- a/website/docs/components/alert/partials/accessibility/accessibility.md
+++ b/website/docs/components/alert/partials/accessibility/accessibility.md
@@ -14,6 +14,6 @@ Since alerts are not required to receive focus, it should not be required that t
 
 ## Applicable WCAG Success Criteria
 
-This section is for reference only. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />

--- a/website/docs/components/breadcrumb/partials/accessibility/accessibility.md
+++ b/website/docs/components/breadcrumb/partials/accessibility/accessibility.md
@@ -16,6 +16,6 @@ When the browser zoom is used to scale content to 400%, if the breadcrumb is not
 
 ## Applicable WCAG Success Criteria
 
-This section is for reference only. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.3" "1.4.4" "1.4.10" "1.4.12" "2.1.1" "2.1.2" "2.4.3" "2.4.5" "2.4.6" "2.4.7" "3.2.3" }} />

--- a/website/docs/components/button/partials/accessibility/accessibility.md
+++ b/website/docs/components/button/partials/accessibility/accessibility.md
@@ -12,7 +12,7 @@ Provide annotations alongside each design of the non-visual experience. This cou
 
 ## Applicable WCAG Success Criteria
 
-This section is for reference only. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.4.7" "4.1.1" "4.1.2" }} />
 

--- a/website/docs/components/dropdown/partials/accessibility/accessibility.md
+++ b/website/docs/components/dropdown/partials/accessibility/accessibility.md
@@ -43,7 +43,7 @@ Focus order annotated with Figma plugin, [A11y Focus Order](https://www.figma.co
 
 ## Applicable WCAG Success Criteria
 
-This section is for reference only. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.4.3" "2.4.7" }} />
 

--- a/website/docs/components/form/checkbox/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/checkbox/partials/accessibility/accessibility.md
@@ -29,7 +29,7 @@ If a link is used within a label, helper text, or error text, it will not be pre
 
 This section is for reference only, some descriptions have been truncated for brevity.
 
-This component intends to conform to the following WCAG success criteria:
+This component intends to conform to the following WCAG Success Criteria:
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
 
 ## Support

--- a/website/docs/components/form/primitives/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/primitives/partials/accessibility/accessibility.md
@@ -12,7 +12,7 @@ If a link is used within a label, helper text, or error text, it will not be pre
 
 This section is for reference only, some descriptions have been truncated for brevity. 
 
-This component intends to conform to the following WCAG success criteria:
+This component intends to conform to the following WCAG Success Criteria:
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "3.3.2" "4.1.1" "4.1.2" }} />
 
 ---

--- a/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
@@ -33,7 +33,7 @@ Navigate between radio cards. As the card is focused it also becomes selected.
 
 This section is for reference only, some descriptions have been truncated for brevity.
 
-This component intends to conform to the following WCAG success criteria:
+This component intends to conform to the following WCAG Success Criteria:
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
 
 ## Support

--- a/website/docs/components/form/radio/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio/partials/accessibility/accessibility.md
@@ -29,7 +29,7 @@ If a link is used within a label, helper text, or error text, it will not be pre
 
 This section is for reference only, some descriptions have been truncated for brevity.
 
-This component intends to conform to the following WCAG success criteria:
+This component intends to conform to the following WCAG Success Criteria:
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
 
 ## Support

--- a/website/docs/components/form/select/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/select/partials/accessibility/accessibility.md
@@ -71,6 +71,6 @@ Close with changing
 
 #### Applicable WCAG Success Criteria (Reference)
 
-This section is for reference only, some descriptions have been truncated for brevity. The `Form::Select::Base` variation of this component is conditionally conformant; that is, it is not conformant until it has an accessible name. Otherwise, this component intends to conform to the following WCAG success criteria:
+This section is for reference only, some descriptions have been truncated for brevity. The `Form::Select::Base` variation of this component is conditionally conformant; that is, it is not conformant until it has an accessible name. Otherwise, this component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />

--- a/website/docs/components/form/text-input/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/text-input/partials/accessibility/accessibility.md
@@ -17,7 +17,7 @@
 
 This section is for reference only, some descriptions have been truncated for brevity. 
 
-This component intends to conform to the following WCAG success criteria:
+This component intends to conform to the following WCAG Success Criteria:
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.1" "4.1.2" }} />
 
 ## Support

--- a/website/docs/components/form/textarea/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/textarea/partials/accessibility/accessibility.md
@@ -21,6 +21,6 @@ If a link is used within a label, helper text, or error text, it will not be pre
 
 ## Applicable WCAG Success Criteria
 
-This section is for reference only, some descriptions have been truncated for brevity. The `Form::Textarea::Base` variation of this component is conditionally conformant; that is, it is not conformant until it has an accessible name. Otherwise, this component intends to conform to the following WCAG success criteria:
+This section is for reference only, some descriptions have been truncated for brevity. The `Form::Textarea::Base` variation of this component is conditionally conformant; that is, it is not conformant until it has an accessible name. Otherwise, this component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />

--- a/website/docs/components/icon-tile/partials/accessibility/accessibility.md
+++ b/website/docs/components/icon-tile/partials/accessibility/accessibility.md
@@ -10,8 +10,8 @@ IconTiles should be hidden from screen readers.
 
 ![Accessibility example of an IconTile](/assets/components/icon-tile/icontile-hidden-example.png)
 
-## Applicable WCAG success criteria
+## Applicable WCAG Success Criteria
 
-This section is for reference only. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.4.11" }} />

--- a/website/docs/components/link/standalone/partials/accessibility/accessibility.md
+++ b/website/docs/components/link/standalone/partials/accessibility/accessibility.md
@@ -13,6 +13,6 @@ Animations or transitions will not take place if the user has `prefers-reduced-m
 
 ## Applicable WCAG Success Criteria
 
-This section is for reference only. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "2.1.1" "1.3.3" "1.4.1" "2.4.7" }} />

--- a/website/docs/components/modal/partials/accessibility/accessibility.md
+++ b/website/docs/components/modal/partials/accessibility/accessibility.md
@@ -26,6 +26,6 @@ Given the Modal is triggered via a keyboard, the dismiss button is first in the 
 
 #### Applicable WCAG Success Criteria
 
-This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG success criteria:
+This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.3.3" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.5" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.1.4" "2.4.2" "2.4.3" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.3.1" "3.3.2" "3.3.3" "3.3.4" "4.1.1" "4.1.2" "4.1.3" }} />

--- a/website/docs/components/table/partials/accessibility/accessibility.md
+++ b/website/docs/components/table/partials/accessibility/accessibility.md
@@ -32,7 +32,7 @@ There are a few critical items for developers to note:
 
 ## Applicable WCAG Success Criteria
 
-This section is for reference only. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.1.4" "2.4.3" "2.4.7" "4.1.1" "4.1.2" }} />
 

--- a/website/docs/components/tag/partials/accessibility/accessibility.md
+++ b/website/docs/components/tag/partials/accessibility/accessibility.md
@@ -11,6 +11,6 @@ When used as recommended, there should not be any accessibility issues with this
 
 ## Applicable WCAG Success Criteria
 
-This section is for reference only. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.4.1" "1.4.3" "1.4.4" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.4.7" "3.2.1" "4.1.1" "4.1.2" }} />

--- a/website/docs/components/template/partials/accessibility/accessibility.md
+++ b/website/docs/components/template/partials/accessibility/accessibility.md
@@ -25,6 +25,6 @@ The `Component Name` component is not WCAG-conformant on its own. (Explain how t
 
 ## Applicable WCAG Success Criteria
 
-This section is for reference only. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />

--- a/website/docs/components/toast/partials/accessibility/accessibility.md
+++ b/website/docs/components/toast/partials/accessibility/accessibility.md
@@ -10,6 +10,6 @@ When used as recommended, there should not be any WCAG conformance issues with t
 
 ## Applicable WCAG Success Criteria
 
-This section is for reference only. This component intends to conform to the following WCAG success criteria:
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />


### PR DESCRIPTION
### :pushpin: Summary

Noticed an issue where "WCAG Success Critieria" was not being uniformly capitalized. If merged, this PR wholesale fixes that.

***


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
