### PR TITLE
Introduce automatic pull request labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,10 @@
+docs-website:
+  - website/docs/**/*
+packages/compoents:
+  - packages/components/**/*
+packages/ember-flight-icons:
+  - packages/ember-flight-icons/**/*
+packages/flight-icons:
+  - packages/flight-icons/**/*
+packages/tokens:
+  - packages/tokens/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 docs-website:
   - website/docs/**/*
-packages/compoents:
+packages/components:
   - packages/components/**/*
 packages/ember-flight-icons:
   - packages/ember-flight-icons/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@ba790c862c380240c6d5e7427be5ace9a05c754b # v4.0.3
+      with:
+        # Token setup in hashibot-hds' account
+        repo-token: "${{ secrets.PAT_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
### :pushpin: Summary

Uses the [labeler](https://github.com/actions/labeler) GitHub action to automatically apply some common labels to our PRs. For now I've started with labeling this list. We can always adjust or turn this off if we find it unhelpful
* Docs
* Components
* Ember Flight Icons
* Flight Icons
* Tokens
