### PR TITLE
Adds missing style support for table component where th was used in tbody

### DIFF
--- a/.changeset/green-mangos-hug.md
+++ b/.changeset/green-mangos-hug.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Updates table styles to include scoped row support

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -48,11 +48,15 @@ $hds-table-cell-padding-tall: 20px 16px;
       }
     }
   }
+
+  .hds-table__th,
+  .hds-table__th-sort {
+    height: $hds-table-header-height;
+  }
 }
 
 .hds-table__th,
 .hds-table__th-sort {
-  height: $hds-table-header-height;
   text-align: left;
   border-top: none;
   border-right: none;
@@ -119,33 +123,33 @@ $hds-table-cell-padding-tall: 20px 16px;
 }
 
 // TABLE DENSITY (TBODY ROW HEIGHT)
-.hds-table--density-short .hds-table__tbody th,
-.hds-table--density-short .hds-table__tbody td {
-  height: unset;
-  padding: $hds-table-cell-padding-short;
-}
 
-.hds-table--density-medium .hds-table__tbody th,
-.hds-table--density-medium .hds-table__tbody td {
-  height: unset;
-  padding: $hds-table-cell-padding-medium;
-}
+.hds-table__tbody th,
+.hds-table__tbody td {
+  .hds-table--density-short & {
+    padding: $hds-table-cell-padding-short;
+  }
 
-.hds-table--density-tall .hds-table__tbody th,
-.hds-table--density-tall .hds-table__tbody td {
-  height: unset;
-  padding: $hds-table-cell-padding-tall;
+  .hds-table--density-medium & {
+    padding: $hds-table-cell-padding-medium;
+  }
+
+  .hds-table--density-tall & {
+    padding: $hds-table-cell-padding-tall;
+  }
 }
 
 // TABLE CELL VERTICAL ALIGNMENT
-.hds-table--valign-top .hds-table__tbody th,
-.hds-table--valign-top .hds-table__tbody td {
-  vertical-align: top;
-}
 
-.hds-table--valign-middle .hds-table__tbody th,
-.hds-table--valign-middle .hds-table__tbody td {
-  vertical-align: middle;
+.hds-table__tbody th,
+.hds-table__tbody td {
+  .hds-table--valign-top & {
+    vertical-align: top;
+  }
+
+  .hds-table--valign-middle & {
+    vertical-align: middle;
+  }
 }
 
 // TABLE CELL TEXT ALIGNMENT (LEFT IS DEFAULT)

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -119,23 +119,31 @@ $hds-table-cell-padding-tall: 20px 16px;
 }
 
 // TABLE DENSITY (TBODY ROW HEIGHT)
+.hds-table--density-short .hds-table__tbody th,
 .hds-table--density-short .hds-table__tbody td {
+  height: unset;
   padding: $hds-table-cell-padding-short;
 }
 
+.hds-table--density-medium .hds-table__tbody th,
 .hds-table--density-medium .hds-table__tbody td {
+  height: unset;
   padding: $hds-table-cell-padding-medium;
 }
 
+.hds-table--density-tall .hds-table__tbody th,
 .hds-table--density-tall .hds-table__tbody td {
+  height: unset;
   padding: $hds-table-cell-padding-tall;
 }
 
 // TABLE CELL VERTICAL ALIGNMENT
+.hds-table--valign-top .hds-table__tbody th,
 .hds-table--valign-top .hds-table__tbody td {
   vertical-align: top;
 }
 
+.hds-table--valign-middle .hds-table__tbody th,
 .hds-table--valign-middle .hds-table__tbody td {
   vertical-align: middle;
 }
@@ -159,6 +167,7 @@ $hds-table-cell-padding-tall: 20px 16px;
     color: var(--token-color-foreground-primary);
     background-color: var(--token-color-surface-primary);
 
+    th,
     td {
       border-top: none;
       border-right: none;
@@ -166,16 +175,19 @@ $hds-table-cell-padding-tall: 20px 16px;
       border-left: none;
     }
 
-    // BORDER RADIUS: TARGET FIRST AND LAST TD ELEMENTS IN THE LAST ROW
+    // BORDER RADIUS: TARGET FIRST TH (SCOPE OF ROW) AND TD, AND LAST TD ELEMENTS IN THE LAST ROW
     &:last-of-type {
+      th,
       td {
         border-bottom: none;
       }
 
+      th:first-child,
       td:first-child {
         border-bottom-left-radius: $hds-table-inner-border-radius;
       }
 
+      // A TH WILL NEVER BE LAST CHILD, ONLY FIRST CHILD
       td:last-child {
         border-bottom-right-radius: $hds-table-inner-border-radius;
       }


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR addresses the bug where style support was missing for `th scope="row"` when used in the tbody element of the table component. This was causing two issues: content was not aligned correctly when the `@density` option was used (causing the content to be mis-aligned) and the borders were not correct.

### :hammer_and_wrench: Detailed description

- updates density style support 
- updates the border style support
- a showcase example was _not_ included in this PR, per @didoo's request (this will be updated in a different PR)

### :camera_flash: Screenshots

Here's what a table now looks like: 
![image](https://user-images.githubusercontent.com/4587451/219423061-9aff8a23-2a73-47c9-9e21-e7dc9707c1be.png)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1548](https://hashicorp.atlassian.net/browse/HDS-1548)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1548]: https://hashicorp.atlassian.net/browse/HDS-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ