### PR TITLE
Tabs component: moves the icon and count inside of the button for WCAG conformance

### DIFF
--- a/.changeset/silly-dots-smile.md
+++ b/.changeset/silly-dots-smile.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Moves icon inside of tab for WCAG conformance
+Moves icon and count inside of tab (button element) for WCAG conformance

--- a/.changeset/silly-dots-smile.md
+++ b/.changeset/silly-dots-smile.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Moves icon inside of tab for WCAG conformance

--- a/packages/components/addon/components/hds/tabs/tab.hbs
+++ b/packages/components/addon/components/hds/tabs/tab.hbs
@@ -15,10 +15,11 @@
     {{#if @icon}}
       <FlightIcon @name={{@icon}} class="hds-tabs__tab-icon" role="presentation" />
     {{/if}}
-    {{yield}}
-  </button>
 
-  {{#if @count}}
-    <Hds::BadgeCount @text={{@count}} @size="small" class="hds-tabs__tab-count" />
-  {{/if}}
+    {{yield}}
+
+    {{#if @count}}
+      <Hds::BadgeCount @text={{@count}} @size="small" class="hds-tabs__tab-count" role="presentation" />
+    {{/if}}
+  </button>
 </li>

--- a/packages/components/addon/components/hds/tabs/tab.hbs
+++ b/packages/components/addon/components/hds/tabs/tab.hbs
@@ -1,9 +1,5 @@
 {{! template-lint-disable require-context-role no-invalid-role }}
 <li class={{this.classNames}} ...attributes role="presentation">
-  {{#if @icon}}
-    <FlightIcon @name={{@icon}} class="hds-tabs__tab-icon" />
-  {{/if}}
-
   <button
     class="hds-tabs__tab-button hds-typography-body-200 hds-font-weight-medium"
     role="tab"
@@ -16,6 +12,9 @@
     {{on "click" this.onClick}}
     {{on "keyup" this.onKeyUp}}
   >
+    {{#if @icon}}
+      <FlightIcon @name={{@icon}} class="hds-tabs__tab-icon" role="presentation" />
+    {{/if}}
     {{yield}}
   </button>
 

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -66,8 +66,9 @@
     $bottom: var(--token-tabs-tab-focus-inset),
     $left: var(--token-tabs-tab-focus-inset),
   );
-
   position: static;
+  display: flex;
+  align-items: center;
   padding: 0;
   color: inherit;
   background-color: transparent;
@@ -76,11 +77,12 @@
   cursor: pointer;
 
   // Expand click target area
-  &::after {
-    position: absolute;
-    content: "";
-    inset: 0;
-  }
+  // I don't think we need this anymore?
+  // &::after {
+  //   position: absolute;
+  //   content: "";
+  //   inset: 0;
+  // }
 }
 
 .hds-tabs__tab-icon {

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -77,12 +77,11 @@
   cursor: pointer;
 
   // Expand click target area
-  // I don't think we need this anymore?
-  // &::after {
-  //   position: absolute;
-  //   content: "";
-  //   inset: 0;
-  // }
+  &::after {
+    position: absolute;
+    content: "";
+    inset: 0;
+  }
 }
 
 .hds-tabs__tab-icon {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves the issue where the icon was not being rendered inside of the button (with the role of tab) element, causing a WCAG failure.

Failure that was fixed:
![CleanShot 2023-01-24 at 10 10 04](https://user-images.githubusercontent.com/4587451/214346209-77bcb4df-fbda-4371-8510-069623b30b78.png)
 
Screenshot after styles were updated, showing the active/focused tab since that should demonstrate the layout:
<img width="231" alt="" src="https://user-images.githubusercontent.com/4587451/215584925-9f830d5f-5cbd-4067-a85c-e435a939f415.png">


***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
