### PR TITLE
Some alert/toast action style tweaks

### DIFF
--- a/.changeset/proud-mangos-fry.md
+++ b/.changeset/proud-mangos-fry.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Style tweaks to standalone link

--- a/packages/components/app/styles/components/alert.scss
+++ b/packages/components/app/styles/components/alert.scss
@@ -115,13 +115,6 @@
   > * + * {
     margin-left: 16px;
   }
-
-  // this is a customization of standalone.scss specifically scoped to alert actions
-  .hds-link-standalone__icon,
-  .hds-link-standalone--size-small .hds-link-standalone__icon {
-    width: 12px;
-    height: 12px;
-  }
 }
 
 // DISMISS

--- a/packages/components/app/styles/components/alert.scss
+++ b/packages/components/app/styles/components/alert.scss
@@ -113,7 +113,14 @@
   }
 
   > * + * {
-    margin-left: 8px;
+    margin-left: 16px;
+  }
+
+  // this is a customization of standalone.scss specifically scoped to alert actions
+  .hds-link-standalone__icon,
+  .hds-link-standalone--size-small .hds-link-standalone__icon {
+    width: 12px;
+    height: 12px;
   }
 }
 

--- a/packages/components/app/styles/components/link/standalone.scss
+++ b/packages/components/app/styles/components/link/standalone.scss
@@ -49,7 +49,7 @@ $hds-link-standalone-border-width: 1px;
 $size-props: (
   "small": (
     "font-size": 0.8125rem, // 13px;
-    "icon-size": 1rem, // 16px
+    "icon-size": 0.75rem, // 12px
     "line-height": 1.231, // ~16px
   ),
   "medium": (


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates some styling for actions within the alert and toast components.

### :hammer_and_wrench: Detailed description

- space between actions was increased to 16px
- the small standalone icon was reduced to 12px

### :camera_flash: Screenshots
 
In the alert:
![actions in alert](https://github.com/hashicorp/design-system/assets/4587451/78ed8a6d-0096-4c65-a939-d45e6c8c20c2)

In the toast: 
![actions in toast](https://github.com/hashicorp/design-system/assets/4587451/6f3c9319-529a-4ad5-b764-1293413ede71)

In a standalone link: 
![standalone link](https://github.com/hashicorp/design-system/assets/4587451/ff33cd16-7b55-4158-85b9-38d11d1f7872)


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1994](https://hashicorp.atlassian.net/browse/HDS-1994)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1994]: https://hashicorp.atlassian.net/browse/HDS-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ