### PR TITLE
Update Component API documentation pages to standardize the `LinkTo` arguments

### DIFF
--- a/website/docs/components/button/partials/code/component-api.md
+++ b/website/docs/components/button/partials/code/component-api.md
@@ -7,7 +7,7 @@
     Text of the button or value of `aria-label` if `isIconOnly` is set to `true`. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="icon" @type="string">
-    Used to show an icon. Any [icon](/icons/library) name is accepted. 
+    Used to show an icon. Any [icon](/icons/library) name is accepted.
     <br/><br/>
     Tertiary buttons have transparent backgrounds, and interactive elements must communicate interactivity with more than just color. Therefore, a leading or trailing icon is required when using the `tertiary` color. [WCAG 2.1 Criterion 1.4.1: Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=141#use-of-color)
   </C.Property>
@@ -26,7 +26,7 @@
   <C.Property @name="isHrefExternal" @type="boolean" @values={{array "false" "true" }} @default="false">
     Controls if the `<a>` link is external and so for security reasons we need to add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it.
   </C.Property>
-  <C.Property @name="route models model query current-when replace">
+  <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo/LinkToExternal>` component.
   </C.Property>
   <C.Property @name="isRouteExternal" @type="boolean" @values={{array "false" "true" }} @default="false">

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -21,7 +21,7 @@ The Dropdown component is composed of different child components each with their
     By default, the Dropdown List has a `min-width` of `200px` and a `max-width` of `400px`, so it adapts to the content size. If a `@width` parameter is provided then the list will have a fixed width.
   </C.Property>
   <C.Property @name="close" @type="function">
-    Function to programmatically close the dropdown. 
+    Function to programmatically close the dropdown.
     <br/><br/>
     If this function is invoked using an `\{{on "click"}}` modifier applied to the `ListItem::Interactive` element, there is a quirky behavior of the Ember `<LinkTo>` component which requires a workaround to have the events executed in the right order (this happens only if it has a `@route` argument). Read more about the issue and a possible solution [in this GitHub comment](https://github.com/hashicorp/design-system/pull/399#issuecomment-1171186772).
   </C.Property>
@@ -85,7 +85,7 @@ The Dropdown component is composed of different child components each with their
   <C.Property @name="isHrefExternal" @type="boolean" @values={{array "false" "true" }} @default="false">
     Indicates whether or not the `<a>` link is external, in which case `target="_blank"` and `rel="noopener noreferrer"` attributes are added automatically.
   </C.Property>
-  <C.Property @name="route models model query current-when replace">
+  <C.Property @name="route/models/model/query/current-when/replace">
     Parameters passed as arguments to the `<LinkTo/LinkToExternal>` component.
   </C.Property>
   <C.Property @name="isRouteExternal" @type="boolean" @values={{array "false" "true" }} @default="false">

--- a/website/docs/components/link/inline/partials/code/component-api.md
+++ b/website/docs/components/link/inline/partials/code/component-api.md
@@ -14,7 +14,7 @@
   <C.Property @name="isHrefExternal" @type="boolean" @values={{array "false" "true" }} @default="false">
     Controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
   </C.Property>
-  <C.Property @name="route models model query current-when replace">
+  <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
   </C.Property>
   <C.Property @name="isRouteExternal" @type="boolean" @values={{array "false" "true" }} @default="false">

--- a/website/docs/components/link/standalone/partials/code/component-api.md
+++ b/website/docs/components/link/standalone/partials/code/component-api.md
@@ -18,7 +18,7 @@
   <C.Property @name="isHrefExternal" @type="boolean" @values={{array "false" "true" }} @default="false">
     Controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
   </C.Property>
-  <C.Property @name="route models model query current-when replace">
+  <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
   </C.Property>
   <C.Property @name="isRouteExternal" @type="boolean" @values={{array "false" "true" }} @default="false">

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -108,7 +108,7 @@ Controls the visibility of the total items in the informational text.
 <C.Property @name="direction" @required="true" @type="enum" @values={{array "prev" "next"}}>
 Sets the "direction" of the icon and label in the control.
 </C.Property>
-<C.Property @name="route/query/model/models/replace">
+<C.Property @name="route/models/model/query/replace">
 These are the parameters that are passed down as arguments to the `Hds::Interactive` component (used internally). For more details about how this low-level component works, please refer to [its documentation page](/utilities/interactive/).
 </C.Property>
 <C.Property @name="disabled" @type="boolean" @values={{array "true" "false" }} @default="false">
@@ -133,7 +133,7 @@ The value that should go in the control as page number.
 <C.Property @name="isSelected" @type="boolean" @values={{array "true" "false" }} @default="false">
 If the page has a "selected" visual state (usually used to highlight the current page).
 </C.Property>
-<C.Property @name="route/query/model/models/replace">
+<C.Property @name="route/models/model/query/replace">
 These are the parameters that are passed down as arguments to the `Hds::Interactive` component (used internally). For more details about how this low-level component works, please refer to [its documentation page](/utilities/interactive/).
 </C.Property>
 <C.Property @name="onClick" @type="function">

--- a/website/docs/components/tag/partials/code/component-api.md
+++ b/website/docs/components/tag/partials/code/component-api.md
@@ -10,7 +10,7 @@
   <C.Property @name="isHrefExternal" @type="boolean" @values={{array "false" "true" }} @default="false">
     This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
   </C.Property>
-  <C.Property @name="route models model query current-when replace">
+  <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
   </C.Property>
   <C.Property @name="isRouteExternal" @type="boolean" @values={{array "false" "true" }} @default="false">

--- a/website/docs/utilities/interactive/partials/code/component-api.md
+++ b/website/docs/utilities/interactive/partials/code/component-api.md
@@ -7,7 +7,7 @@
   <C.Property @name="isHrefExternal" @type="boolean" @values={{array "false" "true" }} @default="false">
     This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
   </C.Property>
-  <C.Property @name="route models model query current-when replace">
+  <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
   </C.Property>
   <C.Property @name="isRouteExternal" @type="boolean" @values={{array "false" "true" }} @default="false">


### PR DESCRIPTION
### :pushpin: Summary

Small PR to standardize the way we declare the `route/models/model/query/current-when/replace` properties (forwarded to the `Hds::Interactive` component) in the Component API documentation for our components.

(reason: I was searching for an example, and I found only one, and I thought it was the only one; actually there are several ones, only they were with different format, and in different order)

Preview: https://hds-website-git-standardize-component-api-inte-44a682-hashicorp.vercel.app/components/link/inline?tab=code#component-api

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
