### PR TITLE
Accessibility fixes for certain versions of dropdown component

### DIFF
--- a/.changeset/early-emus-attack.md
+++ b/.changeset/early-emus-attack.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Internal accessibility tweaks for dropdown component

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -3,8 +3,8 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{! template-lint-disable require-context-role require-presentational-children }}
-<li class={{this.classNames}}>
+{{! template-lint-disable no-invalid-role require-context-role require-presentational-children }}
+<li class={{this.classNames}} role="none">
   <Hds::Interactive
     @current-when={{@current-when}}
     @models={{hds-link-to-models @model @models}}
@@ -37,4 +37,4 @@
     </span>
   </Hds::Interactive>
 </li>
-{{! template-lint-enable require-context-role require-presentational-children }}
+{{! template-lint-enable no-invalid-role require-context-role require-presentational-children }}

--- a/packages/components/addon/components/hds/dropdown/list-item/separator.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/separator.hbs
@@ -2,4 +2,9 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<li class="hds-dropdown-list-item hds-dropdown-list-item--variant-separator" role="separator" ...attributes></li>
+<li
+  class="hds-dropdown-list-item hds-dropdown-list-item--variant-separator"
+  aria-hidden="true"
+  role="separator"
+  ...attributes
+></li>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -97,7 +97,7 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H4>With icon</Shw::Text::H4>
+  <Shw::Text::H3>With icon</Shw::Text::H3>
 
   <Shw::Flex as |SF|>
     <SF.Item @label="Primary small">
@@ -126,7 +126,7 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H4>With count</Shw::Text::H4>
+  <Shw::Text::H3>With count</Shw::Text::H3>
 
   <Shw::Flex as |SF|>
     <SF.Item @label="Primary small">
@@ -155,7 +155,7 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H4>With badge</Shw::Text::H4>
+  <Shw::Text::H3>With badge</Shw::Text::H3>
 
   <Shw::Flex as |SF|>
     <SF.Item @label="Primary small">

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/separator-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/separator-test.js
@@ -34,5 +34,13 @@ module(
       );
       assert.dom('#test-list-item-separator').hasAttribute('role', 'separator');
     });
+    test('it should render the "list-item/separator" with the aria-hidden attribute', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Separator id="test-list-item-separator" />`
+      );
+      assert
+        .dom('#test-list-item-separator')
+        .hasAttribute('aria-hidden', 'true');
+    });
   }
 );


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves a few accessibility failures (117 down to 9) that were showing up in the dropdown component. 

### :hammer_and_wrench: Detailed description

- added `aria-hidden` attribute to the separator
- added `role="none"` to the checkbox `<li>` (the role of listbox should have a descendant of option; setting the role of none on the list item resolves the issue)
- fixed a heading issue in the preview page


### :camera_flash: Screenshots

This should change nothing for the consumer.

### :link: External links

There's no JIRA ticket, I just noticed the issue when I was looking at the code. 

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
