### PR TITLE
Update existing documentation for `Hds::Table` component

### DIFF
--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -36,10 +36,15 @@
     <dd class="doc-component-api__description doc-component-api__description--description">
       {{yield}}
       {{#if @valueNoteList}}
-        <ul class="doc-component-api__property-value-items" role="list">
+        <ul class="doc-list-generic doc-component-api__description" role="list">
           {{#each @valueNoteList as |valueNoteListItem|}}
             <li class="doc-component-api__property-value-item">
-              {{valueNoteListItem}}
+              <code class="doc-markdown-code">{{valueNoteListItem.code}}</code>
+              {{#if (eq valueNoteListItem.required "true")}}
+                <Doc::Badge @type="outlined">Required</Doc::Badge>
+              {{/if}}
+              ⁠—
+              {{valueNoteListItem.text}}
             </li>
           {{/each}}
         </ul>

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -31,6 +31,19 @@
       {{/if}}
     </dd>
   {{/if}}
+  {{#if @valueList}}
+    <dt class="doc-component-api__term doc-component-api__term--description">Description</dt>
+    <dd class="doc-component-api__description doc-component-api__description--description">
+      <ul class="doc-component-api__property-value-items" role="list">
+        {{#each @valueList as |valueItem|}}
+          <li class="doc-component-api__property-value-item">
+            {{valueItem}}
+          </li>
+        {{/each}}
+      </ul>
+      {{yield}}
+    </dd>
+  {{/if}}
   {{#if (has-block)}}
     <dt class="doc-component-api__term doc-component-api__term--description">Description</dt>
     <dd class="doc-component-api__description doc-component-api__description--description">

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -31,23 +31,19 @@
       {{/if}}
     </dd>
   {{/if}}
-  {{#if @valueList}}
-    <dt class="doc-component-api__term doc-component-api__term--description">Description</dt>
-    <dd class="doc-component-api__description doc-component-api__description--description">
-      <ul class="doc-component-api__property-value-items" role="list">
-        {{#each @valueList as |valueItem|}}
-          <li class="doc-component-api__property-value-item">
-            {{valueItem}}
-          </li>
-        {{/each}}
-      </ul>
-      {{yield}}
-    </dd>
-  {{/if}}
   {{#if (has-block)}}
     <dt class="doc-component-api__term doc-component-api__term--description">Description</dt>
     <dd class="doc-component-api__description doc-component-api__description--description">
       {{yield}}
+      {{#if @valueNoteList}}
+        <ul class="doc-component-api__property-value-items" role="list">
+          {{#each @valueNoteList as |valueNoteListItem|}}
+            <li class="doc-component-api__property-value-item">
+              {{valueNoteListItem}}
+            </li>
+          {{/each}}
+        </ul>
+      {{/if}}
     </dd>
   {{/if}}
 </dl>

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -1,6 +1,6 @@
 ## Component API
 
-The Table component itself is where most of the options will be applied. However, the child components can also be used if a custom implementation is needed.
+The Table component itself is where most of the options will be applied. However, the API for the child components are also documented here, in case a custom implementation is desired.
 
 ### Table
 
@@ -32,6 +32,9 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="density" @type="enum" @values={{array "short" "medium" "tall" }} @default="medium">
     If set, determines the density, or height, of the table’s rows.
   </C.Property>
+  <C.Property @name="align" @type="enum" @values={{array "left" "center" "right"}} @default="left">
+    If set, determines the text alignment for all cell (`td`) content in a table.
+  </C.Property>
   <C.Property @name="valign" @type="enum" @values={{array "top" "middle" }} @default="top">
     If set, determines the vertical alignment for all cell (`td`) content in a table. Does not apply to table headers (`th`).
   </C.Property>
@@ -41,7 +44,7 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="...attributes">
     Supported for the `Hds::Table` component.
   </C.Property>
-     <C.Property @name="onSort" @type="function">
+  <C.Property @name="onSort" @type="function">
     Automatically applied to sortable table headers, `onSort` is the callback function that is invoked when one of the sortable table headers is clicked (or has a keyboard interaction performed). The function receives the values of `sortBy` and `sortOrder` as arguments.
   </C.Property>
 </Doc::ComponentApi>
@@ -50,32 +53,58 @@ The Table component itself is where most of the options will be applied. However
 
 The `Hds::Table::Tr` component is a template-only component.
 
-It supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering) but is not eligible to receive interactions (e.g., it cannot have an `onClick` event handler attached directly to it).
+This component is not eligible to receive interactions (e.g., it cannot have an `onClick` event handler attached directly to it). Instead, an interactive element should be placed _inside_ of a `th` or `td` element.
 
 It can contain `Hds::Table::Th` or `Hds::Table::Td` components.
 
-<!-- <Doc::ComponentApi as |C|>
-</Doc::ComponentApi> -->
+<Doc::ComponentApi as |C|>
+    <C.Property @name="...attributes">
+    This component supports the use of `...attributes`.
+  </C.Property>
+</Doc::ComponentApi>
 
 ### Table::Th
 
-The `Hds::Table::Th` supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering). While it can **contain** interactive elements, it cannot have actions attached to it.
+This component is not eligible to receive interactions (e.g., it cannot have an `onClick` event handler attached directly to it). Instead, an interactive element should be placed _inside_ of a `th` or `td` element.
 
-<!-- <Doc::ComponentApi as |C|>
-</Doc::ComponentApi> -->
+If a `th` is passed as the first "cell" of a table body row, it has `scope="row"` automatically applied to it for accessibility purposes.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="align" @type="enum" @values={{array "left" "center" "right"}} @default="left">
+    If set, determines the text alignment.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports the use of `...attributes`.
+  </C.Property>
+</Doc::ComponentApi>
 
 ### Table::ThSort
 
-The `Hds::Table::ThSort` supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering). While it can **contain** interactive elements, it cannot have actions attached to it.
+This component is not eligible to receive interactions (e.g., it cannot have an `onClick` event handler attached directly to it). Instead, an interactive element should be placed _inside_ of a `th` or `td` element.
 
 This is the component that supports the column sorting.
 
-<!-- <Doc::ComponentApi as |C|>
-</Doc::ComponentApi> -->
+<Doc::ComponentApi as |C|>
+  <C.Property @name="ariaSort" @values={{array "asc "desc"}}>
+   Checks the `isSorted` argument and sets the value of the `aria-sort` attribute accordingly.
+  </C.Property>
+  <C.Property @name="onClick" @type="function">
+    The action handler; sets the sort by the column key.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports the use of `...attributes`.
+  </C.Property>
+</Doc::ComponentApi>
 
 ### Table::Td
 
-The `Hds::Table::Td` component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering). While it can **contain** interactive elements (e.g., `<td><a href="user-info.html">User info</a></td>`) but is not eligible to receive interactions itself (e.g., it cannot have an `onClick` or other actions attached directly to it).
+This component is not eligible to receive interactions (e.g., it cannot have an `onClick` event handler attached directly to it). Instead, an interactive element should be placed _inside_ of a `th` or `td` element.
 
-<!-- <Doc::ComponentApi as |C|>
-</Doc::ComponentApi> -->
+<Doc::ComponentApi as |C|>
+  <C.Property @name="align" @type="enum" @values={{array "left" "center" "right"}} @default="left">
+    If set, determines the text alignment.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports the use of `...attributes`.
+  </C.Property>
+</Doc::ComponentApi>

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -32,7 +32,7 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="density" @type="enum" @values={{array "short" "medium" "tall" }} @default="medium">
     If set, determines the density, or height, of the table’s rows.
   </C.Property>
-  <C.Property @name="align" @type="enum" @values={{array "left" "center" "right"}} @default="left">
+  <C.Property @name="align" @type="enum" @values={{array "left" "center" "right" }} @default="left">
     If set, determines the text alignment for all cell (`td`) content in a table.
   </C.Property>
   <C.Property @name="valign" @type="enum" @values={{array "top" "middle" }} @default="top">
@@ -70,7 +70,7 @@ This component is not eligible to receive interactions (e.g., it cannot have an 
 If a `th` is passed as the first "cell" of a table body row, it has `scope="row"` automatically applied to it for accessibility purposes.
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="align" @type="enum" @values={{array "left" "center" "right"}} @default="left">
+  <C.Property @name="align" @type="enum" @values={{array "left" "center" "right" }} @default="left">
     If set, determines the text alignment.
   </C.Property>
   <C.Property @name="...attributes">
@@ -85,9 +85,6 @@ This component is not eligible to receive interactions (e.g., it cannot have an 
 This is the component that supports the column sorting.
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="ariaSort" @values={{array "asc "desc"}}>
-   Checks the `isSorted` argument and sets the value of the `aria-sort` attribute accordingly.
-  </C.Property>
   <C.Property @name="onClick" @type="function">
     The action handler; sets the sort by the column key.
   </C.Property>
@@ -101,7 +98,7 @@ This is the component that supports the column sorting.
 This component is not eligible to receive interactions (e.g., it cannot have an `onClick` event handler attached directly to it). Instead, an interactive element should be placed _inside_ of a `th` or `td` element.
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="align" @type="enum" @values={{array "left" "center" "right"}} @default="left">
+  <C.Property @name="align" @type="enum" @values={{array "left" "center" "right" }} @default="left">
     If set, determines the text alignment.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -16,8 +16,8 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="model" @type="array">
     If defined, sets the data source that gets yielded by the `:body` named block.
   </C.Property>
-  <C.Property @name="columns" @type="array">
-    Use an `array` hash to define your table columns. While `key` and `label` are required, other options include `isSortable`, `align` (for text-alignment), and `width`.
+  <C.Property @name="columns" @type="array" @valueNoteList={{array "key (required)" "label (required)" "isSortable" "align" "width" }}>
+  Use an `array` hash to define each column's arguments:
   </C.Property>
   <C.Property @name="sortBy" @type="string">
     If defined, indicates which column should be pre-sorted when the table is rendered.

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -16,8 +16,8 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="model" @type="array">
     If defined, sets the data source that gets yielded by the `:body` named block.
   </C.Property>
-  <C.Property @name="columns" @type="array" @valueNoteList={{array "key (required)" "label (required)" "isSortable" "align" "width" }}>
-  Use an `array hash` to define each column’s arguments:
+  <C.Property @name="columns" @type="array" @valueNoteList={{array (hash code="key" required="true" text="the data record’s key") (hash code="label" required="true" text="can be a string or intl object.") (hash code="isSortable" text="should exist and be set to true if you want the column to be sortable") (hash code="align" text="add this option if you need to set the text-alignment for columns that contain numbers (typically currency)") (hash code="width" text="add this option if you need to define a custom width; any valid CSS unit is acceptable (consumers are responsible for the accessibility of this option).") }}>
+  Use a `hash` within the array to define each column:
   </C.Property>
   <C.Property @name="sortBy" @type="string">
     If defined, indicates which column should be pre-sorted when the table is rendered.

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -8,25 +8,22 @@ The Table component itself is where most of the options will be applied. However
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="<:head>" @type="named block">
-    This is a named block where the content for the table head (`<thead>`) is rendered.
+    This is a named block where the content for the table head (`<thead>`) is rendered. It is unlikely that most consumers will need to use this named block directly for most use cases.
   </C.Property>
   <C.Property @name="<:body>" @type="named block">
     This is a named block where the content for the table body (`<tbody>`) is rendered.
   </C.Property>
   <C.Property @name="model" @type="array">
-    If defined, sets the data source that gets yielded by the `:body` named block.
+    Indicates the data model to be used by the table.
   </C.Property>
   <C.Property @name="columns" @type="array" @valueNoteList={{array (hash code="key" required="true" text="the data record’s key") (hash code="label" required="true" text="can be a string or intl object.") (hash code="isSortable" text="should exist and be set to true if you want the column to be sortable") (hash code="align" text="add this option if you need to set the text-alignment for columns that contain numbers (typically currency)") (hash code="width" text="add this option if you need to define a custom width; any valid CSS unit is acceptable (consumers are responsible for the accessibility of this option).") }}>
   Use a `hash` within the array to define each column:
   </C.Property>
   <C.Property @name="sortBy" @type="string">
-    If defined, indicates which column should be pre-sorted when the table is rendered.
+    If defined, the value should be set to the key of the column that should be pre-sorted when the table is rendered.
   </C.Property>
   <C.Property @name="sortOrder" @type="string" @values={{array "asc" "desc" }} @default="asc">
     Use in conjunction with `sortBy`. If defined, indicates which direction the column should be pre-sorted in. If not defined, `asc` is applied by default.
-  </C.Property>
-  <C.Property @name="onSort" @type="function">
-    Callback function invoked (if provided) when one of the sortable table headers is clicked, and a sorting is triggered. The function receives the values of `sortBy` and `sortOrder` as arguments.
   </C.Property>
   <C.Property @name="isStriped" @type="boolean" @values={{array "false" "true" }} @default="false">
     Define on the table invocation. If set to `true`, row striping ("zebra striping") will be applied to the table.
@@ -41,9 +38,12 @@ The Table component itself is where most of the options will be applied. However
     If set, determines the vertical alignment for all cell (`td`) content in a table. Does not apply to table headers (`th`).
   </C.Property>
   <C.Property @name="caption" @type="string">
-    Adds a (non-visible) caption for users with assistive technology. If set on a sortable table, the provided table caption is paired with the automatically generated sorted message text.
+    Adds a (non-visible) caption for users with assistive technology. If set on a sortable table, the provided table caption is paired with the automatically generated sorted message text. Note: it is best practice to provide a table caption for users with assistive technology.
   </C.Property>
   <C.Property @name="...attributes">
     Supported for the `Hds::Table` component.
+  </C.Property>
+   <C.Property @name="onSort" @type="function">
+    Automatically applied to sortable table headers, `onSort` is the callback function that is invoked when one of the sortable table headers is clicked (or has a keyboard interaction performed). The function receives the values of `sortBy` and `sortOrder` as arguments.
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -2,9 +2,7 @@
 
 The Table component itself is where most of the options will be applied. However, the child components can also be used if a custom implementation is needed.
 
-- The `Hds::Table::Tr` component is a template-only component. It supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering) but is not eligible to receive interactions (e.g., it cannot have an `onClick` event handler attached directly to it). It can contain `Hds::Table::Th` or `Hds::Table::Td` components.
-- The `Hds::Table::Th` component is a template-only component. It supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering) and can contain interactive elements but is not eligible to receive interactions itself. It‘s unlikely you‘ll need to add interactive elements, as sorting is already provided.
-- The `Hds::Table::Td` component is a template-only component. It supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering) and can contain interactive elements (e.g., `<td><a href="user-info.html">User info</a></td>`) but is not eligible to receive interactions itself (e.g., it cannot have an `onClick` event handler attached directly to it).
+### Table
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="<:head>" @type="named block">
@@ -43,7 +41,41 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="...attributes">
     Supported for the `Hds::Table` component.
   </C.Property>
-   <C.Property @name="onSort" @type="function">
+     <C.Property @name="onSort" @type="function">
     Automatically applied to sortable table headers, `onSort` is the callback function that is invoked when one of the sortable table headers is clicked (or has a keyboard interaction performed). The function receives the values of `sortBy` and `sortOrder` as arguments.
   </C.Property>
 </Doc::ComponentApi>
+
+### Table::Tr
+
+The `Hds::Table::Tr` component is a template-only component.
+
+It supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering) but is not eligible to receive interactions (e.g., it cannot have an `onClick` event handler attached directly to it).
+
+It can contain `Hds::Table::Th` or `Hds::Table::Td` components.
+
+<!-- <Doc::ComponentApi as |C|>
+</Doc::ComponentApi> -->
+
+### Table::Th
+
+The `Hds::Table::Th` supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering). While it can **contain** interactive elements, it cannot have actions attached to it.
+
+<!-- <Doc::ComponentApi as |C|>
+</Doc::ComponentApi> -->
+
+### Table::ThSort
+
+The `Hds::Table::ThSort` supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering). While it can **contain** interactive elements, it cannot have actions attached to it.
+
+This is the component that supports the column sorting.
+
+<!-- <Doc::ComponentApi as |C|>
+</Doc::ComponentApi> -->
+
+### Table::Td
+
+The `Hds::Table::Td` component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering). While it can **contain** interactive elements (e.g., `<td><a href="user-info.html">User info</a></td>`) but is not eligible to receive interactions itself (e.g., it cannot have an `onClick` or other actions attached directly to it).
+
+<!-- <Doc::ComponentApi as |C|>
+</Doc::ComponentApi> -->

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -17,7 +17,7 @@ The Table component itself is where most of the options will be applied. However
     If defined, sets the data source that gets yielded by the `:body` named block.
   </C.Property>
   <C.Property @name="columns" @type="array" @valueNoteList={{array "key (required)" "label (required)" "isSortable" "align" "width" }}>
-  Use an `array` hash to define each column's arguments:
+  Use an `array hash` to define each column’s arguments:
   </C.Property>
   <C.Property @name="sortBy" @type="string">
     If defined, indicates which column should be pre-sorted when the table is rendered.

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -26,7 +26,7 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="isStriped" @type="boolean" @values={{array "false" "true" }} @default="false">
     Define on the table invocation. If set to `true`, row striping ("zebra striping") will be applied to the table.
   </C.Property>
-  <C.Property @name="isFixed" @type="boolean" @values={{array "false" "true" }} @default="false">
+  <C.Property @name="isFixedLayout" @type="boolean" @values={{array "false" "true" }} @default="false">
     If set to `true`, the `table-display`(CSS) property will be set to `fixed`, which will automatically distribute columns equally based on the total width of the table.
   </C.Property>
   <C.Property @name="density" @type="enum" @values={{array "short" "medium" "tall" }} @default="medium">

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -86,7 +86,7 @@ This is the component that supports the column sorting.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="onClick" @type="function">
-    The action handler; sets the sort by the column key.
+    The action handler; sets the sort to the column key.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports the use of `...attributes`.

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -2,46 +2,19 @@ This component takes advantage of the `sort-by` helper provided in [ember-compos
 
 ## How to use this component
 
-### Static Table (non-sortable)
-
-If you don’t have or want to use a model, a basic invocation could look like:
+### Non-sortable table
 
 ```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
 
-<Hds::Table>
-  <:head as |H|>
-    <H.Tr>
-      <H.Th>Artist</H.Th>
-      <H.Th>Album</H.Th>
-      <H.Th>Release Year</H.Th>
-    </H.Tr>
-  </:head>
-  <:body as |B|>
-    <B.Tr>
-      <B.Td>Custom Cell Content</B.Td>
-      <B.Td>{{t 'translated-cell-content-string'}}</B.Td>
-      <B.Td>Some other custom cell content</B.Td>
-    </B.Tr>
-  </:body>
-</Hds::Table>
-```
-
-### Simple Table with model defined (non-sortable)
-
-To use a table with a model, define the data model and insert your own content into the `:head` and `:body` blocks.
-
-```handlebars{data-execute=false}
-<!-- app/templates/components/table.hbs -->
-
-<Hds::Table @model={{this.model}}>
-  <:head as |H|>
-    <H.Tr>
-      <H.Th>Artist</H.Th>
-      <H.Th>Album</H.Th>
-      <H.Th>Release Year</H.Th>
-    </H.Tr>
-  </:head>
+<Hds::Table 
+  @model={{this.model.data}}
+  @columns={{array
+    (hash key="artist" label="Artist")
+    (hash key="album" label="Album")
+    (hash key="year" label="Release Year")
+  }}
+  >
   <:body as |B|>
     <B.Tr>
       <B.Td>{{B.data.artist}}</B.Td>
@@ -50,95 +23,22 @@ To use a table with a model, define the data model and insert your own content i
     </B.Tr>
   </:body>
 </Hds::Table>
-```
-
-For documentation purposes, we‘ve imitated fetching data from an API and are working with that as our data model.
-
-```javascript
-import Route from '@ember/routing/route';
-
-export default class ComponentsTableRoute extends Route {
-  async model() {
-    let response = await fetch('/api/folk.json');
-    let { data } = await response.json();
-
-    return data.map((model) => {
-      let { attributes } = model;
-      return { ...attributes };
-    });
-  }
-}
 ```
 
 ### Sortable Table
 
-For the sortable table, the invocation and use is a little bit different:
-
-1. Shape the data model for use; we’ve placed it in the page‘s route.
-
-    - In this example, we’re identifying the column headers (keys) and also capitalizing them. 
-    - Each column object has two pieces: 
-      
-        - a `key`\-- used for the model, the `sortingKeys`, and `sortBy`
-        - a `label`\-- used in the table header cells
-
-```javascript
-// app/routes/components/table.js
-
-import Route from '@ember/routing/route';
-import { capitalize } from '@ember/string';
-
-export default class ComponentsTableRoute extends Route {
-  async model() {
-    let response = await fetch('/api/folk.json');
-    let { data } = await response.json();
-
-    // make sure the variable is declared outside of the loop
-    // so we can return it in the model response
-    let columns;
-    let dataResponse = data.map((model) => {
-      let { id, attributes } = model;
-      columns = Object.keys(attributes);
-      return { id, ...attributes };
-    });
-    columns = columns.map((column) => {
-      return { key: column, label: capitalize(column) };
-    });
-    return { data: dataResponse, columns };
-  }
-}
-```
-
-2. Invoke `Hds::Table` in your template file.
+Add `isSortable=true` to each column’s hash that should be sortable.
 
 ```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
 
 <Hds::Table
   @model={{this.model.data}}
-  @columns={{this.model.columns}}
->
-  <:body as |B|>
-    <B.Tr>
-      <B.Td>{{B.data.artist}}</B.Td>
-      <B.Td>{{B.data.album}}</B.Td>
-      <B.Td>{{B.data.year}}</B.Td>
-    </B.Tr>
-  </:body>
-</Hds::Table>
-```
-
-#### Indicate which columns are sortable
-
-If you want, you can indicate that only specific columns should be sortable.
-
-```handlebars{data-execute=false}
-<!-- app/templates/components/table.hbs -->
-
-<Hds::Table
-  @model={{this.model.data}}
-  @columns={{this.model.columns}}
-  @sortingKeys={{array 'artist' 'album'}}
+  @columns={{array
+    (hash key="artist" label="Artist" isSortable="true")
+    (hash key="album" label="Album" isSortable="true")
+    (hash key="year" label="Release Year")
+  }}
 >
   <:body as |B|>
     <B.Tr>
@@ -159,8 +59,11 @@ You can also indicate that a specific column should be pre-sorted.
 
 <Hds::Table
   @model={{this.model.data}}
-  @columns={{this.model.columns}}
-  @sortingKeys={{array 'artist' 'album'}}
+  @columns={{array
+    (hash key="artist" label="Artist" isSortable="true")
+    (hash key="album" label="Album" isSortable="true")
+    (hash key="year" label="Release Year")
+  }}
   @sortBy='artist'
 >
   <:body as |B|>
@@ -182,8 +85,11 @@ You can also indicate that a specific column should be pre-sorted in a specific 
 
 <Hds::Table
   @model={{this.model.data}}
-  @columns={{this.model.columns}}
-  @sortingKeys={{array 'artist' 'album'}}
+  @columns={{array
+    (hash key="artist" label="Artist" isSortable="true")
+    (hash key="album" label="Album" isSortable="true")
+    (hash key="year" label="Release Year")
+  }}
   @sortBy='artist'
   @sortOrder='desc'
 >
@@ -207,12 +113,11 @@ Here’s a table implementation that uses an array hash with localized strings f
 <Hds::Table
   @model={{this.model.data}}
   @columns={{array
-      (hash key='artist' label=(t 'components.table.headers.artist'))
-      (hash key='album' label=(t 'components.table.headers.album'))
-      (hash key='year' label=(t 'components.table.headers.year'))
+      (hash key='artist' label=(t 'components.table.headers.artist') isSortable="true")
+      (hash key='album' label=(t 'components.table.headers.album') isSortable="true")
+      (hash key='year' label=(t 'components.table.headers.year') isSortable="true")
       (hash key='other' label=(t 'global.titles.other'))
     }}
-  @sortingKeys={{array 'artist' 'album' 'year'}}
 >
   <:body as |B|>
     <B.Tr>

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -148,3 +148,28 @@ Here’s a table implementation that uses an array hash with localized strings f
   </:body>
 </Hds::Table>
 ```
+
+#### More Examples: replacing components as a pre-adoption step
+
+If you're not quite ready to replace your existing tables with this component, you can totally try out a pre-adoption spike with just the components themselves. It's a little more typing but it should give you an idea of what will work for you.
+
+```handlebars{data-execute=false}
+<!-- app/templates/components/table.hbs -->
+
+<Hds::Table @model={{this.model}}>
+  <:head as |H|>
+    <H.Tr>
+      <H.Th>Artist</H.Th>
+      <H.Th>Album</H.Th>
+      <H.Th>Release Year</H.Th>
+    </H.Tr>
+  </:head>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.artist}}</B.Td>
+      <B.Td>{{B.album}}</B.Td>
+      <B.Td>{{B.year}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>
+```

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -27,7 +27,7 @@ This component takes advantage of the `sort-by` helper provided in [ember-compos
 
 ### Sortable Table
 
-Add `isSortable=true` to each column’s hash that should be sortable.
+Add `isSortable=true` to the hash for each column that should be sortable.
 
 ```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
@@ -52,7 +52,7 @@ Add `isSortable=true` to each column’s hash that should be sortable.
 
 #### Pre-sorting columns
 
-You can also indicate that a specific column should be pre-sorted.
+You can optionally indicate that a specific column should be pre-sorted by adding `@sortBy` where the value is the key of the column.
 
 ```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->
@@ -78,7 +78,7 @@ You can also indicate that a specific column should be pre-sorted.
 
 ##### Pre-sorting direction
 
-You can also indicate that a specific column should be pre-sorted in a specific direction.
+You can optionally also indicate that the column defined in `@sortBy` should be pre-sorted in a descending order, rather than the default ascending order by passing in `@sortOrder='desc'`.
 
 ```handlebars{data-execute=false}
 <!-- app/templates/components/table.hbs -->

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -103,7 +103,7 @@ You can optionally also indicate that the column defined in `@sortBy` should be 
 </Hds::Table>
 ```
 
-#### Complex sortable Table
+#### More Examples: internationalized column headers, overflow menu dropdown
 
 Here’s a table implementation that uses an array hash with localized strings for the column headers, indicates which columns should be sortable, and adds an overflow menu.
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the code tab (how-to-use and component-api sections) for the `Hds::Table` component, as it was out-of-date and provided unclear instructions for consumer use. It also heavily refactors the component-api page, and updates it to include child component APIs (not sure if we _should_, but that's a different discussion). 

Preview link: https://hds-website-git-melsumner-hds-1537-add-missing-d5073a-hashicorp.vercel.app/components/table?tab=code 

**Note**: this PR builds on #1187 but may conflict with #1184 so some interactive merging/rebasing may be required. It also should preceed any documentation updates that relate to #1160. 

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1537]: https://hashicorp.atlassian.net/browse/HDS-1537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ