### PR TITLE
HDS-1911 Add code and accessibility documentation

### DIFF
--- a/website/docs/components/reveal/index.md
+++ b/website/docs/components/reveal/index.md
@@ -1,0 +1,33 @@
+---
+title: Reveal
+description: A toggle that reveals additional information or details about an element or content to the user when triggered.
+caption: A toggle that reveals additional content to the user when triggered.
+status: released
+links:
+  figma: {link to the "Reveal" page in the components Figma library}
+  github: {link to the "Reveal" component's folder in the GitHub repo}
+previewImage: assets/illustrations/components/reveal.jpg
+navigation:
+  hidden: false
+  keywords: ['toggle', 'disclosure', 'summary', 'details', 'accordion']
+---
+
+<section data-tab="Guidelines">
+  @include "partials/guidelines/overview.md"
+  @include "partials/guidelines/guidelines.md"
+</section>
+
+<section data-tab="Code">
+  @include "partials/code/how-to-use.md"
+  @include "partials/code/component-api.md"
+  <!-- @include "partials/code/showcase.md" -->
+</section>
+
+<section data-tab="Specifications">
+  @include "partials/specifications/anatomy.md"
+  @include "partials/specifications/states.md"
+</section>
+
+<section data-tab="Accessibility">
+  @include "partials/accessibility/accessibility.md"
+</section>

--- a/website/docs/components/reveal/partials/accessibility/accessibility.md
+++ b/website/docs/components/reveal/partials/accessibility/accessibility.md
@@ -1,0 +1,15 @@
+## Conformance rating
+
+<Doc::Badge @type="success">Conformant</Doc::Badge>
+
+When used as recommended, there should not be any WCAG conformance issues with this component.
+
+## Applicable WCAG Success Criteria
+
+This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
+
+<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.4.3" "2.4.6" "2.4.7" "2.5.3" "3.2.1" "3.2.4" "4.1.1" "4.1.2" }} />
+
+---
+
+<Doc::A11ySupport />

--- a/website/docs/components/reveal/partials/code/component-api.md
+++ b/website/docs/components/reveal/partials/code/component-api.md
@@ -1,0 +1,16 @@
+## Component API
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="text" @required="true" @type="string">
+    Plain text string which will appear on the toggle button which controls hiding and showing of the content. If no text value is defined an error will be thrown.
+  </C.Property>
+  <C.Property @name="textWhenOpen" @type="string">
+    Plain text which displays on the toggle button while the content is displayed.
+  </C.Property>
+  <C.Property @name="isOpen" @values={{array "false" "true" }} @default="false" @type="boolean">
+    Used to control whether the content is displayed or hidden on page load.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>

--- a/website/docs/components/reveal/partials/code/how-to-use.md
+++ b/website/docs/components/reveal/partials/code/how-to-use.md
@@ -1,0 +1,29 @@
+## How to use this component
+
+The `Reveal` component renders a button which triggers the display of additional content. The additional content can consist of either plain text or HTML and can include interactive elements such as links.
+
+```handlebars
+<Hds::Reveal @text="Toggle me">
+  Additional content
+</Hds::Reveal>
+```
+
+### textWhenOpen
+
+You can display different text on the toggle button when the `Reveal` is open.
+
+```handlebars
+<Hds::Reveal @text="Open me" @textWhenOpen="Close me">
+  Additional content
+</Hds::Reveal>
+```
+
+### isOpen
+
+Use `isOpen` to display the content on page load instead of initially hiding it.
+
+```handlebars
+<Hds::Reveal @text="Toggle me" @isOpen={{true}}>
+  Additional content
+</Hds::Reveal>
+```

--- a/website/docs/components/reveal/partials/code/showcase.md
+++ b/website/docs/components/reveal/partials/code/showcase.md
@@ -1,0 +1,3 @@
+## Showcase
+
+<!-- Leave it as is, we don't expose the component showcase for now. -->

--- a/website/docs/components/reveal/partials/guidelines/guidelines.md
+++ b/website/docs/components/reveal/partials/guidelines/guidelines.md
@@ -1,0 +1,35 @@
+## Usage
+
+### When to use
+
+- {description}
+
+### When not to use
+
+- {description}, consider {[component](#)}.
+- {description}, consider {[component](#)}.
+- {description}, consider {[component](#)}.
+
+### Variant/property name
+
+<!-- don’t forget to include real examples and do/don’t blocks, as necessary -->
+{description}
+
+### Variant/property name
+
+<!-- don’t forget to include real examples and do/don’t blocks, as necessary -->
+{description}
+
+## Content
+
+- {description}
+- {description}
+- {description}
+- {description}
+- {description}
+
+## Related
+
+<!-- only include the 2 most similar/related components -->
+- {[component name](#)}
+- {[component name](#)}

--- a/website/docs/components/reveal/partials/guidelines/overview.md
+++ b/website/docs/components/reveal/partials/guidelines/overview.md
@@ -1,0 +1,1 @@
+{description}

--- a/website/docs/components/reveal/partials/specifications/anatomy.md
+++ b/website/docs/components/reveal/partials/specifications/anatomy.md
@@ -1,0 +1,15 @@
+## Anatomy
+
+<!-- image then table -->
+![Anatomy of reveal](/assets/components/alert/reveal-anatomy-inline.png)
+
+<!-- this is just an example, refer to other components to see how to fill this table -->
+| Element          | Usage                                           |
+|------------------|-------------------------------------------------|
+| Icon             | Optional, but recommended                       |
+| Title            | Required, if no description Optional, otherwise |
+| Description      | Required, if no title Optional, otherwise       |
+| Actions          | Optional                                        |
+| Dismiss button   | Optional                                        |
+| Content          | Required                                        |
+| Container        | Required                                        |

--- a/website/docs/components/reveal/partials/specifications/states.md
+++ b/website/docs/components/reveal/partials/specifications/states.md
@@ -1,0 +1,2 @@
+<!-- populate with examples and documentation of interactive states -->
+<!-- this can usually be found in the design guidelines -->


### PR DESCRIPTION
### :pushpin: Summary

**WIP**

_**STATUS:** * Initial code and accessibility documentation added._

If merged, this PR adds the `Reveal` component Web documentation to the [`Reveal` component branch](https://github.com/hashicorp/design-system/pull/1381).

### :hammer_and_wrench: Detailed description
**Current status details:**
* Initial code documentation including “How to use” & “API“ added
* “Accessibility” documentation added
* (Design-related docs not yet added)

<!--
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser
-->

### :link: External links
- Jira ticket: [HDS-1911](https://hashicorp.atlassian.net/browse/HDS-1911)
- [Figma file](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/branch/ZXJVYXcw09ZL2Xl2Mfcmic/HDS-Product---Components?type=design&node-id=35103-70091&t=ebnGw7Nz4paIPK7c-0)
- [CRD](https://docs.google.com/document/d/1TKgRk8OI8XKM4WPQ9_lYG7yGsKHOZYx0DIp2Pe5DCBM/edit#heading=h.jxhqdjc34uui)
- [`Reveal` component PR](https://github.com/hashicorp/design-system/pull/1381)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
