### PR TITLE
Updates test helper with global a11y invocation

### DIFF
--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -27,7 +27,7 @@ setupGlobalA11yHooks(() => true, {
   ],
 });
 
-// uncomment this line to turn the tests on globally
+// uncomment this next line to turn the tests on globally
 // setEnableA11yAudit(true);
 
 setRunOptions({

--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -27,6 +27,9 @@ setupGlobalA11yHooks(() => true, {
   ],
 });
 
+// uncomment this line to turn the tests on globally
+// setEnableA11yAudit(true);
+
 setRunOptions({
   runOnly: {
     type: 'tag',

--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -41,14 +41,7 @@ setRunOptions({
     ],
   },
   include: ['#ember-testing-container'],
-  exclude: [
-    '.flight-sprite-container',
-    // trying to exclude SVGs in flight icons
-    '.flight-icon',
-    '.shw-page-main',
-    // This is because we allow role=separator on an LI element in the HDS dropdown
-    '.hds-dropdown__list',
-  ],
+  exclude: ['.flight-sprite-container', '.shw-page-main'],
 });
 
 // uncomment this next line to turn the tests on globally

--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -13,7 +13,7 @@ import {
   DEFAULT_A11Y_TEST_HELPER_NAMES,
   setRunOptions,
   setupGlobalA11yHooks,
-  setEnableA11yAudit,
+  // setEnableA11yAudit,
 } from 'ember-a11y-testing/test-support';
 
 setApplication(Application.create(config.APP));
@@ -52,7 +52,7 @@ setRunOptions({
 });
 
 // uncomment this next line to turn the tests on globally
-setEnableA11yAudit(true);
+//setEnableA11yAudit(true);
 
 setup(QUnit.assert);
 

--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -13,6 +13,7 @@ import {
   DEFAULT_A11Y_TEST_HELPER_NAMES,
   setRunOptions,
   setupGlobalA11yHooks,
+  setEnableA11yAudit,
 } from 'ember-a11y-testing/test-support';
 
 setApplication(Application.create(config.APP));
@@ -27,9 +28,6 @@ setupGlobalA11yHooks(() => true, {
   ],
 });
 
-// uncomment this next line to turn the tests on globally
-// setEnableA11yAudit(true);
-
 setRunOptions({
   runOnly: {
     type: 'tag',
@@ -43,8 +41,18 @@ setRunOptions({
     ],
   },
   include: ['#ember-testing-container'],
-  exclude: ['.flight-sprite-container', '.shw-page-main'],
+  exclude: [
+    '.flight-sprite-container',
+    // trying to exclude SVGs in flight icons
+    '.flight-icon',
+    '.shw-page-main',
+    // This is because we allow role=separator on an LI element in the HDS dropdown
+    '.hds-dropdown__list',
+  ],
 });
+
+// uncomment this next line to turn the tests on globally
+setEnableA11yAudit(true);
 
 setup(QUnit.assert);
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a commented out line in our test-helper.js to globally enable `a11yAudit`

### :hammer_and_wrench: Detailed description

Added to test-helper.js: 

```
// uncomment this next line to turn the tests on globally
// setEnableA11yAudit(true);
```

This is so we have the proper global invocation in the test-helper file if/when we are ready to use it. 

**Note:** Something that I still don't understand- despite the run options set in the test-helper file, if I turn on the global invocation, some tests still fail because it's trying to test the icon sprite. So I'm not sure why it's not being properly excluded, still need to troubleshoot.

***

### 👀 Reviewer's checklist:
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
