### PR TITLE
Website: hide sidebar on error and patterns pages

### DIFF
--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -86,11 +86,3 @@ body.application.error {
   }
 }
 
-// PATTERNS PAGE
-body.application.patterns {
-  @include breakpoint.with-fixed-sidebar () {
-    .doc-page-footer {
-      padding-left: 0;
-    }
-  }
-}

--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -75,3 +75,22 @@
     height: 100%;
   }
 }
+
+
+// ERROR PAGE
+body.application.error {
+  @include breakpoint.with-fixed-sidebar () {
+    .doc-page-footer {
+      padding-left: 0;
+    }
+  }
+}
+
+// PATTERNS PAGE
+body.application.patterns {
+  @include breakpoint.with-fixed-sidebar () {
+    .doc-page-footer {
+      padding-left: 0;
+    }
+  }
+}

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -54,6 +54,7 @@ body.application.index {
 
 // ERROR PAGE
 // now with extra specificity
+// also if you want to change this, change footer.scss too
 body.application.error {
   .doc-page-wrapper {
     @include breakpoint.with-fixed-sidebar () {

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -52,19 +52,6 @@ body.application.index {
   }
 }
 
-// ERROR PAGE
-// now with extra specificity
-// also if you want to change this, change footer.scss too
-body.application.error {
-  .doc-page-wrapper {
-    @include breakpoint.with-fixed-sidebar () {
-      aside.doc-page-sidebar {
-        display: none;
-      }
-    }
-  }
-}
-
 // ALL THE OTHER PAGES
 
 body.application:not(.index) {
@@ -169,6 +156,16 @@ body.application:not(.index) {
     // we also lock the overflow scrolling on the `<body>` element
     &.isSidebarVisibleOnSmallViewport {
       overflow: hidden;
+    }
+  }
+}
+
+// ERROR PAGE
+// also if you want to change this, change footer.scss too
+body.application.error {
+  @include breakpoint.with-fixed-sidebar () {
+    .doc-page-sidebar {
+      display: none;
     }
   }
 }

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -52,6 +52,19 @@ body.application.index {
   }
 }
 
+// ERROR PAGE
+body.application.error {
+  .doc-page-sidebar {
+    display: none;
+  }
+}
+
+// PATTERNS PAGE
+body.application.patterns {
+  .doc-page-sidebar {
+    display: none;
+  }
+}
 
 // ALL THE OTHER PAGES
 

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -53,10 +53,13 @@ body.application.index {
 }
 
 // ERROR PAGE
+// now with extra specificity
 body.application.error {
-  @include breakpoint.with-fixed-sidebar () {
-    .doc-page-sidebar {
-      display: none;
+  .doc-page-wrapper {
+    @include breakpoint.with-fixed-sidebar () {
+      aside.doc-page-sidebar {
+        display: none;
+      }
     }
   }
 }

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -54,15 +54,19 @@ body.application.index {
 
 // ERROR PAGE
 body.application.error {
-  .doc-page-sidebar {
-    display: none;
+  @include breakpoint.with-fixed-sidebar () {
+    .doc-page-sidebar {
+      display: none;
+    }
   }
 }
 
 // PATTERNS PAGE
 body.application.patterns {
-  .doc-page-sidebar {
-    display: none;
+  @include breakpoint.with-fixed-sidebar () {
+    .doc-page-sidebar {
+      display: none;
+    }
   }
 }
 

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -61,15 +61,6 @@ body.application.error {
   }
 }
 
-// PATTERNS PAGE
-body.application.patterns {
-  @include breakpoint.with-fixed-sidebar () {
-    .doc-page-sidebar {
-      display: none;
-    }
-  }
-}
-
 // ALL THE OTHER PAGES
 
 body.application:not(.index) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR hides the sidebar (with CSS)

### :hammer_and_wrench: Detailed description

While we will eventually want to conditionally render layouts based on viewport, for now it's been decided that the sidebar will be hidden with CSS. 

### :camera_flash: Screenshots

Using the CSS approach that was suggested, here's what the error page looks like: 
![CleanShot 2023-01-23 at 13 25 11](https://user-images.githubusercontent.com/4587451/214131420-6262161c-54d2-40c9-b63c-003d8204e927.png)


***


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
