### PR TITLE
Add arguments to expose Pagination SizeSelector label (HDS-1541)

### DIFF
--- a/.changeset/eleven-seals-drum.md
+++ b/.changeset/eleven-seals-drum.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Add @label argument to Pagination::SizeSelector component and associated @sizeSelectorLabel argument to Pagination::Numbered component to make Pagination::SizeSelector label text customizeable.

--- a/packages/components/addon/components/hds/pagination/numbered/index.hbs
+++ b/packages/components/addon/components/hds/pagination/numbered/index.hbs
@@ -58,6 +58,7 @@
   {{#if this.showSizeSelector}}
     <Hds::Pagination::SizeSelector
       @pageSizes={{this.pageSizes}}
+      @label={{@sizeSelectorLabel}}
       @selectedSize={{this.currentPageSize}}
       @onChange={{this.onPageSizeChange}}
     />

--- a/packages/components/addon/components/hds/pagination/size-selector/index.hbs
+++ b/packages/components/addon/components/hds/pagination/size-selector/index.hbs
@@ -1,5 +1,7 @@
 <div class="hds-pagination-size-selector" ...attributes>
-  <label class="hds-typography-body-100 hds-font-weight-medium" for={{this.SizeSelectorId}}>Items per page</label>
+  <label class="hds-typography-body-100 hds-font-weight-medium" for={{this.SizeSelectorId}}>
+    {{this.label}}
+  </label>
   <Hds::Form::Select::Base id={{this.SizeSelectorId}} {{on "change" this.onChange}} as |S|>
     <S.Options>
       {{#each this.pageSizes as |size|}}

--- a/packages/components/addon/components/hds/pagination/size-selector/index.js
+++ b/packages/components/addon/components/hds/pagination/size-selector/index.js
@@ -45,6 +45,18 @@ export default class HdsPaginationSizeSelectorComponent extends Component {
     return selectedSize;
   }
 
+  /**
+   * @param label
+   * @type string
+   * @default "Items per page"
+   * @description The label text for the select
+   */
+  get label() {
+    let { label = 'Items per page' } = this.args;
+
+    return label;
+  }
+
   @action
   onChange(e) {
     let { onChange } = this.args;

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -845,6 +845,9 @@
   <p class="dummy-text-small">With @currentPageSize (selected option)</p>
   <Hds::Pagination::SizeSelector @pageSizes={{array 10 30 50}} @selectedSize={{30}} />
 
+  <p class="dummy-text-small">With @label to add custom label text</p>
+  <Hds::Pagination::SizeSelector @pageSizes={{array 10 30 50}} @label="Items" />
+
   <h5 class="dummy-h5">Pagination::Nav::Arrow</h5>
   <div class="dummy-pagination-base-sample">
     <div>

--- a/packages/components/tests/integration/components/hds/pagination/numbered-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/numbered-test.js
@@ -97,6 +97,13 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
       .exists();
   });
 
+  test('it displays the passed in custom text for the SizeSelector label text', async function (assert) {
+    await render(hbs`
+      <Hds::Pagination::Numbered @totalItems={{100}} @sizeSelectorLabel="Custom text" />
+    `);
+    assert.dom('.hds-pagination-size-selector label').hasText('Custom text');
+  });
+
   // SHOW/HIDE ELEMENTS
   test('it hides the total items from the "info" content when @showTotalItems is false', async function (assert) {
     await render(hbs`

--- a/packages/components/tests/integration/components/hds/pagination/size-selector-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/size-selector-test.js
@@ -67,6 +67,22 @@ module(
         .hasAttribute('for', controlId);
     });
 
+    test('the label text matches the default value if no custom value is set', async function (assert) {
+      await render(hbs`
+        <Hds::Pagination::SizeSelector @pageSizes={{array 10 30 50}} />
+      `);
+      assert
+        .dom('.hds-pagination-size-selector label')
+        .hasText('Items per page');
+    });
+
+    test('it displays the passed in custom text for the label text', async function (assert) {
+      await render(hbs`
+        <Hds::Pagination::SizeSelector @pageSizes={{array 10 30 50}} @label="Custom text" />
+      `);
+      assert.dom('.hds-pagination-size-selector label').hasText('Custom text');
+    });
+
     // ATTRIBUTES
 
     test('it should spread all the attributes passed to the component on the element', async function (assert) {

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -34,6 +34,9 @@ Set the page sizes users can select from. Example: `@pageSizes=\{{array 5 20 30}
 <C.Property @name="currentPage" @type="integer" @values={{array 1 "integer" }} @default={{1}}>
 Set a custom initial selected page.
 </C.Property>
+<C.Property @name="sizeSelectorLabel" @type="string" @values={{array "Items per page" "Custom string" }} @default="Items per page">
+  Add a custom string for the label text overriding the default value.
+</C.Property>
 <C.Property @name="isTruncated" @type="boolean" @values={{array "true" "false" }} @default="true">
 Used to to limit the number of page numbers displayed (to save space, it will display an ellipsis for some numbers).
 </C.Property>
@@ -160,6 +163,9 @@ Used to indicate which of the provided `sizes` options is pre-selected. Normally
 </C.Property>
 <C.Property @name="onChange" @type="function">
 Callback function invoked (if provided) when the page size selector is changed. The function receives the value of the "page size" as argument (an integer number).
+</C.Property>
+<C.Property @name="label" @type="string" @values={{array "Items per page" "Custom string" }} @default="Items per page">
+  Add a custom string for the label text overriding the default value.
 </C.Property>
 <C.Property @name="...attributes">
 This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering). _Notice: it will not be applied to the `<li>` wrapping element but to the nested `<button>/<a>` controls._

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -161,11 +161,11 @@ Set the page sizes users can select from. If no value is defined an error will b
 <C.Property @name="selectedSize" @type="integer">
 Used to indicate which of the provided `sizes` options is pre-selected. Normally this value is passed automatically by the Pagination wrapper component but can be provided as argument to the `Pagination::SizeSelector` component itself when used as a stand alone component.
 </C.Property>
-<C.Property @name="onChange" @type="function">
-Callback function invoked (if provided) when the page size selector is changed. The function receives the value of the "page size" as argument (an integer number).
-</C.Property>
 <C.Property @name="label" @type="string" @values={{array "Items per page" "Custom string" }} @default="Items per page">
   Add a custom string for the label text overriding the default value.
+</C.Property>
+<C.Property @name="onChange" @type="function">
+Callback function invoked (if provided) when the page size selector is changed. The function receives the value of the "page size" as argument (an integer number).
 </C.Property>
 <C.Property @name="...attributes">
 This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering). _Notice: it will not be applied to the `<li>` wrapping element but to the nested `<button>/<a>` controls._

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -59,6 +59,15 @@ Below is an example of some of these extra arguments:
 />
 ```
 
+Example of custom label text for `Pagination::SizeSelector`
+
+```handlebars
+<Hds::Pagination::Numbered
+  @totalItems={{40}}
+  @sizeSelectorLabel="Per page"
+/>
+```
+
 ### Truncation
 
 When there is a large number of items and consequently the number of pages is also large, by default the component automatically "truncates" the number of visible pages (using "ellipses"):


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will add arguments allowing consumers to provide custom label text for `Pagination::SizeSelector` overriding the default value.

(I will add a changeset before merging.)

- **Website Preview:** https://hds-website-git-hds-1541-pagination-add-size-l-ee09f2-hashicorp.vercel.app/components/pagination?tab=code#extra-arguments
- **Showcase Preview:** https://hds-components-git-hds-1541-pagination-add-siz-4291d1-hashicorp.vercel.app/components/pagination#showcase

<!--
### :hammer_and_wrench: Detailed description
 If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
Jira ticket: [HDS-1541](https://hashicorp.atlassian.net/browse/HDS-1541)
Slack chat: https://hashicorp.slack.com/archives/C7KTUHNUS/p1676047419979799

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1541]: https://hashicorp.atlassian.net/browse/HDS-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ