### PR TITLE
New docs website / Persist sidebar's "toggle" state

### DIFF
--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -43,11 +43,7 @@
       </div>
       <nav class="doc-page-sidebar__table-of-contents" aria-label="secondary page navigation">
         {{#if this.hasTableOfContents}}
-          <Doc::TableOfContents
-            @structuredPageTree={{this.structuredPageTree}}
-            @depth={{1}}
-            @isFiltered={{this.isFiltered}}
-          />
+          <Doc::TableOfContents @structuredPageTree={{this.structuredPageTree}} @depth={{1}} />
         {{else}}
           <p class="doc-text-body-small">No results found</p>
         {{/if}}

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -16,11 +16,11 @@
       {{else}}
         {{#if (eq @depth 1)}}
           <div class="doc-table-of-contents__heading">{{humanize key}}</div>
-          <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} @isFiltered={{@isFiltered}} />
+          <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} />
         {{else}}
-          <details class="doc-table-of-contents__folder" open={{@isFiltered}}>
+          <details class="doc-table-of-contents__folder" open={{item.isOpen}}>
             <summary class="doc-table-of-contents__summary">{{humanize key}}</summary>
-            <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} @isFiltered={{@isFiltered}} />
+            <Doc::TableOfContents @structuredPageTree={{item.children}} @depth={{add @depth 1}} />
           </details>
         {{/if}}
       {{/if}}

--- a/website/tests/acceptance/sidebar-test.js
+++ b/website/tests/acceptance/sidebar-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { fillIn, visit, pauseTest } from '@ember/test-helpers';
+import { fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 
 module('Acceptance | Sidebar filter', function (hooks) {

--- a/website/tests/acceptance/sidebar-test.js
+++ b/website/tests/acceptance/sidebar-test.js
@@ -1,9 +1,11 @@
 import { module, test } from 'qunit';
-import { fillIn, visit } from '@ember/test-helpers';
+import { fillIn, visit, pauseTest } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 
 module('Acceptance | Sidebar filter', function (hooks) {
   setupApplicationTest(hooks);
+
+  // FILTERING
 
   test('should show the "Alert" link in the sidebar', async function (assert) {
     await visit('/components');
@@ -18,6 +20,19 @@ module('Acceptance | Sidebar filter', function (hooks) {
     assert
       .dom('.doc-page-sidebar__table-of-contents a[href="/components/alert"]')
       .exists();
+  });
+
+  test('should show the "Checkbox" link in the sidebar (under an opened parent container) if filtering using its "page title" (case insensitive)', async function (assert) {
+    await visit('/components');
+    let link = this.element.querySelector(
+      '.doc-page-sidebar__table-of-contents a[href="/components/form/checkbox"]'
+    );
+    assert.dom(link).exists();
+    assert.dom('.doc-table-of-contents__folder[open]').exists({ count: 0 });
+    await fillIn('.doc-page-sidebar__filter input[type="search"]', 'ChEcKbOx');
+    assert.dom(link).exists();
+    // notice: we can't use `.hasAttribute('open')` here because it returns always false
+    assert.dom('.doc-table-of-contents__folder[open]').exists({ count: 1 });
   });
 
   test('should still show the filter input after filtering', async function (assert) {
@@ -52,5 +67,17 @@ module('Acceptance | Sidebar filter', function (hooks) {
     assert
       .dom('.doc-page-sidebar__table-of-contents a[href="/components/alert"]')
       .exists();
+  });
+
+  // QUERY PARAMS
+
+  test('all "folder" containers should be closed by default if the "current route" link is not inside any of them', async function (assert) {
+    await visit('/components/alert');
+    assert.dom('.doc-table-of-contents__folder[open]').exists({ count: 0 });
+  });
+
+  test('the "folder" container of the "current route" link should be opened by default', async function (assert) {
+    await visit('/components/form/radio-card');
+    assert.dom('.doc-table-of-contents__folder[open]').exists({ count: 1 });
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

This PR refactors the sidebar's content "tree" generation, to take in account both the filtering and the "current route", so that the toggling of the "folder" containers works as expected (in particular, it fixes the issue where on page reload the "toggle" status was lost for nested active links).

### :hammer_and_wrench: Detailed description

In this PR I have:
- refactored generation of sidebar’s content tree to take in account current url and filtering
- added a bunch of tests for the sidebar (and renamed the file)

👉 👉 👉 **Preview**: https://hds-website-git-new-docs-website-persist-sideb-945829-hashicorp.vercel.app/components/form/checkbox

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1412

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
