### PR TITLE
New docs website / Fix double "search" icon

### DIFF
--- a/website/app/styles/doc-components/form/search.scss
+++ b/website/app/styles/doc-components/form/search.scss
@@ -31,7 +31,7 @@
     width: 20px;
     height: 20px;
     margin-right: 10px;
-    background-image: var(--token-form-text-input-background-image-data-url-search-cancel);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='%231D1E1F' d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3E%3C/svg%3E"); // notice: the icon color is hardcoded here!
     background-position: center center;
     background-size: 20px 20px;
     // stylelint-disable-next-line property-no-vendor-prefix

--- a/website/app/styles/doc-components/form/search.scss
+++ b/website/app/styles/doc-components/form/search.scss
@@ -21,6 +21,12 @@
     color: var(--doc-color-gray-300);
   }
 
+  // hide "search" icon in iOS
+  &::-webkit-search-decoration {
+    // stylelint-disable-next-line property-no-vendor-prefix
+    -webkit-appearance: none;
+  }
+
   &::-webkit-search-cancel-button {
     width: 20px;
     height: 20px;


### PR DESCRIPTION
### :pushpin: Summary

In Safari iOS the "search" input field has an extra icons. With this PR we hide it, leaving only the custom one.

### :hammer_and_wrench: Detailed description

In this PR I have:
- hidden the `search` icon on the `Doc::Form::Search` component (for Safari)
- in the process I have also noticed that the “cancel” icon was implemented using an HDS token, so I replaced it with an embedded icon

👉 👉 👉 **Preview**: https://hds-website-git-new-docs-website-fix-double-se-196d79-hashicorp.vercel.app/icons/library

### :camera_flash: Screenshots

![IMG_7144](https://user-images.githubusercontent.com/686239/212888201-280884c1-187e-49a7-9d95-927d9c81afca.PNG)

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1403

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
