### PR TITLE
Percy tests - Added `Tooltip` 

### DIFF
--- a/packages/components/tests/acceptance/percy-test.js
+++ b/packages/components/tests/acceptance/percy-test.js
@@ -131,6 +131,9 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/components/toast');
     await percySnapshot('Toast');
 
+    await visit('/components/tooltip');
+    await percySnapshot('Tooltip');
+
     await visit('/layouts/app-frame');
     await percySnapshot('AppFrame');
 


### PR DESCRIPTION
### :pushpin: Summary

We didn't have visual regression test for `Tooltip` (noticed in #1438)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
