### PR TITLE
[DRAFT] `SideNav` - Introduce a `@isLoading` state for the `Hds::SideNav::Portal` component

### DIFF
--- a/packages/components/addon/components/hds/side-nav/portal/index.hbs
+++ b/packages/components/addon/components/hds/side-nav/portal/index.hbs
@@ -5,8 +5,14 @@
 
 <Portal @target={{if @targetName @targetName "hds-side-nav-portal-target"}}>
   <div class="hds-side-nav__content-panel hds-side-nav-hide-when-minimized" ...attributes>
-    <Hds::SideNav::List aria-label={{@ariaLabel}} as |ListElements|>
-      {{yield ListElements}}
-    </Hds::SideNav::List>
+    {{#if @isLoading}}
+      <div class="hds-side-nav__loading-wrapper">
+        <FlightIcon @name="loading" @size="24" />
+      </div>
+    {{else}}
+      <Hds::SideNav::List aria-label={{@ariaLabel}} as |ListElements|>
+        {{yield ListElements}}
+      </Hds::SideNav::List>
+    {{/if}}
   </div>
 </Portal>

--- a/packages/components/app/styles/components/side-nav/content.scss
+++ b/packages/components/app/styles/components/side-nav/content.scss
@@ -29,6 +29,13 @@
   padding: 0 var(--token-side-nav-wrapper-padding-horizontal);
 }
 
+.hds-side-nav__loading-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px var(--token-side-nav-body-list-item-padding-horizontal);
+}
+
 // (LIST) TITLE
 
 .hds-side-nav__list-title {

--- a/packages/components/tests/dummy/app/templates/components/side-nav.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav.hbs
@@ -80,9 +80,30 @@
         </Hds::SideNav>
       </div>
     </SF.Item>
+    <SF.Item @label="Header + Body with Portal in 'loading' state + Footer">
+      <div class="shw-component-sim-side-nav-root-container">
+        <Hds::SideNav @isResponsive={{false}} @hasA11yRefocus={{false}}>
+          <:header>
+            <Shw::Placeholder @height="72px" @text="header" @background="#e4e4e4" />
+          </:header>
+          <:body>
+            <Hds::SideNav::Portal::Target @targetName="sidenav-portal-demo-1-loading" />
+          </:body>
+          <:footer>
+            <Shw::Placeholder @height="36px" @text="footer" @background="#e4e4e4" />
+          </:footer>
+        </Hds::SideNav>
+      </div>
+    </SF.Item>
   </Shw::Flex>
 
   <Hds::SideNav::Portal @targetName="sidenav-portal-demo-1" as |Nav|>
+    <Nav.extraBefore><Shw::Placeholder @height="72px" @text="extraBefore" @background="#f3d9c5" /></Nav.extraBefore>
+    <Nav.Item><Shw::Placeholder @height="200px" @text="portaled content" @background="#e4e4e4" /></Nav.Item>
+    <Nav.extraAfter><Shw::Placeholder @height="72px" @text="extraAfter" @background="#f3d9c5" /></Nav.extraAfter>
+  </Hds::SideNav::Portal>
+
+  <Hds::SideNav::Portal @targetName="sidenav-portal-demo-1-loading" @isLoading={{true}} as |Nav|>
     <Nav.extraBefore><Shw::Placeholder @height="72px" @text="extraBefore" @background="#f3d9c5" /></Nav.extraBefore>
     <Nav.Item><Shw::Placeholder @height="200px" @text="portaled content" @background="#e4e4e4" /></Nav.Item>
     <Nav.extraAfter><Shw::Placeholder @height="72px" @text="extraAfter" @background="#f3d9c5" /></Nav.extraAfter>


### PR DESCRIPTION
### :pushpin: Summary

This is a WIP in relation to the work that @cbfx is doing around the multi-project feature in Cloud UI.
For context see this thread: https://hashicorp.slack.com/archives/C02ESMK682C/p1683072794798619

### :hammer_and_wrench: Detailed description

TODO

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
