### PR TITLE
Extend `Dropdown` content

### DIFF
--- a/.changeset/sharp-rings-fetch.md
+++ b/.changeset/sharp-rings-fetch.md
@@ -1,0 +1,14 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+Add `Hds::Dropdown::Header` and `Hds::Dropdown::Footer` as generic blocks to `Hds::Dropdown`
+
+Rename `Hds::Dropdown` internal CSS class `hds-dropdown-list` → `hds-dropdown__list`
+
+The `hds-dropdown__list` element is now wrapped in a `hds-dropdown__content` element to accommodate the new header and footer elements. As a result, the following modifiers will be applied to the wrapper element.
+ - `hds-dropdown-list--fixed-width` → `hds-dropdown__content--fixed-width`
+ - `hds-dropdown-list--position-left` → `hds-dropdown__content--position-left`
+ - `hds-dropdown-list--position-right` → `hds-dropdown__content--position-right`
+
+**Note:** If test assertions are relying on these class names, tests will fail. If extensions/overrides have been applied to these classes, they will suffer visual changes.

--- a/packages/components/addon/components/hds/dropdown/footer.hbs
+++ b/packages/components/addon/components/hds/dropdown/footer.hbs
@@ -1,3 +1,3 @@
-<div class="hds-dropdown__footer {{if @hasSeparator 'hds-dropdown__footer--with-separator'}}" ...attributes>
+<div class="hds-dropdown__footer {{if @hasDivider 'hds-dropdown__footer--with-divider'}}" ...attributes>
   {{yield}}
 </div>

--- a/packages/components/addon/components/hds/dropdown/footer.hbs
+++ b/packages/components/addon/components/hds/dropdown/footer.hbs
@@ -1,3 +1,3 @@
-<div class="hds-dropdown__footer" ...attributes>
+<div class="hds-dropdown__footer{{if @hasSeparator ' hds-dropdown__footer--separator'}}" ...attributes>
   {{yield}}
 </div>

--- a/packages/components/addon/components/hds/dropdown/footer.hbs
+++ b/packages/components/addon/components/hds/dropdown/footer.hbs
@@ -1,3 +1,3 @@
-<div class="hds-dropdown__footer{{if @hasSeparator ' hds-dropdown__footer--separator'}}" ...attributes>
+<div class="hds-dropdown__footer {{if @hasSeparator 'hds-dropdown__footer--with-separator'}}" ...attributes>
   {{yield}}
 </div>

--- a/packages/components/addon/components/hds/dropdown/footer.hbs
+++ b/packages/components/addon/components/hds/dropdown/footer.hbs
@@ -1,0 +1,3 @@
+<div class="hds-dropdown__footer" ...attributes>
+  {{yield}}
+</div>

--- a/packages/components/addon/components/hds/dropdown/header.hbs
+++ b/packages/components/addon/components/hds/dropdown/header.hbs
@@ -1,3 +1,3 @@
-<div class="hds-dropdown__header" ...attributes>
+<div class="hds-dropdown__header{{if @hasSeparator ' hds-dropdown__header--separator'}}" ...attributes>
   {{yield}}
 </div>

--- a/packages/components/addon/components/hds/dropdown/header.hbs
+++ b/packages/components/addon/components/hds/dropdown/header.hbs
@@ -1,0 +1,3 @@
+<div class="hds-dropdown__header" ...attributes>
+  {{yield}}
+</div>

--- a/packages/components/addon/components/hds/dropdown/header.hbs
+++ b/packages/components/addon/components/hds/dropdown/header.hbs
@@ -1,3 +1,3 @@
-<div class="hds-dropdown__header {{if @hasSeparator 'hds-dropdown__header--with-separator'}}" ...attributes>
+<div class="hds-dropdown__header {{if @hasDivider 'hds-dropdown__header--with-divider'}}" ...attributes>
   {{yield}}
 </div>

--- a/packages/components/addon/components/hds/dropdown/header.hbs
+++ b/packages/components/addon/components/hds/dropdown/header.hbs
@@ -1,3 +1,3 @@
-<div class="hds-dropdown__header{{if @hasSeparator ' hds-dropdown__header--separator'}}" ...attributes>
+<div class="hds-dropdown__header {{if @hasSeparator 'hds-dropdown__header--with-separator'}}" ...attributes>
   {{yield}}
 </div>

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -12,21 +12,25 @@
     }}
   </:toggle>
   <:content as |c|>
-    <ul class={{this.listClassNames}} {{style width=@width}} {{did-insert this.didInsertList}}>
-      {{yield
-        (hash
-          close=c.close
-          Checkbox=(component "hds/dropdown/list-item/checkbox")
-          Checkmark=(component "hds/dropdown/list-item/checkmark")
-          CopyItem=(component "hds/dropdown/list-item/copy-item")
-          Description=(component "hds/dropdown/list-item/description")
-          Generic=(component "hds/dropdown/list-item/generic")
-          Interactive=(component "hds/dropdown/list-item/interactive")
-          Radio=(component "hds/dropdown/list-item/radio")
-          Separator=(component "hds/dropdown/list-item/separator")
-          Title=(component "hds/dropdown/list-item/title")
-        )
-      }}
-    </ul>
+    <div class={{this.classNames}} {{style width=@width height=@height}}>
+      {{yield (hash Header=(component "hds/dropdown/header"))}}
+      <ul class="hds-dropdown__list" {{did-insert this.didInsertList}}>
+        {{yield
+          (hash
+            close=c.close
+            Checkbox=(component "hds/dropdown/list-item/checkbox")
+            Checkmark=(component "hds/dropdown/list-item/checkmark")
+            CopyItem=(component "hds/dropdown/list-item/copy-item")
+            Description=(component "hds/dropdown/list-item/description")
+            Generic=(component "hds/dropdown/list-item/generic")
+            Interactive=(component "hds/dropdown/list-item/interactive")
+            Radio=(component "hds/dropdown/list-item/radio")
+            Separator=(component "hds/dropdown/list-item/separator")
+            Title=(component "hds/dropdown/list-item/title")
+          )
+        }}
+      </ul>
+      {{yield (hash close=c.close Footer=(component "hds/dropdown/footer"))}}
+    </div>
   </:content>
 </Hds::Disclosure>

--- a/packages/components/addon/components/hds/dropdown/index.js
+++ b/packages/components/addon/components/hds/dropdown/index.js
@@ -31,19 +31,19 @@ export default class HdsDropdownIndexComponent extends Component {
   }
 
   /**
-   * Get the class names to apply to the "list"
-   * @method DropdownIndex#listClassNames
-   * @return {string} The "class" attribute to apply to the "list" element
+   * Get the class names to apply to the content
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the disclosed content
    */
-  get listClassNames() {
-    let classes = ['hds-dropdown-list'];
+  get classNames() {
+    let classes = ['hds-dropdown__content'];
 
     // add a class based on the @listPosition argument
-    classes.push(`hds-dropdown-list--position-${this.listPosition}`);
+    classes.push(`hds-dropdown__content--position-${this.listPosition}`);
 
     // add a class based on the @width argument
     if (this.args.width) {
-      classes.push('hds-dropdown-list--fixed-width');
+      classes.push('hds-dropdown__content--fixed-width');
     }
 
     return classes.join(' ');

--- a/packages/components/app/components/hds/dropdown/footer.js
+++ b/packages/components/app/components/hds/dropdown/footer.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/dropdown/footer';

--- a/packages/components/app/components/hds/dropdown/header.js
+++ b/packages/components/app/components/hds/dropdown/header.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/dropdown/header';

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -156,7 +156,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
-.hds-dropdown__header--separator {
+.hds-dropdown__header--with-separator {
   border-bottom: 1px solid var(--token-color-border-primary);
 }
 
@@ -180,7 +180,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
-.hds-dropdown__footer--separator {
+.hds-dropdown__footer--with-separator {
   border-top: 1px solid var(--token-color-border-primary);
 }
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -115,37 +115,69 @@ $hds-dropdown-toggle-border-radius: 5px;
 // UL ELEMENT
 // GOES INSIDE HDS::DISCLOSURE's :content block
 
-.hds-dropdown-list {
+.hds-dropdown__content {
+  display: flex;
+  flex-direction: column;
   width: max-content; // notice: this is important because being in a position absolute means the layout algorithm assigns a width of 0 and this impacts on the flex algorithm of the children (in some cases they don't use the full width)
   min-width: 200px;
   max-width: 400px;
-  margin: 0;
-  padding: 4px 0;
-  list-style: none;
   background-color: var(--token-color-surface-primary);
   border-radius: 6px;
   box-shadow: var(--token-surface-high-box-shadow);
 }
 
-.hds-dropdown-list--fixed-width {
+.hds-dropdown__content--fixed-width {
   min-width: initial;
   max-width: initial;
 }
 
-.hds-dropdown-list--position-right {
+.hds-dropdown__content--position-right {
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
   z-index: 2; // https://github.com/hashicorp/design-system/issues/114
 }
 
-.hds-dropdown-list--position-left {
+.hds-dropdown__content--position-left {
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
   z-index: 2; // https://github.com/hashicorp/design-system/issues/114
 }
 
+.hds-dropdown__header {
+  flex: none;
+  padding: 6px 8px;
+}
+
+.hds-dropdown__list {
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 4px 0;
+  overflow-y: auto;
+  list-style: none;
+  overscroll-behavior: contain;
+}
+
+.hds-dropdown__footer {
+  position: relative;
+  flex: none;
+  padding: 8px 8px 6px;
+
+  .hds-link-standalone {
+    width: initial;
+    padding: 5px 8px;
+  }
+
+  &::after {
+    position: absolute;
+    top: 0;
+    right: 6px;
+    left: 6px;
+    border-top: 1px solid var(--token-color-border-primary);
+    content: "";
+  }
+}
 
 // LIST > LIST-ITEM
 // HDS::DROPDOWN::LIST-ITEM

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -156,7 +156,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
-.hds-dropdown__header--with-separator {
+.hds-dropdown__header--with-divider {
   border-bottom: 1px solid var(--token-color-border-primary);
 }
 
@@ -180,7 +180,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
-.hds-dropdown__footer--with-separator {
+.hds-dropdown__footer--with-divider {
   border-top: 1px solid var(--token-color-border-primary);
 }
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -146,8 +146,25 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown__header {
+  position: relative;
   flex: none;
   padding: 6px 8px;
+
+  .hds-link-standalone {
+    width: initial;
+    padding: 5px 8px;
+  }
+}
+
+.hds-dropdown__header--separator {
+  &::after {
+    position: absolute;
+    right: 6px;
+    bottom: 0;
+    left: 6px;
+    border-top: 1px solid var(--token-color-border-primary);
+    content: "";
+  }
 }
 
 .hds-dropdown__list {
@@ -168,7 +185,9 @@ $hds-dropdown-toggle-border-radius: 5px;
     width: initial;
     padding: 5px 8px;
   }
+}
 
+.hds-dropdown__footer--separator {
   &::after {
     position: absolute;
     top: 0;

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -157,14 +157,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown__header--separator {
-  &::after {
-    position: absolute;
-    right: 6px;
-    bottom: 0;
-    left: 6px;
-    border-top: 1px solid var(--token-color-border-primary);
-    content: "";
-  }
+  border-bottom: 1px solid var(--token-color-border-primary);
 }
 
 .hds-dropdown__list {
@@ -179,7 +172,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 .hds-dropdown__footer {
   position: relative;
   flex: none;
-  padding: 8px 8px 6px;
+  padding: 8px;
 
   .hds-link-standalone {
     width: initial;
@@ -188,14 +181,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 }
 
 .hds-dropdown__footer--separator {
-  &::after {
-    position: absolute;
-    top: 0;
-    right: 6px;
-    left: 6px;
-    border-top: 1px solid var(--token-color-border-primary);
-    content: "";
-  }
+  border-top: 1px solid var(--token-color-border-primary);
 }
 
 // LIST > LIST-ITEM

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -145,21 +145,6 @@ $hds-dropdown-toggle-border-radius: 5px;
   z-index: 2; // https://github.com/hashicorp/design-system/issues/114
 }
 
-.hds-dropdown__header {
-  position: relative;
-  flex: none;
-  padding: 6px 8px;
-
-  .hds-link-standalone {
-    width: initial;
-    padding: 5px 8px;
-  }
-}
-
-.hds-dropdown__header--with-divider {
-  border-bottom: 1px solid var(--token-color-border-primary);
-}
-
 .hds-dropdown__list {
   flex: 1 1 auto;
   margin: 0;
@@ -169,15 +154,40 @@ $hds-dropdown-toggle-border-radius: 5px;
   overscroll-behavior: contain;
 }
 
+.hds-dropdown__header,
 .hds-dropdown__footer {
   position: relative;
   flex: none;
-  padding: 8px;
+  padding: 0 8px;
 
-  .hds-link-standalone {
+  > .hds-link-standalone {
     width: initial;
-    padding: 5px 8px;
+    margin: 4px 0;
+    padding: 7px 8px; // 7px=8px-1px(accounting for the transparent border)
+
+    // keep focus ring in sync with the padding
+    &::before {
+      top: 0;
+      bottom: 0;
+    }
   }
+
+  > .hds-button,
+  > .hds-form-text-input {
+    margin: 8px 0;
+  }
+
+  > .hds-button-set {
+    margin: 8px 0;
+
+    > * + * {
+      margin-left: 8px;
+    }
+  }
+}
+
+.hds-dropdown__header--with-divider {
+  border-bottom: 1px solid var(--token-color-border-primary);
 }
 
 .hds-dropdown__footer--with-divider {

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -842,7 +842,7 @@
         </ul>
       </div>
     </SF.Item>
-    <SF.Item @label="Generic header with divider">
+    <SF.Item @label="Generic header with separator">
       <div class="hds-dropdown__content">
         <Hds::Dropdown::Header @hasSeparator={{true}}>
           <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
@@ -902,12 +902,12 @@
             <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
           </Hds::Dropdown::ListItem::Generic>
         </ul>
-        <Hds::Dropdown::Footer @hasSeparator={{true}}>
+        <Hds::Dropdown::Footer>
           <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Footer>
       </div>
     </SF.Item>
-    <SF.Item @label="Generic footer with divider">
+    <SF.Item @label="Generic footer with separator">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           <Hds::Dropdown::ListItem::Generic>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -844,7 +844,7 @@
     </SF.Item>
     <SF.Item @label="Generic header with divider">
       <div class="hds-dropdown__content">
-        <Hds::Dropdown::Header @hasDivider={{true}}>
+        <Hds::Dropdown::Header @hasSeparator={{true}}>
           <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -862,7 +862,7 @@
     </SF.Item>
     <SF.Item @label="Input type search">
       <div class="hds-dropdown__content">
-        <Hds::Dropdown::Header @hasDivider={{true}}>
+        <Hds::Dropdown::Header @hasSeparator={{true}}>
           <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -873,7 +873,7 @@
     </SF.Item>
     <SF.Item @label="Link secondary">
       <div class="hds-dropdown__content">
-        <Hds::Dropdown::Header @hasDivider={{true}}>
+        <Hds::Dropdown::Header @hasSeparator={{true}}>
           <Hds::Link::Standalone @icon="list" @text="Organizations" @color="secondary" @href="#" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -902,7 +902,7 @@
             <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
           </Hds::Dropdown::ListItem::Generic>
         </ul>
-        <Hds::Dropdown::Footer>
+        <Hds::Dropdown::Footer @hasSeparator={{true}}>
           <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Footer>
       </div>
@@ -920,7 +920,7 @@
             <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
           </Hds::Dropdown::ListItem::Generic>
         </ul>
-        <Hds::Dropdown::Footer @hasDivider={{true}}>
+        <Hds::Dropdown::Footer @hasSeparator={{true}}>
           <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Footer>
       </div>
@@ -932,7 +932,7 @@
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
         </ul>
-        <Hds::Dropdown::Footer @hasDivider={{true}}>
+        <Hds::Dropdown::Footer @hasSeparator={{true}}>
           <Hds::Button @text="Apply filters" @isFullWidth={{true}} @size="small" />
         </Hds::Dropdown::Footer>
       </div>
@@ -944,7 +944,7 @@
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
         </ul>
-        <Hds::Dropdown::Footer @hasDivider={{true}}>
+        <Hds::Dropdown::Footer @hasSeparator={{true}}>
           <Hds::Link::Standalone @icon="list" @text="Organizations" @color="secondary" @href="#" />
         </Hds::Dropdown::Footer>
       </div>
@@ -958,7 +958,7 @@
   <Shw::Flex as |SF|>
     <SF.Item @label="Generic header and footer">
       <div class="hds-dropdown__content">
-        <Hds::Dropdown::Header @hasDivider={{true}}>
+        <Hds::Dropdown::Header @hasSeparator={{true}}>
           <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -972,7 +972,7 @@
             <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
           </Hds::Dropdown::ListItem::Generic>
         </ul>
-        <Hds::Dropdown::Footer @hasDivider={{true}}>
+        <Hds::Dropdown::Footer @hasSeparator={{true}}>
           <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Footer>
       </div>
@@ -981,7 +981,7 @@
     <SF.Item @label="Generic, fixed height list">
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="max-height:195px">
-        <Hds::Dropdown::Header @hasDivider={{true}}>
+        <Hds::Dropdown::Header @hasSeparator={{true}}>
           <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -998,7 +998,7 @@
             <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
           </Hds::Dropdown::ListItem::Generic>
         </ul>
-        <Hds::Dropdown::Footer @hasDivider={{true}}>
+        <Hds::Dropdown::Footer @hasSeparator={{true}}>
           <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Footer>
       </div>
@@ -1006,7 +1006,7 @@
     </SF.Item>
     <SF.Item @label="Input and Button Set">
       <div class="hds-dropdown__content">
-        <Hds::Dropdown::Header @hasDivider={{true}}>
+        <Hds::Dropdown::Header @hasSeparator={{true}}>
           <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -1014,7 +1014,7 @@
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
         </ul>
-        <Hds::Dropdown::Footer @hasDivider={{true}}>
+        <Hds::Dropdown::Footer @hasSeparator={{true}}>
           <Hds::ButtonSet>
             <Hds::Button @text="Apply" @isFullWidth={{true}} @size="small" />
             <Hds::Button @text="Cancel" @color="secondary" @isFullWidth={{true}} @size="small" />
@@ -1025,7 +1025,7 @@
     <SF.Item @label="Input and Link, fixed height list">
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="max-height:185px">
-        <Hds::Dropdown::Header @hasDivider={{true}}>
+        <Hds::Dropdown::Header @hasSeparator={{true}}>
           <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -1033,7 +1033,7 @@
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
         </ul>
-        <Hds::Dropdown::Footer @hasDivider={{true}}>
+        <Hds::Dropdown::Footer @hasSeparator={{true}}>
           <Hds::Link::Standalone @icon="plus" @text="Add organization" @href="#" />
         </Hds::Dropdown::Footer>
       </div>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -479,7 +479,12 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Large content">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @icon="hexagon" @selected={{true}} @count="12">
+            <Hds::Dropdown::ListItem::Checkmark
+              mock-state-value={{state}}
+              @icon="hexagon"
+              @selected={{true}}
+              @count="12"
+            >
               {{state}}
               with a longer text string that may wrap since max-width is defined on the container
               <Hds::Badge @text="badge" @size="small" />
@@ -842,7 +847,7 @@
         </ul>
       </div>
     </SF.Item>
-    <SF.Item @label="Generic header with separator">
+    <SF.Item @label="Generic header with divider">
       <div class="hds-dropdown__content">
         <Hds::Dropdown::Header @hasDivider={{true}}>
           <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
@@ -862,7 +867,7 @@
     </SF.Item>
     <SF.Item @label="Input type search">
       <div class="hds-dropdown__content">
-        <Hds::Dropdown::Header @hasSeparator={{true}}>
+        <Hds::Dropdown::Header @hasDivider={{true}}>
           <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -907,7 +912,7 @@
         </Hds::Dropdown::Footer>
       </div>
     </SF.Item>
-    <SF.Item @label="Generic footer with separator">
+    <SF.Item @label="Generic footer with divider">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           <Hds::Dropdown::ListItem::Generic>
@@ -958,7 +963,7 @@
   <Shw::Flex as |SF|>
     <SF.Item @label="Generic header and footer">
       <div class="hds-dropdown__content">
-        <Hds::Dropdown::Header @hasSeparator={{true}}>
+        <Hds::Dropdown::Header @hasDivider={{true}}>
           <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -981,7 +986,7 @@
     <SF.Item @label="Generic, fixed height list">
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="max-height:195px">
-        <Hds::Dropdown::Header @hasSeparator={{true}}>
+        <Hds::Dropdown::Header @hasDivider={{true}}>
           <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -1006,7 +1011,7 @@
     </SF.Item>
     <SF.Item @label="Input and Button Set">
       <div class="hds-dropdown__content">
-        <Hds::Dropdown::Header @hasSeparator={{true}}>
+        <Hds::Dropdown::Header @hasDivider={{true}}>
           <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -1024,8 +1029,8 @@
     </SF.Item>
     <SF.Item @label="Input and Link, fixed height list">
       {{! template-lint-disable no-inline-styles }}
-      <div class="hds-dropdown__content" style="max-height:185px">
-        <Hds::Dropdown::Header @hasSeparator={{true}}>
+      <div class="hds-dropdown__content" style="max-height:190px">
+        <Hds::Dropdown::Header @hasDivider={{true}}>
           <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -108,43 +108,49 @@
 
   <Shw::Flex as |SF|>
     <SF.Item @label="Default (min width)">
-      <ul class="hds-dropdown-list">
-        <Hds::Dropdown::ListItem::Title @text="A simple title" />
-        <Hds::Dropdown::ListItem::Description @text="A description." />
-        <Hds::Dropdown::ListItem::Separator />
-        <Hds::Dropdown::ListItem::Interactive @route="index" @text="Item" />
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Title @text="A simple title" />
+          <Hds::Dropdown::ListItem::Description @text="A description." />
+          <Hds::Dropdown::ListItem::Separator />
+          <Hds::Dropdown::ListItem::Interactive @route="index" @text="Item" />
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Default (max width)">
-      <ul class="hds-dropdown-list">
-        <Hds::Dropdown::ListItem::Title
-          @text="A longer title that could span multiple lines if the characters surpass a certain length"
-        />
-        <Hds::Dropdown::ListItem::Description
-          @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
-        />
-        <Hds::Dropdown::ListItem::Separator />
-        <Hds::Dropdown::ListItem::Interactive
-          @route="index"
-          @text="A longer item that could span multiple lines if the characters surpass a certain length"
-        />
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Title
+            @text="A longer title that could span multiple lines if the characters surpass a certain length"
+          />
+          <Hds::Dropdown::ListItem::Description
+            @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
+          />
+          <Hds::Dropdown::ListItem::Separator />
+          <Hds::Dropdown::ListItem::Interactive
+            @route="index"
+            @text="A longer item that could span multiple lines if the characters surpass a certain length"
+          />
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Fixed width">
       {{! template-lint-disable no-inline-styles }}
-      <ul class="hds-dropdown-list" style="width: 250px">
-        <Hds::Dropdown::ListItem::Title
-          @text="A longer title that could span multiple lines if the characters surpass a certain length"
-        />
-        <Hds::Dropdown::ListItem::Description
-          @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
-        />
-        <Hds::Dropdown::ListItem::Separator />
-        <Hds::Dropdown::ListItem::Interactive
-          @route="index"
-          @text="A longer item that could span multiple lines if the characters surpass a certain length"
-        />
-      </ul>
+      <div class="hds-dropdown__content" style="width: 250px">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Title
+            @text="A longer title that could span multiple lines if the characters surpass a certain length"
+          />
+          <Hds::Dropdown::ListItem::Description
+            @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
+          />
+          <Hds::Dropdown::ListItem::Separator />
+          <Hds::Dropdown::ListItem::Interactive
+            @route="index"
+            @text="A longer item that could span multiple lines if the characters surpass a certain length"
+          />
+        </ul>
+      </div>
       {{! template-lint-enable no-inline-styles }}
     </SF.Item>
   </Shw::Flex>
@@ -158,18 +164,22 @@
   <Shw::Flex as |SF|>
     <SF.Item>
       <Shw::Label>Default ⇒ <code>&lt;button&gt;</code></Shw::Label>
-      <ul class="hds-dropdown-list">
-        <Hds::Dropdown::ListItem::Interactive @text="Lorem ipsum dolor" />
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @text="Lorem ipsum dolor" />
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item>
       <Shw::Label>With
         <code>@href</code>
         ⇒
         <code>&lt;a&gt;</code></Shw::Label>
-      <ul class="hds-dropdown-list">
-        <Hds::Dropdown::ListItem::Interactive @href="/" @text="Lorem ipsum dolor" />
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @href="/" @text="Lorem ipsum dolor" />
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item>
       <Shw::Label>With
@@ -178,9 +188,11 @@
         <code>&lt;LinkTo&gt;</code>
         ⇒
         <code>&lt;a&gt;</code></Shw::Label>
-      <ul class="hds-dropdown-list">
-        <Hds::Dropdown::ListItem::Interactive @route="components.dropdown" @text="Lorem ipsum dolor" />
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @route="components.dropdown" @text="Lorem ipsum dolor" />
+        </ul>
+      </div>
     </SF.Item>
   </Shw::Flex>
 
@@ -188,14 +200,18 @@
 
   <Shw::Flex as |SF|>
     <SF.Item @label="Action (default)">
-      <ul class="hds-dropdown-list">
-        <Hds::Dropdown::ListItem::Interactive @icon="settings" @text="Lorem ipsum dolor" @color="action" />
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @icon="settings" @text="Lorem ipsum dolor" @color="action" />
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Critical">
-      <ul class="hds-dropdown-list">
-        <Hds::Dropdown::ListItem::Interactive @icon="trash" @text="Lorem ipsum dolor" @color="critical" />
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @icon="trash" @text="Lorem ipsum dolor" @color="critical" />
+        </ul>
+      </div>
     </SF.Item>
   </Shw::Flex>
 
@@ -206,44 +222,50 @@
       <SF.Item @label={{capitalize color}}>
         <Shw::Flex as |SF|>
           <SF.Item>
-            <ul class="hds-dropdown-list">
-              {{#each @model.ITEM_STATES as |state|}}
-                <Hds::Dropdown::ListItem::Interactive @text={{state}} @color={{color}} mock-state-value={{state}} />
-              {{/each}}
-              <Hds::Dropdown::ListItem::Separator />
-              <Hds::Dropdown::ListItem::Interactive @text="loading" @color={{color}} @isLoading={{true}} />
-            </ul>
+            <div class="hds-dropdown__content">
+              <ul class="hds-dropdown__list">
+                {{#each @model.ITEM_STATES as |state|}}
+                  <Hds::Dropdown::ListItem::Interactive @text={{state}} @color={{color}} mock-state-value={{state}} />
+                {{/each}}
+                <Hds::Dropdown::ListItem::Separator />
+                <Hds::Dropdown::ListItem::Interactive @text="loading" @color={{color}} @isLoading={{true}} />
+              </ul>
+            </div>
           </SF.Item>
           <SF.Item>
-            <ul class="hds-dropdown-list">
-              {{#each @model.ITEM_STATES as |state|}}
+            <div class="hds-dropdown__content">
+              <ul class="hds-dropdown__list">
+                {{#each @model.ITEM_STATES as |state|}}
+                  <Hds::Dropdown::ListItem::Interactive
+                    @icon={{if (eq color "critical") "trash" "settings"}}
+                    @text="{{state}} with icon"
+                    @color={{color}}
+                    mock-state-value={{state}}
+                  />
+                {{/each}}
+                <Hds::Dropdown::ListItem::Separator />
                 <Hds::Dropdown::ListItem::Interactive
                   @icon={{if (eq color "critical") "trash" "settings"}}
-                  @text="{{state}} with icon"
+                  @text="loading with icon"
                   @color={{color}}
-                  mock-state-value={{state}}
+                  @isLoading={{true}}
                 />
-              {{/each}}
-              <Hds::Dropdown::ListItem::Separator />
-              <Hds::Dropdown::ListItem::Interactive
-                @icon={{if (eq color "critical") "trash" "settings"}}
-                @text="loading with icon"
-                @color={{color}}
-                @isLoading={{true}}
-              />
-            </ul>
+              </ul>
+            </div>
           </SF.Item>
           <SF.Item>
-            <ul class="hds-dropdown-list">
-              {{#each @model.ITEM_STATES as |state|}}
-                <Hds::Dropdown::ListItem::Interactive
-                  @icon={{if (eq color "critical") "trash" "settings"}}
-                  @text="{{state}} with a longer text string that may wrap since max-width is defined on the container"
-                  @color={{color}}
-                  mock-state-value={{state}}
-                />
-              {{/each}}
-            </ul>
+            <div class="hds-dropdown__content">
+              <ul class="hds-dropdown__list">
+                {{#each @model.ITEM_STATES as |state|}}
+                  <Hds::Dropdown::ListItem::Interactive
+                    @icon={{if (eq color "critical") "trash" "settings"}}
+                    @text="{{state}} with a longer text string that may wrap since max-width is defined on the container"
+                    @color={{color}}
+                    mock-state-value={{state}}
+                  />
+                {{/each}}
+              </ul>
+            </div>
           </SF.Item>
         </Shw::Flex>
       </SF.Item>
@@ -256,11 +278,13 @@
 
   <Shw::Flex as |SF|>
     <SF.Item>
-      <ul class="hds-dropdown-list">
-        <Hds::Dropdown::ListItem::Generic>
-          <Shw::Placeholder @text="some generic content here" @width="200" @height="40" @background="#e1f5fe" />
-        </Hds::Dropdown::ListItem::Generic>
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="some generic content here" @width="200" @height="40" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+        </ul>
+      </div>
     </SF.Item>
   </Shw::Flex>
 
@@ -274,19 +298,23 @@
     <SF.Item @label="Base">
       {{! Notice: we want to emulate the case of a fixed width list }}
       {{! template-lint-disable no-inline-styles }}
-      <ul class="hds-dropdown-list" style="width: 250px">
-        <Hds::Dropdown::ListItem::CopyItem @text="91ee1e8ef65b337f0e70d793f456c71d" />
-      </ul>
+      <div class="hds-dropdown__content" style="width: 250px">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::CopyItem @text="91ee1e8ef65b337f0e70d793f456c71d" />
+        </ul>
+      </div>
       {{! template-lint-enable no-inline-styles }}
     </SF.Item>
     <SF.Item @label="With 'copyItemTitle'">
       {{! template-lint-disable no-inline-styles }}
-      <ul class="hds-dropdown-list" style="width: 250px">
-        <Hds::Dropdown::ListItem::CopyItem
-          @copyItemTitle="Lorem ipsum dolor"
-          @text="91ee1e8ef65b337f0e70d793f456c71d"
-        />
-      </ul>
+      <div class="hds-dropdown__content" style="width: 250px">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::CopyItem
+            @copyItemTitle="Lorem ipsum dolor"
+            @text="91ee1e8ef65b337f0e70d793f456c71d"
+          />
+        </ul>
+      </div>
       {{! template-lint-enable no-inline-styles }}
     </SF.Item>
   </Shw::Flex>
@@ -297,21 +325,23 @@
     <SF.Item>
       {{! Notice: we want to emulate the case of a fixed width list }}
       {{! template-lint-disable no-inline-styles }}
-      <ul class="hds-dropdown-list" style="width: 250px">
-        {{#each @model.ITEM_STATES as |state|}}
+      <div class="hds-dropdown__content" style="width: 250px">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::CopyItem
+              @text="{{state}}: 91ee1e8ef65b337f0e70d793f456c71d"
+              mock-state-value={{state}}
+              mock-state-selector="button"
+            />
+          {{/each}}
           <Hds::Dropdown::ListItem::CopyItem
-            @text="{{state}}: 91ee1e8ef65b337f0e70d793f456c71d"
-            mock-state-value={{state}}
+            @text="success: 91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d"
+            @isSuccess={{true}}
+            mock-state-value="success"
             mock-state-selector="button"
           />
-        {{/each}}
-        <Hds::Dropdown::ListItem::CopyItem
-          @text="success: 91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d"
-          @isSuccess={{true}}
-          mock-state-value="success"
-          mock-state-selector="button"
-        />
-      </ul>
+        </ul>
+      </div>
       {{! template-lint-enable no-inline-styles }}
     </SF.Item>
   </Shw::Flex>
@@ -322,119 +352,141 @@
 
   <Shw::Flex as |SF|>
     <SF.Item @label="Default">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Default">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Default">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value="disabled" disabled>
+            disabled
           </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Checkmark mock-state-value="disabled" disabled>
-          disabled
-        </Hds::Dropdown::ListItem::Checkmark>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Selected">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Selected">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Selected">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value="disabled" @selected={{true}} disabled>
+            disabled
           </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Checkmark mock-state-value="disabled" @selected={{true}} disabled>
-          disabled
-        </Hds::Dropdown::ListItem::Checkmark>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Icon">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Icon">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}}>
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Icon">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value="disabled" disabled>
+            disabled
           </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value="disabled" disabled>
-          disabled
-        </Hds::Dropdown::ListItem::Checkmark>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Icon, selected">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Icon, selected">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}} @selected={{true}}>
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Icon, selected">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}} @selected={{true}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value="disabled" @selected={{true}} disabled>
+            disabled
           </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value="disabled" @selected={{true}} disabled>
-          disabled
-        </Hds::Dropdown::ListItem::Checkmark>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Count">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Count">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Count">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Count, selected">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Count, selected">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Count, selected">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Custom content">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Custom content">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="128" @height="20" @background="#eee" />
-          </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Custom content">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
+              <Shw::Placeholder @text="custom content" @width="128" @height="20" @background="#eee" />
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Custom content, selected">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Custom content, selected">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="128" @height="20" @background="#eee" />
-          </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Custom content, selected">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
+              <Shw::Placeholder @text="custom content" @width="128" @height="20" @background="#eee" />
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Badge in content">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Badge in content">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
-            {{state}}
-            <Hds::Badge @icon="org" @text="Private" @size="small" />
-          </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Badge in content">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
+              {{state}}
+              <Hds::Badge @icon="org" @text="Private" @size="small" />
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Badge in content, selected">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Badge in content, selected">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
-            {{state}}
-            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
-          </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Badge in content, selected">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
+              {{state}}
+              <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Large content">
-      <ul class="hds-dropdown-list" role="listbox" aria-label="Large content">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @icon="hexagon" @selected={{true}} @count="12">
-            {{state}}
-            with a longer text string that may wrap since max-width is defined on the container
-            <Hds::Badge @text="badge" @size="small" />
-          </Hds::Dropdown::ListItem::Checkmark>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list" role="listbox" aria-label="Large content">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @icon="hexagon" @selected={{true}} @count="12">
+              {{state}}
+              with a longer text string that may wrap since max-width is defined on the container
+              <Hds::Badge @text="badge" @size="small" />
+            </Hds::Dropdown::ListItem::Checkmark>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
   </Shw::Flex>
   <Shw::Flex as |SF|>
@@ -455,122 +507,144 @@
 
   <Shw::Flex as |SF|>
     <SF.Item @label="Default">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" disabled>
+            disabled
           </Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" disabled>
-          disabled
-        </Hds::Dropdown::ListItem::Checkbox>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Checked">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" disabled checked>
+            disabled
           </Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" disabled checked>
-          disabled
-        </Hds::Dropdown::ListItem::Checkbox>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Icon">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon">
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon">
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" @icon="hexagon" disabled>
+            disabled
           </Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" @icon="hexagon" disabled>
-          disabled
-        </Hds::Dropdown::ListItem::Checkbox>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Icon, checked">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon" checked>
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon" checked>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" @icon="hexagon" disabled checked>
+            disabled
           </Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" @icon="hexagon" disabled checked>
-          disabled
-        </Hds::Dropdown::ListItem::Checkbox>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Count">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox
-            mock-state-value={{state}}
-            @count="12"
-          >{{state}}</Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox
+              mock-state-value={{state}}
+              @count="12"
+            >{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Count, checked">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox
-            mock-state-value={{state}}
-            checked
-            @count="12"
-          >{{state}}</Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox
+              mock-state-value={{state}}
+              checked
+              @count="12"
+            >{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Custom content">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
-          </Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
+            </Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Custom content, checked">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">
-            <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
-          </Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
+            </Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Badge in label">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
-            {{state}}
-            <Hds::Badge @icon="org" @text="Private" @size="small" />
-          </Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
+              {{state}}
+              <Hds::Badge @icon="org" @text="Private" @size="small" />
+            </Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Badge in label, checked">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
-            {{state}}
-            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
-          </Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
+              {{state}}
+              <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+            </Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Large content">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12" @icon="hexagon">
-            {{state}}
-            with a longer text string that may wrap since max-width is defined on the container
-            <Hds::Badge @text="badge" @size="small" />
-          </Hds::Dropdown::ListItem::Checkbox>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12" @icon="hexagon">
+              {{state}}
+              with a longer text string that may wrap since max-width is defined on the container
+              <Hds::Badge @text="badge" @size="small" />
+            </Hds::Dropdown::ListItem::Checkbox>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
   </Shw::Flex>
   <Shw::Flex as |SF|>
@@ -591,122 +665,144 @@
 
   <Shw::Flex as |SF|>
     <SF.Item @label="Default">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" disabled>
+            disabled
           </Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" disabled>
-          disabled
-        </Hds::Dropdown::ListItem::Radio>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Checked">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
+              {{state}}
+            </Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" checked disabled>
+            disabled
           </Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" checked disabled>
-          disabled
-        </Hds::Dropdown::ListItem::Radio>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Icon">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @icon="hexagon">
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @icon="hexagon">
+              {{state}}
+            </Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" @icon="hexagon" disabled>
+            disabled
           </Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" @icon="hexagon" disabled>
-          disabled
-        </Hds::Dropdown::ListItem::Radio>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Icon, checked">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @icon="hexagon">
-            {{state}}
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @icon="hexagon">
+              {{state}}
+            </Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+          <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" @icon="hexagon" checked disabled>
+            disabled
           </Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-        <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" @icon="hexagon" checked disabled>
-          disabled
-        </Hds::Dropdown::ListItem::Radio>
-      </ul>
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Count">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio
-            mock-state-value={{state}}
-            @count="12"
-          >{{state}}</Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio
+              mock-state-value={{state}}
+              @count="12"
+            >{{state}}</Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Count, checked">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio
-            mock-state-value={{state}}
-            checked
-            @count="12"
-          >{{state}}</Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio
+              mock-state-value={{state}}
+              checked
+              @count="12"
+            >{{state}}</Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Custom content">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
-          </Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
+            </Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Custom content, checked">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">
-            <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
-          </Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
+            </Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Badge in label">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
-            {{state}}
-            <Hds::Badge @icon="org" @text="Private" @size="small" />
-          </Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
+              {{state}}
+              <Hds::Badge @icon="org" @text="Private" @size="small" />
+            </Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Badge in label, checked">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
-            {{state}}
-            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
-          </Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
+              {{state}}
+              <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+            </Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
     <SF.Item @label="Large content">
-      <ul class="hds-dropdown-list">
-        {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12" @icon="hexagon">
-            {{state}}
-            with a longer text string that may wrap since max-width is defined on the container
-            <Hds::Badge @text="badge" @size="small" />
-          </Hds::Dropdown::ListItem::Radio>
-        {{/each}}
-      </ul>
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12" @icon="hexagon">
+              {{state}}
+              with a longer text string that may wrap since max-width is defined on the container
+              <Hds::Badge @text="badge" @size="small" />
+            </Hds::Dropdown::ListItem::Radio>
+          {{/each}}
+        </ul>
+      </div>
     </SF.Item>
   </Shw::Flex>
   <Shw::Flex as |SF|>
@@ -718,6 +814,230 @@
         <dd.Radio name="radio-item-dropdown" @count="10">docker</dd.Radio>
         <dd.Radio name="radio-item-dropdown" @count="0">hyperv</dd.Radio>
       </Hds::Dropdown>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Divider />
+
+  <Shw::Text::H2>Header and footer</Shw::Text::H2>
+
+  <Shw::Text::H3>Header</Shw::Text::H3>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Generic header">
+      <div class="hds-dropdown__content">
+        <Hds::Dropdown::Header>
+          <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
+        </Hds::Dropdown::Header>
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+        </ul>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Generic header with divider">
+      <div class="hds-dropdown__content">
+        <Hds::Dropdown::Header @hasDivider={{true}}>
+          <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
+        </Hds::Dropdown::Header>
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+        </ul>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Input type search">
+      <div class="hds-dropdown__content">
+        <Hds::Dropdown::Header @hasDivider={{true}}>
+          <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
+        </Hds::Dropdown::Header>
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Create" />
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Edit" />
+        </ul>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Link secondary">
+      <div class="hds-dropdown__content">
+        <Hds::Dropdown::Header @hasDivider={{true}}>
+          <Hds::Link::Standalone @icon="list" @text="Organizations" @color="secondary" @href="#" />
+        </Hds::Dropdown::Header>
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Create" />
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Edit" />
+        </ul>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Footer</Shw::Text::H3>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Generic footer">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+        </ul>
+        <Hds::Dropdown::Footer>
+          <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
+        </Hds::Dropdown::Footer>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Generic footer with divider">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+        </ul>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
+          <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
+        </Hds::Dropdown::Footer>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Button">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization A" />
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
+        </ul>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
+          <Hds::Button @text="Apply filters" @isFullWidth={{true}} @size="small" />
+        </Hds::Dropdown::Footer>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Link">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization A" />
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
+        </ul>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
+          <Hds::Link::Standalone @icon="list" @text="Organizations" @color="secondary" @href="#" />
+        </Hds::Dropdown::Footer>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Header and footer</Shw::Text::H3>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Generic header and footer">
+      <div class="hds-dropdown__content">
+        <Hds::Dropdown::Header @hasDivider={{true}}>
+          <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
+        </Hds::Dropdown::Header>
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+        </ul>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
+          <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
+        </Hds::Dropdown::Footer>
+      </div>
+    </SF.Item>
+
+    <SF.Item @label="Generic, fixed height list">
+      {{! template-lint-disable no-inline-styles }}
+      <div class="hds-dropdown__content" style="max-height:195px">
+        <Hds::Dropdown::Header @hasDivider={{true}}>
+          <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
+        </Hds::Dropdown::Header>
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+          <Hds::Dropdown::ListItem::Generic>
+            <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
+          </Hds::Dropdown::ListItem::Generic>
+        </ul>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
+          <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
+        </Hds::Dropdown::Footer>
+      </div>
+      {{! template-lint-enable no-inline-styles }}
+    </SF.Item>
+    <SF.Item @label="Input and Button Set">
+      <div class="hds-dropdown__content">
+        <Hds::Dropdown::Header @hasDivider={{true}}>
+          <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
+        </Hds::Dropdown::Header>
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization A" />
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
+        </ul>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
+          <Hds::ButtonSet>
+            <Hds::Button @text="Apply" @isFullWidth={{true}} @size="small" />
+            <Hds::Button @text="Cancel" @color="secondary" @isFullWidth={{true}} @size="small" />
+          </Hds::ButtonSet>
+        </Hds::Dropdown::Footer>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Input and Link, fixed height list">
+      {{! template-lint-disable no-inline-styles }}
+      <div class="hds-dropdown__content" style="max-height:185px">
+        <Hds::Dropdown::Header @hasDivider={{true}}>
+          <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
+        </Hds::Dropdown::Header>
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization A" />
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
+        </ul>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
+          <Hds::Link::Standalone @icon="plus" @text="Add organization" @href="#" />
+        </Hds::Dropdown::Footer>
+      </div>
+      {{! template-lint-enable no-inline-styles }}
     </SF.Item>
   </Shw::Flex>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -844,7 +844,7 @@
     </SF.Item>
     <SF.Item @label="Generic header with separator">
       <div class="hds-dropdown__content">
-        <Hds::Dropdown::Header @hasSeparator={{true}}>
+        <Hds::Dropdown::Header @hasDivider={{true}}>
           <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -873,7 +873,7 @@
     </SF.Item>
     <SF.Item @label="Link secondary">
       <div class="hds-dropdown__content">
-        <Hds::Dropdown::Header @hasSeparator={{true}}>
+        <Hds::Dropdown::Header @hasDivider={{true}}>
           <Hds::Link::Standalone @icon="list" @text="Organizations" @color="secondary" @href="#" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
@@ -920,7 +920,7 @@
             <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
           </Hds::Dropdown::ListItem::Generic>
         </ul>
-        <Hds::Dropdown::Footer @hasSeparator={{true}}>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Footer>
       </div>
@@ -932,7 +932,7 @@
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
         </ul>
-        <Hds::Dropdown::Footer @hasSeparator={{true}}>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Hds::Button @text="Apply filters" @isFullWidth={{true}} @size="small" />
         </Hds::Dropdown::Footer>
       </div>
@@ -944,7 +944,7 @@
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
         </ul>
-        <Hds::Dropdown::Footer @hasSeparator={{true}}>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Hds::Link::Standalone @icon="list" @text="Organizations" @color="secondary" @href="#" />
         </Hds::Dropdown::Footer>
       </div>
@@ -972,7 +972,7 @@
             <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
           </Hds::Dropdown::ListItem::Generic>
         </ul>
-        <Hds::Dropdown::Footer @hasSeparator={{true}}>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Footer>
       </div>
@@ -998,7 +998,7 @@
             <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
           </Hds::Dropdown::ListItem::Generic>
         </ul>
-        <Hds::Dropdown::Footer @hasSeparator={{true}}>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Shw::Placeholder @text="generic footer content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Footer>
       </div>
@@ -1014,7 +1014,7 @@
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
         </ul>
-        <Hds::Dropdown::Footer @hasSeparator={{true}}>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Hds::ButtonSet>
             <Hds::Button @text="Apply" @isFullWidth={{true}} @size="small" />
             <Hds::Button @text="Cancel" @color="secondary" @isFullWidth={{true}} @size="small" />
@@ -1033,7 +1033,7 @@
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
           <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
         </ul>
-        <Hds::Dropdown::Footer @hasSeparator={{true}}>
+        <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Hds::Link::Standalone @icon="plus" @text="Add organization" @href="#" />
         </Hds::Dropdown::Footer>
       </div>

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -77,10 +77,10 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     await click('button#test-toggle-button');
     assert
       .dom('#test-dropdown #test-header')
-      .hasClass('hds-dropdown__header--separator');
+      .hasClass('hds-dropdown__header--with-separator');
     assert
       .dom('#test-dropdown #test-footer')
-      .hasClass('hds-dropdown__footer--separator');
+      .hasClass('hds-dropdown__footer--with-separator');
   });
 
   // POSITION

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -66,6 +66,23 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown #test-footer').hasText('Footer');
   });
 
+  test('it renders the "header"/"footer" sub-components with separators', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" as |dd|>
+        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <dd.Header @hasSeparator={{true}} id="test-header">Header</dd.Header>
+        <dd.Footer @hasSeparator={{true}} id="test-footer">Footer</dd.Footer>
+      </Hds::Dropdown>
+    `);
+    await click('button#test-toggle-button');
+    assert
+      .dom('#test-dropdown #test-header')
+      .hasClass('hds-dropdown__header--separator');
+    assert
+      .dom('#test-dropdown #test-footer')
+      .hasClass('hds-dropdown__footer--separator');
+  });
+
   // POSITION
 
   test('it should render the content aligned on the right by default', async function (assert) {

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -70,17 +70,17 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     await render(hbs`
       <Hds::Dropdown id="test-dropdown" as |dd|>
         <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Header @hasSeparator={{true}} id="test-header">Header</dd.Header>
-        <dd.Footer @hasSeparator={{true}} id="test-footer">Footer</dd.Footer>
+        <dd.Header @hasDivider={{true}} id="test-header">Header</dd.Header>
+        <dd.Footer @hasDivider={{true}} id="test-footer">Footer</dd.Footer>
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
     assert
       .dom('#test-dropdown #test-header')
-      .hasClass('hds-dropdown__header--with-separator');
+      .hasClass('hds-dropdown__header--with-divider');
     assert
       .dom('#test-dropdown #test-footer')
-      .hasClass('hds-dropdown__footer--with-separator');
+      .hasClass('hds-dropdown__footer--with-divider');
   });
 
   // POSITION

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -53,6 +53,18 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown #test-list-item-separator').exists();
     assert.dom('#test-dropdown #test-list-item-title').exists();
   });
+  test('it renders the "header"/"footer" sub-components', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" as |dd|>
+        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <dd.Header id="test-header">Header</dd.Header>
+        <dd.Footer id="test-footer">Footer</dd.Footer>
+      </Hds::Dropdown>
+    `);
+    await click('button#test-toggle-button');
+    assert.dom('#test-dropdown #test-header').hasText('Header');
+    assert.dom('#test-dropdown #test-footer').hasText('Footer');
+  });
 
   // POSITION
 
@@ -65,8 +77,8 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     `);
     await click('button#test-toggle-button');
     assert
-      .dom('#test-dropdown ul')
-      .hasClass('hds-dropdown-list--position-right');
+      .dom('#test-dropdown .hds-dropdown__content')
+      .hasClass('hds-dropdown__content--position-right');
   });
   test('it should render the content aligned on the left if the value of @listPosition is "left"', async function (assert) {
     await render(hbs`
@@ -77,8 +89,8 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     `);
     await click('button#test-toggle-button');
     assert
-      .dom('#test-dropdown ul')
-      .hasClass('hds-dropdown-list--position-left');
+      .dom('#test-dropdown .hds-dropdown__content')
+      .hasClass('hds-dropdown__content--position-left');
   });
 
   // WIDTH


### PR DESCRIPTION
### :pushpin: Summary

Extend `Hds::Dropdown` with two generic containers `Hds::Dropdown::Header` and `Hds::Dropdown::Footer` to support the upcoming 'Filter' pattern.

### :hammer_and_wrench: Detailed description

Add `Hds::Dropdown::Header` and `Hds::Dropdown::Footer` as generic containers, before and after the dropdown list, respectively
- Add a `hds-dropdown__content` wrapper to the `hds-dropdown__list` and apply the positioning, width, and the associated style to this new wrapper element
- Prepend the `Header` element and append the `Footer` element to the dropdown list
- Allow custom `@height` to the `hds-dropdown__content` element

> **Note**
> Internal class name change: `hds-dropdown-list` → `hds-dropdown__list`
> The following modifiers will be applied to the `hds-dropdown__content` element instead of `hds-dropdown-list`
> - `hds-dropdown-list--fixed-width` → `hds-dropdown__content--fixed-width`
> - `hds-dropdown-list--position-left` → `hds-dropdown__content--position-left`
> - `hds-dropdown-list--position-right` → `hds-dropdown__content--position-right`
>
> These should not represent a breaking change as the consumers rely on the public API, but if test assertions are based on class names, nesting order, element types, or extensions/overrides have been applied to these elements they may raise issues. For this reason, we flag this change as a **breaking change** to give consumers a heads-up.

[👉 Preview showcase](https://hds-showcase-git-alex-ju-dropdown-extension-2-hashicorp.vercel.app/components/dropdown)

<!-- [👉 Preview showcase](https://hds-components-git-alex-ju-dropdown-extension-2-hashicorp.vercel.app/components/dropdown) -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1009](https://hashicorp.atlassian.net/browse/HDS-1109)
Figma file: https://www.figma.com/file/Kgc8BgB8jGuJXISndgTrD1/Dropdown?node-id=28361%3A64950&t=cv28452FkTz2LkFo-4

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1009]: https://hashicorp.atlassian.net/browse/HDS-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ