### PR TITLE
`SideNav` Polish Exploration

### DIFF
--- a/packages/components/app/styles/components/side-nav/content.scss
+++ b/packages/components/app/styles/components/side-nav/content.scss
@@ -7,8 +7,7 @@
 // SIDE-NAV > CONTENT (PORTALS + LISTS OF ITEMS/LINKS)
 //
 
-@use "../../mixins/focus-ring" as *;
-
+@use '../../mixins/focus-ring' as *;
 
 // PANELS (wrappers used in conjunction with the portal elements)
 
@@ -40,24 +39,26 @@
   color: var(--token-side-nav-color-foreground-faint);
 
   // Remove margin from title at top of all list-items & lists
-  .hds-side-nav__list-wrapper:first-child .hds-side-nav__list-item:first-child > & {
+  .hds-side-nav__list-wrapper:first-child
+    .hds-side-nav__list-item:first-child
+    > & {
     margin-top: 0;
   }
 }
 
-
 // LIST (root elements)
 
 .hds-side-nav__list-wrapper, // <nav> element
-.hds-side-nav__list {        // <ul> element
+.hds-side-nav__list {
+  // <ul> element
   margin: 0;
   padding: 0;
 }
 
-
 // ITEM (generic container)
 
-.hds-side-nav__list-item { // <li> element
+.hds-side-nav__list-item {
+  // <li> element
   list-style-type: none;
 
   & + & {
@@ -65,16 +66,22 @@
   }
 }
 
-.hds-side-nav__list-item-link { // <a>/<button> element (via Hds::Interactive)
+.hds-side-nav__list-item-link {
+  // <a>/<button> element (via Hds::Interactive)
   display: flex;
   gap: var(--token-side-nav-body-list-item-content-spacing-horizontal);
   align-items: center;
   width: 100%;
   min-height: var(--token-side-nav-body-list-item-height);
-  padding: var(--token-side-nav-body-list-item-padding-vertical) var(--token-side-nav-body-list-item-padding-horizontal);
+  padding: var(--token-side-nav-body-list-item-padding-vertical)
+    var(--token-side-nav-body-list-item-padding-horizontal);
   color: var(--token-side-nav-color-foreground-primary);
   text-decoration: none;
-  background: var(--token-side-nav-color-surface-primary);
+
+  // Testing gradients
+  // background: var(--token-side-nav-color-surface-primary);
+  background: transparent;
+
   // "Link" could render as an HTML button element so this overrides the default border style in that case:
   border-color: transparent;
   border-radius: var(--token-side-nav-body-list-item-border-radius);
@@ -134,7 +141,6 @@
     }
   }
 }
-
 
 // LIST ITEM > INNER ELEMENTS
 

--- a/packages/components/app/styles/components/side-nav/content.scss
+++ b/packages/components/app/styles/components/side-nav/content.scss
@@ -7,7 +7,7 @@
 // SIDE-NAV > CONTENT (PORTALS + LISTS OF ITEMS/LINKS)
 //
 
-@use '../../mixins/focus-ring' as *;
+@use "../../mixins/focus-ring" as *;
 
 // PANELS (wrappers used in conjunction with the portal elements)
 
@@ -39,9 +39,7 @@
   color: var(--token-side-nav-color-foreground-faint);
 
   // Remove margin from title at top of all list-items & lists
-  .hds-side-nav__list-wrapper:first-child
-    .hds-side-nav__list-item:first-child
-    > & {
+  .hds-side-nav__list-wrapper:first-child .hds-side-nav__list-item:first-child > & {
     margin-top: 0;
   }
 }
@@ -73,7 +71,8 @@
   align-items: center;
   width: 100%;
   min-height: var(--token-side-nav-body-list-item-height);
-  padding: var(--token-side-nav-body-list-item-padding-vertical)
+  padding:
+    var(--token-side-nav-body-list-item-padding-vertical)
     var(--token-side-nav-body-list-item-padding-horizontal);
   color: var(--token-side-nav-color-foreground-primary);
   text-decoration: none;

--- a/packages/components/app/styles/components/side-nav/main.scss
+++ b/packages/components/app/styles/components/side-nav/main.scss
@@ -11,7 +11,9 @@
   position: sticky;
   top: 0;
   z-index: 20; // needs to stay above the main content
-  width: var(--hds-app-sidenav-width-fixed); // "default" width used by the `SideNav::Base` subcomponent (that is not responsive)
+  width: var(
+    --hds-app-sidenav-width-fixed
+  ); // "default" width used by the `SideNav::Base` subcomponent (that is not responsive)
   height: 100vh;
   min-height: 100vh;
   isolation: isolate; // used to create a new stacking context (so we can set the overlay's z-index to -1)
@@ -19,8 +21,7 @@
   // RESPONSIVENESS - This controls the width of the top-level container ("sidebar") in the grid, and impacts the available space for the "main" grid area
 
   &.hds-side-nav--is-responsive {
-    transition:
-      width var(--hds-app-sidenav-animation-duration)
+    transition: width var(--hds-app-sidenav-animation-duration)
       var(--hds-app-sidenav-animation-easing);
   }
 
@@ -35,7 +36,6 @@
   }
 }
 
-
 // OVERLAY
 
 .hds-side-nav__overlay {
@@ -44,8 +44,7 @@
   inset: 0;
   background-color: var(--token-color-palette-neutral-700);
   opacity: 0.2;
-  transition:
-    opacity var(--hds-app-sidenav-animation-duration)
+  transition: opacity var(--hds-app-sidenav-animation-duration)
     var(--hds-app-sidenav-animation-easing)
     var(--hds-app-sidenav-animation-delay);
 
@@ -60,7 +59,6 @@
     display: none;
   }
 }
-
 
 // MENU/TOGGLE BUTTON
 
@@ -98,8 +96,7 @@
     padding: 1px;
     background-color: var(--token-color-foreground-primary);
     border-radius: 3px;
-    transform:
-      translateX(calc(var(--hds-app-sidenav-width-expanded) + 8px))
+    transform: translateX(calc(var(--hds-app-sidenav-width-expanded) + 8px))
       translateY(24px);
     // z-index: 15; // not needed anymore?
   }
@@ -110,7 +107,8 @@
     height: 36px;
     padding: 5px;
     border-radius: 5px;
-    transform: translateX(22px) translateY(var(--hds-app-sidenav-menu-button-y-shift));
+    transform: translateX(22px)
+      translateY(var(--hds-app-sidenav-menu-button-y-shift));
   }
 
   // when it's desktop we _never_ want to show the menu/toggle button
@@ -119,7 +117,6 @@
   }
 }
 
-
 // RESPONSIVE WRAPPER
 // this container element is used to control the width of the sidebar at different viewports (desktop/mobile) and states (minimized/expanded)
 
@@ -127,14 +124,16 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  color: var(--token-side-nav-color-foreground-primary); // we set a default color (in case generic content is added to the header/body/footer of the sidenav)
-  background: var(--token-side-nav-color-surface-primary);
+  color: var(
+    --token-side-nav-color-foreground-primary
+  ); // we set a default color (in case generic content is added to the header/body/footer of the sidenav)
+
+  // background: var(--token-side-nav-color-surface-primary);
 
   // RESPONSIVENESS - This controls the width of the "sidenav" container, and is independent (bur related) from the parent "sidebar" grid area
 
   .hds-side-nav--is-responsive & {
-    transition:
-      width var(--hds-app-sidenav-animation-duration)
+    transition: width var(--hds-app-sidenav-animation-duration)
       var(--hds-app-sidenav-animation-easing);
   }
 
@@ -164,8 +163,7 @@
 
 .hds-side-nav__wrapper-body {
   flex: 1;
-  padding:
-    var(--token-side-nav-wrapper-padding-vertical)
+  padding: var(--token-side-nav-wrapper-padding-vertical)
     var(--token-side-nav-wrapper-padding-horizontal);
   // this is necessary, otherwise when the sidenav is minimized an horizontal scrollbar may appear
   // (if there are words longer than the width of the available space for the list "item" content)
@@ -175,11 +173,9 @@
 }
 
 .hds-side-nav__wrapper-footer {
-  padding:
-    var(--token-side-nav-wrapper-padding-vertical)
+  padding: var(--token-side-nav-wrapper-padding-vertical)
     var(--token-side-nav-wrapper-padding-horizontal);
 }
-
 
 // "HIDE-WHEN-MINIMIZED" SPECIAL CLASS
 // this is a special class that is used to control which elements of the sidenav need to be:
@@ -197,8 +193,7 @@
   .hds-side-nav--is-desktop & {
     visibility: visible;
     opacity: 1;
-    transition:
-      opacity var(--hds-app-sidenav-animation-duration)
+    transition: opacity var(--hds-app-sidenav-animation-duration)
       var(--hds-app-sidenav-animation-easing)
       var(--hds-app-sidenav-animation-delay);
   }
@@ -207,5 +202,31 @@
   // (elements with `visibility: visible` can already be interacted with, while their opacity is transitioning)
   .hds-side-nav--is-animating & {
     pointer-events: none;
+  }
+}
+
+// THIS IS FOR TESTING
+
+$visual-refresh-props: (
+  '10' rgba(255, 255, 255, 0.1) 0%,
+  '15' rgba(255, 255, 255, 0.15) 0%,
+  '20' rgba(255, 255, 255, 0.2) 0%,
+  '25' rgba(255, 255, 255, 0.25) 0%,
+  '30' rgba(255, 255, 255, 0.3) 0%
+);
+
+$visual-refresh-dark-props: ();
+
+@each $opacity, $value in $visual-refresh-props {
+  .hds-side-nav-polish_visual-refresh--#{$opacity} {
+    background: linear-gradient(225deg, $value, rgba(255, 255, 255, 0) 100%),
+      #111214;
+  }
+}
+
+@each $opacity, $value in $visual-refresh-dark-props {
+  .hds-side-nav-polish_visual-refresh--#{$opacity} {
+    background: linear-gradient(225deg, $value, rgba(255, 255, 255, 0) 100%),
+      var(--token-color-palette-neutral-700);
   }
 }

--- a/packages/components/app/styles/components/side-nav/main.scss
+++ b/packages/components/app/styles/components/side-nav/main.scss
@@ -224,10 +224,11 @@ $visual-refresh-dark-props: (
 );
 
 $explore-01-props: (
-  '10' rgba(132, 79, 186, 0.04) rgba(62, 118, 255, 0.04) rgba(132, 79, 186, 0.1),
+  '10' rgba(132, 79, 186, 0.03) rgba(62, 118, 255, 0.03)
+    rgba(132, 79, 186, 0.06),
   '15' rgba(132, 79, 186, 0.04) rgba(62, 118, 255, 0.04) rgba(132, 79, 186, 0.1),
-  '20' rgba(132, 79, 186, 0.06) rgba(62, 118, 255, 0.06)
-    rgba(132, 79, 186, 0.16),
+  '20' rgba(132, 79, 186, 0.05) rgba(62, 118, 255, 0.05)
+    rgba(132, 79, 186, 0.13),
   '25' rgba(132, 79, 186, 0.06) rgba(62, 118, 255, 0.06)
     rgba(132, 79, 186, 0.16),
   '30' rgba(132, 79, 186, 0.08) rgba(62, 118, 255, 0.08) rgba(132, 79, 186, 0.2)
@@ -239,6 +240,30 @@ $explore-02-props: (
   '20' rgba(63, 63, 74, 0.2),
   '25' rgba(63, 63, 74, 0.25),
   '30' rgba(63, 63, 74, 0.3)
+);
+
+$explore-03-props: (
+  '10' rgba(109, 109, 128, 0.1),
+  '15' rgba(109, 109, 128, 0.15),
+  '20' rgba(109, 109, 128, 0.2),
+  '25' rgba(109, 109, 128, 0.25),
+  '30' rgba(109, 109, 128, 0.3)
+);
+
+$explore-04-props: (
+  '10' rgba(142, 142, 166, 0.1),
+  '15' rgba(142, 142, 166, 0.15),
+  '20' rgba(142, 142, 166, 0.2),
+  '25' rgba(142, 142, 166, 0.25),
+  '30' rgba(142, 142, 166, 0.3)
+);
+
+$explore-05-props: (
+  '10' rgba(164, 164, 191, 0.1),
+  '15' rgba(164, 164, 191, 0.15),
+  '20' rgba(164, 164, 191, 0.2),
+  '25' rgba(164, 164, 191, 0.25),
+  '30' rgba(164, 164, 191, 0.3)
 );
 
 @each $opacity, $value in $visual-refresh-props {
@@ -258,13 +283,34 @@ $explore-02-props: (
 @each $opacity, $stop-1, $stop-2, $stop-3 in $explore-01-props {
   .hds-side-nav-polish_explore-01--#{$opacity} {
     background: linear-gradient(45deg, $stop-1 0%, $stop-2 72.22%, $stop-3 100%),
-      #0c0c0e;
+      var(--token-color-palette-neutral-700);
   }
 }
 
 @each $opacity, $value in $explore-02-props {
   .hds-side-nav-polish_explore-02--#{$opacity} {
-    background: linear-gradient(225deg, $value 0%, rgba(255, 255, 255, 0) 100%),
+    background: linear-gradient(225deg, $value 0%, rgba(63, 63, 74, 0) 100%),
+      var(--token-color-palette-neutral-700);
+  }
+}
+
+@each $opacity, $value in $explore-03-props {
+  .hds-side-nav-polish_explore-03--#{$opacity} {
+    background: linear-gradient(225deg, $value 0%, rgba(109, 109, 128, 0) 100%),
+      var(--token-color-palette-neutral-700);
+  }
+}
+
+@each $opacity, $value in $explore-04-props {
+  .hds-side-nav-polish_explore-04--#{$opacity} {
+    background: linear-gradient(225deg, $value 0%, rgba(142, 142, 166, 0) 100%),
+      var(--token-color-palette-neutral-700);
+  }
+}
+
+@each $opacity, $value in $explore-05-props {
+  .hds-side-nav-polish_explore-05--#{$opacity} {
+    background: linear-gradient(225deg, $value 0%, rgba(164, 164, 191, 0) 100%),
       var(--token-color-palette-neutral-700);
   }
 }

--- a/packages/components/app/styles/components/side-nav/main.scss
+++ b/packages/components/app/styles/components/side-nav/main.scss
@@ -11,9 +11,8 @@
   position: sticky;
   top: 0;
   z-index: 20; // needs to stay above the main content
-  width: var(
-    --hds-app-sidenav-width-fixed
-  ); // "default" width used by the `SideNav::Base` subcomponent (that is not responsive)
+  width:
+ var(--hds-app-sidenav-width-fixed); // "default" width used by the `SideNav::Base` subcomponent (that is not responsive)
   height: 100vh;
   min-height: 100vh;
   isolation: isolate; // used to create a new stacking context (so we can set the overlay's z-index to -1)
@@ -21,7 +20,8 @@
   // RESPONSIVENESS - This controls the width of the top-level container ("sidebar") in the grid, and impacts the available space for the "main" grid area
 
   &.hds-side-nav--is-responsive {
-    transition: width var(--hds-app-sidenav-animation-duration)
+    transition:
+      width var(--hds-app-sidenav-animation-duration)
       var(--hds-app-sidenav-animation-easing);
   }
 
@@ -44,7 +44,8 @@
   inset: 0;
   background-color: var(--token-color-palette-neutral-700);
   opacity: 0.2;
-  transition: opacity var(--hds-app-sidenav-animation-duration)
+  transition:
+    opacity var(--hds-app-sidenav-animation-duration)
     var(--hds-app-sidenav-animation-easing)
     var(--hds-app-sidenav-animation-delay);
 
@@ -96,7 +97,8 @@
     padding: 1px;
     background-color: var(--token-color-foreground-primary);
     border-radius: 3px;
-    transform: translateX(calc(var(--hds-app-sidenav-width-expanded) + 8px))
+    transform:
+      translateX(calc(var(--hds-app-sidenav-width-expanded) + 8px))
       translateY(24px);
     // z-index: 15; // not needed anymore?
   }
@@ -107,7 +109,8 @@
     height: 36px;
     padding: 5px;
     border-radius: 5px;
-    transform: translateX(22px)
+    transform:
+      translateX(22px)
       translateY(var(--hds-app-sidenav-menu-button-y-shift));
   }
 
@@ -124,16 +127,16 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  color: var(
-    --token-side-nav-color-foreground-primary
-  ); // we set a default color (in case generic content is added to the header/body/footer of the sidenav)
+  color:
+ var(--token-side-nav-color-foreground-primary); // we set a default color (in case generic content is added to the header/body/footer of the sidenav)
 
   // background: var(--token-side-nav-color-surface-primary);
 
   // RESPONSIVENESS - This controls the width of the "sidenav" container, and is independent (bur related) from the parent "sidebar" grid area
 
   .hds-side-nav--is-responsive & {
-    transition: width var(--hds-app-sidenav-animation-duration)
+    transition:
+      width var(--hds-app-sidenav-animation-duration)
       var(--hds-app-sidenav-animation-easing);
   }
 
@@ -163,7 +166,8 @@
 
 .hds-side-nav__wrapper-body {
   flex: 1;
-  padding: var(--token-side-nav-wrapper-padding-vertical)
+  padding:
+    var(--token-side-nav-wrapper-padding-vertical)
     var(--token-side-nav-wrapper-padding-horizontal);
   // this is necessary, otherwise when the sidenav is minimized an horizontal scrollbar may appear
   // (if there are words longer than the width of the available space for the list "item" content)
@@ -173,7 +177,8 @@
 }
 
 .hds-side-nav__wrapper-footer {
-  padding: var(--token-side-nav-wrapper-padding-vertical)
+  padding:
+    var(--token-side-nav-wrapper-padding-vertical)
     var(--token-side-nav-wrapper-padding-horizontal);
 }
 
@@ -193,7 +198,8 @@
   .hds-side-nav--is-desktop & {
     visibility: visible;
     opacity: 1;
-    transition: opacity var(--hds-app-sidenav-animation-duration)
+    transition:
+      opacity var(--hds-app-sidenav-animation-duration)
       var(--hds-app-sidenav-animation-easing)
       var(--hds-app-sidenav-animation-delay);
   }
@@ -208,109 +214,110 @@
 // THIS IS FOR TESTING
 
 $visual-refresh-props: (
-  '10' rgba(255, 255, 255, 0.1),
-  '15' rgba(255, 255, 255, 0.15),
-  '20' rgba(255, 255, 255, 0.2),
-  '25' rgba(255, 255, 255, 0.25),
-  '30' rgba(255, 255, 255, 0.3)
+  "10" rgba(255, 255, 255, 10%),
+  "15" rgba(255, 255, 255, 15%),
+  "20" rgba(255, 255, 255, 20%),
+  "25" rgba(255, 255, 255, 25%),
+  "30" rgba(255, 255, 255, 30%)
 );
-
 $visual-refresh-dark-props: (
-  '10' rgba(255, 255, 255, 0.1),
-  '15' rgba(255, 255, 255, 0.15),
-  '20' rgba(255, 255, 255, 0.2),
-  '25' rgba(255, 255, 255, 0.25),
-  '30' rgba(255, 255, 255, 0.3)
+  "10" rgba(255, 255, 255, 10%),
+  "15" rgba(255, 255, 255, 15%),
+  "20" rgba(255, 255, 255, 20%),
+  "25" rgba(255, 255, 255, 25%),
+  "30" rgba(255, 255, 255, 30%)
 );
-
 $explore-01-props: (
-  '10' rgba(132, 79, 186, 0.03) rgba(62, 118, 255, 0.03)
-    rgba(132, 79, 186, 0.06),
-  '15' rgba(132, 79, 186, 0.04) rgba(62, 118, 255, 0.04) rgba(132, 79, 186, 0.1),
-  '20' rgba(132, 79, 186, 0.05) rgba(62, 118, 255, 0.05)
-    rgba(132, 79, 186, 0.13),
-  '25' rgba(132, 79, 186, 0.06) rgba(62, 118, 255, 0.06)
-    rgba(132, 79, 186, 0.16),
-  '30' rgba(132, 79, 186, 0.08) rgba(62, 118, 255, 0.08) rgba(132, 79, 186, 0.2)
+  "10" rgba(132, 79, 186, 3%) rgba(62, 118, 255, 3%)
+  rgba(132, 79, 186, 6%),
+  "15" rgba(132, 79, 186, 4%) rgba(62, 118, 255, 4%) rgba(132, 79, 186, 10%),
+  "20" rgba(132, 79, 186, 5%) rgba(62, 118, 255, 5%)
+  rgba(132, 79, 186, 13%),
+  "25" rgba(132, 79, 186, 6%) rgba(62, 118, 255, 6%)
+  rgba(132, 79, 186, 16%),
+  "30" rgba(132, 79, 186, 8%) rgba(62, 118, 255, 8%) rgba(132, 79, 186, 20%)
 );
-
 $explore-02-props: (
-  '10' rgba(63, 63, 74, 0.1),
-  '15' rgba(63, 63, 74, 0.15),
-  '20' rgba(63, 63, 74, 0.2),
-  '25' rgba(63, 63, 74, 0.25),
-  '30' rgba(63, 63, 74, 0.3)
+  "10" rgba(63, 63, 74, 10%),
+  "15" rgba(63, 63, 74, 15%),
+  "20" rgba(63, 63, 74, 20%),
+  "25" rgba(63, 63, 74, 25%),
+  "30" rgba(63, 63, 74, 30%)
 );
-
 $explore-03-props: (
-  '10' rgba(109, 109, 128, 0.1),
-  '15' rgba(109, 109, 128, 0.15),
-  '20' rgba(109, 109, 128, 0.2),
-  '25' rgba(109, 109, 128, 0.25),
-  '30' rgba(109, 109, 128, 0.3)
+  "10" rgba(109, 109, 128, 10%),
+  "15" rgba(109, 109, 128, 15%),
+  "20" rgba(109, 109, 128, 20%),
+  "25" rgba(109, 109, 128, 25%),
+  "30" rgba(109, 109, 128, 30%)
 );
-
 $explore-04-props: (
-  '10' rgba(142, 142, 166, 0.1),
-  '15' rgba(142, 142, 166, 0.15),
-  '20' rgba(142, 142, 166, 0.2),
-  '25' rgba(142, 142, 166, 0.25),
-  '30' rgba(142, 142, 166, 0.3)
+  "10" rgba(142, 142, 166, 10%),
+  "15" rgba(142, 142, 166, 15%),
+  "20" rgba(142, 142, 166, 20%),
+  "25" rgba(142, 142, 166, 25%),
+  "30" rgba(142, 142, 166, 30%)
 );
-
 $explore-05-props: (
-  '10' rgba(164, 164, 191, 0.1),
-  '15' rgba(164, 164, 191, 0.15),
-  '20' rgba(164, 164, 191, 0.2),
-  '25' rgba(164, 164, 191, 0.25),
-  '30' rgba(164, 164, 191, 0.3)
+  "10" rgba(164, 164, 191, 10%),
+  "15" rgba(164, 164, 191, 15%),
+  "20" rgba(164, 164, 191, 20%),
+  "25" rgba(164, 164, 191, 25%),
+  "30" rgba(164, 164, 191, 30%)
 );
 
 @each $opacity, $value in $visual-refresh-props {
   .hds-side-nav-polish_visual-refresh--#{$opacity} {
-    background: linear-gradient(225deg, $value 0%, rgba(255, 255, 255, 0) 100%),
+    background:
+      linear-gradient(225deg, $value 0%, rgba(255, 255, 255, 0%) 100%),
       #111214;
   }
 }
 
 @each $opacity, $value in $visual-refresh-dark-props {
   .hds-side-nav-polish_visual-refresh-dark--#{$opacity} {
-    background: linear-gradient(225deg, $value 0%, rgba(255, 255, 255, 0) 100%),
+    background:
+      linear-gradient(225deg, $value 0%, rgba(255, 255, 255, 0%) 100%),
       var(--token-color-palette-neutral-700);
   }
 }
 
 @each $opacity, $stop-1, $stop-2, $stop-3 in $explore-01-props {
   .hds-side-nav-polish_explore-01--#{$opacity} {
-    background: linear-gradient(45deg, $stop-1 0%, $stop-2 72.22%, $stop-3 100%),
+    background:
+      linear-gradient(45deg, $stop-1 0%, $stop-2 72.22%, $stop-3 100%),
       var(--token-color-palette-neutral-700);
   }
 }
 
 @each $opacity, $value in $explore-02-props {
   .hds-side-nav-polish_explore-02--#{$opacity} {
-    background: linear-gradient(225deg, $value 0%, rgba(63, 63, 74, 0) 100%),
+    background:
+      linear-gradient(225deg, $value 0%, rgba(63, 63, 74, 0%) 100%),
       var(--token-color-palette-neutral-700);
   }
 }
 
 @each $opacity, $value in $explore-03-props {
   .hds-side-nav-polish_explore-03--#{$opacity} {
-    background: linear-gradient(225deg, $value 0%, rgba(109, 109, 128, 0) 100%),
+    background:
+      linear-gradient(225deg, $value 0%, rgba(109, 109, 128, 0%) 100%),
       var(--token-color-palette-neutral-700);
   }
 }
 
 @each $opacity, $value in $explore-04-props {
   .hds-side-nav-polish_explore-04--#{$opacity} {
-    background: linear-gradient(225deg, $value 0%, rgba(142, 142, 166, 0) 100%),
+    background:
+      linear-gradient(225deg, $value 0%, rgba(142, 142, 166, 0%) 100%),
       var(--token-color-palette-neutral-700);
   }
 }
 
 @each $opacity, $value in $explore-05-props {
   .hds-side-nav-polish_explore-05--#{$opacity} {
-    background: linear-gradient(225deg, $value 0%, rgba(164, 164, 191, 0) 100%),
+    background:
+      linear-gradient(225deg, $value 0%, rgba(164, 164, 191, 0%) 100%),
       var(--token-color-palette-neutral-700);
   }
 }

--- a/packages/components/app/styles/components/side-nav/main.scss
+++ b/packages/components/app/styles/components/side-nav/main.scss
@@ -208,25 +208,63 @@
 // THIS IS FOR TESTING
 
 $visual-refresh-props: (
-  '10' rgba(255, 255, 255, 0.1) 0%,
-  '15' rgba(255, 255, 255, 0.15) 0%,
-  '20' rgba(255, 255, 255, 0.2) 0%,
-  '25' rgba(255, 255, 255, 0.25) 0%,
-  '30' rgba(255, 255, 255, 0.3) 0%
+  '10' rgba(255, 255, 255, 0.1),
+  '15' rgba(255, 255, 255, 0.15),
+  '20' rgba(255, 255, 255, 0.2),
+  '25' rgba(255, 255, 255, 0.25),
+  '30' rgba(255, 255, 255, 0.3)
 );
 
-$visual-refresh-dark-props: ();
+$visual-refresh-dark-props: (
+  '10' rgba(255, 255, 255, 0.1),
+  '15' rgba(255, 255, 255, 0.15),
+  '20' rgba(255, 255, 255, 0.2),
+  '25' rgba(255, 255, 255, 0.25),
+  '30' rgba(255, 255, 255, 0.3)
+);
+
+$explore-01-props: (
+  '10' rgba(132, 79, 186, 0.04) rgba(62, 118, 255, 0.04) rgba(132, 79, 186, 0.1),
+  '15' rgba(132, 79, 186, 0.04) rgba(62, 118, 255, 0.04) rgba(132, 79, 186, 0.1),
+  '20' rgba(132, 79, 186, 0.06) rgba(62, 118, 255, 0.06)
+    rgba(132, 79, 186, 0.16),
+  '25' rgba(132, 79, 186, 0.06) rgba(62, 118, 255, 0.06)
+    rgba(132, 79, 186, 0.16),
+  '30' rgba(132, 79, 186, 0.08) rgba(62, 118, 255, 0.08) rgba(132, 79, 186, 0.2)
+);
+
+$explore-02-props: (
+  '10' rgba(63, 63, 74, 0.1),
+  '15' rgba(63, 63, 74, 0.15),
+  '20' rgba(63, 63, 74, 0.2),
+  '25' rgba(63, 63, 74, 0.25),
+  '30' rgba(63, 63, 74, 0.3)
+);
 
 @each $opacity, $value in $visual-refresh-props {
   .hds-side-nav-polish_visual-refresh--#{$opacity} {
-    background: linear-gradient(225deg, $value, rgba(255, 255, 255, 0) 100%),
+    background: linear-gradient(225deg, $value 0%, rgba(255, 255, 255, 0) 100%),
       #111214;
   }
 }
 
 @each $opacity, $value in $visual-refresh-dark-props {
-  .hds-side-nav-polish_visual-refresh--#{$opacity} {
-    background: linear-gradient(225deg, $value, rgba(255, 255, 255, 0) 100%),
+  .hds-side-nav-polish_visual-refresh-dark--#{$opacity} {
+    background: linear-gradient(225deg, $value 0%, rgba(255, 255, 255, 0) 100%),
+      var(--token-color-palette-neutral-700);
+  }
+}
+
+@each $opacity, $stop-1, $stop-2, $stop-3 in $explore-01-props {
+  .hds-side-nav-polish_explore-01--#{$opacity} {
+    background: linear-gradient(45deg, $stop-1 0%, $stop-2 72.22%, $stop-3 100%),
+      #0c0c0e;
+  }
+}
+
+@each $opacity, $value in $explore-02-props {
+  .hds-side-nav-polish_explore-02--#{$opacity} {
+    background: linear-gradient(225deg, $value 0%, rgba(255, 255, 255, 0) 100%),
       var(--token-color-palette-neutral-700);
   }
 }

--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -53,6 +53,7 @@ Router.map(function () {
     this.route('segmented-group');
     this.route('separator');
     this.route('side-nav');
+    this.route('side-nav-polish');
     this.route('stepper');
     this.route('table');
     this.route('tag');

--- a/packages/components/tests/dummy/app/routes/components/side-nav-polish.js
+++ b/packages/components/tests/dummy/app/routes/components/side-nav-polish.js
@@ -11,6 +11,9 @@ export const GRADIENT_TESTS = [
   'visual-refresh-dark',
   'explore-01',
   'explore-02',
+  'explore-03',
+  'explore-04',
+  'explore-05',
 ];
 
 export default class ComponentsSideNavPolishRoute extends Route {

--- a/packages/components/tests/dummy/app/routes/components/side-nav-polish.js
+++ b/packages/components/tests/dummy/app/routes/components/side-nav-polish.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+
+export const OPACITY_STOPS = ['10', '15', '20', '25', '30'];
+export const GRADIENT_TESTS = [
+  'visual-refresh',
+  'visual-refresh-dark',
+  'explore-01',
+];
+
+export default class ComponentsSideNavPolishRoute extends Route {
+  model() {
+    return {
+      OPACITY_STOPS,
+      GRADIENT_TESTS,
+    };
+  }
+}

--- a/packages/components/tests/dummy/app/routes/components/side-nav-polish.js
+++ b/packages/components/tests/dummy/app/routes/components/side-nav-polish.js
@@ -10,6 +10,7 @@ export const GRADIENT_TESTS = [
   'visual-refresh',
   'visual-refresh-dark',
   'explore-01',
+  'explore-02',
 ];
 
 export default class ComponentsSideNavPolishRoute extends Route {

--- a/packages/components/tests/dummy/app/templates/components/side-nav-polish.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav-polish.hbs
@@ -1,0 +1,87 @@
+{{page-title "SideNav Polish Exploration"}}
+
+<Shw::Text::H1>SideNav Polish Exploration</Shw::Text::H1>
+
+<section data-test-percy>
+
+  <Shw::Text::H2>Gradient</Shw::Text::H2>
+
+  {{#each @model.GRADIENT_TESTS as |category|}}
+
+  <Shw::Text::H3>{{capitalize category}}</Shw::Text::H3>
+
+  <Shw::Flex as |SF|>
+  {{#each @model.OPACITY_STOPS as |opacity|}}
+    <SF.Item @label="{{opacity}}% opacity">
+      <div class="shw-component-sim-side-nav-root-container" {{style height="auto"}}>
+        <Hds::SideNav
+          @isResponsive={{false}}
+          @hasA11yRefocus={{false}}
+          class="hds-side-nav-polish_visual-refresh--{{opacity}}"
+        >
+          <:header>
+            <Hds::SideNav::Header>
+              <:logo>
+                <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
+              </:logo>
+              <:actions>
+                <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
+                <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                  <dd.ToggleIcon @icon="help" @text="help menu" />
+                  <dd.Title @text="Help & Support" />
+                  <dd.Interactive @text="Documentation" @href="#" />
+                  <dd.Interactive @text="Tutorials" @href="#" />
+                  <dd.Interactive @text="Terraform Provider" @href="#" />
+                  <dd.Interactive @text="Changelog" @href="#" />
+                  <dd.Separator />
+                  <dd.Interactive @text="Create support ticket" @href="#" />
+                  <dd.Interactive @text="Give feedback" @href="#" />
+                </Hds::Dropdown>
+                <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                  <dd.ToggleIcon @icon="user" @text="user menu" />
+                  <dd.Title @text="Signed In" />
+                  <dd.Description @text="email@domain.com" />
+                  <dd.Interactive @href="#" @text="Account Settings" />
+                </Hds::Dropdown>
+              </:actions>
+            </Hds::SideNav::Header>
+          </:header>
+
+          <:body>
+            <Hds::SideNav::List as |SNL|>
+              <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
+            </Hds::SideNav::List>
+
+            <Hds::SideNav::List as |SNL|>
+              <SNL.Title>Services</SNL.Title>
+              <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
+              <SNL.Link @text="Consul" @icon="consul" @href="#" />
+              <SNL.Link @text="Packer" @icon="packer" @href="#" />
+              <SNL.Link @text="Vault" @icon="vault" @href="#" />
+              <SNL.Link @text="Vault Secrets" @icon="lock" @href="#" />
+              <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
+              <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
+              <SNL.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} />
+            </Hds::SideNav::List>
+
+            <Hds::SideNav::List as |SNL|>
+              <SNL.Title>Default Org</SNL.Title>
+              <SNL.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />
+              <SNL.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
+              <SNL.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
+              <SNL.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
+              <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
+            </Hds::SideNav::List>
+          </:body>
+
+          <:footer>
+            OrgSelect / ContextSwitcher
+          </:footer>
+        </Hds::SideNav>
+      </div>
+    </SF.Item>
+  {{/each}}
+</Shw::Flex>
+  {{/each}}
+
+</section>

--- a/packages/components/tests/dummy/app/templates/components/side-nav-polish.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav-polish.hbs
@@ -12,8 +12,8 @@
 
     <Shw::Grid @columns={{3}} as |SG|>
       {{#each @model.OPACITY_STOPS as |opacity|}}
-      <SG.Item>
-        <Shw::Flex as |SF|>
+        <SG.Item>
+          <Shw::Flex as |SF|>
             <SF.Item @label="{{opacity}}% opacity">
               <div class="shw-component-sim-side-nav-root-container" {{style height="auto"}}>
                 <Hds::SideNav
@@ -82,9 +82,9 @@
                 </Hds::SideNav>
               </div>
             </SF.Item>
-        </Shw::Flex>
-      </SG.Item>
-          {{/each}}
+          </Shw::Flex>
+        </SG.Item>
+      {{/each}}
     </Shw::Grid>
   {{/each}}
 

--- a/packages/components/tests/dummy/app/templates/components/side-nav-polish.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav-polish.hbs
@@ -8,80 +8,80 @@
 
   {{#each @model.GRADIENT_TESTS as |category|}}
 
-  <Shw::Text::H3>{{capitalize category}}</Shw::Text::H3>
+    <Shw::Text::H3>{{capitalize category}}</Shw::Text::H3>
 
-  <Shw::Flex as |SF|>
-  {{#each @model.OPACITY_STOPS as |opacity|}}
-    <SF.Item @label="{{opacity}}% opacity">
-      <div class="shw-component-sim-side-nav-root-container" {{style height="auto"}}>
-        <Hds::SideNav
-          @isResponsive={{false}}
-          @hasA11yRefocus={{false}}
-          class="hds-side-nav-polish_visual-refresh--{{opacity}}"
-        >
-          <:header>
-            <Hds::SideNav::Header>
-              <:logo>
-                <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
-              </:logo>
-              <:actions>
-                <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
-                <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
-                  <dd.ToggleIcon @icon="help" @text="help menu" />
-                  <dd.Title @text="Help & Support" />
-                  <dd.Interactive @text="Documentation" @href="#" />
-                  <dd.Interactive @text="Tutorials" @href="#" />
-                  <dd.Interactive @text="Terraform Provider" @href="#" />
-                  <dd.Interactive @text="Changelog" @href="#" />
-                  <dd.Separator />
-                  <dd.Interactive @text="Create support ticket" @href="#" />
-                  <dd.Interactive @text="Give feedback" @href="#" />
-                </Hds::Dropdown>
-                <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
-                  <dd.ToggleIcon @icon="user" @text="user menu" />
-                  <dd.Title @text="Signed In" />
-                  <dd.Description @text="email@domain.com" />
-                  <dd.Interactive @href="#" @text="Account Settings" />
-                </Hds::Dropdown>
-              </:actions>
-            </Hds::SideNav::Header>
-          </:header>
+    <Shw::Flex as |SF|>
+      {{#each @model.OPACITY_STOPS as |opacity|}}
+        <SF.Item @label="{{opacity}}% opacity">
+          <div class="shw-component-sim-side-nav-root-container">
+            <Hds::SideNav
+              @isResponsive={{false}}
+              @hasA11yRefocus={{false}}
+              class="hds-side-nav-polish_{{category}}--{{opacity}}"
+            >
+              <:header>
+                <Hds::SideNav::Header>
+                  <:logo>
+                    <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
+                  </:logo>
+                  <:actions>
+                    <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
+                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                      <dd.ToggleIcon @icon="help" @text="help menu" />
+                      <dd.Title @text="Help & Support" />
+                      <dd.Interactive @text="Documentation" @href="#" />
+                      <dd.Interactive @text="Tutorials" @href="#" />
+                      <dd.Interactive @text="Terraform Provider" @href="#" />
+                      <dd.Interactive @text="Changelog" @href="#" />
+                      <dd.Separator />
+                      <dd.Interactive @text="Create support ticket" @href="#" />
+                      <dd.Interactive @text="Give feedback" @href="#" />
+                    </Hds::Dropdown>
+                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                      <dd.ToggleIcon @icon="user" @text="user menu" />
+                      <dd.Title @text="Signed In" />
+                      <dd.Description @text="email@domain.com" />
+                      <dd.Interactive @href="#" @text="Account Settings" />
+                    </Hds::Dropdown>
+                  </:actions>
+                </Hds::SideNav::Header>
+              </:header>
 
-          <:body>
-            <Hds::SideNav::List as |SNL|>
-              <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
-            </Hds::SideNav::List>
+              <:body>
+                <Hds::SideNav::List as |SNL|>
+                  <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
+                </Hds::SideNav::List>
 
-            <Hds::SideNav::List as |SNL|>
-              <SNL.Title>Services</SNL.Title>
-              <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
-              <SNL.Link @text="Consul" @icon="consul" @href="#" />
-              <SNL.Link @text="Packer" @icon="packer" @href="#" />
-              <SNL.Link @text="Vault" @icon="vault" @href="#" />
-              <SNL.Link @text="Vault Secrets" @icon="lock" @href="#" />
-              <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
-              <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
-              <SNL.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} />
-            </Hds::SideNav::List>
+                <Hds::SideNav::List as |SNL|>
+                  <SNL.Title>Services</SNL.Title>
+                  <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
+                  <SNL.Link @text="Consul" @icon="consul" @href="#" />
+                  <SNL.Link @text="Packer" @icon="packer" @href="#" />
+                  <SNL.Link @text="Vault" @icon="vault" @href="#" />
+                  <SNL.Link @text="Vault Secrets" @icon="lock" @href="#" />
+                  <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
+                  <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
+                  <SNL.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} />
+                </Hds::SideNav::List>
 
-            <Hds::SideNav::List as |SNL|>
-              <SNL.Title>Default Org</SNL.Title>
-              <SNL.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />
-              <SNL.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
-              <SNL.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
-              <SNL.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
-              <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
-            </Hds::SideNav::List>
-          </:body>
+                <Hds::SideNav::List as |SNL|>
+                  <SNL.Title>Default Org</SNL.Title>
+                  <SNL.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />
+                  <SNL.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
+                  <SNL.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
+                  <SNL.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
+                  <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
+                </Hds::SideNav::List>
+              </:body>
 
-          <:footer>
-            OrgSelect / ContextSwitcher
-          </:footer>
-        </Hds::SideNav>
-      </div>
-    </SF.Item>
-  {{/each}}
-</Shw::Flex>
+              <:footer>
+                OrgSelect / ContextSwitcher
+              </:footer>
+            </Hds::SideNav>
+          </div>
+        </SF.Item>
+      {{/each}}
+    </Shw::Flex>
   {{/each}}
 
 </section>

--- a/packages/components/tests/dummy/app/templates/components/side-nav-polish.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav-polish.hbs
@@ -10,78 +10,82 @@
 
     <Shw::Text::H3>{{capitalize category}}</Shw::Text::H3>
 
-    <Shw::Flex as |SF|>
+    <Shw::Grid @columns={{3}} as |SG|>
       {{#each @model.OPACITY_STOPS as |opacity|}}
-        <SF.Item @label="{{opacity}}% opacity">
-          <div class="shw-component-sim-side-nav-root-container">
-            <Hds::SideNav
-              @isResponsive={{false}}
-              @hasA11yRefocus={{false}}
-              class="hds-side-nav-polish_{{category}}--{{opacity}}"
-            >
-              <:header>
-                <Hds::SideNav::Header>
-                  <:logo>
-                    <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
-                  </:logo>
-                  <:actions>
-                    <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
-                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
-                      <dd.ToggleIcon @icon="help" @text="help menu" />
-                      <dd.Title @text="Help & Support" />
-                      <dd.Interactive @text="Documentation" @href="#" />
-                      <dd.Interactive @text="Tutorials" @href="#" />
-                      <dd.Interactive @text="Terraform Provider" @href="#" />
-                      <dd.Interactive @text="Changelog" @href="#" />
-                      <dd.Separator />
-                      <dd.Interactive @text="Create support ticket" @href="#" />
-                      <dd.Interactive @text="Give feedback" @href="#" />
-                    </Hds::Dropdown>
-                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
-                      <dd.ToggleIcon @icon="user" @text="user menu" />
-                      <dd.Title @text="Signed In" />
-                      <dd.Description @text="email@domain.com" />
-                      <dd.Interactive @href="#" @text="Account Settings" />
-                    </Hds::Dropdown>
-                  </:actions>
-                </Hds::SideNav::Header>
-              </:header>
+      <SG.Item>
+        <Shw::Flex as |SF|>
+            <SF.Item @label="{{opacity}}% opacity">
+              <div class="shw-component-sim-side-nav-root-container" {{style height="auto"}}>
+                <Hds::SideNav
+                  @isResponsive={{false}}
+                  @hasA11yRefocus={{false}}
+                  class="hds-side-nav-polish_{{category}}--{{opacity}}"
+                >
+                  <:header>
+                    <Hds::SideNav::Header>
+                      <:logo>
+                        <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
+                      </:logo>
+                      <:actions>
+                        <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
+                        <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                          <dd.ToggleIcon @icon="help" @text="help menu" />
+                          <dd.Title @text="Help & Support" />
+                          <dd.Interactive @text="Documentation" @href="#" />
+                          <dd.Interactive @text="Tutorials" @href="#" />
+                          <dd.Interactive @text="Terraform Provider" @href="#" />
+                          <dd.Interactive @text="Changelog" @href="#" />
+                          <dd.Separator />
+                          <dd.Interactive @text="Create support ticket" @href="#" />
+                          <dd.Interactive @text="Give feedback" @href="#" />
+                        </Hds::Dropdown>
+                        <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                          <dd.ToggleIcon @icon="user" @text="user menu" />
+                          <dd.Title @text="Signed In" />
+                          <dd.Description @text="email@domain.com" />
+                          <dd.Interactive @href="#" @text="Account Settings" />
+                        </Hds::Dropdown>
+                      </:actions>
+                    </Hds::SideNav::Header>
+                  </:header>
 
-              <:body>
-                <Hds::SideNav::List as |SNL|>
-                  <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
-                </Hds::SideNav::List>
+                  <:body>
+                    <Hds::SideNav::List as |SNL|>
+                      <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
+                    </Hds::SideNav::List>
 
-                <Hds::SideNav::List as |SNL|>
-                  <SNL.Title>Services</SNL.Title>
-                  <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
-                  <SNL.Link @text="Consul" @icon="consul" @href="#" />
-                  <SNL.Link @text="Packer" @icon="packer" @href="#" />
-                  <SNL.Link @text="Vault" @icon="vault" @href="#" />
-                  <SNL.Link @text="Vault Secrets" @icon="lock" @href="#" />
-                  <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
-                  <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
-                  <SNL.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} />
-                </Hds::SideNav::List>
+                    <Hds::SideNav::List as |SNL|>
+                      <SNL.Title>Services</SNL.Title>
+                      <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
+                      <SNL.Link @text="Consul" @icon="consul" @href="#" />
+                      <SNL.Link @text="Packer" @icon="packer" @href="#" />
+                      <SNL.Link @text="Vault" @icon="vault" @href="#" />
+                      <SNL.Link @text="Vault Secrets" @icon="lock" @href="#" />
+                      <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
+                      <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
+                      <SNL.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} />
+                    </Hds::SideNav::List>
 
-                <Hds::SideNav::List as |SNL|>
-                  <SNL.Title>Default Org</SNL.Title>
-                  <SNL.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />
-                  <SNL.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
-                  <SNL.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
-                  <SNL.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
-                  <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
-                </Hds::SideNav::List>
-              </:body>
+                    <Hds::SideNav::List as |SNL|>
+                      <SNL.Title>Default Org</SNL.Title>
+                      <SNL.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />
+                      <SNL.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
+                      <SNL.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
+                      <SNL.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
+                      <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
+                    </Hds::SideNav::List>
+                  </:body>
 
-              <:footer>
-                OrgSelect / ContextSwitcher
-              </:footer>
-            </Hds::SideNav>
-          </div>
-        </SF.Item>
-      {{/each}}
-    </Shw::Flex>
+                  <:footer>
+                    OrgSelect / ContextSwitcher
+                  </:footer>
+                </Hds::SideNav>
+              </div>
+            </SF.Item>
+        </Shw::Flex>
+      </SG.Item>
+          {{/each}}
+    </Shw::Grid>
   {{/each}}
 
 </section>

--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -182,6 +182,11 @@ SPDX-License-Identifier: MPL-2.0
         </LinkTo>
       </li>
       <li>
+        <LinkTo @route="components.side-nav-polish">
+          SideNav Polish
+        </LinkTo>
+      </li>
+      <li>
         <LinkTo @route="components.stepper">
           Stepper
         </LinkTo>


### PR DESCRIPTION
### :pushpin: Summary

🚨 Do not merge, this is only for testing 🚨

This PR tests a variety of different gradient styles in the context of the showcase.

➡️ See the showcase: https://hds-showcase-j84bii665-hashicorp.vercel.app/components/side-nav-polish

### :hammer_and_wrench: Detailed description

It's difficult to see the differences in Figma, this branch showcases some of the exploration around gradients in the `SideNav`, including:

- The visual refresh exploration (labelled `visual-refresh`)
- Small updates to the visual refresh using more current background/surface colors (labelled `visual-refresh-dark`)
- Exploring different gradient patterns (labelled `explore-01`)
- Various opacity levels and base colors within the gradient (labelled `explore-02` through `explore-05`)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1834](https://hashicorp.atlassian.net/browse/HDS-1834)
Figma file: [Design Exploration](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/branch/wTh4ApHZgGQCogBzwDiUf3/HDS-Product---Components?type=design&node-id=37785%3A71082&mode=design&t=47T5UPNOxKmd4igm-1)

There will be more to come on this branch, I'm just using it currently to see examples in more of a context and test interactive states.

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1834]: https://hashicorp.atlassian.net/browse/HDS-1834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ