### PR TITLE
Add missing `@type` values on `TextInput` API docs

### DIFF
--- a/website/docs/components/form/text-input/partials/code/component-api.md
+++ b/website/docs/components/form/text-input/partials/code/component-api.md
@@ -8,7 +8,7 @@ The `Form::TextInput` component has two different variants, with their own APIs:
 ### Form::TextInput::Base
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @type="enum">
+  <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" }} @default="text">
     Sets the native HTML `type` of the `<input>`. This list covers all the official types (see [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)).
   </C.Property>
   <C.Property @name="value" @type="string|number|date">
@@ -32,7 +32,7 @@ The `Form::TextInput` component has two different variants, with their own APIs:
 ### Form::TextInput::Field
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @type="enum">
+  <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" }} @default="text">
     Sets the native HTML `type` of the `<input>`. This list covers all the official types (see [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)).
   </C.Property>
   <C.Property @name="value" @type="string|number|date">


### PR DESCRIPTION
### :pushpin: Summary

Add missing `@type` values (and default) on `TextInput` API documentation

### :hammer_and_wrench: Detailed description

For some reason (possibly in the automation step) we missed these values. Have checked the codebase again to make sure all 'acceptable values' are ported into the new website and these were the only ones missing.

### :link: External links

[Slack thread](https://hashicorp.slack.com/archives/C03A0N1QK8S/p1673949435297949?thread_ts=1673947051.933269&cid=C03A0N1QK8S)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
