### PR TITLE
Removed event handling for “standalone” radio card elements in showcase

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -16,7 +16,7 @@
   <Shw::Grid @columns={{4}} as |SG|>
     {{#each @model.STATES as |state|}}
       <SG.Item @label={{capitalize state}} mock-state-value={{state}} mock-state-selector="label">
-        <Hds::Form::RadioCard {{on "change" this.onChange}} @disabled={{eq state "disabled"}} as |R|>
+        <Hds::Form::RadioCard @disabled={{eq state "disabled"}} as |R|>
           <R.Icon @name="hexagon" />
           <R.Label>Label</R.Label>
           <R.Description>Description</R.Description>
@@ -25,7 +25,7 @@
     {{/each}}
     {{#each @model.STATES as |state|}}
       <SG.Item @label="{{capitalize state}} selected" mock-state-value={{state}} mock-state-selector="label">
-        <Hds::Form::RadioCard {{on "change" this.onChange}} @checked={{true}} @disabled={{eq state "disabled"}} as |R|>
+        <Hds::Form::RadioCard @checked={{true}} @disabled={{eq state "disabled"}} as |R|>
           <R.Icon @name="hexagon" />
           <R.Label>Label</R.Label>
           <R.Description>Description</R.Description>


### PR DESCRIPTION
### :pushpin: Summary

The base "state" examples on the radio card showcase were triggering an error when clicked, so I removed the event handler associated with them.

<img width="1549" alt="screenshot_2578" src="https://user-images.githubusercontent.com/686239/230134841-d0e6c28c-1923-446c-a04f-080cba4bee4b.png">

### :link: External links

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
