### PR TITLE
Extend `Dropdown::ToggleButton`

### DIFF
--- a/.changeset/dry-cherries-unite.md
+++ b/.changeset/dry-cherries-unite.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Add `@icon`, `@count`, `@badge` and `@badgeCount` to `Dropdown::Toggle::Button`

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -4,8 +4,8 @@
 }}
 <button
   class={{this.classNames}}
-  type="button"
   ...attributes
+  type="button"
   aria-expanded={{if @isOpen "true" "false"}}
   {{on "click" this.onClick}}
 >

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -17,6 +17,14 @@
   <div class="hds-dropdown-toggle-button__text">
     {{this.text}}
   </div>
+  {{#if @count}}
+    <Hds::BadgeCount
+      @text={{@count}}
+      @size="small"
+      @type={{this.countType}}
+      class="hds-dropdown-toggle-button__count"
+    />
+  {{/if}}
   <div class="hds-dropdown-toggle-button__indicator">
     <FlightIcon @name="chevron-down" @size={{this.iconSize}} @stretched={{true}} />
   </div>

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -11,7 +11,7 @@
 >
   {{#if @icon}}
     <div class="hds-dropdown-toggle-button__icon">
-      <FlightIcon @name={{@icon}} @size={{this.iconSize}} @stretched={{true}} />
+      <FlightIcon @name={{@icon}} @stretched={{true}} />
     </div>
   {{/if}}
   <div class="hds-dropdown-toggle-button__text">

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -9,6 +9,11 @@
   aria-expanded={{if @isOpen "true" "false"}}
   {{on "click" this.onClick}}
 >
+  {{#if @icon}}
+    <div class="hds-dropdown-toggle-button__icon">
+      <FlightIcon @name={{@icon}} @size={{this.iconSize}} @stretched={{true}} />
+    </div>
+  {{/if}}
   <div class="hds-dropdown-toggle-button__text">
     {{this.text}}
   </div>

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -21,8 +21,17 @@
     <Hds::BadgeCount
       @text={{@count}}
       @size="small"
-      @type={{this.countType}}
+      @type={{this.badgeType}}
       class="hds-dropdown-toggle-button__count"
+    />
+  {{/if}}
+  {{#if @badge}}
+    <Hds::Badge
+      @text={{@badge}}
+      @icon={{@badgeIcon}}
+      @size="small"
+      @type={{this.badgeType}}
+      class="hds-dropdown-toggle-button__badge"
     />
   {{/if}}
   <div class="hds-dropdown-toggle-button__indicator">

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -9,10 +9,10 @@
   aria-expanded={{if @isOpen "true" "false"}}
   {{on "click" this.onClick}}
 >
-  <div class="hds-button__text">
+  <div class="hds-dropdown-toggle-button__text">
     {{this.text}}
   </div>
-  <div class="hds-button__icon">
+  <div class="hds-dropdown-toggle-button__indicator">
     <FlightIcon @name="chevron-down" @size={{this.iconSize}} @stretched={{true}} />
   </div>
 </button>

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -2,28 +2,17 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-{{!
-// >>>>>>>>>>> WARNING <<<<<<<<<<
-//
-// Notice: in this component we're directly using the `Hds::Button` component
-// (and adding a specialized class for the "toggle-button" variant, see below)
-// If you need to change the styling of the `Button` component, remember that this will impact also
-// this component too.
-// If instead you need to change only the styling of the `toggle-button` component, you can do it
-// in the CSS file using the specialized class declared there.
-// This is NOT a standard approach that we use in the HDS design system implementation, but it's been
-// the least worst option we could find to solve the problem of sharing the exact same style of the
-// `Button (primary)` with other components.
-}}
-
-<Hds::Button
+<button
   class={{this.classNames}}
-  @text={{this.text}}
-  @icon="chevron-down"
-  @iconPosition="trailing"
-  @color={{this.color}}
-  @size={{@size}}
+  type="button"
   ...attributes
   aria-expanded={{if @isOpen "true" "false"}}
   {{on "click" this.onClick}}
-/>
+>
+  <div class="hds-button__text">
+    {{this.text}}
+  </div>
+  <div class="hds-button__icon">
+    <FlightIcon @name="chevron-down" @size={{this.iconSize}} @stretched={{true}} />
+  </div>
+</button>

--- a/packages/components/addon/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.hbs
@@ -34,7 +34,5 @@
       class="hds-dropdown-toggle-button__badge"
     />
   {{/if}}
-  <div class="hds-dropdown-toggle-button__indicator">
-    <FlightIcon @name="chevron-down" @size={{this.iconSize}} @stretched={{true}} />
-  </div>
+  <Hds::Dropdown::Toggle::Chevron />
 </button>

--- a/packages/components/addon/components/hds/dropdown/toggle/button.js
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.js
@@ -110,12 +110,12 @@ export default class HdsDropdownToggleButtonComponent extends Component {
   }
 
   /**
-   * @param countType
+   * @param badgeType
    * @type {string}
    * @default 'filled'
-   * @description ensures that the correct countBadge type size is used to meet contrast requirements
+   * @description ensures that the correct Badge/badgeCount type is used to meet contrast requirements
    */
-  get countType() {
+  get badgeType() {
     return this.color !== 'primary' ? 'inverted' : 'filled';
   }
 

--- a/packages/components/addon/components/hds/dropdown/toggle/button.js
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.js
@@ -115,17 +115,17 @@ export default class HdsDropdownToggleButtonComponent extends Component {
    * @return {string} The "class" attribute to apply to the component.
    */
   get classNames() {
-    let classes = ['hds-dropdown-toggle-button hds-button'];
+    let classes = ['hds-dropdown-toggle-button'];
 
     // add a class based on the @size argument
-    classes.push(`hds-button--size-${this.size}`);
+    classes.push(`hds-dropdown-toggle-button--size-${this.size}`);
 
     // add a class based on the @color argument
-    classes.push(`hds-button--color-${this.color}`);
+    classes.push(`hds-dropdown-toggle-button--color-${this.color}`);
 
     // add a class based on the @isFullWidth argument
     if (this.isFullWidth) {
-      classes.push('hds-button--width-full');
+      classes.push('hds-dropdown-toggle-button--width-full');
     }
 
     // add a class based on the @isOpen argument

--- a/packages/components/addon/components/hds/dropdown/toggle/button.js
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.js
@@ -34,7 +34,7 @@ export default class HdsDropdownToggleButtonComponent extends Component {
    * @param size
    * @type {string}
    * @default medium
-   * @description The size of the button; acceptable values are `small`, `medium`, and `large`
+   * @description The size of the button; acceptable values are `small` and `medium`
    */
   get size() {
     let { size = DEFAULT_SIZE } = this.args;
@@ -69,20 +69,6 @@ export default class HdsDropdownToggleButtonComponent extends Component {
   }
 
   /**
-   * @param iconSize
-   * @type {string}
-   * @default 16
-   * @description ensures that the correct icon size is used. Automatically calculated.
-   */
-  get iconSize() {
-    if (this.args.size === 'large') {
-      return '24';
-    } else {
-      return '16';
-    }
-  }
-
-  /**
    * @param isFullWidth
    * @type {boolean}
    * @default false
@@ -113,7 +99,7 @@ export default class HdsDropdownToggleButtonComponent extends Component {
    * @param badgeType
    * @type {string}
    * @default 'filled'
-   * @description ensures that the correct Badge/badgeCount type is used to meet contrast requirements
+   * @description ensures that the correct Badge/BadgeCount type is used to meet contrast requirements
    */
   get badgeType() {
     return this.color !== 'primary' ? 'inverted' : 'filled';

--- a/packages/components/addon/components/hds/dropdown/toggle/button.js
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.js
@@ -6,7 +6,9 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
+export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_COLOR = 'primary';
+export const SIZES = ['small', 'medium'];
 export const COLORS = ['primary', 'secondary'];
 
 const NOOP = () => {};
@@ -29,6 +31,25 @@ export default class HdsDropdownToggleButtonComponent extends Component {
   }
 
   /**
+   * @param size
+   * @type {string}
+   * @default medium
+   * @description The size of the button; acceptable values are `small`, `medium`, and `large`
+   */
+  get size() {
+    let { size = DEFAULT_SIZE } = this.args;
+
+    assert(
+      `@size for "Hds::Dropdown::Toggle::Button" must be one of the following: ${SIZES.join(
+        ', '
+      )}; received: ${size}`,
+      SIZES.includes(size)
+    );
+
+    return size;
+  }
+
+  /**
    * @param color
    * @type {string}
    * @default primary
@@ -45,6 +66,30 @@ export default class HdsDropdownToggleButtonComponent extends Component {
     );
 
     return color;
+  }
+
+  /**
+   * @param iconSize
+   * @type {string}
+   * @default 16
+   * @description ensures that the correct icon size is used. Automatically calculated.
+   */
+  get iconSize() {
+    if (this.args.size === 'large') {
+      return '24';
+    } else {
+      return '16';
+    }
+  }
+
+  /**
+   * @param isFullWidth
+   * @type {boolean}
+   * @default false
+   * @description Indicates that a button should take up the full width of the parent container. The default is false.
+   */
+  get isFullWidth() {
+    return this.args.isFullWidth ?? false;
   }
 
   /**
@@ -70,7 +115,18 @@ export default class HdsDropdownToggleButtonComponent extends Component {
    * @return {string} The "class" attribute to apply to the component.
    */
   get classNames() {
-    let classes = ['hds-dropdown-toggle-button'];
+    let classes = ['hds-dropdown-toggle-button hds-button'];
+
+    // add a class based on the @size argument
+    classes.push(`hds-button--size-${this.size}`);
+
+    // add a class based on the @color argument
+    classes.push(`hds-button--color-${this.color}`);
+
+    // add a class based on the @isFullWidth argument
+    if (this.isFullWidth) {
+      classes.push('hds-button--width-full');
+    }
 
     // add a class based on the @isOpen argument
     if (this.args.isOpen) {

--- a/packages/components/addon/components/hds/dropdown/toggle/button.js
+++ b/packages/components/addon/components/hds/dropdown/toggle/button.js
@@ -110,6 +110,16 @@ export default class HdsDropdownToggleButtonComponent extends Component {
   }
 
   /**
+   * @param countType
+   * @type {string}
+   * @default 'filled'
+   * @description ensures that the correct countBadge type size is used to meet contrast requirements
+   */
+  get countType() {
+    return this.color !== 'primary' ? 'inverted' : 'filled';
+  }
+
+  /**
    * Get the class names to apply to the component.
    * @method ToggleButton#classNames
    * @return {string} The "class" attribute to apply to the component.

--- a/packages/components/addon/components/hds/dropdown/toggle/chevron.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/chevron.hbs
@@ -1,0 +1,3 @@
+<div class="hds-dropdown-toggle-chevron">
+  <FlightIcon @name="chevron-down" @isInlineBlock={{false}} />
+</div>

--- a/packages/components/addon/components/hds/dropdown/toggle/icon.hbs
+++ b/packages/components/addon/components/hds/dropdown/toggle/icon.hbs
@@ -18,6 +18,6 @@
     {{/if}}
   </div>
   {{#if this.hasChevron}}
-    <FlightIcon @name="chevron-down" class="hds-dropdown-toggle-icon__chevron" @isInlineBlock={{false}} />
+    <Hds::Dropdown::Toggle::Chevron />
   {{/if}}
 </button>

--- a/packages/components/app/components/hds/dropdown/toggle/chevron.js
+++ b/packages/components/app/components/hds/dropdown/toggle/chevron.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export { default } from '@hashicorp/design-system-components/components/hds/dropdown/toggle/chevron';

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -9,25 +9,10 @@
 // notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
 //
 
-$hds-button-sizes: ( "small", "medium", "large" );
-$hds-button-border-radius: 5px;
-$hds-button-border-width: 1px;
-$hds-button-focus-border-width: 3px;
-
+@use "../mixins/button" as *;
 
 .hds-button {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: auto;
-  font-family: var(--token-typography-font-stack-text);
-  text-decoration: none;
-  border: $hds-button-border-width solid transparent; // We need this to be transparent for a11y
-  border-radius: $hds-button-border-radius;
-  outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
-  outline-color: transparent; // We need this to be transparent for a11y
-  isolation: isolate;
+  @include hds-button();
 
   // the <a> element behaves differently than a <button>
   @at-root a#{&} {
@@ -59,15 +44,7 @@ $hds-button-focus-border-width: 3px;
   &:disabled:hover,
   &[disabled]:hover,
   &.mock-disabled:hover {
-    color: var(--token-color-foreground-disabled);
-    background-color: var(--token-color-surface-faint);
-    border-color: var(--token-color-border-primary);
-    box-shadow: none;
-    cursor: not-allowed;
-
-    &::before {
-      border-color: transparent;
-    }
+    @include hds-button-state-disabled();
   }
 
   &.hds-button--width-full {
@@ -81,22 +58,7 @@ $hds-button-focus-border-width: 3px;
 
   &:focus,
   &.mock-focus {
-    box-shadow: none;
-
-    &::before {
-      // the position absolute of an element is computed from the inside of the border of the container
-      // so we have to take in account the border width of the pseudo-element container itself
-      $shift: $hds-button-border-width + $hds-button-focus-border-width;
-      position: absolute;
-      top: -$shift;
-      right: -$shift;
-      bottom: -$shift;
-      left: -$shift;
-      z-index: -1;
-      border: $hds-button-focus-border-width solid transparent;
-      border-radius: $hds-button-border-radius + $hds-button-focus-border-width;
-      content: "";
-    }
+    @include hds-button-state-focus();
   }
 }
 
@@ -114,31 +76,7 @@ $hds-button-focus-border-width: 3px;
 
 
 // SIZE
-
-// these values later may come from the design tokens
-$size-props: (
-  "small": (
-    "font-size": 0.8125rem, // 13px;
-    "line-height": 0.875rem, // 14px - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)
-    "min-height": 1.75rem,  // 28px
-    "padding": 0.375rem 0.6875rem, // 6px 11px - here we're taking into account the 1px border
-    "icon-size": 0.75rem, // 12px
-  ),
-  "medium": (
-    "font-size": 0.875rem, // 14px
-    "line-height": 1rem,// 16px
-    "min-height": 2.25rem, // 36px
-    "padding": 0.5625rem 0.9375rem, // 9px 15px - here we're taking into account the 1px border
-    "icon-size": 1rem, // 16px
-  ),
-  "large": (
-    "font-size": 1rem, // 16px
-    "line-height": 1.5rem, // 24px
-    "min-height": 3rem, // 48px
-    "padding": 0.6875rem 1.1875rem, // 11px 19px - here we're taking into account the 1px border
-    "icon-size": 1.5rem, // 24px
-  )
-);
+// Note: the $size-props matrix is stored in the "../mixins/button"
 
 @each $size in $hds-button-sizes {
   .hds-button--size-#{$size} {
@@ -162,184 +100,19 @@ $size-props: (
 // Note: the order of the pseuo-selectors need to stay the way they are; it doesn't match the Figma file but it's the correct order for browsers to render the styles correctly.
 
 .hds-button--color-primary {
-  color: var(--token-color-foreground-high-contrast);
-  background-color: var(--token-color-palette-blue-200);
-  border-color: var(--token-color-palette-blue-300);
-  box-shadow: var(--token-elevation-low-box-shadow);
-
-  &:hover,
-  &.mock-hover {
-    color: var(--token-color-foreground-high-contrast);
-    background-color: var(--token-color-palette-blue-300);
-    border-color: var(--token-color-palette-blue-400);
-    cursor: pointer;
-  }
-
-  &:focus,
-  &.mock-focus {
-    color: var(--token-color-foreground-high-contrast);
-    background-color: var(--token-color-palette-blue-200);
-    border-color: var(--token-color-focus-action-internal);
-
-    &::before {
-      // the position absolute of an element is computed from the inside of the border of the container
-      // so we have to take in account the border width of the pseudo-element container itself
-      // plus for the primary button we want to have a 2px gap between the button and the focus
-      $shift: $hds-button-border-width + $hds-button-focus-border-width + 2px;
-      top: -$shift;
-      right: -$shift;
-      bottom: -$shift;
-      left: -$shift;
-      border-color: var(--token-color-focus-action-external);
-      border-radius: $hds-button-border-radius + $hds-button-focus-border-width + 2px;
-    }
-  }
-
-  &:active,
-  &.mock-active {
-    color: var(--token-color-foreground-high-contrast);
-    background-color: var(--token-color-palette-blue-400);
-    border-color: var(--token-color-palette-blue-400);
-    box-shadow: none;
-
-    &::before {
-      border-color: transparent;
-    }
-  }
+  @include hds-button-color-primary();
 }
 
 .hds-button--color-secondary {
-  color: var(--token-color-foreground-primary);
-  background-color: var(--token-color-surface-faint);
-  border-color: var(--token-color-border-strong);
-  box-shadow: var(--token-elevation-low-box-shadow);
-
-  &:hover,
-  &.mock-hover {
-    color: var(--token-color-foreground-primary);
-    background-color: var(--token-color-surface-primary);
-    border-color: var(--token-color-border-strong);
-    cursor: pointer;
-  }
-
-  &:focus,
-  &.mock-focus {
-    color: var(--token-color-foreground-primary);
-    background-color: var(--token-color-surface-faint);
-    border-color: var(--token-color-focus-action-internal);
-
-    &::before {
-      border-color: var(--token-color-focus-action-external);
-    }
-  }
-
-  &:active,
-  &.mock-active {
-    color: var(--token-color-foreground-primary);
-    background-color: var(--token-color-surface-interactive-active);
-    border-color: var(--token-color-border-strong);
-    box-shadow: none;
-
-    &::before {
-      border-color: transparent;
-    }
-  }
+  @include hds-button-color-secondary();
 }
 
 .hds-button--color-tertiary {
-  color: var(--token-color-foreground-action);
-  background-color: transparent;
-  border-color: transparent;
-
-  &:hover,
-  &.mock-hover {
-    color: var(--token-color-foreground-action-hover);
-    background-color: var(--token-color-surface-primary);
-    border-color: var(--token-color-border-strong);
-    cursor: pointer;
-  }
-
-  &:focus,
-  &.mock-focus {
-    color: var(--token-color-foreground-action);
-    border-color: var(--token-color-focus-action-internal);
-
-    &::before {
-      border-color: var(--token-color-focus-action-external);
-    }
-  }
-
-  &:active,
-  &.mock-active {
-    color: var(--token-color-foreground-action-active);
-    background-color: var(--token-color-surface-interactive-active);
-    border-color: var(--token-color-border-strong);
-    box-shadow: none;
-
-    &::before {
-      border-color: transparent;
-    }
-  }
-
-  //
-  // IMPORTANT: we need to use also the [disabled] selector because if the "disabled" attribute is applied to a "Button as link",
-  // the ":disabled" pseudo-selector is not applied to the element in the browser (rightly) because a link can't be disabled
-  // but from the product perspective there may be use cases where they need to have a "Button as link" that looks disabled anyway
-  //
-  &:disabled,
-  &[disabled],
-  &.mock-disabled,
-  &:disabled:focus,
-  &[disabled]:focus,
-  &.mock-disabled:focus,
-  &:disabled:hover,
-  &[disabled]:hover,
-  &.mock-disabled:hover {
-    background-color: transparent;
-    border-color: transparent;
-
-    &::before {
-      border-color: transparent;
-    }
-  }
+  @include hds-button-color-tertiary();
 }
 
 .hds-button--color-critical {
-  color: var(--token-color-foreground-critical-on-surface);
-  background-color: var(--token-color-surface-critical);
-  border-color: var(--token-color-foreground-critical-on-surface);
-  box-shadow: var(--token-elevation-low-box-shadow);
-
-  &:hover,
-  &.mock-hover {
-    color: var(--token-color-foreground-high-contrast);
-    background-color: var(--token-color-palette-red-300);
-    border-color: var(--token-color-palette-red-400);
-    cursor: pointer;
-  }
-
-  &:focus,
-  &.mock-focus {
-    color: var(--token-color-foreground-critical-on-surface);
-    background-color: var(--token-color-surface-critical);
-    border-color: var(--token-color-focus-critical-internal);
-
-    &::before {
-      border-color: var(--token-color-focus-critical-external);
-    }
-  }
-
-  &:active,
-  &.mock-active {
-    color: var(--token-color-foreground-high-contrast);
-    background-color: var(--token-color-palette-red-400);
-    border-color: var(--token-color-palette-red-400);
-    box-shadow: none;
-
-    &::before {
-      border-color: transparent;
-    }
-  }
+  @include hds-button-color-critical();
 }
 
 

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -76,25 +76,7 @@
 
 
 // SIZE
-// Note: the $size-props matrix is stored in the "../mixins/button"
-
-@each $size in $hds-button-sizes {
-  .hds-button--size-#{$size} {
-    min-height: map-get($size-props, $size, "min-height");
-    padding: map-get($size-props, $size, "padding");
-
-    .hds-button__icon {
-      width: map-get($size-props, $size, "icon-size");
-      height: map-get($size-props, $size, "icon-size");
-    }
-
-    .hds-button__text {
-      font-size: map-get($size-props, $size, "font-size");
-      line-height: map-get($size-props, $size, "line-height");
-    }
-  }
-}
-
+@include hds-button-size-classes("hds-button");
 
 // COLORS & STATES
 // Note: the order of the pseuo-selectors need to stay the way they are; it doesn't match the Figma file but it's the correct order for browsers to render the styles correctly.

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -143,6 +143,7 @@ $hds-dropdown-toggle-border-radius: 5px;
 
   .hds-dropdown-toggle-button__text {
     flex: 1 0 auto;
+    text-align: left;
   }
 }
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -67,18 +67,6 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
-.hds-dropdown-toggle-icon__chevron {
-  margin-left: 4px;
-
-  @media (prefers-reduced-motion: no-preference) {
-    transition: transform 0.3s;
-  }
-
-  .hds-dropdown-toggle-icon--is-open & {
-    transform: rotate(-180deg);
-  }
-}
-
 // TOGGLE/BUTTON
 
 .hds-dropdown-toggle-button {
@@ -105,22 +93,14 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
-@each $size in $hds-button-sizes {
-  .hds-dropdown-toggle-button--size-#{$size} {
-    min-height: map-get($size-props, $size, "min-height");
-    padding: map-get($size-props, $size, "padding");
+@include hds-button-size-classes("hds-dropdown-toggle-button");
 
-    .hds-dropdown-toggle-button__icon,
-    .hds-dropdown-toggle-button__indicator {
-      width: map-get($size-props, $size, "icon-size");
-      height: map-get($size-props, $size, "icon-size");
-    }
+.hds-dropdown-toggle-button--size-small {
+  padding-right: 0.375rem;
+}
 
-    .hds-dropdown-toggle-button__text {
-      font-size: map-get($size-props, $size, "font-size");
-      line-height: map-get($size-props, $size, "line-height");
-    }
-  }
+.hds-dropdown-toggle-button--size-medium {
+  padding-right: 0.5625rem;
 }
 
 .hds-dropdown-toggle-button--color-primary {
@@ -129,12 +109,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 
 .hds-dropdown-toggle-button--color-secondary {
   @include hds-button-color-secondary();
-}
-
-.hds-dropdown-toggle-button--is-open {
-  .hds-dropdown-toggle-button__indicator {
-    transform: rotate(-180deg);
-  }
 }
 
 .hds-dropdown-toggle-button--width-full {
@@ -151,18 +125,24 @@ $hds-dropdown-toggle-border-radius: 5px;
   margin-right: 0.375rem;
 }
 
-.hds-dropdown-toggle-button__indicator {
-  margin-right: -6px; // we apply a negative margin to counter the padding-right of the button and reduce the visual space between the icon and the right border
+.hds-dropdown-toggle-button__badge,
+.hds-dropdown-toggle-button__count {
+  margin: -3px 0 -3px 6px;
+}
+
+// TOGGLE / CHEVRON
+
+.hds-dropdown-toggle-chevron {
   margin-left: 8px;
 
   @media (prefers-reduced-motion: no-preference) {
     transition: transform 0.3s;
   }
-}
 
-.hds-dropdown-toggle-button__badge,
-.hds-dropdown-toggle-button__count {
-  margin: -3px 0 -3px 6px;
+  .hds-dropdown-toggle-icon--is-open &,
+  .hds-dropdown-toggle-button--is-open & {
+    transform: rotate(-180deg);
+  }
 }
 
 // LIST

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -96,6 +96,11 @@ $hds-dropdown-toggle-border-radius: 5px;
   &:disabled:hover,
   &.mock-disabled:hover {
     @include hds-button-state-disabled();
+
+    .hds-dropdown-toggle-button__count {
+      color: var(--token-color-foreground-primary);
+      background-color: var(--token-color-surface-strong);
+    }
   }
 }
 
@@ -151,6 +156,10 @@ $hds-dropdown-toggle-border-radius: 5px;
   @media (prefers-reduced-motion: no-preference) {
     transition: transform 0.3s;
   }
+}
+
+.hds-dropdown-toggle-button__count {
+  margin: -3px 0 -3px 6px;
 }
 
 // LIST

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -97,6 +97,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   &.mock-disabled:hover {
     @include hds-button-state-disabled();
 
+    .hds-dropdown-toggle-button__badge,
     .hds-dropdown-toggle-button__count {
       color: var(--token-color-foreground-primary);
       background-color: var(--token-color-surface-strong);
@@ -158,6 +159,7 @@ $hds-dropdown-toggle-border-radius: 5px;
   }
 }
 
+.hds-dropdown-toggle-button__badge,
 .hds-dropdown-toggle-button__count {
   margin: -3px 0 -3px 6px;
 }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -84,17 +84,6 @@ $hds-dropdown-toggle-border-radius: 5px;
 .hds-dropdown-toggle-button {
   @include hds-button();
 
-  box-shadow: none; // we override this to remove the elevation style
-
-  .hds-dropdown-toggle-button__indicator {
-    margin-right: -6px; // we apply a negative margin to counter the padding-right of the button and reduce the visual space between the icon and the right border
-    margin-left: 8px; // this overrides the rule `.hds-button__text + .hds-button__icon`
-
-    @media (prefers-reduced-motion: no-preference) {
-      transition: transform 0.3s;
-    }
-  }
-
   &:focus,
   &.mock-focus {
     @include hds-button-state-focus();
@@ -115,6 +104,7 @@ $hds-dropdown-toggle-border-radius: 5px;
     min-height: map-get($size-props, $size, "min-height");
     padding: map-get($size-props, $size, "padding");
 
+    .hds-dropdown-toggle-button__icon,
     .hds-dropdown-toggle-button__indicator {
       width: map-get($size-props, $size, "icon-size");
       height: map-get($size-props, $size, "icon-size");
@@ -147,6 +137,19 @@ $hds-dropdown-toggle-border-radius: 5px;
 
   .hds-dropdown-toggle-button__text {
     flex: 1 0 auto;
+  }
+}
+
+.hds-dropdown-toggle-button__icon {
+  margin-right: 0.375rem;
+}
+
+.hds-dropdown-toggle-button__indicator {
+  margin-right: -6px; // we apply a negative margin to counter the padding-right of the button and reduce the visual space between the icon and the right border
+  margin-left: 8px;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: transform 0.3s;
   }
 }
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -137,13 +137,17 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   margin-left: auto;
   padding-left: 8px;
 
-  @media (prefers-reduced-motion: no-preference) {
-    transition: transform 0.3s;
+  .flight-icon-chevron-down {
+    @media (prefers-reduced-motion: no-preference) {
+      transition: transform 0.3s;
+    }
   }
 
   .hds-dropdown-toggle-icon--is-open &,
   .hds-dropdown-toggle-button--is-open & {
-    transform: rotate(-180deg);
+    .flight-icon-chevron-down {
+      transform: rotate(-180deg);
+    }
   }
 }
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -43,6 +43,11 @@ $hds-dropdown-toggle-border-radius: 5px;
     background-color: var(--token-color-surface-interactive-active);
     border-color: var(--token-color-border-strong);
   }
+
+  &:disabled,
+  &.mock-disabled {
+    @include hds-button-state-disabled();
+  }
 }
 
 .hds-dropdown-toggle-icon__wrapper {

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -112,16 +112,17 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 }
 
 .hds-dropdown-toggle-button--width-full {
+  justify-content: space-between;
   width: 100%;
   max-width: 100%;
+}
 
-  .hds-dropdown-toggle-button__text {
-    flex: 1 0 auto;
-    text-align: left;
-  }
+.hds-dropdown-toggle-button__text {
+  text-align: left;
 }
 
 .hds-dropdown-toggle-button__icon {
+  flex: none;
   margin-right: 0.375rem;
 }
 
@@ -133,7 +134,8 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 // TOGGLE / CHEVRON
 
 .hds-dropdown-toggle-chevron {
-  margin-left: 8px;
+  margin-left: auto;
+  padding-left: 8px;
 
   @media (prefers-reduced-motion: no-preference) {
     transition: transform 0.3s;

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -24,8 +24,8 @@ $hds-dropdown-toggle-border-radius: 5px;
   min-width: $hds-dropdown-toggle-base-height;
   height: $hds-dropdown-toggle-base-height;
   padding: 1px;
-  background-color: transparent;
-  border: 1px solid transparent; // We need this to be transparent for a11y
+  background-color: var(--token-color-surface-faint);
+  border: 1px solid var(--token-color-border-strong);
   border-radius: $hds-dropdown-toggle-border-radius;
   outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
   outline-color: transparent; // We need this to be transparent for a11y
@@ -33,7 +33,6 @@ $hds-dropdown-toggle-border-radius: 5px;
   &:hover,
   &.mock-hover {
     background-color: var(--token-color-surface-interactive);
-    border-color: var(--token-color-border-strong);
     cursor: pointer;
   }
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -13,7 +13,7 @@
 @use "../mixins/focus-ring" as *;
 
 $hds-dropdown-toggle-base-height: 36px;
-$hds-dropdown-toggle-border-radius: 5px;
+$hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 
 // TOGGLE/ICON
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -3,30 +3,17 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-/* stylelint-disable selector-class-pattern */
-// >>>>>>>>>> WARNING <<<<<<<<<<<
-//
-// Notice: in this component we're using directly the `Hds::Button` component
-// (and adding a specialized class for the "toggle-button" variant, see below)
-// If you need to change the styling of the `Button` component, remember that this will impact also
-// this component too.
-// If instead you need to change only the styling of the `toggle-button` component, you can do it here using
-// the specialized class declared below.
-// This is NOT a standard approach that we use in the HDS design system implementation, but it's been
-// the least worst option we could find to solve the problem of sharing the exact same style of the
-// `Button (primary)` with other components.
-
 //
 // DROPDOWN COMPONENT
 //
 // notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
 //
 
+@use "../mixins/button" as *;
 @use "../mixins/focus-ring" as *;
 
 $hds-dropdown-toggle-base-height: 36px;
 $hds-dropdown-toggle-border-radius: 5px;
-
 
 // TOGGLE/ICON
 
@@ -91,9 +78,11 @@ $hds-dropdown-toggle-border-radius: 5px;
 // TOGGLE/BUTTON
 
 .hds-dropdown-toggle-button {
+  @include hds-button();
+
   box-shadow: none; // we override this to remove the elevation style
 
-  .hds-button__icon {
+  .hds-dropdown-toggle-button__indicator {
     margin-right: -6px; // we apply a negative margin to counter the padding-right of the button and reduce the visual space between the icon and the right border
     margin-left: 8px; // this overrides the rule `.hds-button__text + .hds-button__icon`
 
@@ -101,15 +90,61 @@ $hds-dropdown-toggle-border-radius: 5px;
       transition: transform 0.3s;
     }
   }
+
+  &:focus,
+  &.mock-focus {
+    @include hds-button-state-focus();
+  }
+
+  &:disabled,
+  &.mock-disabled,
+  &:disabled:focus,
+  &.mock-disabled:focus,
+  &:disabled:hover,
+  &.mock-disabled:hover {
+    @include hds-button-state-disabled();
+  }
 }
 
+@each $size in $hds-button-sizes {
+  .hds-dropdown-toggle-button--size-#{$size} {
+    min-height: map-get($size-props, $size, "min-height");
+    padding: map-get($size-props, $size, "padding");
+
+    .hds-dropdown-toggle-button__indicator {
+      width: map-get($size-props, $size, "icon-size");
+      height: map-get($size-props, $size, "icon-size");
+    }
+
+    .hds-dropdown-toggle-button__text {
+      font-size: map-get($size-props, $size, "font-size");
+      line-height: map-get($size-props, $size, "line-height");
+    }
+  }
+}
+
+.hds-dropdown-toggle-button--color-primary {
+  @include hds-button-color-primary();
+}
+
+.hds-dropdown-toggle-button--color-secondary {
+  @include hds-button-color-secondary();
+}
 
 .hds-dropdown-toggle-button--is-open {
-  .hds-button__icon {
+  .hds-dropdown-toggle-button__indicator {
     transform: rotate(-180deg);
   }
 }
 
+.hds-dropdown-toggle-button--width-full {
+  width: 100%;
+  max-width: 100%;
+
+  .hds-dropdown-toggle-button__text {
+    flex: 1 0 auto;
+  }
+}
 
 // LIST
 // UL ELEMENT

--- a/packages/components/app/styles/mixins/_button.scss
+++ b/packages/components/app/styles/mixins/_button.scss
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+$hds-button-sizes: ( "small", "medium", "large" );
+$hds-button-border-radius: 5px;
+$hds-button-border-width: 1px;
+$hds-button-focus-border-width: 3px;
+
+// these values later may come from the design tokens
+$size-props: (
+  "small": (
+    "font-size": 0.8125rem, // 13px;
+    "line-height": 0.875rem, // 14px - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)
+    "min-height": 1.75rem,  // 28px
+    "padding": 0.375rem 0.6875rem, // 6px 11px - here we're taking into account the 1px border
+    "icon-size": 0.75rem, // 12px
+  ),
+  "medium": (
+    "font-size": 0.875rem, // 14px
+    "line-height": 1rem,// 16px
+    "min-height": 2.25rem, // 36px
+    "padding": 0.5625rem 0.9375rem, // 9px 15px - here we're taking into account the 1px border
+    "icon-size": 1rem, // 16px
+  ),
+  "large": (
+    "font-size": 1rem, // 16px
+    "line-height": 1.5rem, // 24px
+    "min-height": 3rem, // 48px
+    "padding": 0.6875rem 1.1875rem, // 11px 19px - here we're taking into account the 1px border
+    "icon-size": 1.5rem, // 24px
+  )
+);
+
+@mixin hds-button() {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  font-family: var(--token-typography-font-stack-text);
+  text-decoration: none;
+  border: $hds-button-border-width solid transparent; // We need this to be transparent for a11y
+  border-radius: $hds-button-border-radius;
+  outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
+  outline-color: transparent; // We need this to be transparent for a11y
+  isolation: isolate;
+}
+
+@mixin hds-button-state-disabled() {
+  color: var(--token-color-foreground-disabled);
+  background-color: var(--token-color-surface-faint);
+  border-color: var(--token-color-border-primary);
+  box-shadow: none;
+  cursor: not-allowed;
+
+  &::before {
+    border-color: transparent;
+  }
+}
+
+@mixin hds-button-state-focus() {
+  box-shadow: none;
+
+  &::before {
+    // the position absolute of an element is computed from the inside of the border of the container
+    // so we have to take in account the border width of the pseudo-element container itself
+    $shift: $hds-button-border-width + $hds-button-focus-border-width;
+    position: absolute;
+    top: -$shift;
+    right: -$shift;
+    bottom: -$shift;
+    left: -$shift;
+    z-index: -1;
+    border: $hds-button-focus-border-width solid transparent;
+    border-radius: $hds-button-border-radius + $hds-button-focus-border-width;
+    content: "";
+  }
+}
+
+@mixin hds-button-color-primary() {
+  color: var(--token-color-foreground-high-contrast);
+  background-color: var(--token-color-palette-blue-200);
+  border-color: var(--token-color-palette-blue-300);
+  box-shadow: var(--token-elevation-low-box-shadow);
+
+  &:hover,
+  &.mock-hover {
+    color: var(--token-color-foreground-high-contrast);
+    background-color: var(--token-color-palette-blue-300);
+    border-color: var(--token-color-palette-blue-400);
+    cursor: pointer;
+  }
+
+  &:focus,
+  &.mock-focus {
+    color: var(--token-color-foreground-high-contrast);
+    background-color: var(--token-color-palette-blue-200);
+    border-color: var(--token-color-focus-action-internal);
+
+    &::before {
+      // the position absolute of an element is computed from the inside of the border of the container
+      // so we have to take in account the border width of the pseudo-element container itself
+      // plus for the primary button we want to have a 2px gap between the button and the focus
+      $shift: $hds-button-border-width + $hds-button-focus-border-width + 2px;
+      top: -$shift;
+      right: -$shift;
+      bottom: -$shift;
+      left: -$shift;
+      border-color: var(--token-color-focus-action-external);
+      border-radius: $hds-button-border-radius + $hds-button-focus-border-width + 2px;
+    }
+  }
+
+  &:active,
+  &.mock-active {
+    color: var(--token-color-foreground-high-contrast);
+    background-color: var(--token-color-palette-blue-400);
+    border-color: var(--token-color-palette-blue-400);
+    box-shadow: none;
+
+    &::before {
+      border-color: transparent;
+    }
+  }
+}
+
+@mixin hds-button-color-secondary() {
+  color: var(--token-color-foreground-primary);
+  background-color: var(--token-color-surface-faint);
+  border-color: var(--token-color-border-strong);
+  box-shadow: var(--token-elevation-low-box-shadow);
+
+  &:hover,
+  &.mock-hover {
+    color: var(--token-color-foreground-primary);
+    background-color: var(--token-color-surface-primary);
+    border-color: var(--token-color-border-strong);
+    cursor: pointer;
+  }
+
+  &:focus,
+  &.mock-focus {
+    color: var(--token-color-foreground-primary);
+    background-color: var(--token-color-surface-faint);
+    border-color: var(--token-color-focus-action-internal);
+
+    &::before {
+      border-color: var(--token-color-focus-action-external);
+    }
+  }
+
+  &:active,
+  &.mock-active {
+    color: var(--token-color-foreground-primary);
+    background-color: var(--token-color-surface-interactive-active);
+    border-color: var(--token-color-border-strong);
+    box-shadow: none;
+
+    &::before {
+      border-color: transparent;
+    }
+  }
+}
+
+@mixin hds-button-color-tertiary() {
+  color: var(--token-color-foreground-action);
+  background-color: transparent;
+  border-color: transparent;
+
+  &:hover,
+  &.mock-hover {
+    color: var(--token-color-foreground-action-hover);
+    background-color: var(--token-color-surface-primary);
+    border-color: var(--token-color-border-strong);
+    cursor: pointer;
+  }
+
+  &:focus,
+  &.mock-focus {
+    color: var(--token-color-foreground-action);
+    border-color: var(--token-color-focus-action-internal);
+
+    &::before {
+      border-color: var(--token-color-focus-action-external);
+    }
+  }
+
+  &:active,
+  &.mock-active {
+    color: var(--token-color-foreground-action-active);
+    background-color: var(--token-color-surface-interactive-active);
+    border-color: var(--token-color-border-strong);
+    box-shadow: none;
+
+    &::before {
+      border-color: transparent;
+    }
+  }
+
+  //
+  // IMPORTANT: we need to use also the [disabled] selector because if the "disabled" attribute is applied to a "Button as link",
+  // the ":disabled" pseudo-selector is not applied to the element in the browser (rightly) because a link can't be disabled
+  // but from the product perspective there may be use cases where they need to have a "Button as link" that looks disabled anyway
+  //
+  &:disabled,
+  &[disabled],
+  &.mock-disabled,
+  &:disabled:focus,
+  &[disabled]:focus,
+  &.mock-disabled:focus,
+  &:disabled:hover,
+  &[disabled]:hover,
+  &.mock-disabled:hover {
+    background-color: transparent;
+    border-color: transparent;
+
+    &::before {
+      border-color: transparent;
+    }
+  }
+}
+
+@mixin hds-button-color-critical() {
+  color: var(--token-color-foreground-critical-on-surface);
+  background-color: var(--token-color-surface-critical);
+  border-color: var(--token-color-foreground-critical-on-surface);
+  box-shadow: var(--token-elevation-low-box-shadow);
+
+  &:hover,
+  &.mock-hover {
+    color: var(--token-color-foreground-high-contrast);
+    background-color: var(--token-color-palette-red-300);
+    border-color: var(--token-color-palette-red-400);
+    cursor: pointer;
+  }
+
+  &:focus,
+  &.mock-focus {
+    color: var(--token-color-foreground-critical-on-surface);
+    background-color: var(--token-color-surface-critical);
+    border-color: var(--token-color-focus-critical-internal);
+
+    &::before {
+      border-color: var(--token-color-focus-critical-external);
+    }
+  }
+
+  &:active,
+  &.mock-active {
+    color: var(--token-color-foreground-high-contrast);
+    background-color: var(--token-color-palette-red-400);
+    border-color: var(--token-color-palette-red-400);
+    box-shadow: none;
+
+    &::before {
+      border-color: transparent;
+    }
+  }
+}

--- a/packages/components/app/styles/mixins/_button.scss
+++ b/packages/components/app/styles/mixins/_button.scss
@@ -259,3 +259,22 @@ $size-props: (
     }
   }
 }
+
+@mixin hds-button-size-classes($blockName) {
+  @each $size in $hds-button-sizes {
+    .#{$blockName}--size-#{$size} {
+      min-height: map-get($size-props, $size, "min-height");
+      padding: map-get($size-props, $size, "padding");
+
+      .#{$blockName}__icon {
+        width: map-get($size-props, $size, "icon-size");
+        height: map-get($size-props, $size, "icon-size");
+      }
+
+      .#{$blockName}__text {
+        font-size: map-get($size-props, $size, "font-size");
+        line-height: map-get($size-props, $size, "line-height");
+      }
+    }
+  }
+}

--- a/packages/components/tests/dummy/app/routes/components/dropdown.js
+++ b/packages/components/tests/dummy/app/routes/components/dropdown.js
@@ -11,7 +11,7 @@ import { COLORS as ITEM_INTERACTIVE_COLORS } from '@hashicorp/design-system-comp
 export default class ComponentsDropdownRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
-    const TOGGLE_STATES = ['default', 'hover', 'active', 'focus'];
+    const TOGGLE_STATES = ['default', 'hover', 'active', 'focus', 'disabled'];
     const ITEM_STATES = ['default', 'hover', 'active', 'focus'];
     return {
       TOGGLE_BUTTON_COLORS,

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -32,6 +32,7 @@
 @import "./showcase-pages/button";
 @import "./showcase-pages/card";
 @import "./showcase-pages/disclosure";
+@import "./showcase-pages/dropdown";
 @import "./showcase-pages/dismiss-button";
 @import "./showcase-pages/flyout";
 @import "./showcase-pages/form/base-elements";

--- a/packages/components/tests/dummy/app/styles/showcase-pages/dropdown.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/dropdown.scss
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// DROPDOWN
+
+body.components-dropdown {
+  .shw-component-dropdown-states-matrix {
+    .shw-grid__item {
+      // we hide all the labels (except for the first "row")
+      &:nth-child(n + 7) {
+        .shw-label {
+          visibility: hidden;
+        }
+      }
+      // we show the labels in the first "column"
+      &:nth-child(6n + 1) {
+        .shw-label {
+          visibility: visible;
+        }
+      }
+    }
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -105,60 +105,73 @@
 
   <Shw::Text::H4>With count</Shw::Text::H4>
 
-  <Shw::Grid @columns="5" as |SG|>
-    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
-      {{#each @model.TOGGLE_STATES as |state|}}
-        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
-          <Hds::Dropdown::Toggle::Button @count="12" @text="Lipsum" @color={{color}} mock-state-value={{state}} />
-        </SG.Item>
-      {{/each}}
-    {{/each}}
-    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
-      {{#each @model.TOGGLE_STATES as |state|}}
-        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
-          <Hds::Dropdown::Toggle::Button
-            @count="12"
-            @text="Lipsum"
-            @size="small"
-            @color={{color}}
-            mock-state-value={{state}}
-          />
-        </SG.Item>
-      {{/each}}
-    {{/each}}
-  </Shw::Grid>
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Primary small">
+      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @count="12" @size="small" />
+    </SF.Item>
+    <SF.Item @label="Primary medium">
+      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @count="12" />
+    </SF.Item>
+    <SF.Item @label="Primary full width">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::Dropdown::Toggle::Button @isFullWidth={{true}} @text="Lorem ipsum" @count="12" />
+      </Shw::Outliner>
+    </SF.Item>
+  </Shw::Flex>
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Secondary small">
+      <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" @count="12" @size="small" />
+    </SF.Item>
+    <SF.Item @label="Secondary medium">
+      <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" @count="12" />
+    </SF.Item>
+    <SF.Item @label="Secondary full width">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::Dropdown::Toggle::Button @color="secondary" @isFullWidth={{true}} @text="Lorem ipsum" @count="12" />
+      </Shw::Outliner>
+    </SF.Item>
+  </Shw::Flex>
 
   <Shw::Text::H4>With badge</Shw::Text::H4>
 
-  <Shw::Grid @columns="5" as |SG|>
-    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
-      {{#each @model.TOGGLE_STATES as |state|}}
-        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
-          <Hds::Dropdown::Toggle::Button
-            @badge="Badge"
-            @badgeIcon="hexagon"
-            @text="Lipsum"
-            @color={{color}}
-            mock-state-value={{state}}
-          />
-        </SG.Item>
-      {{/each}}
-    {{/each}}
-    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
-      {{#each @model.TOGGLE_STATES as |state|}}
-        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
-          <Hds::Dropdown::Toggle::Button
-            @badge="Badge"
-            @badgeIcon="hexagon"
-            @text="Lipsum"
-            @size="small"
-            @color={{color}}
-            mock-state-value={{state}}
-          />
-        </SG.Item>
-      {{/each}}
-    {{/each}}
-  </Shw::Grid>
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Primary small">
+      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" @size="small" />
+    </SF.Item>
+    <SF.Item @label="Primary medium">
+      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
+    </SF.Item>
+    <SF.Item @label="Primary full width">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::Dropdown::Toggle::Button @isFullWidth={{true}} @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
+      </Shw::Outliner>
+    </SF.Item>
+  </Shw::Flex>
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Secondary small">
+      <Hds::Dropdown::Toggle::Button
+        @color="secondary"
+        @text="Lorem ipsum"
+        @badge="Badge"
+        @badgeIcon="hexagon"
+        @size="small"
+      />
+    </SF.Item>
+    <SF.Item @label="Secondary medium">
+      <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
+    </SF.Item>
+    <SF.Item @label="Secondary full width">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::Dropdown::Toggle::Button
+          @color="secondary"
+          @isFullWidth={{true}}
+          @text="Lorem ipsum"
+          @badge="Badge"
+          @badgeIcon="hexagon"
+        />
+      </Shw::Outliner>
+    </SF.Item>
+  </Shw::Flex>
 
   <Shw::Divider @level={{2}} />
 
@@ -180,20 +193,68 @@
 
   <Shw::Text::H3>States</Shw::Text::H3>
 
-  <Shw::Grid @columns="6" as |SG|>
+  <Shw::Grid @columns="6" class="shw-component-dropdown-states-matrix" as |SG|>
+
+    {{! Notice: we use a non-standard way to showcase the states to reduce the (visual) complexity of this matrix }}
+
+    {{#each @model.TOGGLE_STATES as |state|}}
+      <SG.Item>
+        <span class="shw-label">{{capitalize state}}</span>
+      </SG.Item>
+    {{/each}}
+    <SG.Item>
+      <span class="shw-label">Open</span>
+    </SG.Item>
+
     {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
       {{#each @model.TOGGLE_STATES as |state|}}
-        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+        <SG.Item @label="{{capitalize color}}">
           <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} mock-state-value={{state}} />
         </SG.Item>
       {{/each}}
-      <SG.Item @label="{{color}}/open">
+      <SG.Item @label="{{capitalize color}}">
         <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @isOpen={{true}} @color={{color}} />
+      </SG.Item>
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="With icon">
+          <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="With icon">
+        <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @isOpen={{true}} @color={{color}} />
+      </SG.Item>
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="With count">
+          <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="With count">
+        <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @isOpen={{true}} @color={{color}} />
+      </SG.Item>
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="With badge">
+          <Hds::Dropdown::Toggle::Button
+            @badge="Sit"
+            @badgeIcon="hexagon"
+            @text="Lorem"
+            @color={{color}}
+            mock-state-value={{state}}
+          />
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="With badge">
+        <Hds::Dropdown::Toggle::Button
+          @badge="Sit"
+          @badgeIcon="hexagon"
+          @text="Lorem"
+          @isOpen={{true}}
+          @color={{color}}
+        />
       </SG.Item>
     {{/each}}
 
     {{#each @model.TOGGLE_STATES as |state|}}
-      <SG.Item @label="Icon / {{capitalize state}}">
+      <SG.Item @label="Icon">
         <Hds::Dropdown::Toggle::Icon
           @icon="more-horizontal"
           @text="overflow menu"
@@ -202,7 +263,7 @@
         />
       </SG.Item>
     {{/each}}
-    <SG.Item @label="Icon/open">
+    <SG.Item @label="Icon">
       <Hds::Dropdown::Toggle::Icon
         @icon="more-horizontal"
         @text="overflow menu"
@@ -212,20 +273,20 @@
     </SG.Item>
 
     {{#each @model.TOGGLE_STATES as |state|}}
-      <SG.Item @label="Icon+chevron / {{capitalize state}}">
+      <SG.Item @label="Icon+chevron">
         <Hds::Dropdown::Toggle::Icon @icon="user" @text={{state}} mock-state-value={{state}} />
       </SG.Item>
     {{/each}}
-    <SG.Item @label="Icon+chevron/open">
+    <SG.Item @label="Icon+chevron">
       <Hds::Dropdown::Toggle::Icon @icon="user" @text="open" @isOpen={{true}} />
     </SG.Item>
 
     {{#each @model.TOGGLE_STATES as |state|}}
-      <SG.Item @label="Avatar+chevron / {{capitalize state}}">
+      <SG.Item @label="Avatar+chevron">
         <Hds::Dropdown::Toggle::Icon @text={{state}} @imageSrc="/assets/images/avatar.png" mock-state-value={{state}} />
       </SG.Item>
     {{/each}}
-    <SG.Item @label="Avatar+chevron/open">
+    <SG.Item @label="Avatar+chevron">
       <Hds::Dropdown::Toggle::Icon @text="open" @isOpen={{true}} @imageSrc="/assets/images/avatar.png" />
     </SG.Item>
   </Shw::Grid>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -75,6 +75,7 @@
   </Shw::Flex>
 
   <Shw::Text::H4>With icon</Shw::Text::H4>
+
   <Shw::Flex as |SF|>
     <SF.Item @label="Primary small">
       <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem ipsum" @size="small" />
@@ -101,6 +102,37 @@
       </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Text::H4>With count</Shw::Text::H4>
+
+  <Shw::Grid @columns="6" as |SG|>
+    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+          <Hds::Dropdown::Toggle::Button @count="12" @text="Lipsum" @color={{color}} mock-state-value={{state}} />
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="{{color}}/open">
+        <Hds::Dropdown::Toggle::Button @count="12" @text="Lipsum" @isOpen={{true}} @color={{color}} />
+      </SG.Item>
+    {{/each}}
+    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+          <Hds::Dropdown::Toggle::Button
+            @count="12"
+            @text="Lipsum"
+            @size="small"
+            @color={{color}}
+            mock-state-value={{state}}
+          />
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="{{color}}/open">
+        <Hds::Dropdown::Toggle::Button @count="12" @text="Lipsum" @size="small" @isOpen={{true}} @color={{color}} />
+      </SG.Item>
+    {{/each}}
+  </Shw::Grid>
 
   <Shw::Divider @level={{2}} />
 

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -94,7 +94,7 @@
 
   <Shw::Text::H3>States</Shw::Text::H3>
 
-  <Shw::Grid @columns="5" as |SG|>
+  <Shw::Grid @columns="6" as |SG|>
     {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
       {{#each @model.TOGGLE_STATES as |state|}}
         <SG.Item @label="{{capitalize color}} / {{capitalize state}}">

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -105,16 +105,13 @@
 
   <Shw::Text::H4>With count</Shw::Text::H4>
 
-  <Shw::Grid @columns="6" as |SG|>
+  <Shw::Grid @columns="5" as |SG|>
     {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
       {{#each @model.TOGGLE_STATES as |state|}}
         <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
           <Hds::Dropdown::Toggle::Button @count="12" @text="Lipsum" @color={{color}} mock-state-value={{state}} />
         </SG.Item>
       {{/each}}
-      <SG.Item @label="{{color}}/open">
-        <Hds::Dropdown::Toggle::Button @count="12" @text="Lipsum" @isOpen={{true}} @color={{color}} />
-      </SG.Item>
     {{/each}}
     {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
       {{#each @model.TOGGLE_STATES as |state|}}
@@ -128,9 +125,38 @@
           />
         </SG.Item>
       {{/each}}
-      <SG.Item @label="{{color}}/open">
-        <Hds::Dropdown::Toggle::Button @count="12" @text="Lipsum" @size="small" @isOpen={{true}} @color={{color}} />
-      </SG.Item>
+    {{/each}}
+  </Shw::Grid>
+
+  <Shw::Text::H4>With badge</Shw::Text::H4>
+
+  <Shw::Grid @columns="5" as |SG|>
+    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+          <Hds::Dropdown::Toggle::Button
+            @badge="Badge"
+            @badgeIcon="hexagon"
+            @text="Lipsum"
+            @color={{color}}
+            mock-state-value={{state}}
+          />
+        </SG.Item>
+      {{/each}}
+    {{/each}}
+    {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+          <Hds::Dropdown::Toggle::Button
+            @badge="Badge"
+            @badgeIcon="hexagon"
+            @text="Lipsum"
+            @size="small"
+            @color={{color}}
+            mock-state-value={{state}}
+          />
+        </SG.Item>
+      {{/each}}
     {{/each}}
   </Shw::Grid>
 

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -46,22 +46,31 @@
 
   <Shw::Text::H2>Toggles</Shw::Text::H2>
 
-  <Shw::Text::H3>Button</Shw::Text::H3>
-
-  <Shw::Flex as |SF|>
-    <SF.Item @label="Primary">
-      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" />
-    </SF.Item>
-    <SF.Item @label="Secondary">
-      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color="secondary" />
-    </SF.Item>
-  </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Primary small">
       <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @size="small" />
     </SF.Item>
+    <SF.Item @label="Primary medium">
+      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" />
+    </SF.Item>
+    <SF.Item @label="Primary full width">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::Dropdown::Toggle::Button @isFullWidth={{true}} @text="Lorem ipsum" />
+      </Shw::Outliner>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex as |SF|>
     <SF.Item @label="Secondary small">
-      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @size="small" @color="secondary" />
+      <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" @size="small" />
+    </SF.Item>
+    <SF.Item @label="Secondary medium">
+      <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" />
+    </SF.Item>
+    <SF.Item @label="Secondary full width">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::Dropdown::Toggle::Button @color="secondary" @isFullWidth={{true}} @text="Lorem ipsum" />
+      </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>
 

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -74,6 +74,34 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Text::H4>With icon</Shw::Text::H4>
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Primary small">
+      <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem ipsum" @size="small" />
+    </SF.Item>
+    <SF.Item @label="Primary medium">
+      <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem ipsum" />
+    </SF.Item>
+    <SF.Item @label="Primary full width">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::Dropdown::Toggle::Button @icon="hexagon" @isFullWidth={{true}} @text="Lorem ipsum" />
+      </Shw::Outliner>
+    </SF.Item>
+  </Shw::Flex>
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Secondary small">
+      <Hds::Dropdown::Toggle::Button @color="secondary" @icon="hexagon" @text="Lorem ipsum" @size="small" />
+    </SF.Item>
+    <SF.Item @label="Secondary medium">
+      <Hds::Dropdown::Toggle::Button @color="secondary" @icon="hexagon" @text="Lorem ipsum" />
+    </SF.Item>
+    <SF.Item @label="Secondary full width">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::Dropdown::Toggle::Button @color="secondary" @icon="hexagon" @isFullWidth={{true}} @text="Lorem ipsum" />
+      </Shw::Outliner>
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>Icon</Shw::Text::H3>

--- a/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
@@ -51,6 +51,17 @@ module(
       assert.dom('.flight-icon.flight-icon-hexagon').exists();
     });
 
+    // COUNT
+
+    test('it should render a badge count if @count is defined', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @count="3" id="test-toggle-button" />`
+      );
+      assert
+        .dom('#test-toggle-button .hds-dropdown-toggle-button__count')
+        .hasText('3');
+    });
+
     // COLOR
 
     test('it should render the primary color as the default if no color is declared', async function (assert) {

--- a/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
@@ -46,7 +46,7 @@ module(
 
     test('it should render an icon if @icon is defined', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" @icon="hexagon" id="test-toggle-button" />`
+        hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" @icon="hexagon" />`
       );
       assert.dom('.flight-icon.flight-icon-hexagon').exists();
     });
@@ -60,6 +60,9 @@ module(
       assert
         .dom('#test-toggle-button .hds-dropdown-toggle-button__badge')
         .hasText('badge');
+      assert
+        .dom('.hds-dropdown-toggle-button__badge .flight-icon')
+        .doesNotExist();
     });
     test('it should render a badge with icon if @badge and @badgeIcon is defined', async function (assert) {
       await render(

--- a/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
@@ -48,13 +48,17 @@ module(
       await render(
         hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" id="test-toggle-button" />`
       );
-      assert.dom('#test-toggle-button').hasClass('hds-button--color-primary');
+      assert
+        .dom('#test-toggle-button')
+        .hasClass('hds-dropdown-toggle-button--color-primary');
     });
     test('it should render the correct CSS color class if the @color prop is declared', async function (assert) {
       await render(
         hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" @color="secondary" id="test-toggle-button" />`
       );
-      assert.dom('#test-toggle-button').hasClass('hds-button--color-secondary');
+      assert
+        .dom('#test-toggle-button')
+        .hasClass('hds-dropdown-toggle-button--color-secondary');
     });
 
     // SIZE
@@ -63,13 +67,17 @@ module(
       await render(
         hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" id="test-toggle-button" />`
       );
-      assert.dom('#test-toggle-button').hasClass('hds-button--size-medium');
+      assert
+        .dom('#test-toggle-button')
+        .hasClass('hds-dropdown-toggle-button--size-medium');
     });
     test('it should render the correct CSS size class if the @size prop is declared', async function (assert) {
       await render(
         hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" @size="small" id="test-toggle-button" />`
       );
-      assert.dom('#test-toggle-button').hasClass('hds-button--size-small');
+      assert
+        .dom('#test-toggle-button')
+        .hasClass('hds-dropdown-toggle-button--size-small');
     });
 
     // A11Y

--- a/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
@@ -51,6 +51,30 @@ module(
       assert.dom('.flight-icon.flight-icon-hexagon').exists();
     });
 
+    // BADGE
+
+    test('it should render a badge if @badge is defined', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @badge="badge" id="test-toggle-button" />`
+      );
+      assert
+        .dom('#test-toggle-button .hds-dropdown-toggle-button__badge')
+        .hasText('badge');
+    });
+    test('it should render a badge with icon if @badge and @badgeIcon is defined', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @badge="badge" @badgeIcon="hexagon" id="test-toggle-button" />`
+      );
+      assert
+        .dom('#test-toggle-button .hds-dropdown-toggle-button__badge')
+        .hasText('badge');
+      assert
+        .dom(
+          '.hds-dropdown-toggle-button__badge .flight-icon.flight-icon-hexagon'
+        )
+        .exists();
+    });
+
     // COUNT
 
     test('it should render a badge count if @count is defined', async function (assert) {

--- a/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/toggle/button-test.js
@@ -42,6 +42,15 @@ module(
       assert.dom('.flight-icon.flight-icon-chevron-down').exists();
     });
 
+    // ICON
+
+    test('it should render an icon if @icon is defined', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::Toggle::Button @text="text toggle" @icon="hexagon" id="test-toggle-button" />`
+      );
+      assert.dom('.flight-icon.flight-icon-hexagon').exists();
+    });
+
     // COLOR
 
     test('it should render the primary color as the default if no color is declared', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

Extend `Hds::Dropdown::ToggleButton` with support for leading `Icon`, `Badge`, and `BadgeCount` and update  `Dropdown::ToggleIcon` styles.

### :hammer_and_wrench: Detailed description

This is an alternative approach to #1251, in which we only change the `Hds::Dropdown::ToggleButton` API without interfering with `Hds::Button`:

 - we refactor the `Hds::Dropdown::ToggleButton` to have its own markup and only share button styles via mixins
 - we update the `Hds::Dropdown::ToggleIcon` default styles to resemble the secondary button styles
 - we make sure the disabled states are styled correctly for both Toggle types
 - we add support for icon as a leading element in `ToggleButton`  (via `@icon`)
 - we add support for badge count as a trailing element in `ToggleButton`  (via `@count`)
 - we add support for badge and badge icon as trailing elements in `ToggleButton`  (via `@badge` and `@badgeIcon`)

[👉 Preview changes](https://hds-showcase-git-alex-ju-dropdown-extension-5-hashicorp.vercel.app/components/dropdown)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1109](https://hashicorp.atlassian.net/browse/HDS-1109)
Figma file: https://www.figma.com/file/Kgc8BgB8jGuJXISndgTrD1/Dropdown?node-id=29345%3A69392&t=h2KjNpimGUUm0DCW-4 and https://www.figma.com/file/SBw7wkwlPBnkNERKRAMxoR/Badge-in-Button?node-id=30893%3A117893&t=t6G71WRPZBKwfjhr-4

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1109]: https://hashicorp.atlassian.net/browse/HDS-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ