### PR TITLE
Responsive cleanup / List Items

### DIFF
--- a/website/app/styles/doc-components/font-helpers-list.scss
+++ b/website/app/styles/doc-components/font-helpers-list.scss
@@ -45,7 +45,8 @@
 
 .doc-font-helpers-list__content {
   padding: 16px;
-  border: solid var(--doc-color-gray-500);
+  border-style: solid;
+  border-color: var(--doc-color-gray-500);
   border-width: 0 1px 1px 1px;
   border-radius: 0 0 3px 3px;
 

--- a/website/app/styles/doc-components/font-helpers-list.scss
+++ b/website/app/styles/doc-components/font-helpers-list.scss
@@ -1,36 +1,58 @@
 // DOC FONT HELPERS LIST
 
 @use "../typography/mixins" as *;
+@use "../breakpoints" as breakpoint;
 
 .doc-font-helpers-list {
-  display: grid;
-  grid-template-columns: minmax(120px, max-content) auto;
+  display: flex;
+  flex-direction: column;
   gap: 16px 0;
   margin: 1.5rem 0;
   padding: 0;
   list-style: none;
+
+  @include breakpoint.medium-and-above () {
+    display: grid;
+    grid-template-columns: minmax(120px, max-content) auto;
+  }
 }
 
 .doc-font-helpers-list__item {
-  display: contents;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+
+  @include breakpoint.medium-and-above () {
+    display: contents;
+  }
 }
 
 .doc-font-helpers-list__preview {
   display: flex;
-  align-items: center;
   align-self: stretch;
-  justify-content: center;
+  align-items: center;
+  justify-content: flex-start;
   min-width: 120px;
   padding: 16px;
   border: 1px solid var(--doc-color-gray-500);
-  border-radius: 3px 0 0 3px;
+  border-radius: 3px 3px 0 0;
+  
+  @include breakpoint.medium-and-above () {
+    justify-content: center;
+    border-radius: 3px 0 0 3px;
+  }
 }
 
 .doc-font-helpers-list__content {
   padding: 16px;
-  border: 1px solid var(--doc-color-gray-500);
-  border-left: none;
-  border-radius: 0 3px 0 3px;
+  border: solid var(--doc-color-gray-500);
+  border-width: 0 1px 1px 1px;
+  border-radius: 0 0 3px 3px;
+  
+  @include breakpoint.medium-and-above () {
+    border-width: 1px 1px 1px 0;
+    border-radius: 0 3px 3px 0;
+  }
 }
 
 .doc-font-helpers-list__simple-code {

--- a/website/app/styles/doc-components/font-helpers-list.scss
+++ b/website/app/styles/doc-components/font-helpers-list.scss
@@ -39,6 +39,7 @@
   
   @include breakpoint.medium-and-above () {
     justify-content: center;
+    text-align: center;
     border-radius: 3px 0 0 3px;
   }
 }

--- a/website/app/styles/doc-components/font-helpers-list.scss
+++ b/website/app/styles/doc-components/font-helpers-list.scss
@@ -20,7 +20,6 @@
 .doc-font-helpers-list__item {
   display: flex;
   flex-direction: column;
-  gap: 0;
 
   @include breakpoint.medium-and-above () {
     display: contents;

--- a/website/app/styles/doc-components/font-helpers-list.scss
+++ b/website/app/styles/doc-components/font-helpers-list.scss
@@ -28,14 +28,14 @@
 
 .doc-font-helpers-list__preview {
   display: flex;
-  align-self: stretch;
   align-items: center;
+  align-self: stretch;
   justify-content: flex-start;
   min-width: 120px;
   padding: 16px;
   border: 1px solid var(--doc-color-gray-500);
   border-radius: 3px 3px 0 0;
-  
+
   @include breakpoint.medium-and-above () {
     justify-content: center;
     text-align: center;
@@ -48,7 +48,7 @@
   border: solid var(--doc-color-gray-500);
   border-width: 0 1px 1px 1px;
   border-radius: 0 0 3px 3px;
-  
+
   @include breakpoint.medium-and-above () {
     border-width: 1px 1px 1px 0;
     border-radius: 0 3px 3px 0;

--- a/website/app/styles/doc-components/font-helpers-list.scss
+++ b/website/app/styles/doc-components/font-helpers-list.scss
@@ -45,8 +45,8 @@
 
 .doc-font-helpers-list__content {
   padding: 16px;
-  border-style: solid;
   border-color: var(--doc-color-gray-500);
+  border-style: solid;
   border-width: 0 1px 1px 1px;
   border-radius: 0 0 3px 3px;
 

--- a/website/app/styles/doc-components/icons-list/index.scss
+++ b/website/app/styles/doc-components/icons-list/index.scss
@@ -64,12 +64,16 @@
 
 .doc-icons-list-grid-item {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
   padding: 0;
   background: var(--doc-color-white);
   border: 1px solid var(--doc-color-gray-500);
   border-radius: 3px;
+
+  @include breakpoint.medium-and-above () {
+    flex-direction: row;
+  }
 }
 
 .doc-icons-list-grid-item__frame {
@@ -77,9 +81,16 @@
   flex: none;
   align-items: center;
   justify-content: center;
-  width: 120px;
-  height: 100%;
-  border-right: 1px solid var(--doc-color-gray-500);
+  width: 100%;
+  height: 120px;
+  border-bottom: 1px solid var(--doc-color-gray-500);
+  
+  @include breakpoint.medium-and-above () {
+    width: 120px;
+    height: 100%;
+    border-right: 1px solid var(--doc-color-gray-500);
+    border-bottom: none;
+  }
 }
 
 .doc-icons-list-grid-item__outline {
@@ -87,6 +98,7 @@
 }
 
 .doc-icons-list-grid-item__meta {
+  width: 100%;
   padding: 16px;
 }
 

--- a/website/app/styles/doc-components/icons-list/index.scss
+++ b/website/app/styles/doc-components/icons-list/index.scss
@@ -84,7 +84,7 @@
   width: 100%;
   height: 120px;
   border-bottom: 1px solid var(--doc-color-gray-500);
-  
+
   @include breakpoint.medium-and-above () {
     width: 120px;
     height: 100%;

--- a/website/app/styles/doc-components/tokens-list/index.scss
+++ b/website/app/styles/doc-components/tokens-list/index.scss
@@ -11,7 +11,7 @@
   margin: 1.5rem 0;
   padding: 0;
   list-style: none;
-  
+
   @include breakpoint.medium-and-above () {
     display: grid;
     grid-template-columns: minmax(100px, max-content) auto;
@@ -37,7 +37,7 @@
   padding: 16px;
   border: 1px solid var(--doc-color-gray-500);
   border-radius: 3px 3px 0 0;
-  
+
   @include breakpoint.medium-and-above () {
     justify-content: center;
     border-radius: 3px 0 0 3px;
@@ -124,11 +124,11 @@
   min-width: 0; // needed to avoid the grid to explode if the content is too wide
   padding: 16px 48px 16px 16px;
   border: 1px solid var(--doc-color-gray-500);
-  border-width: 0px 1px 1px 1px;
+  border-width: 0 1px 1px 1px;
   border-radius: 0 0 3px 3px;
-  
+
   @include breakpoint.medium-and-above () {
-    border-width: 1px 1px 1px 0px;
+    border-width: 1px 1px 1px 0;
     border-radius: 0 3px 3px 0;
   }
 }

--- a/website/app/styles/doc-components/tokens-list/index.scss
+++ b/website/app/styles/doc-components/tokens-list/index.scss
@@ -1,19 +1,30 @@
 // TOKENS LIST
 
 @use "../../typography/mixins" as *;
+@use "../../breakpoints" as breakpoint;
 
 
 .doc-tokens-list {
-  display: grid;
-  grid-template-columns: minmax(100px, max-content) auto;
+  display: flex;
+  flex-direction: column;
   gap: 16px 0;
   margin: 1.5rem 0;
   padding: 0;
   list-style: none;
+  
+  @include breakpoint.medium-and-above () {
+    display: grid;
+    grid-template-columns: minmax(100px, max-content) auto;
+  }
 }
 
 .doc-tokens-list__item {
-  display: contents;
+  display: flex;
+  flex-direction: column;
+
+  @include breakpoint.medium-and-above () {
+    display: contents;
+  }
 }
 
 // PREVIEW
@@ -22,10 +33,15 @@
   display: flex;
   align-items: center;
   align-self: stretch;
-  justify-content: center;
+  justify-content: flex-start;
   padding: 16px;
   border: 1px solid var(--doc-color-gray-500);
-  border-radius: 3px 0 0 3px;
+  border-radius: 3px 3px 0 0;
+  
+  @include breakpoint.medium-and-above () {
+    justify-content: center;
+    border-radius: 3px 0 0 3px;
+  }
 }
 
 .doc-tokens-list__preview-color {
@@ -108,8 +124,13 @@
   min-width: 0; // needed to avoid the grid to explode if the content is too wide
   padding: 16px 48px 16px 16px;
   border: 1px solid var(--doc-color-gray-500);
-  border-left: none;
-  border-radius: 0 3px 3px 0;
+  border-width: 0px 1px 1px 1px;
+  border-radius: 0 0 3px 3px;
+  
+  @include breakpoint.medium-and-above () {
+    border-width: 1px 1px 1px 0px;
+    border-radius: 0 3px 3px 0;
+  }
 }
 
 .doc-tokens-grid-item__meta-row {


### PR DESCRIPTION
### :pushpin: Summary

if merged this PR adds a breakpoint to assist in the list items in smaller viewports.

### :hammer_and_wrench: Detailed description

The `tokens-list`, `font-helpers-list`, and `icons-list` all break at around less that 500px. I added a new `x-small` breakpoint to account for the smaller viewport (though now the mixins are starting to become a little non-semantic).

All of these pages use relatively the same structure so I mirrored the stacking in all three.

### :camera_flash: Screenshots

Tokens before
<img width="386" alt="tokens-before" src="https://user-images.githubusercontent.com/2200899/213062868-458e5f6f-f46c-4bb2-a2f5-ef28f03339c8.png">

Tokens after
<img width="391" alt="tokens-after" src="https://user-images.githubusercontent.com/2200899/213062894-a44a4528-d54f-40e9-b9a7-00c6b646f02a.png">

Font helpers before
<img width="388" alt="typography-before" src="https://user-images.githubusercontent.com/2200899/213062988-40bc547a-9c40-4767-b985-b530afab1471.png">

Font helpers after
<img width="386" alt="typography-after" src="https://user-images.githubusercontent.com/2200899/213062998-fe9e7eff-b464-4b53-a6e0-391a2e2e63c4.png">

Icons before
<img width="387" alt="icons-before" src="https://user-images.githubusercontent.com/2200899/213063012-d40a1b3b-d253-4ce6-b01d-2f48d7b07430.png">

Icons after
<img width="383" alt="icons-after" src="https://user-images.githubusercontent.com/2200899/213063021-785094e0-cdbe-429e-99d8-80ab268e7265.png">


### :link: External links

No jira ticket

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
