### PR TITLE
New docs website / Fix issue with sidebar filter results persisting across pages

### DIFF
--- a/website/app/components/doc/page/sidebar.hbs
+++ b/website/app/components/doc/page/sidebar.hbs
@@ -33,6 +33,7 @@
     {{#if (or this.structuredPageTree this.isFiltered)}}
       <div class="doc-page-sidebar__filter">
         <Doc::Form::Filter
+          @filterQuery={{this.filterQuery}}
           @placeholder="Filter sidebar"
           autocomplete="off"
           autocorrect="off"

--- a/website/app/components/doc/page/sidebar.js
+++ b/website/app/components/doc/page/sidebar.js
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
 import { restartableTask, timeout } from 'ember-concurrency';
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 const DEBOUNCE_MS = 250;
 
@@ -79,7 +81,17 @@ const isActiveTree = (subTree, currentURL) => {
 };
 
 export default class DocPageSidebarComponent extends Component {
+  @service router;
+
   @tracked filterQuery = '';
+
+  constructor() {
+    super(...arguments);
+
+    // used to detect changes in top-route navigation
+    this._currentTopRoute = this.args.currentTopRoute;
+    this.router.on('routeDidChange', this.onRouteDidChange);
+  }
 
   get isFiltered() {
     return this.filterQuery !== '';
@@ -134,5 +146,13 @@ export default class DocPageSidebarComponent extends Component {
     yield timeout(DEBOUNCE_MS);
 
     this.filterQuery = filterQuery.trim();
+  }
+
+  @action
+  onRouteDidChange() {
+    if (this._currentTopRoute !== this.args.currentTopRoute) {
+      this.filterQuery = '';
+    }
+    this._currentTopRoute = this.args.currentTopRoute;
   }
 }

--- a/website/app/templates/application.hbs
+++ b/website/app/templates/application.hbs
@@ -14,6 +14,7 @@
     @toc={{this.model.toc}}
     @currentPath={{this.target.currentPath}}
     @currentRoute={{this.target.currentRoute}}
+    @currentTopRoute={{this.currentTopRoute}}
   />
   {{outlet}}
   <Doc::Page::Footer />


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes a bug where the sidebar filter "query" was persisting across pages.

Notice: this is the best way I could find to solve the problem, if you have other suggestions please chime in in the comments/review.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated sidebar logic to reset filter when `currentTopRoute` change across route transitions

👉 👉 👉 **Preview:** https://hds-website-git-new-docs-website-fix-sidebar-f-45a48c-hashicorp.vercel.app/

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1428

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
