### PR TITLE
Refactor Pagination child component layout styles (HDS-1542)

### DIFF
--- a/.changeset/tame-mangos-arrive.md
+++ b/.changeset/tame-mangos-arrive.md
@@ -3,4 +3,5 @@
 "@hashicorp/design-system-tokens": patch
 ---
 
-Scope group layout styles to nested child components. Fix bug with --token-pagination-child-spacing-vertical value so that it adds "px" unit.
+* Scope group layout styles to nested child components. 
+* Fix bug with --token-pagination-child-spacing-vertical value so that it adds "px" unit.

--- a/.changeset/tame-mangos-arrive.md
+++ b/.changeset/tame-mangos-arrive.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": patch
+"@hashicorp/design-system-tokens": patch
+---
+
+Scope group layout styles to nested child components. Fix bug with --token-pagination-child-spacing-vertical value so that it adds "px" unit.

--- a/packages/components/app/styles/components/pagination.scss
+++ b/packages/components/app/styles/components/pagination.scss
@@ -26,27 +26,55 @@ $pagination-layout-breakpoint: 1000px;
   align-items: center;
   margin: 0 auto;
 
+  &,
+  & > * { outline: 1px dotted blue; }
+
   @media screen and (max-width: $pagination-layout-breakpoint) {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+  }
+
+  // Apply group layout styles to child components only when used inside pagination wrapper:
+  .hds-pagination-nav {
+    grid-area: nav;
+
+    @media screen and (max-width: $pagination-layout-breakpoint) {
+      justify-content: center;
+      order: -1;
+      // Force nav to occupy a full row so other components will wrap:
+      width: 100%;
+    }
+  }
+
+  .hds-pagination-size-selector {
+    grid-area: selector;
+    justify-self: flex-end;
+    margin-left: var(--token-pagination-child-spacing-horizontal);
+
+    @media screen and (max-width: $pagination-layout-breakpoint) {
+      margin-top: var(--token-pagination-child-spacing-vertical);
+      margin-right: var(--token-pagination-child-spacing-horizontal);
+    }
+  }
+
+  .hds-pagination-info {
+    grid-area: info;
+    justify-self: flex-start;
+    margin-right: var(--token-pagination-child-spacing-horizontal);
+
+    @media screen and (max-width: $pagination-layout-breakpoint) {
+      margin-top: var(--token-pagination-child-spacing-vertical);
+      margin-left: var(--token-pagination-child-spacing-horizontal);
+    }
   }
 }
 
 
 // * Sub-component: Info
 // ---------------------------------------
-
 .hds-pagination-info {
-  grid-area: info;
-  justify-self: flex-start;
-  margin-right: var(--token-pagination-child-spacing-horizontal);
   white-space: nowrap;
-
-  @media screen and (max-width: $pagination-layout-breakpoint) {
-    margin-top: var(--token-pagination-child-spacing-vertical);
-    margin-left: var(--token-pagination-child-spacing-horizontal);
-  }
 }
 
 
@@ -55,14 +83,6 @@ $pagination-layout-breakpoint: 1000px;
 
 .hds-pagination-nav {
   display: flex;
-  grid-area: nav;
-
-  @media screen and (max-width: $pagination-layout-breakpoint) {
-    justify-content: center;
-    order: -1;
-    // Force nav to occupy a full row so other components will wrap:
-    width: 100%;
-  }
 }
 
 .hds-pagination-nav__page-list {
@@ -170,18 +190,9 @@ $pagination-layout-breakpoint: 1000px;
 
 // * Sub-component: SizeSelector
 // -------------------------------------------------------------------
-
 .hds-pagination-size-selector {
   display: flex;
-  grid-area: selector;
   align-items: center;
-  justify-self: flex-end;
-  margin-left: var(--token-pagination-child-spacing-horizontal);
-
-  @media screen and (max-width: $pagination-layout-breakpoint) {
-    margin-top: var(--token-pagination-child-spacing-vertical);
-    margin-right: var(--token-pagination-child-spacing-horizontal);
-  }
 
   > label { white-space: nowrap; }
 

--- a/packages/components/app/styles/components/pagination.scss
+++ b/packages/components/app/styles/components/pagination.scss
@@ -26,9 +26,6 @@ $pagination-layout-breakpoint: 1000px;
   align-items: center;
   margin: 0 auto;
 
-  &,
-  & > * { outline: 1px dotted blue; }
-
   @media screen and (max-width: $pagination-layout-breakpoint) {
     display: flex;
     flex-wrap: wrap;

--- a/packages/components/app/styles/components/pagination.scss
+++ b/packages/components/app/styles/components/pagination.scss
@@ -33,6 +33,17 @@ $pagination-layout-breakpoint: 1000px;
   }
 
   // Apply group layout styles to child components only when used inside pagination wrapper:
+  .hds-pagination-info {
+    grid-area: info;
+    justify-self: flex-start;
+    margin-right: var(--token-pagination-child-spacing-horizontal);
+
+    @media screen and (max-width: $pagination-layout-breakpoint) {
+      margin-top: var(--token-pagination-child-spacing-vertical);
+      margin-left: var(--token-pagination-child-spacing-horizontal);
+    }
+  }
+
   .hds-pagination-nav {
     grid-area: nav;
 
@@ -52,17 +63,6 @@ $pagination-layout-breakpoint: 1000px;
     @media screen and (max-width: $pagination-layout-breakpoint) {
       margin-top: var(--token-pagination-child-spacing-vertical);
       margin-right: var(--token-pagination-child-spacing-horizontal);
-    }
-  }
-
-  .hds-pagination-info {
-    grid-area: info;
-    justify-self: flex-start;
-    margin-right: var(--token-pagination-child-spacing-horizontal);
-
-    @media screen and (max-width: $pagination-layout-breakpoint) {
-      margin-top: var(--token-pagination-child-spacing-vertical);
-      margin-left: var(--token-pagination-child-spacing-horizontal);
     }
   }
 }

--- a/packages/tokens/dist/devdot/css/helpers/color.css
+++ b/packages/tokens/dist/devdot/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Jan 2023 00:09:59 GMT
+ * Generated on Tue, 14 Feb 2023 00:14:16 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/devdot/css/helpers/elevation.css
+++ b/packages/tokens/dist/devdot/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Jan 2023 00:09:59 GMT
+ * Generated on Tue, 14 Feb 2023 00:14:16 GMT
  */
 
 .hds-elevation-inset { box-shadow: var(--token-elevation-inset-box-shadow); }

--- a/packages/tokens/dist/devdot/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/devdot/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Jan 2023 00:09:59 GMT
+ * Generated on Tue, 14 Feb 2023 00:14:16 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/devdot/css/helpers/typography.css
+++ b/packages/tokens/dist/devdot/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Jan 2023 00:09:59 GMT
+ * Generated on Tue, 14 Feb 2023 00:14:16 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/devdot/css/tokens.css
+++ b/packages/tokens/dist/devdot/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Jan 2023 00:09:59 GMT
+ * Generated on Tue, 14 Feb 2023 00:14:16 GMT
  */
 
 :root {
@@ -252,7 +252,7 @@
   --token-pagination-nav-control-icon-spacing: 6px;
   --token-pagination-nav-indicator-height: 2px;
   --token-pagination-nav-indicator-spacing: 6px;
-  --token-pagination-child-spacing-vertical: 8;
+  --token-pagination-child-spacing-vertical: 8px;
   --token-pagination-child-spacing-horizontal: 20px;
   --token-tabs-tab-height: 36px;
   --token-tabs-tab-padding-horizontal: 12px;

--- a/packages/tokens/dist/docs/devdot/tokens.json
+++ b/packages/tokens/dist/docs/devdot/tokens.json
@@ -5372,11 +5372,11 @@
     ]
   },
   {
-    "value": "8",
-    "type": "0",
+    "value": "8px",
+    "type": "size",
     "original": {
       "value": "8",
-      "type": "0"
+      "type": "size"
     },
     "name": "token-pagination-child-spacing-vertical",
     "attributes": {

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -5326,11 +5326,11 @@
     ]
   },
   {
-    "value": "8",
-    "type": "0",
+    "value": "8px",
+    "type": "size",
     "original": {
       "value": "8",
-      "type": "0"
+      "type": "size"
     },
     "name": "token-pagination-child-spacing-vertical",
     "attributes": {

--- a/packages/tokens/dist/products/css/helpers/color.css
+++ b/packages/tokens/dist/products/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Jan 2023 00:09:59 GMT
+ * Generated on Tue, 14 Feb 2023 00:14:16 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/products/css/helpers/elevation.css
+++ b/packages/tokens/dist/products/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Jan 2023 00:09:59 GMT
+ * Generated on Tue, 14 Feb 2023 00:14:16 GMT
  */
 
 .hds-elevation-inset { box-shadow: var(--token-elevation-inset-box-shadow); }

--- a/packages/tokens/dist/products/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/products/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Jan 2023 00:09:59 GMT
+ * Generated on Tue, 14 Feb 2023 00:14:16 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/products/css/helpers/typography.css
+++ b/packages/tokens/dist/products/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Jan 2023 00:09:59 GMT
+ * Generated on Tue, 14 Feb 2023 00:14:16 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Jan 2023 00:09:59 GMT
+ * Generated on Tue, 14 Feb 2023 00:14:16 GMT
  */
 
 :root {
@@ -250,7 +250,7 @@
   --token-pagination-nav-control-icon-spacing: 6px;
   --token-pagination-nav-indicator-height: 2px;
   --token-pagination-nav-indicator-spacing: 6px;
-  --token-pagination-child-spacing-vertical: 8;
+  --token-pagination-child-spacing-vertical: 8px;
   --token-pagination-child-spacing-horizontal: 20px;
   --token-tabs-tab-height: 36px;
   --token-tabs-tab-padding-horizontal: 12px;

--- a/packages/tokens/src/products/shared/pagination.json
+++ b/packages/tokens/src/products/shared/pagination.json
@@ -36,7 +36,7 @@
             "spacing": {
                 "vertical": {
                     "value": "8",
-                    "type": "0"
+                    "type": "size"
                 },
                 "horizontal": {
                     "value": "20",


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will apply group-related layout styles for Pagination child components only if they are nested inside the Pagination wrapper component. It will also fix a bug with the --token-pagination-child-spacing-vertical design token that was causing top margins of child components to not be applied.

- **Website Preview:** https://hds-website-git-hds-1542-refactor-pagination-margins-hashicorp.vercel.app/components/pagination?tab=code
- **Showcase Preview:** https://hds-components-git-hds-1542-refactor-paginatio-0662ac-hashicorp.vercel.app/components/pagination#showcase

### :hammer_and_wrench: Detailed description
* Moved layout styles applied to stand alone components to parent selector so they instead will only apply to nested child components
* Fix bug with --token-pagination-child-spacing-vertical token that was causing spacing between components in the wrapped mobile view not to render. (Top margins of components on 2nd line underneath the 1st line with the navigation controls wasn't working.)

<!-- 
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1542](https://hashicorp.atlassian.net/browse/HDS-1542)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1542]: https://hashicorp.atlassian.net/browse/HDS-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ