### PR TITLE
`AppFrame` - Remove `z-indez` value from footer

### DIFF
--- a/.changeset/tall-birds-help.md
+++ b/.changeset/tall-birds-help.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+removed `z-index` value from `AppFrame::Footer`

--- a/packages/components/app/styles/components/app-frame.scss
+++ b/packages/components/app/styles/components/app-frame.scss
@@ -36,7 +36,6 @@
 }
 
 .hds-app-frame__footer {
-  z-index: 5;
   grid-area: footer;
 }
 


### PR DESCRIPTION
### :pushpin: Summary

When implementing the `Hds::AppFrame` component from the existing `HcAppFrame` implementation, I've added a `z-index` value for the "footer" of the "app frame".  This has caused a regression in Cloud UI (see links below).

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed the `z-index` value from the `Hds::AppFrame::Footer` element.

### :camera_flash: Screenshots

How it was implemented in Cloud UI (see the style applied, that doesn't contain a value for `z-index`
<img width="720" alt="screenshot_2674" src="https://github.com/hashicorp/design-system/assets/686239/e92d6402-5950-4fef-998b-f50a456a1325">

### :link: External links

- https://hashicorp.slack.com/archives/C7KTUHNUS/p1683567057174769
- https://hashicorp.atlassian.net/browse/HCPF-590
- https://github.com/hashicorp/cloud-ui/pull/5923

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
