### PR TITLE
`Hds:Table` - Fix documentation

### DIFF
--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -32,13 +32,13 @@
   </thead>
   <tbody class="hds-table__tbody">
     {{#if @columns}}
-      {{#each (sort-by this.getSortCriteria @model) as |data|}}
+      {{#each (sort-by this.getSortCriteria @model) as |record|}}
         {{yield
           (hash
             Tr=(component "hds/table/tr")
             Th=(component "hds/table/th" scope="row")
             Td=(component "hds/table/td" align=@align)
-            data=data
+            data=record
           )
           to="body"
         }}

--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -32,6 +32,11 @@
   </thead>
   <tbody class="hds-table__tbody">
     {{#if @columns}}
+      {{! ----------------------------------------------------------------------------------------
+        IMPORTANT: we loop on the `model` array and for each record
+        we yield the Tr/Td/Th elements _and_ the record itself as `data`
+        this means the consumer will *have to* use the `data` key to access it in their template
+      -------------------------------------------------------------------------------------------- }}
       {{#each (sort-by this.getSortCriteria @model) as |record|}}
         {{yield
           (hash

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -29,46 +29,67 @@ If you don’t have or want to use a model, a basic invocation could look like:
 
 ### Simple Table with model defined (non-sortable)
 
-To use a table with a model, define the data model and insert your own content into the `:head` and `:body` blocks.
+To use a table with a model, first of all you need to define the data model (usually in your route):
+
+```javascript
+// app/routes/components/table.js
+
+import Route from '@ember/routing/route';
+
+export default class ComponentsTableRoute extends Route {
+  async model() {
+    // example of data retrieved:
+    // [
+    //   {
+    //     "id": 1,
+    //     "name": "Burnaby Kuscha",
+    //     "email": "1_bkuscha0@tiny.cc",
+    //     "role": "Owner"
+    //   },
+    //   {
+    //     "id": 2,
+    //     "name": "Barton Penley",
+    //     "email": "2_bpenley1@miibeian.gov.cn",
+    //     "role": "Admin"
+    //   },
+    //   ...
+    let response = await fetch('/api/demo.json');
+    let { data } = await response.json();
+    return { myDemoData: data };
+  }
+}
+```
+
+For documentation purposes, we‘re imitating fetching data from an API and working with that as data model. Depending on your context and needs, you may want to manipulate and adapt the structure of your data to better suit your needs in the templating code.
+
+You can insert your own content into the and `:body` block and the component will take care of looping over the `@model` provided:
 
 ```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
 
-<Hds::Table @model={{this.model}}>
-  <:head as |H|>
-    <H.Tr>
-      <H.Th>Artist</H.Th>
-      <H.Th>Album</H.Th>
-      <H.Th>Release Year</H.Th>
-    </H.Tr>
-  </:head>
+<Hds::Table
+  @model={{this.model.myDemoData}}
+  @columns={{array (hash label="Name") (hash label="Email") (hash label="Role")}}
+>
   <:body as |B|>
     <B.Tr>
-      <B.Td>{{B.data.artist}}</B.Td>
-      <B.Td>{{B.data.album}}</B.Td>
-      <B.Td>{{B.data.year}}</B.Td>
+      <B.Td>{{B.data.name}}</B.Td>
+      <B.Td>{{B.data.email}}</B.Td>
+      <B.Td>{{B.data.role}}</B.Td>
     </B.Tr>
   </:body>
 </Hds::Table>
 ```
 
-For documentation purposes, we‘ve imitated fetching data from an API and are working with that as our data model.
+!!! Info
 
-```javascript
-import Route from '@ember/routing/route';
+**Important**
 
-export default class ComponentsTableRoute extends Route {
-  async model() {
-    let response = await fetch('/api/folk.json');
-    let { data } = await response.json();
+To be able to use this `Table` variant, you need to:
+- provide a `@columns` argument (see [Component API](#component-api) for details about its shape)
+- use the `.data` key to access the `@model` record content (it's yielded as `data`)
+!!!
 
-    return data.map((model) => {
-      let { attributes } = model;
-      return { ...attributes };
-    });
-  }
-}
-```
 
 ### Sortable Table
 
@@ -76,9 +97,9 @@ For the sortable table, the invocation and use is a little bit different:
 
 1. Shape the data model for use; we’ve placed it in the page‘s route.
 
-    - In this example, we’re identifying the column headers (keys) and also capitalizing them. 
-    - Each column object has two pieces: 
-      
+    - In this example, we’re identifying the column headers (keys) and also capitalizing them.
+    - Each column object has two pieces:
+
         - a `key`\-- used for the model, the `sortingKeys`, and `sortBy`
         - a `label`\-- used in the table header cells
 


### PR DESCRIPTION
### :pushpin: Summary

During a recent discussion with @aklkv about the Table API and some difficulties he was having in adopting the component in his codebase, we have realized that one important factor was that the existing documentation was not correct, in particular the example of "Simple Table with model defined (non-sortable)" is taken as is it would not work.

This PR updates the documentation to make it clearer how the component should be used and declared in that specific case.

👉 👉 👉 **Preview**: https://hds-website-git-fix-table-docs-hashicorp.vercel.app/components/table?tab=code#simple-table-with-model-defined-non-sortable

_Notice: we will review the whole documentation once the work around the component API extension will be concluded._

### :hammer_and_wrench: Detailed description

In this PR I have:
- renamed an internal variable to `record` for clarity (too many `data` variables moving around, it was hard to understand what was what)
- added comment in code, to help other developers understand what's happening in that specific loop
- updated (and simplified in some parts) the "Simple Table with model defined (non-sortable)" example in the “How to use” section of the documentation

### :camera_flash: Screenshots

The existing documentation:
<img width="773" alt="screenshot_2358" src="https://user-images.githubusercontent.com/686239/217802129-038b1ab5-d656-4041-ae24-fef494c00e4d.png">

This example will not work, because the table needs the `@columns` argument to loop over the model (this is something we may want to reconsider, but if we decide to make this change it will be in a separate task).

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
