### PR TITLE
Table: extends functionality of identityKey table component option

### DIFF
--- a/packages/components/addon/components/hds/table/index.js
+++ b/packages/components/addon/components/hds/table/index.js
@@ -48,7 +48,12 @@ export default class HdsTableIndexComponent extends Component {
    * this would be relevant for any table that would have data that could update or change, i.e., polling.
    */
   get identityKey() {
-    return this.args.identityKey ?? '@identity';
+    // we have to provide a way for the consumer to pass undefined because Ember tries to interpret undefined as missing an arg and therefore falls back to the default
+    if (this.args.identityKey === 'none') {
+      return undefined;
+    } else {
+      return this.args.identityKey ?? '@identity';
+    }
   }
 
   /**

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -58,8 +58,8 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="caption" @type="string">
     Adds a (non-visible) caption for users with assistive technology. If set on a sortable table, the provided table caption is paired with the automatically generated sorted message text.
   </C.Property>
-  <C.Property @name="identityKey" @type="string" @default="@identity">
-    Option to pass a custom key.
+  <C.Property @name="identityKey" @type="'none'|string" @default="@identity">
+    Option to [specify a custom key](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each#:~:text=%3C/ul%3E-,Specifying%20Keys,-In%20order%20to) to the `each` iterator. If `identityKey="none"`, this is interpreted as an `undefined` value for the `@identity` key option.
   </C.Property>
   <C.Property @name="sortedMessageText" @type="string" @default="Sorted by (label), (asc/desc)ending">
     Customizable text added to `caption` element when a sort is performed.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds support for `none` as an optional value for `@identityKey` in the `Hds::Table` component.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
