### PR TITLE
`Pagination` - Support routing arguments in API (final implementation)

### DIFF
--- a/packages/components/addon/components/hds/pagination/compact/index.hbs
+++ b/packages/components/addon/components/hds/pagination/compact/index.hbs
@@ -3,12 +3,22 @@
     <Hds::Pagination::Nav::Arrow
       @direction="prev"
       @showLabel={{this.showLabels}}
+      @route={{this.routing.route}}
+      @query={{this.routing.queryPrev}}
+      @model={{this.routing.model}}
+      @models={{this.routing.models}}
+      @replace={{this.routing.replace}}
       @onClick={{this.onPageChange}}
       @disabled={{@isDisabledPrev}}
     />
     <Hds::Pagination::Nav::Arrow
       @direction="next"
       @showLabel={{this.showLabels}}
+      @route={{this.routing.route}}
+      @query={{this.routing.queryNext}}
+      @model={{this.routing.model}}
+      @models={{this.routing.models}}
+      @replace={{this.routing.replace}}
       @onClick={{this.onPageChange}}
       @disabled={{@isDisabledNext}}
     />

--- a/packages/components/addon/components/hds/pagination/compact/index.js
+++ b/packages/components/addon/components/hds/pagination/compact/index.js
@@ -9,7 +9,7 @@ export default class HdsPaginationCompactIndexComponent extends Component {
   constructor() {
     super(...arguments);
 
-    let { queryPrev, queryNext, queryFunction } = this.args;
+    let { queryFunction } = this.args;
 
     // This component works in two different ways, depending if we need to support
     // routing through links (`LinkTo`) for the "navigation controls", or not.
@@ -19,24 +19,13 @@ export default class HdsPaginationCompactIndexComponent extends Component {
     // then the component behaves as "controlled", where the state is
     // initialized and updated using the arguments passed to it.
 
-    if (
-      queryPrev === undefined &&
-      queryNext === undefined &&
-      queryFunction === undefined
-    ) {
+    if (queryFunction === undefined) {
       this.hasRouting = false;
     } else {
-      if (queryFunction) {
-        assert(
-          '@queryFunction for "Hds::Pagination::Numbered" must be a function',
-          typeof queryFunction === 'function'
-        );
-      } else {
-        assert(
-          '@queryPrev and @queryNext for "Hds::Numbered" must be both or undefined or defined as objects/hashes (you can\'t have only one defined)',
-          typeof queryPrev === 'object' && typeof queryNext === 'object'
-        );
-      }
+      assert(
+        '@queryFunction for "Hds::Pagination::Numbered" must be a function',
+        typeof queryFunction === 'function'
+      );
       this.hasRouting = true;
     }
   }
@@ -58,19 +47,8 @@ export default class HdsPaginationCompactIndexComponent extends Component {
   }
 
   buildQueryParamsObject(page) {
-    let { queryPrev, queryNext, queryFunction } = this.args;
     if (this.hasRouting) {
-      if (queryFunction) {
-        return this.args.queryFunction(page, this.currentPage);
-      } else {
-        let queryParams;
-        if (page === 'prev') {
-          queryParams = Object.assign({}, this.routeQueryParams, queryPrev);
-        } else if (page === 'next') {
-          queryParams = Object.assign({}, this.routeQueryParams, queryNext);
-        }
-        return queryParams;
-      }
+      return this.args.queryFunction(page, this.currentPage);
     } else {
       return {};
     }

--- a/packages/components/addon/components/hds/pagination/compact/index.js
+++ b/packages/components/addon/components/hds/pagination/compact/index.js
@@ -1,7 +1,46 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { assert } from '@ember/debug';
+import { inject as service } from '@ember/service';
 
 export default class HdsPaginationCompactIndexComponent extends Component {
+  @service router;
+
+  constructor() {
+    super(...arguments);
+
+    let { queryPrev, queryNext, queryFunction } = this.args;
+
+    // This component works in two different ways, depending if we need to support
+    // routing through links (`LinkTo`) for the "navigation controls", or not.
+    // If there's no routing then the component behaves as "uncontrolled"
+    // (the state updates are handled by its internal logic).
+    // If instead the component needs to update the routing (and we infer this via the "query" arguments)
+    // then the component behaves as "controlled", where the state is
+    // initialized and updated using the arguments passed to it.
+
+    if (
+      queryPrev === undefined &&
+      queryNext === undefined &&
+      queryFunction === undefined
+    ) {
+      this.hasRouting = false;
+    } else {
+      if (queryFunction) {
+        assert(
+          '@queryFunction for "Hds::Pagination::Numbered" must be a function',
+          typeof queryFunction === 'function'
+        );
+      } else {
+        assert(
+          '@queryPrev and @queryNext for "Hds::Numbered" must be both or undefined or defined as objects/hashes (you can\'t have only one defined)',
+          typeof queryPrev === 'object' && typeof queryNext === 'object'
+        );
+      }
+      this.hasRouting = true;
+    }
+  }
+
   /**
    * @param showLabels
    * @type {boolean}
@@ -12,6 +51,49 @@ export default class HdsPaginationCompactIndexComponent extends Component {
     let { showLabels = true } = this.args;
 
     return showLabels;
+  }
+
+  get routeQueryParams() {
+    return this.router.currentRoute?.queryParams || {};
+  }
+
+  buildQueryParamsObject(page) {
+    let { queryPrev, queryNext, queryFunction } = this.args;
+    if (this.hasRouting) {
+      if (queryFunction) {
+        return this.args.queryFunction(page, this.currentPage);
+      } else {
+        let queryParams;
+        if (page === 'prev') {
+          queryParams = Object.assign({}, this.routeQueryParams, queryPrev);
+        } else if (page === 'next') {
+          queryParams = Object.assign({}, this.routeQueryParams, queryNext);
+        }
+        return queryParams;
+      }
+    } else {
+      return {};
+    }
+  }
+
+  get routing() {
+    let routing = {
+      route: this.args.route ?? undefined,
+      model: this.args.model ?? undefined,
+      models: this.args.models ?? undefined,
+      replace: this.args.replace ?? undefined,
+    };
+
+    // the "query" is dynamic and needs to be calculated
+    if (this.hasRouting) {
+      routing.queryPrev = this.buildQueryParamsObject('prev');
+      routing.queryNext = this.buildQueryParamsObject('next');
+    } else {
+      routing.queryPrev = undefined;
+      routing.queryNext = undefined;
+    }
+
+    return routing;
   }
 
   @action

--- a/packages/components/addon/components/hds/pagination/nav/arrow.hbs
+++ b/packages/components/addon/components/hds/pagination/nav/arrow.hbs
@@ -10,14 +10,10 @@
 {{else}}
   <Hds::Interactive
     class={{this.classNames}}
-    @current-when={{@current-when}}
-    @models={{hds-link-to-models @model @models}}
-    @query={{hds-link-to-query @query}}
-    @replace={{@replace}}
     @route={{@route}}
-    @href={{@href}}
-    {{! This can be removed once this is fixed: https://hashicorp.atlassian.net/browse/HDS-705 }}
-    @isHrefExternal={{false}}
+    @query={{hds-link-to-query @query}}
+    @models={{hds-link-to-models @model @models}}
+    @replace={{@replace}}
     {{on "click" this.onClick}}
     aria-label={{this.content.ariaLabel}}
     ...attributes

--- a/packages/components/addon/components/hds/pagination/nav/number.hbs
+++ b/packages/components/addon/components/hds/pagination/nav/number.hbs
@@ -1,8 +1,12 @@
 <Hds::Interactive
   class={{this.classNames}}
-  aria-current={{if @isSelected "page" null}}
+  @route={{@route}}
+  @query={{hds-link-to-query @query}}
+  @models={{hds-link-to-models @model @models}}
+  @replace={{@replace}}
   {{on "click" this.onClick}}
   ...attributes
+  aria-current={{if @isSelected "page" null}}
 >
   <span class="sr-only">page </span>{{this.page}}
 </Hds::Interactive>

--- a/packages/components/addon/components/hds/pagination/numbered/index.hbs
+++ b/packages/components/addon/components/hds/pagination/numbered/index.hbs
@@ -3,7 +3,7 @@
     <Hds::Pagination::Info
       @itemsRangeStart={{this.itemsRangeStart}}
       @itemsRangeEnd={{this.itemsRangeEnd}}
-      @totalItems={{this.totalItems}}
+      @totalItems={{@totalItems}}
       @showTotalItems={{@showTotalItems}}
     />
   {{/if}}
@@ -12,6 +12,11 @@
     <Hds::Pagination::Nav::Arrow
       @direction="prev"
       @showLabel={{this.showLabels}}
+      @route={{this.routing.route}}
+      @query={{this.routing.queryPrev}}
+      @model={{this.routing.model}}
+      @models={{this.routing.models}}
+      @replace={{this.routing.replace}}
       @onClick={{this.onPageChange}}
       @disabled={{this.isDisabledPrev}}
     />
@@ -24,6 +29,11 @@
             {{else}}
               <Hds::Pagination::Nav::Number
                 @page={{page}}
+                @route={{this.routing.route}}
+                @query={{get this.routing.queryPages page}}
+                @model={{this.routing.model}}
+                @models={{this.routing.models}}
+                @replace={{this.routing.replace}}
                 @onClick={{this.onPageChange}}
                 @isSelected={{if (eq page this.currentPage) true false}}
               />
@@ -35,6 +45,11 @@
     <Hds::Pagination::Nav::Arrow
       @direction="next"
       @showLabel={{this.showLabels}}
+      @route={{this.routing.route}}
+      @query={{this.routing.queryNext}}
+      @model={{this.routing.model}}
+      @models={{this.routing.models}}
+      @replace={{this.routing.replace}}
       @onClick={{this.onPageChange}}
       @disabled={{this.isDisabledNext}}
     />
@@ -43,7 +58,7 @@
   {{#if this.showSizeSelector}}
     <Hds::Pagination::SizeSelector
       @pageSizes={{this.pageSizes}}
-      @selectedSize={{this.itemsPerPage}}
+      @selectedSize={{this.currentPageSize}}
       @onChange={{this.onPageSizeChange}}
     />
   {{/if}}

--- a/packages/components/addon/components/hds/pagination/numbered/index.js
+++ b/packages/components/addon/components/hds/pagination/numbered/index.js
@@ -88,7 +88,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   constructor() {
     super(...arguments);
 
-    let { queryParamPage, queryParamPageSize, queryFunction } = this.args;
+    let { queryFunction } = this.args;
 
     // This component works in two different ways, depending if we need to support
     // routing through links (`LinkTo`) for the "navigation controls", or not.
@@ -99,32 +99,19 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
     // then the component behaves as "controlled", where the state is
     // initialized and updated using the arguments passed to it.
 
-    if (
-      queryParamPage === undefined &&
-      queryParamPageSize === undefined &&
-      queryFunction === undefined
-    ) {
+    if (queryFunction === undefined) {
       this.hasRouting = false;
     } else {
-      if (queryFunction) {
-        assert(
-          '@queryFunction for "Hds::Pagination::Numbered" must be a function',
-          typeof queryFunction === 'function'
-        );
-      } else {
-        assert(
-          '@queryParamPage and @queryParamPageSize for "Hds::Pagination::Numbered" must be both or undefined or defined as strings (you can\'t have only one defined)',
-          typeof queryParamPage === 'string' &&
-            typeof queryParamPageSize === 'string'
-        );
-      }
-      this.hasRouting = true;
-
+      assert(
+        '@queryFunction for "Hds::Pagination::Numbered" must be a function',
+        typeof queryFunction === 'function'
+      );
       assert(
         '@currentPage and @itemsPerPage for "Hds::Pagination::Numbered" must be provided as numeric arguments when the pagination controls the routing',
         typeof this.args.itemsPerPage === 'number' &&
           typeof this.args.currentPage === 'number'
       );
+      this.hasRouting = true;
     }
 
     assert(
@@ -239,16 +226,8 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   }
 
   buildQueryParamsObject(page, pageSize) {
-    let { queryParamPage, queryParamPageSize, queryFunction } = this.args;
     if (this.hasRouting) {
-      if (queryFunction) {
-        return this.args.queryFunction(page, pageSize);
-      } else {
-        let queryParams = Object.assign({}, this.routeQueryParams);
-        queryParams[queryParamPage] = page;
-        queryParams[queryParamPageSize] = pageSize;
-        return queryParams;
-      }
+      return this.args.queryFunction(page, pageSize);
     } else {
       return {};
     }

--- a/packages/components/addon/components/hds/pagination/numbered/index.js
+++ b/packages/components/addon/components/hds/pagination/numbered/index.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
+import { inject as service } from '@ember/service';
 
 export const DEFAULT_PAGE_SIZES = [10, 30, 50];
 
@@ -65,9 +66,18 @@ export const elliptize = ({ pages, current, limit = 7 }) => {
 };
 
 export default class HdsPaginationNumberedIndexComponent extends Component {
-  @tracked currentItemsPerPage = this.args.itemsPerPage ?? this.pageSizes[0];
-  @tracked totalPages = this.calculateTotalPages();
-  @tracked currentPage = this.args.currentPage ?? 1;
+  @service router;
+
+  // These two private variables are used to differentiate between
+  // "uncontrolled" component (where the state is handled internally) and
+  // "controlled" component (where the state is handled externally, by the consumer's code).
+  // In the first case, these variables store the internal state of the component at any moment,
+  // and their value is updated internally according to the user's interaction with the component.
+  // In the second case, these variables store *only* the initial state of the component (coming from the arguments)
+  // at rendering time, but from that moment on they're not updated anymore, no matter what interaction the user
+  // has with the component (the state is controlled externally, eg. via query parameters)
+  @tracked _currentPage = this.args.currentPage ?? 1;
+  @tracked _currentPageSize = this.args.itemsPerPage ?? this.pageSizes[0];
 
   showInfo = this.args.showInfo ?? true; // if the "info" block is visible
   showLabels = this.args.showLabels ?? false; // if the labels for the "prev/next" controls are visible
@@ -75,36 +85,97 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   showPageNumbers = this.args.showPageNumbers ?? true; // if the "page numbers" block is visible
   isTruncated = this.args.isTruncated ?? true; // if the list of "page numbers" is truncated
 
-  /**
-   * Gets the current page
-   *
-   * @param currentPage
-   * @type {number}
-   */
+  constructor() {
+    super(...arguments);
+
+    let { queryParamPage, queryParamPageSize, queryFunction } = this.args;
+
+    // This component works in two different ways, depending if we need to support
+    // routing through links (`LinkTo`) for the "navigation controls", or not.
+    // If there's no routing then the component behaves as "uncontrolled"
+    // (the state updates - eg to the "currentPage" and "currentPageSize"
+    // are handled by its internal logic).
+    // If instead the component needs to update the routing (and we infer this via the "query" arguments)
+    // then the component behaves as "controlled", where the state is
+    // initialized and updated using the arguments passed to it.
+
+    if (
+      queryParamPage === undefined &&
+      queryParamPageSize === undefined &&
+      queryFunction === undefined
+    ) {
+      this.hasRouting = false;
+    } else {
+      if (queryFunction) {
+        assert(
+          '@queryFunction for "Hds::Pagination::Numbered" must be a function',
+          typeof queryFunction === 'function'
+        );
+      } else {
+        assert(
+          '@queryParamPage and @queryParamPageSize for "Hds::Pagination::Numbered" must be both or undefined or defined as strings (you can\'t have only one defined)',
+          typeof queryParamPage === 'string' &&
+            typeof queryParamPageSize === 'string'
+        );
+      }
+      this.hasRouting = true;
+
+      assert(
+        '@currentPage and @itemsPerPage for "Hds::Pagination::Numbered" must be provided as numeric arguments when the pagination controls the routing',
+        typeof this.args.itemsPerPage === 'number' &&
+          typeof this.args.currentPage === 'number'
+      );
+    }
+
+    assert(
+      '@totalItems for "Hds::Pagination::Numbered" must be defined as an integer number',
+      typeof this.args.totalItems === 'number'
+    );
+  }
+
+  // This very specific `get/set` pattern is used to handle the two different use cases of the component
+  // being "controlled" (when it has routing, meaning it needs to support links as controls)
+  // vs being "uncontrolled" (see comments above for details).
+  //
+  // If it has routing (and so it's "controlled"), than the value ("state") of the `currentPage/currentPageSize` variables
+  // is *always* determined by the controller via arguments (most of the times, connected to query parameters in the URL).
+  // For this reason the "get" method always returns the value from the `args`,
+  // while the "set" method never updates the private internal state (_variable).
+  //
+  // If instead it doesn't have routing (and so it's "uncontrolled") than the value ("state") of the `currentPage/currentPageSize` variables
+  // is *always* determined by the component's internal logic (and updated according to the user interaction with it).
+  // For this reason the "get" and "set" methods always read from or write to the private internal state (_variable).
+
   get currentPage() {
-    let { currentPage = 1 } = this.args;
-
-    return currentPage;
+    if (this.hasRouting) {
+      return this.args.currentPage;
+    } else {
+      return this._currentPage;
+    }
   }
 
-  /**
-   * @param totalItems
-   * @type {number}
-   * @description Pass the total number of items to be paginated. If no value is defined an error will be thrown.
-   */
-  get totalItems() {
-    let { totalItems } = this.args;
-
-    return totalItems;
+  set currentPage(value) {
+    if (this.hasRouting) {
+      // noop
+    } else {
+      this._currentPage = value;
+    }
   }
 
-  /**
-   * @param itemsPerPage
-   * @type {number}
-   * @description Pass the maximum number of items to display on each page initially.
-   */
-  get itemsPerPage() {
-    return this.currentItemsPerPage;
+  get currentPageSize() {
+    if (this.hasRouting) {
+      return this.args.itemsPerPage;
+    } else {
+      return this._currentPageSize;
+    }
+  }
+
+  set currentPageSize(value) {
+    if (this.hasRouting) {
+      // noop
+    } else {
+      this._currentPageSize = value;
+    }
   }
 
   /**
@@ -130,18 +201,18 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
     //  ( (1 - 1 = 0) * 10 = 0 ) + 1 = 1
     // if current page = 2nd page:
     // ( (2 - 1 = 1) * 10 = 10 ) + 1 = 11
-    return (this.currentPage - 1) * this.itemsPerPage + 1;
+    return (this.currentPage - 1) * this.currentPageSize + 1;
   }
 
   get itemsRangeEnd() {
     // Calculate ending range of items displayed on current page
     // 2 cases: 1) full page of items or 2) last page of items
-    if (this.currentPage * this.itemsPerPage < this.totalItems) {
+    if (this.currentPage * this.currentPageSize < this.args.totalItems) {
       // 1) full page of items (pages 1 to page before last):
-      return this.itemsRangeStart + this.itemsPerPage - 1;
+      return this.itemsRangeStart + this.currentPageSize - 1;
     } else {
       // 2) last page of items:
-      return this.totalItems;
+      return this.args.totalItems;
     }
   }
 
@@ -157,6 +228,68 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
     } else {
       return pages;
     }
+  }
+
+  get totalPages() {
+    return Math.max(Math.ceil(this.args.totalItems / this.currentPageSize), 1);
+  }
+
+  get routeQueryParams() {
+    return this.router.currentRoute?.queryParams || {};
+  }
+
+  buildQueryParamsObject(page, pageSize) {
+    let { queryParamPage, queryParamPageSize, queryFunction } = this.args;
+    if (this.hasRouting) {
+      if (queryFunction) {
+        return this.args.queryFunction(page, pageSize);
+      } else {
+        let queryParams = Object.assign({}, this.routeQueryParams);
+        queryParams[queryParamPage] = page;
+        queryParams[queryParamPageSize] = pageSize;
+        return queryParams;
+      }
+    } else {
+      return {};
+    }
+  }
+
+  get routing() {
+    let routing = {
+      route: this.args.route ?? undefined,
+      model: this.args.model ?? undefined,
+      models: this.args.models ?? undefined,
+      replace: this.args.replace ?? undefined,
+    };
+
+    // the "query" is dynamic and needs to be calculated
+    if (this.hasRouting) {
+      routing.queryPrev = this.buildQueryParamsObject(
+        this.currentPage - 1,
+        this.currentPageSize
+      );
+      routing.queryNext = this.buildQueryParamsObject(
+        this.currentPage + 1,
+        this.currentPageSize
+      );
+      // IMPORTANT: here we neeed to use an object and not an array
+      // otherwise the {{get object page}} will be shifted by one
+      // (the pages are 1-based while the array would be zero-based)
+      routing.queryPages = {};
+      this.pages.forEach(
+        (page) =>
+          (routing.queryPages[page] = this.buildQueryParamsObject(
+            page,
+            this.currentPageSize
+          ))
+      );
+    } else {
+      routing.queryPrev = undefined;
+      routing.queryNext = undefined;
+      routing.queryByPage = {};
+    }
+
+    return routing;
   }
 
   get isDisabledPrev() {
@@ -185,29 +318,29 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
       let { onPageChange } = this.args;
 
       if (typeof onPageChange === 'function') {
-        onPageChange(this.currentPage, this.currentItemsPerPage);
+        onPageChange(this.currentPage, this.currentPageSize);
       }
     }
   }
 
   @action
   onPageSizeChange(newPageSize) {
-    this.currentItemsPerPage = newPageSize;
-    this.currentPage = 1; // we agreed to reset the pagination to the first element (any alternative would result in an unpredictable UX)
-    this.totalPages = this.calculateTotalPages();
-
     let { onPageSizeChange } = this.args;
 
+    // we need to manually update the query parameters in the route (it's not a link!)
+    if (this.hasRouting) {
+      let queryParams = Object.assign({}, this.routeQueryParams);
+      // we agreed to reset the pagination to the first element (any alternative would result in an unpredictable UX)
+      queryParams = this.buildQueryParamsObject(1, newPageSize);
+      this.router.transitionTo({ queryParams });
+    } else {
+      this.currentPage = 1; // we agreed to reset the pagination to the first element (any alternative would result in an unpredictable UX)
+      this.currentPageSize = newPageSize;
+    }
+
+    // invoke the callback function
     if (typeof onPageSizeChange === 'function') {
       onPageSizeChange(newPageSize);
-    }
-  }
-
-  calculateTotalPages() {
-    if (this.totalItems) {
-      return Math.max(Math.ceil(this.totalItems / this.itemsPerPage), 1);
-    } else {
-      return undefined;
     }
   }
 }

--- a/packages/components/addon/components/hds/pagination/size-selector/index.hbs
+++ b/packages/components/addon/components/hds/pagination/size-selector/index.hbs
@@ -3,7 +3,7 @@
   <Hds::Form::Select::Base id={{this.SizeSelectorId}} {{on "change" this.onChange}} as |S|>
     <S.Options>
       {{#each this.pageSizes as |size|}}
-        <option value={{size}} selected={{if (eq size @selectedSize) true null}}>{{size}}</option>
+        <option value={{size}} selected={{if (eq size this.selectedSize) true null}}>{{size}}</option>
       {{/each}}
     </S.Options>
   </Hds::Form::Select::Base>

--- a/packages/components/addon/components/hds/pagination/size-selector/index.js
+++ b/packages/components/addon/components/hds/pagination/size-selector/index.js
@@ -27,6 +27,24 @@ export default class HdsPaginationSizeSelectorComponent extends Component {
     return pageSizes;
   }
 
+  /**
+   * @param selectedSize
+   * @type integer
+   * @description The selected ("current") page size
+   */
+  get selectedSize() {
+    let { selectedSize } = this.args;
+
+    assert(
+      `@selectedSize for "Pagination::SizeSelector" must one of the @pageSizes provided (${this.pageSizes.join(
+        ','
+      )}), received ${selectedSize}`,
+      selectedSize === undefined || this.pageSizes.includes(selectedSize)
+    );
+
+    return selectedSize;
+  }
+
   @action
   onChange(e) {
     let { onChange } = this.args;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -63,7 +63,6 @@
     "@percy/ember": "^4.0.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "ember-a11y-refocus": "^2.1.0",
     "ember-a11y-testing": "^5.0.0",
     "ember-cli": "~4.7.0",
     "ember-cli-clipboard": "^1.0.0",

--- a/packages/components/tests/dummy/app/controllers/components/pagination.js
+++ b/packages/components/tests/dummy/app/controllers/components/pagination.js
@@ -51,37 +51,42 @@ export default class PaginationController extends Controller {
     'demoCurrentCursor',
     'demoExtraParam',
     // ---------
-    // 'currentPage_demo2',
-    // 'currentPageSize_demo2',
-    // 'currentSortBy_demo2',
-    // 'currentSortOrder_demo2',
-    // 'prevToken_demo4',
-    // 'nextToken_demo4',
+    'currentPage_demo2',
+    'currentPageSize_demo2',
+    'currentSortBy_demo2',
+    'currentSortOrder_demo2',
+    'prevCursor_demo4',
+    'nextCursor_demo4',
   ];
 
   @service router;
 
   @tracked showHighlight = false;
+  // -----
   @tracked demoCurrentPage = 1;
   @tracked demoCurrentPageSize = 5;
   @tracked demoCurrentCursor = btoa(`next__1`);
+  @tracked demoPageSizes = [5, 10, 30];
+  @tracked demoExtraParam = '';
   // -----
-  @tracked currentPage_demo1 = 2;
+  @tracked currentPage_demo1 = 1;
   @tracked currentPageSize_demo1 = 5;
-  @tracked currentPage_demo2 = 2;
-  @tracked currentPageSize_demo2 = 30;
+  // -----
+  @tracked currentPage_demo2 = 1;
+  @tracked currentPageSize_demo2 = 5;
   @tracked currentSortBy_demo2;
   @tracked currentSortOrder_demo2;
-  @tracked demoExtraParam = '';
+  // -----
   @tracked currentCursor_demo3 = btoa(`next__1`);
-  @tracked newPrevCursor_demo3 = null;
-  @tracked newNextCursor_demo3 = btoa(`next__6`);
   @tracked currentPageSize_demo3 = 5;
-  @tracked prevToken_demo4 = null;
-  @tracked nextToken_demo4 = btoa(`next__1`);
-  @tracked newPrevCursor_demo4;
-  @tracked newNextCursor_demo4;
+  // -----
+  @tracked prevCursor_demo4 = null;
+  @tracked nextCursor_demo4 = btoa(`next__1`);
   @tracked currentPageSize_demo4 = 5;
+
+  // =============================
+  // "HOW TO USE" SECTION
+  // =============================
 
   get demoRouteName() {
     // eg. 'components.pagination';
@@ -101,7 +106,7 @@ export default class PaginationController extends Controller {
     };
   }
 
-  get newPrevNextCursors() {
+  get demoNewPrevNextCursors() {
     let { newPrevCursor, newNextCursor } = getNewPrevNextCursors(
       this.demoCurrentCursor,
       this.demoCurrentPageSize,
@@ -114,7 +119,7 @@ export default class PaginationController extends Controller {
   }
 
   get demoQueryFunctionCompact() {
-    let { newPrevCursor, newNextCursor } = this.newPrevNextCursors;
+    let { newPrevCursor, newNextCursor } = this.demoNewPrevNextCursors;
     return (page) => {
       return {
         demoCurrentCursor: page === 'prev' ? newPrevCursor : newNextCursor,
@@ -124,14 +129,192 @@ export default class PaginationController extends Controller {
   }
 
   get demoIsDisabledPrev() {
-    let { newPrevCursor } = this.newPrevNextCursors;
+    let { newPrevCursor } = this.demoNewPrevNextCursors;
     return newPrevCursor === null;
   }
 
   get demoIsDisabledNext() {
-    let { newNextCursor } = this.newPrevNextCursors;
+    let { newNextCursor } = this.demoNewPrevNextCursors;
     return newNextCursor === null;
   }
+
+  // =============================
+  // "SHOWCASE" SECTION
+  // =============================
+
+  // DEMO #1
+
+  get paginatedData_demo1() {
+    const start = (this.currentPage_demo1 - 1) * this.currentPageSize_demo1;
+    const end = this.currentPage_demo1 * this.currentPageSize_demo1;
+    return this.model.records.slice(start, end);
+  }
+
+  @action
+  onPageChange_demo1(page, pageSize) {
+    this.currentPage_demo1 = page;
+    this.currentPageSize_demo1 = pageSize;
+  }
+
+  @action
+  onPageSizeChange_demo1(pageSize) {
+    // we agreed to reset the pagination to the first element (any alternative would result in an unpredictable UX)
+    this.currentPage_demo1 = 1;
+    this.currentPageSize_demo1 = pageSize;
+  }
+
+  // DEMO #2
+
+  get consumerQueryFunction_demo2() {
+    return (page, pageSize) => {
+      return {
+        currentPage_demo2: page,
+        currentPageSize_demo2: pageSize,
+        currentSortBy_demo2: this.currentSortBy_demo2,
+        currentSortOrder_demo2: this.currentSortOrder_demo2,
+        demoExtraParam: 'hello',
+      };
+    };
+  }
+
+  @action
+  onTableSort_demo2(sortBy, sortOrder) {
+    this.currentSortBy_demo2 = sortBy;
+    this.currentSortOrder_demo2 = sortOrder;
+    // should we reset the selected page?
+    // this.currentPage_demo2 = 1;
+  }
+
+  get paginatedData_demo2() {
+    const start = (this.currentPage_demo2 - 1) * this.currentPageSize_demo2;
+    const end = this.currentPage_demo2 * this.currentPageSize_demo2;
+    return this.model.records.slice(start, end);
+  }
+
+  // DEMO #3
+
+  get newPrevNextCursors_demo3() {
+    let { newPrevCursor, newNextCursor } = getNewPrevNextCursors(
+      this.currentCursor_demo3,
+      this.currentPageSize_demo3,
+      this.model.records
+    );
+    return {
+      newPrevCursor,
+      newNextCursor,
+    };
+  }
+
+  get isDisabledPrev_demo3() {
+    let { newPrevCursor } = this.newPrevNextCursors_demo3;
+    return newPrevCursor === null;
+  }
+
+  get isDisabledNext_demo3() {
+    let { newNextCursor } = this.newPrevNextCursors_demo3;
+    return newNextCursor === null;
+  }
+
+  @action
+  onPageChange_demo3(page) {
+    // get the next/prev cursors
+    let { newPrevCursor, newNextCursor } = this.newPrevNextCursors_demo3;
+    // update the "current" cursor
+    if (page === 'prev') {
+      this.currentCursor_demo3 = newPrevCursor;
+    } else if (page === 'next') {
+      this.currentCursor_demo3 = newNextCursor;
+    }
+  }
+
+  get paginatedData_demo3() {
+    const { direction, cursorIndex } = getCursorParts(
+      this.currentCursor_demo3,
+      this.model.records
+    );
+
+    let start;
+    let end;
+    let pageSize = this.currentPageSize_demo3;
+    if (direction === 'prev') {
+      end = cursorIndex;
+      start = cursorIndex - pageSize;
+    } else {
+      start = cursorIndex;
+      end = cursorIndex + pageSize;
+    }
+    return this.model.records.slice(start, end);
+  }
+
+  // DEMO #4 (this emulates the current implementation in Cloud UI)
+
+  get newPrevNextCursors_demo4() {
+    let cursor;
+    // In cloud UI they use two distinct query params for the cursor depending if it's "prev" or "next"
+    if (this.prevCursor_demo4) {
+      cursor = this.prevCursor_demo4;
+    } else if (this.nextCursor_demo4) {
+      cursor = this.nextCursor_demo4;
+    }
+    return getNewPrevNextCursors(
+      cursor,
+      this.currentPageSize_demo3,
+      this.model.records
+    );
+  }
+
+  get consumerQueryFunction_demo4() {
+    let { newPrevCursor, newNextCursor } = this.newPrevNextCursors_demo4;
+    return (page) => {
+      return {
+        prevCursor_demo4: page === 'prev' ? newPrevCursor : undefined,
+        nextCursor_demo4: page === 'next' ? newNextCursor : undefined,
+        demoExtraParam: 'hello',
+      };
+    };
+  }
+
+  get isDisabledPrev_demo4() {
+    let { newPrevCursor } = this.newPrevNextCursors_demo4;
+    return newPrevCursor === null;
+  }
+
+  get isDisabledNext_demo4() {
+    let { newNextCursor } = this.newPrevNextCursors_demo4;
+    return newNextCursor === null;
+  }
+
+  get paginatedData_demo4() {
+    let token;
+    if (this.prevCursor_demo4) {
+      token = this.prevCursor_demo4;
+    } else if (this.nextCursor_demo4) {
+      token = this.nextCursor_demo4;
+    }
+
+    const { direction, cursorIndex } = getCursorParts(
+      token,
+      this.model.records
+    );
+
+    let start;
+    let end;
+    let pageSize = this.currentPageSize_demo4;
+    if (direction === 'prev') {
+      end = cursorIndex;
+      start = cursorIndex - pageSize;
+    } else {
+      start = cursorIndex;
+      end = cursorIndex + pageSize;
+    }
+
+    // return data
+    return this.model.records.slice(start, end);
+  }
+
+  // =============================
+  // GENERIC HANDLERS
+  // =============================
 
   @action
   toggleHighlight() {

--- a/packages/components/tests/dummy/app/controllers/components/pagination.js
+++ b/packages/components/tests/dummy/app/controllers/components/pagination.js
@@ -1,9 +1,137 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+
+const getCursorParts = (cursor, records) => {
+  const token = atob(cursor);
+  const tokenParts = [...token.split('__')];
+  const direction = tokenParts[0];
+  const cursorID = parseInt(tokenParts[1]);
+  const cursorIndex = records.findIndex(
+    (element) => element.id === parseInt(cursorID)
+  );
+  return { direction, cursorID, cursorIndex };
+};
+
+const getNewPrevNextCursors = (cursor, pageSize, records) => {
+  const { direction, cursorIndex } = getCursorParts(cursor, records);
+
+  let newPrevCursor;
+  let newNextCursor;
+
+  const prevCursorIndex =
+    direction === 'prev' ? cursorIndex - pageSize : cursorIndex;
+  if (prevCursorIndex > 0) {
+    const newPrevRecordId = records[prevCursorIndex].id;
+    newPrevCursor = btoa(`prev__${newPrevRecordId}`);
+  } else {
+    newPrevCursor = null;
+  }
+
+  const nextCursorIndex =
+    direction === 'next' ? cursorIndex + pageSize : cursorIndex;
+  if (nextCursorIndex < records.length) {
+    const newNextRecordId = records[nextCursorIndex].id;
+    newNextCursor = btoa(`next__${newNextRecordId}`);
+  } else {
+    newNextCursor = null;
+  }
+
+  return {
+    newPrevCursor,
+    newNextCursor,
+  };
+};
 
 export default class PaginationController extends Controller {
+  queryParams = [
+    'demoCurrentPage',
+    'demoCurrentPageSize',
+    'demoCurrentCursor',
+    'demoExtraParam',
+    // ---------
+    // 'currentPage_demo2',
+    // 'currentPageSize_demo2',
+    // 'currentSortBy_demo2',
+    // 'currentSortOrder_demo2',
+    // 'prevToken_demo4',
+    // 'nextToken_demo4',
+  ];
+
+  @service router;
+
   @tracked showHighlight = false;
+  @tracked demoCurrentPage = 1;
+  @tracked demoCurrentPageSize = 5;
+  @tracked demoCurrentCursor = btoa(`next__1`);
+  // -----
+  @tracked currentPage_demo1 = 2;
+  @tracked currentPageSize_demo1 = 5;
+  @tracked currentPage_demo2 = 2;
+  @tracked currentPageSize_demo2 = 30;
+  @tracked currentSortBy_demo2;
+  @tracked currentSortOrder_demo2;
+  @tracked demoExtraParam = '';
+  @tracked currentCursor_demo3 = btoa(`next__1`);
+  @tracked newPrevCursor_demo3 = null;
+  @tracked newNextCursor_demo3 = btoa(`next__6`);
+  @tracked currentPageSize_demo3 = 5;
+  @tracked prevToken_demo4 = null;
+  @tracked nextToken_demo4 = btoa(`next__1`);
+  @tracked newPrevCursor_demo4;
+  @tracked newNextCursor_demo4;
+  @tracked currentPageSize_demo4 = 5;
+
+  get demoRouteName() {
+    // eg. 'components.pagination';
+    return this.router.currentRouteName;
+  }
+
+  get demoTotalItems() {
+    return this.model.records.length;
+  }
+
+  get demoQueryFunctionNumbered() {
+    return (page, pageSize) => {
+      return {
+        demoCurrentPage: page,
+        demoCurrentPageSize: pageSize,
+      };
+    };
+  }
+
+  get newPrevNextCursors() {
+    let { newPrevCursor, newNextCursor } = getNewPrevNextCursors(
+      this.demoCurrentCursor,
+      this.demoCurrentPageSize,
+      this.model.records
+    );
+    return {
+      newPrevCursor,
+      newNextCursor,
+    };
+  }
+
+  get demoQueryFunctionCompact() {
+    let { newPrevCursor, newNextCursor } = this.newPrevNextCursors;
+    return (page) => {
+      return {
+        demoCurrentCursor: page === 'prev' ? newPrevCursor : newNextCursor,
+        demoExtraParam: 'hello',
+      };
+    };
+  }
+
+  get demoIsDisabledPrev() {
+    let { newPrevCursor } = this.newPrevNextCursors;
+    return newPrevCursor === null;
+  }
+
+  get demoIsDisabledNext() {
+    let { newNextCursor } = this.newPrevNextCursors;
+    return newNextCursor === null;
+  }
 
   @action
   toggleHighlight() {

--- a/packages/components/tests/dummy/app/routes/components/pagination.js
+++ b/packages/components/tests/dummy/app/routes/components/pagination.js
@@ -1,3 +1,9 @@
 import Route from '@ember/routing/route';
 
-export default class ComponentsPaginationRoute extends Route {}
+export default class ComponentsPaginationRoute extends Route {
+  async model() {
+    let response = await fetch('/api/mock-users.json');
+    let records = await response.json();
+    return { records };
+  }
+}

--- a/packages/components/tests/dummy/app/styles/pages/db-pagination.scss
+++ b/packages/components/tests/dummy/app/styles/pages/db-pagination.scss
@@ -58,3 +58,14 @@
     width: fit-content;
   }
 }
+
+// paginated tables demo
+
+.dummy-pagination-table-demo {
+  margin: 18px auto 36px;
+
+  .hds-table + .hds-pagination {
+    margin-top: 12px;
+  }
+}
+

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,5 @@
 {{page-title "HDS Design System"}}
 <header class="dummy-header">
-  <NavigationNarrator @routeChangeValidator={{this.transitionValidator}} />
   <h1 class="dummy-h1">
     HashiCorp Design System (HDS)
   </h1>

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -581,11 +581,70 @@
     elements in the page).</p>
 
   <h5 class="dummy-h5">Routing/URL updates</h5>
-  <p class="dummy-paragraph">If you want the pagination to change the URL of the page directly (eg. adding/removing
-    query parameters) you need to pass the routing parameters to the component:</p>
-  <pre>🚨 TODO </pre>
+  <p class="dummy-paragraph">If you want the pagination to change the URL of the page directly (eg. updating the query
+    parameters) you need to pass the routing parameters to the component:</p>
+  <CodeBlock
+    @language="markup"
+    @code="
+      <Hds::Pagination::Numbered
+        @totalItems=\{{this.demoTotalItems}}
+        @itemsPerPage=\{{this.demoCurrentPageSize}}
+        @currentPage=\{{this.demoCurrentPage}}
+        @route=\{{this.demoRouteName}}
+        @queryFunction=\{{this.demoQueryFunctionNumbered}}
+      />
+    "
+  />
+  <p class="dummy-paragraph">where the
+    <code class="dummy-code">@queryFunction</code>
+    function will be something like this:</p>
+  <CodeBlock
+    @language="javascript"
+    @code="
+        get demoQueryFunctionNumbered() {
+          return (page, pageSize) => {
+            return {
+              demoCurrentPage: page,
+              demoCurrentPageSize: pageSize,
+              demoExtraParam: 'hello',
+            };
+          };
+        }
+      "
+  />
   <p class="dummy-paragraph">Renders to:</p>
-  <pre>🚨 TODO 🚨</pre>
+  <Hds::Pagination::Numbered
+    @totalItems={{this.demoTotalItems}}
+    @itemsPerPage={{this.demoCurrentPageSize}}
+    @currentPage={{this.demoCurrentPage}}
+    @route={{this.demoRouteName}}
+    @queryFunction={{this.demoQueryFunctionNumbered}}
+  />
+  <p class="dummy-paragraph">When the routing parameters are provided, the "navigation controls" are rendered as links
+    and if the user clicks on one of them the page URL is automatically updated. This means that the component's state
+    is persisted
+    <strong>outside</strong>
+    of the component and so its whole state
+    <strong>must</strong>
+    be "controlled" by the consumer's code (otherwise there would be confliting states).</p>
+  <p class="dummy-paragraph">In this case, the component doesn't update its internal "state" but the value of the state
+    variables (eg.
+    <code class="dummy-code">currentPage/currentPageSize</code>) is
+    <strong>always</strong>
+    determined by the consumer's controller code via the component's arguments (most of the times, they are directly
+    connected to the query parameters in the URL).
+  </p>
+  <p class="dummy-paragraph">The reason for using a consumer-side function to determine the
+    <code class="dummy-code">query</code>
+    argument is because it's dynamic (it depends on the value of the
+    <code class="dummy-code">page</code>
+    variable) and gives consumers the ability to specify their own query parameters (they will likely be different case
+    by case).
+  </p>
+  <p class="dummy-paragraph">Even if the pagination is based on routing, the
+    <code class="dummy-code">onPageChange/onPageSizeChange</code>
+    callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.)
+  </p>
 
   {{! =============================== }}
   {{! ===== PAGINATION::COMPACT ===== }}
@@ -645,12 +704,66 @@
     to a "page" change (eg. updating the list of items in the page and/or updating the routing/URL).</p>
 
   <h5 class="dummy-h5">Routing/URL updates</h5>
-  <p class="dummy-paragraph">If you want the pagination to change the URL of the page directly (eg. adding/removing
-    query parameters), you need to pass the routing parameters to the component:</p>
-  <pre>🚨 TODO </pre>
+  <p class="dummy-paragraph">If you want the pagination to change the URL of the page directly (eg. updating the query
+    parameters) you need to pass the routing parameters to the component:</p>
+  <CodeBlock
+    @language="markup"
+    @code="
+      <Hds::Pagination::Compact
+        @route=\{{this.demoRouteName}}
+        @queryFunction=\{{this.demoQueryFunctionCompact}}
+        @isDisabledPrev=\{{this.demoIsDisabledPrev}}
+        @isDisabledNext=\{{this.demoIsDisabledNext}}
+      />
+    "
+  />
+  <p class="dummy-paragraph">where the
+    <code class="dummy-code">@queryFunction</code>
+    function will be something like this:</p>
+  <CodeBlock
+    @language="javascript"
+    @code="
+        get demoQueryFunctionCompact() {
+          return (page) => {
+            return {
+              demoCurrentToken: page === 'prev' ? this.getPrevToken : this.getNextToken,
+              demoExtraParam: 'hello',
+            };
+          };
+        }
+      "
+  />
   <p class="dummy-paragraph">Renders to:</p>
-  <pre>🚨 TODO 🚨</pre>
-
+  <Hds::Pagination::Compact
+    @route={{this.demoRouteName}}
+    @queryFunction={{this.demoQueryFunctionCompact}}
+    @isDisabledPrev={{this.demoIsDisabledPrev}}
+    @isDisabledNext={{this.demoIsDisabledNext}}
+  />
+  <p class="dummy-paragraph">When the routing parameters are provided, the "prev/next" controls are rendered as links
+    and if the user clicks on one of them the page URL is automatically updated. This means that the component's state
+    is persisted
+    <strong>outside</strong>
+    of the component and so its whole state
+    <strong>must</strong>
+    be "controlled" by the consumer's code (otherwise there would be confliting states).</p>
+  <p class="dummy-paragraph">In this case, the component doesn't update its internal "state" but the value of the state
+    variables is
+    <strong>always</strong>
+    determined by the consumer's controller code via the component's arguments (most of the times, they are directly
+    connected to the query parameters in the URL).
+  </p>
+  <p class="dummy-paragraph">The reason for using a consumer-side function to determine the
+    <code class="dummy-code">query</code>
+    argument is because it's dynamic (it depends on the value of the
+    <code class="dummy-code">page/cursor</code>
+    variable) and gives consumers the ability to specify their own query parameters (they will likely be different case
+    by case).
+  </p>
+  <p class="dummy-paragraph">Even if the pagination is based on routing, the
+    <code class="dummy-code">onPageChange/onPageSizeChange</code>
+    callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.)
+  </p>
 </section>
 
 <section data-test-percy class="{{if this.showHighlight 'dummy-pagination-layout-highlight'}}">

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -590,6 +590,7 @@
         @totalItems=\{{this.demoTotalItems}}
         @itemsPerPage=\{{this.demoCurrentPageSize}}
         @currentPage=\{{this.demoCurrentPage}}
+        @pageSizes=\{{this.demoPageSizes}}
         @route=\{{this.demoRouteName}}
         @queryFunction=\{{this.demoQueryFunctionNumbered}}
       />
@@ -617,6 +618,7 @@
     @totalItems={{this.demoTotalItems}}
     @itemsPerPage={{this.demoCurrentPageSize}}
     @currentPage={{this.demoCurrentPage}}
+    @pageSizes={{this.demoPageSizes}}
     @route={{this.demoRouteName}}
     @queryFunction={{this.demoQueryFunctionNumbered}}
   />
@@ -923,4 +925,160 @@
   <h5 class="dummy-h5">Pagination::Nav::Ellipsis</h5>
   <p class="dummy-text-small">Base</p>
   <Hds::Pagination::Nav::Ellipsis />
+
+  <hr class="dummy-divider" />
+
+  <h4 class="dummy-h4">Examples of paginated tables</h4>
+
+  {{! ============================================ }}
+  {{! ===== DEMO #1 - NUMBERED - WITH EVENTS ===== }}
+  {{! ============================================ }}
+
+  <h5 class="dummy-h5">Numbered - Events-based pagination</h5>
+  <p class="dummy-paragraph">When using an "events-based" strategy, the status of the UI is transient, and it's not
+    preserved across page reloads.</p>
+
+  <div class="dummy-pagination-table-demo">
+    <Hds::Table
+      @model={{this.paginatedData_demo1}}
+      @columns={{array
+        (hash key="id" label="ID")
+        (hash key="name" label="Name")
+        (hash key="email" label="Email")
+        (hash key="role" label="Role")
+      }}
+      @density={{if (eq this.currentPageSize_demo1 30) "short" "medium"}}
+    >
+      <:body as |B|>
+        <B.Tr>
+          <B.Td>{{B.data.id}}</B.Td>
+          <B.Td>{{B.data.name}}</B.Td>
+          <B.Td>{{B.data.email}}</B.Td>
+          <B.Td>{{B.data.role}}</B.Td>
+        </B.Tr>
+      </:body>
+    </Hds::Table>
+    <Hds::Pagination::Numbered
+      @totalItems={{this.demoTotalItems}}
+      @itemsPerPage={{this.currentPageSize_demo1}}
+      @pageSizes={{array 5 10 30}}
+      @onPageChange={{this.onPageChange_demo1}}
+      @onPageSizeChange={{this.onPageSizeChange_demo1}}
+    />
+  </div>
+
+  {{! ============================================= }}
+  {{! ===== DEMO #2 - NUMBERED - WITH ROUTING ===== }}
+  {{! ============================================= }}
+
+  <h5 class="dummy-h5">Numbered - Routing-based pagination</h5>
+  <p class="dummy-paragraph">When using a "routing-based" strategy, the status of the UI is preserved across page
+    reloads using the query parameters stored in the URL.</p>
+  <div class="dummy-pagination-table-demo">
+    <Hds::Table
+      @model={{this.paginatedData_demo2}}
+      @columns={{array
+        (hash key="id" label="ID" isSortable="true")
+        (hash key="name" label="Name" isSortable="true")
+        (hash key="email" label="Email")
+        (hash key="role" label="Role")
+      }}
+      @sortBy={{this.currentSortBy_demo2}}
+      @sortOrder={{this.currentSortOrder_demo2}}
+      @onSort={{this.onTableSort_demo2}}
+      @density={{if (eq this.currentPageSize_demo2 30) "short" "medium"}}
+    >
+      <:body as |B|>
+        <B.Tr>
+          <B.Td>{{B.data.id}}</B.Td>
+          <B.Td>{{B.data.name}}</B.Td>
+          <B.Td>{{B.data.email}}</B.Td>
+          <B.Td>{{B.data.role}}</B.Td>
+        </B.Tr>
+      </:body>
+    </Hds::Table>
+    <Hds::Pagination::Numbered
+      @totalItems={{this.demoTotalItems}}
+      @itemsPerPage={{this.currentPageSize_demo2}}
+      @pageSizes={{array 5 10 30}}
+      @currentPage={{this.currentPage_demo2}}
+      @route={{this.demoRouteName}}
+      @queryFunction={{this.consumerQueryFunction_demo2}}
+      @onPageChange={{this.genericHandlePageChange}}
+      @onPageSizeChange={{this.genericHandlePageSizeChange}}
+    />
+  </div>
+
+  {{! =========================================== }}
+  {{! ===== DEMO #3 - COMPACT - WITH EVENTS ===== }}
+  {{! =========================================== }}
+
+  <h5 class="dummy-h5">Compact - Events-based pagination</h5>
+  <p class="dummy-paragraph">When using an "events-based" strategy, the status of the UI is transient, and it's not
+    preserved across page reloads.</p>
+
+  <div class="dummy-pagination-table-demo">
+    <Hds::Table
+      @model={{this.paginatedData_demo3}}
+      @columns={{array
+        (hash key="id" label="ID")
+        (hash key="name" label="Name")
+        (hash key="email" label="Email")
+        (hash key="role" label="Role")
+      }}
+    >
+      <:body as |B|>
+        <B.Tr>
+          <B.Td>{{B.data.id}}</B.Td>
+          <B.Td>{{B.data.name}}</B.Td>
+          <B.Td>{{B.data.email}}</B.Td>
+          <B.Td>{{B.data.role}}</B.Td>
+        </B.Tr>
+      </:body>
+    </Hds::Table>
+    <Hds::Pagination::Compact
+      @isDisabledPrev={{this.isDisabledPrev_demo3}}
+      @isDisabledNext={{this.isDisabledNext_demo3}}
+      @onPageChange={{this.onPageChange_demo3}}
+    />
+  </div>
+
+  {{! ============================================ }}
+  {{! ===== DEMO #4 - COMPACT - WITH ROUTING ===== }}
+  {{! ============================================ }}
+
+  {{! Notice: this demo emulates the current implementation in Cloud UI }}
+
+  <h5 class="dummy-h5">Compact - Routing-based pagination</h5>
+  <p class="dummy-paragraph">When using a "routing-based" strategy, the status of the UI is preserved across page
+    reloads using the query parameters stored in the URL.</p>
+
+  <div class="dummy-pagination-table-demo">
+    <Hds::Table
+      @model={{this.paginatedData_demo4}}
+      @columns={{array
+        (hash key="id" label="ID")
+        (hash key="name" label="Name")
+        (hash key="email" label="Email")
+        (hash key="role" label="Role")
+      }}
+    >
+      <:body as |B|>
+        <B.Tr>
+          <B.Td>{{B.data.id}}</B.Td>
+          <B.Td>{{B.data.name}}</B.Td>
+          <B.Td>{{B.data.email}}</B.Td>
+          <B.Td>{{B.data.role}}</B.Td>
+        </B.Tr>
+      </:body>
+    </Hds::Table>
+    <Hds::Pagination::Compact
+      @route={{this.demoRouteName}}
+      @queryFunction={{this.consumerQueryFunction_demo4}}
+      @isDisabledPrev={{this.isDisabledPrev_demo4}}
+      @isDisabledNext={{this.isDisabledNext_demo4}}
+      @onPageChange={{this.genericHandlePageChange}}
+    />
+  </div>
+
 </section>

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -123,6 +123,23 @@
       <p>Used to control the visibility of the "prev/next" text labels.</p>
       <p>Default: <span class="default">false</span></p>
     </dd>
+    <dt>route/model/models/replace</dt>
+    <dd>
+      <p>These are the parameters that are passed down as arguments to the
+        <code class="dummy-code">Hds::Pagination::Arrow</code>/<code class="dummy-code">Hds::Pagination::Number</code>
+        child components, and from them to the
+        <code class="dummy-code">Hds::Interactive</code>
+        component (used internally). For more details about how this low-level component works please refer to
+        <LinkTo @route="utilities.interactive">its documentation page</LinkTo>.</p>
+    </dd>
+    <dt>queryFunction <code>function</code></dt>
+    <dd>
+      <p>A function that returns an object that can be provided as
+        <code class="dummy-code">query</code>
+        argument for the routing, and that is passed down to the to the child components together with the other routing
+        parameters.</p>
+      <p>The function receives the value of the "go to" page and "page size" as arguments (integer numbers).</p>
+    </dd>
     <dt>onPageChange <code>function</code></dt>
     <dd>
       <p>Callback function invoked (if provided) when one of the navigation controls is clicked, and a "page" change is
@@ -146,25 +163,28 @@
     component:
   </p>
   <dl class="dummy-component-props" aria-labelledby="component-api-pagination-compact">
-    <dt>route[Prev|Next] <code>string</code></dt>
+    <dt>route/model/models/replace</dt>
     <dd>
-      <p>The
-        <code>@route</code>
-        parameter passed down as arguments to internally render a
-        <code>&lt;LinkTo&gt;</code>
-        Ember component instead of a
-        <code>&lt;button&gt;</code>
-        in the "prev" or "next" control.</p>
+      <p>These are the parameters that are passed down as arguments to the
+        <code class="dummy-code">Hds::Pagination::Arrow</code>
+        child components, and from them to the
+        <code class="dummy-code">Hds::Interactive</code>
+        component (used internally). For more details about how this low-level component works please refer to
+        <LinkTo @route="utilities.interactive">its documentation page</LinkTo>.</p>
     </dd>
-    <dt>query[Prev|Next] <code>object</code></dt>
+    <dt>queryFunction <code>function</code></dt>
     <dd>
-      <p>The
-        <code>@query</code>
-        parameter for the
-        <code>&lt;LinkTo&gt;</code>
-        Ember component in the "prev" or "next" control.</p>
+      <p>A function that returns an object that can be provided as
+        <code class="dummy-code">query</code>
+        argument for the routing, and that is passed down to the to the child components together with the other routing
+        parameters.</p>
+      <p>The function receives as argument one of two possible values:</p>
+      <ol>
+        <li>prev</li>
+        <li>next</li>
+      </ol>
     </dd>
-    <dt>isDisabled[Prev|Next] <code>boolean</code></dt>
+    <dt>isDisabledPrev/isDisabledNext <code>boolean</code></dt>
     <dd>
       <p>Used to disable the "prev" or "next" controls.</p>
       <p>Default: <span class="default">false</span></p>
@@ -235,7 +255,7 @@
         <li>next</li>
       </ol>
     </dd>
-    <dt>href + route/models/model/query/current-when/replace</dt>
+    <dt>route/query/model/models/replace</dt>
     <dd>
       <p>These are the parameters that are passed down as arguments to the
         <code class="dummy-code">Hds::Interactive</code>
@@ -280,6 +300,13 @@
     <dd>
       <p>If the page has a "selected" visual state (usually used to highlight the current page).</p>
       <p>Default: <span class="default">false</span></p>
+    </dd>
+    <dt>route/query/model/models/replace</dt>
+    <dd>
+      <p>These are the parameters that are passed down as arguments to the
+        <code class="dummy-code">Hds::Interactive</code>
+        component (used internally). For more details about how this low-level component works please refer to
+        <LinkTo @route="utilities.interactive">its documentation page</LinkTo>.</p>
     </dd>
     <dt>onClick <code>function</code></dt>
     <dd>

--- a/packages/components/tests/dummy/public/api/mock-users.json
+++ b/packages/components/tests/dummy/public/api/mock-users.json
@@ -1,0 +1,236 @@
+[
+  {
+    "id": 1,
+    "name": "Burnaby Kuscha",
+    "email": "1_bkuscha0@tiny.cc",
+    "role": "Owner"
+  },
+  {
+    "id": 2,
+    "name": "Barton Penley",
+    "email": "2_bpenley1@miibeian.gov.cn",
+    "role": "Admin"
+  },
+  {
+    "id": 3,
+    "name": "Norina Emanulsson",
+    "email": "3_nemanulsson2@walmart.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 4,
+    "name": "Orbadiah Smales",
+    "email": "4_osmales3@amazon.co.jp",
+    "role": "Contributor"
+  },
+  {
+    "id": 5,
+    "name": "Dido Titchener",
+    "email": "5_dtitchener4@blogs.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 6,
+    "name": "Trish Horsburgh",
+    "email": "6_thorsburgh5@samsung.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 7,
+    "name": "Orion Laverack",
+    "email": "7_olaverack6@techcrunch.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 8,
+    "name": "Delly Moulsdale",
+    "email": "8_dmoulsdale7@sciencedirect.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 9,
+    "name": "Gil Carlyle",
+    "email": "9_gcarlyle8@canalblog.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 10,
+    "name": "Marinna Corbin",
+    "email": "10_mcorbin9@google.ca",
+    "role": "Contributor"
+  },
+  {
+    "id": 11,
+    "name": "Yardley Entwhistle",
+    "email": "11_yentwhistlea@tumblr.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 12,
+    "name": "Brinn Clack",
+    "email": "12_bclackb@blogger.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 13,
+    "name": "Charleen Millen",
+    "email": "13_cmillenc@mtv.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 14,
+    "name": "Kalie Piers",
+    "email": "14_kpiersd@businessweek.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 15,
+    "name": "Laure Boxer",
+    "email": "15_lboxere@elegantthemes.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 16,
+    "name": "Libby Bonallack",
+    "email": "16_lbonallackf@disqus.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 17,
+    "name": "Zebedee Gofton",
+    "email": "17_zgoftong@bbc.co.uk",
+    "role": "Contributor"
+  },
+  {
+    "id": 18,
+    "name": "Sari Eckford",
+    "email": "18_seckfordh@cloudflare.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 19,
+    "name": "Carlos Byrth",
+    "email": "19_cbyrthi@prlog.org",
+    "role": "Contributor"
+  },
+  {
+    "id": 20,
+    "name": "Avery Allmark",
+    "email": "20_aallmarkj@webnode.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 21,
+    "name": "Ninnette McSpirron",
+    "email": "21_nmcspirronk@amazon.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 22,
+    "name": "Sharlene Ewestace",
+    "email": "22_sewestacel@twitpic.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 23,
+    "name": "Jessamine Kembry",
+    "email": "23_jkembrym@hatena.ne.jp",
+    "role": "Contributor"
+  },
+  {
+    "id": 24,
+    "name": "Homerus Dixcee",
+    "email": "24_hdixceen@deviantart.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 25,
+    "name": "Clevie Clear",
+    "email": "25_cclearo@tmall.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 26,
+    "name": "Mohammed Hubatsch",
+    "email": "26_mhubatschp@salon.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 27,
+    "name": "Gigi Hovard",
+    "email": "27_ghovardq@cbslocal.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 28,
+    "name": "Dorey Tinker",
+    "email": "28_dtinkerr@google.co.uk",
+    "role": "Contributor"
+  },
+  {
+    "id": 29,
+    "name": "Arel Mullarkey",
+    "email": "29_amullarkeys@blogs.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 30,
+    "name": "Veronike Ventura",
+    "email": "30_vventurat@google.fr",
+    "role": "Contributor"
+  },
+  {
+    "id": 31,
+    "name": "Gerti Dranfield",
+    "email": "31_gdranfieldu@vistaprint.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 32,
+    "name": "Brigida Hembrow",
+    "email": "32_bhembrowv@webeden.co.uk",
+    "role": "Contributor"
+  },
+  {
+    "id": 33,
+    "name": "Aluin Dowding",
+    "email": "33_adowdingw@wisc.edu",
+    "role": "Contributor"
+  },
+  {
+    "id": 34,
+    "name": "Alli Pleasaunce",
+    "email": "34_apleasauncex@berkeley.edu",
+    "role": "Contributor"
+  },
+  {
+    "id": 35,
+    "name": "Cosimo Parcell",
+    "email": "35_cparcelly@jalbum.net",
+    "role": "Contributor"
+  },
+  {
+    "id": 36,
+    "name": "Kerri Lequeux",
+    "email": "36_klequeuxz@bing.com",
+    "role": "Contributor"
+  },
+  {
+    "id": 37,
+    "name": "Emilio Fidgin",
+    "email": "37_efidgin10@hud.gov",
+    "role": "Contributor"
+  },
+  {
+    "id": 38,
+    "name": "Ara Oxtiby",
+    "email": "38_aoxtiby11@apache.org",
+    "role": "Contributor"
+  },
+  {
+    "id": 39,
+    "name": "Harv Rapier",
+    "email": "39_hrapier12@amazon.co.jp",
+    "role": "Contributor"
+  }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2768,7 +2768,6 @@ __metadata:
     babel-eslint: ^10.1.0
     broccoli-asset-rev: ^3.0.0
     dialog-polyfill: ^0.5.6
-    ember-a11y-refocus: ^2.1.0
     ember-a11y-testing: ^5.0.0
     ember-auto-import: ^2.4.2
     ember-cached-decorator-polyfill: ^0.1.4
@@ -9826,16 +9825,6 @@ __metadata:
     minimalistic-assert: ^1.0.1
     minimalistic-crypto-utils: ^1.0.1
   checksum: d56d21fd04e97869f7ffcc92e18903b9f67f2d4637a23c860492fbbff5a3155fd9ca0184ce0c865dd6eb2487d234ce9551335c021c376cd2d3b7cb749c7d10f4
-  languageName: node
-  linkType: hard
-
-"ember-a11y-refocus@npm:^2.1.0":
-  version: 2.3.0
-  resolution: "ember-a11y-refocus@npm:2.3.0"
-  dependencies:
-    ember-cli-babel: ^7.26.11
-    ember-cli-htmlbars: ^6.0.1
-  checksum: a90bc2d5a21e1752003b82b5b3f29e53f614b4d1cbdf97f62087079b5fa12d22adb3af97581bd53b9811268d9f8f6bb0100d457215bb6b4782e4dc7f69dfdc35
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: Summary

After feedback from the Engineering Ambassadors, we have decided to refactor even more the API of the `Pagination` component to support also routing (via `<LinkTo>`) to persist the pagination state in the URL via query parameters.

Quoting @randallmorey: 
> "Links make a lot of sense"

This task required (again) a complete rethinking of the APIs, and the introduction of new code patterns to support all the different possible variants of how the pagination could be used:
- numbered - with events-based pagination
- numbered - with routing-based pagination
- compact - with events-based pagination
- compact - with routing-based pagination

**⚠️ IMPORTANT:** The actual work (consisting of almost a hundred of commits, with all the possible tests, changes, failed attempts, half-successes, etc) has been done in https://github.com/hashicorp/design-system/pull/1060 so please refer to that PR (and expecially that branch) to see how to debug the component and the demo examples, in case you need to (all the `console.log` and variables dumping were left in place in that branch, plus there is an alternative implementation based on other `query` parameters).

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed `ember-a11y-refocus` as dependency from the “dummy” website
  - reason being that it was interfering with the routing updates, and since the "dummy" website will be used only for the showcasing of components very soon, there's no need to add it to the application anymore
- updated the pagination-related components
  - `Pagination::Nav::Number` - added support for `@route/query/model(s)/replace` arguments
  - `Pagination::Nav::Arrow` - finalized support for `@route/query/model(s)/replace` arguments
  - `Pagination::SizeSelector` - added assertion to validate `selectedSize`
  - `Pagination::Numbered` - added support for routing with logic for internal (“uncontrolled”) vs external (“controlled”) states
  - `Pagination::Compact` - added support for routing with logic for internal (“uncontrolled”) vs external (“controlled”) states
- updated the "pagination" documentation
  - added “mock” data for demo of paginated table
  - updated the “Component API” section according to the new APIs
  - updated the “How to use” section adding two code demos for routing-based pagination
  - updated the “Showcase” section adding four different demos of paginated tables

👉 👉 👉 **Preview**: https://hds-components-git-hds-972-pagination-cloud-ui-a4c8de-hashicorp.vercel.app/components/pagination

### 🚧 TODOs
- [x] Add the code-related documentation to the new Helios website
  - ~~This will be done in a follow-up ticket~~
  - https://github.com/hashicorp/design-system/pull/1128
- [x] Review all the existing tests + Add integration tests for the routing and query arguments
  - ~~This will be done in a follow-up ticket~~
  - https://github.com/hashicorp/design-system/pull/1131

### ❤️ Special thanks

Special thanks go to @jgwhite for the support and the help he provided guiding us towards the right approach for the "controlled/uncontrolled" status of the component.

### 🖇 Related tickets/PRs
- https://github.com/hashicorp/design-system/pull/661
- https://github.com/hashicorp/design-system/pull/1020
- https://github.com/hashicorp/design-system/pull/1038
- https://github.com/hashicorp/design-system/pull/1050
- https://github.com/hashicorp/design-system/pull/1060

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
