### PR TITLE
`Form::TextInput` - Add loading state on "search" type

### DIFF
--- a/.changeset/bright-cougars-dress.md
+++ b/.changeset/bright-cougars-dress.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-Add loading state on search input
+`Form::TextInput` - Add loading state on "search" type

--- a/.changeset/bright-cougars-dress.md
+++ b/.changeset/bright-cougars-dress.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Add loading state on search input

--- a/.changeset/tricky-badgers-try.md
+++ b/.changeset/tricky-badgers-try.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-tokens": minor
 ---
 
-Add design token for loading state on search input
+Add design token for loading state icon on search input

--- a/.changeset/tricky-badgers-try.md
+++ b/.changeset/tricky-badgers-try.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-tokens": minor
+---
+
+Add design token for loading state on search input

--- a/packages/components/addon/components/hds/form/text-input/base.js
+++ b/packages/components/addon/components/hds/form/text-input/base.js
@@ -14,9 +14,9 @@ export const TYPES = [
   'email',
   'password',
   'url',
-  'search',
   'date',
   'time',
+  'search',
 ];
 
 export default class HdsFormTextInputBaseComponent extends Component {
@@ -54,6 +54,11 @@ export default class HdsFormTextInputBaseComponent extends Component {
     // add a class based on the @isInvalid argument
     if (this.args.isInvalid) {
       classes.push(`hds-form-text-input--is-invalid`);
+    }
+
+    // add a class based on the @isLoading argument
+    if (this.args.isLoading) {
+      classes.push(`hds-form-text-input--is-loading`);
     }
 
     return classes.join(' ');

--- a/packages/components/addon/components/hds/form/text-input/field.hbs
+++ b/packages/components/addon/components/hds/form/text-input/field.hbs
@@ -19,6 +19,7 @@
       @value={{@value}}
       @isInvalid={{@isInvalid}}
       @width={{@width}}
+      @isLoading={{@isLoading}}
       required={{@isRequired}}
       ...attributes
       id={{F.id}}

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -141,5 +141,10 @@
       // stylelint-disable-next-line property-no-vendor-prefix
       -webkit-appearance: none;
     }
+
+    // IS LOADING
+    &.hds-form-text-input--is-loading {
+      background-image: var(--token-form-text-input-background-image-data-url-search-loading);
+    }
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -33,7 +33,7 @@
         <Hds::Form::TextInput::Base @type={{type}} @value={{type}} />
       </SG.Item>
     {{/each}}
-    <SG.Item @label="Search loading">
+    <SG.Item @label="Search (loading state)">
       <Hds::Form::TextInput::Base @type="search" @value="search" @isLoading={{true}} />
     </SG.Item>
   </Shw::Grid>

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -27,12 +27,15 @@
 
   <Shw::Text::H3>Types (native)</Shw::Text::H3>
 
-  <Shw::Grid @columns={{5}} as |SG|>
+  <Shw::Grid @columns={{4}} as |SG|>
     {{#each @model.TYPES as |type|}}
       <SG.Item @label={{capitalize type}}>
         <Hds::Form::TextInput::Base @type={{type}} @value={{type}} />
       </SG.Item>
     {{/each}}
+    <SG.Item @label="Search loading">
+      <Hds::Form::TextInput::Base @type="search" @value="search" @isLoading={{true}} />
+    </SG.Item>
   </Shw::Grid>
 
   <Shw::Text::H3>States</Shw::Text::H3>

--- a/packages/components/tests/integration/components/hds/form/text-input/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/base-test.js
@@ -53,6 +53,17 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
       .hasClass('hds-form-text-input--is-invalid');
   });
 
+  // IS LOADING
+
+  test('it should render the correct CSS class if the @isLoading prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @type="search" @isLoading={{true}} />`
+    );
+    assert
+      .dom('#test-form-text-input')
+      .hasClass('hds-form-text-input--is-loading');
+  });
+
   // WIDTH
 
   test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
@@ -77,7 +88,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {
     const errorMessage =
-      '@type for "Hds::Form::TextInput" must be one of the following: text, email, password, url, search, date, time; received: foo';
+      '@type for "Hds::Form::TextInput" must be one of the following: text, email, password, url, date, time, search; received: foo';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/packages/components/tests/integration/components/hds/form/text-input/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/field-test.js
@@ -45,6 +45,15 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
     assert.dom('input').hasClass('hds-form-text-input--is-invalid');
   });
 
+  // IS LOADING
+
+  test('it should render the correct CSS class if the @isLoading prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Form::TextInput::Field @type="search" @isLoading={{true}} />`
+    );
+    assert.dom('input').hasClass('hds-form-text-input--is-loading');
+  });
+
   // WIDTH
 
   test('it should render the input with a fixed width if a @width value is passed', async function (assert) {

--- a/packages/tokens/dist/devdot/css/tokens.css
+++ b/packages/tokens/dist/devdot/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Apr 2023 20:11:40 GMT
+ * Generated on Wed, 28 Jun 2023 07:32:09 GMT
  */
 
 :root {
@@ -234,6 +234,7 @@
   --token-form-text-input-background-image-data-url-time: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%233B3D45'%3e%3cpath d='M8.5 3.75a.75.75 0 00-1.5 0V8c0 .284.16.544.415.67l2.5 1.25a.75.75 0 10.67-1.34L8.5 7.535V3.75z'/%3e%3cpath d='M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e"); /* notice: the icon color is hardcoded here! */
   --token-form-text-input-background-image-data-url-search: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%23656A76'%3e%3cpath d='M7.25 2a5.25 5.25 0 103.144 9.455l2.326 2.325a.75.75 0 101.06-1.06l-2.325-2.326A5.25 5.25 0 007.25 2zM3.5 7.25a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e"); /* notice: the icon color is hardcoded here! */
   --token-form-text-input-background-image-data-url-search-cancel: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3e%3c/svg%3e"); /* notice: the icon color is hardcoded here! */
+  --token-form-text-input-background-image-data-url-search-loading: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e"); /* notice: the icon color and animation are hardcoded here! */
   --token-form-toggle-width: 32px;
   --token-form-toggle-height: 16px;
   --token-form-toggle-base-surface-color-default: #f1f2f3; /* the toggle has a different base surface color, compared to the other controls */

--- a/packages/tokens/dist/docs/devdot/tokens.json
+++ b/packages/tokens/dist/docs/devdot/tokens.json
@@ -4992,6 +4992,27 @@
     ]
   },
   {
+    "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e\")",
+    "comment": "notice: the icon color and animation are hardcoded here!",
+    "original": {
+      "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e\")",
+      "comment": "notice: the icon color and animation are hardcoded here!"
+    },
+    "name": "token-form-text-input-background-image-data-url-search-loading",
+    "attributes": {
+      "category": "form",
+      "type": "text-input",
+      "item": "background-image",
+      "subitem": "data-url-search-loading"
+    },
+    "path": [
+      "form",
+      "text-input",
+      "background-image",
+      "data-url-search-loading"
+    ]
+  },
+  {
     "value": "32px",
     "type": "size",
     "original": {

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -4946,6 +4946,27 @@
     ]
   },
   {
+    "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e\")",
+    "comment": "notice: the icon color and animation are hardcoded here!",
+    "original": {
+      "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e\")",
+      "comment": "notice: the icon color and animation are hardcoded here!"
+    },
+    "name": "token-form-text-input-background-image-data-url-search-loading",
+    "attributes": {
+      "category": "form",
+      "type": "text-input",
+      "item": "background-image",
+      "subitem": "data-url-search-loading"
+    },
+    "path": [
+      "form",
+      "text-input",
+      "background-image",
+      "data-url-search-loading"
+    ]
+  },
+  {
     "value": "32px",
     "type": "size",
     "original": {

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Apr 2023 20:11:40 GMT
+ * Generated on Wed, 28 Jun 2023 07:32:09 GMT
  */
 
 :root {
@@ -232,6 +232,7 @@
   --token-form-text-input-background-image-data-url-time: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%233B3D45'%3e%3cpath d='M8.5 3.75a.75.75 0 00-1.5 0V8c0 .284.16.544.415.67l2.5 1.25a.75.75 0 10.67-1.34L8.5 7.535V3.75z'/%3e%3cpath d='M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e"); /* notice: the icon color is hardcoded here! */
   --token-form-text-input-background-image-data-url-search: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%23656A76'%3e%3cpath d='M7.25 2a5.25 5.25 0 103.144 9.455l2.326 2.325a.75.75 0 101.06-1.06l-2.325-2.326A5.25 5.25 0 007.25 2zM3.5 7.25a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e"); /* notice: the icon color is hardcoded here! */
   --token-form-text-input-background-image-data-url-search-cancel: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3e%3c/svg%3e"); /* notice: the icon color is hardcoded here! */
+  --token-form-text-input-background-image-data-url-search-loading: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e"); /* notice: the icon color and animation are hardcoded here! */
   --token-form-toggle-width: 32px;
   --token-form-toggle-height: 16px;
   --token-form-toggle-base-surface-color-default: #f1f2f3; /* the toggle has a different base surface color, compared to the other controls */

--- a/packages/tokens/src/products/shared/form/text-input.json
+++ b/packages/tokens/src/products/shared/form/text-input.json
@@ -25,6 +25,10 @@
                 "data-url-search-cancel": {
                     "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3e%3c/svg%3e\")",
                     "comment": "notice: the icon color is hardcoded here!"
+                },
+                "data-url-search-loading": {
+                    "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e\")",
+                    "comment": "notice: the icon color and animation are hardcoded here!"
                 }
             }
         }

--- a/website/docs/components/form/text-input/partials/code/component-api.md
+++ b/website/docs/components/form/text-input/partials/code/component-api.md
@@ -17,6 +17,9 @@ The Text Input component has two different variants with their own APIs:
   <C.Property @name="isInvalid" @type="boolean" @default="false">
     Applies an “invalid” appearance to the control but doesn’t modify its logical validity.
   </C.Property>
+  <C.Property @name="isLoading" @type="boolean" @default="false">
+    When true, it shows a loading indicator instead of a magnifying glass; only applicable when `@type="search"`.
+  </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the `<input>` fills the parent container. If a `@width` parameter is provided, the control will have a fixed width.
   </C.Property>
@@ -40,6 +43,9 @@ The Text Input component has two different variants with their own APIs:
   </C.Property>
   <C.Property @name="isInvalid" @type="boolean" @default="false">
     Applies an “invalid” appearance to the control but doesn’t modify its logical validity.
+  </C.Property>
+  <C.Property @name="isLoading" @type="boolean" @default="false">
+    When true, it shows a loading indicator instead of a magnifying glass; only applicable when `@type="search"`.
   </C.Property>
   <C.Property @name="isRequired" @type="boolean" @default="false">
     Appends a `Required` indicator next to the label text and sets the `required` attribute on the control when user input is required.


### PR DESCRIPTION
### :pushpin: Summary

Add `@isLoading` on `<TextInput @type="search"/>`

### :hammer_and_wrench: Detailed description

When a search operation does not happen instantly it is often helpful to reflect the loading state in the search input.

We're introducing the `@isLoading` argument on `<TextInput @type="search"/>` to replace the magnifying glass with a loading spinner to be used while fetching the results in a search operation.

Note: we traditionally apply the animation to the loading icon via CSS, but in the current implementation, the magnifying glass is a background image on the `<input>` element, so it wouldn't work. For this reason, we create an SVG animation.

[Preview showcase](https://hds-showcase-6p7hxb1h8-hashicorp.vercel.app/components/form/text-input)
[Preview docs](https://hds-website-git-alex-ju-add-is-loading-to-sear-3cf15c-hashicorp.vercel.app/components/form/text-input?tab=code#formtextinputbase-1)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2116](https://hashicorp.atlassian.net/browse/HDS-2116)
Figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/branch/905U1TC13EGOlA1DBNHrT1/HDS-Product---Components?type=design&mode=design&t=mvoLMF4ztq7moXzs-1

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2116]: https://hashicorp.atlassian.net/browse/HDS-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ