### PR TITLE
Update `changesets/action` to use trusted version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn
 
       - name: Create Release Pull Request
-        uses: changesets/action@v1 # TSCCR: no entry for repository "changesets/action"
+        uses: changesets/action@2bb9bcbd6bf4996a55ce459a630a0aa699457f59 # v1.4.5
         with:
           version: yarn version
           publish: yarn release


### PR DESCRIPTION
### :pushpin: Summary

Update `changesets/action` to use trusted version (v1.4.5)

### :hammer_and_wrench: Detailed description

Following https://github.com/hashicorp/security-tsccr/pull/411 we update `changesets/action` to use the trusted version, as listed in the registry.

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
