### PR TITLE
Website: Add ember-router-scroll

### DIFF
--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -143,10 +143,11 @@ export default class ShowController extends Controller {
   @action
   setCurrent(current) {
     // TABS
+    // ?? CAN WE EXPLICITLY SET FOCUS ON THE TAB WHEN IT IS SET TO CURRENT?
     this.tabs.forEach((tab) => {
       set(tab, 'isCurrent', tab.index === current);
     });
-    // SECTIONS
+    // SECTIONS (AKA TABPANELS )
     this.sections.forEach((section, index) => {
       if (index === current) {
         section.removeAttribute('hidden');

--- a/website/app/templates/application.hbs
+++ b/website/app/templates/application.hbs
@@ -2,7 +2,7 @@
 
 {{page-title "Helios Design System"}}
 
-<div class="doc-page-wrapper">
+<div class="doc-page-wrapper" id="topofpage">
   <Doc::Page::Header
     @currentTopRoute={{this.currentTopRoute}}
     @isSidebarVisibleOnSmallViewport={{this.isSidebarVisibleOnSmallViewport}}

--- a/website/config/environment.js
+++ b/website/config/environment.js
@@ -6,6 +6,8 @@ module.exports = function (environment) {
     environment,
     rootURL: '/',
     locationType: 'history',
+    targetElement: '#main',
+    historySupportMiddleware: true,
 
     EmberENV: {
       FEATURES: {
@@ -18,8 +20,6 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
-
-    historySupportMiddleware: true,
 
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],

--- a/website/config/environment.js
+++ b/website/config/environment.js
@@ -8,7 +8,7 @@ module.exports = function (environment) {
     locationType: 'history',
     historySupportMiddleware: true,
     routerScroll: {
-      targetElement: '#main',
+      targetElement: '#topofpage',
       scrollWhenAfterRender: true,
     },
 

--- a/website/config/environment.js
+++ b/website/config/environment.js
@@ -6,8 +6,11 @@ module.exports = function (environment) {
     environment,
     rootURL: '/',
     locationType: 'history',
-    targetElement: '#main',
     historySupportMiddleware: true,
+    routerScroll: {
+      targetElement: '#main',
+      scrollWhenAfterRender: true,
+    },
 
     EmberENV: {
       FEATURES: {
@@ -38,8 +41,8 @@ module.exports = function (environment) {
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
-    // ENV.APP.LOG_TRANSITIONS = true;
-    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    ENV.APP.LOG_TRANSITIONS = true;
+    ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
   }
 

--- a/website/config/environment.js
+++ b/website/config/environment.js
@@ -42,7 +42,7 @@ module.exports = function (environment) {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
-    ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
   }
 

--- a/website/config/environment.js
+++ b/website/config/environment.js
@@ -41,7 +41,7 @@ module.exports = function (environment) {
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
-    ENV.APP.LOG_TRANSITIONS = true;
+    // ENV.APP.LOG_TRANSITIONS = true;
     ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
   }

--- a/website/package.json
+++ b/website/package.json
@@ -69,6 +69,7 @@
     "ember-prism": "^0.10.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
+    "ember-router-scroll": "^4.0.2",
     "ember-source": "~4.8.1",
     "ember-template-lint": "^4.14.0",
     "ember-test-selectors": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,6 +3756,182 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ember@npm:^3.16.5":
+  version: 3.16.7
+  resolution: "@types/ember@npm:3.16.7"
+  dependencies:
+    "@types/ember__application": ^3
+    "@types/ember__array": ^3
+    "@types/ember__component": ^3
+    "@types/ember__controller": ^3
+    "@types/ember__debug": ^3
+    "@types/ember__engine": ^3
+    "@types/ember__error": ^3
+    "@types/ember__object": ^3
+    "@types/ember__polyfills": ^3
+    "@types/ember__routing": ^3
+    "@types/ember__runloop": ^3
+    "@types/ember__service": ^3
+    "@types/ember__string": ^2
+    "@types/ember__template": ^3
+    "@types/ember__test": ^3
+    "@types/ember__utils": ^3
+    "@types/htmlbars-inline-precompile": "*"
+    "@types/rsvp": "*"
+  checksum: 3f41498b974b2b42ed03ccff8f7a6edbdf10c9d0ba1b4b97978fdcc4cf4e46ef1480153b0d463e7c548da8c3f8418ac378fa1a54270d17b96d8c64415abce723
+  languageName: node
+  linkType: hard
+
+"@types/ember__application@npm:^3":
+  version: 3.16.4
+  resolution: "@types/ember__application@npm:3.16.4"
+  dependencies:
+    "@types/ember__application": ^3
+    "@types/ember__engine": ^3
+    "@types/ember__object": ^3
+    "@types/ember__routing": ^3
+  checksum: 6f84457801ec4baa77f8542f40d3d65fde1afa3a87be666b00189d0078eac75e23f2013adccb1a5ae13e75e186e55da7f9504aad6a7709726a0ea681ac6a0c45
+  languageName: node
+  linkType: hard
+
+"@types/ember__array@npm:^3":
+  version: 3.16.5
+  resolution: "@types/ember__array@npm:3.16.5"
+  dependencies:
+    "@types/ember__array": ^3
+    "@types/ember__object": ^3
+  checksum: af5164a793ff697850b21ad73cc8a6f560709268ec8f125c20bfa8c2477c3fe4d7a129e669d2d549d28fa88583ea226dcaf33f15f494f1ab8397650eff617c66
+  languageName: node
+  linkType: hard
+
+"@types/ember__component@npm:^3":
+  version: 3.16.7
+  resolution: "@types/ember__component@npm:3.16.7"
+  dependencies:
+    "@types/ember__component": ^3
+    "@types/ember__object": ^3
+    "@types/jquery": "*"
+  checksum: 667f77949985b350ef888fd4646debb4e6118e53a8da24efbf4a390a572955b55ac91f81786e2a788b926f1eeda91be716612a9792fae3f62e73f9b97152b4e9
+  languageName: node
+  linkType: hard
+
+"@types/ember__controller@npm:^3":
+  version: 3.16.7
+  resolution: "@types/ember__controller@npm:3.16.7"
+  dependencies:
+    "@types/ember__object": ^3
+  checksum: 0df414b5076887e277dad2279f4ea8f3e8623ffe9de0bf616cbb6116f2168e7fba72081e9e14e03f6b0d6b78becc60cf511207ab05e5af50ef50dcc8fd8d5929
+  languageName: node
+  linkType: hard
+
+"@types/ember__debug@npm:^3":
+  version: 3.16.7
+  resolution: "@types/ember__debug@npm:3.16.7"
+  dependencies:
+    "@types/ember__debug": ^3
+    "@types/ember__engine": ^3
+    "@types/ember__object": ^3
+  checksum: 4187a40bd202badd66b6ba9a81b6ba96bdf6e12e7aa140cade51077a2139efd7ca5d0f318ec10d631c97e4fd140581b8375a02d9da34b9f5729cc63dc587b8f4
+  languageName: node
+  linkType: hard
+
+"@types/ember__engine@npm:^3":
+  version: 3.16.4
+  resolution: "@types/ember__engine@npm:3.16.4"
+  dependencies:
+    "@types/ember__engine": ^3
+    "@types/ember__object": ^3
+  checksum: 2f444a6f08d99398b55e44b5f4015916c15db6757392425dca4cc7e583431c30291413a48b8f64126de15b96525a2568748540c9478c4849e23346d22a31c02a
+  languageName: node
+  linkType: hard
+
+"@types/ember__error@npm:^3":
+  version: 3.16.2
+  resolution: "@types/ember__error@npm:3.16.2"
+  checksum: 5bb8047c2c012a9068828eaf70e6f4c875c701660668c8c7b94e8c392a6f68c2150b0084bbdf36abe47aa109484026dcb2caf8aeff4de9bf88266b78da5a2b85
+  languageName: node
+  linkType: hard
+
+"@types/ember__object@npm:^3":
+  version: 3.12.8
+  resolution: "@types/ember__object@npm:3.12.8"
+  dependencies:
+    "@types/ember__object": ^3
+    "@types/rsvp": "*"
+  checksum: 89bda43d20d83efe55da385ac92e7d84cef224462b0031e98627dee7fa6a1fffb921cc7b9ebcbfe9df76d42692d55fecb816a2a4a81fdfe3d908d3316677e41d
+  languageName: node
+  linkType: hard
+
+"@types/ember__polyfills@npm:^3":
+  version: 3.12.2
+  resolution: "@types/ember__polyfills@npm:3.12.2"
+  checksum: 9bc363cf11f89f439e2fcd3639b144a1109ba481872b993996b2497fdefc5d080a7655ecd938fac8edb844990af3a6460863b38ea6e2e93791764fc0de3c04ab
+  languageName: node
+  linkType: hard
+
+"@types/ember__routing@npm:^3":
+  version: 3.16.17
+  resolution: "@types/ember__routing@npm:3.16.17"
+  dependencies:
+    "@types/ember__component": ^3
+    "@types/ember__controller": ^3
+    "@types/ember__object": ^3
+    "@types/ember__routing": ^3
+    "@types/ember__service": ^3
+  checksum: 34827778a811132b9d9c45d7c5295bdcad9d9fbf3ddf57117323d7fa3aec0bfc1bced75282944ee213d1548b87ee20e2c85c6abd3bd32725d8fe16fc46b343f4
+  languageName: node
+  linkType: hard
+
+"@types/ember__runloop@npm:^3":
+  version: 3.16.4
+  resolution: "@types/ember__runloop@npm:3.16.4"
+  dependencies:
+    "@types/ember__runloop": ^3
+  checksum: 6de77deaaa09dce6182a67777b460fe359d3375aa172326ddec63c22a26bf9e23cee1ee3aec63f6eb24f9cd8a5d227f3ce9d1984903fd7b88ba4d19d4c65bd17
+  languageName: node
+  linkType: hard
+
+"@types/ember__service@npm:^3":
+  version: 3.16.2
+  resolution: "@types/ember__service@npm:3.16.2"
+  dependencies:
+    "@types/ember__object": ^3
+  checksum: e9c94be28cba6e929a794dfd216c758dbffe740a4f52a3fec1d0d2d59b523c3f5ac5bd5cf253ddefd239f82ffe1dcc67f38496d7ea3d45e59c4151ce42d22c21
+  languageName: node
+  linkType: hard
+
+"@types/ember__string@npm:^2":
+  version: 2.0.0
+  resolution: "@types/ember__string@npm:2.0.0"
+  dependencies:
+    "@types/ember__template": ^3
+  checksum: 4aa8731277a8c632a9ba9d84765325bff838a17d243b071cefb5071090388426c4f396f29fb49ca7f51137607b394921a2c94984fa973a7fc5de8953da4fc0c7
+  languageName: node
+  linkType: hard
+
+"@types/ember__template@npm:^3":
+  version: 3.16.2
+  resolution: "@types/ember__template@npm:3.16.2"
+  checksum: d39a1dc786f732c1b0255c49ffa3d08ba813598c0d67d29ea1222c20898737e6129d2d503fb914a12589081b5f1935f9404c820ae6d9e2b816367ae77a7f5fc9
+  languageName: node
+  linkType: hard
+
+"@types/ember__test@npm:^3":
+  version: 3.16.2
+  resolution: "@types/ember__test@npm:3.16.2"
+  dependencies:
+    "@types/ember__application": ^3
+  checksum: 0b81edcff9e0dfc60bc3c2a5dffde274b7645a41805a1e5d9fdc18bfdd6f01d4847883b4a94c0bedc7aff988de6cd1589efc83c2cd7220158361f7242a23a161
+  languageName: node
+  linkType: hard
+
+"@types/ember__utils@npm:^3":
+  version: 3.16.3
+  resolution: "@types/ember__utils@npm:3.16.3"
+  checksum: c2c079446895e7edb2afdb07b077cc418061dbeeee2f4c3239a7cd6e7159a020a53a76c38110c28653e827ec2f0a8dde75d19fc8278fdb44028af582e89d7771
+  languageName: node
+  linkType: hard
+
 "@types/eslint-scope@npm:^3.7.3":
   version: 3.7.3
   resolution: "@types/eslint-scope@npm:3.7.3"
@@ -3853,12 +4029,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/htmlbars-inline-precompile@npm:*":
+  version: 3.0.0
+  resolution: "@types/htmlbars-inline-precompile@npm:3.0.0"
+  checksum: dd7b1f0a0f9ec560c521673c436329e9edb0197b382520179008b11afe38c3d7a129dc91f303ca0509852f9e081a353b9f9aee9d7043529d70c439aafb7f9a2c
+  languageName: node
+  linkType: hard
+
 "@types/is-ci@npm:^3.0.0":
   version: 3.0.0
   resolution: "@types/is-ci@npm:3.0.0"
   dependencies:
     ci-info: ^3.1.0
   checksum: 7c1f1f16c1fa2134de7400d82766c83fa76057261ba890628af77a09382ebb92d945bb077b98cfcf3d40ab1469c9ffbd2278112867edbe57aa655f53547eb139
+  languageName: node
+  linkType: hard
+
+"@types/jquery@npm:*":
+  version: 3.5.16
+  resolution: "@types/jquery@npm:3.5.16"
+  dependencies:
+    "@types/sizzle": "*"
+  checksum: 13c995f15d1c2f1d322103dc1cb0a22b95eecc3e7546f00279b8731aea21d7ec04550af40e609ee48e755d4e11bf61c25b4aa9f53df3bcbec4b8fe8e81471732
   languageName: node
   linkType: hard
 
@@ -4043,6 +4235,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/rsvp@npm:*, @types/rsvp@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@types/rsvp@npm:4.0.4"
+  checksum: ed59be8246325c3676e67237c00d84830f801710af864dbf7d22e80441892e9a7beee07afcbdcd74ee8fbe3a24f37e93826dac1208199ac5601b663b7293cbed
+  languageName: node
+  linkType: hard
+
 "@types/scheduler@npm:*":
   version: 0.16.2
   resolution: "@types/scheduler@npm:0.16.2"
@@ -4064,6 +4263,13 @@ __metadata:
     "@types/mime": ^1
     "@types/node": "*"
   checksum: eaca858739483e3ded254cad7d7a679dc2c8b3f52c8bb0cd845b3b7eb1984bde0371fdcb0a5c83aa12e6daf61b6beb762545021f520f08a1fe882a3fa4ea5554
+  languageName: node
+  linkType: hard
+
+"@types/sizzle@npm:*":
+  version: 2.3.3
+  resolution: "@types/sizzle@npm:2.3.3"
+  checksum: 586a9fb1f6ff3e325e0f2cc1596a460615f0bc8a28f6e276ac9b509401039dd242fa8b34496d3a30c52f5b495873922d09a9e76c50c2ab2bcc70ba3fb9c4e160
   languageName: node
   linkType: hard
 
@@ -9875,6 +10081,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ember-app-scheduler@npm:^5.1.2 || ^6.0.0 || ^7.0.0":
+  version: 7.0.1
+  resolution: "ember-app-scheduler@npm:7.0.1"
+  dependencies:
+    "@ember/test-waiters": ^3.0.0
+    "@types/ember": ^3.16.5
+    "@types/rsvp": ^4.0.4
+    ember-cli-babel: ^7.26.6
+    ember-cli-typescript: ^4.2.1
+    ember-compatibility-helpers: ^1.2.5
+    ember-destroyable-polyfill: ^2.0.2
+  checksum: cfb1b4098c16e6913ed9c06a480fa3542207232c96abb78817d1ee01be9b97b507258938274a681211834192902353cb496c7129e1a5b8df57ce8692e3d44448
+  languageName: node
+  linkType: hard
+
 "ember-arg-types@npm:^1.0.0":
   version: 1.0.0
   resolution: "ember-arg-types@npm:1.0.0"
@@ -11109,6 +11330,17 @@ __metadata:
     "@babel/traverse": ^7.4.5
     recast: ^0.18.1
   checksum: e163e0d68e49a942658aee7c05638dd5c2db939753b51efc9c6d9f0e582953be185daf4cdd569c1b8a35ed47f35f4cb18067a6a1db68e135d7464bbad6ef9d93
+  languageName: node
+  linkType: hard
+
+"ember-router-scroll@npm:^4.0.2":
+  version: 4.1.2
+  resolution: "ember-router-scroll@npm:4.1.2"
+  dependencies:
+    ember-app-scheduler: ^5.1.2 || ^6.0.0 || ^7.0.0
+    ember-cli-babel: ^7.26.6
+    ember-compatibility-helpers: ^1.2.5
+  checksum: 50446ccedde1dc65e0145bc2ad8bd74c275fee427e35abb9e565058eb7e4f39583da352ff618a804f28fa4cbc001a71410affc3626ae5cb91effc2a6c7dd7278
   languageName: node
   linkType: hard
 
@@ -23214,6 +23446,7 @@ __metadata:
     ember-prism: ^0.10.0
     ember-qunit: ^5.1.5
     ember-resolver: ^8.0.3
+    ember-router-scroll: ^4.0.2
     ember-source: ~4.8.1
     ember-template-lint: ^4.14.0
     ember-test-selectors: ^6.0.0


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `ember-router-scroll` as a dependency, to handle "scroll to top" behavior.

Note: if I open a new tab and visit a hash URL, it's being removed. I don't think it's this addon, since we were seeing it before, I think it's something in one of the controllers. I haven't been able to pinpoint exactly what is causing this behavior, but I'll keep working on it. 

In the meantime, this addon is a step in the right direction for our app.



***


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
