### PR TITLE
Fix `SideNav` issue with content resizing when transitioning its `width`

### DIFF
--- a/.changeset/nice-clouds-sort.md
+++ b/.changeset/nice-clouds-sort.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fixed `SideNav` issue with content resizing when transitioning its `width`

--- a/packages/components/addon/components/hds/side-nav/index.hbs
+++ b/packages/components/addon/components/hds/side-nav/index.hbs
@@ -3,7 +3,13 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<Hds::SideNav::Base class={{this.classNames}} ...attributes {{focus-trap isActive=this.shouldTrapFocus}}>
+<Hds::SideNav::Base
+  class={{this.classNames}}
+  ...attributes
+  {{on "transitionstart" (fn this.setTransition "start")}}
+  {{on "transitionend" (fn this.setTransition "end")}}
+  {{focus-trap isActive=this.shouldTrapFocus}}
+>
   <:root>
     {{#if this.hasA11yRefocus}}
       <NavigationNarrator

--- a/packages/components/addon/components/hds/side-nav/index.js
+++ b/packages/components/addon/components/hds/side-nav/index.js
@@ -12,6 +12,7 @@ import { registerDestructor } from '@ember/destroyable';
 export default class HdsSideNavComponent extends Component {
   @tracked isResponsive = this.args.isResponsive ?? true;
   @tracked isMinimized = this.isResponsive; // we set it minimized by default so that if we switch viewport from desktop to mobile its already minimized
+  @tracked isAnimating = false;
   @tracked isDesktop = true;
   hasA11yRefocus = this.args.hasA11yRefocus ?? true;
 
@@ -84,6 +85,9 @@ export default class HdsSideNavComponent extends Component {
     } else {
       classes.push('hds-side-nav--is-not-minimized');
     }
+    if (this.isAnimating) {
+      classes.push('hds-side-nav--is-animating');
+    }
 
     return classes.join(' ');
   }
@@ -103,6 +107,19 @@ export default class HdsSideNavComponent extends Component {
 
     if (typeof onToggleMinimizedStatus === 'function') {
       onToggleMinimizedStatus(this.isMinimized);
+    }
+  }
+
+  @action
+  setTransition(phase, event) {
+    // we only want to respond to `width` animation/transitions
+    if (event.propertyName !== 'width') {
+      return;
+    }
+    if (phase === 'start') {
+      this.isAnimating = true;
+    } else {
+      this.isAnimating = false;
     }
   }
 

--- a/packages/components/addon/components/hds/side-nav/portal/index.hbs
+++ b/packages/components/addon/components/hds/side-nav/portal/index.hbs
@@ -4,7 +4,7 @@
 }}
 
 <Portal @target={{if @targetName @targetName "hds-side-nav-portal-target"}}>
-  <div class="hds-side-nav__content-panel hds-side-nav-hide-when-minimized" ...attributes>
+  <div class="hds-side-nav__content-panel" ...attributes>
     <Hds::SideNav::List aria-label={{@ariaLabel}} as |ListElements|>
       {{yield ListElements}}
     </Hds::SideNav::List>

--- a/packages/components/addon/components/hds/side-nav/portal/target.hbs
+++ b/packages/components/addon/components/hds/side-nav/portal/target.hbs
@@ -8,7 +8,7 @@
     @multiple={{true}}
     @onChange={{this.panelsChanged}}
     @name={{if @targetName @targetName "hds-side-nav-portal-target"}}
-    class="hds-side-nav__content-panels"
+    class="hds-side-nav__content-panels hds-side-nav-hide-when-minimized"
     {{did-update this.didUpdateSubnav this.numSubnavs}}
   />
 </div>

--- a/packages/components/app/styles/components/side-nav/content.scss
+++ b/packages/components/app/styles/components/side-nav/content.scss
@@ -21,7 +21,7 @@
 .hds-side-nav__content-panels {
   // see https://codepen.io/didoo/pen/YzOeRPr
   display: grid;
-  grid-template-columns: repeat(5, 100%);
+  grid-template-columns: repeat(5, var(--hds-app-sidenav-width-expanded));
   width: 100%;
 }
 

--- a/packages/components/app/styles/components/side-nav/main.scss
+++ b/packages/components/app/styles/components/side-nav/main.scss
@@ -202,5 +202,10 @@
       var(--hds-app-sidenav-animation-easing)
       var(--hds-app-sidenav-animation-delay);
   }
-}
 
+  // we want to avoid accidental interactions with the navigation elements while the sidenav is animating its width
+  // (elements with `visibility: visible` can already be interacted with, while their opacity is transitioning)
+  .hds-side-nav--is-animating & {
+    pointer-events: none;
+  }
+}


### PR DESCRIPTION
### :pushpin: Summary

This PR solves an issue around the resizing of the content when the width of the `SideNav` is animated/transitioned:

https://github.com/hashicorp/design-system/assets/686239/af7a4cef-2921-4e19-826a-de6d915f90d7
(the animation is slowed down for debugging)

This is a regression from the initial implementation and it's due to the changes introduced in https://github.com/hashicorp/design-system/pull/1338/

With these changes, I've move the target of the `hds-side-nav-hide-when-minimized` from the "panels" container to the "panel" elements. The intention was to avoid the navigational elements to be interactive while not fully visible yet (the visibility of an element is not inherited, a child can be set to visible even if the parent is not visible) because their opacity was transitioning. The problem with this change is that the single panels **also** receive some CSS properties' changes via JavaScript (to control the sliding and appearence of the panels) and so there were conflicts with the `visibility` property.

The final effect was hard to spot, because the entire transition is quite quick, but still perceivable.

So in this PR I have reverted the changes, and added a new special class that disables the interactivity of the content while the sidenav is transitioning states, solving the problem at the root.

For context, while debugging I've another issue, almost undetectable, a flickering of the panels when injected (sub-navigation). This will be solved in a separate ticket ([HDS-1971](https://hashicorp.atlassian.net/browse/HDS-1971)), because it needs some non-trivial JS refactoring.

### :hammer_and_wrench: Detailed description

In this PR I have:
- moved back target of "hide when minimized" class to the "panels" container
    - reverted change done in https://github.com/hashicorp/design-system/pull/1338/
- added special class `hds-side-nav--is-animating` to disable interaction while animating/transitioning
  - I've used the same technique used in the previous `hc-nav` implementation:
     - https://github.com/hashicorp/cloud-ui/blob/de3a8b71f7cb5b87d1945866bf20cac55fcc2b7e/addons/hc-nav/addon/components/hc-nav/container/index.hbs#L7-L8
     - https://github.com/hashicorp/cloud-ui/blob/de3a8b71f7cb5b87d1945866bf20cac55fcc2b7e/addons/hc-nav/addon/components/hc-nav/container/index.js#L62-L73
- improved definition of panel’s default width (not visible to users, but technically more correct)

### :camera_flash: Screenshots

A frame captured in the middle of the animation:
<img width="728" alt="screenshot_2722" src="https://github.com/hashicorp/design-system/assets/686239/de2b576d-bdec-4d92-808f-165214de784b">

### :link: External links

Slack conversation: https://hashicorp.slack.com/archives/C7KTUHNUS/p1685041498766739
Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1970

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1971]: https://hashicorp.atlassian.net/browse/HDS-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ