### PR TITLE
remove the note about voice guidelines hyperlink

### DIFF
--- a/packages/ember-flight-icons/CONTRIBUTING.md
+++ b/packages/ember-flight-icons/CONTRIBUTING.md
@@ -64,4 +64,4 @@ module.exports = {
 
 * When associated when Ember, refer to the npm package as "Ember addon" instead of just "addon".
   * Use "package" for other frameworks.
-* Refer to [HashiCorp Voice, Style & Language Guidelines](https://docs.google.com/document/d/1MRvGd6tS5JkIwl_GssbyExkMJqOXKeUE00kSEtFi8m8/edit). _Note: This link is internal only._
+* Refer to [HashiCorp Voice, Style & Language Guidelines](https://docs.google.com/document/d/1MRvGd6tS5JkIwl_GssbyExkMJqOXKeUE00kSEtFi8m8/edit).


### PR DESCRIPTION
### :pushpin: Summary

I am able to access the [HashiCorp Voice, Style & Language Guidelines](https://docs.google.com/document/d/1MRvGd6tS5JkIwl_GssbyExkMJqOXKeUE00kSEtFi8m8/edit) from outside HashiCorp. I guess that it used to be internal but opened up to the public at some point. So creating this pull request to remove the note saying that it is internal.

### :hammer_and_wrench: Detailed description

I am still in the process of reading through the design system docs on the helios website. I wonder if a link to [HashiCorp Voice, Style & Language Guidelines](https://docs.google.com/document/d/1MRvGd6tS5JkIwl_GssbyExkMJqOXKeUE00kSEtFi8m8/edit) is already present somewhere in the docs. If absent, I would be happy to add it at a good spot. Let me know!

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
