### PR TITLE
Remove `no-invalid-interactive` exception

### DIFF
--- a/packages/components/addon/components/hds/modal/index.hbs
+++ b/packages/components/addon/components/hds/modal/index.hbs
@@ -1,4 +1,3 @@
-{{! template-lint-disable no-invalid-interactive }}
 <dialog
   class={{this.classNames}}
   ...attributes


### PR DESCRIPTION
### :pushpin: Summary

Remove `no-invalid-interactive` lint exception.

### Description

The modal component got a refactor before release and this is a remnant from before refactoring.