### PR TITLE
Add “aliases” information to the tokens list in the website documentation

### DIFF
--- a/website/app/components/doc/meta-row.hbs
+++ b/website/app/components/doc/meta-row.hbs
@@ -6,12 +6,24 @@
 <div class="doc-meta-row" ...attributes>
   <div class="doc-meta-row__label">{{@label}}</div>
   <div class="doc-meta-row__value">
+    {{! when we pass a single value, we have two different use cases to support }}
     {{#if @copyable}}
       <Doc::CopyButton @textToCopy={{@valueToCopy}} @textToShow={{(or @valueToShow @valueToCopy)}} @type="ghost" />
-    {{else}}
+    {{/if}}
+    {{#if @valueToShow}}
       <code
         class="doc-meta-row__value-not-copyable {{if @isClipped 'doc-meta-row__value-not-copyable--is-clipped'}}"
       >{{@valueToShow}}</code>
+    {{/if}}
+    {{! instead when we pass an array, we just show the list }}
+    {{#if @multipleValuesToShow}}
+      <div class="doc-meta-row__values-list">
+        {{#each @multipleValuesToShow as |value|}}
+          <code class="doc-meta-row__value-not-copyable">
+            {{value}}
+          </code>
+        {{/each}}
+      </div>
     {{/if}}
   </div>
 </div>

--- a/website/app/components/doc/tokens-list/item.hbs
+++ b/website/app/components/doc/tokens-list/item.hbs
@@ -34,7 +34,7 @@
       <Doc::MetaRow @label="Don't use" @valueToShow="This token is now deprecated" />
       <Doc::MetaRow class="doc-tokens-list__item--is-deprecated" @label="CSS var" @valueToShow={{this.token.name}} />
     {{else}}
-      <Doc::MetaRow @label="CSS var" @valueToCopy={{this.token.name}} @copyable={{true}} />
+      <Doc::MetaRow @label="CSS var" @valueToCopy="--{{this.token.name}}" @copyable={{true}} />
       {{! we don't want developers to use directly HEX values, so we don't add a "copy" button on purpose }}
       <Doc::MetaRow @label="Value" @valueToShow={{this.token.value}} @isClipped={{not this.isExpanded}} />
     {{/if}}

--- a/website/app/components/doc/tokens-list/item.hbs
+++ b/website/app/components/doc/tokens-list/item.hbs
@@ -45,6 +45,9 @@
       {{#if this.isAlias}}
         <Doc::MetaRow @label="Alias of" @valueToShow={{this.token.original_value}} />
       {{/if}}
+      {{#if this.token.aliases}}
+        <Doc::MetaRow @label="Aliased as" @multipleValuesToShow={{this.token.aliases}} />
+      {{/if}}
       {{#if this.token.comment}}
         <Doc::MetaRow @label="Comment" @valueToShow={{this.token.comment}} />
       {{/if}}

--- a/website/app/components/doc/tokens-list/item.js
+++ b/website/app/components/doc/tokens-list/item.js
@@ -17,6 +17,7 @@ export default class DocTokenCardIndexComponent extends Component {
       name: token.name,
       type: token.type,
       value: token.value,
+      aliases: token.aliases,
       category: token.attributes.category,
       original_value: token.original.value,
       deprecated: token.deprecated,

--- a/website/app/styles/doc-components/meta-row.scss
+++ b/website/app/styles/doc-components/meta-row.scss
@@ -45,3 +45,9 @@
     -webkit-box-orient: vertical;
   }
 }
+
+.doc-meta-row__values-list {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+}

--- a/website/docs/foundations/tokens/index.js
+++ b/website/docs/foundations/tokens/index.js
@@ -12,6 +12,15 @@ import TOKENS_RAW from '@hashicorp/design-system-tokens/dist/docs/products/token
 
 const DEBOUNCE_MS = 250;
 
+// get all the aliases of a given token
+const getAliases = (token, TOKENS_RAW) => {
+  const path = token.path.join('.');
+  console.log(path);
+  return TOKENS_RAW.filter(
+    (item) => item.original.value === `{${path}.value}`
+  ).map((alias) => `{${alias.path.join('.')}}`);
+};
+
 export default class Index extends Component {
   @service router;
 
@@ -22,10 +31,17 @@ export default class Index extends Component {
   constructor() {
     super(...arguments);
     this.groupedTokens = {};
+    // prepare the tokens grouped by category
     TOKENS_RAW.forEach((token) => {
       const category = token.attributes.category;
       if (!this.groupedTokens[category]) {
         this.groupedTokens[category] = [];
+      }
+      // add an extra "aliases" attribute if other tokens are alias of it
+      const aliases = getAliases(token, TOKENS_RAW);
+      console.log(token.name, aliases);
+      if (aliases.length > 0) {
+        token.aliases = aliases;
       }
       this.groupedTokens[category].push(token);
     });


### PR DESCRIPTION
### :pushpin: Summary

During conversation with Jake Herschman, he suggested to add the information if which aliases there were associated to a token. Since it's a good idea, and it was simple to do, I've made the changes straightaway (he's in the middle of a large work of mapping colors between Structure and HDS, and this can help him).

Preview: https://hds-website-git-docs-tokens-aliases-hashicorp.vercel.app/foundations/tokens?searchQuery=token-color-foreground-faint

### :camera_flash: Screenshots

<img width="927" alt="screenshot_2410" src="https://user-images.githubusercontent.com/686239/221261800-11bed0b8-6aea-4f80-961b-10a25d4bfdd0.png">

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
