### PR TITLE
`SideNav` - Remove extra `commitStyles` call

### DIFF
--- a/.changeset/fluffy-vans-remain.md
+++ b/.changeset/fluffy-vans-remain.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Removed extra call to `commitStyles` in `SideNav::Portal::Target`

--- a/packages/components/addon/components/hds/side-nav/portal/target.js
+++ b/packages/components/addon/components/hds/side-nav/portal/target.js
@@ -112,10 +112,7 @@ export default class SidenavPortalTarget extends Component {
         fill: 'forwards',
       }
     );
-    // Notice: we don't add the styles by default because it writes a `style` attribute to the element and it causes an additional re-render
-    if (DEBUG) {
-      anim.commitStyles();
-    }
+
     anim.finished.then(() => {
       // uncomment this if we need/want to scroll the element to the top
       // targetElement.scrollIntoView(true);


### PR DESCRIPTION
### :pushpin: Summary

Context: https://hashicorp.slack.com/archives/C02ESMK682C/p1682533403105249?thread_ts=1682528526.401839&cid=C02ESMK682C

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed an extra `commitStyles` call
  - it was added in the porting to the standalone version of the `HcNav` but in the Cloud UI version of the addon it was not present

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
