### PR TITLE
Add `SegmentedGroup` code docs

### DIFF
--- a/website/docs/components/segmented-group/index.md
+++ b/website/docs/components/segmented-group/index.md
@@ -17,6 +17,8 @@ navigation:
 </section>
 
 <section data-tab="Code">
+  @include "partials/code/how-to-use.md"
+  @include "partials/code/component-api.md"
 </section>
 
 <section data-tab="Specifications">
@@ -24,4 +26,5 @@ navigation:
 </section>
 
 <section data-tab="Accessibility">
+  @include "partials/accessibility/accessibility.md"
 </section>

--- a/website/docs/components/segmented-group/partials/accessibility/accessibility.md
+++ b/website/docs/components/segmented-group/partials/accessibility/accessibility.md
@@ -1,0 +1,15 @@
+## Conformance rating
+
+<Doc::Badge @type="warning">Conditionally conformant</Doc::Badge>
+
+You must make sure each `TextInput` or `Select` segment has an accessible name, either by associating them with a `<label>` element, or by setting an `aria-label` on each input control.
+
+## Applicable WCAG Success Criteria
+
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
+
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.1" "4.1.2" }} />
+
+---
+
+<Doc::A11ySupport />

--- a/website/docs/components/segmented-group/partials/code/component-api.md
+++ b/website/docs/components/segmented-group/partials/code/component-api.md
@@ -1,0 +1,29 @@
+## Component API
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>
+
+### Contextual components
+
+The following predefined Segments can be passed into the Segmented Group as yielded components: `Button`, `Dropdown`, `Select`, `TextInput`. For bespoke Segments use the `Generic` block and style it accordingly.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="<[S].Button>" @type="yielded component">
+    For details about its API, check the [`Button`](/components/button?tab=code#component-api) component.
+  </C.Property>
+  <C.Property @name="<[S].Dropdown>" @type="yielded component">
+    For details about its API, check the [`Dropdown`](/components/dropdown?tab=code#component-api) component.
+  </C.Property>
+  <C.Property @name="<[S].Select>" @type="yielded component">
+    For details about its API, check the [`Form::Select::Base`](/components/form/select?tab=code#formselectbase-1) component.
+  </C.Property>
+  <C.Property @name="<[S].TextInput>" @type="yielded component">
+    For details about its API, check the [`Form::TextInput::Base`](/components/form/text-input?tab=code#formtextinputbase-1) component.
+  </C.Property>
+  <C.Property @name="<[S].Generic>" @type="yielded component">
+    A component that yields its content. The content does not inherit any styles.
+  </C.Property>
+</Doc::ComponentApi>

--- a/website/docs/components/segmented-group/partials/code/how-to-use.md
+++ b/website/docs/components/segmented-group/partials/code/how-to-use.md
@@ -1,0 +1,68 @@
+## How to use this component
+
+### Within a filter pattern
+
+```handlebars
+<Hds::SegmentedGroup as |S|>
+  <S.TextInput @type="search" placeholder="Search" aria-label="Search" />
+  <S.Dropdown as |DD|>
+    <DD.ToggleButton @color="secondary" @text="Across" @count="2" />
+    <DD.Checkbox checked>Metadata</DD.Checkbox>
+    <DD.Checkbox checked>Tags</DD.Checkbox>
+    <DD.Checkbox>Service name</DD.Checkbox>
+  </S.Dropdown>
+</Hds::SegmentedGroup> 
+```
+
+For complex filters we recommend grouping related filter criteria into a Segmented Group.
+
+```handlebars
+<Hds::SegmentedGroup as |S|>
+  <S.Dropdown as |DD|>
+    <DD.ToggleButton @color="secondary" @text="Health status" />
+    <DD.Checkbox>Passing</DD.Checkbox>
+    <DD.Checkbox>Warning</DD.Checkbox>
+    <DD.Checkbox>Failing</DD.Checkbox>
+  </S.Dropdown>
+  <S.Dropdown as |DD|>
+    <DD.ToggleButton @color="secondary" @text="Source" />
+    <DD.Checkbox>Consul</DD.Checkbox>
+    <DD.Checkbox>Kubernetes</DD.Checkbox>
+  </S.Dropdown>
+  <S.Dropdown as |DD|>
+    <DD.ToggleButton @color="secondary" @text="Type" />
+    <DD.Checkbox>Service</DD.Checkbox>
+    <DD.Checkbox>Debug service</DD.Checkbox>
+  </S.Dropdown>
+</Hds::SegmentedGroup>
+```
+
+### Within a form
+
+When used within a form we recommend using component composition, passing a `SegmentedGroup` in a [`Form::Field`](/components/form/primitives?tab=code#formfield-1). The `Form::Field` exposes two attributes, `id` and `ariaDescribedBy`, that are used to associate the input with the label, helper text, and error.
+
+```handlebars
+<Hds::Form::Field @layout="vertical" as |F|>
+  <F.Label>New API Key</F.Label>
+  <F.HelperText>Your org must have at least one key and at most five keys</F.HelperText>
+  <F.Control>
+    <Hds::SegmentedGroup as |S|>
+      <S.TextInput id={{F.id}} aria-describedby={{F.ariaDescribedBy}} size="32" />
+      <S.Button @color="secondary" @text="Generate" />
+    </Hds::SegmentedGroup>
+  </F.Control>
+</Hds::Form::Field>
+```
+
+### Generic Segment
+
+Use the `Generic` block to pass custom Segments to the group". The predefined Segments adjust their styles automatically depending on their placement within the group. You will need to ensure similar styling for your custom Segment.
+
+```handlebars
+<Hds::SegmentedGroup as |S|>
+  <S.TextInput aria-label="input leading generic segment" size="32" />
+  <S.Generic>
+    <Doc::Placeholder @text="generic segment" @height="36" @background="#eee" />
+  </S.Generic>
+</Hds::SegmentedGroup>
+```


### PR DESCRIPTION
### :pushpin: Summary

Add `SegmentedGroup` code docs

### :hammer_and_wrench: Detailed description

 - [How to use & Component API](https://hds-website-git-alex-ju-segmented-group-docs-hashicorp.vercel.app/components/segmented-group?tab=code)
 - [Accessibility](https://hds-website-git-alex-ju-segmented-group-docs-hashicorp.vercel.app/components/segmented-group?tab=accessibility)

Note: This is a follow-up on #1316. The intention is to merge this into #1282 so we get all the documentation in at once – will change the base before merging.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1686](https://hashicorp.atlassian.net/browse/HDS-1686)

***

[HDS-1686]: https://hashicorp.atlassian.net/browse/HDS-1686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ