### PR TITLE
`SideNav` - Add ariaLabel arg to `HomeLink`

### DIFF
--- a/packages/components/addon/components/hds/side-nav/home-link.hbs
+++ b/packages/components/addon/components/hds/side-nav/home-link.hbs
@@ -9,6 +9,7 @@
   @href={{@href}}
   @isHrefExternal={{@isHrefExternal}}
   ...attributes
+  aria-label={{this.ariaLabel}}
 >
   <FlightIcon @name={{@icon}} @color={{@color}} @stretched={{true}} />
 </Hds::Interactive>

--- a/packages/components/addon/components/hds/side-nav/home-link.js
+++ b/packages/components/addon/components/hds/side-nav/home-link.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+export default class HdsSideNavHomeLinkComponent extends Component {
+  /**
+   * @param ariaLabel
+   * @type {string}
+   * @description The value of `aria-label`
+   */
+  get ariaLabel() {
+    let { ariaLabel } = this.args;
+
+    assert(
+      '@ariaLabel for "Hds::SideNav::HomeLink" must have a valid value',
+      ariaLabel !== undefined
+    );
+
+    return ariaLabel;
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/side-nav.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav.hbs
@@ -12,7 +12,7 @@
           <:header>
             <Hds::SideNav::Header>
               <:logo>
-                <Hds::SideNav::HomeLink @icon="hashicorp" @text="HashiCorp" @href="#" />
+                <Hds::SideNav::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
               </:logo>
               <:actions>
                 <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
@@ -67,7 +67,7 @@
           <:header>
             <Hds::SideNav::Header>
               <:logo>
-                <Hds::SideNav::HomeLink @icon="hashicorp" @text="HashiCorp" @href="#" />
+                <Hds::SideNav::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
               </:logo>
               <:actions>
                 <Hds::SideNav::IconButton @icon="search" @ariaLabel="Search" />
@@ -205,7 +205,7 @@
       <div class="shw-component-sim-side-nav-header">
         <Hds::SideNav::Header>
           <:logo>
-            <Hds::SideNav::HomeLink @icon="hashicorp" @text="HashiCorp" @href="#" />
+            <Hds::SideNav::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
           </:logo>
           <:actions>
             <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
@@ -238,14 +238,14 @@
   <Shw::Flex as |SF|>
     <SF.Item @label="Icon">
       <div class="shw-component-side-nav-home-link-wrapper">
-        <Hds::SideNav::HomeLink @icon="hashicorp" @text="HashiCorp" @href="#" />
+        <Hds::SideNav::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
       </div>
     </SF.Item>
     <SF.Item @label="Icon with custom color">
       <div class="shw-component-side-nav-home-link-wrapper">
         <Hds::SideNav::HomeLink
           @icon="boundary"
-          @text="Boundary"
+          @ariaLabel="Boundary"
           @color="var(--token-color-boundary-brand)"
           @href="#"
         />
@@ -260,7 +260,7 @@
       {{#each states as |state|}}
         <SF.Item @label={{state}}>
           <div class="shw-component-side-nav-home-link-wrapper">
-            <Hds::SideNav::HomeLink @icon="hashicorp" @text="HashiCorp" @href="#" mock-state-value={{state}} />
+            <Hds::SideNav::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" mock-state-value={{state}} />
           </div>
         </SF.Item>
       {{/each}}
@@ -273,6 +273,7 @@
           <div class="shw-component-side-nav-home-link-wrapper">
             <Hds::SideNav::HomeLink
               @icon="boundary"
+              @ariaLabel="Boundary"
               @color="var(--token-color-boundary-brand)"
               @href="#"
               mock-state-value={{state}}

--- a/packages/components/tests/integration/components/hds/side-nav/home-link-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/home-link-test.js
@@ -1,21 +1,27 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | hds/side-nav/home-link', function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
+
   // Basic
 
   test('it renders the component', async function (assert) {
-    await render(hbs`<Hds::SideNav::HomeLink @icon="hashicorp" />`);
+    await render(
+      hbs`<Hds::SideNav::HomeLink @icon="hashicorp" @ariaLabel="Hashicorp" />`
+    );
     assert.dom(this.element).exists();
   });
 
   test('it should render with a CSS class that matches the component name', async function (assert) {
     await render(
-      hbs`<Hds::SideNav::HomeLink @icon="hashicorp" id="test-home-link" />`
+      hbs`<Hds::SideNav::HomeLink @icon="hashicorp" @ariaLabel="Hashicorp" id="test-home-link" />`
     );
     assert.dom('#test-home-link').hasClass('hds-side-nav__home-link');
   });
@@ -24,7 +30,7 @@ module('Integration | Component | hds/side-nav/home-link', function (hooks) {
 
   test('it renders the passed in args', async function (assert) {
     await render(
-      hbs`<Hds::SideNav::HomeLink @icon="hashicorp" @href="https://www.hashicorp.com/" id="test-home-link" />`
+      hbs`<Hds::SideNav::HomeLink @icon="hashicorp" @ariaLabel="Hashicorp" @href="https://www.hashicorp.com/" id="test-home-link" />`
     );
     assert.dom('.flight-icon-hashicorp').exists();
     assert
@@ -34,7 +40,7 @@ module('Integration | Component | hds/side-nav/home-link', function (hooks) {
 
   test('it renders the logo with a custom passed in color', async function (assert) {
     await render(
-      hbs`<Hds::SideNav::HomeLink @icon="boundary" @color="var(--token-color-boundary-brand)" @href="#" />`
+      hbs`<Hds::SideNav::HomeLink @icon="boundary" @ariaLabel="Boundary" @color="var(--token-color-boundary-brand)" @href="#" />`
     );
     assert
       .dom('.flight-icon-boundary')
@@ -45,10 +51,25 @@ module('Integration | Component | hds/side-nav/home-link', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the element', async function (assert) {
     await render(
-      hbs`<Hds::SideNav::HomeLink @icon="hashicorp" id="test-sidenav-homelink" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::SideNav::HomeLink @icon="hashicorp" @ariaLabel="Hashicorp" id="test-sidenav-homelink" class="my-class" data-test1 data-test2="test" />`
     );
     assert.dom('#test-sidenav-homelink').hasClass('my-class');
     assert.dom('#test-sidenav-homelink').hasAttribute('data-test1');
     assert.dom('#test-sidenav-homelink').hasAttribute('data-test2', 'test');
+  });
+
+  // ASSERTIONS
+
+  test('it should throw an assertion if @ariaLabel is missing/has no value', async function (assert) {
+    const errorMessage =
+      '@ariaLabel for "Hds::SideNav::HomeLink" must have a valid value';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::SideNav::HomeLink @icon="hashicorp" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
   });
 });


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will add an `@ariaLabel` arg to the `SideNav::HomeLink` component to help ensure better accessibility and to match the API of the very similar `SideNav::IconButton` component.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser 
-->

### :link: External links
See [related discussion in this PR](https://github.com/hashicorp/design-system/pull/1250#discussion_r1137752758).
<!--
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]
-->

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
