### PR TITLE
Updates test for a11y

### DIFF
--- a/packages/components/tests/integration/components/hds/table/th-test.js
+++ b/packages/components/tests/integration/components/hds/table/th-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | hds/table/th', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Table::Th id="data-test-table-th" />`);
+    await render(
+      hbs`<Hds::Table::Th id="data-test-table-th">Artist</Hds::Table::Th>`
+    );
     assert.dom('#data-test-table-th').hasClass('hds-table__th');
   });
 
@@ -31,17 +33,23 @@ module('Integration | Component | hds/table/th', function (hooks) {
   });
 
   test('it should render with the appropriate `@align` CSS class', async function (assert) {
-    await render(hbs`<Hds::Table::Th id="data-test-table-th" @align="right"/>`);
+    await render(
+      hbs`<Hds::Table::Th id="data-test-table-th" @align="right">Artist</Hds::Table::Th>`
+    );
     assert.dom('#data-test-table-th').hasClass('hds-table__th--text-right');
   });
 
   test('it should add inline styles if `@width` is declared', async function (assert) {
-    await render(hbs`<Hds::Table::Th id="data-test-table-th" @width="10%" />`);
+    await render(
+      hbs`<Hds::Table::Th id="data-test-table-th" @width="10%">Artist</Hds::Table::Th>`
+    );
     assert.dom('#data-test-table-th').hasAttribute('style');
   });
 
   test('it should support splattributes', async function (assert) {
-    await render(hbs`<Hds::Table::Th id="data-test-table-th" lang="es" />`);
+    await render(
+      hbs`<Hds::Table::Th id="data-test-table-th" lang="es">Artist</Hds::Table::Th>`
+    );
     assert.dom('#data-test-table-th').hasAttribute('lang', 'es');
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the table/th test so that it will pass the `a11yAudit`

~~The PR itself will also test this new PR labeling thing we're trying out.~~ (it worked)

### :hammer_and_wrench: Detailed description

The test component invocation was contrived and wasn't invoked fully enough to pass accessibility audit tests. In those instances, content was placed into the `Th` element. 

### :camera_flash: Screenshots

nothing changes externally


***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
