### PR TITLE
Skip flakey test in modal component

### DIFF
--- a/packages/components/tests/integration/components/hds/modal/index-test.js
+++ b/packages/components/tests/integration/components/hds/modal/index-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
   click,
@@ -204,7 +204,7 @@ module('Integration | Component | hds/modal/index', function (hooks) {
     assert.ok(opened);
   });
   // the following test is flakey so we're going to skip it until we find a more reliable way
-  test('it should call `onClose` function if provided', async function (assert) {
+  skip('it should call `onClose` function if provided', async function (assert) {
     let closed = false;
     this.set('onClose', () => (closed = true));
     await render(


### PR DESCRIPTION
### :pushpin: Summary

Unfortunately one of the callback tests in our Modal component is flakey (it became stable for a while but it now started to become a problem again) so we're going to skip it until we find a stable way to test it.

As reported here: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1675112561810589