### PR TITLE
Make the Disclosure mechanism more resilient

### DIFF
--- a/.changeset/hip-icons-dance.md
+++ b/.changeset/hip-icons-dance.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Make the `Disclosure` mechanism more resilient

--- a/packages/components/addon/components/hds/disclosure/index.js
+++ b/packages/components/addon/components/hds/disclosure/index.js
@@ -30,10 +30,9 @@ export default class HdsDisclosureComponent extends Component {
 
   @action
   onFocusOut(event) {
-    if (
-      !event.relatedTarget || // click or tap a non-related target (e.g. outside the element)
-      !this.element.contains(event.relatedTarget) // move focus to a target outside the element
-    ) {
+    // due to inconsitent implementation of relatedTarget across browsers we use the activeElement as a fallback
+    // if the related target is not part of the disclosed content we close the disclosed container
+    if (!this.element.contains(event.relatedTarget || document.activeElement)) {
       this.close();
     }
   }

--- a/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities/disclosure.hbs
@@ -52,6 +52,31 @@
   </Shw::Flex>
 
   <Shw::Flex as |SF|>
+    <SF.Label>With generic HTML
+      <code>&lt;button&gt;</code>
+      and generic
+      <code>&lt;input type="date"&gt;</code>
+    </SF.Label>
+    <SF.Item @grow={{true}}>
+      <div class="shw-utility-disclosure-container">
+        <Hds::Disclosure>
+          <:toggle as |t|>
+            <button type="button" {{on "click" t.onClickToggle}}>Click me</button>
+          </:toggle>
+          <:content>
+            <ul class="shw-utility-disclosure-content-list-of-links">
+              <li>
+                <label for="date-input">Select date</label>
+                <input id="date-input" type="date" />
+              </li>
+            </ul>
+          </:content>
+        </Hds::Disclosure>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex as |SF|>
     <SF.Label>With <code>&lt;Hds::Button&gt;</code> and generic list of <code>&lt;a&gt;</code> links</SF.Label>
     <SF.Item @grow={{true}}>
       <div class="shw-utility-disclosure-container">

--- a/packages/components/tests/integration/components/hds/disclosure/index-test.js
+++ b/packages/components/tests/integration/components/hds/disclosure/index-test.js
@@ -93,7 +93,10 @@ module('Integration | Component | hds/disclosure/index', function (hooks) {
     await click('button#test-disclosure-button');
     assert.dom('.hds-disclosure__content').exists();
     assert.dom('a#test-disclosure-link').exists();
-    await triggerEvent('#test-disclosure', 'focusout');
+    // simulating the focus moves to the body element
+    await triggerEvent('#test-disclosure', 'focusout', {
+      relatedTarget: document.body,
+    });
     assert.dom('.hds-disclosure__content').doesNotExist();
     assert.dom('a#test-disclosure-link').doesNotExist();
   });


### PR DESCRIPTION
### :pushpin: Summary

Use `document.activeElement` as fallback for `event.relatedTarget` to make the disclosure mechanism more resilient.

### :hammer_and_wrench: Detailed description

The specific example where the current implementation resulted in unexpected behavior is when a native `<input type="date">` is used inside the disclosed content, causing the dropdown to close when the widget was open in Firefox.

To prevent the inconsistent implementation of `relatedTarget` across browsers from causing these issues, we use the `activeElement` as a fallback.

This change also enables developers to debug the disclosed content, which was previously closed as soon as the developer toolbar received focus.

[👉 Preview changes](https://hds-showcase-f0sqgkgou-hashicorp.vercel.app/utilities/disclosure)

### :camera_flash: Screenshots

Firefox on macOS

#### Before


https://user-images.githubusercontent.com/788096/226340159-066fed4a-a18a-4d79-bdb7-6c88a99758f9.mov


#### After


https://user-images.githubusercontent.com/788096/226340201-a9c96978-c9dc-48d4-859c-4cf94be135bf.mov



### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1540](https://hashicorp.atlassian.net/browse/HDS-1540)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1540]: https://hashicorp.atlassian.net/browse/HDS-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ