### PR TITLE
Browser support matrix - Added  browser support table to “Getting started / For engineers"

### DIFF
--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -129,3 +129,14 @@ Import CSS helper classes by adding any of the following lines to the main Sass 
 ```
 
 For more examples and guidelines read [the tokens documentation](/foundations/tokens).
+
+## Browser support
+
+The code of our styles, components and icons supports the following browsers:
+
+| Browser        | Version         |
+|----------------|-----------------|
+| Chrome         | last 2 versions |
+| Safari         | last 2 versions |
+| Firefox        | last 2 versions |
+| Microsoft Edge | last 2 versions |

--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -132,7 +132,7 @@ For more examples and guidelines read [the tokens documentation](/foundations/to
 
 ## Browser support
 
-The code of our styles, components and icons supports the following browsers:
+Our styles, components and icons are supported by the following browsers:
 
 | Browser        | Version         |
 |----------------|-----------------|


### PR DESCRIPTION
### :pushpin: Summary

This PR adds a browser support table to the “Getting started / For engineers” page, according to the [[DS-054] Introduce a browser support matrix for the design system](https://docs.google.com/document/d/1NkHOt4ULP5pTLb1B4iWCr9msUCpwzG-4_BclSkgskZ4/edit) RFC

### :hammer_and_wrench: Detailed description

In this PR I have:
- added  browser support table to the “Getting started / For engineers” page

👉 👉 👉 **Preview**: https://hds-website-git-browser-support-matrix-update-website-hashicorp.vercel.app/getting-started/for-engineers#browser-support

### :camera_flash: Screenshots

<img width="858" alt="screenshot_2781" src="https://github.com/hashicorp/design-system/assets/686239/814757df-d174-446a-828f-4ab6111606cc">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2106

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
