### PR TITLE
HDS-960: Add support for aria-label customization

### DIFF
--- a/packages/components/addon/components/hds/breadcrumb/index.hbs
+++ b/packages/components/addon/components/hds/breadcrumb/index.hbs
@@ -2,7 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<nav class={{this.classNames}} aria-label="breadcrumbs" ...attributes>
+<nav class={{this.classNames}} aria-label={{this.ariaLabel}} ...attributes>
   <ol class="hds-breadcrumb__list" {{did-insert this.didInsert}}>
     {{yield}}
   </ol>

--- a/packages/components/addon/components/hds/breadcrumb/index.js
+++ b/packages/components/addon/components/hds/breadcrumb/index.js
@@ -33,6 +33,15 @@ export default class HdsBreadcrumbComponent extends Component {
   }
 
   /**
+   * @param ariaLabel
+   * @type {string}
+   * @default 'breadcrumbs'
+   */
+  get ariaLabel() {
+    return this.args.ariaLabel ?? 'breadcrumbs';
+  }
+
+  /**
    * Get the class names to apply to the component.
    * @method Breadcrumb#classNames
    * @return {string} The "class" attribute to apply to the component.

--- a/packages/components/tests/integration/components/hds/breadcrumb/index-test.js
+++ b/packages/components/tests/integration/components/hds/breadcrumb/index-test.js
@@ -34,10 +34,21 @@ module('Integration | Component | hds/breadcrumb/index', function (hooks) {
 
   // A11Y
 
-  test('it should render with the correct semantic tags and aria attributes', async function (assert) {
+  test('it should render with the correct semantic tags', async function (assert) {
     await render(hbs`<Hds::Breadcrumb id="test-breadcrumb" />`);
     assert.dom('#test-breadcrumb').hasTagName('nav');
     assert.dom('#test-breadcrumb').hasAria('label', 'breadcrumbs');
     assert.dom('#test-breadcrumb > ol').exists();
+  });
+  test('it should support a custom aria-label attribute', async function (assert) {
+    await render(
+      hbs`<Hds::Breadcrumb id="test-breadcrumb" aria-label="my aria label" />`
+    );
+    assert.dom('#test-breadcrumb').hasAria('label', 'my aria label');
+    assert.dom('#test-breadcrumb > ol').exists();
+  });
+  test('it should have a fallback aria-label if no custom aria-label is provided', async function (assert) {
+    await render(hbs`<Hds::Breadcrumb id="test-breadcrumb" />`);
+    assert.dom('#test-breadcrumb').hasAria('label', 'breadcrumbs');
   });
 });

--- a/website/docs/components/breadcrumb/partials/code/component-api.md
+++ b/website/docs/components/breadcrumb/partials/code/component-api.md
@@ -12,12 +12,14 @@ The Breadcrumb component is composed of three different parts, each with their o
   <C.Property @name="itemsCanWrap" @type="boolean" @values={{array "false" "true" }} @default="true">
     This controls if the Breadcrumb Items can wrap if they don’t fit within the container.
   </C.Property>
+  <C.Property @name="ariaLabel" @type="string">
+    Accepts a localized string; the fallback is set to `breadcrumbs`.
+  </C.Property>
   <C.Property @name="didInsert" @type="function">
     This hook method is called when the component is inserted in the DOM. Internally we use the `did-insert` modifier from `@ember/render-modifiers`.
   </C.Property>
   <C.Property @name="...attributes">
-    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).<br/><br/>
-    By default, an attribute `aria-label="breadcrumbs"` is assigned to the component. However, if you want to localize it, override it by passing the same attribute with a different value.
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).<br/>
   </C.Property>
 </Doc::ComponentApi>
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves issue HDS-960 by adding aria-label localization support. 

### :hammer_and_wrench: Detailed description

- changed `aria-label` value from "breadcrumbs" to `{{{this.ariaLabel}}` which returns the custom text if defined, otherwise falls back to "breadcrumbs" 
- updated tests

### :camera_flash: Screenshots

![CleanShot 2023-05-18 at 10 29 01](https://github.com/hashicorp/design-system/assets/4587451/ecc34ebe-7bac-48b0-8745-8e64785b5c2a)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-960](https://hashicorp.atlassian.net/browse/HDS-960)


***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-960]: https://hashicorp.atlassian.net/browse/HDS-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ