### PR TITLE
New docs website / Dynamic paths for open-graph images

### DIFF
--- a/website/app/services/head-data.js
+++ b/website/app/services/head-data.js
@@ -18,8 +18,9 @@ export default class CustomHeadDataService extends HeadDataService {
   }
 
   get imgSrc() {
-    return this.currentRouteMeta?.frontmatter?.previewImage
+    const previewImage = this.currentRouteMeta?.frontmatter?.previewImage
       ? this.currentRouteMeta.frontmatter.previewImage
-      : config['ember-meta'].imgSrc;
+      : 'assets/logos/share-card.jpg';
+    return `${config['ember-meta'].url}/${previewImage}`;
   }
 }

--- a/website/app/templates/head.hbs
+++ b/website/app/templates/head.hbs
@@ -38,16 +38,22 @@ We've made some small customizations to simplify this compared to the default te
   <meta property="og:description" content={{this.model.description}} />
 {{/if}}
 
-<meta property="og:image" content="https://helios.hashicorp.design/assets/logos/share-card.jpg" />
+{{#if this.model.imgSrc}}
+  <meta property="og:image" content={{this.model.imgSrc}} />
+{{/if}}
 
 {{! END OPENGRAPH }}
 
 {{! BEGIN TWITTER }}
 
 <meta name="twitter:card" content="summary_large_image" />
+
 {{! template-lint-disable no-forbidden-elements no-potential-path-strings }}
 <meta name="twitter:site" content="@HashiCorp" />
-<meta name="twitter:image" content="https://helios.hashicorp.design/assets/logos/share-card.jpg" />
+
+{{#if this.model.imgSrc}}
+  <meta name="twitter:image" content={{this.model.imgSrc}} />
+{{/if}}
 
 {{#if this.model.title}}
   <meta name="twitter:title" content={{this.model.title}} />


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of #1032 #1155, where I changed the image cards path to use components preview images, as suggested by @Dhaulagiri .

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
