### PR TITLE
New docs website / Hide "showcase" content from the website

### DIFF
--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/alert.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/avatar/index.md
+++ b/website/docs/components/avatar/index.md
@@ -15,7 +15,7 @@ previewImage: assets/illustrations/components/avatar.jpg
 <section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Accessibility">

--- a/website/docs/components/badge-count/index.md
+++ b/website/docs/components/badge-count/index.md
@@ -16,7 +16,7 @@ previewImage: assets/illustrations/components/badge-count.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Accessibility">

--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/badge.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/breadcrumb.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/button-set/index.md
+++ b/website/docs/components/button-set/index.md
@@ -16,5 +16,5 @@ previewImage: assets/illustrations/components/button-set.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>

--- a/website/docs/components/button/index.md
+++ b/website/docs/components/button/index.md
@@ -16,7 +16,7 @@ previewImage: assets/illustrations/components/button.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/card/index.md
+++ b/website/docs/components/card/index.md
@@ -16,7 +16,7 @@ previewImage: assets/illustrations/components/card.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Accessibility">

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/dropdown.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/empty-state/index.md
+++ b/website/docs/components/empty-state/index.md
@@ -6,7 +6,7 @@ hidden: true
 <section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/form/checkbox/index.md
+++ b/website/docs/components/form/checkbox/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/form/checkbox.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/form/primitives/index.md
+++ b/website/docs/components/form/primitives/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/form/primitives.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Accessibility">

--- a/website/docs/components/form/radio-card/index.md
+++ b/website/docs/components/form/radio-card/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/form/radio-card.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/form/radio/index.md
+++ b/website/docs/components/form/radio/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/form/radio.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/form/select/index.md
+++ b/website/docs/components/form/select/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/form/select.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/form/text-input.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/form/textarea/index.md
+++ b/website/docs/components/form/textarea/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/form/textarea.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/form/toggle/index.md
+++ b/website/docs/components/form/toggle/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/form/toggle.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/icon-tile.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/link/inline/index.md
+++ b/website/docs/components/link/inline/index.md
@@ -17,5 +17,5 @@ previewImage: assets/illustrations/components/link/inline.jpg
 <section data-tab="Code">
   @include "partials/code/component-api.md"
   @include "partials/code/how-to-use.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>

--- a/website/docs/components/link/standalone/index.md
+++ b/website/docs/components/link/standalone/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/link/standalone.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/modal.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/stepper/index.md
+++ b/website/docs/components/stepper/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/stepper.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/table/index.md
+++ b/website/docs/components/table/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/table.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/tabs/index.md
+++ b/website/docs/components/tabs/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/tabs.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/tag.jpg
 <section data-tab="Code">
  @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/template/index.md
+++ b/website/docs/components/template/index.md
@@ -17,7 +17,7 @@ links:
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/toast/index.md
+++ b/website/docs/components/toast/index.md
@@ -17,7 +17,7 @@ previewImage: assets/illustrations/components/toast.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/foundations/elevation/index.md
+++ b/website/docs/foundations/elevation/index.md
@@ -7,7 +7,7 @@ previewImage: assets/illustrations/foundations/elevation.jpg
 
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Guidelines">

--- a/website/docs/overrides/power-select/index.md
+++ b/website/docs/overrides/power-select/index.md
@@ -7,6 +7,6 @@ previewImage: assets/illustrations/overrides/power-select.jpg
 
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 

--- a/website/docs/utilities/disclosure/index.md
+++ b/website/docs/utilities/disclosure/index.md
@@ -8,6 +8,6 @@ previewImage: assets/illustrations/utilities/disclosure.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 

--- a/website/docs/utilities/dismiss-button/index.md
+++ b/website/docs/utilities/dismiss-button/index.md
@@ -6,9 +6,9 @@ previewImage: assets/illustrations/utilities/dismiss-button.jpg
 ---
 
 <section data-tab="Code">
-  
+
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 

--- a/website/docs/utilities/interactive/index.md
+++ b/website/docs/utilities/interactive/index.md
@@ -8,6 +8,6 @@ previewImage: assets/illustrations/utilities/interactive.jpg
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 


### PR DESCRIPTION
### :pushpin: Summary

Per team discussion and decision, we're hiding the "showcase" content from the website, and gather feedback on this decision from the stakeholders.

### :hammer_and_wrench: Detailed description

In this PR I have:
- commented out `showcase` file inclusion in the doc pages

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1318

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
