### PR TITLE
Website `Component API` properties - Allow to show a "default" value even when `@values` is not provided

### DIFF
--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -35,6 +35,16 @@
         {{@valueNote}}
       {{/if}}
     </dd>
+  {{else if @default}}
+    <dt class="doc-component-api__term doc-component-api__term--values">Default</dt>
+    <dd class="doc-component-api__description doc-component-api__description--values">
+      <ul class="doc-component-api__property-values" role="list">
+        <li class="doc-component-api__property-value--default">
+          {{@default}}
+          <span class="doc-sr-only">(default)</span>
+        </li>
+      </ul>
+    </dd>
   {{/if}}
   {{#if (has-block)}}
     <dt class="doc-component-api__term doc-component-api__term--description">Description</dt>


### PR DESCRIPTION
### :pushpin: Summary

While reviewing @MelSumner PR #1361 I noticed something that found missing before: the possibility to show what the default value of an argument is, even when there is no `@value` argument.

In this PR I am proposing to use the existing `@default` argument to achieve this result.

The actual changes to the documentation will be done in a follow-up PR: https://github.com/hashicorp/design-system/pull/1369

### :hammer_and_wrench: Detailed description

In this PR I have:

- allowed the “Component API” `property` block to show a `@default` value even if a list of `@values` is not provided

### :camera_flash: Screenshots

<img width="642" alt="screenshot_2700" src="https://github.com/hashicorp/design-system/assets/686239/10ad855f-2693-4969-af5a-70dc1b63101f">

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
