### PR TITLE
remove copy standards section

### DIFF
--- a/packages/ember-flight-icons/CONTRIBUTING.md
+++ b/packages/ember-flight-icons/CONTRIBUTING.md
@@ -59,9 +59,3 @@ module.exports = {
   },
 };
 ```
-
-## Copy standards
-
-* When associated when Ember, refer to the npm package as "Ember addon" instead of just "addon".
-  * Use "package" for other frameworks.
-* Refer to [HashiCorp Voice, Style & Language Guidelines](https://docs.google.com/document/d/1MRvGd6tS5JkIwl_GssbyExkMJqOXKeUE00kSEtFi8m8/edit). _Note: This link is internal only._


### PR DESCRIPTION
this level of granularity is not necessary for contributors to ember-flight-icons 
