### PR TITLE
remove version caveat

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -10,7 +10,6 @@ Compatibility
 ------------------------------------------------------------------------------
 
 * Ember.js v3.28 or above
-  * Note: The library _should_ work with earlier versions of Ember, but we only test with Ember 3.28 and newer
 * Ember CLI v3.28 or above
 * Node.js v12 or above
 

--- a/packages/ember-flight-icons/README.md
+++ b/packages/ember-flight-icons/README.md
@@ -16,7 +16,6 @@ Goals:
 ## Compatibility
 
 * Ember.js v3.28 or above
-  * Note: The library _should_ work with earlier versions of Ember, but we only test with Ember 3.28 and newer
 * Ember CLI v3.28 or above
 * Node.js v12 or above
 


### PR DESCRIPTION
This was added in https://github.com/hashicorp/design-system/pull/670 but now that all our consumer are on >= 3.28 this caveat isn't really necessary