### PR TITLE
re-enables inline disabled linting rules in components

### DIFF
--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -37,3 +37,4 @@
     </span>
   </Hds::Interactive>
 </li>
+{{! template-lint-enable require-context-role require-presentational-children }}

--- a/packages/components/addon/components/hds/menu-primitive/index.hbs
+++ b/packages/components/addon/components/hds/menu-primitive/index.hbs
@@ -19,3 +19,4 @@
     </div>
   {{/if}}
 </div>
+{{! template-lint-enable no-invalid-interactive }}

--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -35,3 +35,4 @@
     )
   }}
 </div>
+{{! template-lint-enable no-invalid-role }}

--- a/packages/components/addon/components/hds/tabs/tab.hbs
+++ b/packages/components/addon/components/hds/tabs/tab.hbs
@@ -27,3 +27,4 @@
     {{/if}}
   </button>
 </li>
+{{! template-lint-enable require-context-role no-invalid-role }}

--- a/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
@@ -60,6 +60,7 @@
               />
             </SG.Item>
           {{/unless}}
+          {{! template-lint-enable simple-unless }}
         </Shw::Grid>
       </SF.Item>
     {{/each}}

--- a/packages/components/tests/dummy/app/templates/components/form/radio.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio.hbs
@@ -43,6 +43,7 @@
               <Hds::Form::Radio::Base checked="checked" disabled="disabled" aria-label="Checked, disabled radio" />
             </SG.Item>
           {{/unless}}
+          {{! template-lint-enable simple-unless }}
         </Shw::Grid>
       </SF.Item>
     {{/each}}

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -111,6 +111,7 @@
               </Shw::Flex>
             </SG.Item>
           {{/unless}}
+          {{! template-lint-enable simple-unless }}
         {{/each}}
       </Shw::Grid>
     {{/each}}

--- a/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
@@ -65,6 +65,7 @@
               </Shw::Flex>
             </SG.Item>
           {{/unless}}
+          {{! template-lint-enable simple-unless }}
         {{/each}}
       </Shw::Grid>
     {{/each}}

--- a/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
@@ -43,6 +43,7 @@
               <Hds::Form::Toggle::Base checked="checked" disabled="disabled" aria-label="Checked, disabled toggle" />
             </SG.Item>
           {{/unless}}
+          {{! template-lint-enable simple-unless }}
         </Shw::Grid>
       </SF.Item>
     {{/each}}

--- a/packages/components/tests/dummy/app/templates/components/modal.hbs
+++ b/packages/components/tests/dummy/app/templates/components/modal.hbs
@@ -274,3 +274,4 @@
     </Hds::Modal>
   {{/if}}
 </section>
+{{! template-lint-enable no-autofocus-attribute }}

--- a/packages/components/tests/dummy/app/templates/foundations/icon.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations/icon.hbs
@@ -64,6 +64,7 @@
       <div style="color:green !important">
         <FlightIcon @name="heart-fill" @color="orange" />
       </div>
+      {{! template-lint-enable no-inline-styles }}
     </SF.Item>
   </Shw::Flex>
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR re-enables template linting rules that were disabled inline but never re-enabled.

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
