### PR TITLE
[SPIKE] New docs website / Possible fix to the 404 HTTP header for the `error` page?

### DIFF
--- a/website/app/routes/error.js
+++ b/website/app/routes/error.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ErrorRoute extends Route {
+  @service fastboot;
+
+  beforeModel() {
+    if (this.fastboot.isFastBoot) {
+      this.fastboot.response.statusCode = 404;
+    }
+  }
+}

--- a/website/lib/markdown/index.js
+++ b/website/lib/markdown/index.js
@@ -65,14 +65,7 @@ module.exports = {
   urlsForPrember(distDir) {
     const flatPageListJson = fs.readJsonSync(`${distDir}/toc.json`);
     // TODO is there a way to have this list generated automatically (or exported) from the routes (`website/app/router.js`)?
-    const staticURLs = [
-      '/',
-      'about',
-      'foundations',
-      'components',
-      'patterns',
-      'error',
-    ];
+    const staticURLs = ['/', 'about', 'foundations', 'components', 'patterns'];
     const docsURLs = flatPageListJson.flat.map((page) => page.pageURL);
 
     return [...staticURLs, ...docsURLs];


### PR DESCRIPTION
### :pushpin: Summary

Test to see if it's possible to have the "error" page to return a `404` HTTP header (so we can use https://github.com/styfle/links-awakening/ to look for for broken links in the website)

/cc @jorytindall 

### :hammer_and_wrench: Detailed description

In this PR I have:
- added an `error` route file with a `beforeModel` declaration that returns a 404 status code via fastboot (source: https://ember-fastboot.com/docs/user-guide#status-code)

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1364

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
