### PR TITLE
`Table` - Update showcase for "base elements"

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -456,50 +456,9 @@
     </:body>
   </Hds::Table>
 
-  <Shw::Text::H2>Table elements</Shw::Text::H2>
+  <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H3>Head</Shw::Text::H3>
-
-  <Shw::Flex @label="ThSort states" as |SF|>
-    <SF.Item @grow={{true}}>
-      <Hds::Table>
-        <:head>
-          <Hds::Table::Tr>
-            {{#each @model.STATES as |state|}}
-              <Hds::Table::ThSort mock-state-value={{state}} mock-state-selector="button">
-                {{capitalize state}}
-              </Hds::Table::ThSort>
-            {{/each}}
-          </Hds::Table::Tr>
-        </:head>
-      </Hds::Table>
-    </SF.Item>
-  </Shw::Flex>
-
-  <Shw::Flex @label="Th with custom width" as |SF|>
-    <SF.Item @grow={{true}}>
-      <Hds::Table @caption="a custom table with no model defined">
-        <:head as |H|>
-          <H.Tr>
-            <H.Th>Auto</H.Th>
-            <H.Th>Auto</H.Th>
-            <H.Th>Auto</H.Th>
-            <H.Th @width="50px">Custom</H.Th>
-          </H.Tr>
-        </:head>
-        <:body as |B|>
-          <B.Tr>
-            <B.Th>Scope Row</B.Th>
-            <B.Td>Cell Content</B.Td>
-            <B.Td>Cell Content</B.Td>
-            <B.Td>50px</B.Td>
-          </B.Tr>
-        </:body>
-      </Hds::Table>
-    </SF.Item>
-  </Shw::Flex>
-
-  <Shw::Text::H3>Body</Shw::Text::H3>
+  <Shw::Text::H2>Striping</Shw::Text::H2>
 
   <Shw::Flex @label="Static table with row striping" as |SF|>
     <SF.Item @grow={{true}}>
@@ -542,4 +501,221 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider />
+
+  <Shw::Text::H2>Base elements</Shw::Text::H2>
+
+  <Shw::Text::H3>ThSort</Shw::Text::H3>
+
+  <Shw::Flex @label="Interactive states" as |SF|>
+    <SF.Item @grow={{true}}>
+      <Hds::Table>
+        <:head>
+          <Hds::Table::Tr>
+            {{#each @model.STATES as |state|}}
+              <Hds::Table::ThSort mock-state-value={{state}} mock-state-selector="button">
+                {{capitalize state}}
+              </Hds::Table::ThSort>
+            {{/each}}
+          </Hds::Table::Tr>
+        </:head>
+        <:body as |B|>
+          <B.Td colspan="4" />
+        </:body>
+      </Hds::Table>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex @label="Sorting order" as |SF|>
+    <SF.Item @grow={{true}}>
+      <Hds::Table>
+        <:head>
+          <Hds::Table::Tr>
+            <Hds::Table::ThSort>
+              Unsorted (default)
+            </Hds::Table::ThSort>
+            <Hds::Table::ThSort @sortOrder="asc">
+              Ascending
+            </Hds::Table::ThSort>
+            <Hds::Table::ThSort @sortOrder="desc">
+              Descending
+            </Hds::Table::ThSort>
+          </Hds::Table::Tr>
+        </:head>
+        <:body as |B|>
+          <B.Td colspan="3" />
+        </:body>
+      </Hds::Table>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Text::H3>Th</Shw::Text::H3>
+
+  <Shw::Flex @label="Th with custom width" as |SF|>
+    <SF.Item @grow={{true}}>
+      <Hds::Table>
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Auto</H.Th>
+            <H.Th>Auto</H.Th>
+            <H.Th>Auto</H.Th>
+            <H.Th @width="100px">Custom</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
+          <B.Tr>
+            <B.Th>Scope Row</B.Th>
+            <B.Td>Cell Content</B.Td>
+            <B.Td>Cell Content</B.Td>
+            <B.Td>100px</B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Text::H3>Td</Shw::Text::H3>
+
+  <Shw::Flex @label="Horizontal alignment" as |SF|>
+    <SF.Item @grow={{true}}>
+      <Hds::Table>
+        <:head as |H|>
+          <H.Tr>
+            <H.Th @align="left">Entity</H.Th>
+            <H.Th @align="left">Left</H.Th>
+            <H.Th @align="center">Center</H.Th>
+            <H.Th @align="right">Right</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
+          <B.Tr>
+            <B.Th>Text</B.Th>
+            <B.Td @align="left">Text is left aligned</B.Td>
+            <B.Td @align="center">Text is center aligned</B.Td>
+            <B.Td @align="right">Text is right aligned</B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Th>Icon</B.Th>
+            <B.Td @align="left"><FlightIcon @name="film" /></B.Td>
+            <B.Td @align="center"><FlightIcon @name="film" /></B.Td>
+            <B.Td @align="right"><FlightIcon @name="film" /></B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Th>Icon + Inline text</B.Th>
+            <B.Td @align="left"><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td @align="center"><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td @align="right"><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Th>Badge</B.Th>
+            <B.Td @align="left"><Hds::Badge @text="Badge" /></B.Td>
+            <B.Td @align="center"><Hds::Badge @text="Badge" /></B.Td>
+            <B.Td @align="right"><Hds::Badge @text="Badge" /></B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Th>Dropdown (with inline container)</B.Th>
+            <B.Td @align="left">
+              <div {{style display="inline-block"}}>
+                <Hds::Dropdown @listPosition="right" as |dd|>
+                  <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
+                  <dd.Interactive @route="components.table" @text="Dropdown" />
+                </Hds::Dropdown>
+              </div>
+            </B.Td>
+            <B.Td @align="center">
+              <div {{style display="inline-block"}}>
+                <Hds::Dropdown as |dd|>
+                  <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
+                  <dd.Interactive @route="components.table" @text="Dropdown" />
+                </Hds::Dropdown>
+              </div>
+            </B.Td>
+            <B.Td @align="right">
+              <div {{style display="inline-block"}}>
+                <Hds::Dropdown as |dd|>
+                  <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
+                  <dd.Interactive @route="components.table" @text="Dropdown" />
+                </Hds::Dropdown>
+              </div>
+            </B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex @label="Vertical alignment" as |SF|>
+    <SF.Item @grow={{true}}>
+      <Hds::Table @valign="top">
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Spacer</H.Th>
+            <H.Th>Text</H.Th>
+            <H.Th>Icon</H.Th>
+            <H.Th>Icon + Text</H.Th>
+            <H.Th>Icon + Text (with flex container)</H.Th>
+            <H.Th>Badge</H.Th>
+            <H.Th>Dropdown</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
+          <B.Tr>
+            <B.Th>Top (default)<Shw::Placeholder @height="50" /></B.Th>
+            <B.Td>Text is top aligned</B.Td>
+            <B.Td><FlightIcon @name="film" /></B.Td>
+            <B.Td><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td>
+              <div {{style display="flex" gap="8px" align-items="center"}}>
+                <FlightIcon @name="film" />
+                <span>Text in a <code>&lt;span&gt;</code></span>
+              </div>
+            </B.Td>
+            <B.Td><Hds::Badge @text="Badge" /></B.Td>
+            <B.Td>
+              <Hds::Dropdown as |dd|>
+                <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
+                <dd.Interactive @route="components.table" @text="Dropdown" />
+              </Hds::Dropdown>
+            </B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
+    </SF.Item>
+    <SF.Item @grow={{true}}>
+      <Hds::Table @valign="middle">
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Spacer</H.Th>
+            <H.Th>Text</H.Th>
+            <H.Th>Icon</H.Th>
+            <H.Th>Icon + Text</H.Th>
+            <H.Th>Icon + Text (with flex container)</H.Th>
+            <H.Th>Badge</H.Th>
+            <H.Th>Dropdown</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
+          <B.Tr>
+            <B.Th><Shw::Placeholder @height="25" />Middle<Shw::Placeholder @height="25" /></B.Th>
+            <B.Td>Text is middle aligned</B.Td>
+            <B.Td><FlightIcon @name="film" /></B.Td>
+            <B.Td><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td>
+              <div {{style display="flex" gap="8px" align-items="center"}}>
+                <FlightIcon @name="film" />
+                <span>Text in a <code>&lt;span&gt;</code></span>
+              </div>
+            </B.Td>
+            <B.Td><Hds::Badge @text="Badge" /></B.Td>
+            <B.Td>
+              <Hds::Dropdown as |dd|>
+                <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
+                <dd.Interactive @route="components.table" @text="Dropdown" />
+              </Hds::Dropdown>
+            </B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
+    </SF.Item>
+  </Shw::Flex>
 </section>


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of #1226 where we add more use cases to the showcase page for the `Table` component, to cover the "base elements" of the table.

Preview: https://hds-showcase-git-table-showcase-hashicorp.vercel.app/components/table (see bottom of the page)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
