### PR TITLE
New docs website / Frontmatter updates ("navigation" group)

### DIFF
--- a/website/app/components/doc/page/sidebar.js
+++ b/website/app/components/doc/page/sidebar.js
@@ -38,21 +38,26 @@ const getSidebarStructuredTree = (subTree, filterQuery, currentURL) => {
   Object.keys(subTree).forEach((key) => {
     const item = subTree[key];
     if (item.pageURL) {
-      const fq = filterQuery.toLowerCase();
-      if (isFiltered) {
-        const titleMatch =
-          item.pageAttributes.title &&
-          item.pageAttributes.title.toLowerCase().includes(fq);
-        const keywordsMatch =
-          item.pageAttributes.keywords &&
-          item.pageAttributes.keywords.some((k) =>
-            k.toLowerCase().includes(fq)
-          );
-        if (titleMatch || keywordsMatch) {
+      if (!item.pageAttributes?.navigation?.hidden) {
+        const fq = filterQuery.toLowerCase();
+        if (isFiltered) {
+          const labelMatch =
+            item.pageAttributes.navigation.label &&
+            item.pageAttributes.navigation.label.toLowerCase().includes(fq);
+          const titleMatch =
+            item.pageAttributes.title &&
+            item.pageAttributes.title.toLowerCase().includes(fq);
+          const keywordsMatch =
+            item.pageAttributes.navigation.keywords &&
+            item.pageAttributes.navigation.keywords.some((k) =>
+              k.toLowerCase().includes(fq)
+            );
+          if (labelMatch || titleMatch || keywordsMatch) {
+            sidebarStructuredTree[key] = item;
+          }
+        } else {
           sidebarStructuredTree[key] = item;
         }
-      } else {
-        sidebarStructuredTree[key] = item;
       }
     } else {
       const subSubTree = getSidebarStructuredTree(item, filterQuery);

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -11,7 +11,11 @@
           @query={{hash tab=null}}
           @current-when={{"show"}}
         >
-          {{item.pageAttributes.title}}
+          {{#if item.pageAttributes.navigation.label}}
+            {{item.pageAttributes.navigation.label}}
+          {{else}}
+            {{item.pageAttributes.title}}
+          {{/if}}
         </LinkTo>
       {{else}}
         {{#if (eq @depth 1)}}

--- a/website/app/controllers/components.js
+++ b/website/app/controllers/components.js
@@ -8,14 +8,18 @@ export default class ComponentsController extends Controller {
     const cards = {};
     sections.forEach((section) => {
       cards[section] = tocTree
-        .filter((page) => page.pageParents[0] === section)
+        .filter(
+          (page) =>
+            page.pageParents[0] === section &&
+            !page.pageAttributes?.navigation?.hidden
+        )
         .map((page) => {
           return {
             image: page.pageAttributes.previewImage,
-            title: page.pageAttributes.title,
-            caption:
-              page.pageAttributes.caption ||
-              'Don\'t forget to add the "caption" to the frontmatter for this page',
+            title:
+              page.pageAttributes?.navigation?.label ||
+              page.pageAttributes.title,
+            caption: page.pageAttributes.caption,
             route: 'show',
             model: page.pageURL,
           };

--- a/website/app/controllers/foundations.js
+++ b/website/app/controllers/foundations.js
@@ -8,14 +8,18 @@ export default class FoundationsController extends Controller {
     const cards = {};
     sections.forEach((section) => {
       cards[section] = tocTree
-        .filter((page) => page.pageParents[0] === section)
+        .filter(
+          (page) =>
+            page.pageParents[0] === section &&
+            !page.pageAttributes?.navigation?.hidden
+        )
         .map((page) => {
           return {
             image: page.pageAttributes.previewImage,
-            title: page.pageAttributes.title,
-            caption:
-              page.pageAttributes.caption ||
-              'Don\'t forget to add the "caption" to the frontmatter for this page',
+            title:
+              page.pageAttributes?.navigation?.label ||
+              page.pageAttributes.title,
+            caption: page.pageAttributes.caption,
             route: 'show',
             model: page.pageURL,
           };

--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -83,10 +83,8 @@ export default class ShowRoute extends Route {
           'status',
           'links',
           'layout',
-          'hidden',
-          'order',
-          'previewImage',
-          'keywords',
+          // 'previewImage', @Brian I think we don't need this in the layout, right? or is it needed somehow the <head> metadata?
+          'navigation',
         ];
         frontmatterAttributes.forEach((attribute) => {
           if (attribute in res.data.attributes) {

--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -83,7 +83,7 @@ export default class ShowRoute extends Route {
           'status',
           'links',
           'layout',
-          // 'previewImage', @Brian I think we don't need this in the layout, right? or is it needed somehow the <head> metadata?
+          'previewImage', // this is needed by the `head-data` to generate the `og:image` in the page <head>
           'navigation',
         ];
         frontmatterAttributes.forEach((attribute) => {

--- a/website/blueprints/hds-component-docs/files/docs/components/__name__/index.md
+++ b/website/blueprints/hds-component-docs/files/docs/components/__name__/index.md
@@ -6,9 +6,10 @@ status: released
 links:
   figma: {link to the "<%= columnizedModuleName %>" page in the components Figma library}
   github: {link to the "<%= columnizedModuleName %>" component's folder in the GitHub repo}
-hidden: true
 previewImage: assets/illustrations/components/<%= kebabizedModuleName %>.jpg
-keywords: ['add', 'alternate', 'keywords', 'here']
+navigation:
+  hidden: true
+  keywords: ['add', 'alternate', 'keywords', 'here']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/about/accessibility-statement.md
+++ b/website/docs/about/accessibility-statement.md
@@ -1,6 +1,7 @@
 ---
 title: Accessibility statement
-order: 105
+navigation:
+  order: 105
 ---
 
 We believe accessibility is a core requirement and not an optional feature. Our approach to accessibility closely aligns with our [HashiCorp principles](https://www.hashicorp.com/our-principles), such as our core principle of integrity.

--- a/website/docs/about/contribution.md
+++ b/website/docs/about/contribution.md
@@ -1,6 +1,7 @@
 ---
 title: Contribution
-order: 104
+navigation:
+  order: 104
 ---
 
 !!! Info

--- a/website/docs/about/overview.md
+++ b/website/docs/about/overview.md
@@ -2,7 +2,8 @@
 title: Overview
 caption: Get an overview of the design system.
 description: Learn about the Helios Design System, why it exists, and the strategy behind the system.
-order: 101
+navigation:
+  order: 101
 ---
 
 ## What is a design system?

--- a/website/docs/about/principles.md
+++ b/website/docs/about/principles.md
@@ -2,7 +2,8 @@
 title: Principles
 description: We consider the whole when creating the parts.
 caption: Read the principles that guide the design system team.
-order: 102
+navigation:
+  order: 102
 layout:
   sidecar: false
 ---

--- a/website/docs/about/support.md
+++ b/website/docs/about/support.md
@@ -1,6 +1,7 @@
 ---
 title: Support
-order: 103
+navigation:
+  order: 103
 ---
 
 !!! Info

--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=1377%3A11987
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/alert
 previewImage: assets/illustrations/components/alert.jpg
-keywords: ['alert', 'toast', 'notification', 'banner', 'message']
+navigation:
+  keywords: ['alert', 'toast', 'notification', 'banner', 'message']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/avatar/index.md
+++ b/website/docs/components/avatar/index.md
@@ -2,7 +2,8 @@
 title: Avatar
 description: An avatar
 caption: An avatar
-hidden: true
+navigation:
+  hidden: true
 previewImage: assets/illustrations/components/avatar.jpg
 ---
 

--- a/website/docs/components/badge-count/index.md
+++ b/website/docs/components/badge-count/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A20946&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/badge-count
 previewImage: assets/illustrations/components/badge-count.jpg
-keywords: ['chip', 'pill', 'version number', 'counter']
+navigation:
+  keywords: ['chip', 'pill', 'version number', 'counter']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2337%3A20761&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/badge
 previewImage: assets/illustrations/components/badge.jpg
-keywords: ['chip', 'pill', 'tag', 'label']
+navigation:
+  keywords: ['chip', 'pill', 'tag', 'label']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=3073%3A11771&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/breadcrumb
 previewImage: assets/illustrations/components/breadcrumb.jpg
-keywords: ['navigation', 'crumb', 'path']
+navigation:
+  keywords: ['navigation', 'crumb', 'path']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/button-set/index.md
+++ b/website/docs/components/button-set/index.md
@@ -6,7 +6,8 @@ status: code-only
 links:
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button-set
 previewImage: assets/illustrations/components/button-set.jpg
-keywords: ['button group', 'button', 'button spacing', 'button alignment', 'button layout']
+navigation:
+  keywords: ['button group', 'button', 'button spacing', 'button alignment', 'button layout']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/button/index.md
+++ b/website/docs/components/button/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A21001&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button
 previewImage: assets/illustrations/components/button.jpg
-keywords: ['action', 'link']
+navigation:
+  keywords: ['action', 'link']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/card/index.md
+++ b/website/docs/components/card/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2359%3A19245&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/card
 previewImage: assets/illustrations/components/card.jpg
-keywords: ['tile', 'container', 'box']
+navigation:
+  keywords: ['tile', 'container', 'box']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=5633%3A16319&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/dropdown
 previewImage: assets/illustrations/components/dropdown.jpg
-keywords: ['select', 'menu', 'action menu', 'list']
+navigation:
+  keywords: ['select', 'menu', 'action menu', 'list']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/empty-state/index.md
+++ b/website/docs/components/empty-state/index.md
@@ -1,6 +1,7 @@
 ---
 title: EmptyState
-hidden: true
+navigation:
+  hidden: true
 ---
 
 <section data-tab="Code">

--- a/website/docs/components/flyout/index.md
+++ b/website/docs/components/flyout/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=23645%3A53756&t=FL2rOHuh3Trg6gxA-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/flyout
 previewImage: assets/illustrations/components/flyout.jpg
-keywords: ['drawer', 'panel', 'side', 'modal']
+navigation:
+  keywords: ['drawer', 'panel', 'side', 'modal']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/flyout/index.md
+++ b/website/docs/components/flyout/index.md
@@ -4,7 +4,7 @@ description: Displays additional details and information about an item or object
 caption: Displays additional details and information about an item or object, overlaid on the main page content.
 status: experimental
 links:
-  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=23645%3A53756&t=FL2rOHuh3Trg6gxA-1
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=23645%3A53756
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/flyout
 previewImage: assets/illustrations/components/flyout.jpg
 navigation:

--- a/website/docs/components/form/checkbox/index.md
+++ b/website/docs/components/form/checkbox/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=9120%3A23132&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/checkbox
 previewImage: assets/illustrations/components/form/checkbox.jpg
-keywords: ['option', 'select']
+navigation:
+  keywords: ['option', 'select']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/primitives/index.md
+++ b/website/docs/components/form/primitives/index.md
@@ -3,12 +3,12 @@ title: Primitives
 description: Elements used to compose form fields.
 caption: Elements used to compose form fields.
 status: released
-navigation:
-  order: 99
 links:
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form
 previewImage: assets/illustrations/components/form/primitives.jpg
-keywords: ['form', 'base controls', 'field', 'label', 'legend', 'fieldset', 'input']
+navigation:
+  order: 99
+  keywords: ['form', 'base controls', 'field', 'label', 'legend', 'fieldset', 'input']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/primitives/index.md
+++ b/website/docs/components/form/primitives/index.md
@@ -3,7 +3,8 @@ title: Primitives
 description: Elements used to compose form fields.
 caption: Elements used to compose form fields.
 status: released
-order: 99
+navigation:
+  order: 99
 links:
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form
 previewImage: assets/illustrations/components/form/primitives.jpg

--- a/website/docs/components/form/radio-card/index.md
+++ b/website/docs/components/form/radio-card/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=17482%3A56258&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/radio-card
 previewImage: assets/illustrations/components/form/radio-card.jpg
-keywords: ['container', 'tile', 'select', 'box']
+navigation:
+  keywords: ['container', 'tile', 'select', 'box']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/radio/index.md
+++ b/website/docs/components/form/radio/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13181%3A36977&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/radio
 previewImage: assets/illustrations/components/form/radio.jpg
-keywords: ['radio group', 'radio button', 'select']
+navigation:
+  keywords: ['radio group', 'radio button', 'select']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/select/index.md
+++ b/website/docs/components/form/select/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=14283%3A34475&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/select
 previewImage: assets/illustrations/components/form/select.jpg
-keywords: ['dropdown', 'form']
+navigation:
+  keywords: ['dropdown', 'form']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=11530%3A28348&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/text-input
 previewImage: assets/illustrations/components/form/text-input.jpg
-keywords: ['text field', 'search', 'form']
+navigation:
+  keywords: ['text field', 'search', 'form']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/textarea/index.md
+++ b/website/docs/components/form/textarea/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13343%3A31585&t=pDgL7LJUJXZUN7Xq-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/textarea
 previewImage: assets/illustrations/components/form/textarea.jpg
-keywords: ['text field', 'textbox', 'text box', 'form']
+navigation:
+  keywords: ['text field', 'textbox', 'text box', 'form']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/toggle/index.md
+++ b/website/docs/components/form/toggle/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13181%3A36435&t=pDgL7LJUJXZUN7Xq-3
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/toggle
 previewImage: assets/illustrations/components/form/toggle.jpg
-keywords: ['toggle button', 'switch', 'light switch']
+navigation:
+  keywords: ['toggle button', 'switch', 'light switch']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2632%3A8072&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/icon-tile
 previewImage: assets/illustrations/components/icon-tile.jpg
-keywords: ['symbol', 'logo']
+navigation:
+  keywords: ['symbol', 'logo']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/link/inline/index.md
+++ b/website/docs/components/link/inline/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2365%3A21590&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/link
 previewImage: assets/illustrations/components/link/inline.jpg
-keywords: ['hyperlink', 'anchor', 'external link', 'text link']
+navigation:
+  keywords: ['hyperlink', 'anchor', 'external link', 'text link']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/link/standalone/index.md
+++ b/website/docs/components/link/standalone/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2365%3A21590&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/link
 previewImage: assets/illustrations/components/link/standalone.jpg
-keywords: ['hyperlink', 'anchor', 'external link', 'text link', 'cta']
+navigation:
+  keywords: ['hyperlink', 'anchor', 'external link', 'text link', 'cta']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=22928%3A56204&t=pDgL7LJUJXZUN7Xq-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/modal
 previewImage: assets/illustrations/components/modal.jpg
-keywords: ['flyout', 'popover', 'popup', 'dialog']
+navigation:
+  keywords: ['flyout', 'popover', 'popup', 'dialog']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/pagination/index.md
+++ b/website/docs/components/pagination/index.md
@@ -7,6 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=18709%3A42011&t=pIE459t8qucXP9uR-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/pagination
 previewImage: assets/illustrations/components/pagination.jpg
+navigation:
+  hidden: true
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/stepper/index.md
+++ b/website/docs/components/stepper/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=15313%3A50538&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/stepper
 previewImage: assets/illustrations/components/stepper.jpg
-keywords: ['progress', 'progress bar', 'steps', 'tracker']
+navigation:
+  keywords: ['progress', 'progress bar', 'steps', 'tracker']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/table/index.md
+++ b/website/docs/components/table/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=18814%3A54972&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/table
 previewImage: assets/illustrations/components/table.jpg
-keywords: ['data table', 'data grid', 'datagrid', 'grid', 'list']
+navigation:
+  keywords: ['data table', 'data grid', 'datagrid', 'grid', 'list']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/tabs/index.md
+++ b/website/docs/components/tabs/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=16384%3A46484&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/tabs
 previewImage: assets/illustrations/components/tabs.jpg
-keywords: ['tabbed interface']
+navigation:
+  keywords: ['tabbed interface']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13720%3A34360&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/tag
 previewImage: assets/illustrations/components/tag.jpg
-keywords: ['chip', 'badge', 'pill', 'label', 'filter'] 
+navigation:
+  keywords: ['chip', 'badge', 'pill', 'label', 'filter']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/toast/index.md
+++ b/website/docs/components/toast/index.md
@@ -7,7 +7,8 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=7636%3A30467&t=XC8SUxxJOFHgqYzK-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/toast
 previewImage: assets/illustrations/components/toast.jpg
-keywords: ['alert', 'toast', 'notification', 'banner', 'message']
+navigation:
+  keywords: ['alert', 'toast', 'notification', 'banner', 'message']
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/getting-started/adoption.md
+++ b/website/docs/getting-started/adoption.md
@@ -1,8 +1,9 @@
 ---
 title: Adoption
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-order: 103
-hidden: true
+navigation:
+  order: 103
+  hidden: true
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/getting-started/for-designers.md
+++ b/website/docs/getting-started/for-designers.md
@@ -1,6 +1,8 @@
 ---
 title: Getting started for designers
-order: 101
+navigation:
+  order: 101
+  label: For designers
 ---
 
 
@@ -16,16 +18,16 @@ For documentation around broader Figma best practices within HashiCorp design te
 ## Enabling Helios libraries
 
 1. Open the Library modal via one of the following methods:
-    
-    - Click the `Assets` panel in the left sidebar, then click the `book` icon to open the modal. 
-    
+
+    - Click the `Assets` panel in the left sidebar, then click the `book` icon to open the modal.
+
     ![Opening the library modal via the assets panel](/assets/getting-started/designers/enable-libraries-icon.png =295x*)
-    
-    - Click the `Figma` icon in the top toolbar, then click "Libraries". 
-    
+
+    - Click the `Figma` icon in the top toolbar, then click "Libraries".
+
     ![Opening the library modal via the menu](/assets/getting-started/designers/enable-libraries-menu.png =290x*)
 
-    - Or use the keyboard shortcut: 
+    - Or use the keyboard shortcut:
 
         - Mac: `⌥ option`+`3`
         - Windows: `alt`+`3`
@@ -47,7 +49,7 @@ Once the libraries are enabled, you can access the components from the [assets p
 
 ## Foundational styles
 
-Styles, sometimes referred to as Tokens, allow consistent application of color (as a fill or stroke), typography, and effects within Figma. You can find these in the [Product Foundations library](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=2916%3A4&t=5MKbTaM2QzE0F5KA-1). 
+Styles, sometimes referred to as Tokens, allow consistent application of color (as a fill or stroke), typography, and effects within Figma. You can find these in the [Product Foundations library](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=2916%3A4&t=5MKbTaM2QzE0F5KA-1).
 
 Because the usage of Helios Foundations reinforces consistency across the products, we don’t recommend detaching from these styles within your designs.
 
@@ -61,7 +63,7 @@ Because the usage of Helios Foundations reinforces consistency across the produc
 
 ![Applying styles to a text layer](/assets/getting-started/designers/apply-text-style.png =784x*)
 
-To learn more about how to use the foundational styles, visit: 
+To learn more about how to use the foundational styles, visit:
 
 - [Colors](/foundations/colors)
 - [Typography](/foundations/typography)
@@ -92,11 +94,11 @@ A component inserted from a library into a project is called an [instance](https
 
 ### Adding components to your project
 
-Add Helios components to your design project by inserting them directly from the assets panel or resources menu or copying the component from the stickersheet and pasting it into your project. 
+Add Helios components to your design project by inserting them directly from the assets panel or resources menu or copying the component from the stickersheet and pasting it into your project.
 
 #### Inserting from the assets panel
 
-1. Open the [assets panel](https://help.figma.com/hc/en-us/articles/360038663994-Name-and-organize-components#assetspanel) by clicking "Assets" at the top of the left sidebar. 
+1. Open the [assets panel](https://help.figma.com/hc/en-us/articles/360038663994-Name-and-organize-components#assetspanel) by clicking "Assets" at the top of the left sidebar.
 
 2. Scroll through the list or use the search feature to locate the component you’d like to use.
 
@@ -104,13 +106,13 @@ Add Helios components to your design project by inserting them directly from the
 
 3. Click and drag the component into the canvas or frame.
 
-4. Configure the component properties as necessary in the right sidebar. 
+4. Configure the component properties as necessary in the right sidebar.
 
 ![Inserting components from the assets panel](/assets/getting-started/designers/component-assets-panel.png =895x*)
 
 #### Inserting from the resources menu
 
-Open the [resources menu](https://help.figma.com/hc/en-us/articles/360039150413-Swap-components-and-instances#quick-insert) (`shift`+`i`) in the toolbar to expose a list of recently used components, plugins, and widgets enabled in your project. Use this method to access your more commonly or recently used components quickly.  
+Open the [resources menu](https://help.figma.com/hc/en-us/articles/360039150413-Swap-components-and-instances#quick-insert) (`shift`+`i`) in the toolbar to expose a list of recently used components, plugins, and widgets enabled in your project. Use this method to access your more commonly or recently used components quickly.
 
 ![Inserting components from the resources menu](/assets/getting-started/designers/component-resources-panel.png =321x*)
 
@@ -122,13 +124,13 @@ If you prefer to select a component visually, the [Product Components](https://w
 
 2. Navigate to the relevant component page.
 
-3. Select and copy the component variant from the stickersheet. 
+3. Select and copy the component variant from the stickersheet.
 
-4. Navigate back to your project file and paste the component wherever needed. 
+4. Navigate back to your project file and paste the component wherever needed.
 
 ![Copy from the stickersheet](/assets/getting-started/designers/copy-from-stickersheet.png =752x*)
 
-### Working with components 
+### Working with components
 
 #### Detaching components
 
@@ -140,7 +142,7 @@ Contact us for [support](/about/support) or [request a new component](https://do
 
 #### Overriding component styles
 
-While you can technically override the styles within a component without detaching it, we recommend against doing so without consulting the Design Systems Team first. 
+While you can technically override the styles within a component without detaching it, we recommend against doing so without consulting the Design Systems Team first.
 
 Changing a component's color or font size may seem simple, but this can have trickle-down effects in code. Overriding styles forces engineers to create custom classes and styles to implement the changes. Overriding styles can have unexpected long-term effects within the [CSS cascade](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#:~:text=The%20cascade%20is%20an%20algorithm,a%20property%20on%20an%20element) and lead to tech debt. In addition to being difficult to scale, overrides nudge the design language of your product out of sync with Helios and the rest of the HashiCorp product suite.
 
@@ -163,7 +165,7 @@ Components and patterns unique to your product should be designed and built loca
 
 ![Local component patterns](/assets/getting-started/designers/local-component-patterns.png =706x*)
 
-When creating local components for your product, it’s helpful to separate them from your main project files and house them in their own Figma library file. Using a dedicated library creates a consistent location for your product’s local components so that other designers on your team can access and use them. 
+When creating local components for your product, it’s helpful to separate them from your main project files and house them in their own Figma library file. Using a dedicated library creates a consistent location for your product’s local components so that other designers on your team can access and use them.
 
 !!! Insight
 
@@ -172,7 +174,7 @@ Consider using [Atomic Design](https://bradfrost.com/blog/post/atomic-web-design
 
 ## Patterns
 
-We’ve spent much of the past year building lower-level components and, therefore, don’t yet offer <LinkTo class="doc-link-generic" @route="patterns">patterns</LinkTo>. 
+We’ve spent much of the past year building lower-level components and, therefore, don’t yet offer <LinkTo class="doc-link-generic" @route="patterns">patterns</LinkTo>.
 
 See which patterns we plan to work on in the [Helios roadmap](https://go.hashi.co/hds-rollout).
 
@@ -180,7 +182,7 @@ See which patterns we plan to work on in the [Helios roadmap](https://go.hashi.c
 
 ### Helios Figma libraries
 
-HashiCorp product teams can use the Helios libraries published under the [HDS Design System UI Kit](https://www.figma.com/files/team/1030156573400567478) team within Figma. 
+HashiCorp product teams can use the Helios libraries published under the [HDS Design System UI Kit](https://www.figma.com/files/team/1030156573400567478) team within Figma.
 
 - [Product Components](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?t=Ooe3pkDap3cGcgAH-1): the set of components published in the Helios Design System
 - [Product Foundations](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?t=4kdgl88SMIiEYhbA-1): core styles including typography, color, and elevation that are consumed by Helios components for reuse in your projects
@@ -208,7 +210,7 @@ Explore more content about libraries, components, and styles directly from Figma
 - [Apply styles to layers and objects](https://help.figma.com/hc/en-us/articles/360040316193-Apply-Styles-to-layers-and-objects)
 - [Guide to components](https://help.figma.com/hc/en-us/articles/360038662654-Guide-to-components-in-Figma)
 
---- 
+---
 
 ## Support
 

--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -1,6 +1,8 @@
 ---
 title: Getting started for engineers
-order: 102
+navigation:
+  order: 102
+  label: For engineers
 ---
 
 The Design Systems Team maintains design tokens, icons, and components in a [monorepo](https://github.com/hashicorp/design-system) and publishes them regularly to npm.

--- a/website/docs/getting-started/tutorials.md
+++ b/website/docs/getting-started/tutorials.md
@@ -1,8 +1,9 @@
 ---
 title: Tutorials
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-order: 105
-hidden: true
+navigation:
+  order: 105
+  hidden: true
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/overrides/power-select/index.md
+++ b/website/docs/overrides/power-select/index.md
@@ -3,7 +3,8 @@ title: PowerSelect
 description: Style overrides for the ember-power-select addon.
 caption: Style overrides for the ember-power-select addon.
 previewImage: assets/illustrations/overrides/power-select.jpg
-keywords: ['select', 'dropdown', 'menu']
+navigation:
+  keywords: ['select', 'dropdown', 'menu']
 ---
 
 <section data-tab="Code">

--- a/website/docs/patterns/button-alignment/index.md
+++ b/website/docs/patterns/button-alignment/index.md
@@ -1,7 +1,8 @@
 ---
 title: Button alignment
 description: Guidelines for aligning, ordering, and grouping action buttons.
-hidden: true
+navigation:
+  hidden: true
 ---
 
 <section data-tab="Overview">

--- a/website/docs/testing/markdown/basic-styling.md
+++ b/website/docs/testing/markdown/basic-styling.md
@@ -1,6 +1,7 @@
 ---
 title: Basic styling
-order: 99
+navigation:
+  order: 99
 ---
 
 # Header 1

--- a/website/docs/updates/newsletter.md
+++ b/website/docs/updates/newsletter.md
@@ -1,8 +1,9 @@
 ---
 title: Newsletter
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-order: 103
-hidden: true
+navigation:
+  order: 103
+  hidden: true
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/updates/release-notes.md
+++ b/website/docs/updates/release-notes.md
@@ -1,8 +1,9 @@
 ---
 title: Release notes
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-order: 101
-hidden: true
+navigation:
+  order: 101
+  hidden: true
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/updates/roadmap.md
+++ b/website/docs/updates/roadmap.md
@@ -1,8 +1,9 @@
 ---
 title: Roadmap
 description: This is the (missing) long description of the component, that will come from the frontmatter attributes
-order: 102
-hidden: true
+navigation:
+  order: 102
+  hidden: true
 ---
 
 ## Lorem ipsum dolor

--- a/website/docs/utilities/disclosure/index.md
+++ b/website/docs/utilities/disclosure/index.md
@@ -3,7 +3,8 @@ title: Disclosure
 description: An internal utility component that provides show/hide functionality.
 caption: An internal utility component that provides show/hide functionality.
 previewImage: assets/illustrations/utilities/disclosure.jpg
-keywords: ['show', 'hide', 'accordion', 'dropdown', 'reveal']
+navigation:
+  keywords: ['show', 'hide', 'accordion', 'dropdown', 'reveal']
 ---
 
 <section data-tab="Code">

--- a/website/docs/utilities/dismiss-button/index.md
+++ b/website/docs/utilities/dismiss-button/index.md
@@ -3,7 +3,8 @@ title: Dismiss Button
 description: An internal utility component used to provide "dismiss" functionality in other components.
 caption: An internal utility component used to provide "dismiss" functionality in other components.
 previewImage: assets/illustrations/utilities/dismiss-button.jpg
-keywords: ['dismiss', 'button', 'close', 'exit']
+navigation:
+  keywords: ['dismiss', 'button', 'close', 'exit']
 ---
 
 <section data-tab="Code">

--- a/website/docs/utilities/interactive/index.md
+++ b/website/docs/utilities/interactive/index.md
@@ -3,7 +3,8 @@ title: Interactive
 description: An internal utility component used to provide interactivity to other components.
 caption: An internal utility component used to provide interactivity to other components.
 previewImage: assets/illustrations/utilities/interactive.jpg
-keywords: ['interactive', 'button', 'link']
+navigation:
+  keywords: ['interactive', 'button', 'link']
 ---
 
 <section data-tab="Code">

--- a/website/lib/markdown/index.js
+++ b/website/lib/markdown/index.js
@@ -73,7 +73,10 @@ module.exports = {
       'patterns',
       'error',
     ];
-    const docsURLs = flatPageListJson.flat.map((page) => page.pageURL);
+    const docsURLs = flatPageListJson.flat
+      // since this list will used to generate the sitemap.xml file, we need to hide the `hidden` pages from the output
+      .filter((page) => !page.pageAttributes?.navigation?.hidden)
+      .map((page) => page.pageURL);
 
     return [...staticURLs, ...docsURLs];
   },

--- a/website/lib/markdown/markdown-to-jsonapi.js
+++ b/website/lib/markdown/markdown-to-jsonapi.js
@@ -24,10 +24,8 @@ class MarkdownToJsonApi extends PersistentFilter {
         'status',
         'links',
         'layout',
-        'hidden',
-        'order',
         'previewImage',
-        'keywords',
+        'navigation',
       ],
     };
 

--- a/website/lib/markdown/table-of-contents.js
+++ b/website/lib/markdown/table-of-contents.js
@@ -23,10 +23,12 @@ const CATEGORIES = [
 const sortPages = (s1, s2) => {
   // if they are siblings...
   if (isEqual(s1.pageParents, s2.pageParents)) {
-    //  we use the order first...
-    if (s1.pageAttributes.order < s2.pageAttributes.order) {
+    // we use the order first... (notice: we know it's _always_ defined in the TOC items)
+    const o1 = s1.pageAttributes.navigation.order;
+    const o2 = s2.pageAttributes.navigation.order;
+    if (o1 < o2) {
       return -1;
-    } else if (s1.pageAttributes.order > s2.pageAttributes.order) {
+    } else if (o1 > o2) {
       return 1;
     } else {
       // or we fallback to sort alphabetically
@@ -97,29 +99,28 @@ class TableOfContents extends Plugin {
         pageAttributes = pick(jsonData.data.attributes, [
           'title',
           'caption',
-          'order',
-          'hidden',
+          'navigation',
           'previewImage',
-          'keywords',
         ]);
       } else {
         console.log('File NOT found!', fullFilePath);
         pageAttributes = {};
       }
 
-      // assign an "order" using the frontmatter value (or a default)
+      // assign a default "order" value if not explicitly set
       // notice: it's used for sorting criteria in the navigation
-      pageAttributes.order = pageAttributes.order ?? 100;
-
-      if (!pageAttributes.hidden) {
-        flatPageList.push({
-          filePath,
-          pageURL,
-          pageName,
-          pageParents,
-          pageAttributes,
-        });
+      if (!pageAttributes?.navigation?.order) {
+        // IMPORTANT: this automatically ensures that `pageAttributes.navigation` is always defined! (no need to check that exists in other parts of the codebase)
+        set(pageAttributes, 'navigation.order', 100);
       }
+
+      flatPageList.push({
+        filePath,
+        pageURL,
+        pageName,
+        pageParents,
+        pageAttributes,
+      });
     });
 
     // notice: we pre-sort the list so we don't need to do it in the structured tree (much harder!)

--- a/wiki/Website-Doc-folder.md
+++ b/wiki/Website-Doc-folder.md
@@ -107,10 +107,12 @@ links:
 layout:
   cover: false
   sidecar: false
-order: 101
-hidden: false
+navigation:
+  order: 101
+  keywords: ['alert', 'toast', 'notification', 'banner', 'message']
+  label: Alert
+  hidden: false
 previewImage: assets/illustrations/components/alert.jpg
-keywords: ['alert', 'toast', 'notification', 'banner', 'message']
 ---
 ```
 
@@ -135,14 +137,18 @@ The "frontmatter" attributes that we support are the following:
       If the page "cover" is visible - default is `true`
     * `sidecar`
       If the page "sidecar" is visible (if not, the content will fill the entire available space) - default is `true`
-*   `order`
-    Used to control the order of the pages in navigational lists (lower value moves up the page, higher value moves it down) - default is `100`
-*   `hidden`
-    Used to hide the page from the sidebar navigation and the lists on the landing pages - default is `false`
+*   `navigation`
+    Meta-information related to the listing of the page in navigational contexts (eg. sidebar, cards).
+    * `order`
+      Used to control the order of the pages in navigational lists (lower value moves up the page, higher value moves it down) - default is `100`
+    * `keywords`
+      An optional list of keywords that the page can be found with, when a filter is applied to a list of pages.
+    * `label`
+      Alternative text to use in the sidebar navigation, instead of the `title` (which is used by default)
+    * `hidden`
+      Used to hide the page from the sidebar navigation and the lists on the landing pages - default is `false`
 *   `previewImage`
     An optional full path to an image used when listing the page as "card" (eg. in landing pages). The path refers to the `dist` folder generated at build time, so is relative to the content of the `/website/public` folder.
-*   `keywords`
-    An optional list of keywords that the page can be found with, when a filter is applied to a list of pages.
 
 
 Only the `title` attribute is technically required, all the others are optional (even though some of them like `description` and `caption` are necessary for component pages).


### PR DESCRIPTION
### :pushpin: Summary

This PR tries to solve a few different issues around the frontmatter declarations
- pages with `hidden: true` are not just hidden from the navigation, but not rendered at all (making it hard to develop or share work in progress with other people)
- there have been a couple of cases in which we needed the label (eg _For designers_) in the sidebar to be different from the page title (eg. _Getting started for designers_).
- there's a bunch of frontmatter properties that are strictly related but scattered around, making it hard to understand at first sight what are the properties of a document.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the "frontmatter" block in our markdown files to introduce a new `navigation` property/block
  - moved `order`, `hidden` and `keywords` under it
  - added `label` to it
- updated the markdown-to-json conversion code to use `navigation` in “frontmatter”
  - IMPORTANT: now all the pages are listed under the `toc.json` files, even if they have `hidden: true` but they’re simply not listed in the sidebar or the cards decks
  - @Dhaulagiri we have to understand how to avoid that they appear in the sitemap file, though (I have some ideas but let's discuss what options we have)
- updated “sidebar” to use new `navigation` object and keys/values
- updated “cards lists” to use new `navigation` object and keys/values
- updated `show` route to use new `navigation` object and keys/values
- updated the “wiki" documentation to reflect these changes

👉 👉 👉 **Previews**:
- **About section** - see "For designers/developers" in the sidebar: https://hds-website-git-new-docs-website-frontmatter-updates-hashicorp.vercel.app/about
- **Components section** - see the order is the same as the previous one, and the `Avatar` page is not listed in the sidebar or cards: https://hds-website-git-new-docs-website-frontmatter-updates-hashicorp.vercel.app/components
- Avatar page - see how it's available and rendered correctly, despite being "hidden": https://hds-website-git-new-docs-website-frontmatter-updates-hashicorp.vercel.app/components/avatar
  - Same thing for the "Button alignment" pattern page: https://hds-website-git-new-docs-website-frontmatter-updates-hashicorp.vercel.app/patterns/button-alignment

### 🚧 Things to do/decide/discuss before merging
- [x] make sure all the pages have the updated frontmatter format (new docs pages were added after the PR was approved)
- [x] what is the name of the frontmatter block: `navigation`, `listing`, `catalog`, other ideas?
   - decided to use `navigation`
- [x] should we move `previewImage` under the `navigation` block as well?
   - decided to leave it as is
- [x] how to avoid that the "hidden" pages appear in the sitemap file (with @Dhaulagiri)

### :link: External links

Jira tickets:
- https://github.com/hashicorp/design-system/pull/1137

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
