### PR TITLE
`Dropdown` component - rename `@isInlineBlock` to `@isInline`

### DIFF
--- a/.changeset/nice-steaks-prove.md
+++ b/.changeset/nice-steaks-prove.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-Added a `@isInlineBlock` argument to the `Hds::Dropdown` component
+Added a `@isInline` argument to the `Hds::Dropdown` component

--- a/packages/components/addon/components/hds/dropdown/index.js
+++ b/packages/components/addon/components/hds/dropdown/index.js
@@ -46,9 +46,9 @@ export default class HdsDropdownIndexComponent extends Component {
   get classNames() {
     let classes = ['hds-dropdown'];
 
-    // add a class based on the @isInlineBlock argument
-    if (this.args.isInlineBlock) {
-      classes.push('hds-dropdown--is-inline-block');
+    // add a class based on the @isInline argument
+    if (this.args.isInline) {
+      classes.push('hds-dropdown--is-inline');
     }
 
     return classes.join(' ');

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -16,7 +16,7 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 
 // DROPDOWN
 
-.hds-dropdown--is-inline-block {
+.hds-dropdown--is-inline {
   display: inline-block;
 
   .hds-dropdown-toggle-icon,

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -56,7 +56,7 @@
     </SF.Item>
     <SF.Item @label="Inline">
       <div class="shw-component-dropdown-display-sample">
-        <Hds::Dropdown @listPosition="bottom-left" @isInlineBlock={{true}} as |dd|>
+        <Hds::Dropdown @listPosition="bottom-left" @isInline={{true}} as |dd|>
           <dd.ToggleButton @color="secondary" @text="Menu" />
           <dd.Interactive @href="#" @text="Create" />
           <dd.Interactive @href="#" @text="Edit" />

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -286,7 +286,7 @@
         <B.Td>{{B.data.services.imported}}</B.Td>
         <B.Td>{{B.data.services.exported}}</B.Td>
         <B.Td @align="right">
-          <Hds::Dropdown @isInlineBlock={{true}} as |dd|>
+          <Hds::Dropdown @isInline={{true}} as |dd|>
             <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
             <dd.Interactive @route="components.table" @text="Create" />
             <dd.Interactive @route="components.table" @text="Read" />
@@ -333,7 +333,7 @@
         <B.Td>{{B.data.services.imported}}</B.Td>
         <B.Td>{{B.data.services.exported}}</B.Td>
         <B.Td @align="right">
-          <Hds::Dropdown @isInlineBlock={{true}} as |dd|>
+          <Hds::Dropdown @isInline={{true}} as |dd|>
             <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
             <dd.Interactive @route="components.table" @text="Create" />
             <dd.Interactive @route="components.table" @text="Read" />
@@ -368,7 +368,7 @@
         <B.Td>{{B.data.album}}</B.Td>
         <B.Td>{{B.data.year}}</B.Td>
         <B.Td @align="right">
-          <Hds::Dropdown @isInlineBlock={{true}} as |dd|>
+          <Hds::Dropdown @isInline={{true}} as |dd|>
             <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
             <dd.Interactive @route="components.table" @text="Create" />
             <dd.Interactive @route="components.table" @text="Read" />
@@ -631,7 +631,7 @@
               </div>
             </B.Td>
             <B.Td @align="right">
-              <Hds::Dropdown @isInlineBlock={{true}} as |dd|>
+              <Hds::Dropdown @isInline={{true}} as |dd|>
                 <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
                 <dd.Interactive @route="components.table" @text="Dropdown" />
               </Hds::Dropdown>

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -105,6 +105,16 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
       .dom('#test-dropdown .hds-dropdown__content')
       .hasClass('hds-dropdown__content--position-left');
   });
+  test('it should render the element as `inline` if the value of @isInline is "true"', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" @isInline={{true}} as |dd|>
+        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <dd.Interactive @route="components.dropdown" @text="interactive" />
+      </Hds::Dropdown>
+    `);
+    await click('button#test-toggle-button');
+    assert.dom('#test-dropdown').hasClass('hds-dropdown--is-inline');
+  });
 
   // WIDTH
 

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -24,8 +24,8 @@ The Dropdown component is composed of different child components each with their
   <C.Property @name="height" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     If a `@height` parameter is provided then the list will have a fixed height.
   </C.Property>
-  <C.Property @name="isInlineBlock" @type="boolean" @values={{array "true" "false" }} @default="false">
-    If a `@isInlineBlock` parameter is provided then the element will be displayed as `inline-block` (useful to achieve specific layouts like in a container with right alignment).
+  <C.Property @name="isInline" @type="boolean" @values={{array "true" "false" }} @default="false">
+    If a `@isInline` parameter is provided then the element will be displayed as `inline-block` (useful to achieve specific layouts like in a container with right alignment). Otherwise it will be have a `block` layout.
   </C.Property>
   <C.Property @name="close" @type="function">
     Function to programmatically close the dropdown.

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -31,11 +31,11 @@ By default, the list is positioned below the button, aligned to the right. To ch
 </Hds::Dropdown>
 ```
 
-In contexts where the dropdown needs to be _inline_, to inherit the alignment from a parent, you can use the `@isInlineBlock` argument (and set the `@listPosition` accordingly to your needs):
+In contexts where the dropdown needs to be _inline_, to inherit the alignment from a parent, you can use the `@isInline` argument (and set the `@listPosition` accordingly to your needs):
 
 ```handlebars
 <div class="doc-dropdown-mock-text-align-right">
-  <Hds::Dropdown @isInlineBlock={{true}} @listPosition="bottom-right" as |dd|>
+  <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
     <dd.ToggleButton @text="Text Toggle" @color="secondary" />
     <dd.Interactive @route="components" @text="Item One" />
     <dd.Interactive @route="components" @text="Item Two" />


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of https://github.com/hashicorp/design-system/pull/1315 based on the conversation on [this Slack thread](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1682358468189789?thread_ts=1682071830.504549&cid=C025N5V4PFZ).

### :hammer_and_wrench: Detailed description

In this PR I have:
- renamed the `@isInlineBlock` argument for `Dropdown` component to `@isInline`
- updated documentation and showcase accordingly
- added a missing test (that I forgot to add in the previous PR)
- updated the `changeset` entry (no need to add a new one)

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] ~~Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed~~
    - I've updated the existing changeset entry to avoid a double entry in the changelog

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
