### PR TITLE
Remove the `hidden` attribute from the “frontmatter” block in `Pagination` documentation

### DIFF
--- a/website/docs/components/pagination/index.md
+++ b/website/docs/components/pagination/index.md
@@ -7,8 +7,6 @@ links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=18709%3A42011&t=pIE459t8qucXP9uR-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/pagination
 previewImage: assets/illustrations/components/pagination.jpg
-navigation:
-  hidden: true
 ---
 
 <section data-tab="Guidelines">


### PR DESCRIPTION
### :pushpin: Summary

In https://github.com/hashicorp/design-system/pull/1137/files#diff-558fde910429167b23ea87d7519f4091c28d38c600c571405607d6f2b7e73b7b I forgot to remove the `hidden` attribute from the “frontmatter” block in `Pagination` documentation.

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
