### PR TITLE
`Table` - Change internal logic for `Thsort` arguments conditionals

### DIFF
--- a/.changeset/heavy-paws-study.md
+++ b/.changeset/heavy-paws-study.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Changed inner logic for `ThSort` arguments

--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -14,8 +14,7 @@
         {{#each @columns as |column|}}
           {{#if column.isSortable}}
             <Hds::Table::ThSort
-              @isSorted={{eq column.key this.sortBy}}
-              @sortOrder={{this.sortOrder}}
+              @sortOrder={{if (eq column.key this.sortBy) this.sortOrder}}
               @onClick={{fn this.setSortBy column.key}}
               @align={{column.align}}
               @width={{column.width}}

--- a/packages/components/addon/components/hds/table/th-sort.js
+++ b/packages/components/addon/components/hds/table/th-sort.js
@@ -19,11 +19,14 @@ export default class HdsTableThSortComponent extends Component {
    * @description Sets the aria-sort attribute based on the sort order defined; acceptable values are ascending, descending, none(default) and other. Authors SHOULD only apply this property to table headers or grid headers. If the property is not provided, there is no defined sort order. For each table or grid, authors SHOULD apply aria-sort to only one header at a time.
    */
   get ariaSort() {
-    if (this.args.isSorted) {
-      return this.args.sortOrder === 'asc' ? 'ascending' : 'descending';
-    } else {
-      // none is the default per the spec.
-      return 'none';
+    switch (this.args.sortOrder) {
+      case 'asc':
+        return 'ascending';
+      case 'desc':
+        return 'descending';
+      default:
+        // none is the default per the spec.
+        return 'none';
     }
   }
 
@@ -35,11 +38,20 @@ export default class HdsTableThSortComponent extends Component {
    * @description Determines which icon to use based on the sort order defined
    */
   get icon() {
-    if (this.args.isSorted && this.args.sortOrder) {
-      return this.args.sortOrder === 'asc' ? 'arrow-up' : 'arrow-down';
-    } else {
-      return 'swap-vertical';
+    switch (this.args.sortOrder) {
+      case 'asc':
+        return 'arrow-up';
+      case 'desc':
+        return 'arrow-down';
+      default:
+        // none is the default per the spec.
+        return 'swap-vertical';
     }
+    // if (this.args.isSorted && this.args.sortOrder) {
+    //   return this.args.sortOrder === 'asc' ? 'arrow-up' : 'arrow-down';
+    // } else {
+    //   return 'swap-vertical';
+    // }
   }
 
   /**

--- a/packages/components/addon/components/hds/table/th-sort.js
+++ b/packages/components/addon/components/hds/table/th-sort.js
@@ -44,14 +44,8 @@ export default class HdsTableThSortComponent extends Component {
       case 'desc':
         return 'arrow-down';
       default:
-        // none is the default per the spec.
         return 'swap-vertical';
     }
-    // if (this.args.isSorted && this.args.sortOrder) {
-    //   return this.args.sortOrder === 'asc' ? 'arrow-up' : 'arrow-down';
-    // } else {
-    //   return 'swap-vertical';
-    // }
   }
 
   /**


### PR DESCRIPTION
### :pushpin: Summary

While working on the documentation update for the `Table` component (#1198) we have realized that the internal logic for how the `ThSort` component is rendered based on the sorting arguments was working, but technically not correct (the `isSorted` argument was redundant, and when used as standalone component the `ThSort` element could not render the icons states just on the base of the `sortOrder` argument).

(A follow-up PR will also update the showcase to collect more use cases for the `Table` base elements).

### :hammer_and_wrench: Detailed description

In this PR I have:

- updated the internal logic of the `ThSort` to rely only on the `sortOrder` argument to render its sorting state

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
