### PR TITLE
Adds args with string fallback to aria-labels in components

### DIFF
--- a/.changeset/clean-frogs-dance.md
+++ b/.changeset/clean-frogs-dance.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Updates aria-label support for consistency

--- a/.changeset/clean-frogs-dance.md
+++ b/.changeset/clean-frogs-dance.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Updates aria-label support for consistency
+Updates aria-label support for consistency. Consumers can now see in the component API docs where `@ariaLabel` is supported for a custom value, and what the fallback value is.

--- a/packages/components/addon/components/hds/breadcrumb/truncation.hbs
+++ b/packages/components/addon/components/hds/breadcrumb/truncation.hbs
@@ -8,7 +8,7 @@
       <button
         type="button"
         class="hds-breadcrumb__truncation-toggle"
-        aria-label="show more"
+        aria-label={{if @ariaLabel @ariaLabel "show more"}}
         aria-expanded={{if t.isOpen "true" "false"}}
         {{on "click" t.onClickToggle}}
       >

--- a/packages/components/addon/components/hds/breadcrumb/truncation.hbs
+++ b/packages/components/addon/components/hds/breadcrumb/truncation.hbs
@@ -8,7 +8,7 @@
       <button
         type="button"
         class="hds-breadcrumb__truncation-toggle"
-        aria-label={{if @ariaLabel @ariaLabel "show more"}}
+        aria-label={{this.ariaLabel}}
         aria-expanded={{if t.isOpen "true" "false"}}
         {{on "click" t.onClickToggle}}
       >

--- a/packages/components/addon/components/hds/breadcrumb/truncation.js
+++ b/packages/components/addon/components/hds/breadcrumb/truncation.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+export default class HdsBreadcrumbTruncationComponent extends Component {
+  /**
+   * @param ariaLabel
+   * @type {string}
+   * @default 'show more'
+   */
+  get ariaLabel() {
+    return this.args.ariaLabel ?? 'show more';
+  }
+}

--- a/packages/components/addon/components/hds/dismiss-button/index.hbs
+++ b/packages/components/addon/components/hds/dismiss-button/index.hbs
@@ -2,6 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<button class="hds-dismiss-button" type="button" aria-label={{if @ariaLAbel @ariaLabel "Dismiss"}} ...attributes>
+<button class="hds-dismiss-button" type="button" aria-label={{this.ariaLabel}} ...attributes>
   <FlightIcon @name="x" @size="16" @isInlineBlock={{false}} />
 </button>

--- a/packages/components/addon/components/hds/dismiss-button/index.hbs
+++ b/packages/components/addon/components/hds/dismiss-button/index.hbs
@@ -2,6 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<button class="hds-dismiss-button" type="button" aria-label="Dismiss" ...attributes>
+<button class="hds-dismiss-button" type="button" aria-label={{if @ariaLAbel @ariaLabel "Dismiss"}} ...attributes>
   <FlightIcon @name="x" @size="16" @isInlineBlock={{false}} />
 </button>

--- a/packages/components/addon/components/hds/dismiss-button/index.js
+++ b/packages/components/addon/components/hds/dismiss-button/index.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+export default class HdsDismissButtonIndexComponent extends Component {
+  /**
+   * @param ariaLabel
+   * @type {string}
+   * @default 'Dismiss'
+   */
+  get ariaLabel() {
+    return this.args.ariaLabel ?? 'Dismiss';
+  }
+}

--- a/packages/components/addon/components/hds/pagination/compact/index.hbs
+++ b/packages/components/addon/components/hds/pagination/compact/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 <div class="hds-pagination" ...attributes>
-  <nav class="hds-pagination-nav" aria-label="Pagination navigation">
+  <nav class="hds-pagination-nav" aria-label={{this.ariaLabel}}>
     <Hds::Pagination::Nav::Arrow
       @direction="prev"
       @showLabel={{this.showLabels}}

--- a/packages/components/addon/components/hds/pagination/compact/index.js
+++ b/packages/components/addon/components/hds/pagination/compact/index.js
@@ -47,6 +47,15 @@ export default class HdsPaginationCompactIndexComponent extends Component {
     return showLabels;
   }
 
+  /**
+   * @param ariaLabel
+   * @type {string}
+   * @default 'Pagination navigation'
+   */
+  get ariaLabel() {
+    return this.args.ariaLabel ?? 'Pagination navigation';
+  }
+
   get routeQueryParams() {
     return this.router.currentRoute?.queryParams || {};
   }

--- a/packages/components/addon/components/hds/pagination/numbered/index.hbs
+++ b/packages/components/addon/components/hds/pagination/numbered/index.hbs
@@ -12,7 +12,7 @@
     />
   {{/if}}
 
-  <nav class="hds-pagination-nav" aria-label="Pagination navigation">
+  <nav class="hds-pagination-nav" aria-label={{this.ariaLabel}}>
     <Hds::Pagination::Nav::Arrow
       @direction="prev"
       @showLabel={{this.showLabels}}

--- a/packages/components/addon/components/hds/pagination/numbered/index.js
+++ b/packages/components/addon/components/hds/pagination/numbered/index.js
@@ -127,6 +127,15 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
     );
   }
 
+  /**
+   * @param ariaLabel
+   * @type {string}
+   * @default 'Pagination navigation'
+   */
+  get ariaLabel() {
+    return this.args.ariaLabel ?? 'Pagination navigation';
+  }
+
   // This very specific `get/set` pattern is used to handle the two different use cases of the component
   // being "controlled" (when it has routing, meaning it needs to support links as controls)
   // vs being "uncontrolled" (see comments above for details).
@@ -258,7 +267,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
         this.currentPage + 1,
         this.currentPageSize
       );
-      // IMPORTANT: here we neeed to use an object and not an array
+      // IMPORTANT: here we need to use an object and not an array
       // otherwise the {{get object page}} will be shifted by one
       // (the pages are 1-based while the array would be zero-based)
       routing.queryPages = {};

--- a/packages/components/addon/components/hds/side-nav/index.hbs
+++ b/packages/components/addon/components/hds/side-nav/index.hbs
@@ -21,8 +21,7 @@
         class="hds-side-nav__menu-toggle-button"
         type="button"
         {{on "click" this.toggleMinimizedStatus}}
-        {{! To be localized - see: https://hashicorp.atlassian.net/browse/HDS-567 }}
-        aria-label={{if this.isMinimized "Open menu" "Close menu"}}
+        aria-label={{this.ariaLabel}}
       >
         <FlightIcon @name={{if this.isMinimized "menu" "x"}} @size="24" @stretched={{true}} />
       </button>

--- a/packages/components/addon/components/hds/side-nav/index.js
+++ b/packages/components/addon/components/hds/side-nav/index.js
@@ -55,6 +55,18 @@ export default class HdsSideNavComponent extends Component {
     return this.isResponsive && !this.isDesktop && !this.isMinimized;
   }
 
+  /**
+   * @param ariaLabel
+   * @type {string}
+   * @default 'close menu'
+   */
+  get ariaLabel() {
+    if (this.isMinimized) {
+      return this.args.ariaLabel ?? 'open menu';
+    }
+    return this.args.ariaLabel ?? 'close menu';
+  }
+
   get classNames() {
     let classes = []; // `hds-side-nav` is already set by the "Hds::SideNav::Base" component
 

--- a/packages/components/addon/components/hds/side-nav/index.js
+++ b/packages/components/addon/components/hds/side-nav/index.js
@@ -62,9 +62,9 @@ export default class HdsSideNavComponent extends Component {
    */
   get ariaLabel() {
     if (this.isMinimized) {
-      return this.args.ariaLabel ?? 'open menu';
+      return this.args.ariaLabel ?? 'Open menu';
     }
-    return this.args.ariaLabel ?? 'close menu';
+    return this.args.ariaLabel ?? 'Close menu';
   }
 
   get classNames() {

--- a/packages/components/addon/components/hds/tag/index.hbs
+++ b/packages/components/addon/components/hds/tag/index.hbs
@@ -4,12 +4,7 @@
 }}
 <span class={{this.classNames}} ...attributes>
   {{#if this.onDismiss}}
-    <button
-      class="hds-tag__dismiss"
-      type="button"
-      aria-label={{concat (this.ariaLabel) (this.text)}}
-      {{on "click" this.onDismiss}}
-    >
+    <button class="hds-tag__dismiss" type="button" aria-label={{this.ariaLabel}} {{on "click" this.onDismiss}}>
       <FlightIcon class="hds-tag__dismiss-icon" @name="x" @size="16" @isInlineBlock={{false}} />
     </button>
   {{/if}}

--- a/packages/components/addon/components/hds/tag/index.hbs
+++ b/packages/components/addon/components/hds/tag/index.hbs
@@ -4,7 +4,12 @@
 }}
 <span class={{this.classNames}} ...attributes>
   {{#if this.onDismiss}}
-    <button class="hds-tag__dismiss" type="button" aria-label="Dismiss {{this.text}}" {{on "click" this.onDismiss}}>
+    <button
+      class="hds-tag__dismiss"
+      type="button"
+      aria-label={{concat (this.ariaLabel) (this.text)}}
+      {{on "click" this.onDismiss}}
+    >
       <FlightIcon class="hds-tag__dismiss-icon" @name="x" @size="16" @isInlineBlock={{false}} />
     </button>
   {{/if}}

--- a/packages/components/addon/components/hds/tag/index.js
+++ b/packages/components/addon/components/hds/tag/index.js
@@ -39,6 +39,15 @@ export default class HdsTagIndexComponent extends Component {
   }
 
   /**
+   * @param ariaLabel
+   * @type {string}
+   * @default 'Dismiss'
+   */
+  get ariaLabel() {
+    return this.args.ariaLabel ?? 'Dismiss';
+  }
+
+  /**
    * @param color
    * @type {string}
    * @default primary

--- a/packages/components/addon/components/hds/tag/index.js
+++ b/packages/components/addon/components/hds/tag/index.js
@@ -44,7 +44,8 @@ export default class HdsTagIndexComponent extends Component {
    * @default 'Dismiss'
    */
   get ariaLabel() {
-    return this.args.ariaLabel ?? 'Dismiss';
+    let tagAriaLabel = this.args.ariaLabel ?? 'Dismiss';
+    return tagAriaLabel + ' ' + this.args.text;
   }
 
   /**

--- a/packages/components/tests/integration/components/hds/tag/index-test.js
+++ b/packages/components/tests/integration/components/hds/tag/index-test.js
@@ -34,6 +34,16 @@ module('Integration | Component | hds/tag/index', function (hooks) {
       .hasAttribute('aria-label', 'Dismiss My tag');
   });
 
+  test('it should render a customized label for the dismiss button if custom @ariaLabel text is defined', async function (assert) {
+    this.set('NOOP', () => {});
+    await render(
+      hbs`<Hds::Tag @text="My tag" @onDismiss={{this.NOOP}} @ariaLabel="Please dismiss" />`
+    );
+    assert.dom('button.hds-tag__dismiss').exists();
+    assert
+      .dom('button.hds-tag__dismiss')
+      .hasAttribute('aria-label', 'Please dismiss My tag');
+  });
   // COLOR
 
   test('it should render the primary color as the default if no @color prop is declared when the text is a link', async function (assert) {

--- a/website/docs/components/breadcrumb/partials/code/component-api.md
+++ b/website/docs/components/breadcrumb/partials/code/component-api.md
@@ -46,6 +46,9 @@ The Breadcrumb component is composed of three different parts, each with their o
 ### Breadcrumb::Truncation
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="ariaLabel" @type="string">
+    Set on the truncation toggle button. Accepts a localized string; the fallback is set to `show more`.
+  </C.Property>
   <C.Property @name="yield">
     Elements passed as children of this child component are yielded to the content of the [Disclosure](/utilities/disclosure) component (used to show/hide the yielded Breadcrumb Items via a "toggle" button).
   </C.Property>

--- a/website/docs/components/breadcrumb/partials/code/component-api.md
+++ b/website/docs/components/breadcrumb/partials/code/component-api.md
@@ -46,8 +46,8 @@ The Breadcrumb component is composed of three different parts, each with their o
 ### Breadcrumb::Truncation
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="ariaLabel" @type="string">
-    Set on the truncation toggle button. Accepts a localized string; the fallback is set to `show more`.
+  <C.Property @name="ariaLabel" @type="string" @default="show more">
+    Set on the truncation toggle button. Accepts a localized string.
   </C.Property>
   <C.Property @name="yield">
     Elements passed as children of this child component are yielded to the content of the [Disclosure](/utilities/disclosure) component (used to show/hide the yielded Breadcrumb Items via a "toggle" button).

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -22,8 +22,8 @@ These pagination sub-elements may be used directly if you need to cover a very s
 ### Pagination::Numbered
 
 <Doc::ComponentApi as |C|>
-<C.Property @name="ariaLabel" @type="string">
-    Accepts a localized string; the fallback is set to `Pagination navigation`.
+<C.Property @name="ariaLabel" @type="string" @default="Pagination navigation">
+    Accepts a localized string.
 </C.Property>
 <C.Property @name="totalItems" @required="true" @type="number">
 Pass the total number of items to be paginated. If no value is defined an error will be thrown.

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -22,6 +22,9 @@ These pagination sub-elements may be used directly if you need to cover a very s
 ### Pagination::Numbered
 
 <Doc::ComponentApi as |C|>
+<C.Property @name="ariaLabel" @type="string">
+    Accepts a localized string; the fallback is set to `Pagination navigation`.
+</C.Property>
 <C.Property @name="totalItems" @required="true" @type="number">
 Pass the total number of items to be paginated. If no value is defined an error will be thrown.
 </C.Property>
@@ -63,6 +66,9 @@ This component supports use of [`...attributes`](https://guides.emberjs.com/rele
 ### Pagination::Compact
 
 <Doc::ComponentApi as |C|>
+<C.Property @name="ariaLabel" @type="string">
+    Accepts a localized string; the fallback is set to `Pagination navigation`.
+</C.Property>
 <C.Property @name="route/model/models/replace">
 These are the parameters that are passed down as arguments to the `Hds::Pagination::Arrow` child components, and from them to the `Hds::Interactive` component (used internally). For more details about how this low-level component works, please refer to [its documentation page](/utilities/interactive/).
 </C.Property>

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -66,8 +66,8 @@ This component supports use of [`...attributes`](https://guides.emberjs.com/rele
 ### Pagination::Compact
 
 <Doc::ComponentApi as |C|>
-<C.Property @name="ariaLabel" @type="string">
-    Accepts a localized string; the fallback is set to `Pagination navigation`.
+<C.Property @name="ariaLabel" @type="string" @default="Pagination navigation">
+    Accepts a localized string.
 </C.Property>
 <C.Property @name="route/model/models/replace">
 These are the parameters that are passed down as arguments to the `Hds::Pagination::Arrow` child components, and from them to the `Hds::Interactive` component (used internally). For more details about how this low-level component works, please refer to [its documentation page](/utilities/interactive/).

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -14,6 +14,9 @@ This is the full-fledged component (responsive and animated).
   <C.Property @name="<:footer>" @type="named block">
     A named block where the content for the “footer” section of the SideNav is rendered. It yields the value of `isMinimized` too.
   </C.Property>
+  <C.Property @name="ariaLabel" @type="string">
+    Accepts a localized string; the fallback is set to `open menu` if the menu is closed, and `close menu` if the menu is open.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -15,7 +15,7 @@ This is the full-fledged component (responsive and animated).
     A named block where the content for the “footer” section of the SideNav is rendered. It yields the value of `isMinimized` too.
   </C.Property>
   <C.Property @name="ariaLabel" @type="string">
-    Accepts a localized string; the fallback is set to `open menu` if the menu is closed, and `close menu` if the menu is open.
+    Accepts a localized string; the fallback is set to `Open menu` if the menu is closed, and `Close menu` if the menu is open.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/tag/partials/code/component-api.md
+++ b/website/docs/components/tag/partials/code/component-api.md
@@ -4,6 +4,9 @@
   <C.Property @name="text" @type="string">
     The text of the tag; or link text when the `@route` or `@href` are set. If no text value is defined an error will be thrown.
   </C.Property>
+  <C.Property @name="ariaLabel" @type="string">
+    Accepts a localized string; the fallback is set to `Dismiss`. Note that the total value of the `aria-label` attribute is `@ariaLabel` + `@text`.
+</C.Property>
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>

--- a/website/docs/utilities/dismiss-button/partials/code/component-api.md
+++ b/website/docs/utilities/dismiss-button/partials/code/component-api.md
@@ -1,8 +1,8 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="ariaLabel" @type="string">
-    Accepts a localized string; the fallback is set to `dismiss`.
+  <C.Property @name="ariaLabel" @type="string" @default="dismiss">
+    Accepts a localized string.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/utilities/dismiss-button/partials/code/component-api.md
+++ b/website/docs/utilities/dismiss-button/partials/code/component-api.md
@@ -1,6 +1,9 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="ariaLabel" @type="string">
+    Accepts a localized string; the fallback is set to `dismiss`.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves instances where a bare string was being set as the value for the `aria-label` attribute. It adds support for an arg with a string fallback. 

### :hammer_and_wrench: Detailed description

Why? 

First and foremost, this is nothing new. We're already doing this, just inconsistently. This PR fixes that. 

While we could just make sure each component supports `...attributes` and leave it up to the consumer to remember to use `aria-label`, explicitly adding it to the appropriate components will have a few benefits: 

1. as a side effect of "because it's a supported arg, it's in the API docs" may help developers more easily remember to add it
2. the fallback ensures that it's there even if they forget, but can be localized if they remember and want to do that (I think also some products will have some level of linting enabled that should yell at them for [no-bare-strings]())
3. there are some places where it's (by necessity) in a composed component but not one exposed to the consumer directly. By ensuring that it can be set every time by consumers, it's more convenient to remember because it's consistent across the board (and consistent with how we've tried to approach components in general)

You may also notice that there are a couple of instances where a component-class was added to support this, instead of just using a conditional statements. While we do use conditional statements in some cases, our eng team felt as though it would be easier to search for `get ariaLabel` and get all of the results, and would be easier than trying to remember that it was also potentially a conditional statement. 

Components changed: 
- breadcrumb/truncation
- pagination/compact
- pagination/numbered
- side-nav/index
- dismiss-button
- tag

Component API files updated: 
- breadcrumb
- pagination
- side-nav
- tag
- utils/dismiss-button

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
