### PR TITLE
Fix position relative on focus ring mixin

### DIFF
--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -66,10 +66,10 @@
 
 .hds-tabs__tab-button {
   @include hds-focus-ring-with-pseudo-element(
-    $top: var(--token-tabs-tab-focus-inset),
-    $right: var(--token-tabs-tab-focus-inset),
-    $bottom: var(--token-tabs-tab-focus-inset),
-    $left: var(--token-tabs-tab-focus-inset),
+    $top: -2px,
+    $right: -6px,
+    $bottom: -2px,
+    $left: -6px,
   );
   position: static;
   display: flex;

--- a/packages/components/app/styles/mixins/_focus-ring.scss
+++ b/packages/components/app/styles/mixins/_focus-ring.scss
@@ -32,20 +32,24 @@
 }
 
 @mixin hds-focus-ring-with-pseudo-element($top: 0, $right: 0, $bottom: 0, $left: 0, $radius: 5px, $color: action) {
-  position: relative;
-  outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
-  outline-color: transparent;
-  isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
+  &:focus,
+  &.mock-focus,
+  &:focus-visible {
+    position: relative;
+    outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
+    outline-color: transparent;
+    isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
 
-  &::before {
-    position: absolute;
-    top: $top;
-    right: $right;
-    bottom: $bottom;
-    left: $left;
-    z-index: -1;
-    border-radius: $radius;
-    content: "";
+    &::before {
+      position: absolute;
+      top: $top;
+      right: $right;
+      bottom: $bottom;
+      left: $left;
+      z-index: -1;
+      border-radius: $radius;
+      content: "";
+    }
   }
 
   // default focus for browsers that still rely on ":focus"


### PR DESCRIPTION
### :pushpin: Summary

Fix position relative on focus ring mixin

### :hammer_and_wrench: Detailed description

We are updating `hds-focus-ring-with-pseudo-element` to set `position: relative` to the element only when focused.

This is because `position: relative` adds the element to the level stack, meaning that it can interfere with other elements on the stack (with a `z-index` value). Below there's an example of `Hds::Tooltip` (that uses `hds-focus-ring-with-pseudo-element`) interfering with `Hds::Dropdown` (part of the `PageHeader`). All the elements that have a tooltip pear 'in front' of the dropdown.

#### Alternatives

When looking into options we determined that potential alternatives to this solution would be:
 - to set `position: relative; z-index: 1;` on `Hds::PageHeader`
   - this would resolve the immediate issue shown below but does not address the root problem and introduces even more elements on the level stack
 - look into alternatives to the pseudo-element implementation (such as multiple `box-shadow`s or so)
   -  this would reduce the number of elements on the levels stack, but would require minor visual adjustments on multiple components
 - refactor the `PageHeader` component to avoid using container queries

### :camera_flash: Screenshots

#### Before
<img width="1510" alt="Screenshot 2023-06-21 at 20 33 02" src="https://github.com/hashicorp/design-system/assets/788096/b1a67cbf-d2fa-43e4-a23a-3063fe46ded4">


#### After
<img width="1508" alt="Screenshot 2023-06-21 at 20 33 27" src="https://github.com/hashicorp/design-system/assets/788096/cb48af81-4e36-45a6-bed4-64f689201781">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2114](https://hashicorp.atlassian.net/browse/HDS-2114)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2114]: https://hashicorp.atlassian.net/browse/HDS-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ