### PR TITLE
Browser support matrix - Updated `targets.js` files in the monorepo

### DIFF
--- a/packages/components/tests/dummy/config/targets.js
+++ b/packages/components/tests/dummy/config/targets.js
@@ -6,9 +6,9 @@
 'use strict';
 
 const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions',
+  'last 2 Chrome versions',
+  'last 2 Firefox versions',
+  'last 2 Safari versions',
 ];
 
 module.exports = {

--- a/packages/ember-flight-icons/tests/dummy/config/targets.js
+++ b/packages/ember-flight-icons/tests/dummy/config/targets.js
@@ -6,9 +6,9 @@
 'use strict';
 
 const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions',
+  'last 2 Chrome versions',
+  'last 2 Firefox versions',
+  'last 2 Safari versions',
 ];
 
 module.exports = {

--- a/website/config/targets.js
+++ b/website/config/targets.js
@@ -6,9 +6,9 @@
 'use strict';
 
 const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions',
+  'last 2 Chrome versions',
+  'last 2 Firefox versions',
+  'last 2 Safari versions',
 ];
 
 module.exports = {


### PR DESCRIPTION
### :pushpin: Summary

This PR updates the `targets.js` files in the monorepo to indicate support for “last 2 versions” of browsers.

This is a result of this RFC: [[DS-054] Introduce a browser support matrix for the design system](https://docs.google.com/document/d/1NkHOt4ULP5pTLb1B4iWCr9msUCpwzG-4_BclSkgskZ4/edit)

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated all the `targets.js` files in the monorepo to indicate support for “last 2 versions” of browsers

_Notice: this does not impact in any way our consumers (they will have their own `config.js` files, that will be used to compile our code when consumed in their applications as NPM package)._

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2105
RFC: https://docs.google.com/document/d/1NkHOt4ULP5pTLb1B4iWCr9msUCpwzG-4_BclSkgskZ4/edit

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
