### PR TITLE
Table component docs: render examples

### DIFF
--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -32,6 +32,7 @@
 @import "pages/components/modal";
 @import "pages/components/pagination";
 @import "pages/components/radio-card";
+@import "pages/components/table";
 
 // Third-party declarations
 @import "prism-dracula";

--- a/website/app/styles/pages/components/table.scss
+++ b/website/app/styles/pages/components/table.scss
@@ -5,8 +5,10 @@
 
 // COMPONENTS > TABLE
 
-.table-demo-flexbox {
-  display: flex;
-  gap: 5px;
-  align-items: center;
+#show-content-components-table {
+  .doc-table-valign-demo {
+    display: flex;
+    gap: 5px;
+    align-items: center;
+  }
 }

--- a/website/app/styles/pages/components/table.scss
+++ b/website/app/styles/pages/components/table.scss
@@ -7,9 +7,6 @@
 
 .table-demo-flexbox {
   display: flex;
+  gap: 5px;
   align-items: center;
-
-  svg {
-    margin-right: 5px;
-  }
 }

--- a/website/app/styles/pages/components/table.scss
+++ b/website/app/styles/pages/components/table.scss
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// COMPONENTS > TABLE
+
+.table-demo-flexbox {
+  display: flex;
+  align-items: center;
+
+  svg {
+    margin-right: 5px;
+  }
+}

--- a/website/docs/components/table/index.js
+++ b/website/docs/components/table/index.js
@@ -116,6 +116,6 @@ export default class Index extends Component {
     const columns = keys.map((key) => {
       return { key, label: capitalize(key) };
     });
-    return { data: dataResponse, columns };
+    return { myDemoData: dataResponse, columns };
   }
 }

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -48,14 +48,6 @@ export default class ComponentsTableRoute extends Route {
     //      year: '1969'
     //    },
     //  },
-    //  {
-    //    id: '3',
-    //    attributes: {
-    //      artist: 'Melanie',
-    //      album: 'Candles in the Rain',
-    //      year: '1971'
-    //    },
-    //  },
     // ...
     let response = await fetch('/api/demo.json');
     let { data } = await response.json();

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -115,7 +115,7 @@ Add `isSortable=true` to the hash for each column that should be sortable.
 
 To indicate that a specific column should be pre-sorted, add `@sortBy`, where the value is the column's key.
 
-```handlebars{data-execute=false}
+```handlebars
 <Hds::Table
   @model={{this.model.data}}
   @columns={{array
@@ -123,7 +123,7 @@ To indicate that a specific column should be pre-sorted, add `@sortBy`, where th
     (hash key="album" label="Album" isSortable=true)
     (hash key="year" label="Release Year")
   }}
-  @sortBy='artist'
+  @sortBy="artist"
 >
   <:body as |B|>
     <B.Tr>
@@ -139,7 +139,7 @@ To indicate that a specific column should be pre-sorted, add `@sortBy`, where th
 
 By default, the sort order is set to ascending. To indicate that the column defined in `@sortBy` should be pre-sorted in descending order, pass in `@sortOrder='desc'`.
 
-```handlebars{data-execute=false}
+```handlebars
 <Hds::Table
   @model={{this.model.data}}
   @columns={{array
@@ -147,8 +147,8 @@ By default, the sort order is set to ascending. To indicate that the column defi
     (hash key="album" label="Album" isSortable=true)
     (hash key="year" label="Release Year")
   }}
-  @sortBy='artist'
-  @sortOrder='desc'
+  @sortBy="artist"
+  @sortOrder="desc"
 >
   <:body as |B|>
     <B.Tr>

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -31,23 +31,35 @@ import Route from '@ember/routing/route';
 export default class ComponentsTableRoute extends Route {
   async model() {
     // example of data retrieved:
-    // [
-    //   {
-    //     "id": 1,
-    //     "name": "Burnaby Kuscha",
-    //     "email": "1_bkuscha0@tiny.cc",
-    //     "role": "Owner"
-    //   },
-    //   {
-    //     "id": 2,
-    //     "name": "Barton Penley",
-    //     "email": "2_bpenley1@miibeian.gov.cn",
-    //     "role": "Admin"
-    //   },
-    //   ...
+    //[
+    //  {
+    //    id: '1',
+    //    attributes: {
+    //      artist: 'Nick Drake',
+    //      album: 'Pink Moon',
+    //      year: '1972'
+    //    },
+    //  },
+    //  {
+    //    id: '2',
+    //    attributes: {
+    //      artist: 'The Beatles',
+    //      album: 'Abbey Road',
+    //      year: '1969'
+    //    },
+    //  },
+    //  {
+    //    id: '3',
+    //    attributes: {
+    //      artist: 'Melanie',
+    //      album: 'Candles in the Rain',
+    //      year: '1971'
+    //    },
+    //  },
+    // ...
     let response = await fetch('/api/demo.json');
     let { data } = await response.json();
-    return { myDemoData: data };
+    return { data: data };
   }
 }
 ```
@@ -56,16 +68,16 @@ For documentation purposes, we’re imitating fetching data from an API and work
 
 You can insert your own content into the `:body` block and the component will take care of looping over the `@model` provided:
 
-```handlebars{data-execute=false}
+```handlebars
 <Hds::Table
-  @model={{this.model.myDemoData}}
-  @columns={{array (hash label="Name") (hash label="Email") (hash label="Role")}}
+  @model={{this.model.data}}
+  @columns={{array (hash label="Artist") (hash label="Album") (hash label="Year")}}
 >
   <:body as |B|>
     <B.Tr>
-      <B.Td>{{B.data.name}}</B.Td>
-      <B.Td>{{B.data.email}}</B.Td>
-      <B.Td>{{B.data.role}}</B.Td>
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
     </B.Tr>
   </:body>
 </Hds::Table>
@@ -137,7 +149,7 @@ To indicate that a specific column should be pre-sorted, add `@sortBy`, where th
 
 ##### Pre-sorting direction
 
-By default, the sort order is set to ascending. To indicate that the column defined in `@sortBy` should be pre-sorted in descending order, pass in `@sortOrder='desc'`.
+By default, the sort order is set to ascending. To indicate that the column defined in `@sortBy` should be pre-sorted in descending order, pass in `@sortOrder="desc"`.
 
 ```handlebars
 <Hds::Table
@@ -165,9 +177,9 @@ By default, the sort order is set to ascending. To indicate that the column defi
 To implement a custom sort callback on a column:
 
 1. add a custom function as the value for `sortingFunction` in the column hash,
-2. include a custom `onSort` action in your table invocation to track the sorting order and use it in the custom sorting function. 
+2. include a custom `onSort` action in your table invocation to track the sorting order and use it in the custom sorting function.
 
-This is useful for cases where the key might not be A-Z or 0-9 sortable by default, e.g., status, and you’re otherwise unable to influence the shape of the data in the model. 
+This is useful for cases where the key might not be A-Z or 0-9 sortable by default, e.g., status, and you’re otherwise unable to influence the shape of the data in the model.
 
 _The code has been truncated for clarity._
 

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -2,7 +2,7 @@
 
 ### Table with no model defined
 
-```handlebars{data-execute=false}
+```handlebars
 <Hds::Table @caption="your custom, meaningful caption goes here">
   <:head as |H|>
     <H.Tr>
@@ -92,7 +92,7 @@ This component takes advantage of the `sort-by` helper provided by [ember-compos
 
 Add `isSortable=true` to the hash for each column that should be sortable.
 
-```handlebars{data-execute=false}
+```handlebars
 <Hds::Table
   @model={{this.model.data}}
   @columns={{array
@@ -232,7 +232,7 @@ customOnSort(_sortBy, sortOrder) {
 
 To create a condensed or spacious table, add `@density` to the table's invocation. Note that it only affects the table body, not the table header.
 
-```handlebars{data-execute=false}
+```handlebars
 <Hds::Table
   @model={{this.model.data}}
   @columns={{array
@@ -258,7 +258,7 @@ To create a condensed or spacious table, add `@density` to the table's invocatio
 
 To indicate that the table's content should have a middle vertical-align, use `@valign` in the table's invocation.
 
-```handlebars{data-execute=false}
+```handlebars
 <Hds::Table
   @model={{this.model.data}}
   @columns={{array
@@ -316,7 +316,7 @@ If you have more than just text content in the table cell, you'll want to wrap t
 
 To create a column that has right-aligned content, set `@align` to `right` on both the column's header and cell (the cell's horizontal content alignment should be the same as the column's horizontal content alignment).
 
-```handlebars{data-execute=false}
+```handlebars
 <Hds::Table
   @model={{this.model.data}}
   @columns={{array

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -51,7 +51,7 @@ export default class ComponentsTableRoute extends Route {
     // ...
     let response = await fetch('/api/demo.json');
     let { data } = await response.json();
-    return { data: data };
+    return { myDemoData: data };
   }
 }
 ```
@@ -62,7 +62,7 @@ You can insert your own content into the `:body` block and the component will ta
 
 ```handlebars
 <Hds::Table
-  @model={{this.model.data}}
+  @model={{this.model.myDemoData}}
   @columns={{array (hash label="Artist") (hash label="Album") (hash label="Year")}}
 >
   <:body as |B|>
@@ -98,7 +98,7 @@ Add `isSortable=true` to the hash for each column that should be sortable.
 
 ```handlebars
 <Hds::Table
-  @model={{this.model.data}}
+  @model={{this.model.myDemoData}}
   @columns={{array
     (hash key="artist" label="Artist" isSortable=true)
     (hash key="album" label="Album" isSortable=true)
@@ -121,7 +121,7 @@ To indicate that a specific column should be pre-sorted, add `@sortBy`, where th
 
 ```handlebars
 <Hds::Table
-  @model={{this.model.data}}
+  @model={{this.model.myDemoData}}
   @columns={{array
     (hash key="artist" label="Artist" isSortable=true)
     (hash key="album" label="Album" isSortable=true)
@@ -145,7 +145,7 @@ By default, the sort order is set to ascending. To indicate that the column defi
 
 ```handlebars
 <Hds::Table
-  @model={{this.model.data}}
+  @model={{this.model.myDemoData}}
   @columns={{array
     (hash key="artist" label="Artist" isSortable=true)
     (hash key="album" label="Album" isSortable=true)
@@ -177,7 +177,7 @@ _The code has been truncated for clarity._
 
 ```handlebars{data-execute=false}
 <Hds::Table
-  @model={{this.model.data}}
+  @model={{this.model.myDemoData}}
   @columns={{array
       (hash 
         key='status'
@@ -238,7 +238,7 @@ To create a condensed or spacious table, add `@density` to the table's invocatio
 
 ```handlebars
 <Hds::Table
-  @model={{this.model.data}}
+  @model={{this.model.myDemoData}}
   @columns={{array
     (hash key="artist" label="Artist" isSortable=true)
     (hash key="album" label="Album" isSortable=true)
@@ -264,7 +264,7 @@ To indicate that the table's content should have a middle vertical-align, use `@
 
 ```handlebars
 <Hds::Table
-  @model={{this.model.data}}
+  @model={{this.model.myDemoData}}
   @columns={{array
     (hash key="artist" label="Artist" isSortable=true)
     (hash key="album" label="Album" isSortable=true)
@@ -294,7 +294,7 @@ If you have more than just text content in the table cell, you'll want to wrap t
 
 ```handlebars
 <Hds::Table
-  @model={{this.model.data}}
+  @model={{this.model.myDemoData}}
   @columns={{array
     (hash key="artist" label="Artist" isSortable=true)
     (hash key="album" label="Album" isSortable=true)
@@ -322,7 +322,7 @@ To create a column that has right-aligned content, set `@align` to `right` on bo
 
 ```handlebars
 <Hds::Table
-  @model={{this.model.data}}
+  @model={{this.model.myDemoData}}
   @columns={{array
     (hash key="artist" label="Artist" isSortable=true)
     (hash key="album" label="Album" isSortable=true)
@@ -347,7 +347,7 @@ Here’s a table implementation that uses an array hash with localized strings f
 
 ```handlebars{data-execute=false}
 <Hds::Table
-  @model={{this.model.data}}
+  @model={{this.model.myDemoData}}
   @columns={{array
       (hash key='artist' label=(t 'components.table.headers.artist') isSortable=true)
       (hash key='album' label=(t 'components.table.headers.album') isSortable=true)

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -288,7 +288,7 @@ If you have more than just text content in the table cell, you'll want to wrap t
 
 !!!
 
-```handlebars{data-execute=false}
+```handlebars
 <Hds::Table
   @model={{this.model.data}}
   @columns={{array
@@ -301,7 +301,7 @@ If you have more than just text content in the table cell, you'll want to wrap t
   <:body as |B|>
     <B.Tr>
       <B.Td>
-        <div class="my-flexbox">
+        <div class="table-demo-flexbox">
           <FlightIcon @name="headphones" /> {{B.data.artist}}
         </div>
       </B.Td>

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -305,7 +305,7 @@ If you have more than just text content in the table cell, you'll want to wrap t
   <:body as |B|>
     <B.Tr>
       <B.Td>
-        <div class="table-demo-flexbox">
+        <div class="doc-table-valign-demo">
           <FlightIcon @name="headphones" /> {{B.data.artist}}
         </div>
       </B.Td>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR renders the component "how to use" examples to be aligned with other components.

### :hammer_and_wrench: Detailed description

**Code samples now rendered:**
- [x] Table with no model defined
- [x] Non-sortable table with model defined (Note: updated this example use the same model as the rest of the samples)
- [x] Sortable Table
- [x] Pre-sorting columns
- [x] Pre-sorting direction
- [x] Density
- [x] Vertical Alignment
- [x] Vertical Alignment with additional cell content
- [x] Text Alignment

**Code samples not rendered:** 
- Custom sort callback; the code was truncated for clarity.
- Internationalized column headers with overflow menu dropdown; we decided not to add internationalization support to the website for code samples.

**Other details:**
- added a `table-demo-flexbox` css class to handle the vertical alignment with extra cell content example
- fixed some instances of single quotes being used instead of double quotes (which was causing the code samples to not render)
- removed some extra whitespaces as indicated by the markdown linter

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1587](https://hashicorp.atlassian.net/browse/HDS-1587)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1587]: https://hashicorp.atlassian.net/browse/HDS-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ