### PR TITLE
`RadioCard` Wrap long strings in label (HDS-1917)

### DIFF
--- a/.changeset/serious-ghosts-jam.md
+++ b/.changeset/serious-ghosts-jam.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`RadioCard` - Update CSS to enable wrapping of long strings in label which were overflowing the container

--- a/packages/components/app/styles/components/form/radio-card.scss
+++ b/packages/components/app/styles/components/form/radio-card.scss
@@ -140,6 +140,7 @@
   display: block;
   margin: 8px 0;
   color: var(--token-form-label-color);
+  overflow-wrap: break-word;
 
   &:first-child {
     margin-top: 0;

--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -259,4 +259,15 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Text::H3>Edge cases</Shw::Text::H3>
+
+  <Shw::Flex @direction="column" as |SF|>
+    <SF.Item @label="Long string in label">
+      <Hds::Form::RadioCard @maxWidth="300px" as |R|>
+        <R.Icon @name="hexagon" />
+        <R.Label>Label12345678901231241231314324123454654654756767657657657657</R.Label>
+        <R.Description>Description</R.Description>
+      </Hds::Form::RadioCard>
+    </SF.Item>
+  </Shw::Flex>
 </section>


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR adds a style to make long unbroken strings in RadioCard label wrap and adds example to Showcase.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots
<img width="342" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/bbfa66b3-249b-4862-bc13-e5e3d389e3ee">

### :link: External links
<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1917](https://hashicorp.atlassian.net/browse/HDS-1917)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1917]: https://hashicorp.atlassian.net/browse/HDS-1917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ