### PR TITLE
Fix Dropdown example with generic content

### DIFF
--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -183,7 +183,7 @@ When using the “generic” ListItem, the product team is responsible for imple
   <dd.Title @text="Integrate with Terraform Cloud" />
   <dd.Description @text="Create a new run task in Terraform using the URL and key below." />
   <dd.Generic>
-    <Hds::Link::Standalone @text="Watch tutorial video" @icon="film" href="/" />
+    <Hds::Link::Standalone @text="Watch tutorial video" @icon="film" @href="/" />
   </dd.Generic>
   <dd.CopyItem @text="https://api.cloud.hashicorp.com" @copyItemTitle="Endpoint URL" />
   <dd.CopyItem @text="91ee1e8ef65b337f0e70d793f456c71d" @copyItemTitle="HMAC Key" />


### PR DESCRIPTION
### :pushpin: Summary

Fix Dropdown example with generic content

### :hammer_and_wrench: Detailed description

The `Hds::Link::Standalone` component requires an `@href` or `@route` – due to a typo we have `href` and the dropdown errors on click

> Uncaught (in promise) Error: Assertion Failed: `@href` or `@route` must be defined for `<Hds::Link::Standalone>`

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="630" alt="Screenshot 2023-03-03 at 18 33 10" src="https://user-images.githubusercontent.com/788096/222800145-2179540f-8e38-4238-a2c1-ec214e1c2f4e.png">


</td><td>

<img width="630" alt="Screenshot 2023-03-03 at 18 32 22" src="https://user-images.githubusercontent.com/788096/222800155-d2c45516-fcf2-4c6f-9310-673586835f07.png">


</td></tr>
</table>



***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
