### PR TITLE
Update documentation for `{{on "click"}}` for `Alert` and `Toast`

### DIFF
--- a/packages/components/tests/dummy/app/controllers/components/alert.js
+++ b/packages/components/tests/dummy/app/controllers/components/alert.js
@@ -6,4 +6,9 @@ export default class AlertController extends Controller {
   // I tried to use an helper, but without success (see https://hashicorp.slack.com/archives/C11JCBJTW/p1648751235987409)
   @action
   noop() {}
+
+  @action
+  yourOnClickFunction() {
+    console.log('Clicked the button in the "alert"!');
+  }
 }

--- a/packages/components/tests/dummy/app/controllers/components/toast.js
+++ b/packages/components/tests/dummy/app/controllers/components/toast.js
@@ -6,4 +6,9 @@ export default class ToastController extends Controller {
   // I tried to use an helper, but without success (see https://hashicorp.slack.com/archives/C11JCBJTW/p1648751235987409)
   @action
   noop() {}
+
+  @action
+  yourOnClickFunction() {
+    console.log('Clicked the button in the "toast"!');
+  }
 }

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -441,7 +441,7 @@
       <Hds::Alert @type="inline" as |A|>
         <A.Title>Title here</A.Title>
         <A.Description>Description here</A.Description>
-        <A.Button @text="Your action" @color="secondary" @onClick=\{{this.noop}} />
+        <A.Button @text="Your action" @color="secondary" \{{on "click" this.yourOnClickFunction}} />
         <A.Link::Standalone @color="secondary" @icon="plus" @text="Another action" @route="..." />
         <A.Link::Standalone @icon="arrow-right" @iconPosition="leading" @text="Another action" @href="#" />
       </Hds::Alert>
@@ -453,7 +453,7 @@
   <Hds::Alert @type="inline" as |A|>
     <A.Title>Title here</A.Title>
     <A.Description>Description here</A.Description>
-    <A.Button @text="Your action" @color="secondary" />
+    <A.Button @text="Your action" @color="secondary" {{on "click" this.yourOnClickFunction}} />
     <A.Link::Standalone @color="secondary" @icon="plus" @text="Another action" @route="index" />
     <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @text="Another action" @href="#" />
   </Hds::Alert>

--- a/packages/components/tests/dummy/app/templates/components/toast.hbs
+++ b/packages/components/tests/dummy/app/templates/components/toast.hbs
@@ -217,7 +217,7 @@
       <Hds::Toast @color="critical" @onDismiss=\{{...}} as |T|>
         <T.Title>Title here</T.Title>
         <T.Description>Description here</T.Description>
-        <T.Button @text="Your action" @color="secondary" @onClick=\{{ your function here }} />
+        <T.Button @text="Your action" @color="secondary" \{{on "click" this.yourOnClickFunction}} />
         <T.Link::Standalone @color="secondary" @icon="plus" @text="Another action" @route="..." @color="secondary" />
       </Hds::Toast>
     '
@@ -228,7 +228,7 @@
   <Hds::Toast @color="critical" @onDismiss={{this.noop}} as |T|>
     <T.Title>Title here</T.Title>
     <T.Description>Description here</T.Description>
-    <T.Button @text="Your action" @color="secondary" />
+    <T.Button @text="Your action" @color="secondary" {{on "click" this.yourOnClickFunction}} />
     <T.Link::Standalone @color="secondary" @icon="plus" @text="Another action" @route="index" />
   </Hds::Toast>
 

--- a/website/docs/components/alert/index.js
+++ b/website/docs/components/alert/index.js
@@ -19,4 +19,9 @@ export default class Index extends Component {
   noop() {
     //
   }
+
+  @action
+  yourOnClickFunction() {
+    console.log('Clicked the button in the "alert"!');
+  }
 }

--- a/website/docs/components/alert/partials/code/how-to-use.md
+++ b/website/docs/components/alert/partials/code/how-to-use.md
@@ -95,7 +95,7 @@ Actions can be passed to the component using one of the suggested `Button` or `L
 <Hds::Alert @type="inline" as |A|>
   <A.Title>Title here</A.Title>
   <A.Description>Description here</A.Description>
-  <A.Button @text="Your action" @color="secondary" @onClick={{this.noop}} />
+  <A.Button @text="Your action" @color="secondary" {{on "click" this.yourOnClickFunction}} />
   <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @text="Another action" @href="#" />
 </Hds::Alert>
 ```

--- a/website/docs/components/toast/index.js
+++ b/website/docs/components/toast/index.js
@@ -21,6 +21,6 @@ export default class Index extends Component {
 
   @action
   yourOnClickFunction() {
-    console.log('Clicked the button in the "tag"!');
+    console.log('Clicked the button in the "toast"!');
   }
 }

--- a/website/docs/components/toast/partials/code/how-to-use.md
+++ b/website/docs/components/toast/partials/code/how-to-use.md
@@ -68,7 +68,7 @@ Actions can optionally be passed into the component using one of the suggested `
 <Hds::Toast @color="critical" @onDismiss={{this.yourOnDismissFunction}} as |T|>
   <T.Title>Title here</T.Title>
   <T.Description>Description here</T.Description>
-  <T.Button @text="Your action" @color="secondary" @onClick={{this.yourOnClickFunction}} />
+  <T.Button @text="Your action" @color="secondary" {{on "click" this.yourOnClickFunction}} />
   <T.Link::Standalone @color="secondary" @icon="plus" @text="Another action" @route="components" @color="secondary" />
 </Hds::Toast>
 ```


### PR DESCRIPTION
### :pushpin: Summary

Context: https://hashicorp.slack.com/archives/C7KTUHNUS/p1674077398271439

### :hammer_and_wrench: Detailed description

Previews:
- https://hds-components-git-fix-documentation-hashicorp.vercel.app/components/alert
- https://hds-components-git-fix-documentation-hashicorp.vercel.app/components/toast
- https://hds-website-git-fix-documentation-hashicorp.vercel.app/components/alert?tab=code#actions-1
- https://hds-website-git-fix-documentation-hashicorp.vercel.app/components/toast?tab=code#actions-1

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
