### PR TITLE
NOT FOR MERGE demo: split button

### DIFF
--- a/packages/components/addon/components/hds/button-split/index.hbs
+++ b/packages/components/addon/components/hds/button-split/index.hbs
@@ -1,0 +1,5 @@
+<div class="hds-button-split">
+  {{yield (hash
+    Button=(component "hds/button" class="hds-button-split__button")
+    Dropdown=(component "hds/dropdown" class="hds-button-split__dropdown"))}}
+</div>

--- a/packages/components/app/components/hds/button-split/index.js
+++ b/packages/components/app/components/hds/button-split/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/button-split/index';

--- a/packages/components/app/styles/@hashicorp/design-system-components.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-components.scss
@@ -19,6 +19,7 @@
 @use "../components/breadcrumb";
 @use "../components/button";
 @use "../components/button-set";
+@use "../components/button-split";
 @use "../components/card";
 @use "../components/disclosure";
 @use "../components/dismiss-button";

--- a/packages/components/app/styles/components/button-split.scss
+++ b/packages/components/app/styles/components/button-split.scss
@@ -1,0 +1,21 @@
+.hds-button-split {
+  display: flex;
+
+  .hds-button,
+  .hds-dropdown-toggle-icon {
+    color: var(--token-color-foreground-high-contrast);
+    background-color: var(--token-color-palette-blue-200);
+    border-color: var(--token-color-palette-blue-300);
+    box-shadow: var(--token-elevation-low-box-shadow);
+  }
+
+  .hds-button {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .hds-dropdown-toggle-icon {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+}

--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -53,6 +53,7 @@ Router.map(function () {
     this.route('toast');
     this.route('tabs');
     this.route('side-nav');
+    this.route('button-split');
   });
   this.route('utilities', function () {
     this.route('disclosure');

--- a/packages/components/tests/dummy/app/routes/components/button-split.js
+++ b/packages/components/tests/dummy/app/routes/components/button-split.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ComponentsButtonSplitRoute extends Route {}

--- a/packages/components/tests/dummy/app/templates/components/button-split.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button-split.hbs
@@ -1,0 +1,31 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{page-title "Button (Split)"}}
+
+<Shw::Text::H1>Split-Button component</Shw::Text::H1>
+
+<section data-test-percy>
+
+  <Shw::Text::H2>Generated element</Shw::Text::H2>
+
+  <Shw::Flex as |SF|>
+    <SF.Item class="shw-component-button-split">
+      <Hds::Button-Split as |B|>
+        <B.Button @text="Lorem ipsum" @color="primary" />
+        <B.Dropdown as |dd|>
+          <dd.ToggleIcon @icon="chevron-down" @text="user menu" @hasChevron={{false}} @color="primary" />
+          <dd.Title @text="Signed In" />
+          <dd.Description @text="email@domain.com" />
+          <dd.Separator />
+          <dd.Interactive @route="components" @text="Settings and Preferences" />
+          <dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+        </B.Dropdown>
+      </Hds::Button-Split> 
+    </SF.Item>
+    
+  </Shw::Flex>
+
+  </section>

--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -68,6 +68,11 @@
         </LinkTo>
       </li>
       <li>
+        <LinkTo @route="components.button-split">
+          Button (Split)
+        </LinkTo>
+      </li>
+      <li>
         <LinkTo @route="components.card">
           Card
         </LinkTo>

--- a/packages/components/tests/integration/components/hds/button-split/index-test.js
+++ b/packages/components/tests/integration/components/hds/button-split/index-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/button-split/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Hds::ButtonSplit::Index />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Hds::ButtonSplit::Index>
+        template block text
+      </Hds::ButtonSplit::Index>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

This PR is a simple demo that shows how a split-button could be created with the button component and the dropdown component with a little extra CSS. Some extra work would probably need to be done around the focus rings and maybe active states(?) but this PR is just more of a demo to show potential.

![closed state](https://user-images.githubusercontent.com/4587451/227984362-d8044160-be30-464c-9403-301ea6845ade.png)

![open state](https://user-images.githubusercontent.com/4587451/227986569-7b831100-0741-4b04-8d8a-d04f59ec0b57.png)

