### PR TITLE
Fix checkmark and disabled state on `power-select` style overrides

### DIFF
--- a/.changeset/wicked-trainers-dress.md
+++ b/.changeset/wicked-trainers-dress.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix checkmark and disabled state on `power-select` style overrides

--- a/packages/components/app/styles/@hashicorp/design-system-power-select-overrides.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-power-select-overrides.scss
@@ -18,13 +18,12 @@
   .ember-basic-dropdown-trigger,
   .ember-power-select-trigger {
     max-width: 100%;
-    min-height: 34px;
+    min-height: 36px;
     padding: calc(var(--token-form-control-padding) + 1px);
     padding-right: calc(var(--token-form-control-padding) + 24px); // extra space for the icon
-    padding-left: 44px;
     color: var(--token-form-control-base-foreground-value-color);
     background-color: var(--token-form-control-base-surface-color-default);
-    background-image: var(--token-form-select-background-image-data-url), url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M14.78 4.28a.75.75 0 00-1.06-1.06l-7.97 7.97-3.47-3.47a.75.75 0 00-1.06 1.06l4 4a.75.75 0 001.06 0l8.5-8.5z' fill='%231060ff'/%3E%3C/svg%3E");
+    background-image: var(--token-form-select-background-image-data-url);
     background-repeat: no-repeat;
     background-position: right var(--token-form-select-background-image-position-right-x) center, top 8px left 20px;
     background-size: var(--token-form-select-background-image-size) var(--token-form-select-background-image-size);
@@ -53,10 +52,16 @@
     &[aria-disabled="true"] {
       color: var(--token-form-control-disabled-foreground-color);
       background-color: var(--token-form-control-disabled-surface-color);
-      background-image: var(--token-form-select-background-image-data-url-disabled), url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M14.78 4.28a.75.75 0 00-1.06-1.06l-7.97 7.97-3.47-3.47a.75.75 0 00-1.06 1.06l4 4a.75.75 0 001.06 0l8.5-8.5z' fill='%238c909c'/%3E%3C/svg%3E");
+      background-image: var(--token-form-select-background-image-data-url-disabled);
       border-color: var(--token-form-control-disabled-border-color);
       box-shadow: none;
       cursor: not-allowed;
+      opacity: 0.7;
+
+      .ember-power-select-selected-item {
+        background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M14.78 4.28a.75.75 0 00-1.06-1.06l-7.97 7.97-3.47-3.47a.75.75 0 00-1.06 1.06l4 4a.75.75 0 001.06 0l8.5-8.5z' fill='%238c909c'/%3E%3C/svg%3E");
+        opacity: inherit;
+      }
     }
   }
 
@@ -142,7 +147,14 @@
   .ember-power-select-selected-item {
     display: block;
     margin-left: 0;
+    padding-left: 37px;
+    color: var(--token-color-foreground-strong);
     line-height: normal;
+    background-color: inherit;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M14.78 4.28a.75.75 0 00-1.06-1.06l-7.97 7.97-3.47-3.47a.75.75 0 00-1.06 1.06l4 4a.75.75 0 001.06 0l8.5-8.5z' fill='%231060ff'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: top 0 left 13px;
+    background-size: var(--token-form-select-background-image-size) var(--token-form-select-background-image-size);
   }
 
   .ember-power-select-options {

--- a/packages/components/tests/dummy/app/templates/overrides/power-select.hbs
+++ b/packages/components/tests/dummy/app/templates/overrides/power-select.hbs
@@ -9,6 +9,30 @@
 
 <section data-test-percy>
 
+  <Shw::Text::H2>Interaction status</Shw::Text::H2>
+  <Shw::Flex {{style max-width="50%"}} @direction="column" as |SF|>
+    <SF.Item @label="No option selected">
+      <div class="hds-power-select">
+        <PowerSelect @options={{@model.OPTIONS}} @onChange={{this.noop}} @renderInPlace={{true}} as |option|>
+          {{option}}
+        </PowerSelect>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Option selected">
+      <div class="hds-power-select">
+        <PowerSelect
+          @options={{@model.OPTIONS}}
+          @selected={{@model.SELECTED}}
+          @onChange={{this.noop}}
+          @renderInPlace={{true}}
+          as |option|
+        >
+          {{option}}
+        </PowerSelect>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Text::H2>States</Shw::Text::H2>
 
   <Shw::Flex {{style max-width="50%"}} @direction="column" as |SF|>


### PR DESCRIPTION
### :pushpin: Summary

Fix checkmark and disabled state on `power-select` style overrides

### :hammer_and_wrench: Detailed description

- Move the checkmark from `ember-power-select-trigger ` to `ember-power-select-selected-item` to prevent it from appearing when no option is selected (updated showcase to reflect this scenario)
- Align height with form select (set it to a minimum of 36px)
- Align opacity when disabled with form select (to 0.7)

### :camera_flash: Screenshots

#### Before
![localhost_3000_overrides_power-select](https://user-images.githubusercontent.com/788096/222766909-973be7af-c431-46e4-a547-8a641a0c0806.png)


#### After
![localhost_3000_overrides_power-select (1)](https://user-images.githubusercontent.com/788096/222766952-036f334a-4d1e-4777-a152-9123ab4ae3d8.png)


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1648](https://hashicorp.atlassian.net/browse/HDS-1648)
Many thanks to @valeriia-ruban for flagging these issues!

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1648]: https://hashicorp.atlassian.net/browse/HDS-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ