### PR TITLE
Allow deep linking

### DIFF
--- a/website/app/controllers/application.js
+++ b/website/app/controllers/application.js
@@ -20,6 +20,7 @@ export default class ApplicationController extends Controller {
 
   routeDidChange() {
     scheduleOnce('afterRender', this, this.resetSidebar);
+    scheduleOnce('afterRender', this, this.scrollToId);
   }
 
   willDestroy() {
@@ -42,6 +43,19 @@ export default class ApplicationController extends Controller {
         cancel(this.runLater);
       }
     }
+  }
+
+  scrollToId() {
+    later(
+      this,
+      function () {
+        let id = this.target?.url?.split('#')[1];
+        if (id) {
+          document.getElementById(id)?.scrollIntoView();
+        }
+      },
+      1
+    );
   }
 
   showSidebarOnSmallViewport() {

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -164,8 +164,6 @@ export default class ShowController extends Controller {
     if (this.tabs.length > 1 && this.currentActiveTabIndex != 0) {
       // for consistency we always set the query param tab to a lowercase version of the tab label
       set(this, 'selectedTab', this.tabs[current].label.toLowerCase());
-    } else {
-      set(this, 'selectedTab', null);
     }
 
     // leave for debugging

--- a/website/tests/acceptance/component-query-test.js
+++ b/website/tests/acceptance/component-query-test.js
@@ -46,7 +46,7 @@ module('Acceptance | Component Tabs', function (hooks) {
   test('specifying a component tab that does not exist defaults to the first tab', async function (assert) {
     await visit('/components/alert?tab=wubalubadubdub');
 
-    assert.strictEqual(currentURL(), '/components/alert');
+    assert.strictEqual(currentURL(), '/components/alert?tab=wubalubadubdub');
 
     assert.dom('.doc-page-tabs__tab--is-current').exists({ count: 1 });
     assert


### PR DESCRIPTION
### :pushpin: Summary

Allow deep linking – linking to headings or sections using URI fragments.

Preview link: https://hds-website-git-alex-ju-allow-fragment-navigation-hashicorp.vercel.app/components/alert#usage

### :hammer_and_wrench: Detailed description

There are two commits in this PR:
 - one that identifies when the fragment gets removed (there's a tradeoff here)
 - another one that proposes a solution for automatic scroll to heading/section, if the `id` exists on the page

Note: code is rather snappy, but wanted to get it up to get feedback

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1419](https://hashicorp.atlassian.net/browse/HDS-1419)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1419]: https://hashicorp.atlassian.net/browse/HDS-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ