### PR TITLE
`Pagination` - "How to use" and "Component API" sections in documentation for Helios website

### DIFF
--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -30,6 +30,11 @@ export default class ShowController extends Controller {
     },
     'searchQuery',
     'selectedIconSize',
+    // these are used in the "pagination > how to use" demos
+    'demoCurrentPage',
+    'demoCurrentPageSize',
+    'demoCurrentCursor',
+    'demoExtraParam',
   ];
 
   @service fastboot;

--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -100,11 +100,18 @@ export default class ShowRoute extends Route {
         // TODO! probably we should also check if we have TOC data for the sidecar
         const hasSidecar = frontmatter?.layout?.sidecar ?? true;
 
+        const showContentId = `show-content-${res.data.id
+          .replace(/\/index$/, '')
+          .replace('/', '-')}`;
+
         return {
           // IMPORTANT: this is the "component" ID which is used to get the correct backing class for the markdown "component"
           // This ID comes from the markdown-to-json conversion (see `id: relativePath.replace(/\.md$/, '')` in `addons/field-guide/lib/markdown-to-jsonapi.js`)
           id: res.data.id, // eg. 'components/alert/index'
           ...res.data.attributes,
+          // this is used to target in CSS specific content in the `show` pages
+          showContentId, // eg. show-content-components-alert
+          // extra metadata for this page
           frontmatter,
           hasCover,
           hasSidecar,

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -23,6 +23,7 @@
 @import "pages/about/principles";
 @import "pages/foundations/landing";
 @import "pages/components/landing";
+@import "pages/components/pagination";
 
 // Third-party declarations
 @import "prism-dracula";

--- a/website/app/styles/pages/components/pagination.scss
+++ b/website/app/styles/pages/components/pagination.scss
@@ -1,0 +1,9 @@
+// COMPONENTS > PAGINATION
+
+#show-content-components-pagination {
+  .doc-pagination-table-demo {
+    .hds-table + .hds-pagination {
+      margin-top: 12px;
+    }
+  }
+}

--- a/website/app/templates/show.hbs
+++ b/website/app/templates/show.hbs
@@ -9,7 +9,7 @@
       @extra={{this.extra}}
     />
   {{/if}}
-  <Doc::Page::Content @breakthrough={{not this.model.hasSidecar}}>
+  <Doc::Page::Content @breakthrough={{not this.model.hasSidecar}} id={{this.model.showContentId}}>
     <DynamicTemplate @templateString={{this.renderedContent}} @componentId={{this.model.id}} />
   </Doc::Page::Content>
   {{#if this.model.hasSidecar}}

--- a/website/docs/components/pagination/index.js
+++ b/website/docs/components/pagination/index.js
@@ -47,11 +47,39 @@ const getNewPrevNextCursors = (cursor, pageSize, records) => {
 export default class Index extends Component {
   @service router;
 
-  @tracked demoCurrentPage = 1;
-  @tracked demoCurrentPageSize = 5;
-  @tracked demoCurrentCursor = btoa(`next__1`);
   @tracked demoPageSizes = [5, 10, 30];
-  @tracked demoExtraParam = '';
+
+  // ----------------------------
+  // since this is techically a component and not a controller
+  // we can't directly access the query parameters values (and then track them)
+  // using the `queryParams` declaration, so we need to access them directly
+  // via the router, and provide them as getter to the code snippets so they're
+  // kept in sync with the URL whenever the user interacts with the demo component
+
+  get demoCurrentPage() {
+    return parseInt(
+      this.router?.currentRoute?.queryParams?.demoCurrentPage ?? 1
+    );
+  }
+
+  get demoCurrentPageSize() {
+    return parseInt(
+      this.router?.currentRoute?.queryParams?.demoCurrentPageSize ?? 5
+    );
+  }
+
+  get demoExtraParam() {
+    return this.router?.currentRoute?.queryParams?.demoExtraParam ?? '';
+  }
+
+  get demoCurrentCursor() {
+    return (
+      this.router?.currentRoute?.queryParams?.demoCurrentCursor ??
+      btoa(`next__1`)
+    );
+  }
+
+  // ----------------------------
 
   get model() {
     let records = Array.from(Array(39), (x, i) => ({ id: i + 1 }));

--- a/website/docs/components/pagination/index.js
+++ b/website/docs/components/pagination/index.js
@@ -1,0 +1,124 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+
+const getCursorParts = (cursor, records) => {
+  const token = atob(cursor);
+  const tokenParts = [...token.split('__')];
+  const direction = tokenParts[0];
+  const cursorID = parseInt(tokenParts[1]);
+  const cursorIndex = records.findIndex(
+    (element) => element.id === parseInt(cursorID)
+  );
+  return { direction, cursorID, cursorIndex };
+};
+
+const getNewPrevNextCursors = (cursor, pageSize, records) => {
+  const { direction, cursorIndex } = getCursorParts(cursor, records);
+
+  let newPrevCursor;
+  let newNextCursor;
+
+  const prevCursorIndex =
+    direction === 'prev' ? cursorIndex - pageSize : cursorIndex;
+  if (prevCursorIndex > 0) {
+    const newPrevRecordId = records[prevCursorIndex].id;
+    newPrevCursor = btoa(`prev__${newPrevRecordId}`);
+  } else {
+    newPrevCursor = null;
+  }
+
+  const nextCursorIndex =
+    direction === 'next' ? cursorIndex + pageSize : cursorIndex;
+  if (nextCursorIndex < records.length) {
+    const newNextRecordId = records[nextCursorIndex].id;
+    newNextCursor = btoa(`next__${newNextRecordId}`);
+  } else {
+    newNextCursor = null;
+  }
+
+  return {
+    newPrevCursor,
+    newNextCursor,
+  };
+};
+
+export default class Index extends Component {
+  @service router;
+
+  @tracked demoCurrentPage = 1;
+  @tracked demoCurrentPageSize = 5;
+  @tracked demoCurrentCursor = btoa(`next__1`);
+  @tracked demoPageSizes = [5, 10, 30];
+  @tracked demoExtraParam = '';
+
+  get model() {
+    let records = Array.from(Array(39), (x, i) => ({ id: i + 1 }));
+    return { records };
+  }
+
+  get demoRouteName() {
+    // eg. 'components.pagination';
+    return this.router.currentRouteName;
+  }
+
+  get demoTotalItems() {
+    return this.model.records.length;
+  }
+
+  get demoQueryFunctionNumbered() {
+    return (page, pageSize) => {
+      return {
+        demoCurrentPage: page,
+        demoCurrentPageSize: pageSize,
+      };
+    };
+  }
+
+  get demoNewPrevNextCursors() {
+    let { newPrevCursor, newNextCursor } = getNewPrevNextCursors(
+      this.demoCurrentCursor,
+      this.demoCurrentPageSize,
+      this.model.records
+    );
+    return {
+      newPrevCursor,
+      newNextCursor,
+    };
+  }
+
+  get demoQueryFunctionCompact() {
+    let { newPrevCursor, newNextCursor } = this.demoNewPrevNextCursors;
+    return (page) => {
+      return {
+        demoCurrentCursor: page === 'prev' ? newPrevCursor : newNextCursor,
+        demoExtraParam: 'hello',
+      };
+    };
+  }
+
+  get demoIsDisabledPrev() {
+    let { newPrevCursor } = this.demoNewPrevNextCursors;
+    return newPrevCursor === null;
+  }
+
+  get demoIsDisabledNext() {
+    let { newNextCursor } = this.demoNewPrevNextCursors;
+    return newNextCursor === null;
+  }
+
+  @action
+  handlePageChange(page, pageSize) {
+    console.log(
+      pageSize !== undefined
+        ? `Page changed to "${page}" with page size equal to "${pageSize}"!`
+        : `Page changed to "${page}"!`
+    );
+  }
+
+  @action
+  handlePageSizeChange(size) {
+    console.log(`Page size changed to "${size}"!`);
+  }
+}

--- a/website/docs/components/pagination/index.js
+++ b/website/docs/components/pagination/index.js
@@ -47,6 +47,8 @@ const getNewPrevNextCursors = (cursor, pageSize, records) => {
 export default class Index extends Component {
   @service router;
 
+  debugger;
+
   @tracked demoPageSizes = [5, 10, 30];
 
   // ----------------------------
@@ -80,11 +82,253 @@ export default class Index extends Component {
   }
 
   // ----------------------------
+  // At the moment we can't fetch data and pass it down here via the model
+  // because this is a component, not a controller, so we don't have access
+  // to the `show` model. We will figure out better approaches in the future.
 
   get model() {
-    let records = Array.from(Array(39), (x, i) => ({ id: i + 1 }));
+    let records = [
+      {
+        id: 1,
+        name: 'Burnaby Kuscha',
+        email: '1_bkuscha0@tiny.cc',
+        role: 'Owner',
+      },
+      {
+        id: 2,
+        name: 'Barton Penley',
+        email: '2_bpenley1@miibeian.gov.cn',
+        role: 'Admin',
+      },
+      {
+        id: 3,
+        name: 'Norina Emanulsson',
+        email: '3_nemanulsson2@walmart.com',
+        role: 'Contributor',
+      },
+      {
+        id: 4,
+        name: 'Orbadiah Smales',
+        email: '4_osmales3@amazon.co.jp',
+        role: 'Contributor',
+      },
+      {
+        id: 5,
+        name: 'Dido Titchener',
+        email: '5_dtitchener4@blogs.com',
+        role: 'Contributor',
+      },
+      {
+        id: 6,
+        name: 'Trish Horsburgh',
+        email: '6_thorsburgh5@samsung.com',
+        role: 'Contributor',
+      },
+      {
+        id: 7,
+        name: 'Orion Laverack',
+        email: '7_olaverack6@techcrunch.com',
+        role: 'Contributor',
+      },
+      {
+        id: 8,
+        name: 'Delly Moulsdale',
+        email: '8_dmoulsdale7@sciencedirect.com',
+        role: 'Contributor',
+      },
+      {
+        id: 9,
+        name: 'Gil Carlyle',
+        email: '9_gcarlyle8@canalblog.com',
+        role: 'Contributor',
+      },
+      {
+        id: 10,
+        name: 'Marinna Corbin',
+        email: '10_mcorbin9@google.ca',
+        role: 'Contributor',
+      },
+      {
+        id: 11,
+        name: 'Yardley Entwhistle',
+        email: '11_yentwhistlea@tumblr.com',
+        role: 'Contributor',
+      },
+      {
+        id: 12,
+        name: 'Brinn Clack',
+        email: '12_bclackb@blogger.com',
+        role: 'Contributor',
+      },
+      {
+        id: 13,
+        name: 'Charleen Millen',
+        email: '13_cmillenc@mtv.com',
+        role: 'Contributor',
+      },
+      {
+        id: 14,
+        name: 'Kalie Piers',
+        email: '14_kpiersd@businessweek.com',
+        role: 'Contributor',
+      },
+      {
+        id: 15,
+        name: 'Laure Boxer',
+        email: '15_lboxere@elegantthemes.com',
+        role: 'Contributor',
+      },
+      {
+        id: 16,
+        name: 'Libby Bonallack',
+        email: '16_lbonallackf@disqus.com',
+        role: 'Contributor',
+      },
+      {
+        id: 17,
+        name: 'Zebedee Gofton',
+        email: '17_zgoftong@bbc.co.uk',
+        role: 'Contributor',
+      },
+      {
+        id: 18,
+        name: 'Sari Eckford',
+        email: '18_seckfordh@cloudflare.com',
+        role: 'Contributor',
+      },
+      {
+        id: 19,
+        name: 'Carlos Byrth',
+        email: '19_cbyrthi@prlog.org',
+        role: 'Contributor',
+      },
+      {
+        id: 20,
+        name: 'Avery Allmark',
+        email: '20_aallmarkj@webnode.com',
+        role: 'Contributor',
+      },
+      {
+        id: 21,
+        name: 'Ninnette McSpirron',
+        email: '21_nmcspirronk@amazon.com',
+        role: 'Contributor',
+      },
+      {
+        id: 22,
+        name: 'Sharlene Ewestace',
+        email: '22_sewestacel@twitpic.com',
+        role: 'Contributor',
+      },
+      {
+        id: 23,
+        name: 'Jessamine Kembry',
+        email: '23_jkembrym@hatena.ne.jp',
+        role: 'Contributor',
+      },
+      {
+        id: 24,
+        name: 'Homerus Dixcee',
+        email: '24_hdixceen@deviantart.com',
+        role: 'Contributor',
+      },
+      {
+        id: 25,
+        name: 'Clevie Clear',
+        email: '25_cclearo@tmall.com',
+        role: 'Contributor',
+      },
+      {
+        id: 26,
+        name: 'Mohammed Hubatsch',
+        email: '26_mhubatschp@salon.com',
+        role: 'Contributor',
+      },
+      {
+        id: 27,
+        name: 'Gigi Hovard',
+        email: '27_ghovardq@cbslocal.com',
+        role: 'Contributor',
+      },
+      {
+        id: 28,
+        name: 'Dorey Tinker',
+        email: '28_dtinkerr@google.co.uk',
+        role: 'Contributor',
+      },
+      {
+        id: 29,
+        name: 'Arel Mullarkey',
+        email: '29_amullarkeys@blogs.com',
+        role: 'Contributor',
+      },
+      {
+        id: 30,
+        name: 'Veronike Ventura',
+        email: '30_vventurat@google.fr',
+        role: 'Contributor',
+      },
+      {
+        id: 31,
+        name: 'Gerti Dranfield',
+        email: '31_gdranfieldu@vistaprint.com',
+        role: 'Contributor',
+      },
+      {
+        id: 32,
+        name: 'Brigida Hembrow',
+        email: '32_bhembrowv@webeden.co.uk',
+        role: 'Contributor',
+      },
+      {
+        id: 33,
+        name: 'Aluin Dowding',
+        email: '33_adowdingw@wisc.edu',
+        role: 'Contributor',
+      },
+      {
+        id: 34,
+        name: 'Alli Pleasaunce',
+        email: '34_apleasauncex@berkeley.edu',
+        role: 'Contributor',
+      },
+      {
+        id: 35,
+        name: 'Cosimo Parcell',
+        email: '35_cparcelly@jalbum.net',
+        role: 'Contributor',
+      },
+      {
+        id: 36,
+        name: 'Kerri Lequeux',
+        email: '36_klequeuxz@bing.com',
+        role: 'Contributor',
+      },
+      {
+        id: 37,
+        name: 'Emilio Fidgin',
+        email: '37_efidgin10@hud.gov',
+        role: 'Contributor',
+      },
+      {
+        id: 38,
+        name: 'Ara Oxtiby',
+        email: '38_aoxtiby11@apache.org',
+        role: 'Contributor',
+      },
+      {
+        id: 39,
+        name: 'Harv Rapier',
+        email: '39_hrapier12@amazon.co.jp',
+        role: 'Contributor',
+      },
+    ];
     return { records };
   }
+
+  // =============================
+  // ROUTING DEMOS
+  // =============================
 
   get demoRouteName() {
     // eg. 'components.pagination';
@@ -135,6 +379,37 @@ export default class Index extends Component {
     let { newNextCursor } = this.demoNewPrevNextCursors;
     return newNextCursor === null;
   }
+
+  get demoPaginatedDataNumbered() {
+    const start = (this.demoCurrentPage - 1) * this.demoCurrentPageSize;
+    const end = this.demoCurrentPage * this.demoCurrentPageSize;
+    return this.model.records.slice(start, end);
+  }
+
+  get demoPaginatedDataCompact() {
+    const { direction, cursorIndex } = getCursorParts(
+      this.demoCurrentCursor,
+      this.model.records
+    );
+
+    let start;
+    let end;
+    let pageSize = this.demoPageSizes[0];
+    if (direction === 'prev') {
+      end = cursorIndex;
+      start = cursorIndex - pageSize;
+    } else {
+      start = cursorIndex;
+      end = cursorIndex + pageSize;
+    }
+
+    // return data
+    return this.model.records.slice(start, end);
+  }
+
+  // =============================
+  // GENERIC HANDLERS
+  // =============================
 
   @action
   handlePageChange(page, pageSize) {

--- a/website/docs/components/pagination/index.md
+++ b/website/docs/components/pagination/index.md
@@ -1,12 +1,12 @@
 ---
 title: Pagination
-hidden: false
 description: Used to let users navigate through content broken down into pages. Usually paired with tables.
 caption: Used to let users navigate through content broken down into pages.
 status: experimental
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=18709%3A42011&t=pIE459t8qucXP9uR-1
-  github: 
+  github:
+previewImage: assets/illustrations/components/pagination.jpg
 ---
 
 <section data-tab="Guidelines">
@@ -17,7 +17,7 @@ links:
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  @include "partials/code/showcase.md"
+  <!-- @include "partials/code/showcase.md" -->
 </section>
 
 <section data-tab="Specifications">

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -109,7 +109,7 @@ Sets the "direction" of the icon and label in the control.
 These are the parameters that are passed down as arguments to the `Hds::Interactive` component (used internally). For more details about how this low-level component works, please refer to [its documentation page](/utilities/interactive/).
 </C.Property>
 <C.Property @name="disabled" @type="boolean" @values={{array "true" "false" }} @default="false">
-If the control is disabled. Notice: when the control is disabled, it's always rendered as an HTML `Button` element.
+Sets the control as disabled. Notice: when the control is disabled, it’s always rendered as an HTML `Button` element.
 </C.Property>
 <C.Property @name="showLabel" @type="boolean" @values={{array "true" "false" }} @default="true">
 Used to control the visibility of the text label in the control.

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -1,20 +1,161 @@
 ## Component API
 
-<!-- fill this out based on the API found in the scrappy site -->
+The term “`Pagination` component” is an umbrella term used to indicate a set of Pagination-related components and sub-components, each with their own APIs.
+
+There are two main **high-level “container” components**, which control the layout and some of the logic that connects the different sub-components:
+
+- `Pagination::Numbered` - used when the number of items is known (this component handles all the complexity of the pagination information shown to the user: "info", "page numbers", "current page", "page size")
+- `Pagination::Compact` - used when the number of items is unknown or the pagination needs to be [cursor-based](https://jsonapi.org/profiles/ethanresnick/cursor-pagination/) (so there is no concept of "current page")
+
+For more details on when and how to use these two components, refer to the "How to use" section below.
+
+There is also a set of **low-level sub-components**, used to build the "numbered" and "compact" variants:
+
+- `Pagination::Info` - used to display the current range of items shown and the total number of items
+- `Pagination::Nav::Arrow` - used to provide "prev/next" navigation controls
+- `Pagination::Nav::Number` - used to provide "page number" navigation controls
+- `Pagination::Nav::Ellipsis` - used to display an ellipsis instead of a set of page numbers
+- `Pagination::SizeSelector` - used to allow users to change the number of items displayed per page
+
+These pagination sub-elements may be used directly if you need to cover a very specific use case that is not covered by the "numbered" or "compact" paginations. In that case, refer to their specific APIs below.
+
+### Pagination::Numbered
+
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @required="true" @type="enum" @values={{array "page" "inline" "compact"}}>
-    Sets the type of alert.
-  </C.Property>
-  <C.Property @name="color" @type="enum" @values={{array "neutral" "highlight" "success" "warning" "critical"}} @default="neutral">
-    Sets the color scheme for `background`, `border`, `title`, and `description`, which **cannot** be overridden.<br/><br/>`color` results in a default `icon`, which **can** be overridden.
-  </C.Property>
-  <C.Property @name="icon" @type="string | false">
-    Override the default `icon` name, which is determined by the `color` argument.<br/><br/>Accepts any [icon](/foundations/icons) name, or `false`, for no icon.
-  </C.Property>
-  <C.Property @name="onDismiss" @type="function">
-    The alert can be dismissed by the user. When a function is passed, the "dismiss" button is displayed.
-  </C.Property>
-  <C.Property @name="...attributes">
-    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
-  </C.Property>
+<C.Property @name="totalItems" @required="true" @type="number">
+Pass the total number of items to be paginated. If no value is defined an error will be thrown.
+</C.Property>
+<C.Property @name="itemsPerPage" @type="number">
+Pass the maximum number of items to display on each page. If no value is defined, the first page size in `pageSizes` will be used. Default is `10` if custom `pageSizes` are not defined.
+</C.Property>
+<C.Property @name="pageSizes" @type="array" @values={{array "[10, 30, 50]" "array of integers" }} @default="[10, 30, 50]">
+Set the page sizes users can select from. Example: `@pageSizes=\{{array 5 20 30}}`.
+</C.Property>
+<C.Property @name="currentPage" @type="integer" @values={{array 1 "integer" }} @default={{1}}>
+Set a custom initial selected page.
+</C.Property>
+<C.Property @name="isTruncated" @type="boolean" @values={{array "true" "false" }} @default="true">
+Used to to limit the number of page numbers displayed (to save space, it will display an ellipsis for some numbers).
+</C.Property>
+<C.Property @name="showLabels" @type="boolean" @values={{array "true" "false" }} @default="false">
+Used to control the visibility of the "prev/next" text labels.
+</C.Property>
+<C.Property @name="route/model/models/replace">
+These are the parameters that are passed down as arguments to the `Hds::Pagination::Arrow`/`Hds::Pagination::Number` child components, and from them to the `Hds::Interactive` component (used internally). For more details about how this low-level component works please refer to [its documentation page](/utilities/interactive/).
+</C.Property>
+<C.Property @name="queryFunction" @type="function">
+A function that returns an object that can be provided as `query` argument for the routing, and that is passed down to the to the child components together with the other routing parameters. The function receives the value of the "go to" page and "page size" as arguments (integer numbers).
+</C.Property>
+<C.Property @name="onPageChange" @type="function">
+Callback function invoked (if provided) when one of the navigation controls is clicked, and a "page" change is triggered. The function receives the value of the "go to" page and "page size" as arguments (integer numbers).
+</C.Property>
+<C.Property @name="onPageSizeChange" @type="function">
+Callback function invoked (if provided) when the page size selector is changed, and a "page size" change is triggered. The function receives the value of the "page size" as argument (an integer number).
+</C.Property>
+<C.Property @name="...attributes">
+This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+</C.Property>
+</Doc::ComponentApi>
+
+### Pagination::Compact
+
+<Doc::ComponentApi as |C|>
+<C.Property @name="route/model/models/replace">
+These are the parameters that are passed down as arguments to the `Hds::Pagination::Arrow` child components, and from them to the `Hds::Interactive` component (used internally). For more details about how this low-level component works please refer to [its documentation page](/utilities/interactive/).
+</C.Property>
+<C.Property @name="queryFunction" @type="function">
+A function that returns an object that can be provided as `query` argument for the routing, and that is passed down to the to the child components together with the other routing parameters. The function receives as argument one of two possible values: `prev` / `next`.
+</C.Property>
+<C.Property @name="isDisabledPrev/isDisabledNext" @type="boolean" @values={{array "true" "false" }} @default="false">
+Used to disable the "prev" or "next" controls. Notice: when the control is disabled, it's always rendered as an HTML `<button>` element.
+</C.Property>
+<C.Property @name="showLabels" @type="boolean" @values={{array "true" "false" }} @default="true">
+Used to control the visibility of the "prev/next" text labels.
+</C.Property>
+<C.Property @name="onPageChange" @type="function">
+Callback function invoked (if provided) when a "prev" or "next" control is clicked. The function receives as argument one of two possible values: `prev` / `next`
+</C.Property>
+<C.Property @name="...attributes">
+This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+</C.Property>
+</Doc::ComponentApi>
+
+### Base elements
+
+#### Pagination::Info
+
+<Doc::ComponentApi as |C|>
+<C.Property @name="itemsRangeStart" @required="true" @type="string|number">
+The "start" value of the range in the informational text.
+</C.Property>
+<C.Property @name="itemsRangeEnd" @required="true" @type="string|number">
+The "end" value of the range in the informational text.
+</C.Property>
+<C.Property @name="totalItems" @required="true" @type="string|number">
+The "out of" total items in the informational text. It's not required if `showTotalItems` is set to `false`.
+</C.Property>
+<C.Property @name="showTotalItems" @type="boolean" @values={{array "true" "false" }} @default="true">
+Controls the visibility of the total items in the informational text.
+</C.Property>
+</Doc::ComponentApi>
+
+#### Pagination::Nav::Arrow
+
+<Doc::ComponentApi as |C|>
+<C.Property @name="direction" @required="true" @type="enum" @values={{array "prev" "next"}}>
+Sets the "direction" of the icon and label in the control.
+</C.Property>
+<C.Property @name="route/query/model/models/replace">
+These are the parameters that are passed down as arguments to the `Hds::Interactive` component (used internally). For more details about how this low-level component works please refer to [its documentation page](/utilities/interactive/).
+</C.Property>
+<C.Property @name="disabled" @type="boolean" @values={{array "true" "false" }} @default="false">
+If the control is disabled. Notice: when the control is disabled, it's always rendered as an HTML `Button` element.
+</C.Property>
+<C.Property @name="showLabel" @type="boolean" @values={{array "true" "false" }} @default="true">
+Used to control the visibility of the text label in the control.
+</C.Property>
+<C.Property @name="onClick" @type="function">
+Callback function invoked (if provided) when the control is clicked.
+</C.Property>
+<C.Property @name="...attributes">
+This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+</C.Property></Doc::ComponentApi>
+
+#### Pagination::Nav::Number
+
+<Doc::ComponentApi as |C|>
+<C.Property @name="page" @required="true" @type="number">
+The value that should go in the control as page number.
+</C.Property>
+<C.Property @name="isSelected" @type="boolean" @values={{array "true" "false" }} @default="false">
+If the page has a "selected" visual state (usually used to highlight the current page).
+</C.Property>
+<C.Property @name="route/query/model/models/replace">
+These are the parameters that are passed down as arguments to the `Hds::Interactive` component (used internally). For more details about how this low-level component works please refer to [its documentation page](/utilities/interactive/).
+</C.Property>
+<C.Property @name="onClick" @type="function">
+Callback function invoked (if provided) when the control is clicked.
+</C.Property>
+<C.Property @name="...attributes">
+This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering). _Notice: it will not be applied to the `<li>` wrapping element but to the nested `<button>/<a>` controls._
+</C.Property>
+</Doc::ComponentApi>
+
+#### Pagination::Nav::Ellipsis
+
+<Doc::ComponentApi as |C|>
+<C.Property @name="...attributes">
+This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering). _Notice: it will not be applied to the `<li>` wrapping element but to the nested `<button>/<a>` controls._
+</C.Property>
+</Doc::ComponentApi>
+
+#### Pagination::SizeSelector
+
+<Doc::ComponentApi as |C|>
+<C.Property @name="pageSizes" @required="true" @type="array of integers">
+Set the page sizes users can select from. If no value is defined an error will be thrown. Example: `@pageSizes=\{{array 5 20 30}}`
+</C.Property>
+<C.Property @name="selectedSize" @type="integer">
+Used to indicate which of the provided `sizes` options is pre-selected. Normally this value is passed automatically by the Pagination wrapper component but can be provided as argument to the `Pagination::SizeSelector` component itself when used as a stand alone component.
+</C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -61,13 +61,13 @@ This component supports use of [`...attributes`](https://guides.emberjs.com/rele
 
 <Doc::ComponentApi as |C|>
 <C.Property @name="route/model/models/replace">
-These are the parameters that are passed down as arguments to the `Hds::Pagination::Arrow` child components, and from them to the `Hds::Interactive` component (used internally). For more details about how this low-level component works please refer to [its documentation page](/utilities/interactive/).
+These are the parameters that are passed down as arguments to the `Hds::Pagination::Arrow` child components, and from them to the `Hds::Interactive` component (used internally). For more details about how this low-level component works, please refer to [its documentation page](/utilities/interactive/).
 </C.Property>
 <C.Property @name="queryFunction" @type="function">
 A function that returns an object that can be provided as `query` argument for the routing, and that is passed down to the to the child components together with the other routing parameters. The function receives as argument one of two possible values: `prev` / `next`.
 </C.Property>
 <C.Property @name="isDisabledPrev/isDisabledNext" @type="boolean" @values={{array "true" "false" }} @default="false">
-Used to disable the "prev" or "next" controls. Notice: when the control is disabled, it's always rendered as an HTML `<button>` element.
+Used to disable the "prev" or "next" controls. Notice: when the control is disabled, it’s always rendered as an HTML `<button>` element.
 </C.Property>
 <C.Property @name="showLabels" @type="boolean" @values={{array "true" "false" }} @default="true">
 Used to control the visibility of the "prev/next" text labels.
@@ -92,7 +92,7 @@ The "start" value of the range in the informational text.
 The "end" value of the range in the informational text.
 </C.Property>
 <C.Property @name="totalItems" @required="true" @type="string|number">
-The "out of" total items in the informational text. It's not required if `showTotalItems` is set to `false`.
+The "out of" total items in the informational text. Not required if `showTotalItems` is set to `false`.
 </C.Property>
 <C.Property @name="showTotalItems" @type="boolean" @values={{array "true" "false" }} @default="true">
 Controls the visibility of the total items in the informational text.
@@ -106,7 +106,7 @@ Controls the visibility of the total items in the informational text.
 Sets the "direction" of the icon and label in the control.
 </C.Property>
 <C.Property @name="route/query/model/models/replace">
-These are the parameters that are passed down as arguments to the `Hds::Interactive` component (used internally). For more details about how this low-level component works please refer to [its documentation page](/utilities/interactive/).
+These are the parameters that are passed down as arguments to the `Hds::Interactive` component (used internally). For more details about how this low-level component works, please refer to [its documentation page](/utilities/interactive/).
 </C.Property>
 <C.Property @name="disabled" @type="boolean" @values={{array "true" "false" }} @default="false">
 If the control is disabled. Notice: when the control is disabled, it's always rendered as an HTML `Button` element.
@@ -131,7 +131,7 @@ The value that should go in the control as page number.
 If the page has a "selected" visual state (usually used to highlight the current page).
 </C.Property>
 <C.Property @name="route/query/model/models/replace">
-These are the parameters that are passed down as arguments to the `Hds::Interactive` component (used internally). For more details about how this low-level component works please refer to [its documentation page](/utilities/interactive/).
+These are the parameters that are passed down as arguments to the `Hds::Interactive` component (used internally). For more details about how this low-level component works, please refer to [its documentation page](/utilities/interactive/).
 </C.Property>
 <C.Property @name="onClick" @type="function">
 Callback function invoked (if provided) when the control is clicked.

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -25,7 +25,7 @@ These pagination sub-elements may be used directly if you need to cover a very s
 <C.Property @name="totalItems" @required="true" @type="number">
 Pass the total number of items to be paginated. If no value is defined an error will be thrown.
 </C.Property>
-<C.Property @name="itemsPerPage" @type="number">
+<C.Property @name="currentPageSize" @type="number">
 Pass the maximum number of items to display on each page. If no value is defined, the first page size in `pageSizes` will be used. Default is `10` if custom `pageSizes` are not defined.
 </C.Property>
 <C.Property @name="pageSizes" @type="array" @values={{array "[10, 30, 50]" "array of integers" }} @default="[10, 30, 50]">

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -52,10 +52,10 @@ Below is an example of some of these extra arguments:
 ```handlebars
 <Hds::Pagination::Numbered
   @totalItems={{40}}
-  @itemsPerPage={{20}}
   @showTotalItems={{false}}
   @showSizeSelector={{false}}
   @pageSizes={{array 5 20 60}}
+  @currentPageSize={{20}}
 />
 ```
 
@@ -101,9 +101,9 @@ If you want the pagination to change the URL of the page directly (eg. updating 
 ```handlebars
 <Hds::Pagination::Numbered
   @totalItems={{this.demoTotalItems}}
-  @itemsPerPage={{this.demoCurrentPageSize}}
   @currentPage={{this.demoCurrentPage}}
   @pageSizes={{this.demoPageSizes}}
+  @currentPageSize={{this.demoCurrentPageSize}}
   @route={{this.demoRouteName}}
   @queryFunction={{this.demoQueryFunctionNumbered}}
 />
@@ -159,9 +159,9 @@ Below you can find an example of an integration between the sortable [`Table`](/
   </Hds::Table>
   <Hds::Pagination::Numbered
     @totalItems={{this.demoTotalItems}}
-    @itemsPerPage={{this.demoCurrentPageSize}}
     @currentPage={{this.demoCurrentPage}}
     @pageSizes={{this.demoPageSizes}}
+    @currentPageSize={{this.demoCurrentPageSize}}
     @route={{this.demoRouteName}}
     @queryFunction={{this.demoQueryFunctionNumbered}}
   />

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -134,36 +134,38 @@ Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` 
 Below you can find an example of an integration between the sortable [`Table`](/components/table) component and the `Pagination::Numbered` component that uses query parameters in the URL to preserve the UI state:
 
 ```handlebars
-<Hds::Table
-  @model={{this.demoPaginatedDataNumbered}}
-  @columns={{array
-    (hash key="id" label="ID" isSortable="true")
-    (hash key="name" label="Name" isSortable="true")
-    (hash key="email" label="Email")
-    (hash key="role" label="Role")
-  }}
-  @sortBy={{this.demoCurrentSortBy}}
-  @sortOrder={{this.demoCurrentSortOrder}}
-  @onSort={{this.demoOnTableSort}}
-  @density={{if (eq this.demoCurrentPageSize 30) "short" "medium"}}
->
-  <:body as |B|>
-    <B.Tr>
-      <B.Td>{{B.data.id}}</B.Td>
-      <B.Td>{{B.data.name}}</B.Td>
-      <B.Td>{{B.data.email}}</B.Td>
-      <B.Td>{{B.data.role}}</B.Td>
-    </B.Tr>
-  </:body>
-</Hds::Table>
-<Hds::Pagination::Numbered
-  @totalItems={{this.demoTotalItems}}
-  @itemsPerPage={{this.demoCurrentPageSize}}
-  @currentPage={{this.demoCurrentPage}}
-  @pageSizes={{this.demoPageSizes}}
-  @route={{this.demoRouteName}}
-  @queryFunction={{this.demoQueryFunctionNumbered}}
-/>
+<div class="doc-pagination-table-demo">
+  <Hds::Table
+    @model={{this.demoPaginatedDataNumbered}}
+    @columns={{array
+      (hash key="id" label="ID" isSortable="true")
+      (hash key="name" label="Name" isSortable="true")
+      (hash key="email" label="Email")
+      (hash key="role" label="Role")
+    }}
+    @sortBy={{this.demoCurrentSortBy}}
+    @sortOrder={{this.demoCurrentSortOrder}}
+    @onSort={{this.demoOnTableSort}}
+    @density={{if (eq this.demoCurrentPageSize 30) "short" "medium"}}
+  >
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.id}}</B.Td>
+        <B.Td>{{B.data.name}}</B.Td>
+        <B.Td>{{B.data.email}}</B.Td>
+        <B.Td>{{B.data.role}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+  <Hds::Pagination::Numbered
+    @totalItems={{this.demoTotalItems}}
+    @itemsPerPage={{this.demoCurrentPageSize}}
+    @currentPage={{this.demoCurrentPage}}
+    @pageSizes={{this.demoPageSizes}}
+    @route={{this.demoRouteName}}
+    @queryFunction={{this.demoQueryFunctionNumbered}}
+  />
+</div>
 ```
 
 ## How to use the "Compact" pagination
@@ -237,28 +239,30 @@ Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` 
 Below you can find an example of an integration between the [`Table`](/components/table) component and the `Pagination::Compact` component that uses query parameters in the URL to preserve the UI state:
 
 ```handlebars
-<Hds::Table
-  @model={{this.demoPaginatedDataCompact}}
-  @columns={{array
-    (hash key="id" label="ID")
-    (hash key="name" label="Name")
-    (hash key="email" label="Email")
-    (hash key="role" label="Role")
-  }}
->
-  <:body as |B|>
-    <B.Tr>
-      <B.Td>{{B.data.id}}</B.Td>
-      <B.Td>{{B.data.name}}</B.Td>
-      <B.Td>{{B.data.email}}</B.Td>
-      <B.Td>{{B.data.role}}</B.Td>
-    </B.Tr>
-  </:body>
-</Hds::Table>
-<Hds::Pagination::Compact
-  @route={{this.demoRouteName}}
-  @queryFunction={{this.demoQueryFunctionCompact}}
-  @isDisabledPrev={{this.demoIsDisabledPrev}}
-  @isDisabledNext={{this.demoIsDisabledNext}}
-/>
+<div class="doc-pagination-table-demo">
+  <Hds::Table
+    @model={{this.demoPaginatedDataCompact}}
+    @columns={{array
+      (hash key="id" label="ID")
+      (hash key="name" label="Name")
+      (hash key="email" label="Email")
+      (hash key="role" label="Role")
+    }}
+  >
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.id}}</B.Td>
+        <B.Td>{{B.data.name}}</B.Td>
+        <B.Td>{{B.data.email}}</B.Td>
+        <B.Td>{{B.data.role}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+  <Hds::Pagination::Compact
+    @route={{this.demoRouteName}}
+    @queryFunction={{this.demoQueryFunctionCompact}}
+    @isDisabledPrev={{this.demoIsDisabledPrev}}
+    @isDisabledNext={{this.demoIsDisabledNext}}
+  />
+</div>
 ```

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -1,22 +1,200 @@
-## How to use this component
+## "Compact" vs "Numbered" pagination
 
-<!-- use the same heading order from Guidelines -->
-{basic invocation details}
+There are two different variants of the `Pagination` component (with different ways to invoke them) built to cover different use cases, contexts, and designs you may need them for.
+
+This differentiation is necessary to cover both use cases of a pagination for a list with a known number of elements (**"numbered"**) and one in which this information is not available or is [cursor-based](https://jsonapi.org/profiles/ethanresnick/cursor-pagination/) (**"compact"**).
+
+In the first one, the user is presented with a list of navigation controls ("prev/next" and "page numbers" to go directly to a specific page) and other optional UI elements; in the second, much simpler one, the user is presented with only the "prev/next" controls.
+
+When pagination is invoked directly using one of these two components, it will **automatically**:
+
+- provide the correct responsive layout for the entire pagination and its sub-parts
+- manage the "current page" status across the different sub-components it's made of (based on the arguments provided to it and its children).
+- when one of the "navigation controls" is clicked, a callback function (if provided) is called, and a route (if provided) update is triggered.
+- when the "page size" is changed via the provided selector, it will automatically recalculate the total number of pages to display to the user.
+
+
+## Pagination sub-components
+
+If you need more control on the specific pagination parts, and/or you need to cover a very specific use case, you can use the pagination sub-elements directly (`Pagination::Info/Nav(*)/SizeSelector`).
+
+In this case, you will have to take care of different things **yourself**
+
+- the organization/layout of the elements on the page.
+- the logic to handle the "current page" status.
+- the logic connecting the different parts (if using "numbered").
+
+
+## Events handling and routing
+
+As described above, the main `Pagination::Numbered` and `Pagination::Compact` components expose an `onPageChange` callback function, invoked whenever a page change occurs. All the "navigation controls" in this cases are `<button>` elements that fire an `onClick` event that calls the `onPageChange` function.
+
+This means that if you need to update the URL when the user changes the "page" in the Pagination (eg. to add/remove/update some query parameters), you have to do it whithin the `onPageChange` callback you provide to the component.
+
+If instead you need to update the URL directly when the user clicks on one of the "navigation control" elements, you have to provide routing parameters (`route/query/model/etc`) to the component; refer to the "Component API" section below for specifications about these parameters (the APIs are slightly different for the two components).
+
+## How to use the "Numbered" pagination
+
+The basic invocation of the "numbered" pagination requires the `@totalItems` argument to be provided (plus the event/routing handlers, see below):
 
 ```handlebars
-<Hds::Alert @type="inline" as |A|>
-  <A.Title>Title here</A.Title>
-  <A.Description>Description here</A.Description>
-</Hds::Alert>
+<Hds::Pagination::Numbered @totalItems={{40}} />
 ```
 
-### Variant/property name
+By default the "Info" and "SizeSelector" are displayed, and the component takes care of updating the values and the states of the different elements, according to the user interactions with the component.
 
-{description}
+### Extra arguments
+
+It's possible to customize the "Info", "Controls", and "SizeSelector" providing additional arguments to them. For more details about these parameters, refer to the "Components API" section.
+
+Below is an example of some of these extra arguments:
 
 ```handlebars
-<Hds::Alert @type="page" as |A|>
-  <A.Title>Title here</A.Title>
-  <A.Description>Description here</A.Description>
-</Hds::Alert>
+<Hds::Pagination::Numbered
+  @totalItems={{40}}
+  @itemsPerPage={{20}}
+  @showTotalItems={{false}}
+  @showSizeSelector={{false}}
+  @pageSizes={{array 5 20 60}}
+/>
 ```
+
+### Truncation
+
+When there is a large number of items and consequently the number of pages is also large, by default the component automatically "truncates" the number of visible pages (using "ellipsises"):
+
+```handlebars
+<Hds::Pagination::Numbered
+  @totalItems={{120}}
+/>
+```
+
+If necessary, it's possible to disable this functionality using a specific `@isTruncated` argument:
+
+```handlebars
+<Hds::Pagination::Numbered
+  @totalItems={{120}}
+  @isTruncated={{false}}
+/>
+```
+
+### Events handling
+
+The component exposes two callback functions that can be used to respond to specific events:
+
+```handlebars
+<Hds::Pagination::Numbered
+  @totalItems={{40}}
+  @onPageChange={{this.handlePageChange}}
+  @onPageSizeChange={{this.handlePageSizeChange}}
+/>
+```
+
+The first `onPageChange` function is invoked when a user interacts with a navigation control ("prev/next" or "page number") and so can be used to respond to a "page" change (eg. updating the list of items in the page and/or updating the routing/URL).
+
+The second `onPageSizeChange` function is invoked when a user interacts with the "size selector" and so can be used to respond to a "page size" change (eg. updating the number of items listed in the page, updating the routing/URL, and/or updating other elements in the page).
+
+### Routing/URL updates
+
+If you want the pagination to change the URL of the page directly (eg. updating the query parameters) you need to pass the routing parameters to the component:
+
+```handlebars
+<Hds::Pagination::Numbered
+  @totalItems={{this.demoTotalItems}}
+  @itemsPerPage={{this.demoCurrentPageSize}}
+  @currentPage={{this.demoCurrentPage}}
+  @pageSizes={{this.demoPageSizes}}
+  @route={{this.demoRouteName}}
+  @queryFunction={{this.demoQueryFunctionNumbered}}
+/>
+```
+
+where the `@queryFunction` function will be something like this:
+
+```javascript
+get demoQueryFunctionNumbered() {
+  return (page, pageSize) => {
+    return {
+      demoCurrentPage: page,
+      demoCurrentPageSize: pageSize,
+      demoExtraParam: 'hello',
+    };
+  };
+}
+```
+
+When the routing parameters are provided, the "navigation controls" are rendered as links and if the user clicks on one of them the page URL is automatically updated. This means that the component's state is persisted **outside** of the component and so its whole state **must** be "controlled" by the consumer's code (otherwise there would be confliting states).
+
+In this case, the component doesn't update its internal "state" but the value of the state variables (eg. `currentPage/currentPageSize`) is **always** determined by the consumer's controller code via the component's arguments (most of the times, they are directly connected to the query parameters in the URL).
+
+The reason for using a consumer-side function to determine the `query` argument is because it's dynamic (it depends on the value of the `page` variable) and gives consumers the ability to specify their own query parameters (they will likely be different case by case).
+
+Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.)
+
+## How to use the "Compact" pagination
+
+By default, the basic use of the pagination provides:
+
+The basic invocation of the "compact" pagination doesn't require any arguments (apart from the event/routing handlers, see below):
+
+```handlebars
+<Hds::Pagination::Compact />
+```
+
+Renders to:
+
+In this variant only the "prev" and "next" navigation controls are displayed.
+
+### Extra arguments
+
+If necessary, it's possible to hide the labels in the controls:
+
+```handlebars
+<Hds::Pagination::Compact @showLabels={{false}} />
+```
+
+### Events handling
+
+The component exposes a callback function that can be used to respond to page changes:
+
+```handlebars
+<Hds::Pagination::Compact
+  @onPageChange={{this.handlePageChange}}
+/>
+```
+
+The `onPageChange` function is invoked when a user interacts with a "prev" or "next" navigation control and so can be used to respond to a "page" change (eg. updating the list of items in the page and/or updating the routing/URL).
+
+### Routing/URL updates
+
+If you want the pagination to change the URL of the page directly (eg. updating the query parameters) you need to pass the routing parameters to the component:
+
+```handlebars
+<Hds::Pagination::Compact
+  @route={{this.demoRouteName}}
+  @queryFunction={{this.demoQueryFunctionCompact}}
+  @isDisabledPrev={{this.demoIsDisabledPrev}}
+  @isDisabledNext={{this.demoIsDisabledNext}}
+/>
+```
+
+where the `@queryFunction` function will be something like this:
+
+```javascript
+get demoQueryFunctionCompact() {
+  return (page) => {
+    return {
+      demoCurrentToken: page === 'prev' ? this.getPrevToken : this.getNextToken,
+      demoExtraParam: 'hello',
+    };
+  };
+}
+```
+
+When the routing parameters are provided, the "prev/next" controls are rendered as links and if the user clicks on one of them the page URL is automatically updated. This means that the component's state is persisted **outside** of the component and so its whole state **must** be "controlled" by the consumer's code (otherwise there would be confliting states).
+
+In this case, the component doesn't update its internal "state" but the value of the state variables is **always** determined by the consumer's controller code via the component's arguments (most of the times, they are directly connected to the query parameters in the URL).
+
+The reason for using a consumer-side function to determine the `query` argument is because it's dynamic (it depends on the value of the `page/cursor` variable) and gives consumers the ability to specify their own query parameters (they will likely be different case by case).
+
+Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.)

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -9,7 +9,7 @@ In the first one, the user is presented with a list of navigation controls ("pre
 When pagination is invoked directly using one of these two components, it will **automatically**:
 
 - provide the correct responsive layout for the entire pagination and its sub-parts
-- manage the "current page" status across the different sub-components it's made of (based on the arguments provided to it and its children).
+- manage the "current page" status across the different sub-components it’s made of (based on the arguments provided to it and its children).
 - when one of the "navigation controls" is clicked, a callback function (if provided) is called, and a route (if provided) update is triggered.
 - when the "page size" is changed via the provided selector, it will automatically recalculate the total number of pages to display to the user.
 
@@ -41,11 +41,11 @@ The basic invocation of the "numbered" pagination requires the `@totalItems` arg
 <Hds::Pagination::Numbered @totalItems={{40}} />
 ```
 
-By default the "Info" and "SizeSelector" are displayed, and the component takes care of updating the values and the states of the different elements, according to the user interactions with the component.
+By default the "Info" and "SizeSelector" sub-components are displayed, and the component takes care of updating the values and the states of the different elements, according to the user interactions with the component.
 
 ### Extra arguments
 
-It's possible to customize the "Info", "Controls", and "SizeSelector" providing additional arguments to them. For more details about these parameters, refer to the "Components API" section.
+It’s possible to customize the "Info", "Controls", and "SizeSelector" components by providing additional arguments to them. For more details about these parameters, refer to the "Component API" section.
 
 Below is an example of some of these extra arguments:
 
@@ -61,7 +61,7 @@ Below is an example of some of these extra arguments:
 
 ### Truncation
 
-When there is a large number of items and consequently the number of pages is also large, by default the component automatically "truncates" the number of visible pages (using "ellipsises"):
+When there is a large number of items and consequently the number of pages is also large, by default the component automatically "truncates" the number of visible pages (using "ellipses"):
 
 ```handlebars
 <Hds::Pagination::Numbered
@@ -69,7 +69,7 @@ When there is a large number of items and consequently the number of pages is al
 />
 ```
 
-If necessary, it's possible to disable this functionality using a specific `@isTruncated` argument:
+If necessary, it’s possible to disable this functionality using the `@isTruncated` argument:
 
 ```handlebars
 <Hds::Pagination::Numbered
@@ -123,19 +123,19 @@ get demoQueryFunctionNumbered() {
 }
 ```
 
-When the routing parameters are provided, the "navigation controls" are rendered as links and if the user clicks on one of them the page URL is automatically updated. This means that the component's state is persisted **outside** of the component and so its whole state **must** be "controlled" by the consumer's code (otherwise there would be confliting states).
+When the routing parameters are provided, the "navigation controls" are rendered as links and if the user clicks on one of them the page URL is automatically updated. This means that the component’s state is persisted **outside** of the component and so its whole state **must** be "controlled" by the consumer’s code (otherwise there would be conflicting states).
 
-In this case, the component doesn't update its internal "state" but the value of the state variables (eg. `currentPage/currentPageSize`) is **always** determined by the consumer's controller code via the component's arguments (most of the times, they are directly connected to the query parameters in the URL).
+In this case, the component doesn’t update its internal "state" but the value of the state variables (eg. `currentPage/currentPageSize`) is **always** determined by the consumer’s controller code via the component’s arguments (usually, they are directly connected to the query parameters in the URL).
 
-The reason for using a consumer-side function to determine the `query` argument is because it's dynamic (it depends on the value of the `page` variable) and gives consumers the ability to specify their own query parameters (they will likely be different case by case).
+The reason for using a consumer-side function to determine the `query` argument is because it’s dynamic (it depends on the value of the `page` variable) and gives consumers the ability to specify their own query parameters (which will likely differ case by case).
 
-Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.)
+Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users’ actions (eg. for logging, tracking, etc.)
 
 ## How to use the "Compact" pagination
 
 By default, the basic use of the pagination provides:
 
-The basic invocation of the "compact" pagination doesn't require any arguments (apart from the event/routing handlers, see below):
+The basic invocation of the "compact" pagination doesn’t require any arguments (apart from the event/routing handlers, see below):
 
 ```handlebars
 <Hds::Pagination::Compact />
@@ -143,11 +143,11 @@ The basic invocation of the "compact" pagination doesn't require any arguments (
 
 Renders to:
 
-In this variant only the "prev" and "next" navigation controls are displayed.
+In this variant, only the "prev" and "next" navigation controls are displayed.
 
 ### Extra arguments
 
-If necessary, it's possible to hide the labels in the controls:
+If necessary, it’s possible to hide the control labels:
 
 ```handlebars
 <Hds::Pagination::Compact @showLabels={{false}} />
@@ -191,10 +191,10 @@ get demoQueryFunctionCompact() {
 }
 ```
 
-When the routing parameters are provided, the "prev/next" controls are rendered as links and if the user clicks on one of them the page URL is automatically updated. This means that the component's state is persisted **outside** of the component and so its whole state **must** be "controlled" by the consumer's code (otherwise there would be confliting states).
+When the routing parameters are provided, the "prev/next" controls are rendered as links and the page URL is automatically updated when the user clicks them. This means that the component’s state is persisted **outside** of the component and so its whole state **must** be "controlled" by the consumer’s code (otherwise there would be conflicting states).
 
-In this case, the component doesn't update its internal "state" but the value of the state variables is **always** determined by the consumer's controller code via the component's arguments (most of the times, they are directly connected to the query parameters in the URL).
+In this case, the component doesn’t update its internal "state" but the value of the state variables is **always** determined by the consumer’s controller code via the component’s arguments (usually, they are directly connected to the query parameters in the URL).
 
-The reason for using a consumer-side function to determine the `query` argument is because it's dynamic (it depends on the value of the `page/cursor` variable) and gives consumers the ability to specify their own query parameters (they will likely be different case by case).
+The reason for using a consumer-side function to determine the `query` argument is because it’s dynamic (it depends on the value of the `page/cursor` variable) and gives consumers the ability to specify their own query parameters (which will likely differ case by case).
 
 Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.)

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -129,7 +129,42 @@ In this case, the component doesn’t update its internal "state" but the value 
 
 The reason for using a consumer-side function to determine the `query` argument is because it’s dynamic (it depends on the value of the `page` variable) and gives consumers the ability to specify their own query parameters (which will likely differ case by case).
 
-Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users’ actions (eg. for logging, tracking, etc.)
+Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users’ actions (eg. for logging, tracking, etc.).
+
+Below you can find an example of an integration between the sortable [`Table`](/components/table) component and the `Pagination::Numbered` component that uses query parameters in the URL to preserve the UI state:
+
+```handlebars
+<Hds::Table
+  @model={{this.demoPaginatedDataNumbered}}
+  @columns={{array
+    (hash key="id" label="ID" isSortable="true")
+    (hash key="name" label="Name" isSortable="true")
+    (hash key="email" label="Email")
+    (hash key="role" label="Role")
+  }}
+  @sortBy={{this.demoCurrentSortBy}}
+  @sortOrder={{this.demoCurrentSortOrder}}
+  @onSort={{this.demoOnTableSort}}
+  @density={{if (eq this.demoCurrentPageSize 30) "short" "medium"}}
+>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.data.id}}</B.Td>
+      <B.Td>{{B.data.name}}</B.Td>
+      <B.Td>{{B.data.email}}</B.Td>
+      <B.Td>{{B.data.role}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>
+<Hds::Pagination::Numbered
+  @totalItems={{this.demoTotalItems}}
+  @itemsPerPage={{this.demoCurrentPageSize}}
+  @currentPage={{this.demoCurrentPage}}
+  @pageSizes={{this.demoPageSizes}}
+  @route={{this.demoRouteName}}
+  @queryFunction={{this.demoQueryFunctionNumbered}}
+/>
+```
 
 ## How to use the "Compact" pagination
 
@@ -197,4 +232,33 @@ In this case, the component doesn’t update its internal "state" but the value 
 
 The reason for using a consumer-side function to determine the `query` argument is because it’s dynamic (it depends on the value of the `page/cursor` variable) and gives consumers the ability to specify their own query parameters (which will likely differ case by case).
 
-Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.)
+Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.).
+
+Below you can find an example of an integration between the [`Table`](/components/table) component and the `Pagination::Compact` component that uses query parameters in the URL to preserve the UI state:
+
+```handlebars
+<Hds::Table
+  @model={{this.demoPaginatedDataCompact}}
+  @columns={{array
+    (hash key="id" label="ID")
+    (hash key="name" label="Name")
+    (hash key="email" label="Email")
+    (hash key="role" label="Role")
+  }}
+>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.data.id}}</B.Td>
+      <B.Td>{{B.data.name}}</B.Td>
+      <B.Td>{{B.data.email}}</B.Td>
+      <B.Td>{{B.data.role}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>
+<Hds::Pagination::Compact
+  @route={{this.demoRouteName}}
+  @queryFunction={{this.demoQueryFunctionCompact}}
+  @isDisabledPrev={{this.demoIsDisabledPrev}}
+  @isDisabledNext={{this.demoIsDisabledNext}}
+/>
+```


### PR DESCRIPTION
### :pushpin: Summary

This PR ports the "dummy" documentation for the `Pagination` component to the Helios website (specifically, the code-related "How to use" and "Component API" sections).

👉 👉 👉 **Preview:** https://hds-website-git-hds-972-pagination-cloud-ui-re-0ef467-hashicorp.vercel.app/components/pagination

### 🚧 TODOs
- [ ]  ~~solve the problem with `btoa/atob` not being available in Node (they're browser specific functions) and fastboot complaining about it~~
  - after discussion and pairing with @Dhaulagiri we've decided that for the moment is OK this way

<img width="521" alt="screenshot_2300" src="https://user-images.githubusercontent.com/686239/215184656-534367ef-4cc7-4748-8f15-999386087b44.png">

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
