### PR TITLE
`SideNav` - Fix target of the "hide when minimized" class in the panels

### DIFF
--- a/.changeset/modern-shrimps-marry.md
+++ b/.changeset/modern-shrimps-marry.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav` - Fix issue with links being clickable even if not visible

--- a/packages/components/addon/components/hds/side-nav/portal/index.hbs
+++ b/packages/components/addon/components/hds/side-nav/portal/index.hbs
@@ -4,7 +4,7 @@
 }}
 
 <Portal @target={{if @targetName @targetName "hds-side-nav-portal-target"}}>
-  <div class="hds-side-nav__content-panel" ...attributes>
+  <div class="hds-side-nav__content-panel hds-side-nav-hide-when-minimized" ...attributes>
     <Hds::SideNav::List aria-label={{@ariaLabel}} as |ListElements|>
       {{yield ListElements}}
     </Hds::SideNav::List>

--- a/packages/components/addon/components/hds/side-nav/portal/target.hbs
+++ b/packages/components/addon/components/hds/side-nav/portal/target.hbs
@@ -8,7 +8,7 @@
     @multiple={{true}}
     @onChange={{this.panelsChanged}}
     @name={{if @targetName @targetName "hds-side-nav-portal-target"}}
-    class="hds-side-nav__content-panels hds-side-nav-hide-when-minimized"
+    class="hds-side-nav__content-panels"
     {{did-update this.didUpdateSubnav this.numSubnavs}}
   />
 </div>


### PR DESCRIPTION
### :pushpin: Summary

When I converted the generic styling applied to the panels of the navigation with a reusable class name, I applied the class to the `panels` (parent) container instead of the `panel` (children) container(s) as it was done in Cloud UI before.

The result was that the panels were not visible (because the parent was hidden) but the panels were clickable anyway (and may have caused overflow problems in some cases).

### :hammer_and_wrench: Detailed description

In this PR I have:
- moved the `hds-side-nav-hide-when-minimized` class name from the `hds-side-nav__content-panels` element (the portal "target" element, the "panels" wrapper) to the `hds-side-nav__content-panel` element(s) (the portal "content", the "panels" children).

### :camera_flash: Screenshots

<img width="950" alt="modified" src="https://user-images.githubusercontent.com/686239/235239573-7e74cebd-b7a2-45b5-921b-6c1067a3aa32.png">

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
