### PR TITLE
Fix custom `RadioCard` example

### DIFF
--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -99,7 +99,7 @@ export default class ShowRoute extends Route {
         const hasSidecar = frontmatter?.layout?.sidecar ?? true;
         const showContentId = `show-content-${res.data.id
           .replace(/\/index$/, '')
-          .replace('/', '-')}`;
+          .replaceAll('/', '-')}`;
 
         return {
           // IMPORTANT: this is the "component" ID which is used to get the correct backing class for the markdown "component"

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -31,6 +31,7 @@
 @import "pages/components/landing";
 @import "pages/components/modal";
 @import "pages/components/pagination";
+@import "pages/components/radio-card";
 
 // Third-party declarations
 @import "prism-dracula";

--- a/website/app/styles/pages/components/radio-card.scss
+++ b/website/app/styles/pages/components/radio-card.scss
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// COMPONENTS > RADIO CARD
+
+#show-content-components-form-radio-card {
+  .doc-radio-card-list-demo {
+    margin: 0;
+    padding: 0;
+    color: #3b3d45;
+
+    li {
+      margin: 0;
+      padding: 8px 0 8px 24px;
+      list-style: none;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11.78 5.22a.75.75 0 010 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.97-3.97a.75.75 0 011.06 0z' fill='%233b3d45'/%3E%3Cpath d='M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z' fill='%233b3d45'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: left 9px;
+      background-size: 16px;
+      border-bottom: 1px solid #ddd;
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+  }
+}

--- a/website/docs/components/form/radio-card/partials/code/how-to-use.md
+++ b/website/docs/components/form/radio-card/partials/code/how-to-use.md
@@ -48,27 +48,27 @@ Customizable options include:
 ```handlebars
 <Hds::Form::RadioCard::Group @name="radio-card-custom-example" as |G|>
   <G.Legend>Cluster type</G.Legend>
-  <G.RadioCard @maxWidth="33%" @checked={{true}} {{on "change" this.onChange}} as |R|>
+  <G.RadioCard @checked={{true}} {{on "change" this.onChange}} as |R|>
     <R.Label>HCP-managed Consul</R.Label>
     <R.Badge @text="6 clusters left" />
     <R.Generic>
-      <ul>
-        <li>Connect workloads in your cloud provider network with HCP</li>
-        <li>Offload Consul operations to Hashicorp Experts</li>
+      <ul class="doc-radio-card-list-demo">
+        <li class="hds-typography-display-100">Connect workloads in your cloud provider network with HCP</li>
+        <li class="hds-typography-display-100">Offload Consul operations to Hashicorp Experts</li>
       </ul>
     </R.Generic>
   </G.RadioCard>
-  <G.RadioCard @maxWidth="33%" {{on "change" this.onChange}} as |R|>
+  <G.RadioCard {{on "change" this.onChange}} as |R|>
     <R.Label>Self-managed Consul</R.Label>
     <R.Badge @text="5 clusters left" />
     <R.Badge @text="Kubernetes only" @icon="kubernetes" />
     <R.Generic>
-      <ul>
-        <li>Multi-cloud artifact registry</li>
-        <li>Golden images workflow</li>
-        <li>Terraform Cloud integration</li>
-        <li>10 free images/month</li>
-        <li>250 free requests/month</li>
+      <ul class="doc-radio-card-list-demo">
+        <li class="hds-typography-display-100">Multi-cloud artifact registry</li>
+        <li class="hds-typography-display-100">Golden images workflow</li>
+        <li class="hds-typography-display-100">Terraform Cloud integration</li>
+        <li class="hds-typography-display-100">10 free images/month</li>
+        <li class="hds-typography-display-100">250 free requests/month</li>
       </ul>
     </R.Generic>
   </G.RadioCard>


### PR DESCRIPTION
### :pushpin: Summary

Fix the custom `RadioCard` example to resemble the scrappy website and the design reference.

### :hammer_and_wrench: Detailed description

Bring back styles from scrappy/showcase website to the docs website

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="748" alt="Screenshot 2023-02-14 at 14 51 37" src="https://user-images.githubusercontent.com/788096/218773525-33150def-9a84-4d10-8c2b-c09fcb47843f.png">


</td><td>

<img width="748" alt="Screenshot 2023-02-14 at 14 52 21" src="https://user-images.githubusercontent.com/788096/218773538-a254646b-80d4-42c6-b6a0-6f02bd643a7e.png">


</td></tr>
</table>

### :link: External links

<!-- Issues, RFC, etc. -->
Figma file: https://www.figma.com/file/Kgc8BgB8jGuJXISndgTrD1/Dropdown?node-id=17482%3A57763&t=5atttDvWTNWF9oRx-4

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
