### PR TITLE
Aligning accessibility support section

### DIFF
--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -27,6 +27,5 @@ keywords: ['alert', 'toast', 'notification', 'banner', 'message']
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>
 

--- a/website/docs/components/alert/partials/accessibility/accessibility.md
+++ b/website/docs/components/alert/partials/accessibility/accessibility.md
@@ -17,3 +17,9 @@ Since alerts are not required to receive focus, it should not be required that t
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/alert/partials/accessibility/support.md
+++ b/website/docs/components/alert/partials/accessibility/support.md
@@ -1,4 +1,0 @@
----
-
-## Support
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/avatar/partials/accessibility/accessibility.md
+++ b/website/docs/components/avatar/partials/accessibility/accessibility.md
@@ -4,6 +4,8 @@
 
 The avatar is hidden from assistive technology with `aria-hidden="true"`. The accessible name should be provided by the containing element (e.g., if the `avatar` is used within a `button` element, use the `aria-label` to provide an accessible name).
 
+---
+
 ## Support
 
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/badge-count/partials/accessibility/accessibility.md
+++ b/website/docs/components/badge-count/partials/accessibility/accessibility.md
@@ -4,6 +4,8 @@
 
 When used as recommended, there should not be any accessibility issues with this component.
 
+---
+
 ## Support
 
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -26,5 +26,4 @@ previewImage: assets/illustrations/components/badge.jpg
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/badge/partials/accessibility/accessibility.md
+++ b/website/docs/components/badge/partials/accessibility/accessibility.md
@@ -3,3 +3,9 @@
 <Doc::Badge @type="success">Conformant</Doc::Badge>
 
 When used as recommended, there should not be any accessibility issues with this component.
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/badge/partials/accessibility/support.md
+++ b/website/docs/components/badge/partials/accessibility/support.md
@@ -1,5 +1,0 @@
----
-
-## Support
-
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -27,5 +27,4 @@ previewImage: assets/illustrations/components/breadcrumb.jpg
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/breadcrumb/partials/accessibility/accessibility.md
+++ b/website/docs/components/breadcrumb/partials/accessibility/accessibility.md
@@ -19,3 +19,9 @@ When the browser zoom is used to scale content to 400%, if the breadcrumb is not
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.3" "1.4.4" "1.4.10" "1.4.12" "2.1.1" "2.1.2" "2.4.3" "2.4.5" "2.4.6" "2.4.7" "3.2.3" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/breadcrumb/partials/accessibility/support.md
+++ b/website/docs/components/breadcrumb/partials/accessibility/support.md
@@ -1,5 +1,0 @@
----
-
-## Support
-
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/button/partials/accessibility/accessibility.md
+++ b/website/docs/components/button/partials/accessibility/accessibility.md
@@ -28,6 +28,8 @@ This section is for reference only. This component intends to conform to the fol
 
 <Doc::WcagList @criteriaList={{array "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.4.7" "4.1.1" "4.1.2" }} />
 
+---
+
 ## Support
 
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/card/partials/accessibility/accessibility.md
+++ b/website/docs/components/card/partials/accessibility/accessibility.md
@@ -6,6 +6,8 @@ By default, the Card Container component has `@overflow="hidden"` applied to it.
 
 Additionally, if the component is altered to be an interactive element, and also contains interactive elements like links or buttons, it can cause a conformance failure for having nested interactive elements.
 
+---
+
 ## Support
 
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/dropdown/partials/accessibility/accessibility.md
+++ b/website/docs/components/dropdown/partials/accessibility/accessibility.md
@@ -47,6 +47,8 @@ This section is for reference only. This component intends to conform to the fol
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.4.3" "2.4.7" }} />
 
+---
+
 ## Support
 
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/form/checkbox/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/checkbox/partials/accessibility/accessibility.md
@@ -32,6 +32,8 @@ This section is for reference only, some descriptions have been truncated for br
 This component intends to conform to the following WCAG Success Criteria:
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
 
+---
+
 ## Support
 
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/form/primitives/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/primitives/partials/accessibility/accessibility.md
@@ -18,4 +18,5 @@ This component intends to conform to the following WCAG Success Criteria:
 ---
 
 ## Support
-If any accessibility issues have been found within these components, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
@@ -36,6 +36,8 @@ This section is for reference only, some descriptions have been truncated for br
 This component intends to conform to the following WCAG Success Criteria:
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
 
+---
+
 ## Support
 
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/form/radio/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio/partials/accessibility/accessibility.md
@@ -32,6 +32,8 @@ This section is for reference only, some descriptions have been truncated for br
 This component intends to conform to the following WCAG Success Criteria:
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
 
+---
+
 ## Support
 
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/form/select/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/select/partials/accessibility/accessibility.md
@@ -74,3 +74,9 @@ Close with changing
 This section is for reference only, some descriptions have been truncated for brevity. The `Form::Select::Base` variation of this component is conditionally conformant; that is, it is not conformant until it has an accessible name. Otherwise, this component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/form/text-input/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/text-input/partials/accessibility/accessibility.md
@@ -20,6 +20,8 @@ This section is for reference only, some descriptions have been truncated for br
 This component intends to conform to the following WCAG Success Criteria:
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.1" "4.1.2" }} />
 
+---
+
 ## Support
 
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/form/textarea/index.md
+++ b/website/docs/components/form/textarea/index.md
@@ -27,5 +27,4 @@ previewImage: assets/illustrations/components/form/textarea.jpg
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/form/textarea/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/textarea/partials/accessibility/accessibility.md
@@ -24,3 +24,9 @@ If a link is used within a label, helper text, or error text, it will not be pre
 This section is for reference only, some descriptions have been truncated for brevity. The `Form::Textarea::Base` variation of this component is conditionally conformant; that is, it is not conformant until it has an accessible name. Otherwise, this component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/form/textarea/partials/accessibility/support.md
+++ b/website/docs/components/form/textarea/partials/accessibility/support.md
@@ -1,4 +1,0 @@
----
-
-## Support
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/form/toggle/index.md
+++ b/website/docs/components/form/toggle/index.md
@@ -27,5 +27,4 @@ previewImage: assets/illustrations/components/form/toggle.jpg
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/form/toggle/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/toggle/partials/accessibility/accessibility.md
@@ -9,3 +9,9 @@ If a link is used within a label, helper text, or error text, it will not be pre
 ## Applicable WCAG Success Criteria
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/form/toggle/partials/accessibility/support.md
+++ b/website/docs/components/form/toggle/partials/accessibility/support.md
@@ -1,5 +1,0 @@
----
-
-## Support
-
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -26,5 +26,4 @@ previewImage: assets/illustrations/components/icon-tile.jpg
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/icon-tile/partials/accessibility/accessibility.md
+++ b/website/docs/components/icon-tile/partials/accessibility/accessibility.md
@@ -15,3 +15,9 @@ IconTiles should be hidden from screen readers.
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.4.11" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/icon-tile/partials/accessibility/support.md
+++ b/website/docs/components/icon-tile/partials/accessibility/support.md
@@ -1,4 +1,0 @@
----
-
-## Support
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/link/standalone/index.md
+++ b/website/docs/components/link/standalone/index.md
@@ -27,5 +27,4 @@ previewImage: assets/illustrations/components/link/standalone.jpg
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/link/standalone/partials/accessibility/accessibility.md
+++ b/website/docs/components/link/standalone/partials/accessibility/accessibility.md
@@ -16,3 +16,9 @@ Animations or transitions will not take place if the user has `prefers-reduced-m
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "2.1.1" "1.3.3" "1.4.1" "2.4.7" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/link/standalone/partials/accessibility/support.md
+++ b/website/docs/components/link/standalone/partials/accessibility/support.md
@@ -1,4 +1,0 @@
----
-## Support
-
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/modal/partials/accessibility/accessibility.md
+++ b/website/docs/components/modal/partials/accessibility/accessibility.md
@@ -29,3 +29,9 @@ Given the Modal is triggered via a keyboard, the dismiss button is first in the 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.3.3" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.5" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.1.4" "2.4.2" "2.4.3" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.3.1" "3.3.2" "3.3.3" "3.3.4" "4.1.1" "4.1.2" "4.1.3" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/pagination/index.md
+++ b/website/docs/components/pagination/index.md
@@ -27,5 +27,4 @@ links:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/pagination/partials/accessibility/accessibility.md
+++ b/website/docs/components/pagination/partials/accessibility/accessibility.md
@@ -38,3 +38,9 @@ Trigger button to navigate to another page.
 This section is for reference only. This component intends to conform to the following WCAG success criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/pagination/partials/accessibility/support.md
+++ b/website/docs/components/pagination/partials/accessibility/support.md
@@ -1,3 +1,0 @@
-## Support
-
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/stepper/index.md
+++ b/website/docs/components/stepper/index.md
@@ -26,5 +26,4 @@ previewImage: assets/illustrations/components/stepper.jpg
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/stepper/partials/accessibility/accessibility.md
+++ b/website/docs/components/stepper/partials/accessibility/accessibility.md
@@ -7,3 +7,9 @@ The `Stepper Indicator` components are not WCAG-conformant on their own.
 ## Applicable WCAG Success Criteria
 
 There is no specific WCAG Success Criteria applicable to the stepper indicator on its own. Since we are only providing the stepper indicator and not the entire stepper (at this time), authors are responsible to ensure WCAG conformance is met in any components they build.
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/stepper/partials/accessibility/support.md
+++ b/website/docs/components/stepper/partials/accessibility/support.md
@@ -1,4 +1,0 @@
----
-
-## Support
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/table/partials/accessibility/accessibility.md
+++ b/website/docs/components/table/partials/accessibility/accessibility.md
@@ -36,6 +36,8 @@ This section is for reference only. This component intends to conform to the fol
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.1.4" "2.4.3" "2.4.7" "4.1.1" "4.1.2" }} />
 
+---
+
 ## Support
 
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/tabs/index.md
+++ b/website/docs/components/tabs/index.md
@@ -27,5 +27,4 @@ previewImage: assets/illustrations/components/tabs.jpg
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/tabs/partials/accessibility/accessibility.md
+++ b/website/docs/components/tabs/partials/accessibility/accessibility.md
@@ -9,3 +9,9 @@ No indicator animation will be present for users that have enabled `prefers-redu
 ## Applicable WCAG Success Criteria
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.4.6" "2.4.7" "3.2.1" "4.1.1" "4.1.2" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/tabs/partials/accessibility/support.md
+++ b/website/docs/components/tabs/partials/accessibility/support.md
@@ -1,4 +1,0 @@
----
-
-## Support
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -26,5 +26,4 @@ previewImage: assets/illustrations/components/tag.jpg
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/tag/partials/accessibility/accessibility.md
+++ b/website/docs/components/tag/partials/accessibility/accessibility.md
@@ -14,3 +14,9 @@ When used as recommended, there should not be any accessibility issues with this
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.4.1" "1.4.3" "1.4.4" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.4.7" "3.2.1" "4.1.1" "4.1.2" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/tag/partials/accessibility/support.md
+++ b/website/docs/components/tag/partials/accessibility/support.md
@@ -1,4 +1,0 @@
----
-
-## Support
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/template/index.md
+++ b/website/docs/components/template/index.md
@@ -27,5 +27,4 @@ links:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/template/partials/accessibility/accessibility.md
+++ b/website/docs/components/template/partials/accessibility/accessibility.md
@@ -28,3 +28,9 @@ The `Component Name` component is not WCAG-conformant on its own. (Explain how t
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/template/partials/accessibility/support.md
+++ b/website/docs/components/template/partials/accessibility/support.md
@@ -1,3 +1,0 @@
-## Support
-
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/toast/index.md
+++ b/website/docs/components/toast/index.md
@@ -26,5 +26,4 @@ previewImage: assets/illustrations/components/toast.jpg
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
-  @include "partials/accessibility/support.md"
 </section>

--- a/website/docs/components/toast/partials/accessibility/accessibility.md
+++ b/website/docs/components/toast/partials/accessibility/accessibility.md
@@ -13,3 +13,9 @@ When used as recommended, there should not be any WCAG conformance issues with t
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
 <Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />
+
+---
+
+## Support
+
+If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).

--- a/website/docs/components/toast/partials/accessibility/support.md
+++ b/website/docs/components/toast/partials/accessibility/support.md
@@ -1,4 +1,0 @@
----
-
-## Support
-If any accessibility issues have been found within this component, please let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR introduces a minor adjustment to the way the "support" section is handled in the Accessibility tab for all components. 

**Example preview link:** https://hds-website-git-heatherlarsen-a11y-support-iteration-hashicorp.vercel.app/components/alert?tab=accessibility

### :hammer_and_wrench: Detailed description

Changes included:
- Moving the "support" section directly into the accessibility.md file
- Deleting the accessibility/support.md files
- Removing reference to accessibility/support.md file
- Removed "please" to align with our content guidelines

Why?
- Because there was not a consistent approach to this across the components

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1351](https://hashicorp.atlassian.net/browse/HDS-1351)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1351]: https://hashicorp.atlassian.net/browse/HDS-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ