### PR TITLE
Embed page scroll management into `Modal` and `Flyout`

### DIFF
--- a/.changeset/thin-otters-chew.md
+++ b/.changeset/thin-otters-chew.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Embed page scroll management into the `Modal` and `Flyout` components

--- a/packages/components/addon/components/hds/flyout/index.js
+++ b/packages/components/addon/components/hds/flyout/index.js
@@ -60,8 +60,14 @@ export default class HdsFlyoutIndexComponent extends Component {
 
   @action
   didInsert(element) {
-    // Store a reference of the `<dialog>` element
+    // Store references of `<dialog>` and `<body>` elements
     this.element = element;
+    this.body = document.body;
+
+    if (this.body) {
+      // Store the initial `overflow` value of `<body>` so we can reset to it
+      this.bodyInitialOverflowValue = this.body.style.overflow;
+    }
 
     // Register `<dialog>` element for polyfilling if no native support is available
     if (!element.showModal) {
@@ -98,6 +104,9 @@ export default class HdsFlyoutIndexComponent extends Component {
     this.element.showModal();
     this.isOpen = true;
 
+    // Prevent page from scrolling when the dialog is open
+    if (this.body) this.body.style.overflow = 'hidden';
+
     // Call "onOpen" callback function
     if (this.args.onOpen && typeof this.args.onOpen === 'function') {
       this.args.onOpen();
@@ -108,5 +117,8 @@ export default class HdsFlyoutIndexComponent extends Component {
   onDismiss() {
     // Make flyout dialog invisible using the native `close` method
     this.element.close();
+
+    // Reset page `overflow` property
+    if (this.body) this.body.style.overflow = this.bodyInitialOverflowValue;
   }
 }

--- a/packages/components/addon/components/hds/modal/index.js
+++ b/packages/components/addon/components/hds/modal/index.js
@@ -86,8 +86,14 @@ export default class HdsModalIndexComponent extends Component {
 
   @action
   didInsert(element) {
-    // Store a reference of the `<dialog>` element
+    // Store references of `<dialog>` and `<body>` elements
     this.element = element;
+    this.body = document.body;
+
+    if (this.body) {
+      // Store the initial `overflow` value of `<body>` so we can reset to it
+      this.bodyInitialOverflowValue = this.body.style.overflow;
+    }
 
     // Register `<dialog>` element for polyfilling if no native support is available
     if (!element.showModal) {
@@ -135,6 +141,9 @@ export default class HdsModalIndexComponent extends Component {
     this.element.showModal();
     this.isOpen = true;
 
+    // Prevent page from scrolling when the dialog is open
+    if (this.body) this.body.style.overflow = 'hidden';
+
     // Call "onOpen" callback function
     if (this.args.onOpen && typeof this.args.onOpen === 'function') {
       this.args.onOpen();
@@ -145,5 +154,8 @@ export default class HdsModalIndexComponent extends Component {
   onDismiss() {
     // Make modal dialog invisible using the native `close` method
     this.element.close();
+
+    // Reset page `overflow` property
+    if (this.body) this.body.style.overflow = this.bodyInitialOverflowValue;
   }
 }

--- a/packages/components/tests/dummy/app/controllers/components/flyout.js
+++ b/packages/components/tests/dummy/app/controllers/components/flyout.js
@@ -14,12 +14,10 @@ export default class FlyoutController extends Controller {
   @action
   activateFlyout(Flyout) {
     this[Flyout] = true;
-    document.body.style.overflow = 'hidden';
   }
 
   @action
   deactivateFlyout(Flyout) {
     this[Flyout] = false;
-    document.body.style.overflow = 'auto';
   }
 }

--- a/packages/components/tests/dummy/app/controllers/components/modal.js
+++ b/packages/components/tests/dummy/app/controllers/components/modal.js
@@ -16,14 +16,12 @@ export default class ModalController extends Controller {
   activateModal(modal) {
     this.isModalDismissDisabled = false;
     this[modal] = true;
-    document.body.style.overflow = 'hidden';
   }
 
   @action
   deactivateModal(modal) {
     this.isModalDismissDisabled = false;
     this[modal] = false;
-    document.body.style.overflow = 'auto';
   }
 
   @action markFormAsChanged() {

--- a/website/docs/components/flyout/index.js
+++ b/website/docs/components/flyout/index.js
@@ -24,12 +24,10 @@ export default class Index extends Component {
   @action
   activateFlyout(flyout) {
     this[flyout] = true;
-    document.body.style.overflow = 'hidden';
   }
 
   @action
   deactivateFlyout(flyout) {
     this[flyout] = false;
-    document.body.style.overflow = 'auto';
   }
 }

--- a/website/docs/components/flyout/partials/code/how-to-use.md
+++ b/website/docs/components/flyout/partials/code/how-to-use.md
@@ -4,7 +4,7 @@ The `Hds::Flyout` component leverages the `<dialog>` element which is [currently
 
 ## Page scroll
 
-When an `Hds::Flyout` component is open, the rest of the page is disabled (via `inert`). However, scrolling at the page level is still available. To make it clear to the user that the underlying elements are not interactive and to avoid confusion, we recommend disabling the page scroll `onOpen` and enabling it back `onClose` (for example, by setting `overflow: hidden;` and `overflow: auto;` respectively) by applying it to the `<body>` element.
+When an `Hds::Flyout` component is open, the rest of the page is disabled (via `inert`). The page scrolling is also disabled by applying `overflow: hidden` to the `<body>` element, to make it clear to the user that the underlying elements are not interactive and to avoid confusion.
 
 ## Positioning
 

--- a/website/docs/components/modal/index.js
+++ b/website/docs/components/modal/index.js
@@ -33,14 +33,12 @@ export default class Index extends Component {
   activateModal(modal) {
     this.isModalDismissDisabled = false;
     this[modal] = true;
-    document.body.style.overflow = 'hidden';
   }
 
   @action
   deactivateModal(modal) {
     this.isModalDismissDisabled = false;
     this[modal] = false;
-    document.body.style.overflow = 'auto';
   }
 
   @action markFormAsChanged() {

--- a/website/docs/components/modal/partials/code/how-to-use.md
+++ b/website/docs/components/modal/partials/code/how-to-use.md
@@ -4,7 +4,7 @@ The Modal component leverages the `<dialog>` element which is currently supporte
 
 ## Page scroll
 
-When a Modal is open, the rest of the page is disabled (via `inert`). However, scrolling at the page level is still available. To make it clear to the user that the underlying elements are not interactive and to avoid confusion, we recommend disabling the page scroll `onOpen` and enabling it back `onClose` (for example, by setting `overflow: hidden;` and `overflow: auto;` respectively) by applying it to the `<body>` element.
+When a Modal is open, the rest of the page is disabled (via `inert`). The page scrolling is also disabled by applying `overflow: hidden` to the `<body>` element, to make it clear to the user that the underlying elements are not interactive and to avoid confusion.
 
 ## Positioning
 


### PR DESCRIPTION
### :pushpin: Summary

Embed page scroll management into `Modal` and `Flyout`

### :hammer_and_wrench: Detailed description

We currently [recommend consumers implement the page scroll management](https://helios.hashicorp.design/components/modal?tab=code#page-scroll) (disabled page scroll when open and enable when closed) for `Modal` and `Flyout` using the `onOpen` and `onClose` callbacks. The reason behind this initial approach was to keep components encapsulated and avoid interfering with other elements on the page (in this case the `<body>` element).

Based on feedback from Terraform/Atlas and after observing the above recommendation is not followed in practice we decided to embed the logic into the `Modal` and `Flyout` components and remove the recommendation from the associated docs.

Note: have tried a few approaches for testing this new logic, but the way qunit tests are set up does not allow access to the `<body>` element

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1963](https://hashicorp.atlassian.net/browse/HDS-1963)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
