### PR TITLE
Hds 1974 fix doc inconsistency

### DIFF
--- a/website/docs/components/alert/partials/code/how-to-use.md
+++ b/website/docs/components/alert/partials/code/how-to-use.md
@@ -1,6 +1,6 @@
 ## How to use this component
 
-The most basic invocation requires the `type` argument to be passed, along with the `title` and/or `description` content. By default, a `neutral` alert is generated.
+The most basic invocation requires the `type` argument to be passed, along with the `title` and/or `description` content. By default, a `neutral` Alert is generated.
 
 ```handlebars
 <Hds::Alert @type="inline" as |A|>
@@ -11,7 +11,7 @@ The most basic invocation requires the `type` argument to be passed, along with 
 
 ### Type
 
-A different type of alert can be invoked using the `type` argument.
+A different type of Alert can be invoked using the `type` argument.
 
 ```handlebars
 <Hds::Alert @type="page" as |A|>
@@ -45,7 +45,7 @@ Optionally, you can pass only `title` or only `description`.
 
 ### Color
 
-A different color can be applied to the alert using the `color` argument. This will determine the default icon used in the alert, unless overwritten.
+A different color can be applied to the Alert using the `color` argument. This will determine the default icon used in the Alert, unless overwritten.
 
 ```handlebars
 <Hds::Alert @type="inline" @color="success" as |A|>
@@ -56,7 +56,7 @@ A different color can be applied to the alert using the `color` argument. This w
 
 ### Icons
 
-A different icon can be used in the alert using the `icon` argument. This accepts any [icon](/icons/library) name.
+A different icon can be used in the Alert using the `icon` argument. This accepts any [icon](/icons/library) name.
 
 ```handlebars
 <Hds::Alert @type="inline" @color="success" @icon="bulb" as |A|>
@@ -65,7 +65,7 @@ A different icon can be used in the alert using the `icon` argument. This accept
 </Hds::Alert>
 ```
 
-If you need to hide the icon, pass `false` to the `icon` argument. This is only an option on page and inline alerts as compact alerts require an icon.
+If you need to hide the icon, pass `false` to the `icon` argument. This is only an option on page and inline Alerts as compact Alerts require an icon.
 
 ```handlebars
 <Hds::Alert @type="inline" @color="success" @icon={{false}} as |A|>
@@ -76,7 +76,7 @@ If you need to hide the icon, pass `false` to the `icon` argument. This is only 
 
 ### Dismissal
 
-To enable dismissibility, pass a callback function to the `onDismiss` argument. This will add a dismiss button to the alert. When that button is clicked, the callback function will be executed. 
+To enable dismissibility, pass a callback function to the `onDismiss` argument. This will add a dismiss button to the Alert. When that button is clicked, the callback function will be executed. 
 
 Given the variety of use cases and contexts in which alerts are used across products, application teams will need to implement the callback function.
 

--- a/website/docs/components/badge/partials/code/component-api.md
+++ b/website/docs/components/badge/partials/code/component-api.md
@@ -5,7 +5,7 @@
   <C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
   <C.Property @name="text" @type="string">
-    The text of the badge or value of the screen-reader only element if `isIconOnly` is set to `true`. If no text value is defined an error will be thrown.
+    The text of the Badge or value of the screen-reader only element if `isIconOnly` is set to `true`. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="icon" @type="string">
     Use this parameter to show an icon. Any [icon](/icons/library) name is acceptable.

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -55,7 +55,7 @@ There are four available colors for the Button: `primary`, `secondary`, `tertiar
 
 ### Size
 
-There are three sizes available for Buttons: `small`, `medium`, and `large`. The default is `medium`. To use a different size, declare a value for `@size`:
+There are three sizes available for the Button: `small`, `medium`, and `large`. The default is `medium`. To use a different size, declare a value for `@size`:
 
 ```handlebars
 <Hds::Button @text="Small button" @size="small" />
@@ -67,7 +67,7 @@ There are three sizes available for Buttons: `small`, `medium`, and `large`. The
 
 ### Full-width
 
-This indicates that a Button should take up the full-width of the parent container. It’s set to `false` by default.
+This indicates that the Button should take up the full-width of the parent container. It’s set to `false` by default.
 
 ```handlebars
 <Hds::Button @text="Copy to clipboard" @isFullWidth={{true}} />
@@ -104,7 +104,7 @@ The `Hds::Button` component uses the generic `Hds::Interactive` component. For m
 
 #### With @href
 
-If you pass an `@href` argument, a `<a>` link will be generated.
+If you pass an `@href` argument, an `<a>` link will be generated.
 
 `target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied by default. This is the most common case, as internal links are generally handled using a `@route` argument but can be overridden. If the `href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{true}}` and it will not add the `target` and `rel` attributes.
 
@@ -114,7 +114,7 @@ If you pass an `@href` argument, a `<a>` link will be generated.
 
 #### With @route
 
-If you pass a `@route` argument, a `<a>` link will be generated using a `<LinkTo>` Ember component. All of the standard arguments for the `<LinkTo/LinkToExternal>` components are supported (eg. `models/model/query/current-when/replace`).
+If you pass a `@route` argument, an `<a>` link will be generated using a `<LinkTo>` Ember component. All of the standard arguments for the `<LinkTo/LinkToExternal>` components are supported (eg. `models/model/query/current-when/replace`).
 
 If the route is external to your current engine, you have to pass `@isRouteExternal={{true}}` so it will use `<LinkToExternal>` instead of `<LinkTo>` for the `@route`. For more details, see the [Hds::Interactive component](/utilities/interactive).
 

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -1,4 +1,4 @@
-The button component is used to trigger an action or event. For accessibility, buttons should not be used to route to a URL; use a [Link](/components/link/standalone) instead.
+The Button component is used to trigger an action or event. For accessibility, Buttons should not be used to route to a URL; use a [Link](/components/link/standalone) instead.
 
 ## How to use this component
 
@@ -10,7 +10,7 @@ The basic invocation requires text to be passed:
 
 ### Add an icon
 
-To add an icon to your button, give the `@icon` any [icon](/icons/library) name:
+To add an icon to your Button, give the `@icon` any [icon](/icons/library) name:
 
 ```handlebars
 <Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" />
@@ -24,14 +24,14 @@ By default, if you define an icon, it is placed in the leading position (before 
 <Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" @iconPosition="trailing" />
 ```
 
-### Icon-only button
+### Icon-only Button
 
 !!! Info
 
-To add a tooltip to an icon-only button, here’s an example of how to do it in an accessible way: [Accessible Button Tooltip Pattern](https://codepen.io/melsumner/pen/bGGdmMV).
+To add a tooltip to an icon-only Button, here’s an example of how to do it in an accessible way: [Accessible Button Tooltip Pattern](https://codepen.io/melsumner/pen/bGGdmMV).
 !!!
 
-If you would like to create an icon-only button, set `@isIconOnly` to `true`. Note that you still have to define the `@text` value; it will be used as the `aria-label` attribute value on the `button` element.
+If you would like to create an icon-only Button, set `@isIconOnly` to `true`. Note that you still have to define the `@text` value; it will be used as the `aria-label` attribute value on the `Button` element.
 
 ```handlebars
 <Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" @isIconOnly={{true}} />
@@ -39,7 +39,7 @@ If you would like to create an icon-only button, set `@isIconOnly` to `true`. No
 
 ### Color
 
-There are four available colors for a button: `primary`, `secondary`, `tertiary`, and `critical`. The default is `primary`. To use a different color, declare another value for `@color`:
+There are four available colors for the Button: `primary`, `secondary`, `tertiary`, and `critical`. The default is `primary`. To use a different color, declare another value for `@color`:
 
 ```handlebars
 <Hds::Button @text="Secondary" @color="secondary" />
@@ -55,7 +55,7 @@ There are four available colors for a button: `primary`, `secondary`, `tertiary`
 
 ### Size
 
-There are three sizes available for buttons: `small`, `medium` and `large`. The default is `medium`. To use a different size, declare a value for `@size`:
+There are three sizes available for Buttons: `small`, `medium`, and `large`. The default is `medium`. To use a different size, declare a value for `@size`:
 
 ```handlebars
 <Hds::Button @text="Small button" @size="small" />
@@ -67,7 +67,7 @@ There are three sizes available for buttons: `small`, `medium` and `large`. The 
 
 ### Full-width
 
-This allows indication that a button should take up the full-width of the parent container. It’s set to `false` by default.
+This indicates that a Button should take up the full-width of the parent container. It’s set to `false` by default.
 
 ```handlebars
 <Hds::Button @text="Copy to clipboard" @isFullWidth={{true}} />
@@ -75,7 +75,7 @@ This allows indication that a button should take up the full-width of the parent
 
 ### Type
 
-This is the native button attribute, `type`. There are three possible values: `button`, `submit`, and `reset`. The default `type` for the button is `submit`. To prevent a button from submitting a form, set `type` to `button`.
+This is the native HTML button attribute, `type`. There are three possible values: `button`, `submit`, and `reset`. The default `type` for the Button is `submit`. To prevent a Button from submitting a form, set `type` to `button`.
 
 ```handlebars
 <Hds::Button @text="Submit" type="submit" />
@@ -93,18 +93,18 @@ Read the Ember.js guides for more information: [Patterns for Actions](https://gu
 
 ### Links
 
-You can generate a link with the visual appearance of a button passing a `@href` or a `@route` argument to the component.
+You can generate a link with the visual appearance of a button, by passing an `@href` or a `@route` argument to the component.
 
-If you’re passing a `@href` or a `@route` argument to the component, this will generate a `<a>` link, not a `<button>`. In this case no `type` is needed.
+If you’re passing an `@href` or a `@route` argument to the component, this will generate an `<a>` link, not a `<button>`. In this case, no `type` is needed.
 
 !!! Info
 
-The `Hds::Button` component uses the generic `Hds::Interactive` component. For more details about how this utility component works please refer to [its documentation page](/utilities/interactive).
+The `Hds::Button` component uses the generic `Hds::Interactive` component. For more details about how this utility component works, please refer to [its documentation page](/utilities/interactive).
 !!!
 
 #### With @href
 
-If you pass a `@href` argument a `<a>` link will be generated.
+If you pass an `@href` argument, a `<a>` link will be generated.
 
 `target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied by default. This is the most common case, as internal links are generally handled using a `@route` argument but can be overridden. If the `href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{true}}` and it will not add the `target` and `rel` attributes.
 
@@ -114,21 +114,21 @@ If you pass a `@href` argument a `<a>` link will be generated.
 
 #### With @route
 
-If you pass a `@route` argument a `<a>` link will be generated using a `<LinkTo>` Ember component. All of the standard arguments for the `<LinkTo/LinkToExternal>` components are supported (eg. `models/model/query/current-when/replace`).
+If you pass a `@route` argument, a `<a>` link will be generated using a `<LinkTo>` Ember component. All of the standard arguments for the `<LinkTo/LinkToExternal>` components are supported (eg. `models/model/query/current-when/replace`).
 
-If the route is external to your current engine you have to pass `@isRouteExternal={{true}}` so it will use `<LinkToExternal>` instead of `<LinkTo>` for the `@route`. For more details see the [Hds::Interactive component](/utilities/interactive).
+If the route is external to your current engine, you have to pass `@isRouteExternal={{true}}` so it will use `<LinkToExternal>` instead of `<LinkTo>` for the `@route`. For more details, see the [Hds::Interactive component](/utilities/interactive).
 
 ```handlebars
 <Hds::Button @text="Back to homepage" @icon="arrow-left" @route="index" />
 ```
 
-### Disabled buttons
+### Disabled Buttons
 
-To disable a button, manually add the native `disabled` attribute:
+To disable a Button, manually add the native `disabled` attribute:
 
 !!! Info
 
-If using a `@href` or `@route` and needing to disable the component, you’ll need to intercept the events since links can’t be disabled.
+If using an `@href` or `@route` and needing to disable the component, you’ll need to intercept the events since links can’t be disabled.
 !!!
 
 ```handlebars

--- a/website/docs/components/card/partials/code/component-api.md
+++ b/website/docs/components/card/partials/code/component-api.md
@@ -14,7 +14,7 @@
     Controls the background color.
   </C.Property>
   <C.Property @name="hasBorder" @type="boolean" @default="false">
-    Controls whether or not the card has a visible external border.
+    Controls whether or not the Card has a visible external border.
   </C.Property>
   <C.Property @name="overflow" @type="enum" @values={{array "hidden" "visible" }} @default="hidden">
     Controls the "overflow" property for the component.

--- a/website/docs/components/card/partials/code/how-to-use.md
+++ b/website/docs/components/card/partials/code/how-to-use.md
@@ -2,7 +2,7 @@
 
 **Just a container**
 
-The layout of the card itself, and its content, is left to the consumer of the component. The `Hds::Card::Container` is nothing more than a block container—a `<div>`—that provides styling for the `elevation`, `border`, and `background`. Sizing of the card, internal padding, and content alignment are all the consumer’s responsibility.
+The layout of the Card itself, and its content, is left to the consumer of the component. The `Hds::Card::Container` is nothing more than a block container—a `<div>`—that provides styling for the `elevation`, `border`, and `background`. Sizing of the card, internal padding, and content alignment are all the consumer’s responsibility.
 
 !!!
 
@@ -14,13 +14,13 @@ The layout of the card itself, and its content, is left to the consumer of the c
 </Hds::Card::Container>
 ```
 
-To style the cards, you can add an external element that wraps the card, with a custom class that controls the width of the wrapper itself and an internal element that wraps the content and applies padding around it (resulting in visual internal padding for the card) and aligns the text to the center.
+To style the Cards, you can add an external element that wraps the Card, with a custom class that controls the width of the wrapper itself and an internal element that wraps the content and applies padding around it (resulting in visual internal padding for the Card) and aligns the text to the center.
 
-Alternatively, you could use the card containers in a CSS `flex` or `grid` container.
+Alternatively, you could use the Card Containers in a CSS `flex` or `grid` container.
 
 ### Interactive states
 
-At the moment, we do not recommend using the card component as an interactive element, although we may add this feature in the future. Despite this, some products have implemented designs that provide visual feedback to the user interacting with a card by changing the elevation style (on `:hover` or `:active`).
+At the moment, we do not recommend using the Card component as an interactive element, although we may add this feature in the future. Despite this, some products have implemented designs that provide visual feedback to the user interacting with a Card by changing the elevation style (on `:hover` or `:active`).
 
 As a stopgap, we have introduced two specific arguments `@levelHover` and `@levelActive` to allow users to declare the specific "level" they want to use for each of these interactive states.
 
@@ -31,7 +31,7 @@ As a stopgap, we have introduced two specific arguments `@levelHover` and `@leve
 This is only an example and not a recommendation. If you have any doubt about which level to use for the different states, please speak with your product designer or contact the Design Systems Team.
 !!!
 
-In the following example, the card transitions between these elevations _mid → high → mid_ depending on these iteration states _rest → hover → active_:
+In the following example, the Card transitions between these elevations _mid → high → mid_ depending on these iteration states _rest → hover → active_:
 
 ```handlebars
 <div class="my-custom-class-to-set-the-card-layout">

--- a/website/docs/components/card/partials/code/how-to-use.md
+++ b/website/docs/components/card/partials/code/how-to-use.md
@@ -6,7 +6,7 @@ The layout of the card itself, and its content, is left to the consumer of the c
 
 !!!
 
-## Usage
+## How to use this component
 
 ```handlebars
 <Hds::Card::Container @level="mid" @hasBorder={{true}}>

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -4,10 +4,10 @@ The Dropdown component is composed of different child components each with their
 
 - The Dropdown component
     - Optional header and footer
-- Toggle components to open/close the dropdown
+- Toggle components to open/close the Dropdown
     - ToggleButton
     - ToggleIcon
-- ListItem components, to build the dropdown’s list items
+- ListItem components, to build the Dropdown’s list items
     - Description
     - Generic
     - Interactive
@@ -28,12 +28,12 @@ The Dropdown component is composed of different child components each with their
     If a `@isInline` parameter is provided then the element will be displayed as `inline-block` (useful to achieve specific layouts like in a container with right alignment). Otherwise it will be have a `block` layout.
   </C.Property>
   <C.Property @name="close" @type="function">
-    Function to programmatically close the dropdown.
+    Function to programmatically close the Dropdown.
     <br/><br/>
     If this function is invoked using an `\{{on "click"}}` modifier applied to the `ListItem::Interactive` element, there is a quirky behavior of the Ember `<LinkTo>` component which requires a workaround to have the events executed in the right order (this happens only if it has a `@route` argument). Read more about the issue and a possible solution [in this GitHub comment](https://github.com/hashicorp/design-system/pull/399#issuecomment-1171186772).
   </C.Property>
   <C.Property @name="onClose" @type="function">
-    Callback function invoked when the dropdown is closed, if provided.
+    Callback function invoked when the Dropdown is closed, if provided.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -42,11 +42,11 @@ The Dropdown component is composed of different child components each with their
 
 #### Dropdown::Header and Dropdown::Footer
 
-If the dropdown content exceeds the height of the container, the header and footer remain fixed while the list of items adjusts its height.
+If the Dropdown content exceeds the height of the container, the header and footer remain fixed while the list of items adjusts its height.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements nested in this child component are yielded inside the dropdown header/footer.
+    Elements nested in this child component are yielded inside the Dropdown header/footer.
   </C.Property>
   <C.Property @name="hasDivider" @type="boolean" @default="false" />
   <C.Property @name="...attributes">

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -31,7 +31,7 @@ By default, the list is positioned below the button, aligned to the right. To ch
 </Hds::Dropdown>
 ```
 
-In contexts where the dropdown needs to be _inline_, to inherit the alignment from a parent, you can use the `@isInline` argument (and set the `@listPosition` accordingly to your needs):
+In contexts where the Dropdown needs to be _inline_, to inherit the alignment from a parent, you can use the `@isInline` argument (and set the `@listPosition` accordingly to your needs):
 
 ```handlebars
 <div class="doc-dropdown-mock-text-align-right">

--- a/website/docs/components/form/primitives/partials/code/how-to-use.md
+++ b/website/docs/components/form/primitives/partials/code/how-to-use.md
@@ -95,7 +95,7 @@ If no `isRequired/isOptional` argument is provided, the component will not rende
 
 #### Required
 
-Pass an `isRequired` argument, to render a `Required` indicator.
+Pass an `isRequired` argument, to render a `Required` Indicator.
 
 ```handlebars
 <Hds::Form::Indicator @isRequired={{true}} />
@@ -103,7 +103,7 @@ Pass an `isRequired` argument, to render a `Required` indicator.
 
 #### Optional
 
-Pass an `isOptional` argument, to render an `Optional` indicator.
+Pass an `isOptional` argument, to render an `Optional` Indicator.
 
 ```handlebars
 <Hds::Form::Indicator @isOptional={{true}} />

--- a/website/docs/components/form/radio-card/partials/code/component-api.md
+++ b/website/docs/components/form/radio-card/partials/code/component-api.md
@@ -16,16 +16,16 @@
     The `disabled` attribute of the input control.
   </C.Property>
   <C.Property @name="controlPosition" @type="enum" @values={{array "bottom" "left" }} @default="bottom">
-    Sets the position of the form control in relation to the card content.
+    Sets the position of the form control in relation to the Radio Card content.
   </C.Property>
   <C.Property @name="alignment" @type="enum" @values={{array "left" "center" }} @default="left">
-    Sets the alignment of the card content.
+    Sets the alignment of the Radio Card content.
   </C.Property>
   <C.Property @name="layout" @type="enum" @values={{array "fluid" "fixed" }} @default="fluid">
-    By default, the card will expand to fit the parent container. When used in a group the cards will equally share the width to fit the available space. If the `@layout` parameter is set to `fixed` a `@maxWidth` value must be specified to constrain the card.
+    By default, the Radio Card will expand to fit the parent container. When used in a group, the cards will equally share the width to fit the available space. If the `@layout` parameter is set to `fixed`, a `@maxWidth` value must be specified to constrain the card.
   </C.Property>
   <C.Property @name="maxWidth" @type="string" @valueNote="any valid CSS width (%, vw, etc)">
-    When used with a `fluid` layout, this parameter will determine the number of cards shown per row (for example `25%` will result in 4 cards). When used with a `fixed` layout, this parameter will preserve the width of the card and wrap cards on multiple rows if necessary.
+    When used with a `fluid` layout, this parameter will determine the number of Radio Cards shown per row (for example `25%` will result in 4 cards). When used with a `fixed` layout, this parameter will preserve the width of the card and wrap cards on multiple rows if necessary.
   </C.Property>
   <C.Property @name="extraAriaDescribedBy" @type="string">
     An additional ID attribute to be added to the `aria-describedby` HTML attribute.
@@ -47,23 +47,23 @@
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="<[R].Icon>">
-    Yields an icon inside the card container. For details about its API check the [icon](/icons/usage-guidelines?tab=code) component.
+    Yields an icon inside the Radio Card container. For details about its API, check the [icon](/icons/usage-guidelines?tab=code) component.
   </C.Property>
   <C.Property @name="<[R].Label>" @type="yielded component">
-    A container that yields its content emphasized inside the card.
+    A container that yields its content emphasized inside the Radio Card.
     <br/><br/>
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
   <C.Property @name="<[R].Badge>">
-    A badge inside the card container. For details about its API check the [Badge](/components/badge) component.
+    A badge inside the Radio Card container. For details about its API, check the [Badge](/components/badge) component.
   </C.Property>
   <C.Property @name="<[R].Description>" @type="yielded component">
-    A container that yields its content inside the card. The content can be a simple string or a more complex/structured one, in which case it inherits the text style.
+    A container that yields its content inside the Radio Card. The content can be a simple string or a more complex/structured one, in which case it inherits the text style.
     <br/><br/>
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
   <C.Property @name="<[R].Generic>" @type="yielded component">
-    A container that yields its content inside the card. The content does not inherit any styles and can be customized as desired.
+    A container that yields its content inside the Radio Card. The content does not inherit any styles and can be customized as desired.
     <br/><br/>
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
@@ -73,10 +73,10 @@
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="controlPosition" @type="enum" @values={{array "bottom" "left" }} @default="bottom">
-    Sets the position of the form control in relation to the card content.
+    Sets the position of the form control in relation to the Radio Card content.
   </C.Property>
   <C.Property @name="alignment" @type="enum" @values={{array "left" "center" }} @default="left">
-    Sets the alignment of the card content.
+    Sets the alignment of the Radio Card content.
   </C.Property>
   <C.Property @name="name" @type="string">
     Sets the `name` attribute for each form control within the group.
@@ -85,7 +85,7 @@
     Appends a `Required` indicator next to the legend text and sets the `required` attribute on the controls when user input is required.
   </C.Property>
   <C.Property @name="layout" @type="string" @values={{array "fluid" "fixed" }} @default="fluid">
-    By default, the cards will expand to fit the parent container and will equally share the width to fit the available space. If the `@layout` parameter is set to `fixed` a `@maxWidth` value must be specified for each `RadioCard` to constrain them.
+    By default, the Radio Cards will expand to fit the parent container and will equally share the width to fit the available space. If the `@layout` parameter is set to `fixed`, a `@maxWidth` value must be specified for each `RadioCard` to constrain them.
   </C.Property>
 </Doc::ComponentApi>
 
@@ -100,15 +100,15 @@ The group of elements is automatically wrapped in a `<fieldset>` element.
     An optional container that yields its content inside the `<legend>` element. The content can be a simple string, or a more complex/structured one (in which case it inherits the text style). For details about its API check the [`Form::Legend`](/components/form/primitives) component.
   </C.Property>
   <C.Property @name="<[G].HelperText>" @type="yielded component">
-    A container that yields its content inside the "helper text" block (at group level). The content can be a simple string, or a more complex/structured one (in which case it inherits the text style). For details about its API check the [`Form::HelperText`](/components/form/primitives) component.
+    A container that yields its content inside the "helper text" block (at group level). The content can be a simple string, or a more complex/structured one (in which case it inherits the text style). For details about its API, check the [`Form::HelperText`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the element is automatically generated.
   </C.Property>
   <C.Property @name="<[G].RadioCard>" @type="yielded component">
-    Used to yield one or more cards inside the group. For details about its API check the `RadioCard` component above.
+    Used to yield one or more Radio Cards inside the group. For details about its API, check the `RadioCard` component above.
   </C.Property>
   <C.Property @name="<[G].Error>" @type="yielded component">
-    Container that yields its content inside the "error" block (at group level). The content can be a simple string, or a more complex/structured one (in which case it inherits the text style). For details about its API check the [`Form::Error`](/components/form/primitives) component.
+    Container that yields its content inside the "error" block (at group level). The content can be a simple string, or a more complex/structured one (in which case it inherits the text style). For details about its API, check the [`Form::Error`](/components/form/primitives) component.
     <br/><br/>
     The `id` attribute of the `Error` element is automatically generated.
     <Doc::ComponentApi as |C|>

--- a/website/docs/components/form/radio-card/partials/code/how-to-use.md
+++ b/website/docs/components/form/radio-card/partials/code/how-to-use.md
@@ -8,7 +8,7 @@
 
 !!! Warning
 
-The `<Hds::Form::RadioCard::Group>` component does not provide the logic for handling the mutually exclusive nature of radio controls (when a radio card is checked, any other radio cards with the same name that were previously checked become unchecked). You can implement this yourself in an `\{{on "change" this.onChange}}` function or manage the `checked` state of radio cards by updating the underlying data.
+The `<Hds::Form::RadioCard::Group>` component does not provide the logic for handling the mutually exclusive nature of radio controls (when a Radio Card is checked, any other Radio Cards with the same name that were previously checked become unchecked). You can implement this yourself in an `\{{on "change" this.onChange}}` function or manage the `checked` state of Radio Cards by updating the underlying data.
 !!!
 
 The `@name` argument offers an easy way to provide the same name for all the radio controls with a single declaration.

--- a/website/docs/components/form/toggle/partials/code/how-to-use.md
+++ b/website/docs/components/form/toggle/partials/code/how-to-use.md
@@ -63,7 +63,7 @@ Pass a `@value` argument.
 
 #### Checked
 
-Pass the standard HTML `checked` attribute to set the toggle to “checked”.
+Pass the standard HTML `checked` attribute to set the Toggle to “checked”.
 
 ```handlebars
 <Hds::Form::Toggle::Field @value="enable" checked as |F|>

--- a/website/docs/components/link/inline/partials/code/how-to-use.md
+++ b/website/docs/components/link/inline/partials/code/how-to-use.md
@@ -20,7 +20,7 @@ There are two available colors for a Inline Link: `primary` and `secondary`. The
 
 ### Icon
 
-To add an icon to your inline link, give the `@icon` argument any [icon](/icons/library) name.
+To add an icon to your Inline Link, give the `@icon` argument any [icon](/icons/library) name.
 
 `Hds::Link::Inline` does not have an intrinsic size. Instead, the size of the icon is calculated proportionally (via `em`) in relation to the font-size of the text.
 

--- a/website/docs/components/modal/partials/code/component-api.md
+++ b/website/docs/components/modal/partials/code/component-api.md
@@ -2,19 +2,19 @@
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium">
-    Sets the width of the modal.
+    Sets the width of the Modal.
   </C.Property>
   <C.Property @name="color" @type="enum" @values={{array "neutral" "warning" "critical" }} @default="neutral">
-    Sets the color scheme for the modal header elements: icon, tagline, and title.
+    Sets the color scheme for the Modal Header elements: icon, tagline, and title.
   </C.Property>
   <C.Property @name="onOpen" @type="function">
-    Callback function invoked when the modal is opened.
+    Callback function invoked when the Modal is opened.
   </C.Property>
   <C.Property @name="onClose" @type="function">
-    Callback function invoked when the modal is closed.
+    Callback function invoked when the Modal is closed.
   </C.Property>
   <C.Property @name="isDismissDisabled" @type="boolean" @default="false">
-    Set this boolean to `true` if you want to prevent the modal from being closed (for instance, to avoid accidental data loss in a form that hasn't been submitted). Make sure you communicate to users the reason why the modal is still open, and what they need to do to resolve the problem that is preventing the modal from being closed.
+    Set this boolean to `true` if you want to prevent the Modal from being closed (for instance, to avoid accidental data loss in a form that hasn't been submitted). Make sure you communicate to users the reason why the Modal is still open, and what they need to do to resolve the problem that is preventing the Modal from being closed.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -23,7 +23,7 @@
 
 ### Contextual components
 
-The title, the content of the modal dialog, and the actions are passed into the modal as yielded components, using the `Header`, `Body`, `Footer` keys.
+The title, the content of the Modal dialog, and the actions are passed into the Modal as yielded components, using the `Header`, `Body`, `Footer` keys.
 
 #### Modal::Header
 
@@ -34,7 +34,7 @@ A container that yields its content as the title of the Modal.
     Accepts any [icon](/icons/library) name.
   </C.Property>
   <C.Property @name="tagline" @type="string">
-    String that helps the user maintain context when a modal dialog is open.
+    String that helps the user maintain context when a Modal dialog is open.
     <br/><br/>
      This is **not** the title text, but a small piece of text above the title text.
   </C.Property>

--- a/website/docs/components/modal/partials/code/how-to-use.md
+++ b/website/docs/components/modal/partials/code/how-to-use.md
@@ -14,7 +14,7 @@ As an overlaying component, the `Hds::Modal` requires a high value on the z-axis
 
 This component uses [`ember-focus-trap`](https://github.com/josemarluedke/ember-focus-trap) to prevent the focus from going outside the Modal and to dismiss the Modal when clicking outside the Modal. This Ember modifier requires at least one interactive element to be present within the Modal, which is by default achieved by the dismiss button in the header.
 
-When a modal is opened with the keyboard, the focus is automatically set to the first focusable element inside the modal, which is the “Dismiss” button. The action of this button has no effect on the system, so focusing on it helps prevent users from accidentally confirming the modal.
+When a Modal is opened with the keyboard, the focus is automatically set to the first focusable element inside the Modal, which is the “Dismiss” button. The action of this button has no effect on the system, so focusing on it helps prevent users from accidentally confirming the Modal.
 
 ## How to use this component
 
@@ -40,11 +40,11 @@ When a modal is opened with the keyboard, the focus is automatically set to the 
 {{/if}}
 ```
 
-### Form within a modal dialog
+### Form within a Modal dialog
 
-If a modal dialog contains interactive elements, such as a form, the initial focus should be set on the first input, which is the first focusable element within the form. This can be achieved by setting the `autofocus` property on the first form element.
+If a Modal dialog contains interactive elements, such as a form, the initial focus should be set on the first input, which is the first focusable element within the form. This can be achieved by setting the `autofocus` property on the first form element.
 
-When the modal dialog contains information that might be lost on close, use a confirmation message before discarding it.
+When the Modal dialog contains information that might be lost on close, use a confirmation message before discarding it.
 
 ```handlebars
 <Hds::Button

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -17,7 +17,7 @@ There is also a set of **low-level sub-components**, used to build the "numbered
 - `Pagination::Nav::Ellipsis` - used to display an ellipsis instead of a set of page numbers
 - `Pagination::SizeSelector` - used to allow users to change the number of items displayed per page
 
-These pagination sub-elements may be used directly if you need to cover a very specific use case that is not covered by the "numbered" or "compact" pagination components. In that case, refer to their specific APIs below.
+These Pagination sub-elements may be used directly if you need to cover a very specific use case that is not covered by the Numbered or Compact Pagination components. In that case, refer to their specific APIs below.
 
 ### Pagination::Numbered
 

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -9,7 +9,7 @@ There are two main **high-level “container” components**, which control the 
 
 For more details on when and how to use these two components, refer to the "How to use" section below.
 
-There is also a set of **low-level sub-components**, used to build the "numbered" and "compact" variants:
+There is also a set of **low-level sub-components**, used to build the Numbered and Compact variants:
 
 - `Pagination::Info` - used to display the current range of items shown and the total number of items
 - `Pagination::Nav::Arrow` - used to provide "prev/next" navigation controls

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -1,8 +1,8 @@
-## “Compact” vs “Numbered” Pagination
+## Compact vs Numbered Pagination
 
 There are two different variants of the `Pagination` component (with different ways to invoke them) built to cover different use cases, contexts, and designs you may need them for.
 
-This differentiation is necessary to cover both use cases of pagination for a list with a known number of elements (**"numbered"**) and one in which this information is not available or is [cursor-based](https://jsonapi.org/profiles/ethanresnick/cursor-pagination/) (**"compact"**).
+This differentiation is necessary to cover both use cases of pagination for a list with a known number of elements (i.e., "numbered") and one in which this information is not available or is [cursor-based](https://jsonapi.org/profiles/ethanresnick/cursor-pagination/) (i.e., "compact").
 
 In the first one, the user is presented with a list of navigation controls ("prev/next" and "page numbers" to go directly to a specific page) and other optional UI elements; in the second, much simpler one, the user is presented with only the "prev/next" controls.
 
@@ -22,7 +22,7 @@ In this case, you will have to take care of different things **yourself**
 
 - the organization/layout of the elements on the page.
 - the logic to handle the "current page" status.
-- the logic connecting the different parts (if using "numbered").
+- the logic connecting the different parts (if using Numbered Pagination).
 
 
 ## Events handling and routing
@@ -33,9 +33,9 @@ This means that if you need to update the URL when the user changes the "page" i
 
 If instead you need to update the URL directly when the user clicks on one of the "navigation control" elements, you have to provide routing parameters (`route/query/model/etc`) to the component; refer to the "Component API" section below for specifications about these parameters (the APIs are slightly different for the two components).
 
-## How to use the "Numbered" Pagination
+## How to use Numbered Pagination
 
-The basic invocation of the Numbered Pagination requires the `@totalItems` argument to be provided (plus the event/routing handlers, see below):
+The basic invocation of Numbered Pagination requires the `@totalItems` argument to be provided (plus the event/routing handlers, see below):
 
 ```handlebars
 <Hds::Pagination::Numbered @totalItems={{40}} />
@@ -177,7 +177,7 @@ Below you can find an example of an integration between the sortable [`Table`](/
 </div>
 ```
 
-## How to use the "Compact" Pagination
+## How to use Compact Pagination
 
 By default, the basic use of the Pagination provides:
 

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -1,14 +1,14 @@
-## "Compact" vs "Numbered" pagination
+## “Compact” vs “Numbered” Pagination
 
 There are two different variants of the `Pagination` component (with different ways to invoke them) built to cover different use cases, contexts, and designs you may need them for.
 
-This differentiation is necessary to cover both use cases of a pagination for a list with a known number of elements (**"numbered"**) and one in which this information is not available or is [cursor-based](https://jsonapi.org/profiles/ethanresnick/cursor-pagination/) (**"compact"**).
+This differentiation is necessary to cover both use cases of pagination for a list with a known number of elements (**"numbered"**) and one in which this information is not available or is [cursor-based](https://jsonapi.org/profiles/ethanresnick/cursor-pagination/) (**"compact"**).
 
 In the first one, the user is presented with a list of navigation controls ("prev/next" and "page numbers" to go directly to a specific page) and other optional UI elements; in the second, much simpler one, the user is presented with only the "prev/next" controls.
 
 When pagination is invoked directly using one of these two components, it will **automatically**:
 
-- provide the correct responsive layout for the entire pagination and its sub-parts
+- provide the correct responsive layout for the entire Pagination and its sub-parts.
 - manage the "current page" status across the different sub-components it’s made of (based on the arguments provided to it and its children).
 - when one of the "navigation controls" is clicked, a callback function (if provided) is called, and a route (if provided) update is triggered.
 - when the "page size" is changed via the provided selector, it will automatically recalculate the total number of pages to display to the user.
@@ -16,7 +16,7 @@ When pagination is invoked directly using one of these two components, it will *
 
 ## Pagination sub-components
 
-If you need more control on the specific pagination parts, and/or you need to cover a very specific use case, you can use the pagination sub-elements directly (`Pagination::Info/Nav(*)/SizeSelector`).
+If you need more control on the specific Pagination parts, and/or you need to cover a very specific use case, you can use the Pagination sub-elements directly (`Pagination::Info/Nav(*)/SizeSelector`).
 
 In this case, you will have to take care of different things **yourself**
 
@@ -33,19 +33,19 @@ This means that if you need to update the URL when the user changes the "page" i
 
 If instead you need to update the URL directly when the user clicks on one of the "navigation control" elements, you have to provide routing parameters (`route/query/model/etc`) to the component; refer to the "Component API" section below for specifications about these parameters (the APIs are slightly different for the two components).
 
-## How to use the "Numbered" pagination
+## How to use the "Numbered" Pagination
 
-The basic invocation of the "numbered" pagination requires the `@totalItems` argument to be provided (plus the event/routing handlers, see below):
+The basic invocation of the Numbered Pagination requires the `@totalItems` argument to be provided (plus the event/routing handlers, see below):
 
 ```handlebars
 <Hds::Pagination::Numbered @totalItems={{40}} />
 ```
 
-By default the "Info" and "SizeSelector" sub-components are displayed, and the component takes care of updating the values and the states of the different elements, according to the user interactions with the component.
+By default the Info and SizeSelector sub-components are displayed, and the component takes care of updating the values and the states of the different elements, according to the user interactions with the component.
 
 ### Extra arguments
 
-It’s possible to customize the "Info", "Controls", and "SizeSelector" components by providing additional arguments to them. For more details about these parameters, refer to the "Component API" section.
+It’s possible to customize the Info, Controls, and SizeSelector components by providing additional arguments to them. For more details about these parameters, refer to the "Component API" section.
 
 Below is an example of some of these extra arguments:
 
@@ -105,7 +105,7 @@ The second `onPageSizeChange` function is invoked when a user interacts with the
 
 ### Routing/URL updates
 
-If you want the pagination to change the URL of the page directly (eg. updating the query parameters) you need to pass the routing parameters to the component:
+If you want the Pagination to change the URL of the page directly (eg. updating the query parameters) you need to pass the routing parameters to the component:
 
 ```handlebars
 <Hds::Pagination::Numbered
@@ -138,7 +138,7 @@ In this case, the component doesn’t update its internal "state" but the value 
 
 The reason for using a consumer-side function to determine the `query` argument is because it’s dynamic (it depends on the value of the `page` variable) and gives consumers the ability to specify their own query parameters (which will likely differ case by case).
 
-Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users’ actions (eg. for logging, tracking, etc.).
+Even if the Pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users’ actions (eg. for logging, tracking, etc.).
 
 Below you can find an example of an integration between the sortable [`Table`](/components/table) component and the `Pagination::Numbered` component that uses query parameters in the URL to preserve the UI state:
 
@@ -177,11 +177,11 @@ Below you can find an example of an integration between the sortable [`Table`](/
 </div>
 ```
 
-## How to use the "Compact" pagination
+## How to use the "Compact" Pagination
 
-By default, the basic use of the pagination provides:
+By default, the basic use of the Pagination provides:
 
-The basic invocation of the "compact" pagination doesn’t require any arguments (apart from the event/routing handlers, see below):
+The basic invocation of the Compact Pagination doesn’t require any arguments (apart from the event/routing handlers, see below):
 
 ```handlebars
 <Hds::Pagination::Compact />
@@ -199,7 +199,7 @@ If necessary, it’s possible to hide the control labels:
 <Hds::Pagination::Compact @showLabels={{false}} />
 ```
 
-### Events handling
+### Event handling
 
 The component exposes a callback function that can be used to respond to page changes:
 
@@ -213,7 +213,7 @@ The `onPageChange` function is invoked when a user interacts with a "prev" or "n
 
 ### Routing/URL updates
 
-If you want the pagination to change the URL of the page directly (eg. updating the query parameters) you need to pass the routing parameters to the component:
+If you want the Pagination to change the URL of the page directly (eg. updating the query parameters) you need to pass the routing parameters to the component:
 
 ```handlebars
 <Hds::Pagination::Compact
@@ -243,7 +243,7 @@ In this case, the component doesn’t update its internal "state" but the value 
 
 The reason for using a consumer-side function to determine the `query` argument is because it’s dynamic (it depends on the value of the `page/cursor` variable) and gives consumers the ability to specify their own query parameters (which will likely differ case by case).
 
-Even if the pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.).
+Even if the Pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.).
 
 Below you can find an example of an integration between the [`Table`](/components/table) component and the `Pagination::Compact` component that uses query parameters in the URL to preserve the UI state:
 

--- a/website/docs/components/stepper/partials/code/component-api.md
+++ b/website/docs/components/stepper/partials/code/component-api.md
@@ -1,9 +1,9 @@
 ## Component API
 
-We provide two separate but related `Stepper Indicator` components that serve different hierarchical purposes:
+We provide two separate but related Stepper Indicator components that serve different hierarchical purposes:
 
 1.  `Stepper::Step::Indicator`: used for step-based flows containing multiple steps a user must complete sequentially.
-2.  `Stepper::Task::Indicator`: used either on its own to denote smaller task-oriented flows or combined with the `Step` indicator to list multiple tasks within a step.
+2.  `Stepper::Task::Indicator`: used either on its own to denote smaller task-oriented flows or combined with the Step Indicator to list multiple tasks within a step.
 
 ### Stepper::Step::Indicator
 

--- a/website/docs/components/stepper/partials/code/how-to-use.md
+++ b/website/docs/components/stepper/partials/code/how-to-use.md
@@ -3,7 +3,7 @@ The Stepper Indicator indicates the relational step value, helping users maintai
 There are two types of indicators: `Step::Indicator` and `Task::Indicator`, which can be used in conjunction, or separately depending on hierarchical needs or requirements.
 
 
-## Stepper::Step::Indicator
+## How to use the Stepper::Step::Indicator
 
 Although not required, the basic invocation should include `text` and `status` arguments.
 
@@ -29,7 +29,7 @@ To change the status of the Step Indicator, set the `@status` argument to `incom
 <Hds::Stepper::Step::Indicator @text="1" @status="complete" @isInteractive={{true}} />
 ```
 
-## Stepper::Task::Indicator
+## How to use the Stepper::Task::Indicator
 
 Although not required, the basic invocation should include a `status` argument.
 

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -53,9 +53,9 @@ If you want to use the component but have no model defined (e.g., there are only
 </Hds::Table>
 ```
 
-### Non-sortable table with model defined
+### Non-sortable Table with model defined
 
-To use a table with a model, first define the data model in your route or model:
+To use a Table with a model, first define the data model in your route or model:
 
 ```javascript
 import Route from '@ember/routing/route';
@@ -201,7 +201,7 @@ By default, the sort order is set to ascending. To indicate that the column defi
 To implement a custom sort callback on a column:
 
 1. add a custom function as the value for `sortingFunction` in the column hash,
-2. include a custom `onSort` action in your table invocation to track the sorting order and use it in the custom sorting function.
+2. include a custom `onSort` action in your Table invocation to track the sorting order and use it in the custom sorting function.
 
 This is useful for cases where the key might not be A-Z or 0-9 sortable by default, e.g., status, and you’re otherwise unable to influence the shape of the data in the model.
 
@@ -266,7 +266,7 @@ customOnSort(_sortBy, sortOrder) {
 
 ### Density
 
-To create a condensed or spacious table, add `@density` to the table's invocation. Note that it only affects the table body, not the table header.
+To create a condensed or spacious Table, add `@density` to the Table's invocation. Note that it only affects the Table body, not the Table header.
 
 ```handlebars
 <Hds::Table
@@ -384,7 +384,7 @@ To create a column that has right-aligned content, set `@align` to `right` on bo
 
 #### Internationalized column headers, overflow menu dropdown
 
-Here’s a table implementation that uses an array hash with localized strings for the column headers, indicates which columns should be sortable, and adds an overflow menu.
+Here’s a Table implementation that uses an array hash with localized strings for the column headers, indicates which columns should be sortable, and adds an overflow menu.
 
 ```handlebars{data-execute=false}
 <Hds::Table

--- a/website/docs/components/tag/partials/code/component-api.md
+++ b/website/docs/components/tag/partials/code/component-api.md
@@ -2,7 +2,7 @@
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="text" @type="string">
-    The text of the tag; or link text when the `@route` or `@href` are set. If no text value is defined an error will be thrown.
+    The text of the Tag; or link text when the `@route` or `@href` are set. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="ariaLabel" @type="string">
     Accepts a localized string; the fallback is set to `Dismiss`. Note that the total value of the `aria-label` attribute is `@ariaLabel` + `@text`.

--- a/website/docs/components/tag/partials/code/how-to-use.md
+++ b/website/docs/components/tag/partials/code/how-to-use.md
@@ -20,7 +20,7 @@ There are two available colors for a link: `primary` and `secondary`. The defaul
 
 ### Dismiss
 
-In most cases, the tag should be dismissable. If you don’t provide a callback function to the `onDismiss` argument the dismiss button will not be rendered.
+In most cases, the Tag should be dismissable. If you don’t provide a callback function to the `onDismiss` argument the dismiss button will not be rendered.
 
 ```handlebars
 <Hds::Tag @color="primary" @text="My link tag" @route="show" @model="components/tag" />


### PR DESCRIPTION
**NOTE:** For some of the changes to capitalize “component” names I wasn't sure so if I've gone overboard with those please let me know.

### :pushpin: Summary
If merged, this PR will update text in the “Code” tab for component Web documentation to fix minor inconsistencies

- **Web Preview:** https://hds-website-git-hds-1974-fix-doc-inconsistency-hashicorp.vercel.app/components

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
- Jira ticket: [HDS-1974](https://hashicorp.atlassian.net/browse/HDS-1974)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1974]: https://hashicorp.atlassian.net/browse/HDS-1974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ