### PR TITLE
`SideNav` - Fix `overflow-x: auto` declaration

### DIFF
--- a/.changeset/shaggy-lies-worry.md
+++ b/.changeset/shaggy-lies-worry.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav` - Updated CSS declaration that was causing an horizontal scrollbar to appear in some conditions

--- a/packages/components/app/styles/components/side-nav/main.scss
+++ b/packages/components/app/styles/components/side-nav/main.scss
@@ -167,6 +167,10 @@
   padding:
     var(--token-side-nav-wrapper-padding-vertical)
     var(--token-side-nav-wrapper-padding-horizontal);
+  // this is necessary, otherwise when the sidenav is minimized an horizontal scrollbar may appear
+  // (if there are words longer than the width of the available space for the list "item" content)
+  overflow-x: hidden;
+  // we want the content to vertically scroll if needed
   overflow-y: auto;
 }
 


### PR DESCRIPTION
### :pushpin: Summary

While working on the adoption of the HDS `SideNav` component in Vault, @zofskeez noticed that an horizontal scrollbar was appearing in the sidenav when minimized:

![image (1)](https://user-images.githubusercontent.com/686239/235262425-683c7a45-0c25-47e7-ab60-457344f0eab7.png)

The reason why he was seeing the sidenav and I didn't, it's because of a different setting in the OS preferences:
![image (2)](https://user-images.githubusercontent.com/686239/235262529-d518ba49-dd20-448e-9643-3c142e60aa95.png)

After investigation, I have realized that there was a CSS declaration `overflow-x: hidden` in Cloud UI:

<img width="834" alt="screenshot_2662" src="https://user-images.githubusercontent.com/686239/235264888-a7ebbb82-d446-459b-bd6d-6c8913731c67.png">

but when I ported it to HDS I changed it to `overflow-x: auto` thinking that it was better. In reality this triggered the visibility of the scrollbar when the OS settings was not to automatically hide it. 

### :hammer_and_wrench: Detailed description

In this PR I have:
- changed the `overflow-x: auto` declaration in the wrapper's "body" to `hidden`

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
