### PR TITLE
WIP: update test config for a11y tests

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -36,6 +36,27 @@ jobs:
         working-directory: packages/components
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_COMPONENTS }}
+  test-with-a11y:
+    name: "Tests with A11y"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Install Node
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+          cache-dependency-path: yarn.lock
+      - name: Install Dependencies
+        run: yarn install --immutable
+      - name: Lint
+        run: yarn run lint
+        working-directory: packages/components
+      - name: Run Tests with A11y
+        run: yarn run test:ember:a11y
+        working-directory: packages/components
+        
 
   try-scenarios:
     name: ${{ matrix.try-scenario }}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,7 +34,8 @@
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each",
-    "test:ember:percy": "percy exec ember test"
+    "test:ember:percy": "percy exec ember test",
+    "test:ember:a11y": "ENABLE_A11Y_AUDIT=true ember test"
   },
   "dependencies": {
     "@ember/render-modifiers": "^2.0.5",
@@ -68,7 +69,7 @@
     "@percy/ember": "^4.2.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "ember-a11y-testing": "^5.2.0",
+    "ember-a11y-testing": "^5.2.1",
     "ember-body-class": "^3.0.0",
     "ember-cli": "~4.10.0",
     "ember-cli-clipboard": "^1.0.0",

--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -18,7 +18,13 @@ import {
 setApplication(Application.create(config.APP));
 
 setupGlobalA11yHooks(() => true, {
-  helpers: [...DEFAULT_A11Y_TEST_HELPER_NAMES, 'render', 'tab'],
+  helpers: [
+    ...DEFAULT_A11Y_TEST_HELPER_NAMES,
+    'render',
+    'tab',
+    'focus',
+    'select',
+  ],
 });
 
 setRunOptions({
@@ -29,10 +35,15 @@ setRunOptions({
       'wcag2aa',
       'wcag21a',
       'wcag21aa',
+      'wcag22aa',
       'best-practice',
-      'ACT',
     ],
   },
+  rules: {
+    'duplicate-id': { enabled: false },
+  },
+  include: [['#ember-testing-container']],
+  exclude: [['.flight-sprite-container'], ['.shw-page-main']],
 });
 
 setup(QUnit.assert);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,7 +2563,7 @@ __metadata:
     broccoli-asset-rev: ^3.0.0
     dialog-polyfill: ^0.5.6
     ember-a11y-refocus: ^3.0.2
-    ember-a11y-testing: ^5.2.0
+    ember-a11y-testing: ^5.2.1
     ember-auto-import: ^2.6.0
     ember-body-class: ^3.0.0
     ember-cached-decorator-polyfill: ^0.1.4
@@ -8974,6 +8974,32 @@ __metadata:
     qunit:
       optional: true
   checksum: 93457b4ee798e38631d6b9a041bb90673c004eca12cc0ffc12753556d2c31a7fcbd43d885a0bd91e930582b7dc321831ec0a327194a143607ee5e8ece775f248
+  languageName: node
+  linkType: hard
+
+"ember-a11y-testing@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "ember-a11y-testing@npm:5.2.1"
+  dependencies:
+    "@ember/test-waiters": ^2.4.3 || ^3.0.0
+    "@scalvert/ember-setup-middleware-reporter": ^0.1.1
+    axe-core: ^4.6.3
+    body-parser: ^1.19.1
+    broccoli-persistent-filter: ^3.1.2
+    ember-auto-import: ^2.2.4
+    ember-cli-babel: ^7.26.11
+    ember-cli-typescript: ^4.2.1
+    ember-cli-version-checker: ^5.1.2
+    ember-destroyable-polyfill: ^2.0.1
+    fs-extra: ^10.0.0
+    validate-peer-dependencies: ^2.0.0
+  peerDependencies:
+    "@ember/test-helpers": ^2.0.0
+    qunit: ">= 2"
+  peerDependenciesMeta:
+    qunit:
+      optional: true
+  checksum: 4c8a2c1a04751c995679f537af3c93036c648dc7e289a2bfa044b8cab189662a8c451507ae6a7777d1b77e0589c0e2304f0c5c76e2ee53e75cf2c3c0845d23da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR tweaks the configuration of our global a11y tests. 

### :hammer_and_wrench: Detailed description

- updates to the latest version of ember-a11y-testing
- updated the package.json to include a run option that explicitly enables a11yAudits (`test:ember:a11y`)
- updated the ci-components.yml (CI config to include a test run (not included in ember try) that are the tests + the a11y audit
- removes ACT from the `setRunOptions` because it was including AAA tests
- excludes (for now), showcase pages and the icon sprite
- a few other minor tweaks to accommodate some of the axe-core magic

This option took approx 16 minutes to run, and there should be 191 failed tests.

This option demonstrates that our tests would need to be tidied up- the invocations in the tests should more accurately reflect a complete invocation. 

For example:

```js
test('it should render with a CSS class that matches the component name', async function (assert) {
    await render(hbs`<Hds::Table::Th id="data-test-table-th" />`);
    assert.dom('#data-test-table-th').hasClass('hds-table__th');
  });
```

This tests that the component renders and that it has the correct CSS class. However, it fails an a11y audit because it does not have an accessible name, and TH elements are required to have an accessible name. 

To fix, the invocation would need to be updated slightly:

```js
test('it should render with a CSS class that matches the component name', async function (assert) {
    await render(hbs`<Hds::Table::Th id="data-test-table-th">Artist</Hds::Table::Th>`);
    assert.dom('#data-test-table-th').hasClass('hds-table__th');
  });
```



### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
