### PR TITLE
[DRAFT] `Pagination` - Split "numbered" and "compact"

### DIFF
--- a/packages/components/addon/components/hds/pagination/compact/index.hbs
+++ b/packages/components/addon/components/hds/pagination/compact/index.hbs
@@ -1,0 +1,28 @@
+{{! template-lint-disable simple-unless }}
+<div class="hds-pagination" ...attributes>
+  <nav class="hds-pagination-nav" aria-label="Pagination navigation">
+    {{! TODO use `has-block-params`? https://api.emberjs.com/ember/4.4/classes/Ember.Templates.helpers/methods/action?anchor=has-block-params }}
+    {{#unless (has-block)}}
+      <Hds::Pagination::Nav::ButtonArrow
+        @direction="prev"
+        @hideLabel={{(not this.showLabels)}}
+        @onClick={{this.onPageChange}}
+        @disabled={{@isDisabledPrev}}
+      />
+      <Hds::Pagination::Nav::ButtonArrow
+        @direction="next"
+        @hideLabel={{(not this.showLabels)}}
+        @onClick={{this.onPageChange}}
+        @disabled={{@isDisabledNext}}
+      />
+    {{else}}
+      {{yield
+        (hash
+          ButtonPrev=(component "hds/pagination/nav/button-arrow" direction="prev" onClick=this.onPageChange)
+          ButtonNext=(component "hds/pagination/nav/button-arrow" direction="next" onClick=this.onPageChange)
+        )
+      }}
+    {{/unless}}
+  </nav>
+</div>
+{{! template-lint-enable simple-unless }}

--- a/packages/components/addon/components/hds/pagination/compact/index.js
+++ b/packages/components/addon/components/hds/pagination/compact/index.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class HdsPaginationCompactIndexComponent extends Component {
+  /**
+   * @param showLabels
+   * @type {boolean}
+   * @default true
+   * @description Show the labels for the "prev/next" controls
+   */
+  get showLabels() {
+    let { showLabels = true } = this.args;
+
+    return showLabels;
+  }
+
+  @action
+  onPageChange(newPage) {
+    this.currentPage = newPage;
+
+    let { onPageChange } = this.args;
+
+    if (typeof onPageChange === 'function') {
+      onPageChange(newPage);
+    }
+  }
+}

--- a/packages/components/addon/components/hds/pagination/numbered/index.hbs
+++ b/packages/components/addon/components/hds/pagination/numbered/index.hbs
@@ -1,0 +1,24 @@
+<div class="hds-pagination" ...attributes>
+  {{#if this.showInfo}}
+    <Hds::Pagination::Info
+      @itemsRangeStart={{this.itemsRangeStart}}
+      @itemsRangeEnd={{this.itemsRangeEnd}}
+      @totalItems={{this.totalItems}}
+      @showTotalItems={{@showTotalItems}}
+    />
+  {{/if}}
+  <Hds::Pagination::Nav
+    @totalPages={{this.totalPages}}
+    @currentPage={{this.currentPage}}
+    @onPageChange={{this.onPageChange}}
+    @hideLabels={{(not this.showLabels)}}
+    @isTruncated={{@isTruncated}}
+  />
+  {{#if this.showSizeSelector}}
+    <Hds::Pagination::SizeSelector
+      @sizes={{@sizes}}
+      @selectedSize={{this.itemsPerPage}}
+      @onChange={{this.onPageSizeChange}}
+    />
+  {{/if}}
+</div>

--- a/packages/components/addon/components/hds/pagination/numbered/index.hbs
+++ b/packages/components/addon/components/hds/pagination/numbered/index.hbs
@@ -7,13 +7,37 @@
       @showTotalItems={{@showTotalItems}}
     />
   {{/if}}
-  <Hds::Pagination::Nav
-    @totalPages={{this.totalPages}}
-    @currentPage={{this.currentPage}}
-    @onPageChange={{this.onPageChange}}
-    @hideLabels={{(not this.showLabels)}}
-    @isTruncated={{@isTruncated}}
-  />
+
+  <nav class="hds-pagination-nav" aria-label="Pagination navigation">
+    <Hds::Pagination::Nav::ButtonArrow
+      @direction="prev"
+      @hideLabel={{(not this.showLabels)}}
+      @onClick={{this.onPageChange}}
+      @disabled={{this.isDisabledPrev}}
+    />
+    {{#if this.showPageNumbers}}
+      <ul class="hds-pagination-nav__page-list">
+        {{#each this.pages as |page|}}
+          {{#if (eq page "…")}}
+            <Hds::Pagination::Nav::Ellipsis />
+          {{else}}
+            <Hds::Pagination::Nav::ButtonNumber
+              @page={{page}}
+              @onClick={{this.onPageChange}}
+              @isSelected={{if (eq page this.currentPage) true false}}
+            />
+          {{/if}}
+        {{/each}}
+      </ul>
+    {{/if}}
+    <Hds::Pagination::Nav::ButtonArrow
+      @direction="next"
+      @hideLabel={{(not this.showLabels)}}
+      @onClick={{this.onPageChange}}
+      @disabled={{this.isDisabledNext}}
+    />
+  </nav>
+
   {{#if this.showSizeSelector}}
     <Hds::Pagination::SizeSelector
       @sizes={{@sizes}}

--- a/packages/components/addon/components/hds/pagination/numbered/index.js
+++ b/packages/components/addon/components/hds/pagination/numbered/index.js
@@ -1,0 +1,112 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class HdsPaginationNumberedIndexComponent extends Component {
+  @tracked currentItemsPerPage = this.args.itemsPerPage;
+  @tracked totalPages = this.calculateTotalPages();
+  @tracked currentPage = this.args.currentPage ?? 1;
+
+  /**
+   * @param showInfo
+   * @type {boolean}
+   * @default true
+   * @description Show the "info" block
+   */
+  get showInfo() {
+    let { showInfo = true } = this.args;
+
+    return showInfo;
+  }
+
+  /**
+   * @param showLabels
+   * @type {boolean}
+   * @default false
+   * @description Show the labels for the "prev/next" controls
+   */
+  get showLabels() {
+    let { showLabels = false } = this.args;
+
+    return showLabels;
+  }
+
+  /**
+   * @param showSizeSelector
+   * @type {boolean}
+   * @default true
+   * @description Show the "size selector" block
+   */
+  get showSizeSelector() {
+    let { showSizeSelector = true } = this.args;
+
+    return showSizeSelector;
+  }
+
+  /**
+   * @param totalItems
+   * @type {number}
+   * @description Pass the total number of items to be paginated. If no value is defined an error will be thrown.
+   */
+  get totalItems() {
+    let { totalItems } = this.args;
+
+    return totalItems;
+  }
+
+  /**
+   * @param itemsPerPage
+   * @type {number}
+   * @description Pass the maximum number of items to display on each page initially.
+   */
+  get itemsPerPage() {
+    return this.currentItemsPerPage;
+  }
+
+  get itemsRangeStart() {
+    // Calculate the starting range of items displayed on current page
+    // if currentPage = 1st page and # of items per page is 10:
+    //  ( (1 - 1 = 0) * 10 = 0 ) + 1 = 1
+    // if current page = 2nd page:
+    // ( (2 - 1 = 1) * 10 = 10 ) + 1 = 11
+    return (this.currentPage - 1) * this.itemsPerPage + 1;
+  }
+
+  get itemsRangeEnd() {
+    // Calculate ending range of items displayed on current page
+    // 2 cases: 1) full page of items or 2) last page of items
+    if (this.currentPage * this.itemsPerPage < this.totalItems) {
+      // 1) full page of items (pages 1 to page before last):
+      return this.itemsRangeStart + this.itemsPerPage - 1;
+    } else {
+      // 2) last page of items:
+      return this.totalItems;
+    }
+  }
+
+  @action
+  onPageChange(newPage) {
+    this.currentPage = newPage;
+
+    let { onPageChange } = this.args;
+
+    if (typeof onPageChange === 'function') {
+      onPageChange(newPage);
+    }
+  }
+
+  @action
+  onPageSizeChange(newPageSize) {
+    this.currentItemsPerPage = newPageSize;
+    this.currentPage = 1;
+    this.totalPages = this.calculateTotalPages();
+  }
+
+  calculateTotalPages() {
+    if (this.totalItems) {
+      return Math.max(Math.ceil(this.totalItems / this.itemsPerPage), 1);
+    } else {
+      return undefined;
+    }
+  }
+}

--- a/packages/components/addon/components/hds/pagination/numbered/index.js
+++ b/packages/components/addon/components/hds/pagination/numbered/index.js
@@ -44,6 +44,30 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   }
 
   /**
+   * @param showPageNumbers
+   * @type {boolean}
+   * @default true
+   * @description Show the "page numbers" block
+   */
+  get showPageNumbers() {
+    let { showPageNumbers = true } = this.args;
+
+    return showPageNumbers;
+  }
+
+  /**
+   * Gets the current page
+   *
+   * @param currentPage
+   * @type {number}
+   */
+  get currentPage() {
+    let { currentPage = 1 } = this.args;
+
+    return currentPage;
+  }
+
+  /**
    * @param totalItems
    * @type {number}
    * @description Pass the total number of items to be paginated. If no value is defined an error will be thrown.
@@ -84,14 +108,99 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
     }
   }
 
+  get pages() {
+    let pages = [];
+
+    for (let i = 1; i <= this.totalPages; i++) {
+      pages.push(i);
+    }
+
+    if (this.args.isTruncated) {
+      return this.elliptize({ pages, current: this.currentPage });
+    } else {
+      return pages;
+    }
+  }
+
+  elliptize({ pages, current }) {
+    const limit = 7; // limit # of page numbers shown at a time (should always be an odd number!)
+    const length = pages.length;
+    const ellipsis = '…';
+    let result = [];
+    let start;
+    let end;
+
+    if (length <= limit) {
+      return pages;
+    }
+
+    if (current <= length / 2) {
+      start = Math.ceil(limit / 2);
+      end = limit - start;
+    } else {
+      end = Math.ceil(limit / 2);
+      start = limit - end;
+    }
+
+    const sliceStart = pages.slice(0, start);
+    const sliceEnd = pages.slice(-end);
+
+    if (sliceStart.includes(current) && sliceStart.includes(current + 1)) {
+      // "current" (and its next sibling) is contained within the "sliceStart" block
+      sliceEnd.splice(0, 1, ellipsis);
+      result = [].concat(sliceStart, sliceEnd);
+    } else if (sliceEnd.includes(current - 1) && sliceEnd.includes(current)) {
+      // "current" (and its prev sibling) is contained within the "sliceEnd" block
+      sliceStart.splice(-1, 1, ellipsis);
+      result = [].concat(sliceStart, sliceEnd);
+    } else {
+      // this is a bit more tricky :)
+      // we need to calculate how many items there are before/after the current item
+      // since both the initial and ending blocks are always 2 items long (number + ellipsis)
+      // and there is always the "current" item, we can just subtract 5 from the limit
+      const delta = (limit - 5) / 2; // this is why the limit needs to be an odd number
+      // we slice the array starting at the "current" index, minus the delta, minus one because it's an array (zero-based)
+      const sliceCurr = pages.slice(current - delta - 1, current + delta);
+      result = [].concat(
+        sliceStart.shift(),
+        ellipsis,
+        sliceCurr,
+        ellipsis,
+        sliceEnd.pop()
+      );
+    }
+
+    return result;
+  }
+
+  get isDisabledPrev() {
+    return this.currentPage === 1;
+  }
+
+  get isDisabledNext() {
+    return this.currentPage === this.totalPages;
+  }
+
   @action
-  onPageChange(newPage) {
-    this.currentPage = newPage;
+  onPageChange(page) {
+    let gotoPageNumber;
+    if (page === 'prev' && this.currentPage > 1) {
+      gotoPageNumber = this.currentPage - 1;
+    } else if (page === 'next' && this.currentPage < this.totalPages) {
+      gotoPageNumber = this.currentPage + 1;
+    } else {
+      gotoPageNumber = page;
+    }
 
-    let { onPageChange } = this.args;
+    this.currentPage = gotoPageNumber;
 
-    if (typeof onPageChange === 'function') {
-      onPageChange(newPage);
+    // we want to invoke the `onPageChange` callback only on actual page change
+    if (gotoPageNumber !== this.currentPage) {
+      let { onPageChange } = this.args;
+
+      if (typeof onPageChange === 'function') {
+        onPageChange(gotoPageNumber);
+      }
     }
   }
 

--- a/packages/components/addon/components/hds/pagination/numbered/index.js
+++ b/packages/components/addon/components/hds/pagination/numbered/index.js
@@ -56,6 +56,18 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   }
 
   /**
+   * @param isTruncated
+   * @type {boolean}
+   * @default true
+   * @description Limit the visible "page numbers" (elliptize them)
+   */
+  get isTruncated() {
+    let { isTruncated = true } = this.args;
+
+    return isTruncated;
+  }
+
+  /**
    * Gets the current page
    *
    * @param currentPage

--- a/packages/components/app/components/hds/pagination/compact/index.js
+++ b/packages/components/app/components/hds/pagination/compact/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/pagination/compact/index';

--- a/packages/components/app/components/hds/pagination/numbered/index.js
+++ b/packages/components/app/components/hds/pagination/numbered/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/pagination/numbered/index';

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -1,6 +1,69 @@
 {{page-title "Pagination Component"}}
 
-<h2 class="dummy-h2">Pagination</h2>
+<h2 class="dummy-h2">Pagination (SPLIT IN TWO)</h2>
+
+<h3 class="dummy-h3">Numbered</h3>
+<h4 class="dummy-h4">Previous implementation</h4>
+{{! prettier-ignore-start }}
+{{! template-lint-disable no-unbalanced-curlies }}
+<CodeBlock
+  @language="markup"
+  @code="
+    <Hds::Pagination @totalItems=\{{100}} @itemsPerPage=\{{30}} @currentPage=\{{3}} as |P|>
+      <P.Info @showTotalItems=\{{false}} />
+      <P.Nav @hideLabels=\{{false}} @isTruncated=\{{true}} />
+      <P.SizeSelector @sizes=\{{array 10 30 50}} />
+    </Hds::Pagination>
+  "
+/>
+{{! template-lint-enable no-unbalanced-curlies }}
+{{! prettier-ignore-end }}
+<p class="dummy-paragraph">Renders to:</p>
+<Hds::Pagination @totalItems={{100}} @itemsPerPage={{30}} @currentPage={{3}} as |P|>
+  <P.Info @showTotalItems={{false}} />
+  <P.Nav @hideLabels={{false}} @isTruncated={{true}} />
+  <P.SizeSelector @sizes={{array 10 30 50}} />
+</Hds::Pagination>
+
+<h4 class="dummy-h4">Proposed implementation</h4>
+{{! prettier-ignore-start }}
+{{! template-lint-disable no-unbalanced-curlies }}
+<CodeBlock
+  @language="markup"
+  @code="
+    <Hds::Pagination::Numbered
+      @totalItems=\{{100}}
+      @itemsPerPage=\{{30}}
+      @currentPage=\{{3}}
+      @showInfo=\{{true}}
+      @showTotalItems=\{{false}}
+      @showLabels=\{{true}}
+      @isTruncated=\{{true}}
+      @showSizeSelector=\{{true}}
+      @sizes=\{{array 10 30 50}}
+      @onPageChange=\{{this.handleOnPageChange}}
+    />
+  "
+/>
+{{! template-lint-enable no-unbalanced-curlies }}
+{{! prettier-ignore-end }}
+<p class="dummy-paragraph">Renders to:</p>
+<Hds::Pagination::Numbered
+  @totalItems={{100}}
+  @itemsPerPage={{30}}
+  @currentPage={{3}}
+  @showInfo={{true}}
+  @showTotalItems={{false}}
+  @showLabels={{true}}
+  @isTruncated={{true}}
+  @showSizeSelector={{true}}
+  @sizes={{array 10 30 50}}
+  @onPageChange={{this.handleOnPageChange}}
+/>
+
+<hr class="dummy-divider" />
+
+<h2 class="dummy-h2">Pagination (PREVIOUS IMPLEMENTATION)</h2>
 
 <section>
   <h3 class="dummy-h3" id="overview"><a href="#overview" class="dummy-link-section">§</a> Overview</h3>

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -38,7 +38,7 @@
       @showInfo=\{{true}}
       @showTotalItems=\{{false}}
       @showLabels=\{{true}}
-      @isTruncated=\{{true}}
+      @isTruncated=\{{false}}
       @showSizeSelector=\{{true}}
       @sizes=\{{array 10 30 50}}
       @onPageChange=\{{this.handleOnPageChange}}
@@ -55,7 +55,7 @@
   @showInfo={{true}}
   @showTotalItems={{false}}
   @showLabels={{true}}
-  @isTruncated={{true}}
+  @isTruncated={{false}}
   @showSizeSelector={{true}}
   @sizes={{array 10 30 50}}
   @onPageChange={{this.handleOnPageChange}}

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -61,6 +61,81 @@
   @onPageChange={{this.handleOnPageChange}}
 />
 
+<h3 class="dummy-h3">Compact</h3>
+<h4 class="dummy-h4">Previous implementation</h4>
+{{! prettier-ignore-start }}
+{{! template-lint-disable no-unbalanced-curlies }}
+<CodeBlock
+  @language="markup"
+  @code="
+    <Hds::Pagination @onPageChange=\{{this.handlePageChange}} as |P|>
+      <P.Nav />
+    </Hds::Pagination>
+  "
+/>
+{{! template-lint-enable no-unbalanced-curlies }}
+{{! prettier-ignore-end }}
+<p class="dummy-paragraph">Renders to:</p>
+<Hds::Pagination @onPageChange={{this.handlePageChange}} as |P|>
+  <P.Nav />
+</Hds::Pagination>
+
+<h4 class="dummy-h4">Proposed implementation</h4>
+{{! prettier-ignore-start }}
+{{! template-lint-disable no-unbalanced-curlies }}
+<CodeBlock
+  @language="markup"
+  @code="
+    <Hds::Pagination::Compact
+      @isDisabledPrev=\{{true}}
+      @onPageChange=\{{this.handlePageChange}}
+    />
+  "
+/>
+{{! template-lint-enable no-unbalanced-curlies }}
+{{! prettier-ignore-end }}
+<p class="dummy-paragraph">Renders to:</p>
+<Hds::Pagination::Compact @isDisabledPrev={{true}} @onPageChange={{this.handlePageChange}} />
+
+<h4 class="dummy-h4">With contextual components</h4>
+{{! prettier-ignore-start }}
+{{! template-lint-disable no-unbalanced-curlies }}
+<CodeBlock
+  @language="markup"
+  @code='
+    <Hds::Pagination::Compact @onPageChange=\{{this.handlePageChange}} as |P|>
+      <P.ButtonPrev @route="components.pagination" @query=\{{hash prev="previousPage" next=undefined}} @disabled=\{{true}} />
+      <P.ButtonNext @route="components.pagination" @query=\{{hash prev=undefined next="nextPage"}} />
+    </Hds::Pagination::Compact>
+  '
+/>
+{{! template-lint-enable no-unbalanced-curlies }}
+{{! prettier-ignore-end }}
+<p class="dummy-paragraph">Renders to:</p>
+<Hds::Pagination::Compact @onPageChange={{this.handlePageChange}} as |P|>
+  <P.ButtonPrev @route="components.pagination" @query={{hash prev="previousPage" next=undefined}} @disabled={{true}} />
+  <P.ButtonNext @route="components.pagination" @query={{hash prev=undefined next="nextPage"}} />
+</Hds::Pagination::Compact>
+
+<h4 class="dummy-h4">Possible alternative (not implemented)</h4>
+{{! prettier-ignore-start }}
+{{! template-lint-disable no-unbalanced-curlies }}
+<CodeBlock
+  @language="markup"
+  @code='
+    <Hds::Pagination::Compact
+      @routePrev="components.pagination"
+      @queryPrev=\{{hash prev="previousPage" next=undefined}}
+      @isDisabledPrev=\{{true}}
+      @routeNext="components.pagination"
+      @queryNext=\{{hash prev=undefined next="nextPage"}}
+      @onPageChange=\{{this.handlePageChange}}
+    />
+  '
+/>
+{{! template-lint-enable no-unbalanced-curlies }}
+{{! prettier-ignore-end }}
+
 <hr class="dummy-divider" />
 
 <h2 class="dummy-h2">Pagination (PREVIOUS IMPLEMENTATION)</h2>

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -61,6 +61,25 @@
   @onPageChange={{this.handleOnPageChange}}
 />
 
+<h4 class="dummy-h4">Possible variants</h4>
+<p class="dummy-paragraph">Without "info" and "size-selector":</p>
+<Hds::Pagination::Numbered
+  @totalItems={{100}}
+  @itemsPerPage={{10}}
+  @showInfo={{false}}
+  @showSizeSelector={{false}}
+  @onPageChange={{this.handleOnPageChange}}
+/>
+<p class="dummy-paragraph">Without "page numbers":</p>
+<Hds::Pagination::Numbered
+  @totalItems={{30}}
+  @itemsPerPage={{10}}
+  @showLabels={{true}}
+  @showPageNumbers={{false}}
+  @sizes={{array 10 30 50}}
+  @onPageChange={{this.handleOnPageChange}}
+/>
+
 <h3 class="dummy-h3">Compact</h3>
 <h4 class="dummy-h4">Previous implementation</h4>
 {{! prettier-ignore-start }}


### PR DESCRIPTION
### :pushpin: Summary

This PR is a follow-up of https://github.com/hashicorp/design-system/pull/1020. 

The reason for this is that the previous implementation was trying to do too much in having a single pagination component handling two very different things (pagination with a known number of items, and with an unknown number of items) under the single component/code implementation.

With this PR I propose to split the code in two different components:
- `Hds::Pagination::Numbered` - for use cases when the number of items is known, and this handles all the complexity of the pagination information shown to the user ("info", "page numbers", "current page", "page size") 
- `Hds::Pagination::Compact` - for use cases when the number of items is unknown, so it's impossible to have the "info", the "page numbers" and the "select-size" elements, and there is no concept of "current page"

👉 👉 👉 **Preview** (see top of the page): https://hds-components-git-hds-972-pagination-split-co-ed904c-hashicorp.vercel.app/components/pagination

### :hammer_and_wrench: Detailed description

**🚧 TODO 🚧**

This PR is a work-in-progress, waiting to discuss it with @KristinLBradley and with the HDS Ambassadors.

### 🖇 Related tickets/PRs
- https://github.com/hashicorp/design-system/pull/661
- https://github.com/hashicorp/design-system/pull/1020

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
