### PR TITLE
Use node 16.x for `website` deployments

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -97,7 +97,7 @@
     "yaml-front-matter": "^4.1.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "12.* || 14.* || 16.*"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
### :pushpin: Summary

Use node 16.x for the website deployment to overcome [an issue](https://vercel.com/hashicorp/hds-website/Afg8kd9UHv8mhhwHzDaG99pkqSSW#L78) we have [with 17.x](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported).

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
