### PR TITLE
Add `min-height` to `Hds::Textarea`

### DIFF
--- a/.changeset/large-pianos-bathe.md
+++ b/.changeset/large-pianos-bathe.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Add `min-height` to `Hds::Textarea`

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -13,6 +13,7 @@
 .hds-form-textarea {
   width: 100%;
   max-width: 100%;
+  min-height: 36px;
   padding: var(--token-form-control-padding);
   color: var(--token-form-control-base-foreground-value-color);
   background-color: var(--token-form-control-base-surface-color-default);


### PR DESCRIPTION
### :pushpin: Summary

Add `min-height` to `Hds::Textarea`

### :hammer_and_wrench: Detailed description

To prevent users from accidentally resizing it to such a small height that they become unaware of the content.

Value is determined as 20px content + 2x7px padding + 2x1px border = 36px matching `TextInput`'s determined height, `PowerSelect`'s `min-height` (also coinciding with Dropdown item's and SideNav list item's height).

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1822](https://hashicorp.atlassian.net/browse/HDS-1822)

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1822]: https://hashicorp.atlassian.net/browse/HDS-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ