### PR TITLE
Fix `PowerSelectMultiple` style overrides when search is enabled

### DIFF
--- a/.changeset/strong-frogs-eat.md
+++ b/.changeset/strong-frogs-eat.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix `PowerSelectMultiple` style overrides when search is enabled

--- a/packages/components/app/styles/@hashicorp/design-system-power-select-overrides.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-power-select-overrides.scss
@@ -193,6 +193,17 @@
     }
   }
 
+  .ember-power-select-option--no-matches-message {
+    padding: 8px;
+
+    &:hover {
+      color: inherit;
+      background-color: inherit;
+      border-color: transparent;
+      cursor: default;
+    }
+  }
+
   .ember-power-select-multiple-trigger {
     padding-top: calc(var(--token-form-control-padding) - 3px);
     padding-bottom: calc(var(--token-form-control-padding) - 3px);
@@ -203,7 +214,6 @@
   .ember-power-select-multiple-option {
     display: inline-flex;
     align-items: stretch;
-    float: none;
     margin: 4px 4px 4px 0;
     padding: 3px 10px 5px 10px;
     color: var(--token-color-foreground-primary);
@@ -212,7 +222,7 @@
     font-family: var(--token-typography-font-stack-text);
     line-height: 1rem; // 16px
     vertical-align: middle;
-    background-color: var(--token-color-surface-interactive);
+    background-color: inherit;
     border: 1px solid var(--token-color-border-strong);
     border-radius: 50px;
   }
@@ -231,6 +241,26 @@
       opacity: 1;
     }
   }
+
+  .ember-power-select-trigger-multiple-input {
+    margin: 4px 4px 4px 0;
+
+    &:disabled {
+      display: none;
+    }
+
+    &::-webkit-search-cancel-button {
+      width: var(--token-form-text-input-background-image-size);
+      height: var(--token-form-text-input-background-image-size);
+      background-image: var(--token-form-text-input-background-image-data-url-search-cancel);
+      background-position: center center;
+      background-size: var(--token-form-text-input-background-image-size);
+      cursor: pointer;
+      // stylelint-disable-next-line property-no-vendor-prefix
+      -webkit-appearance: none;
+    }
+  }
+
 
   .hds-power-select__after-options {
     padding: 8px;

--- a/packages/components/tests/dummy/app/templates/overrides/power-select.hbs
+++ b/packages/components/tests/dummy/app/templates/overrides/power-select.hbs
@@ -9,16 +9,18 @@
 
 <section data-test-percy>
 
-  <Shw::Text::H2>Interaction status</Shw::Text::H2>
+  <Shw::Text::H2>Single selection</Shw::Text::H2>
+
+  <Shw::Text::H3>Interaction</Shw::Text::H3>
   <Shw::Flex {{style max-width="50%"}} @direction="column" as |SF|>
-    <SF.Item @label="No option selected">
+    <SF.Item @label="Default">
       <div class="hds-power-select">
         <PowerSelect @options={{@model.OPTIONS}} @onChange={{this.noop}} @renderInPlace={{true}} as |option|>
           {{option}}
         </PowerSelect>
       </div>
     </SF.Item>
-    <SF.Item @label="Option selected">
+    <SF.Item @label="Selected">
       <div class="hds-power-select">
         <PowerSelect
           @options={{@model.OPTIONS}}
@@ -31,9 +33,23 @@
         </PowerSelect>
       </div>
     </SF.Item>
+    <SF.Item @label="Search enabled">
+      <div class="hds-power-select">
+        <PowerSelect
+          @options={{@model.OPTIONS}}
+          @selected={{@model.SELECTED}}
+          @onChange={{this.noop}}
+          @renderInPlace={{true}}
+          @searchEnabled={{true}}
+          as |option|
+        >
+          {{option}}
+        </PowerSelect>
+      </div>
+    </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H2>States</Shw::Text::H2>
+  <Shw::Text::H3>States</Shw::Text::H3>
 
   <Shw::Flex {{style max-width="50%"}} @direction="column" as |SF|>
     <SF.Item @label="Default">
@@ -75,6 +91,94 @@
         >
           {{option}}
         </PowerSelect>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Text::H2>Multiple selection</Shw::Text::H2>
+
+  <Shw::Text::H3>Interaction</Shw::Text::H3>
+
+  <Shw::Flex {{style max-width="50%"}} @direction="column" as |SF|>
+    <SF.Item @label="Default">
+      <div class="hds-power-select">
+        <PowerSelectMultiple @options={{@model.OPTIONS}} @onChange={{this.noop}} @renderInPlace={{true}} as |option|>
+          {{option}}
+        </PowerSelectMultiple>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Selected">
+      <div class="hds-power-select">
+        <PowerSelectMultiple
+          @options={{@model.OPTIONS}}
+          @selected={{@model.SELECTEDMULTIPLE}}
+          @onChange={{this.noop}}
+          @renderInPlace={{true}}
+          as |option|
+        >
+          {{option}}
+        </PowerSelectMultiple>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Search enabled">
+      <div class="hds-power-select">
+        <PowerSelectMultiple
+          @options={{@model.OPTIONS}}
+          @selected={{@model.SELECTEDMULTIPLE}}
+          @onChange={{this.noop}}
+          @renderInPlace={{true}}
+          @searchEnabled={{true}}
+          as |option|
+        >
+          {{option}}
+        </PowerSelectMultiple>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Flex {{style max-width="50%"}} @direction="column" as |SF|>
+    <SF.Item @label="Default">
+      <div class="hds-power-select">
+        <PowerSelectMultiple
+          @options={{@model.OPTIONS}}
+          @selected={{@model.SELECTEDMULTIPLE}}
+          @onChange={{this.noop}}
+          @renderInPlace={{true}}
+          @searchEnabled={{true}}
+          as |option|
+        >
+          {{option}}
+        </PowerSelectMultiple>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Focus">
+      <div class="hds-power-select">
+        <PowerSelectMultiple
+          class="mock-focus"
+          @options={{@model.OPTIONS}}
+          @selected={{@model.SELECTEDMULTIPLE}}
+          @onChange={{this.noop}}
+          @renderInPlace={{true}}
+          as |option|
+        >
+          {{option}}
+        </PowerSelectMultiple>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Disabled">
+      <div class="hds-power-select">
+        <PowerSelectMultiple
+          @options={{@model.OPTIONS}}
+          @selected={{@model.SELECTEDMULTIPLE}}
+          @onChange={{this.noop}}
+          @renderInPlace={{true}}
+          @disabled={{true}}
+          as |option|
+        >
+          {{option}}
+        </PowerSelectMultiple>
       </div>
     </SF.Item>
   </Shw::Flex>


### PR DESCRIPTION
### :pushpin: Summary

Fix `PowerSelectMultiple` style overrides when search is enabled

### :hammer_and_wrench: Detailed description

This use case was not accounted for when applying the overrides.
While at it, also fixed the disabled styles for `<PowerSelectMultiple>` and extended the showcase.

Many thanks to @brianearwood for reporting this and for his patience 🙏 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1580](https://hashicorp.atlassian.net/browse/HDS-1580)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1580]: https://hashicorp.atlassian.net/browse/HDS-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ