### PR TITLE
Alert docs update

### DIFF
--- a/website/docs/components/alert/partials/code/how-to-use.md
+++ b/website/docs/components/alert/partials/code/how-to-use.md
@@ -96,7 +96,7 @@ Actions can be passed to the component using one of the suggested `Button` or `L
   <A.Title>Title here</A.Title>
   <A.Description>Description here</A.Description>
   <A.Button @text="Your action" @color="secondary" {{on "click" this.yourOnClickFunction}} />
-  <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @text="Another action" @href="#" />
+  <A.Link::Standalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Another action" @href="#" />
 </Hds::Alert>
 ```
 

--- a/website/docs/components/alert/partials/guidelines/guidelines.md
+++ b/website/docs/components/alert/partials/guidelines/guidelines.md
@@ -110,7 +110,7 @@ We recommend using the `secondary` button variant for primary actions and the `t
   <A.Title>Recommended button usage</A.Title>
   <A.Description>Lorem ipsum dolar sit amet.</A.Description>
   <A.Button @text="Your action" @color="secondary" @onClick={{this.noop}} />
-  <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @text="Another action" @href="#" />
+  <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @color="secondary" @text="Another action" @href="#" />
 </Hds::Alert>
 
 ##### Usage of critical buttons
@@ -127,12 +127,15 @@ Avoid using critical buttons in alerts. We handle the prominence and importance 
 
 #### Links
 
-Use [standalone links](/components/link/standalone) when an action takes the user to a new destination (URL). Follow the standalone link [usage guidelines](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2522%3A8014&t=s1vlvHztHFnd5T9i-1) to determine what variant “type” to use.
+Use [standalone links](/components/link/standalone) when an action takes the user to a new destination (URL). Follow the standalone link [usage guidelines](https://helios.hashicorp.design/components/link/standalone) to determine what variant “type” to use.
 
-<Hds::Alert @type="inline" as |A|>
+We recommend using the secondary standalone link to maintain visual hierarchy and avoid competing prominence when used with the secondary button.
+
+<Hds::Alert @type="inline" @color="highlight" as |A|>
   <A.Title>Links in alerts</A.Title>
   <A.Description>Lorem ipsum dolar sit amet.</A.Description>
-  <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @text="Another action" @href="#" />
+  <A.Button @text="Your action" @color="secondary" @onClick={{this.noop}} />
+  <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @color="secondary" @text="Standalone link" @href="#" />
 </Hds::Alert>
 
 ### Placement

--- a/website/docs/components/alert/partials/guidelines/guidelines.md
+++ b/website/docs/components/alert/partials/guidelines/guidelines.md
@@ -44,13 +44,6 @@ Use color logically.
 - **Warning** to help users avoid an issue. Provide guidance and actions, if possible.
 - **Critical** to indicate critical errors that need immediate action.
 
-!!! Insight
-
-**Structure migration tip**
-
-Use `neutral` or `highlight` (depending on the level of prominence needed) in place of Structure’s `information` banner.
-!!!
-
 ### Icons
 
 All alerts have icons by default that are intentionally tied to the alert type.
@@ -189,7 +182,7 @@ The title or description should contain the alert type, e.g., “Warning,” if 
   <A.Title>Alert with actions</A.Title>
   <A.Description>Lorem ipsum dolar sit amet.</A.Description>
   <A.Button @text="Your action" @color="secondary" @onClick={{this.noop}} />
-  <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @text="Learn more" @href="#" />
+  <A.Link::Standalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Learn more" @href="#" />
 </Hds::Alert>
 
 #### With generic content

--- a/website/docs/components/alert/partials/guidelines/guidelines.md
+++ b/website/docs/components/alert/partials/guidelines/guidelines.md
@@ -110,7 +110,7 @@ We recommend using the `secondary` button variant for primary actions and the `t
   <A.Title>Recommended button usage</A.Title>
   <A.Description>Lorem ipsum dolar sit amet.</A.Description>
   <A.Button @text="Your action" @color="secondary" @onClick={{this.noop}} />
-  <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @color="secondary" @text="Another action" @href="#" />
+  <A.Button @color="tertiary" @icon="arrow-right" @iconPosition="trailing" @text="Tertiary" />
 </Hds::Alert>
 
 ##### Usage of critical buttons
@@ -127,7 +127,7 @@ Avoid using critical buttons in alerts. We handle the prominence and importance 
 
 #### Links
 
-Use [standalone links](/components/link/standalone) when an action takes the user to a new destination (URL). Follow the standalone link [usage guidelines](https://helios.hashicorp.design/components/link/standalone) to determine what variant “type” to use.
+Use [Standalone Link](/components/link/standalone) when an action takes the user to a new destination (URL).
 
 We recommend using the secondary standalone link to maintain visual hierarchy and avoid competing prominence when used with the secondary button.
 

--- a/website/docs/components/toast/partials/guidelines/guidelines.md
+++ b/website/docs/components/toast/partials/guidelines/guidelines.md
@@ -104,6 +104,8 @@ Avoid using critical Buttons in Toasts. We handle the prominence and importance 
 
 Use [Standalone Links](/components/link/standalone) when an action takes the user to a new destination (URL). Follow the Standalone Link [usage guidelines](https://helios.hashicorp.design/components/link/standalone) to determine what variant to use.
 
+We recommend using the secondary standalone link to maintain visual hierarchy and avoid competing prominence when used with the secondary button.
+
 <Hds::Toast @color="neutral" @onDismiss={{this.noop}} as |T|>
   <T.Title>Links in Toasts</T.Title>
   <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>

--- a/website/docs/components/toast/partials/guidelines/guidelines.md
+++ b/website/docs/components/toast/partials/guidelines/guidelines.md
@@ -106,11 +106,11 @@ Use [Standalone Links](/components/link/standalone) when an action takes the use
 
 We recommend using the secondary standalone link to maintain visual hierarchy and avoid competing prominence when used with the secondary button.
 
-<Hds::Toast @color="neutral" @onDismiss={{this.noop}} as |T|>
+<Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
   <T.Title>Links in Toasts</T.Title>
   <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
   <T.Button @text="Button" @color="secondary" />
-  <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+  <T.Link::Standalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Standalone link" @href="#" />
 </Hds::Toast>
 
 ## Size

--- a/website/docs/components/toast/partials/guidelines/guidelines.md
+++ b/website/docs/components/toast/partials/guidelines/guidelines.md
@@ -17,31 +17,31 @@
     <T.Title>Neutral toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="highlight" @onDismiss={{this.noop}} as |T|>
     <T.Title>Highlight toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
     <T.Title>Success toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="warning" @onDismiss={{this.noop}} as |T|>
     <T.Title>Warning toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="critical" @onDismiss={{this.noop}} as |T|>
     <T.Title>Critical toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
 </Doc::Layout>
 
@@ -63,12 +63,12 @@ Icons within `neutral` and `highlight` Toasts can be replaced with other icons. 
   <Hds::Toast @color="neutral" @icon="running" @onDismiss={{this.noop}} as |T|>
     <T.Title>Plan running</T.Title>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="success" @icon="check-circle" @onDismiss={{this.noop}} as |T|>
     <T.Title>Plan finished</T.Title>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
 </Doc::Layout>
 
@@ -84,7 +84,7 @@ We recommend using the `secondary` Button variant for primary actions and the `t
   <T.Title>Recommended button usage</T.Title>
   <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
   <T.Button @text="Button" @color="secondary" />
-  <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+  <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
 </Hds::Toast>
 
 #### Usage of critical Buttons
@@ -102,12 +102,13 @@ Avoid using critical Buttons in Toasts. We handle the prominence and importance 
 
 ### Links
 
-Use [Standalone Links](/components/link/standalone) when an action takes the user to a new destination (URL). Follow the Standalone Link [usage guidelines](/components/link/standalone#usage) to determine what variant to use.
+Use [Standalone Links](/components/link/standalone) when an action takes the user to a new destination (URL). Follow the Standalone Link [usage guidelines](https://helios.hashicorp.design/components/link/standalone) to determine what variant to use.
 
 <Hds::Toast @color="neutral" @onDismiss={{this.noop}} as |T|>
   <T.Title>Links in Toasts</T.Title>
   <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
-  <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+  <T.Button @text="Button" @color="secondary" />
+  <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
 </Hds::Toast>
 
 ## Size
@@ -157,7 +158,7 @@ The title or description should contain the Toast color type, e.g., â€œWarning,â
   <T.Title>Toast with actions</T.Title>
   <T.Description>Lorem ipsum dolar sit amet, consectetur adi.</T.Description>
   <T.Button @text="Button" @color="secondary" />
-  <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+  <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
 </Hds::Toast>
 
 ### With generic content
@@ -187,7 +188,7 @@ The title or description should contain the Toast color type, e.g., â€œWarning,â
     <T.Title>Cost estimation enabled</T.Title>
     <T.Description>Future runs will now include this step. You can manage this preference in <Hds::Link::Inline @href="#">Organization settings</Hds::Link::Inline>.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="critical" @icon="alert-diamond" @onDismiss={{this.noop}} as |T|>
     <T.Title>Placement failures</T.Title>
@@ -195,6 +196,6 @@ The title or description should contain the Toast color type, e.g., â€œWarning,â
     <T.Description>Resources exhausted on 5 modes</T.Description>
     <T.Description>Missing driver "java" on 5 nodes</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="primary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
 </Doc::Layout>

--- a/website/docs/components/toast/partials/guidelines/guidelines.md
+++ b/website/docs/components/toast/partials/guidelines/guidelines.md
@@ -84,7 +84,7 @@ We recommend using the `secondary` Button variant for primary actions and the `t
   <T.Title>Recommended button usage</T.Title>
   <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
   <T.Button @text="Button" @color="secondary" />
-  <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+  <T.Button @color="tertiary" @icon="arrow-right" @iconPosition="trailing" @text="Tertiary" />
 </Hds::Toast>
 
 #### Usage of critical Buttons
@@ -102,7 +102,7 @@ Avoid using critical Buttons in Toasts. We handle the prominence and importance 
 
 ### Links
 
-Use [Standalone Links](/components/link/standalone) when an action takes the user to a new destination (URL). Follow the Standalone Link [usage guidelines](https://helios.hashicorp.design/components/link/standalone) to determine what variant to use.
+Use [Standalone Link](/components/link/standalone) when an action takes the user to a new destination (URL).
 
 We recommend using the secondary standalone link to maintain visual hierarchy and avoid competing prominence when used with the secondary button.
 


### PR DESCRIPTION
### :pushpin: Summary

This PR updates the recommendation to use the secondary standalone link as secondary action in the `Alert` and `Toast`.

Preview: https://hds-website-git-cv-alert-docs-update-hashicorp.vercel.app/components/alert

<img width="600" alt="Screen Shot 2023-06-22 at 9 29 28 AM" src="https://github.com/hashicorp/design-system/assets/2142312/e3f7b114-bf95-4ff4-b46d-b1aedc94a1f6">

Preview: https://hds-website-git-cv-alert-docs-update-hashicorp.vercel.app/components/toast

<img width="340" alt="Screen Shot 2023-06-22 at 9 29 58 AM" src="https://github.com/hashicorp/design-system/assets/2142312/37bdc9b1-e411-450f-a0cd-09c39a2c3d3a">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1993](https://hashicorp.atlassian.net/browse/HDS-1993)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1993]: https://hashicorp.atlassian.net/browse/HDS-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ