### PR TITLE
Revert ember-keyboard & ember-truth-helpers bumps

### DIFF
--- a/.changeset/large-ligers-tap.md
+++ b/.changeset/large-ligers-tap.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Revert ember-truth-helpers & ember-keyboard dependency updates

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,7 +47,7 @@
     "ember-cli-sass": "^10.0.1",
     "ember-composable-helpers": "^4.5.0",
     "ember-focus-trap": "^1.0.1",
-    "ember-keyboard": "^8.2.0",
+    "ember-keyboard": "^8.1.0",
     "ember-named-blocks-polyfill": "^0.2.5",
     "ember-style-modifier": "^0.8.0",
     "ember-truth-helpers": "^3.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
     "ember-keyboard": "^8.2.0",
     "ember-named-blocks-polyfill": "^0.2.5",
     "ember-style-modifier": "^0.8.0",
-    "ember-truth-helpers": "^3.1.1",
+    "ember-truth-helpers": "^3.0.0",
     "sass": "^1.58.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3176,7 +3176,7 @@ __metadata:
     ember-style-modifier: ^0.8.0
     ember-template-lint: ^4.18.2
     ember-template-lint-plugin-prettier: ^4.1.0
-    ember-truth-helpers: ^3.1.1
+    ember-truth-helpers: ^3.0.0
     ember-try: ^2.0.0
     eslint: ^7.32.0
     eslint-config-prettier: ^8.6.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2717,17 +2717,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@embroider/addon-shim@npm:^1.8.4":
-  version: 1.8.4
-  resolution: "@embroider/addon-shim@npm:1.8.4"
-  dependencies:
-    "@embroider/shared-internals": ^2.0.0
-    broccoli-funnel: ^3.0.8
-    semver: ^7.3.8
-  checksum: 107220e97bbd46ead81dfbbfc6cf7daa61731096a6e81b989659a9a0b29b48b3c97ebdd446b6dc0636c4be369f3744e514b7f5e5c0fdc54c1c0e026f54404cc2
-  languageName: node
-  linkType: hard
-
 "@embroider/macros@npm:1.8.3, @embroider/macros@npm:^0.50.0 || ^1.0.0, @embroider/macros@npm:^1.2.0":
   version: 1.8.3
   resolution: "@embroider/macros@npm:1.8.3"
@@ -3164,7 +3153,7 @@ __metadata:
     ember-composable-helpers: ^4.5.0
     ember-concurrency: ^2.3.7
     ember-focus-trap: ^1.0.1
-    ember-keyboard: ^8.2.0
+    ember-keyboard: ^8.1.0
     ember-load-initializers: ^2.1.2
     ember-named-blocks-polyfill: ^0.2.5
     ember-page-title: ^7.0.0
@@ -10876,20 +10865,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-keyboard@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "ember-keyboard@npm:8.2.0"
+"ember-keyboard@npm:^8.1.0":
+  version: 8.1.1
+  resolution: "ember-keyboard@npm:8.1.1"
   dependencies:
     "@embroider/addon-shim": ^1.5.0
     ember-destroyable-polyfill: ^2.0.3
-    ember-modifier: ^2.1.2 || ^3.1.0 || ^4.0.0
+    ember-modifier: ^2.1.2 || ^3.1.0
     ember-modifier-manager-polyfill: ^1.2.0
   peerDependencies:
     "@ember/test-helpers": ^2.6.0
   peerDependenciesMeta:
     "@ember/test-helpers":
       optional: true
-  checksum: d8e9c8d78175b411c40b88288ef91902278011d242ed0775e64df492089210e0b3dfc0eee7de4fe11a33d918d40639fc5aee7ba26ba9695b507cabb5e52fa844
+  checksum: 559d23d39e6de4f46226203ef9d5d347c7cee7f1a2d1394d5164af9ef1025aaeb15fa0f7f44834805c16c5e38821ea924d2f3ca017284e7d420384854cdd4393
   languageName: node
   linkType: hard
 
@@ -10949,23 +10938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-modifier@npm:^2.1.2 || ^3.1.0 || ^4.0.0":
-  version: 4.0.0
-  resolution: "ember-modifier@npm:4.0.0"
-  dependencies:
-    "@embroider/addon-shim": ^1.8.4
-    ember-cli-normalize-entity-name: ^1.0.0
-    ember-cli-string-utils: ^1.1.0
-  peerDependencies:
-    ember-source: "*"
-  peerDependenciesMeta:
-    ember-source:
-      optional: true
-  checksum: 8970eee22666426abed22414fc12f1547b4c02618297648ace0c22ec3db5299afe522ac2130148e6daeded0c70ad7005418c21888b8e4198e0c6b04c5f751312
-  languageName: node
-  linkType: hard
-
-"ember-modifier@npm:^3.2.7":
+"ember-modifier@npm:^2.1.2 || ^3.1.0, ember-modifier@npm:^3.2.7":
   version: 3.2.7
   resolution: "ember-modifier@npm:3.2.7"
   dependencies:


### PR DESCRIPTION
### :pushpin: Summary

At least for now, this relaxes a couple of updates we did that were impacting the ability of certain consumers from installing 1.7.x. We'll want to figure out a more sustainable longer term plan for this, but since we didn't _need_ these, relaxing and allowing consumers to install previous versions seems like the pragmatic choice.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1671](https://hashicorp.atlassian.net/browse/HDS-1671)

***

### 👀 Reviewer's checklist:

- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1671]: https://hashicorp.atlassian.net/browse/HDS-1671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ