### PR TITLE
Sort pages using alphabetical order

### DIFF
--- a/website/lib/markdown/table-of-contents.js
+++ b/website/lib/markdown/table-of-contents.js
@@ -29,16 +29,8 @@ const sortPages = (s1, s2) => {
     } else if (s1.pageAttributes.order > s2.pageAttributes.order) {
       return 1;
     } else {
-      // or we fallback to sort alphabethically
-      const p1 = s1.pageName.toLowerCase;
-      const p2 = s2.pageName.toLowerCase;
-      if (p1 < p2) {
-        return 1;
-      } else if (p1 > p2) {
-        return -1;
-      } else {
-        return 0;
-      }
+      // or we fallback to sort alphabetically
+      return s1.pageName.localeCompare(s2.pageName);
     }
   } else {
     // we try to use the top-level category


### PR DESCRIPTION
### :pushpin: Summary

Sort pages in alphabetical order

### :hammer_and_wrench: Detailed description

Update our `sortPages` function to use alphabetical order. This way we'll have, for example: `Badge`, `Badge Count` instead of `Badge Count`, `Badge` and we don't have to worry about case sensitivity or special characters.

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
