### PR TITLE
Update Ember test matrix

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -48,7 +48,8 @@ jobs:
         try-scenario:
          # - ember-lts-3.24
           - ember-lts-3.28
-          - ember-release
+          - ember-lts-4.8
+         # - ember-release
           - ember-beta
          # - ember-canary
          # - ember-classic

--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -52,7 +52,6 @@ jobs:
          # - ember-release
           - ember-beta
          # - ember-canary
-         # - ember-classic
          # - embroider-safe
          # - embroider-optimized
 

--- a/packages/components/config/ember-try.js
+++ b/packages/components/config/ember-try.js
@@ -19,18 +19,18 @@ module.exports = async function () {
     },
     scenarios: [
       {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.3',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
             'ember-source': '~3.28.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.8.0',
           },
         },
       },

--- a/packages/components/config/ember-try.js
+++ b/packages/components/config/ember-try.js
@@ -22,7 +22,7 @@ module.exports = async function () {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
-            'ember-source': '~3.28.0',
+            'ember-source': '~3.28.11',
           },
         },
       },
@@ -30,7 +30,7 @@ module.exports = async function () {
         name: 'ember-lts-4.8',
         npm: {
           devDependencies: {
-            'ember-source': '~4.8.0',
+            'ember-source': '~4.8.2',
           },
         },
       },

--- a/packages/ember-flight-icons/config/ember-try.js
+++ b/packages/ember-flight-icons/config/ember-try.js
@@ -22,7 +22,7 @@ module.exports = async function () {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
-            'ember-source': '~3.28.0',
+            'ember-source': '~3.28.11',
           },
         },
       },
@@ -30,7 +30,7 @@ module.exports = async function () {
         name: 'ember-lts-4.8',
         npm: {
           devDependencies: {
-            'ember-source': '~4.8.0',
+            'ember-source': '~4.8.2',
           },
         },
       },


### PR DESCRIPTION
### :pushpin: Summary

Update Ember test matrix as proposed in RFC [DS-051](https://go.hashi.co/rfc/ds-051).

### :hammer_and_wrench: Detailed description

Adding the latest LTS version (currently 4.8)
Removing `ember-release` (this resolves in 4.12.1, which is the version that we're going to be using across repo so we already have it covered by our CI tests)

<img width="313" alt="Screenshot 2023-06-13 at 12 22 44" src="https://github.com/hashicorp/design-system/assets/788096/2f1aa26a-aecb-40ce-9a5b-6932cd73fca4">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1924](https://hashicorp.atlassian.net/browse/HDS-1924)

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1924]: https://hashicorp.atlassian.net/browse/HDS-1924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ