### PR TITLE
Form pattern documentation fixes

### DIFF
--- a/website/docs/patterns/form-patterns/partials/guidelines/guidelines.md
+++ b/website/docs/patterns/form-patterns/partials/guidelines/guidelines.md
@@ -133,7 +133,7 @@ Text elements within a form should use logical, step-based sizing to reinforce h
 
 ## Button sets
 
-Organize buttons based on the [ButtonSet](/components/button-set) guidelines, e.g., using a 16px horizontal gap between buttons.
+Organize buttons based on the [Button Set](/components/button-set) guidelines, e.g., using a 16px horizontal gap between buttons.
 
 ![Button set](/assets/patterns/form-patterns/button-set.png =500x*)
 

--- a/website/docs/patterns/form-patterns/partials/guidelines/guidelines.md
+++ b/website/docs/patterns/form-patterns/partials/guidelines/guidelines.md
@@ -151,8 +151,6 @@ Generally, fields that are dependencies for other fields benefit from being orga
 
 ![Dependencies within forms example](/assets/patterns/form-patterns/cluster-tier-size-options.png)
 
-Read more about showing elements conditionally with [progressive disclosure](#progressive-disclosure).
-
 #### User needs
 
 Users benefit from logical organization and progressive organization, organizing fields from easiest to hardest.


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR will make slight fixes in the Form Patterns documentation based on feedback from Liz, including:
- Consistency in referring to `Button Set`
- Removal of a dead link that directed to content around progressive disclosure that will be tackled in [HDS-1610](https://hashicorp.atlassian.net/browse/HDS-1610)


[HDS-1610]: https://hashicorp.atlassian.net/browse/HDS-1610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ