### PR TITLE
Style nested `ComponentApi`s

### DIFF
--- a/website/app/styles/doc-components/component-api.scss
+++ b/website/app/styles/doc-components/component-api.scss
@@ -149,3 +149,20 @@
   background-color: var(--doc-color-feedback-information-200);
   border-radius: 3px;
 }
+
+// Nested instances
+
+.doc-component-api__description {
+  .doc-component-api {
+    margin: 16px 0;
+    border-left: 2px solid var(--doc-color-gray-500);
+  }
+
+  .doc-component-api__property {
+    padding: 16px;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+}

--- a/website/docs/components/form/checkbox/partials/code/component-api.md
+++ b/website/docs/components/form/checkbox/partials/code/component-api.md
@@ -43,9 +43,11 @@ The Checkbox component has three different variants with their own APIs:
     Container that yields its content inside the “error” block at group level. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>
 
@@ -90,9 +92,11 @@ The Checkbox component has three different variants with their own APIs:
     Container that yields its content inside the “error” block. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API, check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>
 

--- a/website/docs/components/form/primitives/partials/code/component-api.md
+++ b/website/docs/components/form/primitives/partials/code/component-api.md
@@ -128,12 +128,14 @@ Control, label, helper text and error content are passed to the field as yielded
     Returns the `aria-describedby` attribute for the control element (generated automatically, based on the presence of the `HelperText` an/or the `Error` elements in the field, plus the optional `@extraAriaDescribedBy` argument described above).
   </C.Property>
   <C.Property @name="<[F].Error>" @type="yielded component">
-    A container that yields its content inside the “error” block. The content can be a simple string, or a more complex/structured one (in which case it inherits the text style). For details about its API check the `Form::Error` component.
+    A container that yields its content inside the “error” block. The content can be a simple string, or a more complex/structured one (in which case it inherits the text style). For details about its API check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>
 
@@ -184,11 +186,13 @@ Control, label, helper text and error content are passed to the field as yielded
     Returns the `aria-describedby` attribute for the control element (generated automatically, based on the presence of the `HelperText` an/or the `Error` elements in the field, plus the optional `@extraAriaDescribedBy` argument described above).
   </C.Property>
   <C.Property @name="<[F].Error>" @type="yielded component">
-    A container that yields its content inside the “error” block (at group level). The content can be a simple string, or a more complex/structured one (in which case it inherits the text style).
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`. For details about its API check the `Form::Error` component.
+    Container that yields its content inside the “error” block (at group level). The content can be a simple string, or a more complex/structured one (in which case it inherits the text style). For details about its API check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/form/radio-card/partials/code/component-api.md
+++ b/website/docs/components/form/radio-card/partials/code/component-api.md
@@ -108,11 +108,13 @@ The group of elements is automatically wrapped in a `<fieldset>` element.
     Used to yield one or more cards inside the group. For details about its API check the `RadioCard` component above.
   </C.Property>
   <C.Property @name="<[G].Error>" @type="yielded component">
-    A container that yields its content inside the "error" block (at group level). The content can be a simple string, or a more complex/structured one (in which case it inherits the text style). For details about its API check the [`Form::Error`](/components/form/primitives) component.
+    Container that yields its content inside the "error" block (at group level). The content can be a simple string, or a more complex/structured one (in which case it inherits the text style). For details about its API check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/form/radio/partials/code/component-api.md
+++ b/website/docs/components/form/radio/partials/code/component-api.md
@@ -48,9 +48,11 @@ Since `radio` controls are always used in a list of options, it’s likely you�
     Container that yields its content inside the “error” block at group level. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API, check the [`Form::Error`](/components/form/primitives/) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>
 
@@ -95,9 +97,11 @@ Since `radio` controls are always used in a list of options, it’s likely you�
     Container that yields its content inside the “error” block. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API, check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>
 

--- a/website/docs/components/form/select/partials/code/component-api.md
+++ b/website/docs/components/form/select/partials/code/component-api.md
@@ -89,8 +89,10 @@ The select options are passed to the field as yielded components, using the `Opt
     Container that yields its content inside the "error" block. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API, check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/form/text-input/partials/code/component-api.md
+++ b/website/docs/components/form/text-input/partials/code/component-api.md
@@ -88,8 +88,10 @@ The Text Input component has two different variants with their own APIs:
     Container that yields its content inside the "error" block. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API, check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/form/textarea/partials/code/component-api.md
+++ b/website/docs/components/form/textarea/partials/code/component-api.md
@@ -82,8 +82,10 @@ In addition we provide:
     Container that yields its content inside the "error" block. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API, check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/form/toggle/partials/code/component-api.md
+++ b/website/docs/components/form/toggle/partials/code/component-api.md
@@ -37,12 +37,14 @@ The Toggle component has two different variants with their own APIs:
     Used to yield one or more fields inside the group. For details about its API, check the `Toggle::Field` component above.
   </C.Property>
   <C.Property @name="<[G].Error>" @type="yielded component">
-    Container that yields its content inside the “error” block at group level. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API, check the [`Form::Error`](/components/form/primitives) component. 
+    Container that yields its content inside the “error” block at group level. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API, check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>
 
@@ -84,10 +86,14 @@ The Toggle component has two different variants with their own APIs:
     The `id` attribute of the element is automatically generated using the `controlId` value of the control.
   </C.Property>
   <C.Property @name="<[F].Error>" @type="yielded component">
-    Container that yields its content inside the “error” block. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API, check the [`Form::Error`](/components/form/primitives/) component. The `id` attribute of the `Error` element is automatically generated.
-  </C.Property>
-  <C.Property @name="<[E].Message>" @type="yielded component">
-    If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+    Container that yields its content inside the “error” block. The content can be a simple string or a more complex/structured string, in which case it inherits the text style. For details about its API, check the [`Form::Error`](/components/form/primitives/) component.
+    <br/><br/>
+    The `id` attribute of the `Error` element is automatically generated.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="<[E].Message>" @type="yielded component">
+        If the error is made of multiple messages, you can iterate over a collection of error messages yielding individual items using `Error.Message`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>
 


### PR DESCRIPTION
### :pushpin: Summary

Style nested instances of `Doc::ComponentApi` and nest `Error.Message` in form components.

### :hammer_and_wrench: Detailed description

To enable more granular details on complex component APIs.

👉 [Preview on Checkbox page](https://hds-website-git-alex-ju-nested-component-api-hashicorp.vercel.app/components/form/checkbox?tab=code#formcheckboxgroup-1)

### :link: External links

<!-- Issues, RFC, etc. -->
Figma file: https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?node-id=1686%3A66594&t=V2UmkAHbO2fipW2L-4

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
