### PR TITLE
Website Bug Fix / Select accessibility images broken

### DIFF
--- a/website/docs/components/form/select/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/select/partials/accessibility/accessibility.md
@@ -10,19 +10,19 @@
 
 Hover
 
-![Image of hover interaction on the select](/assets/components/select/accessibility/mouse/select-hover.png)
+![Image of hover interaction on the select](/assets/components/form/select/accessibility/mouse/select-hover.png)
 
 Click to open OptionList
 
-![Image of the interaction of opening the OptionList](/assets/components/select/accessibility/mouse/select-click-to-open.png)
+![Image of the interaction of opening the OptionList](/assets/components/form/select/accessibility/mouse/select-click-to-open.png)
 
 Hover between items
 
-![Image of the hover interaction between two items in an OptionList](/assets/components/select/accessibility/mouse/select-hover-between-items.png)
+![Image of the hover interaction between two items in an OptionList](/assets/components/form/select/accessibility/mouse/select-hover-between-items.png)
 
 Click to select OptionList/Item
 
-![Image of the selected state of a item in the OptionList](/assets/components/select/accessibility/mouse/select-click-to-select.png)
+![Image of the selected state of a item in the OptionList](/assets/components/form/select/accessibility/mouse/select-click-to-select.png)
 
 ### Keyboard
 
@@ -32,7 +32,7 @@ Focus
   <Hds::Badge @color="neutral" @type="filled" @text="Tab" @size="small" />
 </div>
 
-![Example image of focusing on the select with tab on a keyboard](/assets/components/select/accessibility/keyboard/select-focus.png)
+![Example image of focusing on the select with tab on a keyboard](/assets/components/form/select/accessibility/keyboard/select-focus.png)
 
 Open OptionList
 
@@ -41,7 +41,7 @@ Open OptionList
   <Hds::Badge @color="neutral" @type="filled" @text="↓" @size="small" />
 </div>
 
-![Example image of selecting an item in the OptionList with spacebar](/assets/components/select/accessibility/keyboard/select-spacebar.png)
+![Example image of selecting an item in the OptionList with spacebar](/assets/components/form/select/accessibility/keyboard/select-spacebar.png)
 
 Move between items
 
@@ -50,7 +50,7 @@ Move between items
   <Hds::Badge @color="neutral" @type="filled" @text="↓" @size="small" />
 </div>
 
-![Example image of moving between items with up and down arrow keys](/assets/components/select/accessibility/keyboard/select-arrow-keys.png)
+![Example image of moving between items with up and down arrow keys](/assets/components/form/select/accessibility/keyboard/select-arrow-keys.png)
 
 Select OptionList/Item
 
@@ -58,7 +58,7 @@ Select OptionList/Item
   <Hds::Badge @color="neutral" @type="filled" @text="Enter" @size="small" />
 </div>
 
-![Example image of selecting an item in an OptionList with enter](/assets/components/select/accessibility/keyboard/select-enter.png)
+![Example image of selecting an item in an OptionList with enter](/assets/components/form/select/accessibility/keyboard/select-enter.png)
 
 Close with changing
 
@@ -66,7 +66,7 @@ Close with changing
   <Hds::Badge @color="neutral" @type="filled" @text="Esc" @size="small" />
 </div>
 
-![Example image of closing the select with the escape key](/assets/components/select/accessibility/keyboard/select-focus.png)
+![Example image of closing the select with the escape key](/assets/components/form/select/accessibility/keyboard/select-focus.png)
 
 
 #### Applicable WCAG Success Criteria (Reference)


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes the markdown image paths for the images on the `Form / Select / Accessibility` component.

### :link: External links

👉 [Preview](https://hds-website-git-jt-bug-fix-select-accessibilit-c24bbf-hashicorp.vercel.app/components/form/select?tab=accessibility)

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1401](https://hashicorp.atlassian.net/browse/HDS-1401)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1401]: https://hashicorp.atlassian.net/browse/HDS-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ