### PR TITLE
Use `Doc::Layout` in Alert and Toast

### DIFF
--- a/website/docs/components/alert/partials/guidelines/guidelines.md
+++ b/website/docs/components/alert/partials/guidelines/guidelines.md
@@ -12,7 +12,7 @@
 
 ### Color
 
-<div style="display: flex; gap: 1rem;">
+<Doc::Layout @spacing="12px">
   <Hds::Alert @type="inline" @color="neutral" as |A|>
     <A.Title>Neutral alert title</A.Title>
     <A.Description>Lorem ipsum dolar sit amet.</A.Description>
@@ -25,8 +25,6 @@
     <A.Title>Success alert title</A.Title>
     <A.Description>Lorem ipsum dolar sit amet.</A.Description>
   </Hds::Alert>
-</div>
-<div style="display: flex; gap: 1rem; margin: 16px 0px;">
   <Hds::Alert @type="inline" @color="warning" as |A|>
     <A.Title>Warning alert title</A.Title>
     <A.Description>Lorem ipsum dolar sit amet.</A.Description>
@@ -35,7 +33,7 @@
     <A.Title>Critical alert title</A.Title>
     <A.Description>Lorem ipsum dolar sit amet.</A.Description>
   </Hds::Alert>
-</div>
+</Doc::Layout>
 
 Use color logically.
 

--- a/website/docs/components/toast/partials/guidelines/guidelines.md
+++ b/website/docs/components/toast/partials/guidelines/guidelines.md
@@ -12,7 +12,8 @@
 - To display promotional content. Consider using [AlertInline](/components/alert-inline).
 
 ### Color
-<div style="display: flex; flex-direction: column; gap: 1rem; margin-bottom: 20px;">
+
+<Doc::Layout @spacing="12px" @direction="vertical">
   <Hds::Toast @onDismiss={{this.noop}} as |T|>
     <T.Title>Neutral toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
@@ -31,7 +32,6 @@
     <T.Button @text="Button" @color="secondary" />
     <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
-
   <Hds::Toast @color="warning" @onDismiss={{this.noop}} as |T|>
     <T.Title>Warning toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
@@ -44,7 +44,7 @@
     <T.Button @text="Button" @color="secondary" />
     <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
-</div>
+</Doc::Layout>
 
 Use color logically.
 
@@ -60,7 +60,7 @@ Use color logically.
 
 All toasts come with icons by default. They are intentionally tied to the toast type. Icons in Neutral and Highlight alerts can be swapped out with any other icon from Flight, including animated ones. Change them only when the new icon provides the user with extra value; otherwise, leaving the default icon is recommended.
 
-<div style="display: flex; gap: 1rem; flex-direction: column;">
+<Doc::Layout @spacing="12px" @direction="vertical">
   <Hds::Toast @color="neutral" @icon="running" @onDismiss={{this.noop}} as |T|>
     <T.Title>Plan running</T.Title>
     <T.Button @text="Button" @color="secondary" />
@@ -71,7 +71,7 @@ All toasts come with icons by default. They are intentionally tied to the toast 
     <T.Button @text="Button" @color="secondary" />
     <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
-</div>
+</Doc::Layout>
 
 ### Actions
 
@@ -93,10 +93,10 @@ Some common examples are:
 
 #### Button secondary + tertiary
 
-<div style="display: flex; gap: 1rem;">
+<Doc::Layout @spacing="12px">
   <Hds::Button @color="secondary" @text="Send reminder email" @size="small" />
   <Hds::Link::Standalone @color="primary" @iconPosition="leading" @icon="x-circle" @text="Cancel invitation" @href="#" />
-</div>
+</Doc::Layout>
 
 !!! Warning
 
@@ -175,7 +175,7 @@ Toast width: The Figma component is 360px, which is the minimum width. You can m
 
 ### Examples
 
-<div style="display: flex; gap: 1rem; flex-direction: column;">
+<Doc::Layout @spacing="12px" @direction="vertical">
   <Hds::Toast @color="success" @icon="check-circle" @onDismiss={{this.noop}} as |T|>
     <T.Title>Cost estimation enabled</T.Title>
     <T.Description>Future runs will now include this step. You can manage this preference in <Hds::Link::Inline @href="#">Organization settings</Hds::Link::Inline>.</T.Description>
@@ -190,5 +190,4 @@ Toast width: The Figma component is 360px, which is the minimum width. You can m
     <T.Button @text="Button" @color="secondary" />
     <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
-</div>
-
+</Doc::Layout>


### PR DESCRIPTION
### :pushpin: Summary

Use `Doc::Layout` in Alert and Toast examples/showcases

### :hammer_and_wrench: Detailed description

To avoid hardcoded styles, increase consistency, and fix layout issues on narrow viewports (overflowing content).

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![localhost_5000_components_alert](https://user-images.githubusercontent.com/788096/213749933-177c150f-7488-4bce-8e1c-82ffddfbd7ef.png)


</td><td>

![localhost_5000_components_alert (1)](https://user-images.githubusercontent.com/788096/213749947-097038e9-8ea9-4aa4-86bd-9689fac7810d.png)


</td></tr>
</table>

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
