### PR TITLE
Extend `Dropdown::ToggleButton` and update `Dropdown::ToggleIcon` styles

### DIFF
--- a/packages/components/addon/components/hds/button/index.hbs
+++ b/packages/components/addon/components/hds/button/index.hbs
@@ -50,5 +50,10 @@
         <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} />
       </div>
     {{/if}}
+    {{#if @hasChevron}}
+      <div class="hds-button__chevron">
+        <FlightIcon @name="chevron-down" @stretched={{true}} />
+      </div>
+    {{/if}}
   {{/if}}
 </Hds::Interactive>

--- a/packages/components/addon/components/hds/button/index.hbs
+++ b/packages/components/addon/components/hds/button/index.hbs
@@ -20,25 +20,34 @@
       <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} />
     </div>
   {{else}}
-    {{#if this.icon}}
-      {{#if (eq this.iconPosition "leading")}}
-        <div class="hds-button__icon">
-          <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} />
-        </div>
-        <div class="hds-button__text">
-          {{this.text}}
-        </div>
-      {{else}}
-        <div class="hds-button__text">
-          {{this.text}}
-        </div>
-        <div class="hds-button__icon">
-          <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} />
-        </div>
-      {{/if}}
-    {{else}}
-      <div class="hds-button__text">
-        {{this.text}}
+    {{#if (and this.icon (eq this.iconPosition "leading"))}}
+      <div class="hds-button__icon">
+        <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} />
+      </div>
+    {{/if}}
+    <div class="hds-button__text">
+      {{this.text}}
+    </div>
+    {{#if this.badge}}
+      <Hds::Badge
+        class="hds-button__badge"
+        @text={{this.badge}}
+        @icon={{@badgeIcon}}
+        @size="small"
+        @type={{if (not-eq this.color "primary") "inverted"}}
+      />
+    {{/if}}
+    {{#if this.count}}
+      <Hds::BadgeCount
+        class="hds-button__badge"
+        @text={{this.count}}
+        @size="small"
+        @type={{if (not-eq this.color "primary") "inverted"}}
+      />
+    {{/if}}
+    {{#if (and this.icon (eq this.iconPosition "trailing"))}}
+      <div class="hds-button__icon">
+        <FlightIcon @name={{this.icon}} @size={{this.iconSize}} @stretched={{true}} />
       </div>
     {{/if}}
   {{/if}}

--- a/packages/components/addon/components/hds/button/index.js
+++ b/packages/components/addon/components/hds/button/index.js
@@ -84,6 +84,36 @@ export default class HdsButtonIndexComponent extends Component {
   }
 
   /**
+   * @param badge
+   * @type {string}
+   * @default null
+   * @description The badge text
+   */
+  get badge() {
+    assert(
+      `@badge can not be rendered when the "Hds::Button" @color is "critical"`,
+      !(this.color === 'critical' && this.args.badge)
+    );
+
+    return this.args.badge ?? null;
+  }
+
+  /**
+   * @param count
+   * @type {string}
+   * @default null
+   * @description The count text
+   */
+  get count() {
+    assert(
+      `@count can not be rendered when the "Hds::Button" @color is "critical"`,
+      !(this.color === 'critical' && this.args.count)
+    );
+
+    return this.args.count ?? null;
+  }
+
+  /**
    * @param isIconOnly
    * @type {boolean}
    * @default false

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -19,8 +19,8 @@
 <Hds::Button
   class={{this.classNames}}
   @text={{this.text}}
-  @icon="chevron-down"
-  @iconPosition="trailing"
+  @icon={{@icon}}
+  @hasChevron={{true}}
   @color={{this.color}}
   @size={{@size}}
   @badge={{@badge}}

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -23,6 +23,9 @@
   @iconPosition="trailing"
   @color={{this.color}}
   @size={{@size}}
+  @badge={{@badge}}
+  @badgeIcon={{@badgeIcon}}
+  @count={{@count}}
   ...attributes
   aria-expanded={{if @isOpen "true" "false"}}
   {{on "click" this.onClick}}

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -68,6 +68,11 @@ $hds-button-focus-border-width: 3px;
     &::before {
       border-color: transparent;
     }
+
+    .hds-button__badge {
+      color: var(--token-color-foreground-primary);
+      background-color: var(--token-color-surface-strong);
+    }
   }
 
   &.hds-button--width-full {
@@ -112,6 +117,13 @@ $hds-button-focus-border-width: 3px;
   }
 }
 
+.hds-button__badge {
+  margin: -3px 0 -3px 6px;
+
+  & + .hds-button__icon {
+    margin-left: 0.375rem;
+  }
+}
 
 // SIZE
 

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -125,6 +125,11 @@ $hds-button-focus-border-width: 3px;
   }
 }
 
+.hds-button__chevron {
+  margin-right: -6px; // we apply a negative margin to counter the padding-right of the button and reduce the visual space between the icon and the right border
+  margin-left: 8px;
+}
+
 // SIZE
 
 // these values later may come from the design tokens
@@ -157,7 +162,8 @@ $size-props: (
     min-height: map-get($size-props, $size, "min-height");
     padding: map-get($size-props, $size, "padding");
 
-    .hds-button__icon {
+    .hds-button__icon,
+    .hds-button__chevron {
       width: map-get($size-props, $size, "icon-size");
       height: map-get($size-props, $size, "icon-size");
     }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -92,10 +92,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 .hds-dropdown-toggle-button {
   box-shadow: none; // we override this to remove the elevation style
 
-  .hds-button__icon {
-    margin-right: -6px; // we apply a negative margin to counter the padding-right of the button and reduce the visual space between the icon and the right border
-    margin-left: 8px; // this overrides the rule `.hds-button__text + .hds-button__icon`
-
+  .hds-button__chevron {
     @media (prefers-reduced-motion: no-preference) {
       transition: transform 0.3s;
     }
@@ -104,7 +101,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 
 .hds-dropdown-toggle-button--is-open {
-  .hds-button__icon {
+  .hds-button__chevron {
     transform: rotate(-180deg);
   }
 }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -37,8 +37,8 @@ $hds-dropdown-toggle-border-radius: 5px;
   min-width: $hds-dropdown-toggle-base-height;
   height: $hds-dropdown-toggle-base-height;
   padding: 1px;
-  background-color: transparent;
-  border: 1px solid transparent; // We need this to be transparent for a11y
+  background-color: var(--token-color-surface-faint);
+  border: 1px solid var(--token-color-border-strong);
   border-radius: $hds-dropdown-toggle-border-radius;
   outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
   outline-color: transparent; // We need this to be transparent for a11y
@@ -46,7 +46,6 @@ $hds-dropdown-toggle-border-radius: 5px;
   &:hover,
   &.mock-hover {
     background-color: var(--token-color-surface-interactive);
-    border-color: var(--token-color-border-strong);
     cursor: pointer;
   }
 

--- a/packages/components/tests/dummy/app/routes/components/dropdown.js
+++ b/packages/components/tests/dummy/app/routes/components/dropdown.js
@@ -11,7 +11,7 @@ import { COLORS as ITEM_INTERACTIVE_COLORS } from '@hashicorp/design-system-comp
 export default class ComponentsDropdownRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
-    const TOGGLE_STATES = ['default', 'hover', 'active', 'focus'];
+    const TOGGLE_STATES = ['default', 'hover', 'active', 'focus', 'disabled'];
     const ITEM_STATES = ['default', 'hover', 'active', 'focus'];
     return {
       TOGGLE_BUTTON_COLORS,

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -53,6 +53,49 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Text::H3>Badge</Shw::Text::H3>
+
+  {{#each @model.COLORS as |color|}}
+    {{#if (not-eq color "critical")}}
+      <Shw::Grid @columns={{5}} as |SG|>
+        {{#each @model.STATES as |state|}}
+          <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+            <Hds::Button
+              @icon={{if (eq color "tertiary") "arrow-right"}}
+              @iconPosition="trailing"
+              @badge="Badge"
+              @badgeIcon="hexagon"
+              @text={{capitalize state}}
+              @color={{color}}
+              mock-state-value={{state}}
+            />
+          </SG.Item>
+        {{/each}}
+      </Shw::Grid>
+    {{/if}}
+  {{/each}}
+
+  <Shw::Text::H3>Count</Shw::Text::H3>
+
+  {{#each @model.COLORS as |color|}}
+    {{#if (not-eq color "critical")}}
+      <Shw::Grid @columns={{5}} as |SG|>
+        {{#each @model.STATES as |state|}}
+          <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+            <Hds::Button
+              @icon={{if (eq color "tertiary") "arrow-right"}}
+              @iconPosition="trailing"
+              @count="3"
+              @text={{capitalize state}}
+              @color={{color}}
+              mock-state-value={{state}}
+            />
+          </SG.Item>
+        {{/each}}
+      </Shw::Grid>
+    {{/if}}
+  {{/each}}
+
   <Shw::Text::H2>Sizes</Shw::Text::H2>
 
   <Shw::Flex as |SF|>
@@ -64,6 +107,18 @@
     <SF.Item @label="Full width">
       <Shw::Outliner {{style width="300px"}}>
         <Hds::Button @icon="plus" @text="Lorem ipsum" @isFullWidth={{true}} />
+      </Shw::Outliner>
+    </SF.Item>
+  </Shw::Flex>
+  <Shw::Flex as |SF|>
+    {{#each @model.SIZES as |size|}}
+      <SF.Item @label="{{capitalize size}} + badge">
+        <Hds::Button @badge="Badge" @text="Lorem ipsum" @size={{size}} />
+      </SF.Item>
+    {{/each}}
+    <SF.Item @label="Full width + badge">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::Button @badge="Badge" @text="Lorem ipsum" @isFullWidth={{true}} />
       </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>
@@ -86,14 +141,26 @@
       {{#each @model.SIZES as |size|}}
         {{#each @model.STATES as |state|}}
           <SG.Item @label="{{capitalize size}} / {{capitalize state}}">
-            <Hds::Button @icon="plus" @text="Lorem" @size={{size}} @color={{color}} mock-state-value={{state}} />
+            <Hds::Button
+              @icon="plus"
+              @text={{capitalize state}}
+              @size={{size}}
+              @color={{color}}
+              mock-state-value={{state}}
+            />
           </SG.Item>
         {{/each}}
       {{/each}}
       {{#if (not-eq color "tertiary")}}
         {{#each @model.STATES as |state|}}
           <SG.Item @label="Full width / {{capitalize state}}">
-            <Hds::Button @icon="plus" @text="Lorem" @color={{color}} @isFullWidth={{true}} mock-state-value={{state}} />
+            <Hds::Button
+              @icon="plus"
+              @text={{capitalize state}}
+              @color={{color}}
+              @isFullWidth={{true}}
+              mock-state-value={{state}}
+            />
           </SG.Item>
         {{/each}}
       {{/if}}

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -46,7 +46,7 @@
 
   <Shw::Text::H3>States</Shw::Text::H3>
 
-  <Shw::Grid @columns="5" as |SG|>
+  <Shw::Grid @columns="6" as |SG|>
     {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
       {{#each @model.TOGGLE_STATES as |state|}}
         <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
@@ -114,7 +114,7 @@
 
   <Shw::Text::H3>Badge</Shw::Text::H3>
 
-  <Shw::Grid @columns="5" as |SG|>
+  <Shw::Grid @columns="6" as |SG|>
     {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
       {{#each @model.TOGGLE_STATES as |state|}}
         <SG.Item @label="{{capitalize color}} / {{capitalize state}}">

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -58,6 +58,22 @@
       </SG.Item>
     {{/each}}
 
+    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+          <Hds::Dropdown::Toggle::Button
+            @icon="hexagon"
+            @text="Lorem ipsum"
+            @color={{color}}
+            mock-state-value={{state}}
+          />
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="{{color}} / Open">
+        <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem ipsum" @isOpen={{true}} @color={{color}} />
+      </SG.Item>
+    {{/each}}
+
     {{#each @model.TOGGLE_STATES as |state|}}
       <SG.Item @label="Icon / {{capitalize state}}">
         <Hds::Dropdown::Toggle::Icon

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -53,7 +53,7 @@
           <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} mock-state-value={{state}} />
         </SG.Item>
       {{/each}}
-      <SG.Item @label="{{color}}/open">
+      <SG.Item @label="{{color}} / Open">
         <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @isOpen={{true}} @color={{color}} />
       </SG.Item>
     {{/each}}
@@ -68,7 +68,7 @@
         />
       </SG.Item>
     {{/each}}
-    <SG.Item @label="Icon/open">
+    <SG.Item @label="Icon / Open">
       <Hds::Dropdown::Toggle::Icon
         @icon="more-horizontal"
         @text="overflow menu"
@@ -82,7 +82,7 @@
         <Hds::Dropdown::Toggle::Icon @icon="user" @text={{state}} mock-state-value={{state}} />
       </SG.Item>
     {{/each}}
-    <SG.Item @label="Icon+chevron/open">
+    <SG.Item @label="Icon+chevron / Open">
       <Hds::Dropdown::Toggle::Icon @icon="user" @text="open" @isOpen={{true}} />
     </SG.Item>
 
@@ -91,9 +91,45 @@
         <Hds::Dropdown::Toggle::Icon @text={{state}} @imageSrc="/assets/images/avatar.png" mock-state-value={{state}} />
       </SG.Item>
     {{/each}}
-    <SG.Item @label="Avatar+chevron/open">
+    <SG.Item @label="Avatar+chevron / Open">
       <Hds::Dropdown::Toggle::Icon @text="open" @isOpen={{true}} @imageSrc="/assets/images/avatar.png" />
     </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Text::H3>Badge</Shw::Text::H3>
+
+  <Shw::Grid @columns="5" as |SG|>
+    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+          <Hds::Dropdown::Toggle::Button
+            @count="3"
+            @text={{capitalize state}}
+            @color={{color}}
+            mock-state-value={{state}}
+          />
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="{{color}} / Open">
+        <Hds::Dropdown::Toggle::Button @count="3" @text="Open" @isOpen={{true}} @color={{color}} />
+      </SG.Item>
+    {{/each}}
+    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+          <Hds::Dropdown::Toggle::Button
+            @count="3"
+            @text={{capitalize state}}
+            @color={{color}}
+            mock-state-value={{state}}
+            @size="small"
+          />
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="{{color}} / Open">
+        <Hds::Dropdown::Toggle::Button @count="3" @text="Open" @isOpen={{true}} @color={{color}} @size="small" />
+      </SG.Item>
+    {{/each}}
   </Shw::Grid>
 
   <Shw::Divider />

--- a/packages/components/tests/integration/components/hds/button/index-test.js
+++ b/packages/components/tests/integration/components/hds/button/index-test.js
@@ -152,6 +152,17 @@ module('Integration | Component | hds/button/index', function (hooks) {
       .hasText('3');
   });
 
+  // CHEVRON
+
+  test('it should render a chevron "down" if @hasChevron is defined', async function (assert) {
+    await render(
+      hbs`<Hds::Button @text="Button" @hasChevron={{true}} id="test-button" />`
+    );
+    assert
+      .dom('.hds-button__chevron .flight-icon.flight-icon-chevron-down')
+      .exists();
+  });
+
   // A11Y
 
   test('it should have aria-label on the button element if isIconOnly is set to true', async function (assert) {

--- a/packages/components/tests/integration/components/hds/button/index-test.js
+++ b/packages/components/tests/integration/components/hds/button/index-test.js
@@ -105,6 +105,53 @@ module('Integration | Component | hds/button/index', function (hooks) {
     assert.dom('#test-toggle-button').hasText('Copy to clipboard');
   });
 
+  // BADGE AND COUNT
+
+  test('it should render a small badge if @badge is defined', async function (assert) {
+    await render(
+      hbs`<Hds::Button @text="Lorem ipsum" @badge="Badge" id="test-button" />`
+    );
+    assert
+      .dom('#test-button .hds-button__badge')
+      .hasClass('hds-badge--size-small')
+      .hasText('Badge');
+  });
+  test('it should render a small, inverted badge if @badge is defined and @color is secondary', async function (assert) {
+    await render(
+      hbs`<Hds::Button @text="Lorem ipsum" @badge="Badge" @color="secondary" id="test-button" />`
+    );
+    assert
+      .dom('#test-button .hds-button__badge')
+      .hasClass('hds-badge--size-small')
+      .hasClass('hds-badge--type-inverted')
+      .hasText('Badge');
+  });
+  test('it should render a small, inverted badge if @badge is defined and @color is tertiary', async function (assert) {
+    await render(
+      hbs`<Hds::Button @text="Lorem ipsum" @badge="Badge" @color="tertiary" @icon="hexagon" id="test-button" />`
+    );
+    assert
+      .dom('#test-button .hds-button__badge')
+      .hasClass('hds-badge--size-small')
+      .hasClass('hds-badge--type-inverted')
+      .hasText('Badge');
+  });
+  test('it should render a badge with icon if @badgeIcon is defined', async function (assert) {
+    await render(
+      hbs`<Hds::Button @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" id="test-button" />`
+    );
+    assert.dom('#test-button .flight-icon-hexagon').exists();
+  });
+  test('it should render a badge count if @count is defined', async function (assert) {
+    await render(
+      hbs`<Hds::Button @text="Lorem ipsum" @count="3" id="test-button" />`
+    );
+    assert
+      .dom('#test-button .hds-badge-count')
+      .hasClass('hds-button__badge')
+      .hasText('3');
+  });
+
   // A11Y
 
   test('it should have aria-label on the button element if isIconOnly is set to true', async function (assert) {
@@ -201,6 +248,34 @@ module('Integration | Component | hds/button/index', function (hooks) {
     });
     await render(
       hbs`<Hds::Button @text="copy to clipboard" @color="tertiary" />`
+    );
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+  test('it should throw an assertion if @color is "critical" and @badge is provided', async function (assert) {
+    const errorMessage =
+      '@badge can not be rendered when the "Hds::Button" @color is "critical"';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(
+      hbs`<Hds::Button @text="Lorem ipsum" @color="critical" @badge="Badge" />`
+    );
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+  test('it should throw an assertion if @color is "critical" and @count is provided', async function (assert) {
+    const errorMessage =
+      '@count can not be rendered when the "Hds::Button" @color is "critical"';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(
+      hbs`<Hds::Button @text="Lorem ipsum" @color="critical" @count="3" />`
     );
     assert.throws(function () {
       throw new Error(errorMessage);

--- a/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
@@ -42,6 +42,15 @@ module(
       assert.dom('.flight-icon.flight-icon-chevron-down').exists();
     });
 
+    // ICON
+
+    test('it should render an icon if @icon is defined', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" @icon="hexagon" id="test-toggle-button" />`
+      );
+      assert.dom('.flight-icon.flight-icon-hexagon').exists();
+    });
+
     // COLOR
 
     test('it should render the primary color as the default if no color is declared', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

Extend `Hds::Dropdown::ToggleButton` with support for leading `Icon`, `Badge`, and `BadgeCount` and update  `Dropdown::ToggleIcon` styles to support the upcoming 'Filter' pattern.

### :hammer_and_wrench: Detailed description

 - Update `ToggleIcon`'s default state style to align with the style of the secondary button. This improves the affordance of the button and allows us to future-proof for a dark mode version. The other states remain the same.
 - Allow `Badge` (via `@badge` and `@badgeIcon`) and `BadgeCount` (via `@count`) as trailing content in `Button` and `ToggleButton`
 - Allow Icon (via `@icon`) alongside chevron in `ToggleButton` (we're introducing a `@hasChevron` argument to the Button component, for internal usage, to allow the `ToggleButton` to also have a leading icon when needed)

[👉 Preview `Button` showcase](https://hds-showcase-93qco6btu-hashicorp.vercel.app/components/button)
[👉 Preview `Dropdown::ToggleButton` showcase](https://hds-showcase-93qco6btu-hashicorp.vercel.app/components/dropdown)

#### Notes on tradeoffs

To avoid breaking changes on the Button component:
- we're taking the approach of generating the Badge within the Button component and opening the API only for the text and icon of the Badge (e.g. `<Hds::Button @text="button" @badge="badge"/>`), as opposed to allowing users to invoke a Badge instance within the Button component (e.g. `<Hds::Button>button <Hds::Badge @text="badge"></Hds::Button>`) – this also ensures the required adjacent contrast required for accessibility compliance
- we're adding the `@hasChevron` as a workaround to allow a leading icon and the chevron as trailing icon on a Button, as opposed to changing the Button API to allow both a leading and a trailing icon.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1109](https://hashicorp.atlassian.net/browse/HDS-1109)
Figma file: https://www.figma.com/file/Kgc8BgB8jGuJXISndgTrD1/Dropdown?node-id=29345%3A69392&t=h2KjNpimGUUm0DCW-4 and https://www.figma.com/file/SBw7wkwlPBnkNERKRAMxoR/Badge-in-Button?node-id=30893%3A117893&t=t6G71WRPZBKwfjhr-4

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1109]: https://hashicorp.atlassian.net/browse/HDS-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ