### PR TITLE
Remove the "style" attribute on `<body>` when no styles are presented

### DIFF
--- a/.changeset/thin-ants-crash.md
+++ b/.changeset/thin-ants-crash.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix scroll management on `Modal` and `Flyout` resulting in stray `style` attribute on `<body>` element

--- a/packages/components/addon/components/hds/flyout/index.js
+++ b/packages/components/addon/components/hds/flyout/index.js
@@ -68,7 +68,6 @@ export default class HdsFlyoutIndexComponent extends Component {
       // Store the initial `overflow` value of `<body>` so we can reset to it
       this.bodyInitialOverflowValue =
         this.body.style.getPropertyValue('overflow');
-      this.bodyNoInlineStyles = this.body.style.length;
     }
 
     // Register `<dialog>` element for polyfilling if no native support is available
@@ -122,11 +121,12 @@ export default class HdsFlyoutIndexComponent extends Component {
 
     // Reset page `overflow` property
     if (this.body) {
-      if (this.bodyNoInlineStyles === 0) {
-        // If <body> doesn't have any inline style declarations we remove the attribute
-        this.body.removeAttribute('style');
-      } else if (this.bodyInitialOverflowValue) {
-        // Otherwise we reset the property to initial value
+      this.body.style.removeProperty('overflow');
+      if (this.bodyInitialOverflowValue === '') {
+        if (this.body.style.length === 0) {
+          this.body.removeAttribute('style');
+        }
+      } else {
         this.body.style.setProperty('overflow', this.bodyInitialOverflowValue);
       }
     }

--- a/packages/components/addon/components/hds/flyout/index.js
+++ b/packages/components/addon/components/hds/flyout/index.js
@@ -68,6 +68,7 @@ export default class HdsFlyoutIndexComponent extends Component {
       // Store the initial `overflow` value of `<body>` so we can reset to it
       this.bodyInitialOverflowValue =
         this.body.style.getPropertyValue('overflow');
+      this.bodyNoInlineStyles = this.body.style.length;
     }
 
     // Register `<dialog>` element for polyfilling if no native support is available
@@ -121,7 +122,13 @@ export default class HdsFlyoutIndexComponent extends Component {
 
     // Reset page `overflow` property
     if (this.body) {
-      this.body.style.setProperty('overflow', this.bodyInitialOverflowValue);
+      if (this.bodyNoInlineStyles === 0) {
+        // If <body> doesn't have any inline style declarations we remove the attribute
+        this.body.removeAttribute('style');
+      } else if (this.bodyInitialOverflowValue) {
+        // Otherwise we reset the property to initial value
+        this.body.style.setProperty('overflow', this.bodyInitialOverflowValue);
+      }
     }
   }
 }

--- a/packages/components/addon/components/hds/modal/index.js
+++ b/packages/components/addon/components/hds/modal/index.js
@@ -94,6 +94,7 @@ export default class HdsModalIndexComponent extends Component {
       // Store the initial `overflow` value of `<body>` so we can reset to it
       this.bodyInitialOverflowValue =
         this.body.style.getPropertyValue('overflow');
+      this.bodyNoInlineStyles = this.body.style.length;
     }
 
     // Register `<dialog>` element for polyfilling if no native support is available
@@ -158,7 +159,13 @@ export default class HdsModalIndexComponent extends Component {
 
     // Reset page `overflow` property
     if (this.body) {
-      this.body.style.setProperty('overflow', this.bodyInitialOverflowValue);
+      if (this.bodyNoInlineStyles === 0) {
+        // If <body> doesn't have any inline style declarations we remove the attribute
+        this.body.removeAttribute('style');
+      } else if (this.bodyInitialOverflowValue) {
+        // Otherwise we reset the property to initial value
+        this.body.style.setProperty('overflow', this.bodyInitialOverflowValue);
+      }
     }
   }
 }

--- a/packages/components/addon/components/hds/modal/index.js
+++ b/packages/components/addon/components/hds/modal/index.js
@@ -94,7 +94,6 @@ export default class HdsModalIndexComponent extends Component {
       // Store the initial `overflow` value of `<body>` so we can reset to it
       this.bodyInitialOverflowValue =
         this.body.style.getPropertyValue('overflow');
-      this.bodyNoInlineStyles = this.body.style.length;
     }
 
     // Register `<dialog>` element for polyfilling if no native support is available
@@ -159,11 +158,12 @@ export default class HdsModalIndexComponent extends Component {
 
     // Reset page `overflow` property
     if (this.body) {
-      if (this.bodyNoInlineStyles === 0) {
-        // If <body> doesn't have any inline style declarations we remove the attribute
-        this.body.removeAttribute('style');
-      } else if (this.bodyInitialOverflowValue) {
-        // Otherwise we reset the property to initial value
+      this.body.style.removeProperty('overflow');
+      if (this.bodyInitialOverflowValue === '') {
+        if (this.body.style.length === 0) {
+          this.body.removeAttribute('style');
+        }
+      } else {
         this.body.style.setProperty('overflow', this.bodyInitialOverflowValue);
       }
     }


### PR DESCRIPTION
### :pushpin: Summary

Remove the "style" attribute on `<body>` when no styles are presented

### :hammer_and_wrench: Detailed description

When we introduced the scroll management in `Hds::Modal` and `Hds::Flyout` we did not account for the case where no inline style was present on the `<body>` element. Closing a dialog resulted in a stray 'style' attribute on this element.

We update the code to remove the attribute if no styles are presented.

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
