### PR TITLE
`Hds::Table` - Improve columns `@width` handling and documentation

### DIFF
--- a/.changeset/orange-crews-applaud.md
+++ b/.changeset/orange-crews-applaud.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::Table` - Changed the way in which the column `@width` defined by the user is applied

--- a/packages/components/addon/components/hds/table/th-sort.hbs
+++ b/packages/components/addon/components/hds/table/th-sort.hbs
@@ -2,7 +2,13 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<th class={{this.classNames}} aria-sort={{this.ariaSort}} {{style width=@width}} ...attributes scope="col">
+<th
+  class={{this.classNames}}
+  aria-sort={{this.ariaSort}}
+  {{style width=@width minWidth=@width}}
+  ...attributes
+  scope="col"
+>
   <button type="button" {{on "click" this.onClick}}>
     <div class="hds-table__th-sort--button-content">
       <span class="hds-typography-body-200 hds-font-weight-semibold">{{yield}}</span>

--- a/packages/components/addon/components/hds/table/th.hbs
+++ b/packages/components/addon/components/hds/table/th.hbs
@@ -2,6 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<th class={{this.classNames}} {{style width=@width}} ...attributes scope={{(or @scope "col")}}>
+<th class={{this.classNames}} {{style width=@width minWidth=@width}} ...attributes scope={{(or @scope "col")}}>
   {{yield}}
 </th>

--- a/packages/components/tests/dummy/app/routes/components/table.js
+++ b/packages/components/tests/dummy/app/routes/components/table.js
@@ -11,12 +11,15 @@ export default class ComponentsTableRoute extends Route {
   async model() {
     let responseMusic = await fetch('/api/folk.json');
     let responseClusters = await fetch('/api/mock-clusters-with-status.json');
+    let responseManyColumns = await fetch('/api/mock-many-columns.json');
     let { data: music } = await responseMusic.json();
     let clusters = await responseClusters.json();
+    let manycolumns = await responseManyColumns.json();
 
     return {
       music: music.map((record) => ({ id: record.id, ...record.attributes })),
       clusters,
+      manycolumns,
       STATES,
     };
   }

--- a/packages/components/tests/dummy/app/styles/showcase-pages/table.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/table.scss
@@ -16,4 +16,12 @@ body.components-table {
       margin-right: 5px;
     }
   }
+
+  .shw-component-table-scrollable-wrapper {
+    overflow-x: auto;
+  }
+
+  .shw-component-table-max-content-width {
+    width: max-content;
+  }
 }

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -503,6 +503,177 @@
 
   <Shw::Divider />
 
+  <Shw::Text::H2>Layout</Shw::Text::H2>
+
+  <Shw::Text::H3>Interaction between table layout and columns width</Shw::Text::H3>
+
+  <Shw::Text::H4>Width in <code>px</code> + Table-layout = 'auto'</Shw::Text::H4>
+
+  <Hds::Table
+    @model={{this.model.manycolumns}}
+    @columns={{array
+      (hash key="first_name" label="First Name" isSortable="true" width="200px")
+      (hash key="last_name" label="Last Name" isSortable="true" width="200px")
+      (hash key="age" label="Age" isSortable="true")
+      (hash key="email" label="Email")
+      (hash key="bio" label="Biography" width="350px")
+    }}
+  >
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.first_name}}</B.Td>
+        <B.Td>{{B.data.last_name}}</B.Td>
+        <B.Td>{{B.data.age}}</B.Td>
+        <B.Td>{{B.data.email}}</B.Td>
+        <B.Td>{{B.data.bio}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+
+  <Shw::Text::H4>Width in <code>px</code> + Table-layout = 'fixed'</Shw::Text::H4>
+
+  <Hds::Table
+    @model={{this.model.manycolumns}}
+    @columns={{array
+      (hash key="first_name" label="First Name" isSortable="true" width="200px")
+      (hash key="last_name" label="Last Name" isSortable="true" width="200px")
+      (hash key="age" label="Age" isSortable="true")
+      (hash key="email" label="Email")
+      (hash key="bio" label="Biography" width="350px")
+    }}
+    @isFixedLayout={{true}}
+  >
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.first_name}}</B.Td>
+        <B.Td>{{B.data.last_name}}</B.Td>
+        <B.Td>{{B.data.age}}</B.Td>
+        <B.Td>{{B.data.email}}</B.Td>
+        <B.Td>{{B.data.bio}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+
+  <Shw::Text::H4>Width in <code>%</code> + Table-layout = 'auto'</Shw::Text::H4>
+
+  <Hds::Table
+    @model={{this.model.manycolumns}}
+    @columns={{array
+      (hash key="first_name" label="First Name" isSortable="true" width="20%")
+      (hash key="last_name" label="Last Name" isSortable="true" width="20%")
+      (hash key="age" label="Age" isSortable="true")
+      (hash key="email" label="Email")
+      (hash key="bio" label="Biography" width="35%")
+    }}
+  >
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.first_name}}</B.Td>
+        <B.Td>{{B.data.last_name}}</B.Td>
+        <B.Td>{{B.data.age}}</B.Td>
+        <B.Td>{{B.data.email}}</B.Td>
+        <B.Td>{{B.data.bio}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+
+  <Shw::Text::H4>Width in <code>%</code> + Table-layout = 'fixed'</Shw::Text::H4>
+
+  <Hds::Table
+    @model={{this.model.manycolumns}}
+    @columns={{array
+      (hash key="first_name" label="First Name" isSortable="true" width="20%")
+      (hash key="last_name" label="Last Name" isSortable="true" width="20%")
+      (hash key="age" label="Age" isSortable="true")
+      (hash key="email" label="Email")
+      (hash key="bio" label="Biography" width="35%")
+    }}
+    @isFixedLayout={{true}}
+  >
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.first_name}}</B.Td>
+        <B.Td>{{B.data.last_name}}</B.Td>
+        <B.Td>{{B.data.age}}</B.Td>
+        <B.Td>{{B.data.email}}</B.Td>
+        <B.Td>{{B.data.bio}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Large table with overflowing container</Shw::Text::H3>
+
+  <Shw::Text::H4>Container with overflow = 'auto' + Table-layout = 'auto' + Columns width (in
+    <code>px</code>)</Shw::Text::H4>
+
+  <div class="shw-component-table-scrollable-wrapper">
+    <Hds::Table
+      @model={{this.model.manycolumns}}
+      @columns={{array
+        (hash key="first_name" label="First Name" isSortable="true" width="200px")
+        (hash key="last_name" label="Last Name" isSortable="true" width="200px")
+        (hash key="age" label="Age" isSortable="true")
+        (hash key="email" label="Email" isSortable="true")
+        (hash key="phone" label="Phone" isSortable="true")
+        (hash key="bio" label="Biography" width="350px")
+        (hash key="education" label="Education Degree" isSortable="true")
+        (hash key="occupation" label="Occupation" isSortable="true")
+      }}
+    >
+      <:body as |B|>
+        <B.Tr>
+          <B.Td>{{B.data.first_name}}</B.Td>
+          <B.Td>{{B.data.last_name}}</B.Td>
+          <B.Td>{{B.data.age}}</B.Td>
+          <B.Td>{{B.data.email}}</B.Td>
+          <B.Td>{{B.data.phone}}</B.Td>
+          <B.Td>{{B.data.bio}}</B.Td>
+          <B.Td>{{B.data.education}}</B.Td>
+          <B.Td>{{B.data.occupation}}</B.Td>
+        </B.Tr>
+      </:body>
+    </Hds::Table>
+  </div>
+
+  <Shw::Text::H4>Container with overflow = 'auto' + Sub-container with 'max-content' width + Table-layout = 'auto' +
+    Columns width (in
+    <code>px</code>)</Shw::Text::H4>
+
+  <div class="shw-component-table-scrollable-wrapper">
+    <div class="shw-component-table-max-content-width">
+      <Hds::Table
+        @model={{this.model.manycolumns}}
+        @columns={{array
+          (hash key="first_name" label="First Name" isSortable="true" width="200px")
+          (hash key="last_name" label="Last Name" isSortable="true" width="200px")
+          (hash key="age" label="Age" isSortable="true")
+          (hash key="email" label="Email" isSortable="true")
+          (hash key="phone" label="Phone" isSortable="true")
+          (hash key="bio" label="Biography" width="350px")
+          (hash key="education" label="Education Degree" isSortable="true")
+          (hash key="occupation" label="Occupation" isSortable="true")
+        }}
+      >
+        <:body as |B|>
+          <B.Tr>
+            <B.Td>{{B.data.first_name}}</B.Td>
+            <B.Td>{{B.data.last_name}}</B.Td>
+            <B.Td>{{B.data.age}}</B.Td>
+            <B.Td>{{B.data.email}}</B.Td>
+            <B.Td>{{B.data.phone}}</B.Td>
+            <B.Td>{{B.data.bio}}</B.Td>
+            <B.Td>{{B.data.education}}</B.Td>
+            <B.Td>{{B.data.occupation}}</B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
+    </div>
+  </div>
+
+  <Shw::Divider />
+
   <Shw::Text::H2>Base elements</Shw::Text::H2>
 
   <Shw::Text::H3>ThSort</Shw::Text::H3>

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -532,6 +532,10 @@
 
   <Shw::Text::H4>Width in <code>px</code> + Table-layout = 'fixed'</Shw::Text::H4>
 
+  <Shw::Text::Body>⚠️
+    <em>Notice: this example looks broken but we’ve left it on purpose to show what happens when a fixed layout is
+      applied to the table, with only some columns having a width declared.</em></Shw::Text::Body>
+
   <Hds::Table
     @model={{this.model.manycolumns}}
     @columns={{array

--- a/packages/components/tests/dummy/public/api/mock-many-columns.json
+++ b/packages/components/tests/dummy/public/api/mock-many-columns.json
@@ -1,0 +1,32 @@
+[
+  {
+    "first_name": "Judith",
+    "last_name": "Maxene",
+    "age": "43",
+    "email": "j.maxene@randatmail.com",
+    "phone": "697-0732-81",
+    "education": "Upper secondary school",
+    "occupation": "Astronomer",
+    "bio": "Analyst. Gamer. Friendly explorer. Incurable tv lover. Social media scholar. Amateur web geek. Proud zombie guru."
+  },
+  {
+    "first_name": "Elmira",
+    "last_name": "Aishah",
+    "age": "28",
+    "email": "e.aishah@randatmail.com",
+    "phone": "155-6076-27",
+    "education": "Master in Physics",
+    "occupation": "Actress",
+    "bio": "Total coffee guru. Food enthusiast. Social media expert. Tv aficionada. Extreme music advocate. Zombie fan."
+  },
+  {
+    "first_name": "Chinwendu",
+    "last_name": "Henderson",
+    "age": "62",
+    "email": "c.henderson@randatmail.com",
+    "phone": "155-0155-09",
+    "education": "Bachelor in Modern History",
+    "occupation": "Historian",
+    "bio": "Creator. Internet maven. Coffee practitioner. Troublemaker. Alcohol specialist."
+  }
+]

--- a/packages/components/tests/integration/components/hds/table/th-sort-test.js
+++ b/packages/components/tests/integration/components/hds/table/th-sort-test.js
@@ -37,7 +37,9 @@ module('Integration | Component | hds/table/th-sort', function (hooks) {
     await render(
       hbs`<Hds::Table::ThSort id="data-test-table-th-sort" @width="10%" />`
     );
-    assert.dom('#data-test-table-th-sort').hasAttribute('style');
+    assert
+      .dom('#data-test-table-th-sort')
+      .hasAttribute('style', 'width: 10%; min-width: 10%;');
   });
 
   test('if @sortOrder is not defined, the swap-vertical icon should be displayed', async function (assert) {

--- a/packages/components/tests/integration/components/hds/table/th-test.js
+++ b/packages/components/tests/integration/components/hds/table/th-test.js
@@ -43,7 +43,9 @@ module('Integration | Component | hds/table/th', function (hooks) {
     await render(
       hbs`<Hds::Table::Th id="data-test-table-th" @width="10%">Artist</Hds::Table::Th>`
     );
-    assert.dom('#data-test-table-th').hasAttribute('style');
+    assert
+      .dom('#data-test-table-th')
+      .hasAttribute('style', 'width: 10%; min-width: 10%;');
   });
 
   test('it should support splattributes', async function (assert) {

--- a/website/app/styles/pages/components/table.scss
+++ b/website/app/styles/pages/components/table.scss
@@ -11,4 +11,12 @@
     gap: 5px;
     align-items: center;
   }
+
+  .doc-table-scrollable-wrapper {
+    overflow-x: auto;
+  }
+
+  .doc-table-max-content-width {
+    width: max-content;
+  }
 }

--- a/website/docs/components/table/index.js
+++ b/website/docs/components/table/index.js
@@ -13,7 +13,7 @@ export default class Index extends Component {
   }
 
   get model() {
-    let data = [
+    const data = [
       {
         id: '1',
         type: 'folk',
@@ -120,7 +120,7 @@ export default class Index extends Component {
   }
 
   get myDataItems() {
-    let myDataItems = [
+    return [
       {
         product: 'Terraform',
         brandColor: 'purple',
@@ -137,6 +137,40 @@ export default class Index extends Component {
         usesHelios: true,
       },
     ];
-    return myDataItems;
+  }
+
+  get modelWithLargeNumberOfColumns() {
+    return [
+      {
+        first_name: 'Judith',
+        last_name: 'Maxene',
+        age: '43',
+        email: 'j.maxene@randatmail.com',
+        phone: '697-0732-81',
+        education: 'Upper secondary school',
+        occupation: 'Astronomer',
+        bio: 'Analyst. Gamer. Friendly explorer. Incurable TV lover. Social media scholar. Amateur web geek. Proud zombie guru.',
+      },
+      {
+        first_name: 'Elmira',
+        last_name: 'Aishah',
+        age: '28',
+        email: 'e.aishah@randatmail.com',
+        phone: '155-6076-27',
+        education: 'Master in Physics',
+        occupation: 'Actress',
+        bio: 'Total coffee guru. Food enthusiast. Social media expert. TV aficionada. Extreme music advocate. Zombie fan.',
+      },
+      {
+        first_name: 'Chinwendu',
+        last_name: 'Henderson',
+        age: '62',
+        email: 'c.henderson@randatmail.com',
+        phone: '155-0155-09',
+        education: 'Bachelor in Modern History',
+        occupation: 'Historian',
+        bio: 'Creator. Internet maven. Coffee practitioner. Troublemaker. Alcohol specialist.',
+      },
+    ];
   }
 }

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -47,13 +47,13 @@ The Table component itself is where most of the options will be applied. However
     Define on the table invocation. If set to `true`, even-numbered rows will have a different background color from odd-numbered rows.
   </C.Property>
   <C.Property @name="isFixedLayout" @type="boolean" @default="false">
-    If set to `true`, the `table-display`(CSS) property will be set to `fixed`. (See [https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) for more details.)
+    If set to `true`, the `table-display`(CSS) property will be set to `fixed`. See [MDN reference on table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) for more details.
   </C.Property>
   <C.Property @name="density" @type="enum" @values={{array "short" "medium" "tall" }} @default="medium">
     If set, determines the density (height) of the table body’s rows.
   </C.Property>
   <C.Property @name="valign" @type="enum" @values={{array "top" "middle" }} @default="top">
-    Determines the vertical alignment for content in a table. Does not apply to table headers (`th`). See [MDN on vertical-align](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) for more details.
+    Determines the vertical alignment for content in a table. Does not apply to table headers (`th`). See [MDN reference on vertical-align](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) for more details.
   </C.Property>
   <C.Property @name="caption" @type="string">
     Adds a (non-visible) caption for users with assistive technology. If set on a sortable table, the provided table caption is paired with the automatically generated sorted message text.

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -382,9 +382,11 @@ To create a column that has right-aligned content, set `@align` to `right` on bo
 
 ### Scrollable table
 
-As a general principle, tables should contain as little information as possible. Consuming a large amount of data in a tabular format leads to an intense cognitive load for the user. We recommend using functionalities like [pagination](/components/pagination), [sorting](/components/table?tab=code#sortable-table), and [filtering](/patterns/filter-patterns) to reduce this load.
+Consuming a large amount of data in a tabular format can lead to an intense cognitive load for the user. As a general principle, care should be taken to simplify the information within a table as much as possible.
 
-That said, there may be cases in which it's necessary to show a table with a large number of columns, and allow the user to scroll horizontally. In this case the consumer can use different approaches, depending on their context, needs and design specs.
+We recommend using functionalities like [pagination](/components/pagination), [sorting](/components/table?tab=code#sortable-table), and [filtering](/patterns/filter-patterns) to reduce this load.
+
+That said, there may be cases when it's necessary to show a table with a large number of columns and allow the user to scroll horizontally. In this case the consumer can use different approaches, depending on their context, needs and design specs.
 
 Below we show a couple of examples of how a scrollable table could be implemented: use them as starting point (your mileage may vary).
 
@@ -392,7 +394,7 @@ Below we show a couple of examples of how a scrollable table could be implemente
 
 In most cases, wrapping the table with a container that has `overflow: auto` does the trick.
 
-The table layout is `auto` (default) which means the browser will try to optimize the width of the columns to fit their different content. In some cases, this will mean the content may wrap (see the `Phone` column as an example) in which case you may want to apply a `width` to suggest to the browser to apply a specific width to a column (see the `Biography` column).
+The default table layout is `auto` which means the browser will try to optimize the width of the columns to fit their different content. In some cases, this will mean the content may wrap (see the `Phone` column as an example) in which case you may want to apply a `width` to [suggest to the browser](https://www.w3.org/TR/WD-CSS2-971104/tables.html#h-17.2) to apply a specific width to a column (see the `Biography` column).
 
 
 ```handlebars
@@ -429,7 +431,7 @@ The table layout is `auto` (default) which means the browser will try to optimiz
 
 #### Using a container with `overflow: auto` and a sub-container with `width: max-content`
 
-If you want to specify the column width of some of the columns and leave some others adapt automatically to their content, but at the same time avoid the wrapping of the content within the cells, you have to introduce a second wrapping element around the table, that has its `width` set to ` max-content`.
+If you have specified the width of some of the columns, leaving the others to adapt to their content automatically, and you want to avoid the wrapping of content within the cells, you need to introduce a secondary wrapping element around the table with its `width` set to ` max-content`.
 
 In this case the table layout is still set to `auto` (default). If instead you want to set it to `fixed` (using the `@isFixedLayout` argument) you will have to specify the width for **every** column or the table will explode horizontally.
 

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -382,7 +382,7 @@ To create a column that has right-aligned content, set `@align` to `right` on bo
 
 ### Scrollable table
 
-As a general principle, tables should contain as little information as possible. Consuming large amount of data in a tabular format leads to an intense congnitive load for the user. Functionalities like [pagination](/components/pagination), [sorting](/components/table?tab=code#sortable-table) and [filtering](/patterns/filter-patterns) are used exactly to reduce this load.
+As a general principle, tables should contain as little information as possible. Consuming a large amount of data in a tabular format leads to an intense cognitive load for the user. We recommend using functionalities like [pagination](/components/pagination), [sorting](/components/table?tab=code#sortable-table), and [filtering](/patterns/filter-patterns) to reduce this load.
 
 That said, there may be cases in which it's necessary to show a table with a large number of columns, and allow the user to scroll horizontally. In this case the consumer can use different approaches, depending on their context, needs and design specs.
 
@@ -390,9 +390,9 @@ Below we show a couple of examples of how a scrollable table could be implemente
 
 #### Using a container with `overflow: auto`
 
-In most of the cases, wrapping the table with a container that has `overflow: auto` does the trick.
+In most cases, wrapping the table with a container that has `overflow: auto` does the trick.
 
-The table layout is `auto` (default) which means the browser will try to optimize the columns width to fit their different content. In some cases this will mean the content may wrap (see the `Phone` column as an example) in which case you may want to apply a `width` to suggest to the browser to apply a specific width to a column (see the `Biography` column).
+The table layout is `auto` (default) which means the browser will try to optimize the width of the columns to fit their different content. In some cases, this will mean the content may wrap (see the `Phone` column as an example) in which case you may want to apply a `width` to suggest to the browser to apply a specific width to a column (see the `Biography` column).
 
 
 ```handlebars
@@ -429,7 +429,7 @@ The table layout is `auto` (default) which means the browser will try to optimiz
 
 #### Using a container with `overflow: auto` and a sub-container with `width: max-content`
 
-If you want to specify the column width of some of the columns, and leave some others adapt automtically to their content, but at the same time avoid the wrapping of the content within the cells, you have to introduce a second wrapping element around the table, that has its `width` set to ` max-content`.
+If you want to specify the column width of some of the columns and leave some others adapt automatically to their content, but at the same time avoid the wrapping of the content within the cells, you have to introduce a second wrapping element around the table, that has its `width` set to ` max-content`.
 
 In this case the table layout is still set to `auto` (default). If instead you want to set it to `fixed` (using the `@isFixedLayout` argument) you will have to specify the width for **every** column or the table will explode horizontally.
 

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -33,7 +33,7 @@ If you want to use the component but have no model defined (e.g., there are only
 #### Using `each` to loop over records to create rows
 
 ```handlebars
-<Hds::Table @caption="Influential Folk Musicians">
+<Hds::Table @caption="Products that use Helios">
   <:head as |H|>
     <H.Tr>
       <H.Th>Product</H.Th>
@@ -118,7 +118,7 @@ For clarity, there are a couple of important points to note here:
 
 !!!
 
-### Sortable Table
+### Sortable table
 
 !!! Info
 
@@ -378,6 +378,95 @@ To create a column that has right-aligned content, set `@align` to `right` on bo
     </B.Tr>
   </:body>
 </Hds::Table>
+```
+
+### Scrollable table
+
+As a general principle, tables should contain as little information as possible. Consuming large amount of data in a tabular format leads to an intense congnitive load for the user. Functionalities like [pagination](/components/pagination), [sorting](/components/table?tab=code#sortable-table) and [filtering](/patterns/filter-patterns) are used exactly to reduce this load.
+
+That said, there may be cases in which it's necessary to show a table with a large number of columns, and allow the user to scroll horizontally. In this case the consumer can use different approaches, depending on their context, needs and design specs.
+
+Below we show a couple of examples of how a scrollable table could be implemented: use them as starting point (your mileage may vary).
+
+#### Using a container with `overflow: auto`
+
+In most of the cases, wrapping the table with a container that has `overflow: auto` does the trick.
+
+The table layout is `auto` (default) which means the browser will try to optimize the columns width to fit their different content. In some cases this will mean the content may wrap (see the `Phone` column as an example) in which case you may want to apply a `width` to suggest to the browser to apply a specific width to a column (see the `Biography` column).
+
+
+```handlebars
+<!-- this is an element with "overflow: auto" -->
+<div class="doc-table-scrollable-wrapper">
+  <Hds::Table
+    @model={{this.modelWithLargeNumberOfColumns}}
+    @columns={{array
+      (hash key="first_name" label="First Name" isSortable="true")
+      (hash key="last_name" label="Last Name" isSortable="true")
+      (hash key="age" label="Age" isSortable="true")
+      (hash key="email" label="Email")
+      (hash key="phone" label="Phone")
+      (hash key="bio" label="Biography" width="350px")
+      (hash key="education" label="Education Degree")
+      (hash key="occupation" label="Occupation")
+    }}
+  >
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.first_name}}</B.Td>
+        <B.Td>{{B.data.last_name}}</B.Td>
+        <B.Td>{{B.data.age}}</B.Td>
+        <B.Td>{{B.data.email}}</B.Td>
+        <B.Td>{{B.data.phone}}</B.Td>
+        <B.Td>{{B.data.bio}}</B.Td>
+        <B.Td>{{B.data.education}}</B.Td>
+        <B.Td>{{B.data.occupation}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+</div>
+```
+
+#### Using a container with `overflow: auto` and a sub-container with `width: max-content`
+
+If you want to specify the column width of some of the columns, and leave some others adapt automtically to their content, but at the same time avoid the wrapping of the content within the cells, you have to introduce a second wrapping element around the table, that has its `width` set to ` max-content`.
+
+In this case the table layout is still set to `auto` (default). If instead you want to set it to `fixed` (using the `@isFixedLayout` argument) you will have to specify the width for **every** column or the table will explode horizontally.
+
+
+```handlebars
+<!-- this is an element with "overflow: auto" -->
+<div class="doc-table-scrollable-wrapper">
+  <!-- this is an element with "width: max-content" -->
+  <div class="doc-table-max-content-width">
+    <Hds::Table
+      @model={{this.modelWithLargeNumberOfColumns}}
+      @columns={{array
+        (hash key="first_name" label="First Name" isSortable="true" width="200px")
+        (hash key="last_name" label="Last Name" isSortable="true" width="200px")
+        (hash key="age" label="Age" isSortable="true")
+        (hash key="email" label="Email")
+        (hash key="phone" label="Phone")
+        (hash key="bio" label="Biography" width="350px")
+        (hash key="education" label="Education Degree")
+        (hash key="occupation" label="Occupation")
+      }}
+    >
+      <:body as |B|>
+        <B.Tr>
+          <B.Td>{{B.data.first_name}}</B.Td>
+          <B.Td>{{B.data.last_name}}</B.Td>
+          <B.Td>{{B.data.age}}</B.Td>
+          <B.Td>{{B.data.email}}</B.Td>
+          <B.Td>{{B.data.phone}}</B.Td>
+          <B.Td>{{B.data.bio}}</B.Td>
+          <B.Td>{{B.data.education}}</B.Td>
+          <B.Td>{{B.data.occupation}}</B.Td>
+        </B.Tr>
+      </:body>
+    </Hds::Table>
+  </div>
+</div>
 ```
 
 ### More examples


### PR DESCRIPTION
### :pushpin: Summary

This PR is the result of a [thread in Slack](https://hashicorp.slack.com/archives/C7KTUHNUS/p1682372763007829?thread_ts=1682369934.519929&cid=C7KTUHNUS) and a follow-up meeting and discussion with @emailnitram about how the `HDS::Table` component behaves when the user needs a predefined column width, in the specific case where the table has a lot (**a lot**) of columns.

Now, this is more of an edge case, but still a valid case in the context of the product needs ([see here](https://github.com/hashicorp/atlas/blob/main/frontend/atlas/app/templates/v2/organization/explorer/index.hbs)). 
Essentially the need is:
- to have a table that contains a large number of columns (hence the content can't fit in the container) 
- for some of these columns be able to apply a specific width and have the browser respect that width (without having to specify the width for all the columns)
- have a parent container for the table that allows horizontal scrolling

After some exploration in the showcase, I have realized that:
- the way in which the browser renders a table is not always what I was expecting (probably based on heuristic more than strict rules)
- the combination of `table-layout: auto|fixed` + column `width: auto|px|%` leads to different behaviour of the browser layout engine
- it's not possible to satisfy the requirements described above, unless we set **both** the `width` and the `min-width` of the columns (this forces the table to respect the width and not try to collapse the content anyway)

_Notice: using just `table-layout: fixed` won't do the trick, because in that case all the columns that don't have an explicit width will automatically receive the same residual width, no matter what their content is)._

At the end I have left only the "meaningful" examples of combinations in the showcase, and added a couple of useful examples in the "how to use" section of the documentation, to cover the topic of "scrollable tables".

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the `Table` showcase to include variants/use cases for different layouts
    - combination of table-layout + column widths (px/%)
    - large table with overflow scrollable
- updated `Th/ThSort` subcomponents to add also `min-width` inline style
    - this caused a few visual regression in the existing table, but technically they are correct (now the columns width is exactly as declared by the user, while before it was not)
- updated the "How to use" section of the Helios website adding a couple of examples of `Scrollable table` 
- updated a couple of integration tests for `@width` argument

👉 👉 👉 **Previews**:
- **website**: https://hds-website-git-hds-table-fixed-columns-width-hashicorp.vercel.app/components/table?tab=code#scrollable-table
- **showcase**: https://hds-showcase-git-hds-table-fixed-columns-width-hashicorp.vercel.app/components/table (see "Layout" section)

### :camera_flash: Screenshots

<img width="1041" alt="screenshot_2755" src="https://github.com/hashicorp/design-system/assets/686239/b6aad018-ca58-45e4-a317-991d85d3b097">
<img width="862" alt="screenshot_2754" src="https://github.com/hashicorp/design-system/assets/686239/a453df05-cd69-4905-80bf-870b0071236a">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1829

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
