### PR TITLE
Adding note about non-hashi employee contributions

### DIFF
--- a/website/docs/getting-started/contribution/index.md
+++ b/website/docs/getting-started/contribution/index.md
@@ -3,6 +3,11 @@ title: Contribution
 order: 104
 ---
 
+!!! Info
+
+At this time we are not accepting external contributions from non-HashiCorp employees. Many resources and links on this page are only available to HashiCorp employees.
+!!!
+
 ## Types of contribution
 
 While we don’t accept direct contributions of new components or patterns, we do welcome contributions in the following forms:


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add a banner to the Contribution page noting that contributions are not accepted from non-HashiCorp employees. This was the result of a thread in the blog post draft. 

**Preview link:** https://hds-website-git-heatherlarsen-contributing-update-hashicorp.vercel.app/getting-started/contribution

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
