### PR TITLE
Add `--` prefix to `ColorSwatch` for CSS variables

### DIFF
--- a/website/docs/foundations/colors/index.js
+++ b/website/docs/foundations/colors/index.js
@@ -26,7 +26,7 @@ export default class Colors extends Component {
             }
             colors['palette'][tone].push({
               colorName: token.path[2],
-              cssVariable: token.name,
+              cssVariable: `--${token.name}`,
               value: token.value,
             });
           } else if (token.group === 'semantic') {
@@ -36,7 +36,7 @@ export default class Colors extends Component {
             }
             const tokenObj = {
               colorName: `${token.path[1]}-${token.path[2]}`,
-              cssVariable: token.name,
+              cssVariable: `--${token.name}`,
               value: token.value,
             };
             if (['foreground', 'page', 'surface', 'border'].includes(context)) {
@@ -51,7 +51,7 @@ export default class Colors extends Component {
             }
             colors['branding'][brand].push({
               colorName: `${token.path[1]}-${token.path[2]}`,
-              cssVariable: token.name,
+              cssVariable: `--${token.name}`,
               value: token.value,
             });
           } else {


### PR DESCRIPTION
### :pushpin: Summary

Small fix to the `Colors/Palette` page (the `--` prefix was missing for the CSS variables).

Thanks @alexcarpenter for reporting the issue.

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
