### PR TITLE
Add information about icon alignment in Helios documentation

### DIFF
--- a/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
+++ b/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
@@ -198,11 +198,11 @@ For example, to visually center an icon with a generic text node, you will need 
 
 !!! Warning
 
-**Note**
+**Avoid using `vertical-align: middle`**
 
 Just setting `vertical-align: middle` in the parent container doesn’t necessarily achieve a vertical alignment.
 
-This is because, despite what one may think, the [`middle` alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#middle) is not calculated in relation to the whole text ”block” but to its “x-height”. If you want to know more, you can read [this in-depth explanation](https://www.impressivewebs.com/css-vertical-align/) of how vertical align works in CSS.
+This is because the [`middle` alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#middle) is not calculated in relation to the whole text “block” but to its “x-height”. To learn more, read about [how `vertical-align` works in CSS](https://www.impressivewebs.com/css-vertical-align/).
 !!!
 
 

--- a/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
+++ b/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
@@ -192,17 +192,17 @@ The size of the icon is determined by the size of the asset imported (each icon 
 
 ### Aligning icons
 
-By default, the `FlighIcon` component has a `inline-block` display value (this can be changed using the `@isInlineBlock` argument). This means that the icon behaves like an inline element, and that if you want to vertically align it in relation to other sibling elements, you have to use CSS to achieve the expected result.
+By default, the `FlightIcon` component has an `inline-block` display value (this can be changed using the `@isInlineBlock` argument). This means that the icon behaves like an inline element, and that if you want to vertically align it in relation to other sibling elements, you have to use CSS to achieve the expected result.
 
 For example, to visually center an icon with a generic text node, you will need to use a parent `flex` container with `align-items: center`.
 
 !!! Warning
 
-**Notice**
+**Note**
 
-Just setting `vertical-align: middle` in the parent container doesn't necessarily achieve a vertical alignment.
+Just setting `vertical-align: middle` in the parent container doesn’t necessarily achieve a vertical alignment.
 
-This is because, despite what one may think, the [`middle` alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#middle) is not calculated in relation to the whole text "block" but to its “x-height”. If you want to know more, you can read [this in-depth explanation](https://www.impressivewebs.com/css-vertical-align/) of how vertical align works in CSS.
+This is because, despite what one may think, the [`middle` alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#middle) is not calculated in relation to the whole text ”block” but to its “x-height”. If you want to know more, you can read [this in-depth explanation](https://www.impressivewebs.com/css-vertical-align/) of how vertical align works in CSS.
 !!!
 
 

--- a/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
+++ b/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
@@ -190,7 +190,23 @@ The component exposes the following _props_:
 
 The size of the icon is determined by the size of the asset imported (each icon is exported in two sizes, _16_ and _24_). If you need a different size, use CSS to override its intrinsic size.
 
-#### Animated icons
+### Aligning icons
+
+By default, the `FlighIcon` component has a `inline-block` display value (this can be changed using the `@isInlineBlock` argument). This means that the icon behaves like an inline element, and that if you want to vertically align it in relation to other sibling elements, you have to use CSS to achieve the expected result.
+
+For example, to visually center an icon with a generic text node, you will need to use a parent `flex` container with `align-items: center`.
+
+!!! Warning
+
+**Notice**
+
+Just setting `vertical-align: middle` in the parent container doesn't necessarily achieve a vertical alignment.
+
+This is because, despite what one may think, the [`middle` alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#middle) is not calculated in relation to the whole text "block" but to its “x-height”. If you want to know more, you can read [this in-depth explanation](https://www.impressivewebs.com/css-vertical-align/) of how vertical align works in CSS.
+!!!
+
+
+### Animated icons
 
 Some of the icons are meant to be animated (e.g., “loading” and “running”). To use them, import the CSS that controls the icons’ animation:
 


### PR DESCRIPTION
### :pushpin: Summary

This small PR adds some more information about icon alignment to the Helios documentation so it's easy to reference and point people to.

(currently the only reference we have is [this Slack conversation](https://hashicorp.slack.com/archives/C7KTUHNUS/p1643915566937619?thread_ts=1643915085.208079&cid=C7KTUHNUS), quite hard to find).

👉 👉 👉 **Preview**: https://hds-website-git-update-icon-docs-hashicorp.vercel.app/icons/usage-guidelines?tab=code#aligning-icons

### :camera_flash: Screenshots

<img width="888" alt="screenshot_2480" src="https://user-images.githubusercontent.com/686239/224737800-baba67d8-513c-48e2-9351-8a471c9c2807.png">

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
