### PR TITLE
Rename `ember-flight-icons` CI job from `Test` to `Lint`

### DIFF
--- a/.github/workflows/ci-ember-flight-icons.yml
+++ b/.github/workflows/ci-ember-flight-icons.yml
@@ -14,8 +14,8 @@ concurrency:
    cancel-in-progress: true
 
 jobs:
-  test:
-    name: "Tests"
+  lint:
+    name: "Lint"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### :pushpin: Summary

Rename `ember-flight-icons` job from `Test` to `Lint. Follow-up on #1218.

### :hammer_and_wrench: Detailed description

We're only doing linting on this package now, so it makes sense to label it accordingly and align it with the `website` CI setup. This only has an effect on how GitHub checks are labeled.

