### PR TITLE
Website cover adjustments

### DIFF
--- a/website/app/styles/pages/application/cover.scss
+++ b/website/app/styles/pages/application/cover.scss
@@ -7,7 +7,7 @@
   position: relative;
   grid-area: cover;
   min-width: 0; // This is needed to allow the scrolling of the tabs
-  padding: 16px var(--doc-page-stage-gutter-small) 0;
+  padding: 32px var(--doc-page-stage-gutter-small) 0;
   background-color: var(--doc-color-white);
   border-bottom: 1px solid var(--doc-color-gray-500);
 

--- a/website/app/styles/pages/application/cover.scss
+++ b/website/app/styles/pages/application/cover.scss
@@ -63,7 +63,7 @@
   height: min-content;
   margin-top: 24px;
   overflow-x: auto;
-  overflow-y: visible; // needed or it will show a small vertical scrollbar
+  overflow-y: hidden; // .doc-page-tabs__tab--is-current has an ::after pseudoelement that always overflows with 3px, so we disable the vertical scrollbar and rely on the horizontal one
   -webkit-overflow-scrolling: touch;
 
   @include breakpoint.medium-and-above () {

--- a/website/app/styles/pages/application/tabs.scss
+++ b/website/app/styles/pages/application/tabs.scss
@@ -1,5 +1,6 @@
 // TABS
 
+@use "../../breakpoints" as breakpoint;
 @use "../../typography/mixins" as *;
 
 .doc-page-tabs {
@@ -32,11 +33,15 @@
     &::after {
       position: absolute;
       right: 0;
-      bottom: -1px;
+      bottom: 0;
       left: 0;
       height: 3px;
       background-color: var(--doc-color-black);
       content: "";
+
+      @include breakpoint.medium-and-above () {
+        bottom: -1px;
+      }
     }
 
     button {


### PR DESCRIPTION
### :pushpin: Summary

Website cover adjustments

### :hammer_and_wrench: Detailed description

 - Fix cover padding on mobile (from 16px to 32px); 
 - Disable vertical scrollbar on the tabs container (we rely on the horizontal scrollbar for any content overflow, so it's safe to do so)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1239](https://hashicorp.atlassian.net/browse/HDS-1239)
Figma file: https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=1345%3A79255&t=g2MVHOvPp2ehZj31-4

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1239]: https://hashicorp.atlassian.net/browse/HDS-1239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ