### PR TITLE
Website: Add support for lists in component-api descriptions. 

### DIFF
--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -35,6 +35,20 @@
     <dt class="doc-component-api__term doc-component-api__term--description">Description</dt>
     <dd class="doc-component-api__description doc-component-api__description--description">
       {{yield}}
+      {{#if @valueNoteList}}
+        <ul class="doc-list-generic doc-component-api__description" role="list">
+          {{#each @valueNoteList as |valueNoteListItem|}}
+            <li class="doc-component-api__property-value-item">
+              <code class="doc-markdown-code">{{valueNoteListItem.code}}</code>
+              {{#if (eq valueNoteListItem.required "true")}}
+                <Doc::Badge @type="outlined">Required</Doc::Badge>
+              {{/if}}
+              ⁠—
+              {{valueNoteListItem.text}}
+            </li>
+          {{/each}}
+        </ul>
+      {{/if}}
     </dd>
   {{/if}}
 </dl>

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -16,8 +16,8 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="model" @type="array">
     If defined, sets the data source that gets yielded by the `:body` named block.
   </C.Property>
-  <C.Property @name="columns" @type="array">
-    Use an `array` hash to define your table columns. While `key` and `label` are required, other options include `isSortable`, `align` (for text-alignment), and `width`.
+  <C.Property @name="columns" @type="array" @valueNoteList={{array (hash code="key" required="true" text="the data record’s key") (hash code="label" required="true" text="can be a string or intl object.") (hash code="isSortable" text="should exist and be set to true if you want the column to be sortable") (hash code="align" text="add this option if you need to set the text-alignment for columns that contain numbers (typically currency)") (hash code="width" text="add this option if you need to define a custom width; any valid CSS unit is acceptable (consumers are responsible for the accessibility of this option).") }}>
+  Use a `hash` within the array to define each column:
   </C.Property>
   <C.Property @name="sortBy" @type="string">
     If defined, indicates which column should be pre-sorted when the table is rendered.


### PR DESCRIPTION
It would be useful to have a list in the component description in the api docs. What do we think?

Here it is in use to help further clarify the `@column` use for the `Hds::Table` component: 

![CleanShot 2023-02-09 at 12 40 45](https://user-images.githubusercontent.com/4587451/217907207-cd31a7bc-3bc5-4267-8f45-43db64d91639.png)

Some notes: 
- it'll need some tweaking for the design (the bullets should fall in line, the vertical spacing is off, maybe we want the code and/or badges to be a little different?) 
- the CSS classes aren't correct as a result, but was trying to replicate what already existed for exploration purposes
- current limitation: values can't contain any code themselves (it all breaks 😭 ) 