### PR TITLE
Add `google-site-verification` token to the components website

### DIFF
--- a/packages/components/tests/dummy/app/index.html
+++ b/packages/components/tests/dummy/app/index.html
@@ -6,6 +6,7 @@
     <title>Design System Components</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes">
+    <meta name="google-site-verification" content="_aU7ePXLFbs8nz644U2Nv1mpq2OiKnXCrwaDgZFTo-4">
 
     {{content-for "head"}}
 


### PR DESCRIPTION
### :pushpin: Summary

Add `google-site-verification` token to enable indexing removal via Google Search Console.

### :hammer_and_wrench: Detailed description

In #1046 we set `x-robots-tag: none` for the scrappy website (a.ka. 'the components website', hds-components.vercel.app or design-system-components-hashicorp.vercel.app). This means that, in theory, the next time Google Search indexes the website it won't show it in our results. In practice, the pragmatic approach would be to remove it from indexing, using Google Search Console. To be able to do this, we need to verify the ownership of this (sub)domain.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1427](https://hashicorp.atlassian.net/browse/HDS-1427)


[HDS-1427]: https://hashicorp.atlassian.net/browse/HDS-1427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ