### PR TITLE
Prevent Tooltip content from overflowing

### DIFF
--- a/.changeset/gentle-swans-breathe.md
+++ b/.changeset/gentle-swans-breathe.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Prevent Tooltip content from overflowing

--- a/.changeset/gentle-swans-breathe.md
+++ b/.changeset/gentle-swans-breathe.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Prevent Tooltip content from overflowing
+Prevent `Tooltip` content from overflowing

--- a/packages/components/app/styles/components/tooltip.scss
+++ b/packages/components/app/styles/components/tooltip.scss
@@ -75,6 +75,9 @@
     // This needs to go here because Tippy generates a javascript
     // max-width on .tippy-box.
     max-width: var(--token-tooltip-max-width);
+    // prevent the this container from potentially inheriting other values
+    // such as `white-space: nowrap` that would cause content overflow
+    white-space: normal;
   }
 
   // works with Tippy's custom SVG arrow variation:

--- a/packages/components/app/styles/components/tooltip.scss
+++ b/packages/components/app/styles/components/tooltip.scss
@@ -75,7 +75,7 @@
     // This needs to go here because Tippy generates a javascript
     // max-width on .tippy-box.
     max-width: var(--token-tooltip-max-width);
-    // prevent the this container from potentially inheriting other values
+    // prevent this container from potentially inheriting other values
     // such as `white-space: nowrap` that would cause content overflow
     white-space: normal;
   }

--- a/packages/components/tests/dummy/app/templates/components/tooltip.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tooltip.hbs
@@ -152,9 +152,9 @@
     <SF.Item @label="With isInline=false">
       <p class="hds-typography-body-300">
         Lorem ipsum dolor sit amet consectetur
-        <Hds::TooltipButton @text="Here is more info" @isInline={{false}} aria-label="Information"><FlightIcon
-            @name="info"
-          /></Hds::TooltipButton>
+        <Hds::TooltipButton @text="Here is more info" @isInline={{false}} aria-label="Information">
+          <FlightIcon @name="info" />
+        </Hds::TooltipButton>
         adipisicing elit. Doloremque blanditiis sapiente iste beatae voluptates voluptatum.
       </p>
     </SF.Item>
@@ -212,6 +212,20 @@
           Lorem ipsum dolor
         </div>
       </Hds::TooltipButton>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Text::Body>Style interference</Shw::Text::Body>
+
+  <Shw::Flex {{style gap="2rem"}} as |SF|>
+    <SF.Item @label="Parent has `white-space: nowrap`">
+      <div {{style whiteSpace="nowrap"}}>
+        <Hds::TooltipButton
+          @text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        >
+          <FlightIcon @name="info" />
+        </Hds::TooltipButton>
+      </div>
     </SF.Item>
   </Shw::Flex>
 


### PR DESCRIPTION
### :pushpin: Summary

Prevent Tooltip content from overflowing

### :hammer_and_wrench: Detailed description

If the parent container of a tooltip has a `white-space: nowrap` definition it will be inherited by the `.tippy-content` element (the bubble) potentially resulting in a content overflow (depending on the content length).

We set the `white-space: normal;` to prevent the `white-space` value from being inherited.

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="1381" alt="tooltip-before" src="https://github.com/hashicorp/design-system/assets/788096/c7a1bec7-018c-4e34-8bbb-4fe55da8a97e">


</td><td>

<img width="1380" alt="tooltip-after" src="https://github.com/hashicorp/design-system/assets/788096/211250b3-5021-4aba-8ed2-928100d74431">


</td></tr>
<tr><td>

<img width="1336" alt="Screenshot 2023-05-19 at 13 58 45" src="https://github.com/hashicorp/design-system/assets/788096/d00cb5a1-75c0-44c5-8d74-a22b39634405">


</td><td>

<img width="1336" alt="Screenshot 2023-05-19 at 13 57 48" src="https://github.com/hashicorp/design-system/assets/788096/e1ff2bd3-5cca-41ee-84c4-5ad1e73d4672">


</td></tr>
</table>


### :link: External links

For context: https://hashicorp.slack.com/archives/C03A0N1QK8S/p1684114988058939

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
