### PR TITLE
re-enables inline template linting rules that were disabled in the website

### DIFF
--- a/website/app/components/doc/page/tabs.hbs
+++ b/website/app/components/doc/page/tabs.hbs
@@ -20,3 +20,4 @@
     {{/each}}
   </ul>
 {{/if}}
+{{! template-lint-enable no-invalid-role require-context-role }}

--- a/website/app/templates/head.hbs
+++ b/website/app/templates/head.hbs
@@ -71,5 +71,5 @@ We've made some small customizations to simplify this compared to the default te
 {{#if this.model.description}}
   <meta name="twitter:description" content={{this.model.description}} />
 {{/if}}
-
+{{! template-lint-enable no-forbidden-elements no-potential-path-strings }}
 {{! END TWITTER }}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR re-enables some template linting rules that were disabled inline but never re-enabled.


***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
