### PR TITLE
refresh model in all cases of selectedTab change to make back button work

### DIFF
--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -13,6 +13,11 @@ import { reject } from 'rsvp';
 
 export default class ShowRoute extends Route {
   @service router;
+  queryParams = {
+    selectedTab: {
+      refreshModel: true,
+    },
+  };
 
   model(params) {
     // remove trailing slash


### PR DESCRIPTION
### :pushpin: Summary

Fixes bug where clicking the back button would not update the tab you were seeing

### :hammer_and_wrench: Detailed description

Currently, when the back button is clicked there is nothing to trigger our logic to update which tab is selected. This PR "fixes" this by triggering a model refresh every time the `selectedTab` query param is updated. The downside to this is that we are unnecessarily reloading the model, but since it is already cached it is a very small penalty that, at least in my testing, was imperceptible.

### How to test

* Navigate to a component
* Click the code tab
* Click browser back button
* See things working

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1247](https://hashicorp.atlassian.net/browse/HDS-1247)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1247]: https://hashicorp.atlassian.net/browse/HDS-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ