### PR TITLE
Pattern spelling fixes

### DIFF
--- a/website/docs/patterns/button-organization/partials/guidelines/alignment.md
+++ b/website/docs/patterns/button-organization/partials/guidelines/alignment.md
@@ -36,7 +36,7 @@ Actions are aligned to the right of the container or page. This alignment method
 
 Actions are aligned in the middle of the container or page. This alignment method is _not_ recommended in the majority of scenarios.
 
-- Can cause buttons to needlessly fill the horiztonal space of the container
+- Can cause buttons to needlessly fill the horizontal space of the container
 - Can cause buttons to appear detached from the content they are paired with, especially if a user has increased zoom settings within their browser
 
 !!! Dont

--- a/website/docs/patterns/button-organization/partials/research/research.md
+++ b/website/docs/patterns/button-organization/partials/research/research.md
@@ -1,6 +1,6 @@
 !!! Info
 
-This content is largely focused around the research and desicion-making process for button alignment. For detailed specifications regarding implementation, visit the [guidelines](/patterns/button-alignment?tab=guidelines).
+This content is largely focused around the research and decision-making process for button alignment. For detailed specifications regarding implementation, visit the [guidelines](/patterns/button-alignment?tab=guidelines).
 !!!
 
 ## Constrained vs. unconstrained

--- a/website/docs/patterns/form-patterns/partials/guidelines/guidelines.md
+++ b/website/docs/patterns/form-patterns/partials/guidelines/guidelines.md
@@ -6,7 +6,7 @@ Spacing between sections, fields, text, and other form elements should follow a 
 
 A **form** acts as a layout mechanism by wrapping the content, fields and actions to apply consistent spacing while simultaneously handling the logic for submitting information and data collected by the fields.
 
-As a layout mechanism, a form consistenting of more than one section should use a 32px gap in between sections.
+As a layout mechanism, a form consisting of more than one section should use a 32px gap in between sections.
 
 ![Form container](/assets/patterns/form-patterns/form-container.png =450x*)
 


### PR DESCRIPTION
### :pushpin: Summary

This _small_ PR addresses a few small spelling fixes that were missed in the original release of the button organization and the form patterns documentation that were caught while updating the Flyout docs.