### PR TITLE
`Table` - Set `min-height` instead of `height` for the table head cells + fix cells vertical padding

### DIFF
--- a/.changeset/lemon-camels-poke.md
+++ b/.changeset/lemon-camels-poke.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Table` - Set `min-height` instead of `height` for the table head cells

--- a/.changeset/lemon-camels-poke.md
+++ b/.changeset/lemon-camels-poke.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Table` - Set `min-height` instead of `height` for the table head cells
+`Table` - Set `min-height` instead of `height` for the table head cells + Updated the cells' internal padding to align with the design specs in Figma

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -51,7 +51,7 @@ $hds-table-cell-padding-tall: 20px 16px;
 
   .hds-table__th,
   .hds-table__th-sort {
-    height: $hds-table-header-height;
+    min-height: $hds-table-header-height;
   }
 }
 

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -15,9 +15,9 @@ $hds-table-border-width: 1px;
 $hds-table-inner-border-radius: $hds-table-border-radius - $hds-table-border-width;
 $hds-table-border-color: var(--token-color-border-primary);
 $hds-table-header-height: 48px;
-$hds-table-cell-padding-medium: 12px 16px;
-$hds-table-cell-padding-short: 4px 16px;
-$hds-table-cell-padding-tall: 20px 16px;
+$hds-table-cell-padding-medium: 14px 16px 13px 16px; // the 1px difference is to account for the bottom border
+$hds-table-cell-padding-short: 6px 16px 5px 16px; // the 1px difference is to account for the bottom border
+$hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to account for the bottom border
 
 .hds-table {
   width: 100%;


### PR DESCRIPTION
### :pushpin: Summary

A [request in Slack](https://hashicorp.slack.com/archives/C7KTUHNUS/p1686927483726229) has made me realize that probably is better to specify a `min-height` instead of a `height` for the table head cells, so that in those cases where the table is extremely compressed horizontally the text that wraps doesn't overflow the cell boundaries, but the entire row grows in height.

While working on the ticket, though, I noticed that the height of the cells (for all the different densities) was not matching the one in the [Figma file](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=16727-59704). After a quick conversation with @MelSumner and @jorytindall we have realized that this was due at how the padding in Figma was potentially confusing, due to a nesting of containers (to overcome a Figma limitation). We have decided that since this was a simple change to do, and it would align better the designs to a 4px grid, was better to get it right in code too.

### :hammer_and_wrench: Detailed description

In this PR I have:
- changed `height` to `min-height` in the styling of `Table`’s `Th/ThSort` elements
- updated the cells' internal padding to align with the design specs in Figma
  - notice: the cells in the last row of the table don't have a border, so their height is 1px less than the others; if we want to have also this one "perfect" it's possible but it requires a bit more of refactoring (not complex, just a few Sass variables to rename and others new to add).

### :camera_flash: Screenshots

How it looked **before** the fix:
<img width="1035" alt="screenshot_2775" src="https://github.com/hashicorp/design-system/assets/686239/b93c731c-c476-4f4c-9e38-a728f1e225ec">

How it looks **after** the fix:
<img width="1040" alt="screenshot_2776" src="https://github.com/hashicorp/design-system/assets/686239/52273cf1-87c4-42d0-b9a8-760c19314546">

### :link: External links

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
