### PR TITLE
Fix query params for tabs

### DIFF
--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -44,9 +44,9 @@ export default class ShowController extends Controller {
   @tracked tocs = A([]);
 
   get selectedTabIndex() {
-    // if no query param is set then default to the first tab
+    // if no query param is set then we mark it as null
     if (!this.selectedTab) {
-      return 0;
+      return null;
     }
 
     let tab = this.tabs.find((el) => {
@@ -147,6 +147,20 @@ export default class ShowController extends Controller {
 
   @action
   setCurrent(current) {
+    // update the query params if tabs exist and current is defined
+    if (this.tabs.length > 1 && current !== null) {
+      if (current == 0) {
+        // for the first tab we remove the query param
+        set(this, 'selectedTab', null);
+      } else {
+        // for the rest of the tabs we set the query param tab to a lowercase version of the tab label
+        set(this, 'selectedTab', this.tabs[current].label.toLowerCase());
+      }
+    } else {
+      // make the first tab current if not defined
+      current = 0;
+    }
+
     // TABS
     // ?? CAN WE EXPLICITLY SET FOCUS ON THE TAB WHEN IT IS SET TO CURRENT?
     this.tabs.forEach((tab) => {
@@ -164,12 +178,6 @@ export default class ShowController extends Controller {
     this.tocs.forEach((toc) => {
       set(toc, 'isCurrent', toc.index === current);
     });
-
-    // only attempt to update the query params if tabs exist
-    if (this.tabs.length > 1 && this.currentActiveTabIndex != 0) {
-      // for consistency we always set the query param tab to a lowercase version of the tab label
-      set(this, 'selectedTab', this.tabs[current].label.toLowerCase());
-    }
 
     // leave for debugging
     // console.log('show setCurrent', this.sections, this.tabs, this.tocs);

--- a/website/docs/foundations/tokens/index.js
+++ b/website/docs/foundations/tokens/index.js
@@ -15,7 +15,6 @@ const DEBOUNCE_MS = 250;
 // get all the aliases of a given token
 const getAliases = (token, TOKENS_RAW) => {
   const path = token.path.join('.');
-  console.log(path);
   return TOKENS_RAW.filter(
     (item) => item.original.value === `{${path}.value}`
   ).map((alias) => `{${alias.path.join('.')}}`);
@@ -39,7 +38,6 @@ export default class Index extends Component {
       }
       // add an extra "aliases" attribute if other tokens are alias of it
       const aliases = getAliases(token, TOKENS_RAW);
-      console.log(token.name, aliases);
       if (aliases.length > 0) {
         token.aliases = aliases;
       }

--- a/website/tests/acceptance/component-query-test.js
+++ b/website/tests/acceptance/component-query-test.js
@@ -51,7 +51,7 @@ module('Acceptance | Component Tabs', function (hooks) {
   test('specifying a component tab that does not exist defaults to the first tab', async function (assert) {
     await visit('/components/alert?tab=wubalubadubdub');
 
-    assert.strictEqual(currentURL(), '/components/alert?tab=wubalubadubdub');
+    assert.strictEqual(currentURL(), '/components/alert');
 
     assert.dom('.doc-page-tabs__tab--is-current').exists({ count: 1 });
     assert


### PR DESCRIPTION
### :pushpin: Summary

Fix query parameters for tabs by refactoring the `selectedTab` logic and treating the case when no tab is selected separately.

### :hammer_and_wrench: Detailed description

If no tab is selected, we're using `null` to be able to target this specific scenario.

Then I refactored the `setCurrent` logic to treat the case where no tab is selected separately – this way we have the query param removed on the default tab, we keep the browser history neat (allowing accurate back and forward actions in the browser), and we allow deep linking.

While testing various pages I spotted some console logs from previous debugging and commented them out.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1531](https://hashicorp.atlassian.net/browse/HDS-1531)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1531]: https://hashicorp.atlassian.net/browse/HDS-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ