### PR TITLE
fix analytics bug: add url override to head-data overrides

### DIFF
--- a/website/app/services/head-data.js
+++ b/website/app/services/head-data.js
@@ -5,8 +5,11 @@
 
 import HeadDataService from 'ember-meta/services/head-data';
 import config from 'ember-get-config';
+import { inject as service } from '@ember/service';
 
 export default class CustomHeadDataService extends HeadDataService {
+  @service router;
+
   get title() {
     return (
       this.currentRouteMeta?.title ??
@@ -27,5 +30,13 @@ export default class CustomHeadDataService extends HeadDataService {
       ? this.currentRouteMeta.frontmatter.previewImage
       : 'assets/logos/share-card.jpg';
     return `${config['ember-meta'].url}/${previewImage}`;
+  }
+
+  get url() {
+    const url =
+      this.router.currentURL === '/'
+        ? config['ember-meta'].url
+        : `${config['ember-meta'].url}/${this.router.currentURL}`;
+    return url;
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

This will update the `url` property to include the actual full url for each page on the site, fixing a bug with our `canonical` tag that adversely impacts our analytics.

### :hammer_and_wrench: Detailed description

[The Fathom docs hint at this being the root cause](https://usefathom.com/docs/troubleshooting/canonicals):
> Misusing canonical meta tags typically happens when you have a canonical meta tag present on every page, telling analytics and search engines that every page on your site is the homepage (this is obviously incorrect).
>
> If that tag is present on every page, then you’re telling everyone that every page on your site is your homepage. Once you fix this, your stats will show data for all pages...

This tracks with the changes in https://github.com/hashicorp/design-system/pull/1071 landing right around the time we lost this data granularity. This change has meant that the `canonical` tag for **all** pages on the site is https://helios.hashicorp.design/. Oops!

This PR attempts to manually set `url` correctly based on the current route. I did some manual smoke testing of this but please have a 2nd look if you can. 


#### How to test

Visit pages on the site and view source to see the value `link rel="canonical"`

### :camera_flash: Screenshots

#### Before
![image-20230224-203543](https://user-images.githubusercontent.com/1672302/221619161-deb38ccb-9b56-42aa-9d69-aed5c6b042b4.png)

#### After (in  a test account)
<img width="738" alt="Screenshot 2023-02-27 at 10 12 57" src="https://user-images.githubusercontent.com/1672302/221617948-aca00119-0163-4578-9d98-72784f3a379c.png">

### :link: External links

<!-- Issues, RFC, etc. -->

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
