### PR TITLE
Fix showcase structure for a few components

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/badge-count.hbs
+++ b/packages/components/tests/dummy/app/templates/components/badge-count.hbs
@@ -48,7 +48,8 @@
     {{/each}}
   </Shw::Flex>
 
-  <Shw::Text::H2>Color:</Shw::Text::H2>
+  <Shw::Text::H2>Color</Shw::Text::H2>
+
   {{#each @model.BADGE_COUNT_COLORS as |color|}}
     <Shw::Grid @label={{capitalize color}} @columns={{3}} {{style width="fit-content"}} as |SG|>
       {{#each @model.BADGE_COUNT_SIZES as |size|}}

--- a/packages/components/tests/dummy/app/templates/components/badge.hbs
+++ b/packages/components/tests/dummy/app/templates/components/badge.hbs
@@ -52,7 +52,7 @@
     {{/each}}
   </Shw::Flex>
 
-  <Shw::Text::H2>Color:</Shw::Text::H2>
+  <Shw::Text::H2>Color</Shw::Text::H2>
 
   {{#each @model.BADGE_COLORS as |color|}}
     <Shw::Grid @label={{capitalize color}} @columns={{3}} as |SG|>

--- a/packages/components/tests/dummy/app/templates/components/flyout.hbs
+++ b/packages/components/tests/dummy/app/templates/components/flyout.hbs
@@ -24,7 +24,11 @@
     {{/each}}
   </Shw::Flex>
 
-  <Shw::Text::H2>Header</Shw::Text::H2>
+  <Shw::Divider />
+
+  <Shw::Text::H2>Content</Shw::Text::H2>
+
+  <Shw::Text::H3>Header</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="Title with icon" class="shw-component-flyout-sample-item">
@@ -68,7 +72,9 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H2>Body</Shw::Text::H2>
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Body</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="With basic style" class="shw-component-flyout-sample-item">
@@ -100,7 +106,9 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H2>Footer</Shw::Text::H2>
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Footer</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="One action" class="shw-component-flyout-sample-item">

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -294,10 +294,9 @@
       {{/let}}
     </Shw::Grid>
 
-    <br />
-
     {{#let (array "vertical" "flag") as |layouts|}}
       {{#each layouts as |layout|}}
+        <Shw::Divider @level={{2}} />
         <Shw::Text::H3>Content / "{{layout}}" layout</Shw::Text::H3>
         <Shw::Grid @columns={{3}} as |SG|>
 
@@ -400,6 +399,7 @@
 
     {{#let (array "vertical" "flag") as |layouts|}}
       {{#each layouts as |layout|}}
+        <Shw::Divider @level={{2}} />
         <Shw::Text::H3>Containers / "{{layout}}" layout</Shw::Text::H3>
         <Shw::Grid @columns={{3}} as |SG|>
           {{#let (array "block" "flex" "grid") as |displays|}}
@@ -504,8 +504,10 @@
         {{/each}}
       {{/let}}
     </Shw::Flex>
+
     {{#let (array "vertical" "horizontal") as |layouts|}}
       {{#each layouts as |layout|}}
+        <Shw::Divider @level={{2}} />
         <Shw::Text::H3>Containers / "{{layout}}" layout</Shw::Text::H3>
         <Shw::Grid @columns={{3}} as |SG|>
           {{#let (array "block" "flex" "grid") as |displays|}}

--- a/packages/components/tests/dummy/app/templates/components/modal.hbs
+++ b/packages/components/tests/dummy/app/templates/components/modal.hbs
@@ -32,6 +32,8 @@
     {{/each}}
   </Shw::Flex>
 
+  <Shw::Divider />
+
   <Shw::Text::H2>Color</Shw::Text::H2>
 
   <Shw::Flex @direction="column" as |SF|>
@@ -57,7 +59,11 @@
     {{/each}}
   </Shw::Flex>
 
-  <Shw::Text::H2>Title</Shw::Text::H2>
+  <Shw::Divider />
+
+  <Shw::Text::H2>Content</Shw::Text::H2>
+
+  <Shw::Text::H3>Header</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="With icon" class="shw-component-modal-sample-item">
@@ -110,7 +116,9 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H2>Content</Shw::Text::H2>
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H2>Body</Shw::Text::H2>
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="With basic style" class="shw-component-modal-sample-item">
@@ -153,7 +161,9 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H2>Actions</Shw::Text::H2>
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H2>Footer</Shw::Text::H2>
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="One action" class="shw-component-modal-sample-item">


### PR DESCRIPTION
### :pushpin: Summary

Fix showcase structure for a few components to follow existing patterns.

### :hammer_and_wrench: Detailed description

Badge and BadgeCount had some `:` in their headings
Modal, Flyout didn't have the standard 'Content' section
Modal, Flyout, and Form primitives could do with the standard separators
