### PR TITLE
New docs website / Fix "patterns" sidebar

### DIFF
--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -78,6 +78,7 @@
 
 
 // ERROR PAGE
+
 body.application.error {
   @include breakpoint.with-fixed-sidebar () {
     .doc-page-footer {
@@ -86,3 +87,13 @@ body.application.error {
   }
 }
 
+// PATTERNS PAGE
+// This is temporary and will be removed as soon as a pattern page is added to the section
+
+body.application.patterns {
+  @include breakpoint.with-fixed-sidebar () {
+    .doc-page-footer {
+      padding-left: 0;
+    }
+  }
+}

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -162,8 +162,20 @@ body.application:not(.index) {
 
 // ERROR PAGE
 // also if you want to change this, change footer.scss too
+
 body.application.error {
   @include breakpoint.with-fixed-sidebar () {
+    .doc-page-sidebar {
+      display: none;
+    }
+  }
+}
+
+// PATTERNS PAGE
+// This is temporary and will be removed as soon as a pattern page is added to the section
+
+body.application.patterns {
+  @include breakpoint.medium-and-above () {
     .doc-page-sidebar {
       display: none;
     }

--- a/website/app/styles/pages/application/stage.scss
+++ b/website/app/styles/pages/application/stage.scss
@@ -32,3 +32,14 @@
     margin: 0 auto 0 0;
   }
 }
+
+// PATTERNS PAGE
+// This is temporary and will be removed as soon as a pattern page is added to the section
+
+body.application.patterns {
+  @include breakpoint.medium-and-above () {
+    .doc-page-stage {
+      padding-left: 0;
+    }
+  }
+}


### PR DESCRIPTION
Quick fix to hide the sidebar in the “patterns” page (when not on small viewports)

Preview: https://hds-website-git-new-docs-website-fix-patterns-sidebar-hashicorp.vercel.app/patterns

### :link: External links

Context: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1674675209884319

***

### 👀 Reviewer's checklist:
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
