### PR TITLE
`AppFrame` - change position in the DOM for the “modals” container

### DIFF
--- a/.changeset/shaggy-schools-fold.md
+++ b/.changeset/shaggy-schools-fold.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Changed order of "modal" container element in the DOM for the `AppFrame` component

--- a/packages/components/addon/components/hds/app-frame/index.hbs
+++ b/packages/components/addon/components/hds/app-frame/index.hbs
@@ -9,11 +9,16 @@
   {{#if this.hasSidebar}}
     {{yield (hash Sidebar=(component "hds/app-frame/parts/sidebar"))}}
   {{/if}}
+  {{!
+    IMPORTANT: since the modals may be injected via portal or `in-element` with code that lives in the "main" container,
+    the "modal" container needs to be present in the DOM _before_ the "main" block, otherwise it may cause errors
+    where the target DOM element is not found (for example in tests where the modal may be immediately opened on first render).
+  }}
+  {{#if this.hasModals}}
+    {{yield (hash Modals=(component "hds/app-frame/parts/modals"))}}
+  {{/if}}
   {{yield (hash Main=(component "hds/app-frame/parts/main"))}}
   {{#if this.hasFooter}}
     {{yield (hash Footer=(component "hds/app-frame/parts/footer"))}}
-  {{/if}}
-  {{#if this.hasModals}}
-    {{yield (hash Modals=(component "hds/app-frame/parts/modals"))}}
   {{/if}}
 </div>


### PR DESCRIPTION
### :pushpin: Summary

While working with @meirish on https://github.com/hashicorp/cloud-ui/pull/5702 there were a lot of failing tests because of... "something related to modals". After some investigation, Matthew remembered that we talked about the order of the "modals" in the DOM structure, and in fact it was that: as soon as we changed back the order as it was in Cloud UI, the tests started to pass again.

The reason for that is that, since the modals may be injected via portal or `in-element` with code that lives in the "main" container, the "modal" container needs to be present in the DOM _before_ the "main" block, otherwise it may cause error     where the target DOM element is not found (for example in tests where the modal maybe immediately opened on first render).

So in this PR I am restoring the original order as in Cloud UI even if is less intuitive (in theory the "modals" should live on top of all the other elements, so be the last element in the DOM.

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
