### PR TITLE
Move `RadioCard`'s 'long string in label' example under 'Card content'

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -69,23 +69,23 @@
       </Hds::Form::RadioCard::Group>
     </SF.Item>
     <SF.Item @label="With different content height">
-      <Hds::Form::RadioCard::Group @name="radio-card-group-custom" as |G|>
+      <Hds::Form::RadioCard::Group @name="radio-card-group-custom" @layout="fixed" as |G|>
         <G.Legend>Group legend</G.Legend>
-        <G.RadioCard @checked={{true}} {{on "change" this.onChange}} as |R|>
+        <G.RadioCard @maxWidth="330px" @checked={{true}} {{on "change" this.onChange}} as |R|>
           <R.Icon @name="hexagon" />
           <R.Label>Radio card with normal label</R.Label>
           <R.Badge @text="Badge" />
           <R.Description>This is the radio card description text.</R.Description>
         </G.RadioCard>
-        <G.RadioCard {{on "change" this.onChange}} as |R|>
+        <G.RadioCard @maxWidth="330px" {{on "change" this.onChange}} as |R|>
           <R.Icon @name="hexagon" />
           <R.Label>Radio card with long label that spans multiple lines</R.Label>
           <R.Badge @text="Badge" />
           <R.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque erat elit, lacinia at
             magna eget, porttitor lobortis nulla.</R.Description>
         </G.RadioCard>
-        <G.RadioCard {{on "change" this.onChange}} as |R|>
-          <R.Label>Radio card without icon</R.Label>
+        <G.RadioCard @maxWidth="330px" {{on "change" this.onChange}} as |R|>
+          <R.Label>37230f8be8ccf24075cf73805bbfa77537ea17ad</R.Label>
           <R.Description>This is the radio card description text.</R.Description>
         </G.RadioCard>
       </Hds::Form::RadioCard::Group>
@@ -256,18 +256,6 @@
           </G.RadioCard>
         {{/each}}
       </Hds::Form::RadioCard::Group>
-    </SF.Item>
-  </Shw::Flex>
-
-  <Shw::Text::H3>Edge cases</Shw::Text::H3>
-
-  <Shw::Flex @direction="column" as |SF|>
-    <SF.Item @label="Long string in label">
-      <Hds::Form::RadioCard @maxWidth="300px" as |R|>
-        <R.Icon @name="hexagon" />
-        <R.Label>Label12345678901231241231314324123454654654756767657657657657</R.Label>
-        <R.Description>Description</R.Description>
-      </Hds::Form::RadioCard>
     </SF.Item>
   </Shw::Flex>
 </section>


### PR DESCRIPTION
### :pushpin: Summary

Move the 'long string in the label' example under 'Card content', for consistency with other showcases.

Follow-up on #1350