### PR TITLE
add url to meta

### DIFF
--- a/website/config/environment.js
+++ b/website/config/environment.js
@@ -31,6 +31,7 @@ module.exports = function (environment) {
       siteName: 'Helios Design System',
       title: 'Helios Design System',
       imgSrc: '/assets/logos/share-card.jpg',
+      url: 'https://helios.hashicorp.design/',
     },
   };
 


### PR DESCRIPTION
### :pushpin: Summary

Adds our final domain name to ember-meta's config which will inject it a few helpful places in our meta tags

### :hammer_and_wrench: Detailed description

This will also be useful for the twitter meta tag work we're doing, but short term it will also fix a bug preventing our site from being crawled. See [this link](https://support.google.com/webmasters/answer/7440203#duplicate_page_without_canonical_tag) for details.
