### PR TITLE
`Tabs::Panel` - add style to prevent accidental display of hidden panels (HDS-1525)

### DIFF
--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -112,3 +112,8 @@
     transition-property: left, width;
   }
 }
+
+// Prevent consumers from accidentally overriding default styling of HTML “hidden” attribute
+.hds-tabs__panel[hidden] {
+  display: none !important;
+}


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR adds a style to avoid consumers accidentally displaying hidden Tabs Panels.

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
- Jira ticket: [HDS-1525](https://hashicorp.atlassian.net/browse/HDS-1525)
- Slack discussion: https://hashicorp.slack.com/archives/C7KTUHNUS/p1675731491282229

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
