### PR TITLE
Add cross-linking to new pattern docs

### DIFF
--- a/website/docs/components/button-set/partials/guidelines/guidelines.md
+++ b/website/docs/components/button-set/partials/guidelines/guidelines.md
@@ -1,3 +1,5 @@
 ## Usage
 
 Usage documentation for this component is coming soon. In the meantime, help us improve this documentation by letting us know how your team is using it in [#team-design-systems](https://hashicorp.slack.com/archives/C7KTUHNUS) (internal only).
+
+More detailed examples and guidance around button alignment, grouping, and organization can be found in the [button organization](/patterns/button-organization) pattern documentation.

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -93,6 +93,11 @@ Buttons used for a Dropdown (with the chevron icon) can be found in [Dropdown](/
   <Hds::Button @color="secondary" @text="Cancel" />
 </Hds::ButtonSet>
 
+!!! Info
+
+More detailed examples and guidance on button organization can be found in the [button organization](/patterns/button-organization) pattern documentation.
+!!!
+
 ## Content
 
 - Text should be short and to the point (~25 characters). Buttons should not consist of full sentences, but should provide enough context to be useful.

--- a/website/docs/components/form/primitives/partials/guidelines/overview.md
+++ b/website/docs/components/form/primitives/partials/guidelines/overview.md
@@ -9,3 +9,8 @@ Form Primitives are used to compose form fields.
 - `Form::Fieldset` is the generic container to group multiple fields with label, helper text, and error messaging
 
 We use Form Primitives as the building blocks for the “field” and “group” controls. While we recommend using our pre-defined “field” and “group” controls because they provide built-in accessibility support, you can use the Form Primitives to implement custom layouts or controls as necessary.
+
+!!! Info
+
+More details on how to assemble form components in larger form patterns can be found in the [form pattern](/patterns/form-patterns) documentation.
+!!!

--- a/website/docs/patterns/form-patterns/partials/guidelines/guidelines.md
+++ b/website/docs/patterns/form-patterns/partials/guidelines/guidelines.md
@@ -75,6 +75,12 @@ Fields organized in a horizontal set should be aligned to the baseline of each e
 
 ![Baseline alignment within a set](/assets/patterns/form-patterns/baseline-alignment.png =500x*)
 
+### Button sets
+
+Organize buttons based on the [Button Set](/components/button-set) guidelines, e.g., using a 16px horizontal gap between buttons. More specifications and examples can be found in the documentation for [button organization](/patterns/button-organization).
+
+![Button set](/assets/patterns/form-patterns/button-set.png =500x*)
+
 ## Layout
 
 ### Single-column
@@ -123,6 +129,8 @@ Stack fields vertically when the width of the viewport and form container shrink
 
 The width of the overall form can impact multi-column layouts. Use set organization logically based on the layout, width of the page, and overall UX strategy in the application.
 
+Refer to the [button organization stacking guidelines](patterns/button-organization#stacking-order) when determining how buttons should stack as the viewport condenses.
+
 ## Text
 
 In sections consisting of multiple blocks of text, use an 8px vertical gap between elements.
@@ -130,12 +138,6 @@ In sections consisting of multiple blocks of text, use an 8px vertical gap betwe
 ![Example of a text section](/assets/patterns/form-patterns/text-section.png =600x*)
 
 Text elements within a form should use logical, step-based sizing to reinforce hierarchy within sections and the form itself. While specifics around type hierarchy should be determined at the application level, adhering to these guidelines will help establish consistency at the page level and when constrained within another element or component.
-
-## Button sets
-
-Organize buttons based on the [Button Set](/components/button-set) guidelines, e.g., using a 16px horizontal gap between buttons.
-
-![Button set](/assets/patterns/form-patterns/button-set.png =500x*)
 
 ## Order and organization
 

--- a/website/docs/patterns/form-patterns/partials/specifications/anatomy.md
+++ b/website/docs/patterns/form-patterns/partials/specifications/anatomy.md
@@ -11,7 +11,7 @@ Elements and content within a form are variable but can be broken down into sect
 | Text | Titles, headlines, descriptions, and supporting content that further describe the content of the form or specific sections within a form. Typically text elements are wrapped in a `<legend>`. |
 | Fields | An array of one or more fields which can be any input type; text input, toggle, radio, textarea, or any other Helios Form component. |
 | Group | Layout mechanism to group like elements together |
-| Actions | Responsible for submitting the form or giving the user a method to cancel, clear the form, or "go back." |
+| Actions | Responsible for submitting the form or giving the user a method to cancel, clear the form, or "go back." Refer to the [button organization](patterns/button-organization) for more details. |
 
 !!! Info
 


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR will add cross-linking in a number of different places in the documentation to the new patterns that were recently released. This includes:

* Reorganizing the `ButtonSet` guidelines in the form patterns and linking to button organization
* Added a link to button stacking order in form patterns
* Added in a link to button organization in the form patterns anatomy
* Added a link to form patterns in form primitives (this seemed the most straightforward, rather than linking in all form component pages)
* Added a link to button organization in `Button Set` docs.

I largely tried to use the same/similar language where possible, and called out the cross-links using a banner. If that is seen as too much, I'll remove the banner and just include as plain text.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1675](https://hashicorp.atlassian.net/browse/HDS-1675)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
