### PR TITLE
Website: Lower z-index of sidebar (HDS-1325)

### DIFF
--- a/website/app/styles/tokens.scss
+++ b/website/app/styles/tokens.scss
@@ -30,6 +30,6 @@
   --doc-color-feedback-critical-400: #fcf0f2;
   // Z-INDEXES
   --doc-z-index-header: 20;
-  --doc-z-index-sidebar: 15;
+  --doc-z-index-sidebar: 2;
   --doc-z-index-footer: 10;
 }


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR lowers the z-index of the website's sidebar so that it will no longer overlap dropdown examples in the documentation.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots
<img width="1049" alt="Screen Shot 2023-01-18 at 11 18 24 AM" src="https://user-images.githubusercontent.com/108769823/213274153-317c1a5a-23cb-48c7-945c-fc65f10e8d4a.png">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1325](https://hashicorp.atlassian.net/browse/HDS-1325)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
