### PR TITLE
Update alert component integration test to add a11yAudit invocation with conditional

### DIFF
--- a/packages/components/tests/integration/components/hds/alert/index-test.js
+++ b/packages/components/tests/integration/components/hds/alert/index-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { a11yAudit, shouldForceAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | hds/alert/index', function (hooks) {
   setupRenderingTest(hooks);
@@ -18,6 +19,11 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
     await render(hbs`<Hds::Alert @type="inline" id="test-alert" />`);
     assert.dom('#test-alert').hasClass('hds-alert');
+
+    if (shouldForceAudit()) {
+      await a11yAudit();
+    }
+    assert.ok(true, 'no a11y errors found in default component invocation');
   });
 
   // TYPE


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a conditional a11yAudit to the alert component 

### :hammer_and_wrench: Detailed description

Added this to the alert integration test: 

```
import { a11yAudit, shouldForceAudit } from 'ember-a11y-testing/test-support';
```

and updated the default test: 

```
  test('it should render the component with a CSS class that matches the component name', async function (assert) {
    await render(hbs`<Hds::Alert @type="inline" id="test-alert" />`);
    assert.dom('#test-alert').hasClass('hds-alert');

    if (shouldForceAudit()) {
      await a11yAudit();
    }
    assert.ok(true, 'no a11y errors found in default component invocation');
  });
```

### :camera_flash: Screenshots

This changes nothing in the browser

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2076](https://hashicorp.atlassian.net/browse/HDS-2076)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
