### PR TITLE
Extend `Dropdown::ListItem`

### DIFF
--- a/.changeset/olive-avocados-attack.md
+++ b/.changeset/olive-avocados-attack.md
@@ -1,5 +1,15 @@
 ---
-"@hashicorp/design-system-components": minor
+"@hashicorp/design-system-components": major
 ---
 
-Allow `Checkmark`, `Checkbox` and `Radio` as `Hds::Dropdown::ListItem`s
+Add `Checkmark`, `Checkbox` and `Radio` as `Hds::Dropdown::ListItem`s
+
+Rename `Hds::Dropdown::ListItem` internal CSS classes as follows:
+ - `hds-dropdown-list-item--copy-item` → `hds-dropdown-list-item--variant-copy-item`
+ - `hds-dropdown-list-item--description` → `hds-dropdown-list-item--variant-description`
+ - `hds-dropdown-list-item--generic` → `hds-dropdown-list-item--variant-generic`
+ - `hds-dropdown-list-item--interactive` → `hds-dropdown-list-item--variant-interactive`
+ - `hds-dropdown-list-item--separator` → `hds-dropdown-list-item--variant-separator`
+ - `hds-dropdown-list-item--title` → `hds-dropdown-list-item--variant-title`
+
+**Note:** If test assertions are relying on these class names, tests will fail. If extensions/overrides have been applied to these classes, they will suffer visual changes.

--- a/.changeset/olive-avocados-attack.md
+++ b/.changeset/olive-avocados-attack.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Allow `Checkmark`, `Checkbox` and `Radio` as `Hds::Dropdown::ListItem`s

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -16,6 +16,7 @@
       {{yield
         (hash
           close=c.close
+          Checkbox=(component "hds/dropdown/list-item/checkbox")
           Checkmark=(component "hds/dropdown/list-item/checkmark")
           CopyItem=(component "hds/dropdown/list-item/copy-item")
           Description=(component "hds/dropdown/list-item/description")

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -16,6 +16,7 @@
       {{yield
         (hash
           close=c.close
+          Checkmark=(component "hds/dropdown/list-item/checkmark")
           CopyItem=(component "hds/dropdown/list-item/copy-item")
           Description=(component "hds/dropdown/list-item/description")
           Generic=(component "hds/dropdown/list-item/generic")

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -12,7 +12,7 @@
     }}
   </:toggle>
   <:content as |c|>
-    <ul class={{this.listClassNames}} {{style width=@width}}>
+    <ul class={{this.listClassNames}} {{style width=@width}} role="listbox">
       {{yield
         (hash
           close=c.close

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -22,6 +22,7 @@
           Description=(component "hds/dropdown/list-item/description")
           Generic=(component "hds/dropdown/list-item/generic")
           Interactive=(component "hds/dropdown/list-item/interactive")
+          Radio=(component "hds/dropdown/list-item/radio")
           Separator=(component "hds/dropdown/list-item/separator")
           Title=(component "hds/dropdown/list-item/title")
         )

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -12,7 +12,7 @@
     }}
   </:toggle>
   <:content as |c|>
-    <ul class={{this.listClassNames}} {{style width=@width}} role="listbox">
+    <ul class={{this.listClassNames}} {{style width=@width}} {{did-insert this.didInsertList}}>
       {{yield
         (hash
           close=c.close

--- a/packages/components/addon/components/hds/dropdown/index.js
+++ b/packages/components/addon/components/hds/dropdown/index.js
@@ -4,6 +4,7 @@
  */
 
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
 export const DEFAULT_POSITION = 'right';
@@ -46,5 +47,13 @@ export default class HdsDropdownIndexComponent extends Component {
     }
 
     return classes.join(' ');
+  }
+
+  @action
+  didInsertList(element) {
+    let checkmarkItems = element.querySelectorAll(`[role="option"]`);
+    if (checkmarkItems.length) {
+      element.setAttribute('role', 'listbox');
+    }
   }
 }

--- a/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
@@ -1,4 +1,4 @@
-<li class="hds-dropdown-list-item hds-dropdown-list-item--checkbox">
+<li class="hds-dropdown-list-item hds-dropdown-list-item--variant-checkbox">
   <Hds::Form::Checkbox::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
   {{#if @icon}}
     <div class="hds-dropdown-list-item__icon">

--- a/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
@@ -8,7 +8,7 @@
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>
     {{yield}}
   </label>
-  {{#if @resultCount}}
-    <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
+  {{#if @count}}
+    <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
   {{/if}}
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
@@ -1,6 +1,13 @@
 <li class="hds-dropdown-list-item hds-dropdown-list-item--checkbox">
   <Hds::Form::Checkbox::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
-  <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>{{yield}}</label>
+  {{#if @icon}}
+    <div class="hds-dropdown-list-item__icon">
+      <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
+    </div>
+  {{/if}}
+  <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>
+    {{yield}}
+  </label>
   {{#if @resultCount}}
     <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
   {{/if}}

--- a/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
@@ -2,4 +2,7 @@
   <Hds::Form::Checkbox::Field @id={{@id}} @name={{@name}} @value={{@value}} ...attributes as |F|>
     <F.Label>{{yield}}</F.Label>
   </Hds::Form::Checkbox::Field>
+  {{#if @resultCount}}
+    <Hds::BadgeCount class="hds-dropdown-list-item__count" @size="small" @type="filled" @text={{@resultCount}} />
+  {{/if}}
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
@@ -1,7 +1,6 @@
 <li class="hds-dropdown-list-item hds-dropdown-list-item--checkbox">
-  <Hds::Form::Checkbox::Field @id={{@id}} @name={{@name}} @value={{@value}} ...attributes as |F|>
-    <F.Label>{{yield}}</F.Label>
-  </Hds::Form::Checkbox::Field>
+  <Hds::Form::Checkbox::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
+  <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>{{yield}}</label>
   {{#if @resultCount}}
     <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
   {{/if}}

--- a/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
@@ -3,6 +3,6 @@
     <F.Label>{{yield}}</F.Label>
   </Hds::Form::Checkbox::Field>
   {{#if @resultCount}}
-    <Hds::BadgeCount class="hds-dropdown-list-item__count" @size="small" @type="filled" @text={{@resultCount}} />
+    <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
   {{/if}}
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
@@ -1,0 +1,5 @@
+<li class="hds-dropdown-list-item hds-dropdown-list-item--checkbox">
+  <Hds::Form::Checkbox::Field @id={{@id}} @name={{@name}} @value={{@value}} ...attributes as |F|>
+    <F.Label>{{yield}}</F.Label>
+  </Hds::Form::Checkbox::Field>
+</li>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkbox.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkbox.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { getElementId } from '../../form/utils/getElementId';
+
+export default class HdsDropdownListItemCheckboxComponent extends Component {
+  /**
+   * Determines the unique ID to assign to the checkbox control
+   */
+  get id() {
+    return getElementId(this);
+  }
+}

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -1,4 +1,4 @@
-{{! template-lint-disable require-context-role }}
+{{! template-lint-disable require-context-role require-presentational-children }}
 <li class={{this.classNames}}>
   <Hds::Interactive
     @current-when={{@current-when}}
@@ -19,6 +19,9 @@
     </div>
     {{#if @resultCount}}
       <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
+    {{/if}}
+    {{#if @selected}}
+      <FlightIcon class="hds-dropdown-list-item__checkmark" @name="check" @isInlineBlock={{false}} />
     {{/if}}
   </Hds::Interactive>
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -1,0 +1,18 @@
+<li class={{this.classNames}}>
+  <Hds::Interactive
+    @current-when={{@current-when}}
+    @models={{hds-link-to-models @model @models}}
+    @query={{hds-link-to-query @query}}
+    @replace={{@replace}}
+    @route={{@route}}
+    @isRouteExternal={{@isRouteExternal}}
+    @href={{@href}}
+    @isHrefExternal={{@isHrefExternal}}
+    class="hds-dropdown-list-item__interactive"
+    ...attributes
+  >
+    <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
+      {{yield}}
+    </div>
+  </Hds::Interactive>
+</li>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -1,3 +1,4 @@
+{{! template-lint-disable require-context-role }}
 <li class={{this.classNames}}>
   <Hds::Interactive
     @current-when={{@current-when}}
@@ -10,6 +11,8 @@
     @isHrefExternal={{@isHrefExternal}}
     class="hds-dropdown-list-item__interactive"
     ...attributes
+    role="option"
+    aria-selected={{if @selected "true" "false"}}
   >
     <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
       {{yield}}

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -20,8 +20,10 @@
     {{#if @resultCount}}
       <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
     {{/if}}
-    {{#if @selected}}
-      <FlightIcon class="hds-dropdown-list-item__checkmark" @name="check" @isInlineBlock={{false}} />
-    {{/if}}
+    <span class="hds-dropdown-list-item__checkmark">
+      {{#if @selected}}
+        <FlightIcon class="hds-dropdown-list-item__checkmark-icon" @name="check" @isInlineBlock={{false}} />
+      {{/if}}
+    </span>
   </Hds::Interactive>
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -22,8 +22,8 @@
     <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
       {{yield}}
     </div>
-    {{#if @resultCount}}
-      <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
+    {{#if @count}}
+      <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
     {{/if}}
     <span class="hds-dropdown-list-item__checkmark">
       {{#if @selected}}

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -1,4 +1,4 @@
-{{! template-lint-disable require-context-role }}
+{{! template-lint-disable require-context-role require-presentational-children }}
 <li class={{this.classNames}}>
   <Hds::Interactive
     @current-when={{@current-when}}
@@ -17,5 +17,8 @@
     <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
       {{yield}}
     </div>
+    {{#if @resultCount}}
+      <Hds::BadgeCount class="hds-dropdown-list-item__count" @size="small" @type="filled" @text={{@resultCount}} />
+    {{/if}}
   </Hds::Interactive>
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -14,6 +14,11 @@
     role="option"
     aria-selected={{if @selected "true" "false"}}
   >
+    {{#if @icon}}
+      <div class="hds-dropdown-list-item__interactive-icon">
+        <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
+      </div>
+    {{/if}}
     <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
       {{yield}}
     </div>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -1,4 +1,4 @@
-{{! template-lint-disable require-context-role require-presentational-children }}
+{{! template-lint-disable require-context-role }}
 <li class={{this.classNames}}>
   <Hds::Interactive
     @current-when={{@current-when}}
@@ -18,7 +18,7 @@
       {{yield}}
     </div>
     {{#if @resultCount}}
-      <Hds::BadgeCount class="hds-dropdown-list-item__count" @size="small" @type="filled" @text={{@resultCount}} />
+      <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
     {{/if}}
   </Hds::Interactive>
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+
+export default class HdsDropdownListItemCheckmarkComponent extends Component {
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = [
+      'hds-dropdown-list-item',
+      'hds-dropdown-list-item--color-action',
+      'hds-dropdown-list-item--checkmark',
+    ];
+
+    // add a class based on the @selected argument
+    if (this.args.selected) {
+      classes.push('hds-dropdown-list-item--checkmark-selected');
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.js
@@ -10,12 +10,12 @@ export default class HdsDropdownListItemCheckmarkComponent extends Component {
     let classes = [
       'hds-dropdown-list-item',
       'hds-dropdown-list-item--color-action',
-      'hds-dropdown-list-item--checkmark',
+      'hds-dropdown-list-item--variant-checkmark',
     ];
 
     // add a class based on the @selected argument
     if (this.args.selected) {
-      classes.push('hds-dropdown-list-item--checkmark-selected');
+      classes.push('hds-dropdown-list-item--variant-checkmark-selected');
     }
 
     return classes.join(' ');

--- a/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
@@ -35,7 +35,7 @@ export default class HdsDropdownListItemCopyItemComponent extends Component {
   get classNames() {
     let classes = [
       'hds-dropdown-list-item',
-      'hds-dropdown-list-item--copy-item',
+      'hds-dropdown-list-item--variant-copy-item',
     ];
 
     return classes.join(' ');

--- a/packages/components/addon/components/hds/dropdown/list-item/description.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/description.js
@@ -31,7 +31,7 @@ export default class HdsDropdownListItemDescriptionComponent extends Component {
   get classNames() {
     let classes = [
       'hds-dropdown-list-item',
-      'hds-dropdown-list-item--description',
+      'hds-dropdown-list-item--variant-description',
     ];
 
     // add classes for the typographic style

--- a/packages/components/addon/components/hds/dropdown/list-item/generic.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/generic.hbs
@@ -2,6 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<li class="hds-dropdown-list-item hds-dropdown-list-item--generic" ...attributes>
+<li class="hds-dropdown-list-item hds-dropdown-list-item--variant-generic" ...attributes>
   {{yield}}
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/interactive.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/interactive.js
@@ -53,7 +53,7 @@ export default class HdsDropdownListItemInteractiveComponent extends Component {
   get classNames() {
     let classes = [
       'hds-dropdown-list-item',
-      'hds-dropdown-list-item--interactive',
+      'hds-dropdown-list-item--variant-interactive',
     ];
 
     // add a class based on the @color argument

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
@@ -1,4 +1,4 @@
-<li class="hds-dropdown-list-item hds-dropdown-list-item--radio">
+<li class="hds-dropdown-list-item hds-dropdown-list-item--variant-radio">
   <Hds::Form::Radio::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
   {{#if @icon}}
     <div class="hds-dropdown-list-item__icon">

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
@@ -2,4 +2,7 @@
   <Hds::Form::Radio::Field @id={{@id}} @name={{@name}} @value={{@value}} ...attributes as |F|>
     <F.Label>{{yield}}</F.Label>
   </Hds::Form::Radio::Field>
+  {{#if @resultCount}}
+    <Hds::BadgeCount class="hds-dropdown-list-item__count" @size="small" @type="filled" @text={{@resultCount}} />
+  {{/if}}
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
@@ -3,6 +3,6 @@
     <F.Label>{{yield}}</F.Label>
   </Hds::Form::Radio::Field>
   {{#if @resultCount}}
-    <Hds::BadgeCount class="hds-dropdown-list-item__count" @size="small" @type="filled" @text={{@resultCount}} />
+    <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
   {{/if}}
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
@@ -1,5 +1,10 @@
 <li class="hds-dropdown-list-item hds-dropdown-list-item--radio">
   <Hds::Form::Radio::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
+  {{#if @icon}}
+    <div class="hds-dropdown-list-item__icon">
+      <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
+    </div>
+  {{/if}}
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>{{yield}}</label>
   {{#if @resultCount}}
     <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
@@ -1,7 +1,6 @@
 <li class="hds-dropdown-list-item hds-dropdown-list-item--radio">
-  <Hds::Form::Radio::Field @id={{@id}} @name={{@name}} @value={{@value}} ...attributes as |F|>
-    <F.Label>{{yield}}</F.Label>
-  </Hds::Form::Radio::Field>
+  <Hds::Form::Radio::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
+  <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>{{yield}}</label>
   {{#if @resultCount}}
     <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
   {{/if}}

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
@@ -6,7 +6,7 @@
     </div>
   {{/if}}
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>{{yield}}</label>
-  {{#if @resultCount}}
-    <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@resultCount}}</span>
+  {{#if @count}}
+    <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
   {{/if}}
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
@@ -1,0 +1,5 @@
+<li class="hds-dropdown-list-item hds-dropdown-list-item--radio">
+  <Hds::Form::Radio::Field @id={{@id}} @name={{@name}} @value={{@value}} ...attributes as |F|>
+    <F.Label>{{yield}}</F.Label>
+  </Hds::Form::Radio::Field>
+</li>

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { getElementId } from '../../form/utils/getElementId';
+
+export default class HdsDropdownListItemRadioComponent extends Component {
+  /**
+   * Determines the unique ID to assign to the radio control
+   */
+  get id() {
+    return getElementId(this);
+  }
+}

--- a/packages/components/addon/components/hds/dropdown/list-item/separator.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/separator.hbs
@@ -2,4 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<li class="hds-dropdown-list-item hds-dropdown-list-item--separator" role="separator" ...attributes></li>
+<li class="hds-dropdown-list-item hds-dropdown-list-item--variant-separator" role="separator" ...attributes></li>

--- a/packages/components/addon/components/hds/dropdown/list-item/title.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/title.js
@@ -29,7 +29,10 @@ export default class HdsDropdownListItemTitleComponent extends Component {
    * @return {string} The "class" attribute to apply to the component.
    */
   get classNames() {
-    let classes = ['hds-dropdown-list-item', 'hds-dropdown-list-item--title'];
+    let classes = [
+      'hds-dropdown-list-item',
+      'hds-dropdown-list-item--variant-title',
+    ];
 
     // add classes for the typographic style
     classes.push('hds-typography-body-100');

--- a/packages/components/app/components/hds/dropdown/list-item/checkbox.js
+++ b/packages/components/app/components/hds/dropdown/list-item/checkbox.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/dropdown/list-item/checkbox';

--- a/packages/components/app/components/hds/dropdown/list-item/checkmark.js
+++ b/packages/components/app/components/hds/dropdown/list-item/checkmark.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/dropdown/list-item/checkmark';

--- a/packages/components/app/components/hds/dropdown/list-item/radio.js
+++ b/packages/components/app/components/hds/dropdown/list-item/radio.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/dropdown/list-item/radio';

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -474,20 +474,20 @@ $hds-dropdown-toggle-border-radius: 5px;
   display: flex;
   padding: 8px 16px;
 
-  .hds-form-field--layout-flag {
-    flex: 1;
+  .hds-dropdown-list-item__control {
+    flex-shrink: 0;
+    margin-top: 2px;
+    margin-right: 8px;
   }
 
-  .hds-form-label {
-    font-weight: normal;
-
-    .hds-badge {
-      vertical-align: bottom;
-    }
+  .hds-dropdown-list-item__label {
+    flex-grow: 1;
+    width: fit-content;
+    color: var(--token-color-foreground-primary);
   }
 }
 
-// RESULT COUNT & BADGE
+// RESULT COUNT
 .hds-dropdown-list-item__count {
   align-self: flex-start;
   padding: 0.125rem 0.5rem;
@@ -495,6 +495,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   line-height: 1.2308; // 16px
 }
 
+// BADGE INSIDE CHECKMARK, CHECKBOX OR RADIO
 .hds-dropdown-list-item--checkmark,
 .hds-dropdown-list-item--checkbox,
 .hds-dropdown-list-item--radio {

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -486,15 +486,16 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 // RESULT COUNT & BADGE
+.hds-dropdown-list-item__count {
+  align-self: baseline;
+  padding: 0.125rem 0.5rem;
+  color: var(--token-color-foreground-faint);
+  line-height: 1.2308; // 16px
+}
 
 .hds-dropdown-list-item--checkmark,
 .hds-dropdown-list-item--checkbox,
 .hds-dropdown-list-item--radio {
-  .hds-dropdown-list-item__count {
-    align-self: baseline;
-    background: inherit;
-  }
-
   // align any `Hds::Badge` within a selectable list item to match baseline
   .hds-badge {
     vertical-align: bottom;

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -448,7 +448,8 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
-.hds-dropdown-list-item--checkbox {
+.hds-dropdown-list-item--checkbox,
+.hds-dropdown-list-item--radio {
   padding: 8px 16px;
 
   .hds-form-label {

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -447,3 +447,11 @@ $hds-dropdown-toggle-border-radius: 5px;
     color: var(--token-color-foreground-action-active);
   }
 }
+
+.hds-dropdown-list-item--checkbox {
+  padding: 8px 16px;
+
+  .hds-form-label {
+    font-weight: normal;
+  }
+}

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -249,7 +249,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   a,
   button {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     padding: 7px 9px 7px 15px; // notice: we're subtracting 1px because of the transparent border
     text-decoration: none;
     border: 1px solid transparent; // because a border for the button is needed for a11y, we apply it to both the button and the link so they have the same height
@@ -343,6 +343,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown-list-item__interactive-icon {
+  margin-top: 2px;
   margin-right: 8px;
 }
 
@@ -432,7 +433,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 .hds-dropdown-list-item__checkmark {
   display: flex;
-  align-self: flex-start;
   width: 16px;
   height: 20px; // replicating the resulted height of the list item
   margin-left: 8px;
@@ -447,7 +447,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 .hds-dropdown-list-item--checkbox,
 .hds-dropdown-list-item--radio {
   display: flex;
-  align-items: center;
+  align-items: self-start;
   padding: 8px 16px;
 
   .hds-dropdown-list-item__control {
@@ -470,7 +470,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 // COUNT
 .hds-dropdown-list-item__count {
-  align-self: flex-start;
   margin-left: 8px;
   color: var(--token-color-foreground-faint);
   line-height: 20px; // replicating the resulted height of the list item

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -150,6 +150,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 // LIST > LIST-ITEM
 // HDS::DROPDOWN::LIST-ITEM
 
+// HDS::DROPDOWN::LIST-ITEM::COPY-ITEM
 .hds-dropdown-list-item__copy-item-title {
   padding: 2px 0 4px;
   color: var(--token-color-foreground-faint);
@@ -213,16 +214,21 @@ $hds-dropdown-toggle-border-radius: 5px;
   color: var(--token-color-foreground-action);
 }
 
+// HDS::DROPDOWN::LIST-ITEM::DESCRIPTION
+
 .hds-dropdown-list-item--description {
   padding: 2px 16px 4px;
   color: var(--token-color-foreground-faint);
 }
+
+// HDS::DROPDOWN::LIST-ITEM::GENERIC
 
 .hds-dropdown-list-item--generic {
   padding-right: 16px;
   padding-left: 16px;
 }
 
+// HDS::DROPDOWN::LIST-ITEM::INTERACTIVE & HDS::DROPDOWN::LIST-ITEM::CHECKMARK
 .hds-dropdown-list-item--interactive,
 .hds-dropdown-list-item--checkmark {
   position: relative;
@@ -398,6 +404,8 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
+// HDS::DROPDOWN::LIST-ITEM::SEPARATOR
+
 .hds-dropdown-list-item--separator {
   position: relative;
   width: 100%;
@@ -413,15 +421,20 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
+// HDS::DROPDOWN::LIST-ITEM::TITLE
+
 .hds-dropdown-list-item--title {
   padding: 10px 16px 4px;
   color: var(--token-color-foreground-strong);
 }
 
+// HDS::DROPDOWN::LIST-ITEM::CHECKMARK
+
 .hds-dropdown-list-item--checkmark {
   color: var(--token-color-foreground-action-active);
 
-  .hds-dropdown-list-item__interactive {
+  a.hds-dropdown-list-item__interactive,
+  button.hds-dropdown-list-item__interactive {
     // leave room for the checkmark to avoid overlapping with text
     padding-right: 30px;
 
@@ -431,9 +444,13 @@ $hds-dropdown-toggle-border-radius: 5px;
     &.mock-focus,
     &.mock-active {
       &::after {
-        background-color: transparent;
+        background-color: inherit;
       }
     }
+  }
+
+  .hds-dropdown-list-item__interactive-text {
+    flex: 1;
   }
 }
 
@@ -448,11 +465,38 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
+// HDS::DROPDOWN::LIST-ITEM::CHECKBOX & HDS::DROPDOWN::LIST-ITEM::RADIO
+
 .hds-dropdown-list-item--checkbox,
 .hds-dropdown-list-item--radio {
+  display: flex;
   padding: 8px 16px;
+
+  .hds-form-field--layout-flag {
+    flex: 1;
+  }
 
   .hds-form-label {
     font-weight: normal;
+
+    .hds-badge {
+      vertical-align: bottom;
+    }
+  }
+}
+
+// RESULT COUNT & BADGE
+
+.hds-dropdown-list-item--checkmark,
+.hds-dropdown-list-item--checkbox,
+.hds-dropdown-list-item--radio {
+  .hds-dropdown-list-item__count {
+    align-self: baseline;
+    background: inherit;
+  }
+
+  // align any `Hds::Badge` within a selectable list item to match baseline
+  .hds-badge {
+    vertical-align: bottom;
   }
 }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -467,7 +467,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
-// RESULT COUNT
+// COUNT
 .hds-dropdown-list-item__count {
   align-self: flex-start;
   padding: 0 0.5rem;

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -433,9 +433,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 .hds-dropdown-list-item--checkmark {
   a.hds-dropdown-list-item__interactive,
   button.hds-dropdown-list-item__interactive {
-    // leave room for the checkmark to align the result count on non-selected items
-    padding-right: 25px; // 9px default + 16px for the 'check' FlightIcon
-
     // disable background on focus and active states
     &:focus,
     &:active,
@@ -464,7 +461,12 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 .hds-dropdown-list-item__checkmark {
   align-self: flex-start;
-  margin-top: 0.125rem;
+  width: 20px;
+  height: 20px;
+}
+
+.hds-dropdown-list-item__checkmark-icon {
+  height: inherit;
 }
 
 // HDS::DROPDOWN::LIST-ITEM::CHECKBOX & HDS::DROPDOWN::LIST-ITEM::RADIO

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -462,7 +462,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 .hds-dropdown-list-item__checkmark {
   align-self: flex-start;
   width: 20px;
-  height: 20px;
+  height: 20px; // replicating the resulted height of the list item
 }
 
 .hds-dropdown-list-item__checkmark-icon {
@@ -492,9 +492,9 @@ $hds-dropdown-toggle-border-radius: 5px;
 // RESULT COUNT
 .hds-dropdown-list-item__count {
   align-self: flex-start;
-  padding: 0.125rem 0.5rem;
+  padding: 0 0.5rem;
   color: var(--token-color-foreground-faint);
-  line-height: 1.2308; // 16px
+  line-height: 20px; // replicating the resulted height of the list item
 }
 
 // BADGE INSIDE CHECKMARK, CHECKBOX OR RADIO

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -433,8 +433,9 @@ $hds-dropdown-toggle-border-radius: 5px;
 .hds-dropdown-list-item__checkmark {
   display: flex;
   align-self: flex-start;
-  width: 20px;
+  width: 16px;
   height: 20px; // replicating the resulted height of the list item
+  margin-left: 8px;
 }
 
 .hds-dropdown-list-item__checkmark-icon {
@@ -470,7 +471,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 // COUNT
 .hds-dropdown-list-item__count {
   align-self: flex-start;
-  padding: 0 0.5rem;
+  margin-left: 8px;
   color: var(--token-color-foreground-faint);
   line-height: 20px; // replicating the resulted height of the list item
 }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -431,18 +431,18 @@ $hds-dropdown-toggle-border-radius: 5px;
 // HDS::DROPDOWN::LIST-ITEM::CHECKMARK
 
 .hds-dropdown-list-item--checkmark {
-  color: var(--token-color-foreground-action-active);
-
   a.hds-dropdown-list-item__interactive,
   button.hds-dropdown-list-item__interactive {
-    // leave room for the checkmark to avoid overlapping with text
-    padding-right: 30px;
+    // leave room for the checkmark to align the result count on non-selected items
+    padding-right: 25px; // 9px default + 16px for the 'check' FlightIcon
 
     // disable background on focus and active states
     &:focus,
     &:active,
     &.mock-focus,
     &.mock-active {
+      color: var(--token-color-foreground-action-active);
+
       &::after {
         background-color: inherit;
       }
@@ -455,14 +455,16 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown-list-item--checkmark-selected {
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M14.78 4.28a.75.75 0 00-1.06-1.06l-7.97 7.97-3.47-3.47a.75.75 0 00-1.06 1.06l4 4a.75.75 0 001.06 0l8.5-8.5z' fill='%231060ff'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: top 10px right 10px;
-  background-size: var(--token-form-select-background-image-size) var(--token-form-select-background-image-size);
-
-  .hds-dropdown-list-item__interactive {
-    color: var(--token-color-foreground-action-active);
+  a.hds-dropdown-list-item__interactive,
+  button.hds-dropdown-list-item__interactive {
+    padding-right: 9px; // reset to default
+    color: var(--token-color-foreground-action);
   }
+}
+
+.hds-dropdown-list-item__checkmark {
+  align-self: flex-start;
+  margin-top: 0.125rem;
 }
 
 // HDS::DROPDOWN::LIST-ITEM::CHECKBOX & HDS::DROPDOWN::LIST-ITEM::RADIO
@@ -487,7 +489,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 // RESULT COUNT & BADGE
 .hds-dropdown-list-item__count {
-  align-self: baseline;
+  align-self: flex-start;
   padding: 0.125rem 0.5rem;
   color: var(--token-color-foreground-faint);
   line-height: 1.2308; // 16px

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -156,7 +156,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   color: var(--token-color-foreground-faint);
 }
 
-.hds-dropdown-list-item--copy-item {
+.hds-dropdown-list-item--variant-copy-item {
   width: 100%;
   padding: 10px 16px 12px;
 
@@ -216,21 +216,21 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 // HDS::DROPDOWN::LIST-ITEM::DESCRIPTION
 
-.hds-dropdown-list-item--description {
+.hds-dropdown-list-item--variant-description {
   padding: 2px 16px 4px;
   color: var(--token-color-foreground-faint);
 }
 
 // HDS::DROPDOWN::LIST-ITEM::GENERIC
 
-.hds-dropdown-list-item--generic {
+.hds-dropdown-list-item--variant-generic {
   padding-right: 16px;
   padding-left: 16px;
 }
 
 // HDS::DROPDOWN::LIST-ITEM::INTERACTIVE & HDS::DROPDOWN::LIST-ITEM::CHECKMARK
-.hds-dropdown-list-item--interactive,
-.hds-dropdown-list-item--checkmark {
+.hds-dropdown-list-item--variant-interactive,
+.hds-dropdown-list-item--variant-checkmark {
   position: relative;
   min-height: 36px;
   isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
@@ -401,7 +401,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 // HDS::DROPDOWN::LIST-ITEM::SEPARATOR
 
-.hds-dropdown-list-item--separator {
+.hds-dropdown-list-item--variant-separator {
   position: relative;
   width: 100%;
   height: 4px;
@@ -418,14 +418,14 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 // HDS::DROPDOWN::LIST-ITEM::TITLE
 
-.hds-dropdown-list-item--title {
+.hds-dropdown-list-item--variant-title {
   padding: 10px 16px 4px;
   color: var(--token-color-foreground-strong);
 }
 
 // HDS::DROPDOWN::LIST-ITEM::CHECKMARK
 
-.hds-dropdown-list-item--checkmark-selected {
+.hds-dropdown-list-item--variant-checkmark-selected {
   .hds-dropdown-list-item__interactive {
     color: var(--token-color-foreground-action);
   }
@@ -444,8 +444,8 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 // HDS::DROPDOWN::LIST-ITEM::CHECKBOX & HDS::DROPDOWN::LIST-ITEM::RADIO
 
-.hds-dropdown-list-item--checkbox,
-.hds-dropdown-list-item--radio {
+.hds-dropdown-list-item--variant-checkbox,
+.hds-dropdown-list-item--variant-radio {
   display: flex;
   align-items: self-start;
   padding: 8px 16px;
@@ -476,9 +476,9 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 // BADGE INSIDE CHECKMARK, CHECKBOX OR RADIO
-.hds-dropdown-list-item--checkmark,
-.hds-dropdown-list-item--checkbox,
-.hds-dropdown-list-item--radio {
+.hds-dropdown-list-item--variant-checkmark,
+.hds-dropdown-list-item--variant-checkbox,
+.hds-dropdown-list-item--variant-radio {
   // align any `Hds::Badge` within a selectable list item to match baseline
   .hds-badge {
     vertical-align: bottom;

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -300,7 +300,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 
       &::after {
         left: 4px;
-        background-color: var(--current-background-color);
         box-shadow: var(--current-focus-ring-box-shadow);
       }
     }
@@ -317,7 +316,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 
       &::after {
         left: 4px;
-        background-color: var(--current-background-color);
         box-shadow: var(--current-focus-ring-box-shadow);
       }
     }
@@ -339,10 +337,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 
       &::before {
         background-color: currentColor;
-      }
-
-      &::after {
-        background-color: var(--current-background-color);
       }
     }
   }
@@ -368,7 +362,6 @@ $hds-dropdown-toggle-border-radius: 5px;
     --current-color-active: var(--token-color-foreground-action-active);
 
     &::after {
-      --current-background-color: var(--token-color-surface-action);
       --current-focus-ring-box-shadow: var(--token-focus-ring-action-box-shadow);
     }
   }
@@ -431,26 +424,8 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 // HDS::DROPDOWN::LIST-ITEM::CHECKMARK
 
-.hds-dropdown-list-item--checkmark {
-  a.hds-dropdown-list-item__interactive,
-  button.hds-dropdown-list-item__interactive {
-    // disable background on focus and active states
-    &:focus,
-    &:active,
-    &.mock-focus,
-    &.mock-active {
-      color: var(--token-color-foreground-action-active);
-
-      &::after {
-        background-color: inherit;
-      }
-    }
-  }
-}
-
 .hds-dropdown-list-item--checkmark-selected {
-  a.hds-dropdown-list-item__interactive,
-  button.hds-dropdown-list-item__interactive {
+  .hds-dropdown-list-item__interactive {
     color: var(--token-color-foreground-action);
   }
 }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -442,6 +442,13 @@ $hds-dropdown-toggle-border-radius: 5px;
   align-self: center;
 }
 
+.hds-dropdown-list-item__interactive[disabled],
+.hds-dropdown-list-item__interactive[disabled]:hover {
+  color: var(--token-color-foreground-disabled);
+  cursor: not-allowed;
+}
+
+
 // HDS::DROPDOWN::LIST-ITEM::CHECKBOX & HDS::DROPDOWN::LIST-ITEM::RADIO
 
 .hds-dropdown-list-item--variant-checkbox,
@@ -454,6 +461,12 @@ $hds-dropdown-toggle-border-radius: 5px;
     flex-shrink: 0;
     margin-top: 2px;
     margin-right: 8px;
+
+    &[disabled] ~ .hds-dropdown-list-item__label,
+    &[disabled] ~ .hds-dropdown-list-item__icon,
+    &[disabled] ~ .hds-dropdown-list-item__count {
+      color: var(--token-color-foreground-disabled);
+    }
   }
 
   .hds-dropdown-list-item__label {

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -353,6 +353,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown-list-item__interactive-text {
+  flex: 1;
   text-align: left; // the button element was centering text
 }
 
@@ -445,28 +446,24 @@ $hds-dropdown-toggle-border-radius: 5px;
       }
     }
   }
-
-  .hds-dropdown-list-item__interactive-text {
-    flex: 1;
-  }
 }
 
 .hds-dropdown-list-item--checkmark-selected {
   a.hds-dropdown-list-item__interactive,
   button.hds-dropdown-list-item__interactive {
-    padding-right: 9px; // reset to default
     color: var(--token-color-foreground-action);
   }
 }
 
 .hds-dropdown-list-item__checkmark {
+  display: flex;
   align-self: flex-start;
   width: 20px;
   height: 20px; // replicating the resulted height of the list item
 }
 
 .hds-dropdown-list-item__checkmark-icon {
-  height: inherit;
+  align-self: center;
 }
 
 // HDS::DROPDOWN::LIST-ITEM::CHECKBOX & HDS::DROPDOWN::LIST-ITEM::RADIO
@@ -484,7 +481,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 
   .hds-dropdown-list-item__label {
     flex-grow: 1;
-    width: fit-content;
     color: var(--token-color-foreground-primary);
   }
 }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -446,6 +446,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 .hds-dropdown-list-item--checkbox,
 .hds-dropdown-list-item--radio {
   display: flex;
+  align-items: center;
   padding: 8px 16px;
 
   .hds-dropdown-list-item__control {
@@ -456,6 +457,12 @@ $hds-dropdown-toggle-border-radius: 5px;
 
   .hds-dropdown-list-item__label {
     flex-grow: 1;
+    color: var(--token-color-foreground-primary);
+  }
+
+  .hds-dropdown-list-item__icon {
+    margin-top: 2px;
+    margin-right: 4px;
     color: var(--token-color-foreground-primary);
   }
 }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -223,8 +223,8 @@ $hds-dropdown-toggle-border-radius: 5px;
   padding-left: 16px;
 }
 
-
-.hds-dropdown-list-item--interactive {
+.hds-dropdown-list-item--interactive,
+.hds-dropdown-list-item--checkmark {
   position: relative;
   min-height: 36px;
   isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
@@ -418,3 +418,32 @@ $hds-dropdown-toggle-border-radius: 5px;
   color: var(--token-color-foreground-strong);
 }
 
+.hds-dropdown-list-item--checkmark {
+  color: var(--token-color-foreground-action-active);
+
+  .hds-dropdown-list-item__interactive {
+    // leave room for the checkmark to avoid overlapping with text
+    padding-right: 30px;
+
+    // disable background on focus and active states
+    &:focus,
+    &:active,
+    &.mock-focus,
+    &.mock-active {
+      &::after {
+        background-color: transparent;
+      }
+    }
+  }
+}
+
+.hds-dropdown-list-item--checkmark-selected {
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M14.78 4.28a.75.75 0 00-1.06-1.06l-7.97 7.97-3.47-3.47a.75.75 0 00-1.06 1.06l4 4a.75.75 0 001.06 0l8.5-8.5z' fill='%231060ff'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: top 10px right 10px;
+  background-size: var(--token-form-select-background-image-size) var(--token-form-select-background-image-size);
+
+  .hds-dropdown-list-item__interactive {
+    color: var(--token-color-foreground-action-active);
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -347,8 +347,8 @@
     <SF.Item @label="Custom content">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
-            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @resultCount="12">
+            <Shw::Placeholder @text="custom content" @width="123" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
       </ul>
@@ -356,8 +356,8 @@
     <SF.Item @label="Custom content, selected">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
-            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @resultCount="12">
+            <Shw::Placeholder @text="custom content" @width="123" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
       </ul>
@@ -447,8 +447,8 @@
     <SF.Item @label="Custom content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
-            <Shw::Placeholder @text="custom content" @width="144" @height="20" @background="#eee" />
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @resultCount="12">
+            <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
@@ -456,8 +456,8 @@
     <SF.Item @label="Custom content, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
-            <Shw::Placeholder @text="custom content" @width="144" @height="20" @background="#eee" />
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @resultCount="12">
+            <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
@@ -544,8 +544,8 @@
     <SF.Item @label="Custom content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
-            <Shw::Placeholder @text="custom content" @width="144" @height="20" @background="#eee" />
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @resultCount="12">
+            <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
@@ -553,8 +553,8 @@
     <SF.Item @label="Custom content, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
-            <Shw::Placeholder @text="custom content" @width="144" @height="20" @background="#eee" />
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @resultCount="12">
+            <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -329,6 +329,24 @@
     <SF.Item>
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @resultCount="12">
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list" role="listbox">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @resultCount="12">
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list" role="listbox">
+        {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
             <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkmark>
@@ -347,8 +365,30 @@
     <SF.Item>
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
+            {{state}}
+            <Hds::Badge @icon="org" @text="Private" @size="small" />
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list" role="listbox">
+        {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
-            {{state}} with a longer text string that may wrap since max-width is defined on the container
+            {{state}}
+            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list" role="listbox">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @resultCount="12">
+            {{state}} 
+            with a longer text string that may wrap since max-width is defined on the container
+            <Hds::Badge @text="badge" @size="small" />
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
       </ul>
@@ -356,10 +396,10 @@
     <SF.Item>
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Checkmark" @color="secondary" />
-        <dd.Checkmark>virtualbox</dd.Checkmark>
-        <dd.Checkmark @selected={{true}}>vmware</dd.Checkmark>
-        <dd.Checkmark>docker</dd.Checkmark>
-        <dd.Checkmark>hyperv</dd.Checkmark>
+        <dd.Checkmark @resultCount="11">virtualbox</dd.Checkmark>
+        <dd.Checkmark @resultCount="1" @selected={{true}}>vmware</dd.Checkmark>
+        <dd.Checkmark @resultCount="10">docker</dd.Checkmark>
+        <dd.Checkmark @resultCount="0">hyperv</dd.Checkmark>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
@@ -377,6 +417,20 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>{{state}}</Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @resultCount="12">{{state}}</Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @resultCount="12">{{state}}</Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
     </SF.Item>
@@ -402,7 +456,29 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
-            {{state}} with a longer text string that may wrap since max-width is defined on the container
+            {{state}}
+            <Hds::Badge @icon="org" @text="Private" @size="small" />
+          </Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
+            {{state}}
+            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+          </Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @resultCount="12">
+            {{state}} 
+            with a longer text string that may wrap since max-width is defined on the container
+            <Hds::Badge @text="badge" @size="small" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
@@ -410,10 +486,10 @@
     <SF.Item>
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Checkbox" @color="secondary" />
-        <dd.Checkbox @name="checkbox-item-dropdown">virtualbox</dd.Checkbox>
-        <dd.Checkbox @name="checkbox-item-dropdown" checked>vmware</dd.Checkbox>
-        <dd.Checkbox @name="checkbox-item-dropdown">docker</dd.Checkbox>
-        <dd.Checkbox @name="checkbox-item-dropdown">hyperv</dd.Checkbox>
+        <dd.Checkbox @name="checkbox-item-dropdown" @resultCount="11">virtualbox</dd.Checkbox>
+        <dd.Checkbox @name="checkbox-item-dropdown" @resultCount="1" checked>vmware</dd.Checkbox>
+        <dd.Checkbox @name="checkbox-item-dropdown" @resultCount="10">docker</dd.Checkbox>
+        <dd.Checkbox @name="checkbox-item-dropdown" @resultCount="0">hyperv</dd.Checkbox>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
@@ -431,6 +507,20 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>{{state}}</Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @resultCount="12">{{state}}</Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @resultCount="12">{{state}}</Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
     </SF.Item>
@@ -457,7 +547,28 @@
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
             {{state}}
+            <Hds::Badge @icon="org" @text="Private" @size="small" />
+          </Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
+            {{state}}
+            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+          </Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @resultCount="12">
+            {{state}}
             with a longer text string that may wrap since max-width is defined on the container
+            <Hds::Badge @text="badge" @size="small" />
           </Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
@@ -465,10 +576,10 @@
     <SF.Item>
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Radio" @color="secondary" />
-        <dd.Radio @name="radio-item-dropdown">virtualbox</dd.Radio>
-        <dd.Radio @name="radio-item-dropdown" checked>vmware</dd.Radio>
-        <dd.Radio @name="radio-item-dropdown">docker</dd.Radio>
-        <dd.Radio @name="radio-item-dropdown">hyperv</dd.Radio>
+        <dd.Radio @name="radio-item-dropdown" @resultCount="11">virtualbox</dd.Radio>
+        <dd.Radio @name="radio-item-dropdown" @resultCount="1" checked>vmware</dd.Radio>
+        <dd.Radio @name="radio-item-dropdown" @resultCount="10">docker</dd.Radio>
+        <dd.Radio @name="radio-item-dropdown" @resultCount="0">hyperv</dd.Radio>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -386,7 +386,7 @@
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @resultCount="12">
-            {{state}} 
+            {{state}}
             with a longer text string that may wrap since max-width is defined on the container
             <Hds::Badge @text="badge" @size="small" />
           </Hds::Dropdown::ListItem::Checkmark>
@@ -416,21 +416,31 @@
     <SF.Item>
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox
+            mock-state-value={{state}}
+            checked
+          >{{state}}</Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
     </SF.Item>
     <SF.Item>
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @resultCount="12">{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox
+            mock-state-value={{state}}
+            @resultCount="12"
+          >{{state}}</Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
     </SF.Item>
     <SF.Item>
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @resultCount="12">{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox
+            mock-state-value={{state}}
+            checked
+            @resultCount="12"
+          >{{state}}</Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
     </SF.Item>
@@ -438,7 +448,7 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
-            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />          
+            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
@@ -447,7 +457,7 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
-            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />          
+            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
@@ -476,7 +486,7 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @resultCount="12">
-            {{state}} 
+            {{state}}
             with a longer text string that may wrap since max-width is defined on the container
             <Hds::Badge @text="badge" @size="small" />
           </Hds::Dropdown::ListItem::Checkbox>
@@ -513,14 +523,21 @@
     <SF.Item>
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @resultCount="12">{{state}}</Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio
+            mock-state-value={{state}}
+            @resultCount="12"
+          >{{state}}</Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
     </SF.Item>
     <SF.Item>
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @resultCount="12">{{state}}</Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio
+            mock-state-value={{state}}
+            checked
+            @resultCount="12"
+          >{{state}}</Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
     </SF.Item>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -417,4 +417,59 @@
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Text::H3>Radio</Shw::Text::H3>
+  <Shw::Flex as |SF|>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>{{state}}</Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>{{state}}</Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
+            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
+          </Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
+            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
+          </Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
+            {{state}}
+            with a longer text string that may wrap since max-width is defined on the container
+          </Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <Hds::Dropdown @listPosition="left" as |dd|>
+        <dd.ToggleButton @text="Radio" @color="secondary" />
+        <dd.Radio @name="radio-item-dropdown">virtualbox</dd.Radio>
+        <dd.Radio @name="radio-item-dropdown" checked>vmware</dd.Radio>
+        <dd.Radio @name="radio-item-dropdown">docker</dd.Radio>
+        <dd.Radio @name="radio-item-dropdown">hyperv</dd.Radio>
+      </Hds::Dropdown>
+    </SF.Item>
+  </Shw::Flex>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -309,7 +309,7 @@
   <Shw::Text::H3>Checkmark</Shw::Text::H3>
   <Shw::Flex as |SF|>
     <SF.Item>
-      <ul class="hds-dropdown-list">
+      <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
             {{state}}
@@ -318,7 +318,7 @@
       </ul>
     </SF.Item>
     <SF.Item>
-      <ul class="hds-dropdown-list">
+      <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
             {{state}}
@@ -327,7 +327,7 @@
       </ul>
     </SF.Item>
     <SF.Item>
-      <ul class="hds-dropdown-list">
+      <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
             <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
@@ -336,7 +336,7 @@
       </ul>
     </SF.Item>
     <SF.Item>
-      <ul class="hds-dropdown-list">
+      <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
             <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
@@ -345,7 +345,7 @@
       </ul>
     </SF.Item>
     <SF.Item>
-      <ul class="hds-dropdown-list">
+      <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
             {{state}} with a longer text string that may wrap since max-width is defined on the container

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -344,19 +344,19 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item @label="Result count">
+    <SF.Item @label="Count">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @resultCount="12">
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
             {{state}}
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item @label="Result count, selected">
+    <SF.Item @label="Count, selected">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @resultCount="12">
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
             {{state}}
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
@@ -365,7 +365,7 @@
     <SF.Item @label="Custom content">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @resultCount="12">
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
             <Shw::Placeholder @text="custom content" @width="123" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
@@ -374,7 +374,7 @@
     <SF.Item @label="Custom content, selected">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @resultCount="12">
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
             <Shw::Placeholder @text="custom content" @width="123" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
@@ -403,12 +403,7 @@
     <SF.Item @label="Large content">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark
-            mock-state-value={{state}}
-            @icon="hexagon"
-            @selected={{true}}
-            @resultCount="12"
-          >
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @icon="hexagon" @selected={{true}} @count="12">
             {{state}}
             with a longer text string that may wrap since max-width is defined on the container
             <Hds::Badge @text="badge" @size="small" />
@@ -419,10 +414,10 @@
     <SF.Item @label="Interactive">
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Checkmark" @color="secondary" />
-        <dd.Checkmark @resultCount="11">virtualbox</dd.Checkmark>
-        <dd.Checkmark @resultCount="1" @selected={{true}}>vmware</dd.Checkmark>
-        <dd.Checkmark @resultCount="10">docker</dd.Checkmark>
-        <dd.Checkmark @resultCount="0">hyperv</dd.Checkmark>
+        <dd.Checkmark @count="11">virtualbox</dd.Checkmark>
+        <dd.Checkmark @count="1" @selected={{true}}>vmware</dd.Checkmark>
+        <dd.Checkmark @count="10">docker</dd.Checkmark>
+        <dd.Checkmark @count="0">hyperv</dd.Checkmark>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
@@ -467,23 +462,23 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item @label="Result count">
+    <SF.Item @label="Count">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox
             mock-state-value={{state}}
-            @resultCount="12"
+            @count="12"
           >{{state}}</Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item @label="Result count, checked">
+    <SF.Item @label="Count, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox
             mock-state-value={{state}}
             checked
-            @resultCount="12"
+            @count="12"
           >{{state}}</Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
@@ -491,7 +486,7 @@
     <SF.Item @label="Custom content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @resultCount="12">
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">
             <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
@@ -500,7 +495,7 @@
     <SF.Item @label="Custom content, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @resultCount="12">
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">
             <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
@@ -529,7 +524,7 @@
     <SF.Item @label="Large content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @resultCount="12" @icon="hexagon">
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12" @icon="hexagon">
             {{state}}
             with a longer text string that may wrap since max-width is defined on the container
             <Hds::Badge @text="badge" @size="small" />
@@ -540,10 +535,10 @@
     <SF.Item @label="Interactive">
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Checkbox" @color="secondary" />
-        <dd.Checkbox name="checkbox-item-dropdown" @resultCount="11">virtualbox</dd.Checkbox>
-        <dd.Checkbox name="checkbox-item-dropdown" @resultCount="1" checked>vmware</dd.Checkbox>
-        <dd.Checkbox name="checkbox-item-dropdown" @resultCount="10">docker</dd.Checkbox>
-        <dd.Checkbox name="checkbox-item-dropdown" @resultCount="0">hyperv</dd.Checkbox>
+        <dd.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</dd.Checkbox>
+        <dd.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</dd.Checkbox>
+        <dd.Checkbox name="checkbox-item-dropdown" @count="10">docker</dd.Checkbox>
+        <dd.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</dd.Checkbox>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
@@ -585,23 +580,23 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item @label="Result count">
+    <SF.Item @label="Count">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio
             mock-state-value={{state}}
-            @resultCount="12"
+            @count="12"
           >{{state}}</Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item @label="Result count, checked">
+    <SF.Item @label="Count, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio
             mock-state-value={{state}}
             checked
-            @resultCount="12"
+            @count="12"
           >{{state}}</Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
@@ -609,7 +604,7 @@
     <SF.Item @label="Custom content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @resultCount="12">
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">
             <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Radio>
         {{/each}}
@@ -618,7 +613,7 @@
     <SF.Item @label="Custom content, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @resultCount="12">
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">
             <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Radio>
         {{/each}}
@@ -647,7 +642,7 @@
     <SF.Item @label="Large content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @resultCount="12" @icon="hexagon">
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12" @icon="hexagon">
             {{state}}
             with a longer text string that may wrap since max-width is defined on the container
             <Hds::Badge @text="badge" @size="small" />
@@ -658,10 +653,10 @@
     <SF.Item @label="Interactive">
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Radio" @color="secondary" />
-        <dd.Radio name="radio-item-dropdown" @resultCount="11">virtualbox</dd.Radio>
-        <dd.Radio name="radio-item-dropdown" @resultCount="1" checked>vmware</dd.Radio>
-        <dd.Radio name="radio-item-dropdown" @resultCount="10">docker</dd.Radio>
-        <dd.Radio name="radio-item-dropdown" @resultCount="0">hyperv</dd.Radio>
+        <dd.Radio name="radio-item-dropdown" @count="11">virtualbox</dd.Radio>
+        <dd.Radio name="radio-item-dropdown" @count="1" checked>vmware</dd.Radio>
+        <dd.Radio name="radio-item-dropdown" @count="10">docker</dd.Radio>
+        <dd.Radio name="radio-item-dropdown" @count="0">hyperv</dd.Radio>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -436,6 +436,8 @@
         {{/each}}
       </ul>
     </SF.Item>
+  </Shw::Flex>
+  <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Checkmark" @color="secondary" />
@@ -570,6 +572,8 @@
         {{/each}}
       </ul>
     </SF.Item>
+  </Shw::Flex>
+  <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Checkbox" @color="secondary" />
@@ -704,6 +708,8 @@
         {{/each}}
       </ul>
     </SF.Item>
+  </Shw::Flex>
+  <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Radio" @color="secondary" />

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -363,4 +363,58 @@
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Text::H3>Checkbox</Shw::Text::H3>
+  <Shw::Flex as |SF|>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>{{state}}</Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>{{state}}</Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
+            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />          
+          </Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
+            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />          
+          </Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
+            {{state}} with a longer text string that may wrap since max-width is defined on the container
+          </Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <Hds::Dropdown @listPosition="left" as |dd|>
+        <dd.ToggleButton @text="Checkbox" @color="secondary" />
+        <dd.Checkbox @name="checkbox-item-dropdown">virtualbox</dd.Checkbox>
+        <dd.Checkbox @name="checkbox-item-dropdown" checked>vmware</dd.Checkbox>
+        <dd.Checkbox @name="checkbox-item-dropdown">docker</dd.Checkbox>
+        <dd.Checkbox @name="checkbox-item-dropdown">hyperv</dd.Checkbox>
+      </Hds::Dropdown>
+    </SF.Item>
+  </Shw::Flex>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -486,10 +486,10 @@
     <SF.Item>
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Checkbox" @color="secondary" />
-        <dd.Checkbox @name="checkbox-item-dropdown" @resultCount="11">virtualbox</dd.Checkbox>
-        <dd.Checkbox @name="checkbox-item-dropdown" @resultCount="1" checked>vmware</dd.Checkbox>
-        <dd.Checkbox @name="checkbox-item-dropdown" @resultCount="10">docker</dd.Checkbox>
-        <dd.Checkbox @name="checkbox-item-dropdown" @resultCount="0">hyperv</dd.Checkbox>
+        <dd.Checkbox name="checkbox-item-dropdown" @resultCount="11">virtualbox</dd.Checkbox>
+        <dd.Checkbox name="checkbox-item-dropdown" @resultCount="1" checked>vmware</dd.Checkbox>
+        <dd.Checkbox name="checkbox-item-dropdown" @resultCount="10">docker</dd.Checkbox>
+        <dd.Checkbox name="checkbox-item-dropdown" @resultCount="0">hyperv</dd.Checkbox>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
@@ -576,10 +576,10 @@
     <SF.Item>
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Radio" @color="secondary" />
-        <dd.Radio @name="radio-item-dropdown" @resultCount="11">virtualbox</dd.Radio>
-        <dd.Radio @name="radio-item-dropdown" @resultCount="1" checked>vmware</dd.Radio>
-        <dd.Radio @name="radio-item-dropdown" @resultCount="10">docker</dd.Radio>
-        <dd.Radio @name="radio-item-dropdown" @resultCount="0">hyperv</dd.Radio>
+        <dd.Radio name="radio-item-dropdown" @resultCount="11">virtualbox</dd.Radio>
+        <dd.Radio name="radio-item-dropdown" @resultCount="1" checked>vmware</dd.Radio>
+        <dd.Radio name="radio-item-dropdown" @resultCount="10">docker</dd.Radio>
+        <dd.Radio name="radio-item-dropdown" @resultCount="0">hyperv</dd.Radio>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -366,7 +366,7 @@
       <ul class="hds-dropdown-list" role="listbox" aria-label="Custom content">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="123" @height="20" @background="#eee" />
+            <Shw::Placeholder @text="custom content" @width="128" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
       </ul>
@@ -375,7 +375,7 @@
       <ul class="hds-dropdown-list" role="listbox" aria-label="Custom content, selected">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="123" @height="20" @background="#eee" />
+            <Shw::Placeholder @text="custom content" @width="128" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
       </ul>
@@ -487,7 +487,7 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
+            <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
@@ -496,7 +496,7 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">
-            <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
+            <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
@@ -605,7 +605,7 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
+            <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
@@ -614,7 +614,7 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">
-            <Shw::Placeholder @text="custom content" @width="114" @height="20" @background="#eee" />
+            <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -30,6 +30,8 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Icon</Shw::Text::H3>
 
   <Shw::Flex as |SF|>
@@ -43,6 +45,8 @@
       <Hds::Dropdown::Toggle::Icon @imageSrc="/assets/images/avatar.png" @text="user menu" />
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>States</Shw::Text::H3>
 
@@ -145,6 +149,8 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Interactive</Shw::Text::H3>
 
   <Shw::Text::H4>Generated element</Shw::Text::H4>
@@ -244,6 +250,8 @@
     </Shw::Flex>
   {{/each}}
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Generic</Shw::Text::H3>
 
   <Shw::Flex as |SF|>
@@ -255,6 +263,8 @@
       </ul>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>CopyItem</Shw::Text::H3>
 
@@ -306,7 +316,10 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Checkmark</Shw::Text::H3>
+
   <Shw::Flex as |SF|>
     <SF.Item @label="Default">
       <ul class="hds-dropdown-list" role="listbox" aria-label="Default">
@@ -434,7 +447,10 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Checkbox</Shw::Text::H3>
+
   <Shw::Flex as |SF|>
     <SF.Item @label="Default">
       <ul class="hds-dropdown-list">
@@ -565,7 +581,10 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Radio</Shw::Text::H3>
+
   <Shw::Flex as |SF|>
     <SF.Item @label="Default">
       <ul class="hds-dropdown-list">

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -309,7 +309,7 @@
   <Shw::Text::H3>Checkmark</Shw::Text::H3>
   <Shw::Flex as |SF|>
     <SF.Item @label="Default">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Default">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
             {{state}}
@@ -318,7 +318,7 @@
       </ul>
     </SF.Item>
     <SF.Item @label="Selected">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Selected">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
             {{state}}
@@ -327,7 +327,7 @@
       </ul>
     </SF.Item>
     <SF.Item @label="Icon">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Icon">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}}>
             {{state}}
@@ -336,7 +336,7 @@
       </ul>
     </SF.Item>
     <SF.Item @label="Icon, selected">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Icon, selected">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}} @selected={{true}}>
             {{state}}
@@ -345,7 +345,7 @@
       </ul>
     </SF.Item>
     <SF.Item @label="Count">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Count">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
             {{state}}
@@ -354,7 +354,7 @@
       </ul>
     </SF.Item>
     <SF.Item @label="Count, selected">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Count, selected">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
             {{state}}
@@ -363,7 +363,7 @@
       </ul>
     </SF.Item>
     <SF.Item @label="Custom content">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Custom content">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
             <Shw::Placeholder @text="custom content" @width="123" @height="20" @background="#eee" />
@@ -372,7 +372,7 @@
       </ul>
     </SF.Item>
     <SF.Item @label="Custom content, selected">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Custom content, selected">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
             <Shw::Placeholder @text="custom content" @width="123" @height="20" @background="#eee" />
@@ -381,7 +381,7 @@
       </ul>
     </SF.Item>
     <SF.Item @label="Badge in content">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Badge in content">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
             {{state}}
@@ -391,7 +391,7 @@
       </ul>
     </SF.Item>
     <SF.Item @label="Badge in content, selected">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Badge in content, selected">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
             {{state}}
@@ -401,7 +401,7 @@
       </ul>
     </SF.Item>
     <SF.Item @label="Large content">
-      <ul class="hds-dropdown-list" role="listbox">
+      <ul class="hds-dropdown-list" role="listbox" aria-label="Large content">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @icon="hexagon" @selected={{true}} @count="12">
             {{state}}

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -308,7 +308,7 @@
 
   <Shw::Text::H3>Checkmark</Shw::Text::H3>
   <Shw::Flex as |SF|>
-    <SF.Item>
+    <SF.Item @label="Default">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
@@ -317,7 +317,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Selected">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
@@ -326,7 +326,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Result count">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @resultCount="12">
@@ -335,7 +335,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Result count, selected">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @resultCount="12">
@@ -344,7 +344,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Custom content">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
@@ -353,7 +353,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Custom content, selected">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
@@ -362,7 +362,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Badge in content">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
@@ -372,7 +372,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Badge in content, selected">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
@@ -382,7 +382,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Large content">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @resultCount="12">
@@ -393,7 +393,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Interactive">
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Checkmark" @color="secondary" />
         <dd.Checkmark @resultCount="11">virtualbox</dd.Checkmark>
@@ -406,14 +406,14 @@
 
   <Shw::Text::H3>Checkbox</Shw::Text::H3>
   <Shw::Flex as |SF|>
-    <SF.Item>
+    <SF.Item @label="Default">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>{{state}}</Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox
@@ -423,7 +423,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Result count">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox
@@ -433,7 +433,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Result count, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox
@@ -444,25 +444,25 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Custom content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
-            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
+            <Shw::Placeholder @text="custom content" @width="144" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Custom content, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
-            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
+            <Shw::Placeholder @text="custom content" @width="144" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Badge in label">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
@@ -472,7 +472,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Badge in label, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
@@ -482,7 +482,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Large content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @resultCount="12">
@@ -493,7 +493,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Interactive">
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Checkbox" @color="secondary" />
         <dd.Checkbox name="checkbox-item-dropdown" @resultCount="11">virtualbox</dd.Checkbox>
@@ -506,21 +506,21 @@
 
   <Shw::Text::H3>Radio</Shw::Text::H3>
   <Shw::Flex as |SF|>
-    <SF.Item>
+    <SF.Item @label="Default">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>{{state}}</Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>{{state}}</Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Result count">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio
@@ -530,7 +530,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Result count, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio
@@ -541,25 +541,25 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Custom content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
-            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
+            <Shw::Placeholder @text="custom content" @width="144" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Custom content, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
-            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
+            <Shw::Placeholder @text="custom content" @width="144" @height="20" @background="#eee" />
           </Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Badge in label">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
@@ -569,7 +569,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Badge in label, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
@@ -579,7 +579,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Large content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @resultCount="12">
@@ -590,7 +590,7 @@
         {{/each}}
       </ul>
     </SF.Item>
-    <SF.Item>
+    <SF.Item @label="Interactive">
       <Hds::Dropdown @listPosition="left" as |dd|>
         <dd.ToggleButton @text="Radio" @color="secondary" />
         <dd.Radio name="radio-item-dropdown" @resultCount="11">virtualbox</dd.Radio>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -326,6 +326,24 @@
         {{/each}}
       </ul>
     </SF.Item>
+    <SF.Item @label="Icon">
+      <ul class="hds-dropdown-list" role="listbox">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item @label="Icon, selected">
+      <ul class="hds-dropdown-list" role="listbox">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}} @selected={{true}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
     <SF.Item @label="Result count">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
@@ -385,7 +403,12 @@
     <SF.Item @label="Large content">
       <ul class="hds-dropdown-list" role="listbox">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @resultCount="12">
+          <Hds::Dropdown::ListItem::Checkmark
+            mock-state-value={{state}}
+            @icon="hexagon"
+            @selected={{true}}
+            @resultCount="12"
+          >
             {{state}}
             with a longer text string that may wrap since max-width is defined on the container
             <Hds::Badge @text="badge" @size="small" />
@@ -418,6 +441,27 @@
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Checkbox
             mock-state-value={{state}}
+            checked
+          >{{state}}</Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item @label="Icon">
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox
+            mock-state-value={{state}}
+            @icon="hexagon"
+          >{{state}}</Hds::Dropdown::ListItem::Checkbox>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item @label="Icon, checked">
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkbox
+            mock-state-value={{state}}
+            @icon="hexagon"
             checked
           >{{state}}</Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
@@ -485,7 +529,7 @@
     <SF.Item @label="Large content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @resultCount="12">
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @resultCount="12" @icon="hexagon">
             {{state}}
             with a longer text string that may wrap since max-width is defined on the container
             <Hds::Badge @text="badge" @size="small" />
@@ -517,6 +561,27 @@
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
           <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>{{state}}</Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item @label="Icon">
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio
+            mock-state-value={{state}}
+            @icon="hexagon"
+          >{{state}}</Hds::Dropdown::ListItem::Radio>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item @label="Icon, checked">
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Radio
+            mock-state-value={{state}}
+            checked
+            @icon="hexagon"
+          >{{state}}</Hds::Dropdown::ListItem::Radio>
         {{/each}}
       </ul>
     </SF.Item>
@@ -582,7 +647,7 @@
     <SF.Item @label="Large content">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @resultCount="12">
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @resultCount="12" @icon="hexagon">
             {{state}}
             with a longer text string that may wrap since max-width is defined on the container
             <Hds::Badge @text="badge" @size="small" />

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -306,4 +306,61 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Text::H3>Checkmark</Shw::Text::H3>
+  <Shw::Flex as |SF|>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
+            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
+            <Shw::Placeholder @text="custom content" @width="150" @height="20" @background="#eee" />
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <ul class="hds-dropdown-list">
+        {{#each @model.ITEM_STATES as |state|}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
+            {{state}} with a longer text string that may wrap since max-width is defined on the container
+          </Hds::Dropdown::ListItem::Checkmark>
+        {{/each}}
+      </ul>
+    </SF.Item>
+    <SF.Item>
+      <Hds::Dropdown @listPosition="left" as |dd|>
+        <dd.ToggleButton @text="Checkmark" @color="secondary" />
+        <dd.Checkmark>virtualbox</dd.Checkmark>
+        <dd.Checkmark @selected={{true}}>vmware</dd.Checkmark>
+        <dd.Checkmark>docker</dd.Checkmark>
+        <dd.Checkmark>hyperv</dd.Checkmark>
+      </Hds::Dropdown>
+    </SF.Item>
+  </Shw::Flex>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -315,6 +315,9 @@
             {{state}}
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
+        <Hds::Dropdown::ListItem::Checkmark mock-state-value="disabled" disabled>
+          disabled
+        </Hds::Dropdown::ListItem::Checkmark>
       </ul>
     </SF.Item>
     <SF.Item @label="Selected">
@@ -324,6 +327,9 @@
             {{state}}
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
+        <Hds::Dropdown::ListItem::Checkmark mock-state-value="disabled" @selected={{true}} disabled>
+          disabled
+        </Hds::Dropdown::ListItem::Checkmark>
       </ul>
     </SF.Item>
     <SF.Item @label="Icon">
@@ -333,6 +339,9 @@
             {{state}}
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
+        <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value="disabled" disabled>
+          disabled
+        </Hds::Dropdown::ListItem::Checkmark>
       </ul>
     </SF.Item>
     <SF.Item @label="Icon, selected">
@@ -342,6 +351,9 @@
             {{state}}
           </Hds::Dropdown::ListItem::Checkmark>
         {{/each}}
+        <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value="disabled" @selected={{true}} disabled>
+          disabled
+        </Hds::Dropdown::ListItem::Checkmark>
       </ul>
     </SF.Item>
     <SF.Item @label="Count">
@@ -427,39 +439,49 @@
     <SF.Item @label="Default">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
+        <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" disabled>
+          disabled
+        </Hds::Dropdown::ListItem::Checkbox>
       </ul>
     </SF.Item>
     <SF.Item @label="Checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox
-            mock-state-value={{state}}
-            checked
-          >{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
+        <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" disabled checked>
+          disabled
+        </Hds::Dropdown::ListItem::Checkbox>
       </ul>
     </SF.Item>
     <SF.Item @label="Icon">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox
-            mock-state-value={{state}}
-            @icon="hexagon"
-          >{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon">
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
+        <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" @icon="hexagon" disabled>
+          disabled
+        </Hds::Dropdown::ListItem::Checkbox>
       </ul>
     </SF.Item>
     <SF.Item @label="Icon, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox
-            mock-state-value={{state}}
-            @icon="hexagon"
-            checked
-          >{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon" checked>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkbox>
         {{/each}}
+        <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" @icon="hexagon" disabled checked>
+          disabled
+        </Hds::Dropdown::ListItem::Checkbox>
       </ul>
     </SF.Item>
     <SF.Item @label="Count">
@@ -548,36 +570,49 @@
     <SF.Item @label="Default">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>{{state}}</Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Radio>
         {{/each}}
+        <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" disabled>
+          disabled
+        </Hds::Dropdown::ListItem::Radio>
       </ul>
     </SF.Item>
     <SF.Item @label="Checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>{{state}}</Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
+            {{state}}
+          </Hds::Dropdown::ListItem::Radio>
         {{/each}}
+        <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" checked disabled>
+          disabled
+        </Hds::Dropdown::ListItem::Radio>
       </ul>
     </SF.Item>
     <SF.Item @label="Icon">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio
-            mock-state-value={{state}}
-            @icon="hexagon"
-          >{{state}}</Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @icon="hexagon">
+            {{state}}
+          </Hds::Dropdown::ListItem::Radio>
         {{/each}}
+        <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" @icon="hexagon" disabled>
+          disabled
+        </Hds::Dropdown::ListItem::Radio>
       </ul>
     </SF.Item>
     <SF.Item @label="Icon, checked">
       <ul class="hds-dropdown-list">
         {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio
-            mock-state-value={{state}}
-            checked
-            @icon="hexagon"
-          >{{state}}</Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @icon="hexagon">
+            {{state}}
+          </Hds::Dropdown::ListItem::Radio>
         {{/each}}
+        <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" @icon="hexagon" checked disabled>
+          disabled
+        </Hds::Dropdown::ListItem::Radio>
       </ul>
     </SF.Item>
     <SF.Item @label="Count">

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -119,4 +119,27 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown').hasAttribute('data-test1');
     assert.dom('#test-dropdown').hasAttribute('data-test2', 'test');
   });
+
+  // ACCESSIBILITY
+
+  test('it should render a list of items without a role if no selectable items are passed in', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" as |dd|>
+        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <dd.Interactive @text="interactive" id="test-list-item-interactive" {{on "click" dd.close}} />
+      </Hds::Dropdown>
+    `);
+    await click('button#test-toggle-button');
+    assert.dom('#test-dropdown ul').doesNotHaveAttribute('role');
+  });
+  test('it should render a list of items with a `listbox` role if selectable items are passed in', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" as |dd|>
+        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <dd.Checkmark>Checkmark</dd.Checkmark>
+      </Hds::Dropdown>
+    `);
+    await click('button#test-toggle-button');
+    assert.dom('#test-dropdown ul').hasAttribute('role', 'listbox');
+  });
 });

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
@@ -58,6 +58,15 @@ module(
         .hasAttribute('for', controlId);
     });
 
+    // ICON
+
+    test('if an icon is declared the flight icon should render in the component', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkbox @icon="hexagon">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+      );
+      assert.dom('.flight-icon.flight-icon-hexagon').exists();
+    });
+
     // CONTENT
 
     test('it should render the content passed as block in a form label', async function (assert) {

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | hds/dropdown/list-item/checkbox',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders the "list-item/checkbox"', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+      );
+      assert.dom(this.element).exists();
+    });
+
+    test('it should render the "list-item/checkbox" as a <li> element with a CSS class that matches the component name', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+      );
+      assert.dom('.hds-dropdown-list-item').hasTagName('li');
+      assert
+        .dom('.hds-dropdown-list-item')
+        .hasClass('hds-dropdown-list-item--checkbox');
+    });
+
+    // ELEMENTS
+
+    test('it should render the "list-item" with a checkbox field', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+      );
+      assert.dom('.hds-form-label').exists();
+      assert.dom('.hds-form-checkbox').exists();
+    });
+
+    // ARGUMENT FORWARDING: ID, NAME, VALUE
+
+    test('it should forward the `id`, `name` and `value` arguments to the input control', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkbox @id="id" @name="name" @value="value">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+      );
+      assert.dom('.hds-form-checkbox').hasAttribute('id', 'id');
+      assert.dom('.hds-form-checkbox').hasAttribute('name', 'name');
+      assert.dom('.hds-form-checkbox').hasValue('value');
+    });
+
+    // CONTENT
+
+    test('it should render the content passed as block in a form label', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+      );
+      assert.dom('.hds-form-label').hasText('Checkbox item');
+    });
+  }
+);

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
@@ -44,6 +44,20 @@ module(
       assert.dom('.hds-form-checkbox').hasValue('value');
     });
 
+    // CONTROL-LABEL ASSOCIATION
+    test('it automatically creates the control-label relationship via generated id', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkbox @value="value">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+      );
+      let control = this.element.querySelector(
+        '.hds-dropdown-list-item__control'
+      );
+      let controlId = control.id;
+      assert
+        .dom('.hds-dropdown-list-item__label')
+        .hasAttribute('for', controlId);
+    });
+
     // CONTENT
 
     test('it should render the content passed as block in a form label', async function (assert) {
@@ -61,6 +75,15 @@ module(
         hbs`<Hds::Dropdown::ListItem::Checkbox @resultCount="10">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
       );
       assert.dom('.hds-dropdown-list-item__count').hasText('10');
+    });
+
+    // SELECTED
+
+    test('it should render as checked if `checked` is true', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkbox checked={{true}}>Checkbox</Hds::Dropdown::ListItem::Checkbox>`
+      );
+      assert.dom('.hds-form-checkbox').isChecked();
     });
   }
 );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
@@ -27,22 +27,20 @@ module(
 
     // ELEMENTS
 
-    test('it should render the "list-item" with a checkbox field', async function (assert) {
+    test('it should render the "list-item" with a checkbox control', async function (assert) {
       await render(
         hbs`<Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
       );
-      assert.dom('.hds-form-label').exists();
       assert.dom('.hds-form-checkbox').exists();
     });
 
-    // ARGUMENT FORWARDING: ID, NAME, VALUE
+    // ARGUMENT FORWARDING: ID, VALUE
 
-    test('it should forward the `id`, `name` and `value` arguments to the input control', async function (assert) {
+    test('it should forward the `id` and `value` arguments to the input control', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox @id="id" @name="name" @value="value">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<Hds::Dropdown::ListItem::Checkbox @id="id" @value="value">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
       );
       assert.dom('.hds-form-checkbox').hasAttribute('id', 'id');
-      assert.dom('.hds-form-checkbox').hasAttribute('name', 'name');
       assert.dom('.hds-form-checkbox').hasValue('value');
     });
 
@@ -52,7 +50,8 @@ module(
       await render(
         hbs`<Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
       );
-      assert.dom('.hds-form-label').hasText('Checkbox item');
+      assert.dom('.hds-dropdown-list-item__control').exists();
+      assert.dom('.hds-dropdown-list-item__label').hasText('Checkbox item');
     });
 
     // RESULT COUNT

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
@@ -22,7 +22,7 @@ module(
       assert.dom('.hds-dropdown-list-item').hasTagName('li');
       assert
         .dom('.hds-dropdown-list-item')
-        .hasClass('hds-dropdown-list-item--checkbox');
+        .hasClass('hds-dropdown-list-item--variant-checkbox');
     });
 
     // ELEMENTS

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
@@ -77,11 +77,11 @@ module(
       assert.dom('.hds-dropdown-list-item__label').hasText('Checkbox item');
     });
 
-    // RESULT COUNT
+    // COUNT
 
     test('it should render with a result count badge', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox @resultCount="10">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<Hds::Dropdown::ListItem::Checkbox @count="10">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
       );
       assert.dom('.hds-dropdown-list-item__count').hasText('10');
     });

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
@@ -54,5 +54,14 @@ module(
       );
       assert.dom('.hds-form-label').hasText('Checkbox item');
     });
+
+    // RESULT COUNT
+
+    test('it should render with a result count badge', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkbox @resultCount="10">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+      );
+      assert.dom('.hds-dropdown-list-item__count').hasText('10');
+    });
   }
 );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
@@ -74,6 +74,7 @@ module(
       assert
         .dom('.hds-dropdown-list-item')
         .hasClass('hds-dropdown-list-item--checkmark-selected');
+      assert.dom('.hds-dropdown-list-item__checkmark').exists();
     });
 
     // ACCESSIBILITY

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
@@ -64,11 +64,11 @@ module(
       assert.dom('.hds-dropdown-list-item').hasText('Checkmark item');
     });
 
-    // RESULT COUNT
+    // COUNT
 
     test('it should render with a result count badge', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkmark @resultCount="10">Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+        hbs`<Hds::Dropdown::ListItem::Checkmark @count="10">Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
       );
       assert.dom('.hds-dropdown-list-item__count').hasText('10');
     });

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
@@ -22,8 +22,7 @@ module(
       assert.dom('.hds-dropdown-list-item').hasTagName('li');
       assert
         .dom('.hds-dropdown-list-item')
-        .hasClass('hds-dropdown-list-item--checkmark')
-        .hasClass('hds-dropdown-list-item--color-action');
+        .hasClass('hds-dropdown-list-item--checkmark');
     });
 
     // ELEMENTS

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
@@ -66,5 +66,17 @@ module(
         .dom('.hds-dropdown-list-item')
         .hasClass('hds-dropdown-list-item--checkmark-selected');
     });
+
+    // ACCESSIBILITY
+
+    test('it should present the interactive element as a selectable option', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkmark @selected={{true}}>Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+      );
+      assert
+        .dom('.hds-dropdown-list-item__interactive')
+        .hasAttribute('role', 'option')
+        .hasAttribute('aria-selected', 'true');
+    });
   }
 );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
@@ -46,6 +46,15 @@ module(
       assert.dom('a.hds-dropdown-list-item__interactive').exists();
     });
 
+    // ICON
+
+    test('if an icon is declared the flight icon should render in the component', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkmark @icon="hexagon">Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+      );
+      assert.dom('.flight-icon.flight-icon-hexagon').exists();
+    });
+
     // CONTENT
 
     test('it should render the content passed as block', async function (assert) {

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
@@ -22,7 +22,7 @@ module(
       assert.dom('.hds-dropdown-list-item').hasTagName('li');
       assert
         .dom('.hds-dropdown-list-item')
-        .hasClass('hds-dropdown-list-item--checkmark');
+        .hasClass('hds-dropdown-list-item--variant-checkmark');
     });
 
     // ELEMENTS
@@ -81,7 +81,7 @@ module(
       );
       assert
         .dom('.hds-dropdown-list-item')
-        .hasClass('hds-dropdown-list-item--checkmark-selected');
+        .hasClass('hds-dropdown-list-item--variant-checkmark-selected');
       assert.dom('.hds-dropdown-list-item__checkmark').exists();
     });
 

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
@@ -56,6 +56,15 @@ module(
       assert.dom('.hds-dropdown-list-item').hasText('Checkmark item');
     });
 
+    // RESULT COUNT
+
+    test('it should render with a result count badge', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkmark @resultCount="10">Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+      );
+      assert.dom('.hds-dropdown-list-item__count').hasText('10');
+    });
+
     // SELECTED
 
     test('it should render as selected if `@selected` is true', async function (assert) {

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | hds/dropdown/list-item/checkmark',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders the "list-item/checkmark"', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkmark>Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+      );
+      assert.dom(this.element).exists();
+    });
+
+    test('it should render the "list-item/checkmark" as a <li> element with a CSS class that matches the component name', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkmark>Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+      );
+      assert.dom('.hds-dropdown-list-item').hasTagName('li');
+      assert
+        .dom('.hds-dropdown-list-item')
+        .hasClass('hds-dropdown-list-item--checkmark')
+        .hasClass('hds-dropdown-list-item--color-action');
+    });
+
+    // ELEMENTS
+
+    test('it should render the "list-item" with a button by default"', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkmark>Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+      );
+      assert.dom('button.hds-dropdown-list-item__interactive').exists();
+    });
+    test('it should render the "list-item" with a link if it has a @route parameter"', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkmark @route="index">Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+      );
+      assert.dom('a.hds-dropdown-list-item__interactive').exists();
+    });
+    test('it should render the "list-item" with a link if it has a @href argument"', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkmark @href="#">Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+      );
+      assert.dom('a.hds-dropdown-list-item__interactive').exists();
+    });
+
+    // CONTENT
+
+    test('it should render the content passed as block', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkmark>Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+      );
+      assert.dom('.hds-dropdown-list-item').hasText('Checkmark item');
+    });
+
+    // SELECTED
+
+    test('it should render as selected if `@selected` is true', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Checkmark @selected={{true}}>Checkmark item</Hds::Dropdown::ListItem::Checkmark>`
+      );
+      assert
+        .dom('.hds-dropdown-list-item')
+        .hasClass('hds-dropdown-list-item--checkmark-selected');
+    });
+  }
+);

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/copy-item-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/copy-item-test.js
@@ -34,7 +34,7 @@ module(
         .hasClass('hds-dropdown-list-item');
       assert
         .dom('#test-list-item-copy-item')
-        .hasClass('hds-dropdown-list-item--copy-item');
+        .hasClass('hds-dropdown-list-item--variant-copy-item');
     });
 
     // ASSERTIONS

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/description-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/description-test.js
@@ -34,7 +34,7 @@ module(
         .hasClass('hds-dropdown-list-item');
       assert
         .dom('#test-list-item-description')
-        .hasClass('hds-dropdown-list-item--description');
+        .hasClass('hds-dropdown-list-item--variant-description');
     });
 
     // ASSERTIONS

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/generic-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/generic-test.js
@@ -26,7 +26,7 @@ module(
       assert.dom('#test-list-item-generic').hasClass('hds-dropdown-list-item');
       assert
         .dom('#test-list-item-generic')
-        .hasClass('hds-dropdown-list-item--generic');
+        .hasClass('hds-dropdown-list-item--variant-generic');
     });
 
     // CONTENT
@@ -35,8 +35,10 @@ module(
       await render(
         hbs`<Hds::Dropdown::ListItem::Generic><pre>test</pre></Hds::Dropdown::ListItem::Generic>`
       );
-      assert.dom('.hds-dropdown-list-item--generic > pre').exists();
-      assert.dom('.hds-dropdown-list-item--generic > pre').hasText('test');
+      assert.dom('.hds-dropdown-list-item--variant-generic > pre').exists();
+      assert
+        .dom('.hds-dropdown-list-item--variant-generic > pre')
+        .hasText('test');
     });
   }
 );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/interactive-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/interactive-test.js
@@ -35,7 +35,7 @@ module(
       assert.dom('.hds-dropdown-list-item').hasTagName('li');
       assert
         .dom('.hds-dropdown-list-item')
-        .hasClass('hds-dropdown-list-item--interactive');
+        .hasClass('hds-dropdown-list-item--variant-interactive');
     });
 
     // ELEMENTS

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
@@ -54,5 +54,14 @@ module(
       );
       assert.dom('.hds-form-label').hasText('Radio item');
     });
+
+    // RESULT COUNT
+
+    test('it should render with a result count badge', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Radio @resultCount="10">Radio item</Hds::Dropdown::ListItem::Radio>`
+      );
+      assert.dom('.hds-dropdown-list-item__count').hasText('10');
+    });
   }
 );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
@@ -27,22 +27,20 @@ module(
 
     // ELEMENTS
 
-    test('it should render the "list-item" with a radio field', async function (assert) {
+    test('it should render the "list-item" with a radio control', async function (assert) {
       await render(
         hbs`<Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio>`
       );
-      assert.dom('.hds-form-label').exists();
       assert.dom('.hds-form-radio').exists();
     });
 
-    // ARGUMENT FORWARDING: ID, NAME, VALUE
+    // ARGUMENT FORWARDING: ID, VALUE
 
-    test('it should forward the `id`, `name` and `value` arguments to the input control', async function (assert) {
+    test('it should forward the `id` and `value` arguments to the input control', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio @id="id" @name="name" @value="value">Radio item</Hds::Dropdown::ListItem::Radio>`
+        hbs`<Hds::Dropdown::ListItem::Radio @id="id" @value="value">Radio item</Hds::Dropdown::ListItem::Radio>`
       );
       assert.dom('.hds-form-radio').hasAttribute('id', 'id');
-      assert.dom('.hds-form-radio').hasAttribute('name', 'name');
       assert.dom('.hds-form-radio').hasValue('value');
     });
 
@@ -52,7 +50,8 @@ module(
       await render(
         hbs`<Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio>`
       );
-      assert.dom('.hds-form-label').hasText('Radio item');
+      assert.dom('.hds-dropdown-list-item__control').exists();
+      assert.dom('.hds-dropdown-list-item__label').hasText('Radio item');
     });
 
     // RESULT COUNT

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
@@ -58,6 +58,15 @@ module(
         .hasAttribute('for', controlId);
     });
 
+    // ICON
+
+    test('if an icon is declared the flight icon should render in the component', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Radio @icon="hexagon">Radio item</Hds::Dropdown::ListItem::Radio>`
+      );
+      assert.dom('.flight-icon.flight-icon-hexagon').exists();
+    });
+
     // CONTENT
 
     test('it should render the content passed as block in a form label', async function (assert) {

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
@@ -77,11 +77,11 @@ module(
       assert.dom('.hds-dropdown-list-item__label').hasText('Radio item');
     });
 
-    // RESULT COUNT
+    // COUNT
 
     test('it should render with a result count badge', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio @resultCount="10">Radio item</Hds::Dropdown::ListItem::Radio>`
+        hbs`<Hds::Dropdown::ListItem::Radio @count="10">Radio item</Hds::Dropdown::ListItem::Radio>`
       );
       assert.dom('.hds-dropdown-list-item__count').hasText('10');
     });

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
@@ -22,7 +22,7 @@ module(
       assert.dom('.hds-dropdown-list-item').hasTagName('li');
       assert
         .dom('.hds-dropdown-list-item')
-        .hasClass('hds-dropdown-list-item--radio');
+        .hasClass('hds-dropdown-list-item--variant-radio');
     });
 
     // ELEMENTS

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | hds/dropdown/list-item/radio',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders the "list-item/radio"', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio>`
+      );
+      assert.dom(this.element).exists();
+    });
+
+    test('it should render the "list-item/radio" as a <li> element with a CSS class that matches the component name', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio>`
+      );
+      assert.dom('.hds-dropdown-list-item').hasTagName('li');
+      assert
+        .dom('.hds-dropdown-list-item')
+        .hasClass('hds-dropdown-list-item--radio');
+    });
+
+    // ELEMENTS
+
+    test('it should render the "list-item" with a radio field', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio>`
+      );
+      assert.dom('.hds-form-label').exists();
+      assert.dom('.hds-form-radio').exists();
+    });
+
+    // ARGUMENT FORWARDING: ID, NAME, VALUE
+
+    test('it should forward the `id`, `name` and `value` arguments to the input control', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Radio @id="id" @name="name" @value="value">Radio item</Hds::Dropdown::ListItem::Radio>`
+      );
+      assert.dom('.hds-form-radio').hasAttribute('id', 'id');
+      assert.dom('.hds-form-radio').hasAttribute('name', 'name');
+      assert.dom('.hds-form-radio').hasValue('value');
+    });
+
+    // CONTENT
+
+    test('it should render the content passed as block in a form label', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio>`
+      );
+      assert.dom('.hds-form-label').hasText('Radio item');
+    });
+  }
+);

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
@@ -44,6 +44,20 @@ module(
       assert.dom('.hds-form-radio').hasValue('value');
     });
 
+    // CONTROL-LABEL ASSOCIATION
+    test('it automatically creates the control-label relationship via generated id', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Radio @value="value">Checkbox item</Hds::Dropdown::ListItem::Radio>`
+      );
+      let control = this.element.querySelector(
+        '.hds-dropdown-list-item__control'
+      );
+      let controlId = control.id;
+      assert
+        .dom('.hds-dropdown-list-item__label')
+        .hasAttribute('for', controlId);
+    });
+
     // CONTENT
 
     test('it should render the content passed as block in a form label', async function (assert) {
@@ -61,6 +75,15 @@ module(
         hbs`<Hds::Dropdown::ListItem::Radio @resultCount="10">Radio item</Hds::Dropdown::ListItem::Radio>`
       );
       assert.dom('.hds-dropdown-list-item__count').hasText('10');
+    });
+
+    // SELECTED
+
+    test('it should render as checked if `checked` is true', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Radio checked={{true}}>Radio</Hds::Dropdown::ListItem::Radio>`
+      );
+      assert.dom('.hds-form-radio').isChecked();
     });
   }
 );

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/separator-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/separator-test.js
@@ -30,7 +30,7 @@ module(
         .hasClass('hds-dropdown-list-item');
       assert
         .dom('#test-list-item-separator')
-        .hasClass('hds-dropdown-list-item--separator');
+        .hasClass('hds-dropdown-list-item--variant-separator');
     });
 
     // A11Y

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/title-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/title-test.js
@@ -30,7 +30,7 @@ module(
       assert.dom('#test-list-item-title').hasClass('hds-dropdown-list-item');
       assert
         .dom('#test-list-item-title')
-        .hasClass('hds-dropdown-list-item--title');
+        .hasClass('hds-dropdown-list-item--variant-title');
     });
 
     // ASSERTIONS


### PR DESCRIPTION
### :pushpin: Summary

Extend `Hds::Dropdown::ListItem` with selectable items and the option for result counts to support the upcoming 'Filter' pattern.

### :hammer_and_wrench: Detailed description

- Add `Hds::Dropdown::ListItem::Checkmark` as a proxy for `Hds::Interactive` with a `@selected` argument (for context switching)
- Add `Hds::Dropdown::ListItem::Checkbox` as a proxy for `Hds::Form::Checkbox` (for filter)
- Add `Hds::Dropdown::ListItem::Radio` as a proxy for `Hds::Form::Radio` (for filter)
- Add `@count` argument to selectable list items (Checkmark, Checkbox, Radio) 

> **Note**
> Internal class name changes: `hds-dropdown-list-item--[variant]` → `hds-dropdown-list-item--variant-[variant]`
> - `hds-dropdown-list-item--copy-item` → `hds-dropdown-list-item--variant-copy-item`
> - `hds-dropdown-list-item--description` → `hds-dropdown-list-item--variant-description`
> - `hds-dropdown-list-item--generic` → `hds-dropdown-list-item--variant-generic`
> - `hds-dropdown-list-item--interactive` → `hds-dropdown-list-item--variant-interactive`
> - `hds-dropdown-list-item--separator` → `hds-dropdown-list-item--variant-separator`
> - `hds-dropdown-list-item--title` → `hds-dropdown-list-item--variant-title`
>
> These should not represent a breaking change as the consumers rely on the public API, but if test assertions are based on class names or extensions/overrides have been applied to these elements they may raise issues. For this reason, we flag this change as a **breaking change** to give consumers a heads-up.

[👉 Preview showcase](https://hds-showcase-git-alex-ju-dropdown-extension-hashicorp.vercel.app/components/dropdown)

Related work:
- [x] [Test the current API](https://github.com/hashicorp/cloud-ui/commit/d63bb0f6f93771f056d3e6c7efdb7b01fcd46a49) in context (`cloud-ui`s Vault insights seems like a good candidate)
- [x] Figure out if additional filter features (such as allowing result count in content items) should be part of this work or a follow-up PR – decided to group the selectable list item with the result count in this PR and leave search and actions for separate PRs so we can deliver the whole filter pattern work incrementally

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![checkbox-before](https://user-images.githubusercontent.com/788096/218160757-1959618f-4ff0-4570-a733-99c4d1fb96f0.png)


</td><td>

![checkbox-after](https://user-images.githubusercontent.com/788096/218160770-659684df-d330-4abd-9d51-34393ff0461c.png)


</td></tr>
<tr><td>

![radio-before](https://user-images.githubusercontent.com/788096/218160788-ecf8693d-57f6-4b6a-bf05-4dfbc072792d.png)


</td><td>

![radio-after](https://user-images.githubusercontent.com/788096/218160803-d8452cf8-e509-4717-8dd6-26d024c6a282.png)


</td></tr>
</table>


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: Part of [HDS-1109](https://hashicorp.atlassian.net/browse/HDS-1109)
Figma file: https://www.figma.com/file/Kgc8BgB8jGuJXISndgTrD1/Dropdown?node-id=27919%3A58777&t=4MEZaQEQPfhRuVTW-4

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1109]: https://hashicorp.atlassian.net/browse/HDS-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ