### PR TITLE
HDS-1418 Icons: Add new Component API and Accessibility sections

### DIFF
--- a/website/docs/icons/usage-guidelines/index.md
+++ b/website/docs/icons/usage-guidelines/index.md
@@ -10,4 +10,9 @@ previewImage: assets/illustrations/icons/usage-guidelines.jpg
 
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
+  @include "partials/code/component-api.md"
+</section>
+
+<section data-tab="Accessibility">
+  @include "partials/accessibility/accessibility.md"
 </section>

--- a/website/docs/icons/usage-guidelines/partials/accessibility/accessibility.md
+++ b/website/docs/icons/usage-guidelines/partials/accessibility/accessibility.md
@@ -1,0 +1,23 @@
+## Accessibility
+
+Accessibility support for SVGs is inconsistent across browsers and assistive technology. Currently, the best practice is to set the `aria-hidden` attribute to `true` on the SVG itself (as we do by default for the `FlightIcon` component). This means that the icon (both the singular icon and the icon component) will need to be used _in context_. The icons themselves are for presentation purposes only and should never be used on their own.
+
+However, as a _temporary_ bridge, while we work to provide the accessible components in the design system, we have provided the ability to add a title element to the Ember component by defining a value for the `@title` property. This is a temporary measure, and we strongly encourage UI engineering teams to work with their designers and plan to convert any standalone icon use.
+
+### Examples of correct use
+
+```markup
+<button aria-label="Check activity">
+    <FlightIcon @name="activity" />
+</button>
+```
+
+```markup
+<h2>
+    Activity report <FlightIcon @name="activity" />
+</h2>
+```
+
+Some additional best practices include:
+
+- Use icons at 16px or 24px. Use at other sizes sparingly.

--- a/website/docs/icons/usage-guidelines/partials/accessibility/accessibility.md
+++ b/website/docs/icons/usage-guidelines/partials/accessibility/accessibility.md
@@ -1,4 +1,10 @@
-## Accessibility
+## Conformance rating
+
+<Doc::Badge @type="success">Conformant</Doc::Badge>
+
+When used as recommended, there should not be any accessibility issues with this component.
+
+## Browser accessibility support
 
 Accessibility support for SVGs is inconsistent across browsers and assistive technology. Currently, the best practice is to set the `aria-hidden` attribute to `true` on the SVG itself (as we do by default for the `FlightIcon` component). This means that the icon (both the singular icon and the icon component) will need to be used _in context_. The icons themselves are for presentation purposes only and should never be used on their own.
 
@@ -17,7 +23,3 @@ However, as a _temporary_ bridge, while we work to provide the accessible compon
     Activity report <FlightIcon @name="activity" />
 </h2>
 ```
-
-Some additional best practices include:
-
-- Use icons at 16px or 24px. Use at other sizes sparingly.

--- a/website/docs/icons/usage-guidelines/partials/code/component-api.md
+++ b/website/docs/icons/usage-guidelines/partials/code/component-api.md
@@ -1,0 +1,22 @@
+## Component API
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="name" @type="string" @required="true">
+    The name of the icon you wish to use. If the value does not match an existing icon name, an error will be thrown. Search for existing icon names in [the Icon library](icons/library).
+  </C.Property>
+  <C.Property @name="color" @type="string" @default="currentColor">
+    The `@color` argument can be used to change the color. It works by setting the value of the icon SVG’s `fill` property.
+  </C.Property>
+  <C.Property @name="size" @type="number" @default="16" @values={{array 16 24}}>
+    Sets the size of the icon in pixels. Only two sizes are supported. (Setting a non-standard size will cause the SVG to render at the specified size but it will be invisible.)
+  </C.Property>
+  <C.Property @name="stretched" @type="boolean" @default="false">
+    Determines whether the icon will stretch to fill the parent container. Setting it to `true` will make the icon have a height and width of 100% and a display of `block`.
+  </C.Property>
+  <C.Property @name="isInlineBlock" @type="boolean" @default="true">
+    Sets the `display` style for the icon. Setting it to `false` will make the icon have a display of `block`.
+  </C.Property>
+  <C.Property @name="title" @type="string">
+    Use to add accessible text to standalone icons. This will also change the `aria-hidden` value to `false` instead of the default value of `true`.
+  </C.Property>
+</Doc::ComponentApi>

--- a/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
+++ b/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
@@ -2,39 +2,13 @@
 
 Icons can be used in many ways. The package can be installed as an [Ember addon](#using-icons-in-ember-apps) for the convenience of using a component with strong defaults. It can also be [consumed in React applications](#using-icons-in-react-apps) via direct import of the SVG file or as a standalone React/SVG icon component.
 
-### Using icons in Ember apps
-
-#### Installing the `ember-flight-icons` addon
-
-```bash
-yarn add @hashicorp/ember-flight-icons
-```
-
-!!! Information
-
-Because this addon exposes a `data-test-icon` helper, we recommend installing [`ember-test-selectors`](https://github.com/simplabs/ember-test-selectors) which strips out all `data-test-*` attributes for production builds.
-!!!
-
-#### Understanding the component
-
-The component comes with the following defaults:
-
-1.  `fill` attribute: set to currentColor.
-2.  `id` attribute: a unique, automatically generated id.
-3.  `aria-hidden` attribute: set to true.
-4.  `height` and `width`: default size of 16x16 (px).
-5.  `stretched`: if the SVG should have 100% width/height (stretch to fill the parent)—defaults to "false".
-6.  (CSS) `class`: flight-icon, flight-icon-{name}, flight-icon-display-inline.
-7.  CSS display: set to `display:inline-block`.
-8.  `data-test-icon` attribute: for the author’s testing convenience; set to the value of the `@name` property.
-
-This makes the base, required invocation quite terse—`@name` is the only property that requires specification. So this invocation:
+The most basic invocation requires only the `@name` property to be passed with a value matching an existing name in [the Icon library](icons/library).
 
 ```markup
 <FlightIcon @name="alert-circle" />
 ```
 
-Renders to this (where the ID will be unique each time):
+It renders to this (where the `id` will be unique each time):
 
 ```markup
 <svg
@@ -52,21 +26,9 @@ Renders to this (where the ID will be unique each time):
 </svg>
 ```
 
-The `<use>` element will then render the correct SVG to the shadow DOM.
+### Color
 
-#### Customizable properties
-
-The following properties are customizable:
-
-1.  [fill](#fill)
-2.  [size](#size)
-3.  [stretched](#stretched)
-4.  [additional CSS classes](#css-classes)
-5.  [display](#css-display)
-
-##### Fill
-
-To customize the fill attribute, set the `@color` value. To ensure consistency with our design language, we recommend using one of the pre-defined variables:
+The default value is `currentColor` which uses the inherited text color as the icon color. When setting a custom value, we recommend using one of the pre-defined variables to ensure consistency with our design language:
 
 ```handlebars
 <FlightIcon @name="zap" @color="var(--brand)" />
@@ -82,31 +44,31 @@ Other accepted values include named colors and color values themselves (e.g., he
 <FlightIcon @name="zap" @color="rgb(46, 113, 229)" />
 ```
 
-##### Size
+### Size
 
-To use the 24px icon size, set the `@size` value:
+The default size is 16px. To use the alternative 24px icon size, set the `@size` value:
 
 ```handlebars
 <FlightIcon @name="zap" @size="24" />
 ```
 
-##### Stretched
+### Stretched
 
-To have the icon fill the parent container (width: 100%, height: 100%, display: block), set the `@stretched` attribute:
+To have the icon fill the parent container (width: 100%, height: 100%, display: block), set the `@stretched` attribute to true:
 
 ```handlebars
 <FlightIcon @name="zap" @size="24" @stretched={{true}} />
 ```
 
-##### CSS classes
+<!-- ##### CSS classes
 
 To append additional classes to the component, add `class` with value(s):
 
 ```markup
 <FlightIcon @name="triangle-fill" class="ds-rotate-90" />
-```
+``` -->
 
-##### CSS display
+### isInlineBlock
 
 To change the default display from `inline-block` to `block`, set `@isInlineBlock` to false:
 
@@ -115,7 +77,7 @@ To change the default display from `inline-block` to `block`, set `@isInlineBloc
 <FlightIcon @name="triangle-fill" @isInlineBlock={{false}} />
 ```
 
-##### Animated icons
+### Animated icons
 
 Animated icons (e.g., "loading" and "running") are animated by default, meaning no additional properties are needed. 
 
@@ -129,6 +91,19 @@ A `prefers-reduced-motion` media query will automatically disable the animation 
 ```handlebars
 <FlightIcon @name="loading" @size="24" />
 ```
+
+### Using icons in Ember apps
+
+Install the `ember-flight-icons` addon.
+
+```bash
+yarn add @hashicorp/ember-flight-icons
+```
+
+!!! Information
+
+Because this addon exposes a `data-test-icon` helper, we recommend installing [`ember-test-selectors`](https://github.com/simplabs/ember-test-selectors) which strips out all `data-test-*` attributes for production builds.
+!!!
 
 ### Using icons in React apps
 
@@ -180,15 +155,15 @@ import { IconArrowRight24 } from '@hashicorp/flight-icons/svg-react/arrow-right-
 <IconArrowRight24 />
 ```
 
-#### Customizable properties
+<!-- #### Customizable properties
 
 The component exposes the following _props_:
 
 1.  `color`—the color (applied as _fill_) to the SVG—by default is `currentColor` but any valid HTML/CSS color is accepted.
-2.  `title`—the title of the SVG—by default, the icon has an _aria-hidden_ attribute applied to it because it is expected to be used in context (check out [§ Accessibility](#accessibility)); if instead you need to use it without text associated to it, you have to pass a _title_ attribute to make it accessible.
+2.  `title`—the title of the SVG—by default, the icon has an _aria-hidden_ attribute applied to it because it is expected to be used in context (check out [Accessibility](/icons/usage-guidelines?tab=accessibility)); if instead you need to use it without text associated to it, you have to pass a _title_ attribute to make it accessible.
 3.  `...props` - any other _prop_ passed to the component will be applied via spread.
 
-The size of the icon is determined by the size of the asset imported (each icon is exported in two sizes, _16_ and _24_). If you need a different size, use CSS to override its intrinsic size.
+The size of the icon is determined by the size of the asset imported (each icon is exported in two sizes, _16_ and _24_). If you need a different size, use CSS to override its intrinsic size. -->
 
 ### Aligning icons
 
@@ -233,31 +208,6 @@ import svgLoading16 from '@hashicorp/flight-icons/svg/loading-16.svg?include'
 
 A `prefers-reduced-motion` media query will automatically disable the animation if users set this preference in their environment.
 !!!
-
-## Accessibility
-
-Accessibility support for SVGs is inconsistent across browsers and assistive technology. Currently, the best practice is to set the `aria-hidden` attribute to `true` on the SVG itself. This means that the icon (both the singular icon and the icon component) will need to be used _in context_. The icons themselves are for presentation purposes only and should never be used on their own.
-
-However, as a _temporary_ bridge, while we work to provide the accessible components in the design system, we have provided the ability to add a title element to the Ember component by defining a value for the `@title` property. This is a temporary measure, and we strongly encourage UI engineering teams to work with their designers and plan to convert any standalone icon use.
-
-### Examples of correct use
-
-```markup
-<button aria-label="Check activity">
-    <FlightIcon @name="activity" />
-</button>
-```
-
-```markup
-<h2>
-    Activity report <FlightIcon @name="activity" />
-</h2>
-```
-
-Some additional best practices include:
-
-- Use icons at 16px or 24px. Use at other sizes sparingly.
-- Icons do not have a unique id generated; take precautions to avoid [related accessibility conformance failures](https://www.w3.org/TR/WCAG20-TECHS/F77.html).
 
 ## Migrating from Structure
 


### PR DESCRIPTION
**NOTE:** I broke out some of the accessibility info to a new "Accessibility" tab as part of this. Hoping to gather suggestions for improving it.

### :pushpin: Summary
If merged, this PR will update the FlightIcon web docs, especially the API, to more closely follow the format for HDS component docs.

**Preview:** https://hds-website-git-hds-1418-improve-icon-api-docs-hashicorp.vercel.app/icons/usage-guidelines?tab=code

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
- Jira ticket: [HDS-1418](https://hashicorp.atlassian.net/browse/HDS-1418)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1418]: https://hashicorp.atlassian.net/browse/HDS-1418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ