### PR TITLE
Website: add accessible names to lists on home page

### DIFF
--- a/website/app/components/doc/page/header/index.hbs
+++ b/website/app/components/doc/page/header/index.hbs
@@ -8,8 +8,8 @@
   <LinkTo @route="index" class="doc-page-header__logo" aria-label="home page">
     <Doc::Logo::DesignSystem />
   </LinkTo>
-  <nav class="doc-page-header__nav-menu" aria-label="primary navigation">
-    <ul role="list">
+  <nav class="doc-page-header__nav-menu" aria-label="primary navigation" id="primary-navigation">
+    <ul role="list" aria-labelledby="primary-navigation">
       <Doc::Page::Header::NavItem @label="About" @route="about" @currentTopRoute={{@currentTopRoute}} />
       <Doc::Page::Header::NavItem @label="Foundations" @route="foundations" @currentTopRoute={{@currentTopRoute}} />
       <Doc::Page::Header::NavItem @label="Components" @route="components" @currentTopRoute={{@currentTopRoute}} />

--- a/website/app/templates/index.hbs
+++ b/website/app/templates/index.hbs
@@ -26,7 +26,7 @@
         />
       </div>
     </div>
-    <ul class="doc-page-home__cards" role="list">
+    <ul class="doc-page-home__cards" role="list" aria-label="the cornerstones of the helios design system">
       {{#each this.cards as |card|}}
         <li class="doc-page-home__card">
           <p class="doc-page-home__card-title">{{capitalize card.title}}</p>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds accessible names to the lists on the home page. It makes no visible changes to the UI, just provides necessary information to the user with a screen-reader. Closes HDS-1435.

### :hammer_and_wrench: Detailed description

- added an `aria-labelledby` attribute to the `ul` element inside of the primary nav
- added an `aria-label` to the list of four cards

### :camera_flash: Screenshots

Before (neither list has an accessible name): 
![CleanShot 2023-02-28 at 14 49 54](https://user-images.githubusercontent.com/4587451/221976438-61234670-7e19-4e5f-ac81-309e94ac8c52.png)

After the changes were made, it's clear that the "list" elements have accessible names by inspecting the accessibility tree:
![CleanShot 2023-02-28 at 14 36 47](https://user-images.githubusercontent.com/4587451/221974098-2145bdb6-46f9-4068-b111-45b528dca7ae.png)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1435](https://hashicorp.atlassian.net/browse/HDS-1435)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1435]: https://hashicorp.atlassian.net/browse/HDS-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ