### PR TITLE
`Hds::Modal` – Prevent `onClose` callback function invocation when `isDismissDisabled` is `true`

### DIFF
--- a/.changeset/tiny-news-obey.md
+++ b/.changeset/tiny-news-obey.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::Modal` – Prevent `onClose` callback function invocation when `isDismissDisabled` is `true`

--- a/packages/components/addon/components/hds/modal/index.js
+++ b/packages/components/addon/components/hds/modal/index.js
@@ -112,7 +112,11 @@ export default class HdsModalIndexComponent extends Component {
 
     // Register "onClose" callback function to be called when a native 'close' event is dispatched
     this.element.addEventListener('close', () => {
-      if (this.args.onClose && typeof this.args.onClose === 'function') {
+      if (
+        this.args.onClose &&
+        typeof this.args.onClose === 'function' &&
+        !this.isDismissDisabled
+      ) {
         this.args.onClose();
       }
 

--- a/packages/components/addon/components/hds/modal/index.js
+++ b/packages/components/addon/components/hds/modal/index.js
@@ -113,9 +113,9 @@ export default class HdsModalIndexComponent extends Component {
     // Register "onClose" callback function to be called when a native 'close' event is dispatched
     this.element.addEventListener('close', () => {
       if (
+        !this.isDismissDisabled &&
         this.args.onClose &&
-        typeof this.args.onClose === 'function' &&
-        !this.isDismissDisabled
+        typeof this.args.onClose === 'function'
       ) {
         this.args.onClose();
       }

--- a/packages/components/tests/dummy/app/controllers/components/modal.js
+++ b/packages/components/tests/dummy/app/controllers/components/modal.js
@@ -10,36 +10,14 @@ import { tracked } from '@glimmer/tracking';
 export default class ModalController extends Controller {
   @tracked basicModalActive = false;
   @tracked formModalActive = false;
-  @tracked isModalDismissDisabled = false;
 
   @action
   activateModal(modal) {
-    this.isModalDismissDisabled = false;
     this[modal] = true;
   }
 
   @action
   deactivateModal(modal) {
-    this.isModalDismissDisabled = false;
     this[modal] = false;
-  }
-
-  @action markFormAsChanged() {
-    this.isModalDismissDisabled = true;
-  }
-
-  @action saveFormAndClose(modal) {
-    this.isModalDismissDisabled = false;
-    this.deactivateModal(modal);
-  }
-
-  @action checkBeforeDeactivate(modal) {
-    if (this.isModalDismissDisabled) {
-      if (window.confirm('Changes that you made may not be saved')) {
-        this.deactivateModal(modal);
-      }
-    } else {
-      this.deactivateModal(modal);
-    }
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/modal.hbs
+++ b/packages/components/tests/dummy/app/templates/components/modal.hbs
@@ -243,17 +243,12 @@
 
   {{! template-lint-disable no-autofocus-attribute }}
   {{#if this.formModalActive}}
-    <Hds::Modal
-      id="form-modal"
-      @isDismissDisabled={{this.isModalDismissDisabled}}
-      @onClose={{fn this.checkBeforeDeactivate "formModalActive"}}
-      as |M|
-    >
+    <Hds::Modal id="form-modal" @onClose={{fn this.deactivateModal "formModalActive"}} as |M|>
       <M.Header>
         Why do you want to leave the beta?
       </M.Header>
       <M.Body>
-        <form {{on "change" this.markFormAsChanged}} name="leaving-beta-form">
+        <form name="leaving-beta-form">
           <Hds::Form::Select::Field autofocus @width="100%" as |F|>
             <F.Label>Select the primary reason</F.Label>
             <F.Options>
@@ -267,7 +262,7 @@
       </M.Body>
       <M.Footer as |F|>
         <Hds::ButtonSet>
-          <Hds::Button type="submit" @text="Leave Beta" {{on "click" (fn this.saveFormAndClose "formModalActive")}} />
+          <Hds::Button type="submit" @text="Leave Beta" {{on "click" (fn this.deactivateModal "formModalActive")}} />
           <Hds::Button type="button" @text="Cancel" @color="secondary" {{on "click" F.close}} />
         </Hds::ButtonSet>
       </M.Footer>

--- a/website/docs/components/modal/index.js
+++ b/website/docs/components/modal/index.js
@@ -15,7 +15,6 @@ import {
 export default class Index extends Component {
   @tracked basicModalActive = false;
   @tracked formModalActive = false;
-  @tracked isModalDismissDisabled = false;
 
   get SIZES() {
     return SIZES;
@@ -31,32 +30,11 @@ export default class Index extends Component {
 
   @action
   activateModal(modal) {
-    this.isModalDismissDisabled = false;
     this[modal] = true;
   }
 
   @action
   deactivateModal(modal) {
-    this.isModalDismissDisabled = false;
     this[modal] = false;
-  }
-
-  @action markFormAsChanged() {
-    this.isModalDismissDisabled = true;
-  }
-
-  @action saveFormAndClose(modal) {
-    this.isModalDismissDisabled = false;
-    this.deactivateModal(modal);
-  }
-
-  @action checkBeforeDeactivate(modal) {
-    if (this.isModalDismissDisabled) {
-      if (window.confirm('Changes that you made may not be saved')) {
-        this.deactivateModal(modal);
-      }
-    } else {
-      this.deactivateModal(modal);
-    }
   }
 }

--- a/website/docs/components/modal/partials/code/how-to-use.md
+++ b/website/docs/components/modal/partials/code/how-to-use.md
@@ -56,15 +56,14 @@ When the Modal dialog contains information that might be lost on close, use a co
 {{#if this.formModalActive}}
   <Hds::Modal
     id="form-modal"
-    @isDismissDisabled={{this.isModalDismissDisabled}}
-    @onClose={{fn this.checkBeforeDeactivate "formModalActive"}}
+    @onClose={{fn this.deactivateModal "formModalActive"}}
     as |M|
   >
     <M.Header>
       Why do you want to leave the beta?
     </M.Header>
     <M.Body>
-      <form {{on "change" this.markFormAsChanged}} name="leaving-beta-form">
+      <form name="leaving-beta-form">
         <Hds::Form::Select::Field autofocus @width="100%" as |F|>
           <F.Label>Select the primary reason</F.Label>
           <F.Options>
@@ -79,9 +78,11 @@ When the Modal dialog contains information that might be lost on close, use a co
     <M.Footer as |F|>
       <Hds::ButtonSet>
         <Hds::Button type="submit" @text="Leave Beta"
-          {{on "click" (fn this.saveFormAndClose "formModalActive")}}
+          {{on "click" (fn this.deactivateModal "formModalActive")}}
         />
-        <Hds::Button type="button" @text="Cancel" @color="secondary" {{on "click" F.close}} />
+        <Hds::Button type="button" @text="Cancel" @color="secondary"
+          {{on "click" F.close}}
+        />
       </Hds::ButtonSet>
     </M.Footer>
   </Hds::Modal>


### PR DESCRIPTION
### :pushpin: Summary

`Hds::Modal` – Prevent `onClose` callback function invocation when `isDismissDisabled` is `true`

### :hammer_and_wrench: Detailed description

`isDismissDisabled` was introduced in the Modal component, based on ambassadors' feedback/request, as a method of preventing data loss in forms. In practice, this argument and the suggested implementation were never used for such a case.

[Recent feedback from HCP Packer and Hermes](https://hashicorp.slack.com/archives/C7KTUHNUS/p1679918641970839) flags that their expectation is that the `onClose` callback function is not invoked when `isDismissDisabled` is `true`, so we're updating the code to match this consumer expectation.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2146](https://hashicorp.atlassian.net/browse/HDS-2146)

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2146]: https://hashicorp.atlassian.net/browse/HDS-2146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ