### PR TITLE
converts a11y support statement to a component and update docs

### DIFF
--- a/website/app/components/doc/a11y-support.hbs
+++ b/website/app/components/doc/a11y-support.hbs
@@ -1,3 +1,3 @@
-<h2 class="doc-markdown-h2 doc-page-sidecar-scroll-margin-top" id="support">Support</h2>
+<h2 class="doc-text-h2 doc-page-sidecar-scroll-margin-top" id="support">Support</h2>
 <p class="doc-markdown-p">If any accessibility issues have been found within this component, let us know by
   <a class="doc-markdown-a" href="https://github.com/hashicorp/design-system/issues/new/choose">submitting an issue</a>.</p>

--- a/website/app/components/doc/a11y-support.hbs
+++ b/website/app/components/doc/a11y-support.hbs
@@ -1,0 +1,3 @@
+<h2 class="doc-markdown-h2 doc-page-sidecar-scroll-margin-top" id="support">Support</h2>
+<p class="doc-markdown-p">If any accessibility issues have been found within this component, let us know by
+  <a class="doc-markdown-a" href="https://github.com/hashicorp/design-system/issues/new/choose">submitting an issue</a>.</p>

--- a/website/app/components/doc/a11y-support.hbs
+++ b/website/app/components/doc/a11y-support.hbs
@@ -1,3 +1,3 @@
 <h2 class="doc-text-h2 doc-page-sidecar-scroll-margin-top" id="support">Support</h2>
-<p class="doc-markdown-p">If any accessibility issues have been found within this component, let us know by
+<p class="doc-text-body">If any accessibility issues have been found within this component, let us know by
   <a class="doc-markdown-a" href="https://github.com/hashicorp/design-system/issues/new/choose">submitting an issue</a>.</p>

--- a/website/app/components/doc/a11y-support.hbs
+++ b/website/app/components/doc/a11y-support.hbs
@@ -1,3 +1,3 @@
 <h2 class="doc-text-h2 doc-page-sidecar-scroll-margin-top" id="support">Support</h2>
 <p class="doc-text-body">If any accessibility issues have been found within this component, let us know by
-  <a class="doc-markdown-a" href="https://github.com/hashicorp/design-system/issues/new/choose">submitting an issue</a>.</p>
+  <a class="doc-link-generic" href="https://github.com/hashicorp/design-system/issues/new/choose">submitting an issue</a>.</p>

--- a/website/blueprints/hds-component-docs/files/docs/components/__name__/partials/accessibility/accessibility.md
+++ b/website/blueprints/hds-component-docs/files/docs/components/__name__/partials/accessibility/accessibility.md
@@ -21,6 +21,4 @@ This section is for reference only. This component intends to conform to the fol
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/alert/partials/accessibility/accessibility.md
+++ b/website/docs/components/alert/partials/accessibility/accessibility.md
@@ -20,6 +20,4 @@ This section is for reference only. This component intends to conform to the fol
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/avatar/partials/accessibility/accessibility.md
+++ b/website/docs/components/avatar/partials/accessibility/accessibility.md
@@ -6,6 +6,4 @@ The avatar is hidden from assistive technology with `aria-hidden="true"`. The ac
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/badge-count/partials/accessibility/accessibility.md
+++ b/website/docs/components/badge-count/partials/accessibility/accessibility.md
@@ -6,6 +6,4 @@ When used as recommended, there should not be any accessibility issues with this
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/badge/partials/accessibility/accessibility.md
+++ b/website/docs/components/badge/partials/accessibility/accessibility.md
@@ -22,6 +22,4 @@ When using icon-only Badges, include annotations of the non-visual experience in
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/breadcrumb/partials/accessibility/accessibility.md
+++ b/website/docs/components/breadcrumb/partials/accessibility/accessibility.md
@@ -22,6 +22,4 @@ This section is for reference only. This component intends to conform to the fol
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/button/partials/accessibility/accessibility.md
+++ b/website/docs/components/button/partials/accessibility/accessibility.md
@@ -26,6 +26,4 @@ This section is for reference only. This component intends to conform to the fol
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/card/partials/accessibility/accessibility.md
+++ b/website/docs/components/card/partials/accessibility/accessibility.md
@@ -8,6 +8,4 @@ Additionally, if the component is altered to be an interactive element, and also
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/dropdown/partials/accessibility/accessibility.md
+++ b/website/docs/components/dropdown/partials/accessibility/accessibility.md
@@ -37,6 +37,4 @@ This section is for reference only. This component intends to conform to the fol
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/flyout/partials/accessibility/accessibility.md
+++ b/website/docs/components/flyout/partials/accessibility/accessibility.md
@@ -19,6 +19,4 @@ This section is for reference only, some descriptions have been truncated for br
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/form/checkbox/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/checkbox/partials/accessibility/accessibility.md
@@ -30,6 +30,4 @@ This section is for reference only, some descriptions have been truncated for br
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/form/primitives/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/primitives/partials/accessibility/accessibility.md
@@ -16,6 +16,4 @@ This section is for reference only, some descriptions have been truncated for br
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
@@ -45,6 +45,4 @@ This component intends to conform to the following WCAG Success Criteria:
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/form/radio/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio/partials/accessibility/accessibility.md
@@ -27,6 +27,4 @@ This component intends to conform to the following WCAG Success Criteria:
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/form/select/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/select/partials/accessibility/accessibility.md
@@ -12,7 +12,7 @@
 
 `Form::Select::Base` is not conformant until it has an accessible name.
 
-## Interactions 
+## Interactions
 
 ![Mouse and keyboard select interactions](/assets/components/form/select/select-interactions.png =1015x*)
 
@@ -24,6 +24,4 @@ This section is for reference only, some descriptions have been truncated for br
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/form/text-input/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/text-input/partials/accessibility/accessibility.md
@@ -24,6 +24,4 @@ This section is for reference only, some descriptions have been truncated for br
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/form/textarea/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/textarea/partials/accessibility/accessibility.md
@@ -24,6 +24,4 @@ This section is for reference only, some descriptions have been truncated for br
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/form/toggle/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/toggle/partials/accessibility/accessibility.md
@@ -18,6 +18,4 @@ This section is for reference only, some descriptions have been truncated for br
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/icon-tile/partials/accessibility/accessibility.md
+++ b/website/docs/components/icon-tile/partials/accessibility/accessibility.md
@@ -18,6 +18,4 @@ This section is for reference only. This component intends to conform to the fol
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/modal/partials/accessibility/accessibility.md
+++ b/website/docs/components/modal/partials/accessibility/accessibility.md
@@ -29,6 +29,4 @@ This section is for reference only, some descriptions have been truncated for br
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/pagination/partials/accessibility/accessibility.md
+++ b/website/docs/components/pagination/partials/accessibility/accessibility.md
@@ -33,6 +33,4 @@ This section is for reference only. This component intends to conform to the fol
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/stepper/partials/accessibility/accessibility.md
+++ b/website/docs/components/stepper/partials/accessibility/accessibility.md
@@ -14,6 +14,4 @@ There is no specific WCAG Success Criteria applicable to the Stepper Indicator o
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/table/partials/accessibility/accessibility.md
+++ b/website/docs/components/table/partials/accessibility/accessibility.md
@@ -49,6 +49,4 @@ This section is for reference only. This component intends to conform to the fol
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/tabs/partials/accessibility/accessibility.md
+++ b/website/docs/components/tabs/partials/accessibility/accessibility.md
@@ -45,6 +45,4 @@ Move to interactive element within the content area
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/tag/partials/accessibility/accessibility.md
+++ b/website/docs/components/tag/partials/accessibility/accessibility.md
@@ -17,6 +17,4 @@ This section is for reference only. This component intends to conform to the fol
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />

--- a/website/docs/components/toast/partials/accessibility/accessibility.md
+++ b/website/docs/components/toast/partials/accessibility/accessibility.md
@@ -16,6 +16,4 @@ This section is for reference only. This component intends to conform to the fol
 
 ---
 
-## Support
-
-If any accessibility issues have been found within this component, let us know by [submitting an issue](https://github.com/hashicorp/design-system/issues/new/choose).
+<Doc::A11ySupport />


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves HDS-1328 by converting the accessibility support statement to a component and updates the `accessibility.md` files for each component to use the new component.


### :camera_flash: Screenshots

There are no visual changes

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1328](https://hashicorp.atlassian.net/browse/HDS-1328)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1328]: https://hashicorp.atlassian.net/browse/HDS-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ