### PR TITLE
Update 'Accessibility' section for Select

### DIFF
--- a/website/docs/components/form/select/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/select/partials/accessibility/accessibility.md
@@ -1,12 +1,10 @@
-## Conformance
+## Conformance rating
 
 <Doc::Badge @type="success">Conformant</Doc::Badge>
 
 `Form::Select` is conformant when used as directed.
 
-## Accessibility
-
-### Mouse
+## Mouse interaction
 
 Hover
 
@@ -24,52 +22,41 @@ Click to select OptionList/Item
 
 ![Image of the selected state of a item in the OptionList](/assets/components/form/select/accessibility/mouse/select-click-to-select.png)
 
-### Keyboard
+## Keyboard interaction
 
-Focus
+<Doc::Badge @type="neutral">Tab</Doc::Badge>
 
-<div>
-  <Hds::Badge @color="neutral" @type="filled" @text="Tab" @size="small" />
-</div>
+Focus on tab
 
 ![Example image of focusing on the select with tab on a keyboard](/assets/components/form/select/accessibility/keyboard/select-focus.png)
 
-Open OptionList
+<Doc::Badge @type="neutral">Spacebar</Doc::Badge>
+<Doc::Badge @type="neutral"><FlightIcon @name="arrow-down" /></Doc::Badge>
 
-<div>
-  <Hds::Badge @color="neutral" @type="filled" @text="Spacebar" @size="small" />
-  <Hds::Badge @color="neutral" @type="filled" @text="↓" @size="small" />
-</div>
+Open OptionList
 
 ![Example image of selecting an item in the OptionList with spacebar](/assets/components/form/select/accessibility/keyboard/select-spacebar.png)
 
-Move between items
+<Doc::Badge @type="neutral"><FlightIcon @name="arrow-up" /></Doc::Badge>
+<Doc::Badge @type="neutral"><FlightIcon @name="arrow-down" /></Doc::Badge>
 
-<div>
-  <Hds::Badge @color="neutral" @type="filled" @text="↑" @size="small" />
-  <Hds::Badge @color="neutral" @type="filled" @text="↓" @size="small" />
-</div>
+Move between items
 
 ![Example image of moving between items with up and down arrow keys](/assets/components/form/select/accessibility/keyboard/select-arrow-keys.png)
 
-Select OptionList/Item
+<Doc::Badge @type="neutral">Enter</Doc::Badge>
 
-<div>
-  <Hds::Badge @color="neutral" @type="filled" @text="Enter" @size="small" />
-</div>
+Select OptionList/Item
 
 ![Example image of selecting an item in an OptionList with enter](/assets/components/form/select/accessibility/keyboard/select-enter.png)
 
-Close with changing
+<Doc::Badge @type="neutral">Esc</Doc::Badge>
 
-<div>
-  <Hds::Badge @color="neutral" @type="filled" @text="Esc" @size="small" />
-</div>
+Close with changing
 
 ![Example image of closing the select with the escape key](/assets/components/form/select/accessibility/keyboard/select-focus.png)
 
-
-#### Applicable WCAG Success Criteria (Reference)
+## Applicable WCAG Success Criteria
 
 This section is for reference only, some descriptions have been truncated for brevity. The `Form::Select::Base` variation of this component is conditionally conformant; that is, it is not conformant until it has an accessible name. Otherwise, this component intends to conform to the following WCAG Success Criteria:
 


### PR DESCRIPTION

### :pushpin: Summary

Update 'Accessibility' section for Select

### :hammer_and_wrench: Detailed description

 - The `## Accessibility` heading cannot be used as it introduces a duplicate `id` (we already have the accessibility section with `id="accessibility"`); it also doesn't seem in line with other components.
 - Updated navigation keys to match 'Radio Card' and 'Tabs'

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
