### PR TITLE
New docs website - Post launch / Add inline anchor links for headers

### DIFF
--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -57,21 +57,54 @@
 }
 
 .doc-page-heading-link {
+  $box-size: 24px;
+  $icon-size: 16px;
+  $gap: 8px;
   display: inline-block;
-  width: 24px;
-  height: 1em;
-  margin-top: 0.15em;
-  margin-left: -24px;
+  width: $box-size;
+  height: $box-size;
+  margin-right: $gap;
+  margin-left: -($box-size + $gap);
   vertical-align: text-top;
-  // background-color: red;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cg fill='%232264D6'%3E%3Cpath d='M11.141 1a3.893 3.893 0 00-2.738 1.093L7.314 3.175A.75.75 0 008.372 4.24l1.077-1.07a2.393 2.393 0 013.384 3.382l-1.881 1.88a2.393 2.393 0 01-3.608-.258.75.75 0 00-1.202.899 3.893 3.893 0 005.87.42l1.886-1.886.01-.009A3.893 3.893 0 0011.14 1z'/%3E%3Cpath d='M7.019 5.365a3.893 3.893 0 00-3.032 1.13L2.102 8.382l-.01.01a3.893 3.893 0 005.505 5.504l1.084-1.084a.75.75 0 00-1.06-1.06l-1.07 1.07a2.393 2.393 0 01-3.384-3.384l1.881-1.88a2.393 2.393 0 013.609.258.75.75 0 101.2-.899A3.893 3.893 0 007.02 5.365z'/%3E%3C/g%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: center center;
-  background-size: 16px 16px;
+  background-size: $icon-size $icon-size;
+  border-radius: 3px;
   opacity: 0;
 
-  :hover > &,
+  h2 > & {
+    margin-top: 0.16em;
+  }
+
+  h3 > & {
+    margin-top: 0.09em;
+  }
+
+  h4 > & {
+    margin-top: -0.08em;
+  }
+
+  h5 > & {
+    margin-top: -0.12em;
+  }
+
+  :hover > & {
+    border: 1px solid var(--doc-color-gray-300);
+    opacity: 1;
+  }
+
   &:focus-visible {
     opacity: 1;
+  }
+
+  @include breakpoint.small () {
+    display: none;
+    margin-left: 0;
+    opacity: 1;
+
+    :hover > & {
+      display: inline-block;
+    }
   }
 }

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -57,21 +57,47 @@
 }
 
 .doc-page-heading-link {
+  position: relative;
   display: inline-block;
   width: 24px;
   height: 1em;
   margin-top: 0.15em;
   margin-left: -24px;
   vertical-align: text-top;
-  // background-color: red;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cg fill='%232264D6'%3E%3Cpath d='M11.141 1a3.893 3.893 0 00-2.738 1.093L7.314 3.175A.75.75 0 008.372 4.24l1.077-1.07a2.393 2.393 0 013.384 3.382l-1.881 1.88a2.393 2.393 0 01-3.608-.258.75.75 0 00-1.202.899 3.893 3.893 0 005.87.42l1.886-1.886.01-.009A3.893 3.893 0 0011.14 1z'/%3E%3Cpath d='M7.019 5.365a3.893 3.893 0 00-3.032 1.13L2.102 8.382l-.01.01a3.893 3.893 0 005.505 5.504l1.084-1.084a.75.75 0 00-1.06-1.06l-1.07 1.07a2.393 2.393 0 01-3.384-3.384l1.881-1.88a2.393 2.393 0 013.609.258.75.75 0 101.2-.899A3.893 3.893 0 007.02 5.365z'/%3E%3C/g%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: 16px 16px;
-  opacity: 0;
+  outline: none;
 
-  :hover > &,
-  &:focus-visible {
-    opacity: 1;
+  &::after {
+    position: absolute;
+    top: 50%;
+    left: -2px;
+    width: 24px;
+    height: 24px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cg fill='%232264D6'%3E%3Cpath d='M11.141 1a3.893 3.893 0 00-2.738 1.093L7.314 3.175A.75.75 0 008.372 4.24l1.077-1.07a2.393 2.393 0 013.384 3.382l-1.881 1.88a2.393 2.393 0 01-3.608-.258.75.75 0 00-1.202.899 3.893 3.893 0 005.87.42l1.886-1.886.01-.009A3.893 3.893 0 0011.14 1z'/%3E%3Cpath d='M7.019 5.365a3.893 3.893 0 00-3.032 1.13L2.102 8.382l-.01.01a3.893 3.893 0 005.505 5.504l1.084-1.084a.75.75 0 00-1.06-1.06l-1.07 1.07a2.393 2.393 0 01-3.384-3.384l1.881-1.88a2.393 2.393 0 013.609.258.75.75 0 101.2-.899A3.893 3.893 0 007.02 5.365z'/%3E%3C/g%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: 16px 16px;
+    border-radius: 3px;
+    transform: translateY(-50%);
+    opacity: 0;
+    content: "";
+  }
+
+  :hover > & {
+    &::after {
+      opacity: 1;
+
+      @include breakpoint.small () {
+        left: 0;
+      }
+    }
+  }
+
+  @include breakpoint.medium-and-above () {
+    &:focus-visible {
+      &::after {
+        border: 2px solid var(--doc-color-link-on-white);
+        opacity: 1;
+      }
+    }
   }
 }

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -48,3 +48,30 @@
   // potentially we could add again the fixed size to the "sidecar" grid area and remove this max-width (to be tested)
   max-width: calc(var(--doc-page-content-max-width) + 2 * var(--doc-page-stage-gutter-x-large) + var(--doc-page-sidebar-width));
 }
+
+
+// special classes for headings with anchor links
+
+.doc-page-heading-scroll-margin-top {
+  scroll-margin-top: calc(var(--doc-page-header-height) + 20px);
+}
+
+.doc-page-heading-link {
+  display: inline-block;
+  width: 24px;
+  height: 1em;
+  margin-top: 0.15em;
+  margin-left: -24px;
+  vertical-align: text-top;
+  // background-color: red;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cg fill='%232264D6'%3E%3Cpath d='M11.141 1a3.893 3.893 0 00-2.738 1.093L7.314 3.175A.75.75 0 008.372 4.24l1.077-1.07a2.393 2.393 0 013.384 3.382l-1.881 1.88a2.393 2.393 0 01-3.608-.258.75.75 0 00-1.202.899 3.893 3.893 0 005.87.42l1.886-1.886.01-.009A3.893 3.893 0 0011.14 1z'/%3E%3Cpath d='M7.019 5.365a3.893 3.893 0 00-3.032 1.13L2.102 8.382l-.01.01a3.893 3.893 0 005.505 5.504l1.084-1.084a.75.75 0 00-1.06-1.06l-1.07 1.07a2.393 2.393 0 01-3.384-3.384l1.881-1.88a2.393 2.393 0 013.609.258.75.75 0 101.2-.899A3.893 3.893 0 007.02 5.365z'/%3E%3C/g%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: 16px 16px;
+  opacity: 0;
+
+  :hover > &,
+  &:focus-visible {
+    opacity: 1;
+  }
+}

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -57,54 +57,21 @@
 }
 
 .doc-page-heading-link {
-  $box-size: 24px;
-  $icon-size: 16px;
-  $gap: 8px;
   display: inline-block;
-  width: $box-size;
-  height: $box-size;
-  margin-right: $gap;
-  margin-left: -($box-size + $gap);
+  width: 24px;
+  height: 1em;
+  margin-top: 0.15em;
+  margin-left: -24px;
   vertical-align: text-top;
+  // background-color: red;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cg fill='%232264D6'%3E%3Cpath d='M11.141 1a3.893 3.893 0 00-2.738 1.093L7.314 3.175A.75.75 0 008.372 4.24l1.077-1.07a2.393 2.393 0 013.384 3.382l-1.881 1.88a2.393 2.393 0 01-3.608-.258.75.75 0 00-1.202.899 3.893 3.893 0 005.87.42l1.886-1.886.01-.009A3.893 3.893 0 0011.14 1z'/%3E%3Cpath d='M7.019 5.365a3.893 3.893 0 00-3.032 1.13L2.102 8.382l-.01.01a3.893 3.893 0 005.505 5.504l1.084-1.084a.75.75 0 00-1.06-1.06l-1.07 1.07a2.393 2.393 0 01-3.384-3.384l1.881-1.88a2.393 2.393 0 013.609.258.75.75 0 101.2-.899A3.893 3.893 0 007.02 5.365z'/%3E%3C/g%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: center center;
-  background-size: $icon-size $icon-size;
-  border-radius: 3px;
+  background-size: 16px 16px;
   opacity: 0;
 
-  h2 > & {
-    margin-top: 0.16em;
-  }
-
-  h3 > & {
-    margin-top: 0.09em;
-  }
-
-  h4 > & {
-    margin-top: -0.08em;
-  }
-
-  h5 > & {
-    margin-top: -0.12em;
-  }
-
-  :hover > & {
-    border: 1px solid var(--doc-color-gray-300);
-    opacity: 1;
-  }
-
+  :hover > &,
   &:focus-visible {
     opacity: 1;
-  }
-
-  @include breakpoint.small () {
-    display: none;
-    margin-left: 0;
-    opacity: 1;
-
-    :hover > & {
-      display: inline-block;
-    }
   }
 }

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -80,24 +80,22 @@
     transform: translateY(-50%);
     opacity: 0;
     content: "";
+
+    @include breakpoint.small () {
+      left: 0;
+    }
   }
 
   :hover > & {
     &::after {
       opacity: 1;
-
-      @include breakpoint.small () {
-        left: 0;
-      }
     }
   }
 
-  @include breakpoint.medium-and-above () {
-    &:focus-visible {
-      &::after {
-        border: 2px solid var(--doc-color-link-on-white);
-        opacity: 1;
-      }
+  &:focus-visible {
+    &::after {
+      border: 2px solid var(--doc-color-link-on-white);
+      opacity: 1;
     }
   }
 }

--- a/website/app/styles/pages/application/sidecar.scss
+++ b/website/app/styles/pages/application/sidecar.scss
@@ -80,10 +80,3 @@
 .doc-page-sidecar__item--depth-3 {
   --padding-left: 24px;
 }
-
-
-// SPECIAL CLASS FOR HEADINGS
-
-.doc-page-sidecar-scroll-margin-top {
-  scroll-margin-top: calc(var(--doc-page-header-height) + 20px);
-}


### PR DESCRIPTION
### :pushpin: Summary

This PR, built on top of #1140, adds visible (on hover/focus) anchor links to the headings in the page.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated logic that handles the generation of the sections TOCs at runtime
    - now we add anchor links to levels H2-H5, but we list only H2-H3 in the sidecar
- applied styling to the injected anchor links

👉 👉 👉 **Preview**: https://hds-website-git-post-launch-add-inline-headers-5ce71a-hashicorp.vercel.app/components/alert

Notice: after meeting with @heatherlarsen and @MelSumner these decision were taken:
- we will keep the anchor appear only on mouse over (or tap on the heading, on touch devices) - reason: having it always visible would clutter too much the page (we have also received feedback about this on the "scrappy" website)
- we will keep the size of the anchor element fixed (and not relative to the font-size via `em`) and we will define specific margin-top values for the different headings level to define the vertical/optical alignment with the text (not perfect, but acceptable); in this way we can be more in line with the design specs (and to Developer implementation)
- still to decide what to do on small viewports with touch (smaller anchor size or anchor shifting the text to the right)

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1221

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
