### PR TITLE
Fix alignment argument in demo for table with dropdown

### DIFF
--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -366,7 +366,7 @@ To create a column that has right-aligned content, set `@align` to `right` on bo
       <B.Td>{{B.data.artist}}</B.Td>
       <B.Td>{{B.data.album}}</B.Td>
       <B.Td @align="right">
-        <Hds::Dropdown @isInlineBlock={{true}} as |dd|>
+        <Hds::Dropdown @isInline={{true}} as |dd|>
           <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
           <dd.Interactive @route="components" @text="Create" />
           <dd.Interactive @route="components" @text="Read" />


### PR DESCRIPTION
### :pushpin: Summary

Small PR that fixes a demo in the `Table` documentation.

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

Before:
<img width="795" alt="screenshot_2689" src="https://github.com/hashicorp/design-system/assets/686239/9a91be8f-dcbe-4162-89c8-81ff8f8745d8">


After:
<img width="787" alt="screenshot_2687" src="https://github.com/hashicorp/design-system/assets/686239/4089b8fa-f4db-436e-a6c7-29d895e5bfb9">


***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
