### PR TITLE
remove unnecessary parens for ember 3.24 compat

### DIFF
--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -12,7 +12,7 @@
             <Hds::Table::ThSort
               @isSorted={{eq column.key this.sortBy}}
               @sortOrder={{this.sortOrder}}
-              @onClick={{(fn this.setSortBy column.key)}}
+              @onClick={{fn this.setSortBy column.key}}
               @align={{column.align}}
               @width={{column.width}}
             >


### PR DESCRIPTION
### :pushpin: Summary

Bugfix: Allows Table index component to compile for apps with Ember < 3.28. This change doesn't affect any consuming apps.

### :hammer_and_wrench: Detailed description

The parenthesis aren't necessary in this case, and the parenthesis at the beginning of the mustache (`{{(`) prevent the component from being compiled with apps using Ember < 3.28.

Removing the parenthesis still works in Ember 3.24.

Similar to https://github.com/hashicorp/design-system/pull/663

### :camera_flash: Screenshots

N/A, rendering won't change.

### :link: External links

https://hashicorp.slack.com/archives/C7KTUHNUS/p1675961961460639

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
