### PR TITLE
`Pagination` rename itemsPerPage argument (HDS-1441)

### DIFF
--- a/packages/components/addon/components/hds/pagination/numbered/index.js
+++ b/packages/components/addon/components/hds/pagination/numbered/index.js
@@ -77,7 +77,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   // at rendering time, but from that moment on they're not updated anymore, no matter what interaction the user
   // has with the component (the state is controlled externally, eg. via query parameters)
   @tracked _currentPage = this.args.currentPage ?? 1;
-  @tracked _currentPageSize = this.args.itemsPerPage ?? this.pageSizes[0];
+  @tracked _currentPageSize = this.args.currentPageSize ?? this.pageSizes[0];
 
   showInfo = this.args.showInfo ?? true; // if the "info" block is visible
   showLabels = this.args.showLabels ?? false; // if the labels for the "prev/next" controls are visible
@@ -107,8 +107,8 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
         typeof queryFunction === 'function'
       );
       assert(
-        '@currentPage and @itemsPerPage for "Hds::Pagination::Numbered" must be provided as numeric arguments when the pagination controls the routing',
-        typeof this.args.itemsPerPage === 'number' &&
+        '@currentPage and @currentPageSize for "Hds::Pagination::Numbered" must be provided as numeric arguments when the pagination controls the routing',
+        typeof this.args.currentPageSize === 'number' &&
           typeof this.args.currentPage === 'number'
       );
       this.hasRouting = true;
@@ -151,7 +151,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
 
   get currentPageSize() {
     if (this.hasRouting) {
-      return this.args.itemsPerPage;
+      return this.args.currentPageSize;
     } else {
       return this._currentPageSize;
     }

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -88,7 +88,7 @@
       <p>Pass the total number of items to be paginated.</p>
       <p>If no value is defined an error will be thrown.</p>
     </dd>
-    <dt>itemsPerPage <code>number</code></dt>
+    <dt>currentPageSize <code>number</code></dt>
     <dd>
       <p>Pass the maximum number of items to display on each page.</p>
       <p>If no value is defined, the first page size in <code>pageSizes</code> will be used.</p>
@@ -495,7 +495,7 @@
     @code="
       <Hds::Pagination::Numbered
         @totalItems=\{{40}}
-        @itemsPerPage=\{{20}}
+        @currentPageSize=\{{20}}
         @showTotalItems=\{{false}}
         @showSizeSelector=\{{false}}
         @pageSizes=\{{array 5 20 60}}
@@ -507,7 +507,7 @@
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Pagination::Numbered
     @totalItems={{40}}
-    @itemsPerPage={{20}}
+    @currentPageSize={{20}}
     @showTotalItems={{false}}
     @showSizeSelector={{false}}
     @pageSizes={{array 5 20 60}}
@@ -588,7 +588,7 @@
     @code="
       <Hds::Pagination::Numbered
         @totalItems=\{{this.demoTotalItems}}
-        @itemsPerPage=\{{this.demoCurrentPageSize}}
+        @currentPageSize=\{{this.demoCurrentPageSize}}
         @currentPage=\{{this.demoCurrentPage}}
         @pageSizes=\{{this.demoPageSizes}}
         @route=\{{this.demoRouteName}}
@@ -616,7 +616,7 @@
   <p class="dummy-paragraph">Renders to:</p>
   <Hds::Pagination::Numbered
     @totalItems={{this.demoTotalItems}}
-    @itemsPerPage={{this.demoCurrentPageSize}}
+    @currentPageSize={{this.demoCurrentPageSize}}
     @currentPage={{this.demoCurrentPage}}
     @pageSizes={{this.demoPageSizes}}
     @route={{this.demoRouteName}}
@@ -795,8 +795,13 @@
   <p class="dummy-text-small">With showInfo=false + showSizeSelector=false</p>
   <Hds::Pagination::Numbered @totalItems={{40}} @showInfo={{false}} @showSizeSelector={{false}} />
 
-  <p class="dummy-text-small">With @itemsPerPage=30 and @currentPage=2</p>
-  <Hds::Pagination::Numbered @totalItems={{40}} @itemsPerPage={{30}} @currentPage={{2}} @pageSizes={{array 10 30 50}} />
+  <p class="dummy-text-small">With @currentPageSize=30 and @currentPage=2</p>
+  <Hds::Pagination::Numbered
+    @totalItems={{40}}
+    @currentPageSize={{30}}
+    @currentPage={{2}}
+    @pageSizes={{array 10 30 50}}
+  />
 
   <p class="dummy-text-small">With @showPageNumbers=false + @showLabels=true</p>
   <Hds::Pagination::Numbered @totalItems={{40}} @showPageNumbers={{false}} @showLabels={{true}} />
@@ -837,7 +842,7 @@
   <p class="dummy-text-small">Base (default)</p>
   <Hds::Pagination::SizeSelector @pageSizes={{array 10 30 50}} />
 
-  <p class="dummy-text-small">With @itemsPerPage (selected option)</p>
+  <p class="dummy-text-small">With @currentPageSize (selected option)</p>
   <Hds::Pagination::SizeSelector @pageSizes={{array 10 30 50}} @selectedSize={{30}} />
 
   <h5 class="dummy-h5">Pagination::Nav::Arrow</h5>
@@ -960,7 +965,7 @@
     </Hds::Table>
     <Hds::Pagination::Numbered
       @totalItems={{this.demoTotalItems}}
-      @itemsPerPage={{this.currentPageSize_demo1}}
+      @currentPageSize={{this.currentPageSize_demo1}}
       @pageSizes={{array 5 10 30}}
       @onPageChange={{this.onPageChange_demo1}}
       @onPageSizeChange={{this.onPageSizeChange_demo1}}
@@ -999,7 +1004,7 @@
     </Hds::Table>
     <Hds::Pagination::Numbered
       @totalItems={{this.demoTotalItems}}
-      @itemsPerPage={{this.currentPageSize_demo2}}
+      @currentPageSize={{this.currentPageSize_demo2}}
       @pageSizes={{array 5 10 30}}
       @currentPage={{this.currentPage_demo2}}
       @route={{this.demoRouteName}}

--- a/packages/components/tests/integration/components/hds/pagination/numbered-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/numbered-test.js
@@ -41,7 +41,7 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
     assert.dom('.hds-pagination .hds-pagination-size-selector').exists();
   });
 
-  test('it renders the "info" and "size selector" content with default pageSizes and itemsPerPage values', async function (assert) {
+  test('it renders the "info" and "size selector" content with default pageSizes and currentPageSize values', async function (assert) {
     await render(hbs`
       <Hds::Pagination::Numbered @totalItems={{100}} />
     `);
@@ -57,7 +57,7 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
       .hasText('50');
   });
 
-  test('it renders custom options for passed in pageSizes and sets itemsPerPage to the first PageSizes item', async function (assert) {
+  test('it renders custom options for passed in pageSizes and sets currentPageSize to the first PageSizes item', async function (assert) {
     await render(hbs`
       <Hds::Pagination::Numbered @totalItems={{100}} @pageSizes={{array 20 40 60}} />
     `);
@@ -73,9 +73,9 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
       .hasText('60');
   });
 
-  test('it renders the passed in itemsPerPage value', async function (assert) {
+  test('it renders the passed in currentPageSize value', async function (assert) {
     await render(hbs`
-      <Hds::Pagination::Numbered @totalItems={{100}} @itemsPerPage={{40}} @pageSizes={{array 20 40 60}} />
+      <Hds::Pagination::Numbered @totalItems={{100}} @currentPageSize={{40}} @pageSizes={{array 20 40 60}} />
     `);
     assert.dom('.hds-pagination .hds-pagination-info').hasText('1–40 of 100');
   });
@@ -392,7 +392,7 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
   test('it should render links instead of buttons, with the correct "href" values, if it has routing', async function (assert) {
     this.set('myQueryFunction', (page, pageSize) => ({ page, pageSize }));
     await render(
-      hbs`<Hds::Pagination::Numbered @totalItems={{30}} @currentPage={{2}} @itemsPerPage={{10}} @route="components.pagination" @queryFunction={{this.myQueryFunction}} />`
+      hbs`<Hds::Pagination::Numbered @totalItems={{30}} @currentPage={{2}} @currentPageSize={{10}} @route="components.pagination" @queryFunction={{this.myQueryFunction}} />`
     );
     assert
       .dom('.hds-pagination-nav__arrow--direction-prev')
@@ -428,10 +428,10 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
       throw new Error(errorMessage);
     });
   });
-  test('it should throw an assertion if it has routing but @currentPage and @itemsPerPage are not defined as number', async function (assert) {
+  test('it should throw an assertion if it has routing but @currentPage and @currentPageSize are not defined as number', async function (assert) {
     this.set('myQueryFunction', (page, pageSize) => ({ page, pageSize }));
     const errorMessage =
-      '@currentPage and @itemsPerPage for "Hds::Pagination::Numbered" must be provided as numeric arguments when the pagination controls the routing';
+      '@currentPage and @currentPageSize for "Hds::Pagination::Numbered" must be provided as numeric arguments when the pagination controls the routing';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR changes the name of the "itemsPerPage" arg to "currentPageSize" for consistency.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1441](https://hashicorp.atlassian.net/browse/HDS-1441)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1441]: https://hashicorp.atlassian.net/browse/HDS-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ