### PR TITLE
Add new `@listPosition`s for `Dropdown`

### DIFF
--- a/.changeset/slow-masks-fetch.md
+++ b/.changeset/slow-masks-fetch.md
@@ -1,0 +1,11 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Add new `@listPositions` for `Dropdown` as follows:
+ - `bottom-left`
+ - `bottom-right` (default)
+ - `top-left`
+ - `top-right`
+
+ **Note:** `left` and `right` are now deprecated and will be removed in a future major release

--- a/packages/components/addon/components/hds/dropdown/index.js
+++ b/packages/components/addon/components/hds/dropdown/index.js
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
 export const DEFAULT_POSITION = 'right';
-export const POSITIONS = ['right', 'left'];
+export const POSITIONS = ['right', 'left', 'top-left', 'top-right'];
 
 export default class HdsDropdownIndexComponent extends Component {
   /**

--- a/packages/components/addon/components/hds/dropdown/index.js
+++ b/packages/components/addon/components/hds/dropdown/index.js
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
 export const DEFAULT_POSITION = 'bottom-right';
+// TODO: retire 'right' and 'left' in favor of `bottom-right` and `bottom-left` https://github.com/hashicorp/design-system/pull/1262
 export const POSITIONS = [
   'right',
   'left',

--- a/packages/components/addon/components/hds/dropdown/index.js
+++ b/packages/components/addon/components/hds/dropdown/index.js
@@ -7,14 +7,21 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
-export const DEFAULT_POSITION = 'right';
-export const POSITIONS = ['right', 'left', 'top-left', 'top-right'];
+export const DEFAULT_POSITION = 'bottom-right';
+export const POSITIONS = [
+  'right',
+  'left',
+  'bottom-left',
+  'bottom-right',
+  'top-left',
+  'top-right',
+];
 
 export default class HdsDropdownIndexComponent extends Component {
   /**
    * @param listPosition
    * @type {string}
-   * @default primary
+   * @default bottom-right
    * @description Determines the position of the "list"
    */
   get listPosition() {

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -136,7 +136,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
-  z-index: 2; // https://github.com/hashicorp/design-system/issues/114
+  z-index: 2;
 }
 
 .hds-dropdown__content--position-bottom-left,
@@ -144,21 +144,21 @@ $hds-dropdown-toggle-border-radius: 5px;
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
-  z-index: 2; // https://github.com/hashicorp/design-system/issues/114
+  z-index: 2;
 }
 
 .hds-dropdown__content--position-top-right {
   position: absolute;
   right: 0;
   bottom: calc(100% + 4px);
-  z-index: 2; // https://github.com/hashicorp/design-system/issues/114
+  z-index: 2;
 }
 
 .hds-dropdown__content--position-top-left {
   position: absolute;
   bottom: calc(100% + 4px);
   left: 0;
-  z-index: 2; // https://github.com/hashicorp/design-system/issues/114
+  z-index: 2;
 }
 
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -131,6 +131,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   max-width: initial;
 }
 
+.hds-dropdown__content--position-bottom-right,
 .hds-dropdown__content--position-right {
   position: absolute;
   top: calc(100% + 4px);
@@ -138,6 +139,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   z-index: 2; // https://github.com/hashicorp/design-system/issues/114
 }
 
+.hds-dropdown__content--position-bottom-left,
 .hds-dropdown__content--position-left {
   position: absolute;
   top: calc(100% + 4px);

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -145,6 +145,21 @@ $hds-dropdown-toggle-border-radius: 5px;
   z-index: 2; // https://github.com/hashicorp/design-system/issues/114
 }
 
+.hds-dropdown__content--position-top-right {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 4px);
+  z-index: 2; // https://github.com/hashicorp/design-system/issues/114
+}
+
+.hds-dropdown__content--position-top-left {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 0;
+  z-index: 2; // https://github.com/hashicorp/design-system/issues/114
+}
+
+
 .hds-dropdown__list {
   flex: 1 1 auto;
   margin: 0;

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -9,6 +9,41 @@
 
 <section data-test-percy>
 
+  <Shw::Text::H2>Position</Shw::Text::H2>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Left">
+      <Hds::Dropdown @listPosition="left" as |dd|>
+        <dd.ToggleButton @color="secondary" @text="Menu" />
+        <dd.Interactive @href="#" @text="Create" />
+        <dd.Interactive @href="#" @text="Edit" />
+      </Hds::Dropdown>
+    </SF.Item>
+    <SF.Item @label="Right (default)">
+      <Hds::Dropdown as |dd|>
+        <dd.ToggleButton @color="secondary" @text="Menu" />
+        <dd.Interactive @href="#" @text="Create" />
+        <dd.Interactive @href="#" @text="Edit" />
+      </Hds::Dropdown>
+    </SF.Item>
+    <SF.Item @label="Top left">
+      <Hds::Dropdown @listPosition="top-left" as |dd|>
+        <dd.ToggleButton @color="secondary" @text="Menu" />
+        <dd.Interactive @href="#" @text="Create" />
+        <dd.Interactive @href="#" @text="Edit" />
+      </Hds::Dropdown>
+    </SF.Item>
+    <SF.Item @label="Top right">
+      <Hds::Dropdown @listPosition="top-right" as |dd|>
+        <dd.ToggleButton @color="secondary" @text="Menu" />
+        <dd.Interactive @href="#" @text="Create" />
+        <dd.Interactive @href="#" @text="Edit" />
+      </Hds::Dropdown>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Divider />
+
   <Shw::Text::H2>Toggles</Shw::Text::H2>
 
   <Shw::Text::H3>Button</Shw::Text::H3>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -12,14 +12,14 @@
   <Shw::Text::H2>Position</Shw::Text::H2>
 
   <Shw::Flex as |SF|>
-    <SF.Item @label="Left">
-      <Hds::Dropdown @listPosition="left" as |dd|>
+    <SF.Item @label="Bottom left">
+      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
         <dd.ToggleButton @color="secondary" @text="Menu" />
         <dd.Interactive @href="#" @text="Create" />
         <dd.Interactive @href="#" @text="Edit" />
       </Hds::Dropdown>
     </SF.Item>
-    <SF.Item @label="Right (default)">
+    <SF.Item @label="Bottom right (default)">
       <Hds::Dropdown as |dd|>
         <dd.ToggleButton @color="secondary" @text="Menu" />
         <dd.Interactive @href="#" @text="Create" />

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -95,7 +95,7 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     await click('button#test-toggle-button');
     assert
       .dom('#test-dropdown .hds-dropdown__content')
-      .hasClass('hds-dropdown__content--position-right');
+      .hasClass('hds-dropdown__content--position-bottom-right');
   });
   test('it should render the content aligned on the left if the value of @listPosition is "left"', async function (assert) {
     await render(hbs`


### PR DESCRIPTION
### :pushpin: Summary

Add top positions for dropdown list.

### :hammer_and_wrench: Detailed description

Extend the dropdown `@listPosition` API by adding support to `top-left` and `top-right`.

~~The existing properties are `left` and `right` (default); while there is an opportunity to align values by updating these to `bottom-left` and `bottom-right` it would mean a breaking change for the consumers which may arguably be worth pursuing.~~

Update: we decided to add `bottom-left` and `bottom-right` (default) at this time, with the intention to retire `left` and `right` in a future breaking release, after updating the consumers code (potentially via codemod).

[👉 Preview changes](https://hds-showcase-git-alex-ju-dropdown-extension-4-hashicorp.vercel.app/components/dropdown)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1684](https://hashicorp.atlassian.net/browse/HDS-1684)
Figma file: https://www.figma.com/file/Kgc8BgB8jGuJXISndgTrD1/Dropdown?node-id=5793-21152&t=iOJ801rNqXMhUrby-4

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Dependant on #1212 (to apply the modifiers to the content, instead of list)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1684]: https://hashicorp.atlassian.net/browse/HDS-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ