### PR TITLE
`SideNav` - Add missing override of `Dropdown::ToggleButton`

### DIFF
--- a/.changeset/tasty-oranges-behave.md
+++ b/.changeset/tasty-oranges-behave.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav` - added missing override of `Dropdown::ToggleButton`

--- a/packages/components/app/styles/components/side-nav/header.scss
+++ b/packages/components/app/styles/components/side-nav/header.scss
@@ -84,7 +84,8 @@
 // dropdown overrides
 
 .hds-side-nav__dropdown { // ⬅︎ add this class name to the `Hds::Dropdown` component to apply the style overrides
-  .hds-dropdown-toggle-icon {
+  .hds-dropdown-toggle-icon,
+  .hds-dropdown-toggle-button {
     @include hds-side-nav-icon-button($add-visible-border: true);
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/side-nav.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav.hbs
@@ -309,7 +309,7 @@
         </Hds::SideNav::Header>
       </div>
     </SF.Item>
-    <SF.Item @label="Logo (HomeLink) + Actions (IconButton + Dropdowns)">
+    <SF.Item @label="Logo (HomeLink) + Actions (IconButton + Dropdown)">
       <div class="shw-component-sim-side-nav-header">
         <Hds::SideNav::Header>
           <:logo>
@@ -318,7 +318,7 @@
           <:actions>
             <Hds::SideNav::Header::IconButton @icon="terminal-screen" @ariaLabel="Terminal" />
             <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
-              <dd.ToggleIcon @icon="help" @text="help menu" />
+              <dd.ToggleButton @text="Help" />
               <dd.Title @text="Help & Support" />
               <dd.Interactive @text="Documentation" @href="#" />
               <dd.Interactive @text="Tutorials" @href="#" />
@@ -327,12 +327,6 @@
               <dd.Separator />
               <dd.Interactive @text="Create support ticket" @href="#" />
               <dd.Interactive @text="Give feedback" @href="#" />
-            </Hds::Dropdown>
-            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
-              <dd.ToggleIcon @icon="user" @text="user menu" />
-              <dd.Title @text="Signed In" />
-              <dd.Description @text="email@domain.com" />
-              <dd.Interactive @href="#" @text="Account Settings" />
             </Hds::Dropdown>
           </:actions>
         </Hds::SideNav::Header>


### PR DESCRIPTION
### :pushpin: Summary

While working on a fix for Cloud UI sidenav, I have realized we forgot to consider the case where the `Dropdown` uses a `ToggleButton` instead of a `ToggleIcon` (eg. in the switchers).

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a missing override of `Dropdown::ToggleButton` in `SideNav`
- updated the showcase to include one case of action that uses a `ToggleButton`

### :camera_flash: Screenshots

Before:
<img width="329" alt="screenshot_2654" src="https://user-images.githubusercontent.com/686239/235105883-8c77e759-dd49-424f-94c1-b186e14273c4.png">

After:
<img width="329" alt="screenshot_2653" src="https://user-images.githubusercontent.com/686239/235105406-b9066a4b-0ceb-4790-aa1f-763154fe3c97.png">

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
