### PR TITLE
enhancement updated docs for application-state component

### DIFF
--- a/.changeset/sharp-dolls-confess.md
+++ b/.changeset/sharp-dolls-confess.md
@@ -1,5 +1,0 @@
----
-"@hashicorp/design-system-components": patch
----
-
-Updated application-state docs for clarity

--- a/.changeset/sharp-dolls-confess.md
+++ b/.changeset/sharp-dolls-confess.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Updated application-state docs for clarity

--- a/packages/components/tests/integration/components/hds/application-state/body-test.js
+++ b/packages/components/tests/integration/components/hds/application-state/body-test.js
@@ -23,7 +23,7 @@ module(
         .hasClass('hds-application-state__body');
     });
 
-    test('it should render the yielded content', async function (assert) {
+    test('it should render the yielded content when used in block form', async function (assert) {
       await render(
         hbs`<Hds::ApplicationState::Body id="test-application-state-body">
         <pre>test</pre>
@@ -31,6 +31,28 @@ module(
       );
       assert.dom('#test-application-state-body > pre').exists();
       assert.dom('#test-application-state-body > pre').hasText('test');
+    });
+
+    test('it should render the text if defined', async function (assert) {
+      await render(
+        hbs`<Hds::ApplicationState::Body id="test-application-state-body" @text="I am the only thing that should exist"/>`
+      );
+      assert.dom('#test-application-state-body').exists();
+      assert
+        .dom('#test-application-state-body')
+        .hasText('I am the only thing that should exist');
+    });
+
+    test('it should not render defined text if used in block form', async function (assert) {
+      await render(
+        hbs`<Hds::ApplicationState::Body id="test-application-state-body" @text="I should not exist">
+        <pre>test should only exist</pre>
+      </Hds::ApplicationState::Body>`
+      );
+      assert.dom('#test-application-state-body > pre').exists();
+      assert
+        .dom('#test-application-state-body > pre')
+        .hasText('test should only exist');
     });
   }
 );

--- a/website/docs/components/application-state/partials/code/component-api.md
+++ b/website/docs/components/application-state/partials/code/component-api.md
@@ -22,10 +22,12 @@
 
 #### [A].Body
 
-Supports block invocation for custom use.
+Supports block invocation for custom content (see [Block Content](https://guides.emberjs.com/release/components/block-content/) in Ember docs).
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="text" @type="string" />
+  <C.Property @name="text" @type="string">
+    Note: use `@text` for an inline invocation only. This component does not support `@text` on the component invocation if it is used as a block.
+  </C.Property>
 </Doc::ComponentApi>
   
 #### [A].Footer

--- a/website/docs/components/application-state/partials/code/how-to-use.md
+++ b/website/docs/components/application-state/partials/code/how-to-use.md
@@ -60,6 +60,18 @@ This component intends to replace a few different simple error and empty/zero st
 </Hds::ApplicationState>
 ```
 
+#### Empty state with body text
+
+```handlebars
+<Hds::ApplicationState as |A|>
+  <A.Header @title="Empty state title text" />
+  <A.Body @text="Some sentence that conveys a good message to the user" />
+  <A.Footer as |F|>
+    <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
+  </A.Footer>
+</Hds::ApplicationState>
+```
+
 ### As an error state
 
 To indicate that the message is an error state, add `@errorCode` to the `[A].Header` component invocation.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds clarifying language to the Application-State component.

### :hammer_and_wrench: Detailed description

- Added another code sample
- Added additional clarifying language to the component API 
- Added some extra tests for the component to show that you can use `@text` or a block invocation but not both

### :camera_flash: Screenshots

Additional example: 
![CleanShot 2023-06-06 at 10 13 47](https://github.com/hashicorp/design-system/assets/4587451/69a54291-e640-459f-b924-cd6e77a8bae1)

Additional language in the API docs: 
![CleanShot 2023-06-06 at 10 14 13](https://github.com/hashicorp/design-system/assets/4587451/9a0e73d3-689f-405a-bc88-16f3a04bee5e)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1896](https://hashicorp.atlassian.net/browse/HDS-1896)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1896]: https://hashicorp.atlassian.net/browse/HDS-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ