### PR TITLE
Fix inset shadow in form elements

### DIFF
--- a/.changeset/good-boxes-work.md
+++ b/.changeset/good-boxes-work.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fixed missing inset shadow for `TextInput`, `Textarea`, `Checkbox`, `Radio`, `PowerSelect` overrides

--- a/packages/components/app/styles/@hashicorp/design-system-power-select-overrides.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-power-select-overrides.scss
@@ -92,7 +92,7 @@
       background-color: var(--token-form-control-base-surface-color-default);
       border: var(--token-form-control-border-width) solid var(--token-form-control-base-border-color-default);
       border-radius: var(--token-form-control-border-radius);
-      box-shadow: var(--hds-elevation-inset-box-shadow);
+      box-shadow: var(--token-elevation-inset-box-shadow);
 
       // PLACEHOLDER
 

--- a/packages/components/app/styles/components/form/checkbox.scss
+++ b/packages/components/app/styles/components/form/checkbox.scss
@@ -30,7 +30,7 @@
   &:not(:checked, :indeterminate) {
     background-color: var(--token-form-control-base-surface-color-default);
     border-color: var(--token-form-control-base-border-color-default);
-    box-shadow: var(--hds-elevation-inset-box-shadow);
+    box-shadow: var(--token-elevation-inset-box-shadow);
   }
 
   &:checked {

--- a/packages/components/app/styles/components/form/radio.scss
+++ b/packages/components/app/styles/components/form/radio.scss
@@ -30,7 +30,7 @@
   &:not(:checked) {
     background-color: var(--token-form-control-base-surface-color-default);
     border-color: var(--token-form-control-base-border-color-default);
-    box-shadow: var(--hds-elevation-inset-box-shadow);
+    box-shadow: var(--token-elevation-inset-box-shadow);
   }
 
   &:checked {

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -18,7 +18,7 @@
   background-color: var(--token-form-control-base-surface-color-default);
   border: var(--token-form-control-border-width) solid var(--token-form-control-base-border-color-default);
   border-radius: var(--token-form-control-border-radius);
-  box-shadow: var(--hds-elevation-inset-box-shadow);
+  box-shadow: var(--token-elevation-inset-box-shadow);
 
   // PLACEHOLDER
 

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -18,7 +18,7 @@
   background-color: var(--token-form-control-base-surface-color-default);
   border: var(--token-form-control-border-width) solid var(--token-form-control-base-border-color-default);
   border-radius: var(--token-form-control-border-radius);
-  box-shadow: var(--hds-elevation-inset-box-shadow);
+  box-shadow: var(--token-elevation-inset-box-shadow);
   resize: vertical;
 
   // PLACEHOLDER


### PR DESCRIPTION
### :pushpin: Summary

Not sure how it's possible we didn't notice all this time, but apparently we **completely** missed the fact that the inner/inset shadow of some form elements was missing (because of a wrong CSS custom prop name). 

Thankfully @alexcarpenter found the bug! 🙌

### :hammer_and_wrench: Detailed description

In this PR I have:
- replaced the `--hds-elevation` CSS custom prop (wrong) with `--token-elevation` (correct)

👉 **Preview**:

- `TextInput` → [link](https://hds-showcase-git-fix-input-elements-inner-shadow-hashicorp.vercel.app/components/form/text-input)
- `Textarea` → [link](https://hds-showcase-git-fix-input-elements-inner-shadow-hashicorp.vercel.app/components/form/textarea)
- `Checkbox` → [link](https://hds-showcase-git-fix-input-elements-inner-shadow-hashicorp.vercel.app/components/form/checkbox)
- `Radio` → [link](https://hds-showcase-git-fix-input-elements-inner-shadow-hashicorp.vercel.app/components/form/radio)
- `PowerSelect` → [link](https://hds-showcase-git-fix-input-elements-inner-shadow-hashicorp.vercel.app/overrides/power-select)

@heatherlarsen can you please review the showcases above and check that everything is as it should be, from your perspective (expert eye)?

### :camera_flash: Screenshots

**Before:**
<img width="975" alt="screenshot_2590" src="https://user-images.githubusercontent.com/686239/230175157-2f4460f5-cb20-4938-89be-6cfeed44ceaa.png">

**After:**
<img width="977" alt="screenshot_2589" src="https://user-images.githubusercontent.com/686239/230175161-dc247137-e034-4db8-a317-25d51b18f2de.png">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1779

This fixes #1290. 

(Thanks @alexcarpenter for finding the bug)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
