### PR TITLE
`SideNav` - Extract a "base" component

### DIFF
--- a/.changeset/empty-apricots-hear.md
+++ b/.changeset/empty-apricots-hear.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Extracted `Hds::SideNav::Base` from the `Hds::SideNav` component

--- a/packages/components/addon/components/hds/side-nav/base.hbs
+++ b/packages/components/addon/components/hds/side-nav/base.hbs
@@ -1,0 +1,14 @@
+<div class="hds-side-nav" ...attributes>
+  <div class="hds-side-nav__wrapper">
+    {{yield to="root"}}
+    <div class="hds-side-nav__wrapper-header">
+      {{yield to="header"}}
+    </div>
+    <div class="hds-side-nav__wrapper-body">
+      {{yield to="body"}}
+    </div>
+    <div class="hds-side-nav__wrapper-footer">
+      {{yield to="footer"}}
+    </div>
+  </div>
+</div>

--- a/packages/components/addon/components/hds/side-nav/index.hbs
+++ b/packages/components/addon/components/hds/side-nav/index.hbs
@@ -3,23 +3,20 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<div class={{this.classNames}} ...attributes {{focus-trap isActive=this.shouldTrapFocus}}>
-  {{#if this.hasA11yRefocus}}
-    <NavigationNarrator
-      @routeChangeValidator={{@a11yRefocusRouteChangeValidator}}
-      @skipTo="#{{@a11yRefocusSkipTo}}"
-      @skipText={{@a11yRefocusSkipText}}
-      @navigationText={{@a11yRefocusNavigationText}}
-    />
-  {{/if}}
-
-  {{#if this.isResponsive}}
-    {{! template-lint-disable no-invalid-interactive}}
-    <div class="hds-side-nav__overlay" {{on "click" this.toggleMinimizedStatus}} />
-  {{/if}}
-
-  <div class="hds-side-nav__wrapper">
+<Hds::SideNav::Base class={{this.classNames}} ...attributes {{focus-trap isActive=this.shouldTrapFocus}}>
+  <:root>
+    {{#if this.hasA11yRefocus}}
+      <NavigationNarrator
+        @routeChangeValidator={{@a11yRefocusRouteChangeValidator}}
+        @skipTo="#{{@a11yRefocusSkipTo}}"
+        @skipText={{@a11yRefocusSkipText}}
+        @navigationText={{@a11yRefocusNavigationText}}
+      />
+    {{/if}}
     {{#if this.isResponsive}}
+      {{! template-lint-disable no-invalid-interactive}}
+      <div class="hds-side-nav__overlay" {{on "click" this.toggleMinimizedStatus}} />
+      {{! template-lint-enable no-invalid-interactive}}
       <button
         class="hds-side-nav__menu-toggle-button"
         type="button"
@@ -30,14 +27,14 @@
         <FlightIcon @name={{if this.isMinimized "menu" "x"}} @size="24" @stretched={{true}} />
       </button>
     {{/if}}
-    <div class="hds-side-nav__wrapper-header">
-      {{yield (hash isMinimized=this.isMinimized) to="header"}}
-    </div>
-    <div class="hds-side-nav__wrapper-body">
-      {{yield (hash isMinimized=this.isMinimized) to="body"}}
-    </div>
-    <div class="hds-side-nav__wrapper-footer">
-      {{yield (hash isMinimized=this.isMinimized) to="footer"}}
-    </div>
-  </div>
-</div>
+  </:root>
+  <:header as |Header|>
+    {{yield (hash Header=Header isMinimized=this.isMinimized) to="header"}}
+  </:header>
+  <:body as |Body|>
+    {{yield (hash Body=Body isMinimized=this.isMinimized) to="body"}}
+  </:body>
+  <:footer as |Footer|>
+    {{yield (hash Footer=Footer isMinimized=this.isMinimized) to="footer"}}
+  </:footer>
+</Hds::SideNav::Base>

--- a/packages/components/addon/components/hds/side-nav/index.js
+++ b/packages/components/addon/components/hds/side-nav/index.js
@@ -56,7 +56,7 @@ export default class HdsSideNavComponent extends Component {
   }
 
   get classNames() {
-    let classes = ['hds-side-nav'];
+    let classes = []; // `hds-side-nav` is already set by the "Hds::SideNav::Base" component
 
     // add specific class names for the different possible states
     if (this.isDesktop) {

--- a/packages/components/app/components/hds/side-nav/base.js
+++ b/packages/components/app/components/hds/side-nav/base.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export { default } from '@hashicorp/design-system-components/components/hds/side-nav/base';

--- a/packages/components/app/styles/components/side-nav/main.scss
+++ b/packages/components/app/styles/components/side-nav/main.scss
@@ -11,7 +11,7 @@
   position: sticky;
   top: 0;
   z-index: 20; // needs to stay above the main content
-  width: var(--hds-app-sidenav-width-expanded); // "default" width used by the `SideNav::Base` subcomponent
+  width: var(--hds-app-sidenav-width-fixed); // "default" width used by the `SideNav::Base` subcomponent (that is not responsive)
   height: 100vh;
   min-height: 100vh;
   isolation: isolate; // used to create a new stacking context (so we can set the overlay's z-index to -1)

--- a/packages/components/app/styles/components/side-nav/main.scss
+++ b/packages/components/app/styles/components/side-nav/main.scss
@@ -11,6 +11,7 @@
   position: sticky;
   top: 0;
   z-index: 20; // needs to stay above the main content
+  width: var(--hds-app-sidenav-width-expanded); // "default" width used by the `SideNav::Base` subcomponent
   height: 100vh;
   min-height: 100vh;
   isolation: isolate; // used to create a new stacking context (so we can set the overlay's z-index to -1)

--- a/packages/components/app/styles/components/side-nav/vars.scss
+++ b/packages/components/app/styles/components/side-nav/vars.scss
@@ -18,6 +18,7 @@
   // widths
   --hds-app-sidenav-width-minimized: 80px;
   --hds-app-sidenav-width-expanded: 280px;
+  --hds-app-sidenav-width-fixed: var(--hds-app-sidenav-width-expanded);
   // sidebar menu
   --hds-app-sidenav-menu-button-y-shift: 84px;
   // animation

--- a/packages/components/tests/dummy/app/templates/components/side-nav.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav.hbs
@@ -90,6 +90,149 @@
 
 </section>
 
+<Shw::Divider @level={{2}} />
+
+<section data-test-percy>
+  <Shw::Text::H2>Examples of sidebar navigation</Shw::Text::H2>
+
+  <Shw::Grid @columns={{2}} as |SG|>
+
+    <SG.Item>
+      <Shw::Text::H3>Using content injected via portal</Shw::Text::H3>
+      <Shw::Flex as |SF|>
+        <SF.Item @label="With PortalTarget + Portal with “nav” items">
+          <div class="shw-component-sim-side-nav-root-container" {{style height="auto"}}>
+            <Hds::SideNav @isResponsive={{false}} @hasA11yRefocus={{false}}>
+              <:header>
+                <Hds::SideNav::Header>
+                  <:logo>
+                    <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
+                  </:logo>
+                  <:actions>
+                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                      <dd.ToggleIcon @icon="help" @text="help menu" />
+                      <dd.Title @text="Help & Support" />
+                      <dd.Interactive @text="Documentation" @href="#" />
+                      <dd.Interactive @text="Tutorials" @href="#" />
+                      <dd.Interactive @text="Terraform Provider" @href="#" />
+                      <dd.Interactive @text="Changelog" @href="#" />
+                      <dd.Separator />
+                      <dd.Interactive @text="Create support ticket" @href="#" />
+                      <dd.Interactive @text="Give feedback" @href="#" />
+                    </Hds::Dropdown>
+                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                      <dd.ToggleIcon @icon="user" @text="user menu" />
+                      <dd.Title @text="Signed In" />
+                      <dd.Description @text="email@domain.com" />
+                      <dd.Interactive @href="#" @text="Account Settings" />
+                    </Hds::Dropdown>
+                  </:actions>
+                </Hds::SideNav::Header>
+              </:header>
+              <:body>
+                <Hds::SideNav::Portal::Target @targetName="sidenav-portal-demo-2" />
+              </:body>
+              <:footer>
+                OrgSelect / ContextSwitcher
+              </:footer>
+            </Hds::SideNav>
+          </div>
+        </SF.Item>
+      </Shw::Flex>
+      <Hds::SideNav::Portal @targetName="sidenav-portal-demo-2" as |Nav|>
+        <Nav.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
+        <Nav.Title>Services</Nav.Title>
+        <Nav.Link @text="Boundary" @icon="boundary" @href="#" />
+        <Nav.Link @text="Consul" @icon="consul" @href="#" />
+        <Nav.Link @text="Packer" @icon="packer" @href="#" />
+        <Nav.Link @text="Vault" @icon="vault" @href="#" />
+        <Nav.Link @text="Vault Secrets" @icon="lock" @href="#" />
+        <Nav.Link @text="Terraform" @icon="terraform" @href="#" />
+        <Nav.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
+        <Nav.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} />
+        <Nav.Title>Default Org</Nav.Title>
+        <Nav.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />
+        <Nav.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
+        <Nav.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
+        <Nav.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
+        <Nav.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
+      </Hds::SideNav::Portal>
+
+    </SG.Item>
+    <SG.Item>
+      <Shw::Text::H3>Using yielded content</Shw::Text::H3>
+
+      <Shw::Flex as |SF|>
+        <SF.Item @label="With multiple 'list' (nav) containers & extra button in header">
+          <div class="shw-component-sim-side-nav-root-container" {{style height="auto"}}>
+            <Hds::SideNav @isResponsive={{false}} @hasA11yRefocus={{false}}>
+              <:header>
+                <Hds::SideNav::Header>
+                  <:logo>
+                    <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
+                  </:logo>
+                  <:actions>
+                    <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
+                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                      <dd.ToggleIcon @icon="help" @text="help menu" />
+                      <dd.Title @text="Help & Support" />
+                      <dd.Interactive @text="Documentation" @href="#" />
+                      <dd.Interactive @text="Tutorials" @href="#" />
+                      <dd.Interactive @text="Terraform Provider" @href="#" />
+                      <dd.Interactive @text="Changelog" @href="#" />
+                      <dd.Separator />
+                      <dd.Interactive @text="Create support ticket" @href="#" />
+                      <dd.Interactive @text="Give feedback" @href="#" />
+                    </Hds::Dropdown>
+                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                      <dd.ToggleIcon @icon="user" @text="user menu" />
+                      <dd.Title @text="Signed In" />
+                      <dd.Description @text="email@domain.com" />
+                      <dd.Interactive @href="#" @text="Account Settings" />
+                    </Hds::Dropdown>
+                  </:actions>
+                </Hds::SideNav::Header>
+              </:header>
+
+              <:body>
+                <Hds::SideNav::List as |SNL|>
+                  <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
+                </Hds::SideNav::List>
+
+                <Hds::SideNav::List as |SNL|>
+                  <SNL.Title>Services</SNL.Title>
+                  <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
+                  <SNL.Link @text="Consul" @icon="consul" @href="#" />
+                  <SNL.Link @text="Packer" @icon="packer" @href="#" />
+                  <SNL.Link @text="Vault" @icon="vault" @href="#" />
+                  <SNL.Link @text="Vault Secrets" @icon="lock" @href="#" />
+                  <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
+                  <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
+                  <SNL.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} />
+                </Hds::SideNav::List>
+
+                <Hds::SideNav::List as |SNL|>
+                  <SNL.Title>Default Org</SNL.Title>
+                  <SNL.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />
+                  <SNL.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
+                  <SNL.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
+                  <SNL.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
+                  <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
+                </Hds::SideNav::List>
+              </:body>
+
+              <:footer>
+                OrgSelect / ContextSwitcher
+              </:footer>
+            </Hds::SideNav>
+          </div>
+        </SF.Item>
+      </Shw::Flex>
+    </SG.Item>
+  </Shw::Grid>
+
+</section>
+
 <Shw::Divider />
 
 <section data-test-percy>
@@ -637,148 +780,5 @@
       </div>
     </SF.Item>
   </Shw::Flex>
-
-</section>
-
-<Shw::Divider />
-
-<section data-test-percy>
-  <Shw::Text::H2>Examples of sidebar navigation</Shw::Text::H2>
-
-  <Shw::Grid @columns={{2}} as |SG|>
-
-    <SG.Item>
-      <Shw::Text::H3>Using content injected via portal</Shw::Text::H3>
-      <Shw::Flex as |SF|>
-        <SF.Item @label="With PortalTarget + Portal with “nav” items">
-          <div class="shw-component-sim-side-nav-root-container" {{style height="auto"}}>
-            <Hds::SideNav @isResponsive={{false}} @hasA11yRefocus={{false}}>
-              <:header>
-                <Hds::SideNav::Header>
-                  <:logo>
-                    <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
-                  </:logo>
-                  <:actions>
-                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
-                      <dd.ToggleIcon @icon="help" @text="help menu" />
-                      <dd.Title @text="Help & Support" />
-                      <dd.Interactive @text="Documentation" @href="#" />
-                      <dd.Interactive @text="Tutorials" @href="#" />
-                      <dd.Interactive @text="Terraform Provider" @href="#" />
-                      <dd.Interactive @text="Changelog" @href="#" />
-                      <dd.Separator />
-                      <dd.Interactive @text="Create support ticket" @href="#" />
-                      <dd.Interactive @text="Give feedback" @href="#" />
-                    </Hds::Dropdown>
-                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
-                      <dd.ToggleIcon @icon="user" @text="user menu" />
-                      <dd.Title @text="Signed In" />
-                      <dd.Description @text="email@domain.com" />
-                      <dd.Interactive @href="#" @text="Account Settings" />
-                    </Hds::Dropdown>
-                  </:actions>
-                </Hds::SideNav::Header>
-              </:header>
-              <:body>
-                <Hds::SideNav::Portal::Target @targetName="sidenav-portal-demo-2" />
-              </:body>
-              <:footer>
-                OrgSelect / ContextSwitcher
-              </:footer>
-            </Hds::SideNav>
-          </div>
-        </SF.Item>
-      </Shw::Flex>
-      <Hds::SideNav::Portal @targetName="sidenav-portal-demo-2" as |Nav|>
-        <Nav.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
-        <Nav.Title>Services</Nav.Title>
-        <Nav.Link @text="Boundary" @icon="boundary" @href="#" />
-        <Nav.Link @text="Consul" @icon="consul" @href="#" />
-        <Nav.Link @text="Packer" @icon="packer" @href="#" />
-        <Nav.Link @text="Vault" @icon="vault" @href="#" />
-        <Nav.Link @text="Vault Secrets" @icon="lock" @href="#" />
-        <Nav.Link @text="Terraform" @icon="terraform" @href="#" />
-        <Nav.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
-        <Nav.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} />
-        <Nav.Title>Default Org</Nav.Title>
-        <Nav.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />
-        <Nav.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
-        <Nav.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
-        <Nav.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
-        <Nav.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
-      </Hds::SideNav::Portal>
-
-    </SG.Item>
-    <SG.Item>
-      <Shw::Text::H3>Using yielded content</Shw::Text::H3>
-
-      <Shw::Flex as |SF|>
-        <SF.Item @label="With multiple 'list' (nav) containers & extra button in header">
-          <div class="shw-component-sim-side-nav-root-container" {{style height="auto"}}>
-            <Hds::SideNav @isResponsive={{false}} @hasA11yRefocus={{false}}>
-              <:header>
-                <Hds::SideNav::Header>
-                  <:logo>
-                    <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
-                  </:logo>
-                  <:actions>
-                    <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
-                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
-                      <dd.ToggleIcon @icon="help" @text="help menu" />
-                      <dd.Title @text="Help & Support" />
-                      <dd.Interactive @text="Documentation" @href="#" />
-                      <dd.Interactive @text="Tutorials" @href="#" />
-                      <dd.Interactive @text="Terraform Provider" @href="#" />
-                      <dd.Interactive @text="Changelog" @href="#" />
-                      <dd.Separator />
-                      <dd.Interactive @text="Create support ticket" @href="#" />
-                      <dd.Interactive @text="Give feedback" @href="#" />
-                    </Hds::Dropdown>
-                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
-                      <dd.ToggleIcon @icon="user" @text="user menu" />
-                      <dd.Title @text="Signed In" />
-                      <dd.Description @text="email@domain.com" />
-                      <dd.Interactive @href="#" @text="Account Settings" />
-                    </Hds::Dropdown>
-                  </:actions>
-                </Hds::SideNav::Header>
-              </:header>
-
-              <:body>
-                <Hds::SideNav::List as |SNL|>
-                  <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
-                </Hds::SideNav::List>
-
-                <Hds::SideNav::List as |SNL|>
-                  <SNL.Title>Services</SNL.Title>
-                  <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
-                  <SNL.Link @text="Consul" @icon="consul" @href="#" />
-                  <SNL.Link @text="Packer" @icon="packer" @href="#" />
-                  <SNL.Link @text="Vault" @icon="vault" @href="#" />
-                  <SNL.Link @text="Vault Secrets" @icon="lock" @href="#" />
-                  <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
-                  <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
-                  <SNL.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} />
-                </Hds::SideNav::List>
-
-                <Hds::SideNav::List as |SNL|>
-                  <SNL.Title>Default Org</SNL.Title>
-                  <SNL.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />
-                  <SNL.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
-                  <SNL.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
-                  <SNL.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
-                  <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
-                </Hds::SideNav::List>
-              </:body>
-
-              <:footer>
-                OrgSelect / ContextSwitcher
-              </:footer>
-            </Hds::SideNav>
-          </div>
-        </SF.Item>
-      </Shw::Flex>
-    </SG.Item>
-  </Shw::Grid>
 
 </section>

--- a/packages/components/tests/dummy/app/templates/components/side-nav.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav.hbs
@@ -93,6 +93,35 @@
 <Shw::Divider />
 
 <section data-test-percy>
+
+  <Shw::Text::H2>SideNav::Base</Shw::Text::H2>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Header + Body + Footer">
+      <div class="shw-component-sim-side-nav-root-container">
+        <Hds::SideNav::Base>
+          <:root>
+            <Shw::Placeholder @height="72px" @text="root" @background="#e4e4e4" />
+          </:root>
+          <:header>
+            <Shw::Placeholder @height="72px" @text="header" @background="#e4e4e4" />
+          </:header>
+          <:body>
+            <Shw::Placeholder @height="250px" @text="body" @background="#e4e4e4" />
+          </:body>
+          <:footer>
+            <Shw::Placeholder @height="36px" @text="footer" @background="#e4e4e4" />
+          </:footer>
+        </Hds::SideNav::Base>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+</section>
+
+<Shw::Divider />
+
+<section data-test-percy>
   <Shw::Text::H2>SideNav::Header</Shw::Text::H2>
 
   <Shw::Flex as |SF|>

--- a/packages/components/tests/integration/components/hds/side-nav/base-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/base-test.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/side-nav/base', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should render the component with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::SideNav::Base id="test-side-nav" />`);
+    assert.dom('#test-side-nav').hasClass('hds-side-nav');
+  });
+
+  // CONTENT
+
+  test('it renders content passed to the named blocks', async function (assert) {
+    await render(hbs`
+      <Hds::SideNav::Base>
+        <:root>
+          <span id="test-side-nav-root" />
+        </:root>
+        <:header>
+          <span id="test-side-nav-header" />
+        </:header>
+        <:body>
+          <span id="test-side-nav-body" />
+        </:body>
+        <:footer>
+          <span id="test-side-nav-footer" />
+        </:footer>
+      </Hds::SideNav::Base>
+    `);
+    assert.dom('#test-side-nav-root').exists();
+    assert.dom('#test-side-nav-header').exists();
+    assert.dom('#test-side-nav-body').exists();
+    assert.dom('#test-side-nav-footer').exists();
+  });
+
+  // ATTRIBUTES
+
+  test('it should spread all the attributes passed to the component on the element', async function (assert) {
+    await render(
+      hbs`<Hds::SideNav::Base id="test-side-nav" class="my-class" data-test1 data-test2="test" />`
+    );
+    assert.dom('#test-side-nav').hasClass('my-class');
+    assert.dom('#test-side-nav').hasAttribute('data-test1');
+    assert.dom('#test-side-nav').hasAttribute('data-test2', 'test');
+  });
+});

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -25,7 +25,7 @@ This is the basic component (layout only).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="<:root>" @type="named block">
-    A named block that can be used to render content that needs to be rendered outside of the "header/body/footer" containers of the SideNav.
+    A named block for rendering content outside of the "header/body/footer" containers of the SideNav.
   </C.Property>
   <C.Property @name="<:header>" @type="named block">
     A named block where the content for the “header” area of the SideNav is rendered. The `SideNav::Header` component should be added here.

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -2,7 +2,31 @@
 
 ### SideNav
 
+This is the full-fledged component (responsive and animated).
+
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<:header>" @type="named block">
+    A named block where the content for the “header” area of the SideNav is rendered. The `SideNav::Header` component should be added here. It yields the value of `isMinimized` too.
+  </C.Property>
+  <C.Property @name="<:body>" @type="named block">
+    A named block where the content for the “body” or main content of the SideNav is rendered. The `SideNav::List` and `SideNav::PortalTarget` components should be added here when used. It yields the value of `isMinimized` too.
+  </C.Property>
+  <C.Property @name="<:footer>" @type="named block">
+    A named block where the content for the “footer” section of the SideNav is rendered. It yields the value of `isMinimized` too.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>
+
+### SideNav::Base
+
+This is the basic component (layout only).
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="<:root>" @type="named block">
+    A named block that can be used to render content that needs to be rendered outside of the "header/body/footer" containers of the SideNav.
+  </C.Property>
   <C.Property @name="<:header>" @type="named block">
     A named block where the content for the “header” area of the SideNav is rendered. The `SideNav::Header` component should be added here.
   </C.Property>


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of https://github.com/hashicorp/design-system/pull/1304 in which I have extracted the "basic" layout functionality of the `SideNav` in a dedicated component, so that it can be used independently from the full-fledged one, to achieve basic navigations (in which only the layout wrapper is needed, not all the responsiveness/animation etc).

_The idea for this change has materialised when I was starting to write the documentation for "how to use" the sidebar navigation, and I've realised that in cases where a consumer would need just a basic navigation, the implemented `SideNav` could be an overkill (especially for the fact that there's a lot of JavaScript involved, that in the case of a basic navigation may not be necessary at all). So I decided to do test, see how the code would look like, and at the end of the process I saw that it wasn't bad at all, on the contrary: made sense. So I decided to open the PR and gather feedback from the other HDS engineers._

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a `SideNav::Base` component (copy&pasted the existing `SideNav` and stripped away all the non-basic-layout stuff)
- updated the `SideNav` to use (internally) the `SideNav::Base` subcomponent
- added showcase example for `SideNav::Base` + moved `SideNav` examples in the showcase up in the page
- updated the “Component API” section of the website
- added integration tests for `SideNav::Base`

### :link: External links

- https://github.com/hashicorp/design-system/pull/1304

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
