### PR TITLE
Adds aria-label to breadcrumb truncation toggle

### DIFF
--- a/.changeset/yellow-dolls-arrive.md
+++ b/.changeset/yellow-dolls-arrive.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Adds missing aria-label to breadcrumb truncation toggle for WCAG conformance.

--- a/packages/components/addon/components/hds/breadcrumb/truncation.hbs
+++ b/packages/components/addon/components/hds/breadcrumb/truncation.hbs
@@ -4,6 +4,7 @@
       <button
         type="button"
         class="hds-breadcrumb__truncation-toggle"
+        aria-label="show more"
         aria-expanded={{if t.isOpen "true" "false"}}
         {{on "click" t.onClickToggle}}
       >

--- a/packages/components/tests/integration/components/hds/breadcrumb/truncation-test.js
+++ b/packages/components/tests/integration/components/hds/breadcrumb/truncation-test.js
@@ -20,6 +20,13 @@ module('Integration | Component | hds/breadcrumb/truncation', function (hooks) {
     assert.dom('#test-breadcrumb-truncation button').exists();
   });
 
+  test('the toggle button should have an aria-label', async function (assert) {
+    await render(
+      hbs`<Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" />`
+    );
+    assert.dom('#test-breadcrumb-truncation button').hasAttribute('aria-label');
+  });
+
   // CONTENT
 
   test('it should not render the content', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds the missing `aria-label` attribute to the breadcrumb component's truncation button. 

### :hammer_and_wrench: Detailed description

Because the truncation toggle button has only an icon inside of it (hidden with `aria-hidden=true`), the button is required to have an `aria-label` to supply the button element with an accessible name.

This changes nothing that is visually rendered in the browser. 

I've also added a test to make sure the aria-label is always there, just in case the code is refactored in the future.

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
