### PR TITLE
Fix sidecar levels shown in single markdown files 

### DIFF
--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -142,7 +142,8 @@ export default class ShowController extends Controller {
       tocs.push({
         index: 0,
         id: 'toc-all',
-        list: getAnchoredHeadings(container),
+        // we show only the headings level 2 and 3 in the sidecar
+        list: getAnchoredHeadings(container).filter((item) => item.depth <= 3),
       });
     }
 


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes an oversight in the logic that handles the headings levels shown in the "sidecar" for single markdown files.

([context](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1681247451576349))

👉 👉 👉 **Preview**: https://hds-website-git-fix-sidecar-levels-hashicorp.vercel.app/getting-started/for-designers

### :camera_flash: Screenshots

<img width="1789" alt="screenshot_2598" src="https://user-images.githubusercontent.com/686239/231404447-a455f199-624f-40d8-b2c8-8be8f496b2c4.png">

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
