### PR TITLE
Website / Remove focus from tab panel

### DIFF
--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -118,7 +118,6 @@ export default class ShowController extends Controller {
         const id = section.id;
         const name = section.getAttribute('data-tab');
         section.setAttribute('role', 'tabpanel');
-        section.setAttribute('tabindex', '0');
         section.setAttribute('aria-labelledby', `tab-${id}`);
         section.setAttribute('hidden', true);
         sections.push(section);


### PR DESCRIPTION
### :pushpin: Summary

This PR removes the `tabindex` attribute from the tab panels in the website, to avoid them receiving focus and ending in this weird result:

<img width="1233" alt="screenshot_2474" src="https://user-images.githubusercontent.com/686239/224264177-0682cc22-ea60-49c7-a186-67299bd15969.png">

(This is a follow-up of a comment in https://github.com/hashicorp/design-system/pull/1167#issuecomment-1442058154)

👉 👉 👉 **Preview**: https://hds-website-git-website-remove-focus-from-tab-panel-hashicorp.vercel.app/components/alert

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
