### PR TITLE
Disable the "minifyCSS" advanced option in the “components” package

### DIFF
--- a/packages/components/ember-cli-build.js
+++ b/packages/components/ember-cli-build.js
@@ -20,6 +20,12 @@ module.exports = function (defaults) {
     'ember-power-select': {
       theme: false,
     },
+    // we need to add this or Ember Sass compilation will mess up the generated CSS
+    minifyCSS: {
+      options: {
+        advanced: false,
+      },
+    },
   });
 
   /*


### PR DESCRIPTION
### :pushpin: Summary

I noticed that in the showcase website, Ember (or its compiler) is doing that strange thing for which is messing up the CSS order of declarations:

<img width="474" alt="screenshot_2779" src="https://github.com/hashicorp/design-system/assets/686239/1a5387ac-5cd2-47d9-ab85-38fe6dd94d31">

### :hammer_and_wrench: Detailed description

In this PR I have:
- disabled the `minifyCSS` advanced option in the “components” package

(I am waiting to discuss with you all if we want to merge this change, and in that case what kind of semver to use)

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
