### PR TITLE
Adding keywords to Button Set

### DIFF
--- a/website/docs/components/button-set/index.md
+++ b/website/docs/components/button-set/index.md
@@ -6,6 +6,7 @@ status: code-only
 links:
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button-set
 previewImage: assets/illustrations/components/button-set.jpg
+keywords: ['button group', 'button', 'button spacing', 'button alignment', 'button layout']
 ---
 
 <section data-tab="Guidelines">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR introduces keywords to the button set component via frontmatter.

**Preview link:** https://hds-website-git-heatherlarsen-components-buttonset-hashicorp.vercel.app/components/button-set

You can filter by terms such as: "set", "group", "alignment", "layout", "spacing" (or also include "button" in front of any of those too)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1351](https://hashicorp.atlassian.net/browse/HDS-1351)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1351]: https://hashicorp.atlassian.net/browse/HDS-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ