### PR TITLE
New docs website / Add a "filter" to the sidebar navigation

### DIFF
--- a/website/app/components/doc/form/filter.hbs
+++ b/website/app/components/doc/form/filter.hbs
@@ -1,0 +1,10 @@
+<div class="doc-form-filter">
+  <input
+    type="search"
+    class="doc-form-filter__control"
+    placeholder={{@placeholder}}
+    value={{@filterQuery}}
+    {{on "input" (perform @onInput value="target.value")}}
+    ...attributes
+  />
+</div>

--- a/website/app/components/doc/form/filter.hbs
+++ b/website/app/components/doc/form/filter.hbs
@@ -3,6 +3,7 @@
     type="search"
     class="doc-form-filter__control"
     placeholder={{@placeholder}}
+    aria-label={{@placeholder}}
     value={{@filterQuery}}
     {{on "input" (perform @onInput value="target.value")}}
     ...attributes

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -30,7 +30,7 @@
         </li>
       </ul>
     </nav>
-    {{#if this.structuredPageTree}}
+    {{#if (or this.structuredPageTree this.isFiltered)}}
       <div class="doc-page-sidebar__filter">
         <Doc::Form::Filter
           @placeholder="Filter sidebar"
@@ -42,11 +42,15 @@
         />
       </div>
       <nav class="doc-page-sidebar__table-of-contents" aria-label="secondary page navigation">
-        <Doc::TableOfContents
-          @structuredPageTree={{this.structuredPageTree}}
-          @depth={{1}}
-          @isFiltered={{this.isFiltered}}
-        />
+        {{#if this.hasTableOfContents}}
+          <Doc::TableOfContents
+            @structuredPageTree={{this.structuredPageTree}}
+            @depth={{1}}
+            @isFiltered={{this.isFiltered}}
+          />
+        {{else}}
+          <p class="doc-text-body-small">No results found</p>
+        {{/if}}
       </nav>
     {{/if}}
   </div>

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -38,10 +38,15 @@
           autocorrect="off"
           autocapitalize="none"
           spellcheck="false"
+          @onInput={{this.filterPageTree}}
         />
       </div>
       <nav class="doc-page-sidebar__table-of-contents" aria-label="secondary page navigation">
-        <Doc::TableOfContents @structuredPageTree={{this.structuredPageTree}} @depth={{1}} />
+        <Doc::TableOfContents
+          @structuredPageTree={{this.structuredPageTree}}
+          @depth={{1}}
+          @isFiltered={{this.isFiltered}}
+        />
       </nav>
     {{/if}}
   </div>

--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -31,6 +31,15 @@
       </ul>
     </nav>
     {{#if this.structuredPageTree}}
+      <div class="doc-page-sidebar__filter">
+        <Doc::Form::Filter
+          @placeholder="Filter sidebar"
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="none"
+          spellcheck="false"
+        />
+      </div>
       <nav class="doc-page-sidebar__table-of-contents" aria-label="secondary page navigation">
         <Doc::TableOfContents @structuredPageTree={{this.structuredPageTree}} @depth={{1}} />
       </nav>

--- a/website/app/components/doc/page/sidebar.js
+++ b/website/app/components/doc/page/sidebar.js
@@ -7,7 +7,7 @@ const DEBOUNCE_MS = 250;
 // we want to limit the content of the sidebar navigation to only the links related to the current "section".
 // notice: super hacky way to do it, but... it works™ !
 const getTocSectionBundle = (section) => {
-  const ABOUT = ['about', 'getting-started', 'updates'];
+  const ABOUT = ['about', 'getting-started'];
   const FOUNDATIONS = ['foundations', 'icons'];
   const COMPONENTS = ['components', 'overrides', 'utilities'];
   const PATTERNS = ['patterns'];
@@ -83,11 +83,13 @@ export default class DocPageSidebarComponent extends Component {
 
     const subSectionTree = {};
     getTocSectionBundle(currentSection).forEach((section) => {
-      let subTree = {};
+      let subTree;
       if (this.isFiltered) {
         subTree = filterSubTree(this.args.toc.tree[section], this.filterQuery);
       } else {
-        subTree = this.args.toc.tree[section];
+        // the section may exist (eg. because it has an index page)
+        // but be without children, so we need to have a default empty object
+        subTree = this.args.toc.tree[section] ?? {};
       }
       // this check avoids that we show in the sidebar empty "containers"
       if (Object.keys(subTree).length > 0) {

--- a/website/app/components/doc/page/sidebar.js
+++ b/website/app/components/doc/page/sidebar.js
@@ -1,4 +1,8 @@
 import Component from '@glimmer/component';
+import { restartableTask, timeout } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+
+const DEBOUNCE_MS = 250;
 
 // we want to limit the content of the sidebar navigation to only the links related to the current "section".
 // notice: super hacky way to do it, but... it works™ !
@@ -30,6 +34,12 @@ const getTocSectionBundle = (section) => {
 };
 
 export default class DocPageSidebarComponent extends Component {
+  @tracked filterQuery = '';
+
+  get isFiltered() {
+    return this.filterQuery !== '';
+  }
+
   get structuredPageTree() {
     const { currentPath, currentRoute } = this.args;
 
@@ -52,5 +62,11 @@ export default class DocPageSidebarComponent extends Component {
     });
 
     return Object.keys(subSectionTree).length > 0 ? subSectionTree : false;
+  }
+
+  @restartableTask *filterPageTree(filterQuery) {
+    yield timeout(DEBOUNCE_MS);
+
+    this.filterQuery = filterQuery;
   }
 }

--- a/website/app/components/doc/page/sidebar.js
+++ b/website/app/components/doc/page/sidebar.js
@@ -63,6 +63,12 @@ export default class DocPageSidebarComponent extends Component {
     return this.filterQuery !== '';
   }
 
+  get hasTableOfContents() {
+    return (
+      this.structuredPageTree && Object.keys(this.structuredPageTree).length > 0
+    );
+  }
+
   get structuredPageTree() {
     const { currentPath, currentRoute } = this.args;
 

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -16,11 +16,11 @@
       {{else}}
         {{#if (eq @depth 1)}}
           <div class="doc-table-of-contents__heading">{{humanize key}}</div>
-          <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} />
+          <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} @isFiltered={{@isFiltered}} />
         {{else}}
-          <details class="doc-table-of-contents__folder">
+          <details class="doc-table-of-contents__folder" open={{@isFiltered}}>
             <summary class="doc-table-of-contents__summary">{{humanize key}}</summary>
-            <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} />
+            <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} @isFiltered={{@isFiltered}} />
           </details>
         {{/if}}
       {{/if}}

--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -86,6 +86,7 @@ export default class ShowRoute extends Route {
           'hidden',
           'order',
           'previewImage',
+          'keywords',
         ];
         frontmatterAttributes.forEach((attribute) => {
           if (attribute in res.data.attributes) {

--- a/website/app/styles/doc-components/form/filter.scss
+++ b/website/app/styles/doc-components/form/filter.scss
@@ -1,19 +1,22 @@
-// FORM > SEARCH
+// FORM > filter
 
 @use "../../typography/mixins" as *;
 
+.doc-form-filter {
+  position: relative;
+}
 
-.doc-form-search__control {
-  @include doc-font-style-body();
+.doc-form-filter__control {
+  @include doc-font-style-body-small();
   width: 100%;
-  height: 44px;
-  padding-left: 48px;
+  height: 36px;
+  padding: 0 0 0 32px;
   color: var(--doc-color-gray-200);
   background-color: var(--doc-color-white);
-  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%23727374'%3e%3cpath d='M7.25 2a5.25 5.25 0 103.144 9.455l2.326 2.325a.75.75 0 101.06-1.06l-2.325-2.326A5.25 5.25 0 007.25 2zM3.5 7.25a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e"); // notice: the icon color is hardcoded here!
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cg fill='%23727374'%3E%3Cpath d='M1 3.75A.75.75 0 011.75 3h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 3.75zM3.5 7.75A.75.75 0 014.25 7h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM6.75 11a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5z'/%3E%3C/g%3E%3C/svg%3E"); // notice: the icon color is hardcoded here!
   background-repeat: no-repeat;
-  background-position: left 16px top 11px; // we have to take into account the border
-  background-size: 20px 20px;
+  background-position: left 8px top 7px; // we have to take into account the border
+  background-size: 16px 16px;
   border: 1px solid var(--doc-color-gray-300);
   border-radius: 3px;
 
@@ -30,10 +33,10 @@
   &::-webkit-search-cancel-button {
     width: 20px;
     height: 20px;
-    margin-right: 10px;
+    margin-right: 6px;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='%231D1E1F' d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3E%3C/svg%3E"); // notice: the icon color is hardcoded here!
     background-position: center center;
-    background-size: 20px 20px;
+    background-size: 16px 16px;
     // stylelint-disable-next-line property-no-vendor-prefix
     -webkit-appearance: none;
   }

--- a/website/app/styles/doc-components/form/index.scss
+++ b/website/app/styles/doc-components/form/index.scss
@@ -1,6 +1,7 @@
 // FORM
 
 @import "./label";
+@import "./filter";
 @import "./search";
 @import "./select";
 

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -94,6 +94,10 @@ body.application:not(.index) {
       display: none;
     }
   }
+
+  .doc-page-sidebar__filter {
+    margin-bottom: 16px;
+  }
 }
 
 

--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -7,6 +7,7 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=1377%3A11987
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/alert
 previewImage: assets/illustrations/components/alert.jpg
+keywords: ['alert', 'toast', 'notification', 'banner', 'message']
 ---
 
 <section data-tab="Guidelines">

--- a/website/lib/markdown/markdown-to-jsonapi.js
+++ b/website/lib/markdown/markdown-to-jsonapi.js
@@ -27,6 +27,7 @@ class MarkdownToJsonApi extends PersistentFilter {
         'hidden',
         'order',
         'previewImage',
+        'keywords',
       ],
     };
 

--- a/website/lib/markdown/table-of-contents.js
+++ b/website/lib/markdown/table-of-contents.js
@@ -108,6 +108,7 @@ class TableOfContents extends Plugin {
           'order',
           'hidden',
           'previewImage',
+          'keywords',
         ]);
       } else {
         console.log('File NOT found!', fullFilePath);

--- a/website/tests/acceptance/sidebar-filter-test.js
+++ b/website/tests/acceptance/sidebar-filter-test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import { fillIn, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+
+module('Acceptance | Sidebar filter', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('should show the "Alert" link in the sidebar', async function (assert) {
+    await visit('/components');
+    assert
+      .dom('.doc-page-sidebar__table-of-contents a[href="/components/alert"]')
+      .exists();
+  });
+
+  test('should show the "Alert" link in the sidebar if filtering using its "page title" (case insensitive)', async function (assert) {
+    await visit('/components');
+    await fillIn('.doc-page-sidebar__filter input[type="search"]', 'AlErT');
+    assert
+      .dom('.doc-page-sidebar__table-of-contents a[href="/components/alert"]')
+      .exists();
+  });
+
+  test('should still show the filter input after filtering', async function (assert) {
+    await visit('/components');
+    await fillIn('.doc-page-sidebar__filter input[type="search"]', 'xyz');
+    assert.dom('.doc-page-sidebar__filter').exists();
+  });
+
+  test('should show the "Alert" link in the sidebar if filtering using one of its "keyword" (case insensitive)', async function (assert) {
+    await visit('/components');
+    await fillIn('.doc-page-sidebar__filter input[type="search"]', 'MeSsAgE');
+    assert
+      .dom('.doc-page-sidebar__table-of-contents a[href="/components/alert"]')
+      .exists();
+  });
+
+  test('should show a message when no results are found', async function (assert) {
+    await visit('/components');
+    await fillIn('.doc-page-sidebar__filter input[type="search"]', 'xyz');
+    assert
+      .dom('.doc-page-sidebar__table-of-contents a[href="/components/alert"]')
+      .doesNotExist();
+  });
+
+  test('should clear search results if input is cleared', async function (assert) {
+    await visit('/components');
+    await fillIn('.doc-page-sidebar__filter input[type="search"]', 'xyz');
+    assert
+      .dom('.doc-page-sidebar__table-of-contents a[href="/components/alert"]')
+      .doesNotExist();
+    await fillIn('.doc-page-sidebar__filter input[type="search"]', '');
+    assert
+      .dom('.doc-page-sidebar__table-of-contents a[href="/components/alert"]')
+      .exists();
+  });
+});

--- a/wiki/Website-Doc-folder.md
+++ b/wiki/Website-Doc-folder.md
@@ -110,6 +110,7 @@ layout:
 order: 101
 hidden: false
 previewImage: assets/illustrations/components/alert.jpg
+keywords: ['alert', 'toast', 'notification', 'banner', 'message']
 ---
 ```
 
@@ -139,7 +140,9 @@ The "frontmatter" attributes that we support are the following:
 *   `hidden`
     Used to hide the page from the sidebar navigation and the lists on the landing pages - default is `false`
 *   `previewImage`
-  An optional full path to an image used when listing the page as "card" (eg. in landing pages). The path refers to the `dist` folder generated at build time, so is relative to the content of the `/website/public` folder.
+    An optional full path to an image used when listing the page as "card" (eg. in landing pages). The path refers to the `dist` folder generated at build time, so is relative to the content of the `/website/public` folder.
+*   `keywords`
+    An optional list of keywords that the page can be found with, when a filter is applied to a list of pages.
 
 
 Only the `title` attribute is technically required, all the others are optional (even though some of them like `description` and `caption` are necessary for component pages).


### PR DESCRIPTION
### :pushpin: Summary

One of the suggestions received by the ambassadors was to have a "filter" functionality for the sidebar.
This PR implements such functionality, using as a model the "filter" on https://developer.hashicorp.com/

### :hammer_and_wrench: Detailed description

In this PR I have:
- added support for `keywords` attribute in frontmatter
- added filtering logic to the sidebar
- updated the `wiki` documentation adding `keywords` to the "frontmatter" explanation

👉 👉 👉 **Preview**: https://hds-website-git-new-docs-website-sidebar-filter-hashicorp.vercel.app/components

### 🚧 TODOs

- [ ] Once approved and merged, create Jira ticket to add keywords to all the pages (that we think should have them)

### :camera_flash: Screenshots

<img width="1772" alt="screenshot_2280" src="https://user-images.githubusercontent.com/686239/212885161-e97eec51-5e93-4e8c-a4ff-c0a38b0d8ad2.png">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1417

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
