### PR TITLE
remove reference to bot we no longer use

### DIFF
--- a/packages/flight-icons/CONTRIBUTING.md
+++ b/packages/flight-icons/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Whenever there is an update to the Flight Icons library in Figma (e.g. a new ico
 
 We have developed a set of custom Node.js scripts to create a single pipeline for this purpose. The pipeline can be run manually on your local machine or via a GitHub Action.
 
-With either approach, it will be necessary to add a commit creating a changeset entry either [via the instructions in our readme](https://github.com/hashicorp/design-system/blob/main/README.md#changesets) or by clicking the link provided by `changeset-bot` on the PR.
+With either approach, it will be necessary to add a commit creating a changeset entry [via the instructions in our readme](https://github.com/hashicorp/design-system/blob/main/README.md#changesets).
 
 ## Automated process
 


### PR DESCRIPTION
### :pushpin: Summary

Follow up to https://github.com/hashicorp/design-system/pull/1440 to further clarify the instructions to no longer reference the bot we stopped using several months ago.