### PR TITLE
Removes aria-label from stepper/indicator component

### DIFF
--- a/.changeset/tiny-suns-share.md
+++ b/.changeset/tiny-suns-share.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+A11y Fix: removes `aria-label` from stepper/indicator

--- a/.changeset/tiny-suns-share.md
+++ b/.changeset/tiny-suns-share.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-A11y Fix: removes `aria-label` from stepper/indicator
+A11y Fix: removes `aria-label` from stepper/indicator and from task/indicator, which was causing an accessibility test error.

--- a/packages/components/addon/components/hds/stepper/step/indicator.hbs
+++ b/packages/components/addon/components/hds/stepper/step/indicator.hbs
@@ -2,7 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class={{this.classNames}} ...attributes aria-label={{@status}}>
+<div class={{this.classNames}} ...attributes>
   <div class="hds-stepper-indicator-step__svg-hexagon">
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
       <path

--- a/packages/components/addon/components/hds/stepper/task/indicator.hbs
+++ b/packages/components/addon/components/hds/stepper/task/indicator.hbs
@@ -2,6 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class={{this.classNames}} ...attributes aria-label={{@status}}>
+<div class={{this.classNames}} ...attributes>
   <FlightIcon class="hds-stepper-indicator-task__icon" @name={{this.iconName}} @size="16" />
 </div>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR removes the `aria-label` attribute from the hds/stepper/indicator and hds/task/indicator components, which was there incorrectly (a div is not eligible to receive the aria-label attribute)

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

Here's a failing test from a consuming app: 
<img width="810" alt="CleanShot 2023-05-25 at 14 07 15@2x" src="https://github.com/hashicorp/design-system/assets/4587451/fe527412-3908-41c2-b683-37ad3df4b3a0">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket to address the issue of our own tests not catching this: [HDS-1965](https://hashicorp.atlassian.net/browse/HDS-1965)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1965]: https://hashicorp.atlassian.net/browse/HDS-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ