### PR TITLE
Ignore patch releases for Percy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       interval: "weekly"
     allow: 
       - dependency-name: "@percy/*"
+    ignore:
+      # For Percy, ignore all patch updates
+      - dependency-name: "@percy/*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
### :pushpin: Summary

Ignore patch releases for Percy

### :hammer_and_wrench: Detailed description

Further reducing dependabot activity.

Percy is the only dependency where we received automated updates via dependabot. Until we review the overall dependabot activity, we can skip fixes on this dependency and only receive minor and major updates.

[Related Slack thread](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1678113697385509)
