### PR TITLE
`Hds::Table` - Add `onSort` callback

### DIFF
--- a/.changeset/stale-shirts-stare.md
+++ b/.changeset/stale-shirts-stare.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Added `onSort` callback to `Hds::Table` component

--- a/packages/components/addon/components/hds/table/index.js
+++ b/packages/components/addon/components/hds/table/index.js
@@ -117,5 +117,11 @@ export default class HdsTableIndexComponent extends Component {
     }
     // we should allow the user to define a custom value here (e.g., for i18n) - tracked with HDS-965
     this.sortedMessageText = `Sorted by ${this.sortBy} ${this.sortOrder}ending`;
+
+    let { onSort } = this.args;
+
+    if (typeof onSort === 'function') {
+      onSort(this.sortBy, this.sortOrder);
+    }
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -139,6 +139,16 @@
         <li>desc</li>
       </ol>
     </dd>
+    <dt>onSort <code>function</code></dt>
+    <dd>
+      <p>Callback function invoked (if provided) when one of the sortable table headers is clicked, and a sorting is
+        triggered.</p>
+      <p>The function receives the values of
+        <code class="dummy-code">sortBy</code>
+        and
+        <code class="dummy-code">sortOrder</code>
+        as arguments.</p>
+    </dd>
     <dt>isStriped <code>boolean</code></dt>
     <dd>
       <p>Default: <span class="default">false</span></p>

--- a/packages/components/tests/integration/components/hds/table/index-test.js
+++ b/packages/components/tests/integration/components/hds/table/index-test.js
@@ -42,6 +42,7 @@ const hbsSortableTable = hbs`
   @model={{this.model}}
   @sortBy={{this.sortBy}}
   @sortOrder={{this.sortOrder}}
+  @onSort={{this.onSort}}
   @columns={{this.columns}}
   id="data-test-table"
 >
@@ -249,5 +250,22 @@ module('Integration | Component | hds/table/index', function (hooks) {
     assert
       .dom('#data-test-table .hds-table__th-sort:nth-of-type(1)')
       .hasAttribute('aria-sort', 'ascending');
+  });
+
+  test('it invokes the `onSort` callback when a sort is performed', async function (assert) {
+    let sortBy, sortOrder;
+    this.set('onSort', (by, ord) => {
+      sortBy = by;
+      sortOrder = ord;
+    });
+    setSortableTableData(this);
+    await render(hbsSortableTable);
+
+    await click('#data-test-table .hds-table__th-sort:nth-of-type(1) button');
+    assert.strictEqual(sortBy, 'artist');
+    assert.strictEqual(sortOrder, 'desc');
+    await click('#data-test-table .hds-table__th-sort:nth-of-type(1) button');
+    assert.strictEqual(sortBy, 'artist');
+    assert.strictEqual(sortOrder, 'asc');
   });
 });

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -25,6 +25,9 @@ The `Table` component itself is where most of options will be applied. However, 
   <C.Property @name="sortOrder" @type="string" @values={{array "asc" "desc" }} @default="asc">
     Use in conjunction with `sortBy`. If defined, indicates which direction the column should be pre-sorted in. If not defined, `asc` is applied by default.
   </C.Property>
+  <C.Property @name="onSort" @type="function">
+    Callback function invoked (if provided) when one of the sortable table headers is clicked, and a sorting is triggered. The function receives the values of `sortBy` and `sortOrder` as arguments.
+  </C.Property>
   <C.Property @name="isStriped" @type="boolean" @values={{array "false" "true" }} @default="false">
     Define on the table invocation. If set to `true`, row striping ("zebra striping") will be applied to the table.
   </C.Property>


### PR DESCRIPTION
### :pushpin: Summary

While working on an example of a sortable `Hds::Table` with pagination (#1060) I realized we never added a callback to the "sort" event, that could be used by the consumers (eg. to persist the sorting values in the URL).

This PR address this missing piece.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added the `onSort` callback to the `Hsd::Table` component
- updated documentation (new and old)
- added integration tests for `onSort`

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
