### PR TITLE
[SPIKE] New docs website / `iFrame` embedding for showcase

### DIFF
--- a/website/app/components/doc/embed-showcase/index.hbs
+++ b/website/app/components/doc/embed-showcase/index.hbs
@@ -1,0 +1,9 @@
+{{#if @path}}
+  {{! TODO discuss with Melanie how can we solve this }}
+  {{! template-lint-disable require-iframe-title }}
+  <iframe
+    id="doc-embed-showcase-{{dasherize @path}}"
+    src="https://design-system-components-hashicorp.vercel.app/{{@path}}"
+    {{iframe-resizer log=true checkOrigin=false}}
+  ></iframe>
+{{/if}}

--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -20,6 +20,10 @@ previewImage: assets/illustrations/components/alert.jpg
   @include "partials/code/showcase.md"
 </section>
 
+<section data-tab="Showcase">
+  @include "partials/code/showcase-embedded.md"
+</section>
+
 <section data-tab="Specifications">
   @include "partials/specifications/anatomy.md"
 </section>

--- a/website/docs/components/alert/partials/code/showcase-embedded.md
+++ b/website/docs/components/alert/partials/code/showcase-embedded.md
@@ -1,0 +1,3 @@
+## Showcase
+
+<Doc::EmbedShowcase @path="components/alert" />

--- a/website/package.json
+++ b/website/package.json
@@ -62,6 +62,7 @@
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^2.3.7",
     "ember-fetch": "^8.1.2",
+    "ember-iframe-resizer-modifier": "^1.0.2",
     "ember-load-initializers": "^2.1.2",
     "ember-math-helpers": "^2.18.2",
     "ember-meta": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9899,7 +9899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-auto-import@npm:^1.11.3":
+"ember-auto-import@npm:^1.11.3, ember-auto-import@npm:^1.5.3":
   version: 1.12.2
   resolution: "ember-auto-import@npm:1.12.2"
   dependencies:
@@ -10068,7 +10068,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-cli-babel@npm:^7.0.0, ember-cli-babel@npm:^7.1.0, ember-cli-babel@npm:^7.1.2, ember-cli-babel@npm:^7.1.3, ember-cli-babel@npm:^7.10.0, ember-cli-babel@npm:^7.13.0, ember-cli-babel@npm:^7.13.2, ember-cli-babel@npm:^7.19.0, ember-cli-babel@npm:^7.21.0, ember-cli-babel@npm:^7.22.1, ember-cli-babel@npm:^7.23.0, ember-cli-babel@npm:^7.23.1, ember-cli-babel@npm:^7.26.0, ember-cli-babel@npm:^7.26.10, ember-cli-babel@npm:^7.26.11, ember-cli-babel@npm:^7.26.3, ember-cli-babel@npm:^7.26.4, ember-cli-babel@npm:^7.26.6, ember-cli-babel@npm:^7.26.8, ember-cli-babel@npm:^7.7.3":
+"ember-cli-babel@npm:^7.0.0, ember-cli-babel@npm:^7.1.0, ember-cli-babel@npm:^7.1.2, ember-cli-babel@npm:^7.1.3, ember-cli-babel@npm:^7.10.0, ember-cli-babel@npm:^7.13.0, ember-cli-babel@npm:^7.13.2, ember-cli-babel@npm:^7.19.0, ember-cli-babel@npm:^7.20.5, ember-cli-babel@npm:^7.21.0, ember-cli-babel@npm:^7.22.1, ember-cli-babel@npm:^7.23.0, ember-cli-babel@npm:^7.23.1, ember-cli-babel@npm:^7.26.0, ember-cli-babel@npm:^7.26.10, ember-cli-babel@npm:^7.26.11, ember-cli-babel@npm:^7.26.3, ember-cli-babel@npm:^7.26.4, ember-cli-babel@npm:^7.26.6, ember-cli-babel@npm:^7.26.8, ember-cli-babel@npm:^7.7.3":
   version: 7.26.11
   resolution: "ember-cli-babel@npm:7.26.11"
   dependencies:
@@ -10225,7 +10225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-cli-htmlbars@npm:^5.2.0, ember-cli-htmlbars@npm:^5.3.1, ember-cli-htmlbars@npm:^5.3.2, ember-cli-htmlbars@npm:^5.7.1":
+"ember-cli-htmlbars@npm:^5.1.2, ember-cli-htmlbars@npm:^5.2.0, ember-cli-htmlbars@npm:^5.3.1, ember-cli-htmlbars@npm:^5.3.2, ember-cli-htmlbars@npm:^5.7.1":
   version: 5.7.2
   resolution: "ember-cli-htmlbars@npm:5.7.2"
   dependencies:
@@ -10862,6 +10862,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ember-iframe-resizer-modifier@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "ember-iframe-resizer-modifier@npm:1.0.2"
+  dependencies:
+    broccoli-funnel: ^3.0.3
+    broccoli-merge-trees: ^4.2.0
+    ember-auto-import: ^1.5.3
+    ember-cli-babel: ^7.20.5
+    ember-cli-htmlbars: ^5.1.2
+    ember-modifier: ^2.1.0
+    iframe-resizer: ^4.2.11
+  checksum: 765aac11ca1c8cdd8ca3cef4931a5ef685475ec660aa33f28ca95ac5a1a5410338493f4a9965d94d12421fcbc4b1ee05f66e4ccce47060e3726840b1b5fc4a36
+  languageName: node
+  linkType: hard
+
 "ember-in-element-polyfill@npm:^1.0.0, ember-in-element-polyfill@npm:^1.0.1":
   version: 1.0.1
   resolution: "ember-in-element-polyfill@npm:1.0.1"
@@ -10947,7 +10962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-modifier@npm:^2.1.1":
+"ember-modifier@npm:^2.1.0, ember-modifier@npm:^2.1.1":
   version: 2.1.2
   resolution: "ember-modifier@npm:2.1.2"
   dependencies:
@@ -14126,6 +14141,13 @@ __metadata:
   version: 0.1.5
   resolution: "iferr@npm:0.1.5"
   checksum: a18d19b6ad06a2d5412c0d37f6364869393ef6d1688d59d00082c1f35c92399094c031798340612458cd832f4f2e8b13bc9615934a7d8b0c53061307a3816aa1
+  languageName: node
+  linkType: hard
+
+"iframe-resizer@npm:^4.2.11":
+  version: 4.3.2
+  resolution: "iframe-resizer@npm:4.3.2"
+  checksum: 762d934f4fbe7e4b76c0f4574c2a47ef0e3fc6c82564f512ec41e62b62501052d271fb8ca5d268535509c0088132493c0ac78312af0fe3f11bf65cd964dd11a0
   languageName: node
   linkType: hard
 
@@ -23218,6 +23240,7 @@ __metadata:
     ember-cli-terser: ^4.0.2
     ember-concurrency: ^2.3.7
     ember-fetch: ^8.1.2
+    ember-iframe-resizer-modifier: ^1.0.2
     ember-load-initializers: ^2.1.2
     ember-math-helpers: ^2.18.2
     ember-meta: ^2.0.0


### PR DESCRIPTION
### :pushpin: Summary

A quick spike to validate the assumption that we could potentially embed the `showcase` from the "scrappy" website into the new "helios" website.

👉 👉 👉 **Preview**: https://hds-website-git-new-docs-website-iframe-embedding-hashicorp.vercel.app/components/alert?tab=showcase

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1399

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
