### PR TITLE
Updating contextual examples of `Link::Inline`

### DIFF
--- a/website/docs/components/link/inline/index.md
+++ b/website/docs/components/link/inline/index.md
@@ -19,5 +19,4 @@ navigation:
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
-  <!-- @include "partials/code/showcase.md" -->
 </section>

--- a/website/docs/components/link/inline/partials/code/how-to-use.md
+++ b/website/docs/components/link/inline/partials/code/how-to-use.md
@@ -3,9 +3,9 @@
 The most basic invocation requires some content to be passed as children and either an `@href` or `@route` argument.
 
 ```handlebars
-<div class="hds-typography-body-300">
+<span class="hds-typography-body-300">
   Lorem <Hds::Link::Inline @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
-</div>
+</span>
 ```
 
 ### Color
@@ -13,15 +13,15 @@ The most basic invocation requires some content to be passed as children and eit
 There are two available colors for an Inline Link: `primary` and `secondary`. The default is `primary`. To use a different color, set `@color` to `secondary`.
 
 ```handlebars
-<div class="hds-typography-body-300">
+<span class="hds-typography-body-300">
   Lorem <Hds::Link::Inline @color="primary" @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
-</div>
+</span>
 ```
 
 ```handlebars
-<div class="hds-typography-body-300">
+<span class="hds-typography-body-300">
   Lorem <Hds::Link::Inline @color="secondary" @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
-</div>
+</span>
 ```
 
 ### Icon
@@ -31,9 +31,9 @@ To add an icon to the Inline Link, give the `@icon` argument any [icon](/icons/l
 `Hds::Link::Inline` does not have an intrinsic size. Instead, the size of the icon is calculated proportionally (via `em`) in relation to the font-size of the text.
 
 ```handlebars
-<div class="hds-typography-body-300">
+<span class="hds-typography-body-300">
   Lorem <Hds::Link::Inline @color="primary" @icon="external-link" @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
-</div>
+</span>
 ```
 
 ### Icon position
@@ -41,9 +41,9 @@ To add an icon to the Inline Link, give the `@icon` argument any [icon](/icons/l
 By default, if you define an icon, it‘s placed in the trailing (end) position. If you would like to position the icon in the leading (start) position, define `@iconPosition`.
 
 ```handlebars
-<div class="hds-typography-body-300">
-  Lorem <Hds::Link::Inline @color="primary" @icon="external-link" @iconPosition="leading" @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
-</div>
+<span class="hds-typography-body-300">
+  Lorem <Hds::Link::Inline @color="primary" @icon="globe" @iconPosition="leading" @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
+</span>
 ```
 
 ### URL and route handling
@@ -59,9 +59,9 @@ To generate an `<a>` link, pass an `@href` argument with a URL as the value.
 `target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied by default. This is the most common case, as internal links are generally handled using a `@route` argument. 
 
 ```handlebars
-<div class="hds-typography-body-300">
+<span class="hds-typography-body-300">
   Lorem <Hds::Link::Inline @color="primary" @icon="external-link" @href="https://www.hashicorp.com">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
-</div>
+</span>
 ```
 
 If the `@href` argument points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{true}}` to the component and it will omit the `target` and `rel` attributes.
@@ -75,9 +75,9 @@ All the standard arguments for the `<LinkTo/LinkToExternal>` components are supp
 To generate an `<a>` link using a `<LinkTo>` Ember component, pass a `@route` argument. 
 
 ```handlebars
-<div class="hds-typography-body-300">
+<span class="hds-typography-body-300">
   Lorem <Hds::Link::Inline @route="my.page.route" @model="my.page.model">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
-</div>
+</span>
 ```
 
 ##### For `<LinkToExternal>`

--- a/website/docs/components/link/inline/partials/code/how-to-use.md
+++ b/website/docs/components/link/inline/partials/code/how-to-use.md
@@ -3,7 +3,9 @@
 The most basic invocation requires some content to be passed as children and either an `@href` or `@route` argument.
 
 ```handlebars
-<Hds::Link::Inline @href="...">Watch tutorial video</Hds::Link::Inline>
+<div class="hds-typography-body-300">
+  Lorem <Hds::Link::Inline @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
+</div>
 ```
 
 ### Color
@@ -11,11 +13,15 @@ The most basic invocation requires some content to be passed as children and eit
 There are two available colors for a Inline Link: `primary` and `secondary`. The default is `primary`. To use a different color, set `@color` to `secondary`.
 
 ```handlebars
-<Hds::Link::Inline @color="primary" @href="...">Read tutorial</Hds::Link::Inline>
+<div class="hds-typography-body-300">
+  Lorem <Hds::Link::Inline @color="primary" @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
+</div>
 ```
 
 ```handlebars
-<Hds::Link::Inline @color="secondary" @href="...">Read tutorial</Hds::Link::Inline>
+<div class="hds-typography-body-300">
+  Lorem <Hds::Link::Inline @color="secondary" @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
+</div>
 ```
 
 ### Icon
@@ -25,7 +31,9 @@ To add an icon to your Inline Link, give the `@icon` argument any [icon](/icons/
 `Hds::Link::Inline` does not have an intrinsic size. Instead, the size of the icon is calculated proportionally (via `em`) in relation to the font-size of the text.
 
 ```handlebars
-<Hds::Link::Inline @href="..." @icon="external-link">Watch tutorial video</Hds::Link::Inline>
+<div class="hds-typography-body-300">
+  Lorem <Hds::Link::Inline @color="primary" @icon="external-link" @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
+</div>
 ```
 
 ### Icon position
@@ -33,7 +41,9 @@ To add an icon to your Inline Link, give the `@icon` argument any [icon](/icons/
 By default, if you define an icon, it‘s placed in the trailing (right) position. If you would like to position the icon in the leading (left) position, define `@iconPosition`.
 
 ```handlebars
-<Hds::Link::Inline @href="..." @icon="film" @iconPosition="leading">Watch tutorial video</Hds::Link::Inline>
+<div class="hds-typography-body-300">
+  Lorem <Hds::Link::Inline @color="primary" @icon="external-link" @iconPosition="leading" @href="...">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
+</div>
 ```
 
 ### URL and route handling
@@ -49,7 +59,9 @@ To generate an `<a>` link, pass an `@href` argument with a URL as the value.
 `target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied by default. This is the most common case, as internal links are generally handled using a `@route` argument. 
 
 ```handlebars
-<Hds::Link::Inline @href="https://www.hashicorp.com/request-demo/terraform">Request a demo</Hds::Link::Inline>
+<div class="hds-typography-body-300">
+  Lorem <Hds::Link::Inline @color="primary" @icon="external-link" @href="https://www.hashicorp.com">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
+</div>
 ```
 
 If the `@href` argument points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{true}}` to the component and it will omit the `target` and `rel` attributes.
@@ -63,7 +75,9 @@ All the standard arguments for the `<LinkTo/LinkToExternal>` components are supp
 To generate an `<a>` link using a `<LinkTo>` Ember component, pass a `@route` argument. 
 
 ```handlebars
-<Hds::Link::Inline @route="my.page.route" @model="my.page.model">Go to the index page</Hds::Link::Inline>
+<div class="hds-typography-body-300">
+  Lorem <Hds::Link::Inline @route="my.page.route" @model="my.page.model">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
+</div>
 ```
 
 ##### For `<LinkToExternal>`

--- a/website/docs/components/link/inline/partials/code/how-to-use.md
+++ b/website/docs/components/link/inline/partials/code/how-to-use.md
@@ -10,7 +10,7 @@ The most basic invocation requires some content to be passed as children and eit
 
 ### Color
 
-There are two available colors for a Inline Link: `primary` and `secondary`. The default is `primary`. To use a different color, set `@color` to `secondary`.
+There are two available colors for an Inline Link: `primary` and `secondary`. The default is `primary`. To use a different color, set `@color` to `secondary`.
 
 ```handlebars
 <div class="hds-typography-body-300">
@@ -26,7 +26,7 @@ There are two available colors for a Inline Link: `primary` and `secondary`. The
 
 ### Icon
 
-To add an icon to your Inline Link, give the `@icon` argument any [icon](/icons/library) name.
+To add an icon to the Inline Link, give the `@icon` argument any [icon](/icons/library) name.
 
 `Hds::Link::Inline` does not have an intrinsic size. Instead, the size of the icon is calculated proportionally (via `em`) in relation to the font-size of the text.
 
@@ -38,7 +38,7 @@ To add an icon to your Inline Link, give the `@icon` argument any [icon](/icons/
 
 ### Icon position
 
-By default, if you define an icon, it‘s placed in the trailing (right) position. If you would like to position the icon in the leading (left) position, define `@iconPosition`.
+By default, if you define an icon, it‘s placed in the trailing (end) position. If you would like to position the icon in the leading (start) position, define `@iconPosition`.
 
 ```handlebars
 <div class="hds-typography-body-300">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add examples in the `How to use` section of the docs in which the component is inside of a block of text, similarly to how the component is [showcased](https://hds-showcase.vercel.app/components/link/inline).

### :hammer_and_wrench: Detailed description

I considered a couple of different options in this in an attempt to showcase the component in a relevant and semantic manner:

I initially used several different examples of body copy that was relevant to HashiCorp and to HashiCorp products, but ended up going the route of `lorem ipsum` as the generic approach seemed better in this scenario.

I initially wrapped the text in different semantic elements (`<p>` and `<span>`) and passed the typography class name to the element, but this resulted in the website text styling (`doc-markdown-p`) overriding the token in the cascade. In the end I opted to wrap the content in a `<div>` instead which matches the strategy used in the showcase.

All of these examples use the same text example for visual consistency and to more effectively highlight the different properties of the component.

Additionally, I performed some small updates in the prose for increased consistency with other areas of the documentation; namely, referring to position as `start/end` vs. `left/right`.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1883](https://hashicorp.atlassian.net/browse/HDS-1883)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1883]: https://hashicorp.atlassian.net/browse/HDS-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ