### PR TITLE
Retain input focus when filtering

### DIFF
--- a/website/app/components/doc/page/header/index.hbs
+++ b/website/app/components/doc/page/header/index.hbs
@@ -1,5 +1,5 @@
 <header class="doc-page-header" ...attributes>
-  <NavigationNarrator />
+  <NavigationNarrator @routeChangeValidator={{@routeChangeValidator}} />
   <LinkTo @route="index" class="doc-page-header__logo" aria-label="home page">
     <Doc::Logo::DesignSystem />
   </LinkTo>

--- a/website/app/controllers/application.js
+++ b/website/app/controllers/application.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { scheduleOnce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { next, later, cancel } from '@ember/runloop';
+import { defaultValidator } from 'ember-a11y-refocus';
 
 export default class ApplicationController extends Controller {
   @service router;
@@ -64,6 +65,21 @@ export default class ApplicationController extends Controller {
       this.runLater = later(() => {
         document.body.classList.remove('isSidebarInRenderTree');
       }, 250);
+    }
+  }
+
+  transitionValidator(transition) {
+    // Disable transition validation if we're transitioning to the same page
+    // and the page is has a filter functionality based on `queryParams`
+    // namely the Icon library or the Tokens page
+    if (
+      transition.from.params.path === transition.to.params.path &&
+      (transition.from.params.path === 'icons/library' ||
+        transition.from.params.path === 'foundations/tokens')
+    ) {
+      return false;
+    } else {
+      return defaultValidator(transition);
     }
   }
 

--- a/website/app/templates/application.hbs
+++ b/website/app/templates/application.hbs
@@ -7,6 +7,7 @@
     @currentTopRoute={{this.currentTopRoute}}
     @isSidebarVisibleOnSmallViewport={{this.isSidebarVisibleOnSmallViewport}}
     @onToggleBurgerMenu={{this.onToggleBurgerMenu}}
+    @routeChangeValidator={{this.transitionValidator}}
   />
   <Doc::Page::Sidebar
     {{! `this.model.toc` comes from `routes/application.js` }}


### PR DESCRIPTION
### :pushpin: Summary

Retain input focus when performing a filter/search by disabling `ember-a11y-refocus`'s transition validation on two specific paths.

### :hammer_and_wrench: Detailed description

I tried to come up with a more generic solution, but couldn't account for edge cases (for example looking for `searchQuery` to exist wouldn't work in a scenario where the user clears the input to try another search).

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1356](https://hashicorp.atlassian.net/browse/HDS-1356)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1356]: https://hashicorp.atlassian.net/browse/HDS-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ