### PR TITLE
`Doc::Layout` - Align items to the top to prevent stretching (HDS-1551)

### DIFF
--- a/website/app/styles/doc-components/layout.scss
+++ b/website/app/styles/doc-components/layout.scss
@@ -7,6 +7,7 @@
   display: flex;
   flex-flow: wrap;
   gap: var(--doc-layout-spacing, 0);
+  align-items: start;
 }
 
 // Direction:


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will align child elements wrapped by `Doc::Layout` to the top of rows to prevent distortion by stretching.

**Preview:** https://hds-website-git-hds-1551-doc-layout-fix-stretching-hashicorp.vercel.app/components/button

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots
Aligned to top:
<img width="277" alt="image" src="https://user-images.githubusercontent.com/108769823/219784687-d62d796d-8317-491c-b738-012d48b4487f.png">

### :link: External links
Jira ticket: [HDS-1551](https://hashicorp.atlassian.net/browse/HDS-1551)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1551]: https://hashicorp.atlassian.net/browse/HDS-1551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ