### PR TITLE
`Text` component - Part 1 (basic API)

### DIFF
--- a/packages/components/addon/components/hds/text/body.hbs
+++ b/packages/components/addon/components/hds/text/body.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Text @group="body" @size={{this.size}} @weight={{this.weight}} @tag={{@tag}} ...attributes>{{yield}}</Hds::Text>

--- a/packages/components/addon/components/hds/text/body.js
+++ b/packages/components/addon/components/hds/text/body.js
@@ -1,0 +1,68 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+// notice: only some combinations of size + font-weight are allowed (per design specs)
+// see: https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=1262%3A9192
+
+export const DEFAULT_SIZE = '200';
+export const AVAILABLE_SIZES = [300, 200, 100];
+
+export const DEFAULT_WEIGHT = 'regular';
+export const AVAILABLE_WEIGHTS_PER_SIZE = {
+  300: ['regular', 'medium', 'semibold'],
+  200: ['regular', 'medium', 'semibold'],
+  100: ['regular', 'medium', 'semibold'],
+};
+
+export default class HdsTextBodyComponent extends Component {
+  /**
+   * Sets the "size" for the text
+   * Accepted values: see AVAILABLE_SIZES
+   *
+   * @type {string}
+   *
+   * @param size
+   */
+  get size() {
+    let { size = DEFAULT_SIZE } = this.args;
+
+    // let's be a bit forgiving with the consumers
+    if (typeof size === 'string') {
+      size = parseInt(size, 10);
+    }
+
+    assert(
+      `@size for "Hds::Text::Body" must be one of the following: ${AVAILABLE_SIZES.join(
+        ', '
+      )}; received: ${size}`,
+      AVAILABLE_SIZES.includes(size)
+    );
+
+    return size;
+  }
+
+  /**
+   * Sets the "weight" for the text
+   * Accepted values: see AVAILABLE_WEIGHTS_PER_SIZE
+   *
+   * @type {string}
+   *
+   * @param variant
+   */
+  get weight() {
+    let { weight = DEFAULT_WEIGHT } = this.args;
+
+    const availableWeights = AVAILABLE_WEIGHTS_PER_SIZE[this.size];
+
+    assert(
+      `@weight for "Hds::Text::Body" with @size=${
+        this.size
+      } must be one of the following: ${availableWeights.join(
+        ', '
+      )}; received: ${weight}`,
+      availableWeights.includes(weight)
+    );
+
+    return weight;
+  }
+}

--- a/packages/components/addon/components/hds/text/code.hbs
+++ b/packages/components/addon/components/hds/text/code.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Text @group="code" @size={{this.size}} @weight={{this.weight}} @tag={{@tag}} ...attributes>{{yield}}</Hds::Text>

--- a/packages/components/addon/components/hds/text/code.js
+++ b/packages/components/addon/components/hds/text/code.js
@@ -1,0 +1,68 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+// notice: only some combinations of size + font-weight are allowed (per design specs)
+// see: https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=1262%3A9192
+
+export const DEFAULT_SIZE = '200';
+export const AVAILABLE_SIZES = [300, 200, 100];
+
+export const DEFAULT_WEIGHT = '200';
+export const AVAILABLE_WEIGHTS_PER_SIZE = {
+  300: ['regular'],
+  200: ['regular'],
+  100: ['regular'],
+};
+
+export default class HdsTextCodeComponent extends Component {
+  /**
+   * Sets the "size" for the text
+   * Accepted values: see AVAILABLE_SIZES
+   *
+   * @type {string}
+   *
+   * @param size
+   */
+  get size() {
+    let { size = DEFAULT_SIZE } = this.args;
+
+    // let's be a bit forgiving with the consumers
+    if (typeof size === 'string') {
+      size = parseInt(size, 10);
+    }
+
+    assert(
+      `@size for "Hds::Text::Code" must be one of the following: ${AVAILABLE_SIZES.join(
+        ', '
+      )}; received: ${size}`,
+      AVAILABLE_SIZES.includes(size)
+    );
+
+    return size;
+  }
+
+  /**
+   * Sets the "weight" for the text
+   * Accepted values: see AVAILABLE_WEIGHTS_PER_SIZE
+   *
+   * @type {string}
+   *
+   * @param variant
+   */
+  get weight() {
+    let { weight = DEFAULT_WEIGHT } = this.args;
+
+    const availableWeights = AVAILABLE_WEIGHTS_PER_SIZE[this.size];
+
+    assert(
+      `@weight for "Hds::Text::Code" with @size=${
+        this.size
+      } must be one of the following: ${availableWeights.join(
+        ', '
+      )}; received: ${weight}`,
+      availableWeights.includes(weight)
+    );
+
+    return weight;
+  }
+}

--- a/packages/components/addon/components/hds/text/display.hbs
+++ b/packages/components/addon/components/hds/text/display.hbs
@@ -1,0 +1,12 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Text
+  @group="display"
+  @size={{this.size}}
+  @weight={{this.weight}}
+  @tag={{@tag}}
+  ...attributes
+>{{yield}}</Hds::Text>

--- a/packages/components/addon/components/hds/text/display.js
+++ b/packages/components/addon/components/hds/text/display.js
@@ -1,0 +1,74 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+// notice: only some combinations of size + font-weight are allowed (per design specs)
+// see: https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=1262%3A9192
+
+export const DEFAULT_SIZE = '200';
+export const AVAILABLE_SIZES = [500, 400, 300, 200, 100];
+
+// notice: the first item in the array is considered the default
+export const AVAILABLE_WEIGHTS_PER_SIZE = {
+  500: ['bold'],
+  400: ['semibold', 'medium', 'bold'],
+  300: ['semibold', 'medium', 'bold'],
+  200: ['semibold'],
+  100: ['medium'],
+};
+
+export default class HdsTextDisplayComponent extends Component {
+  /**
+   * Sets the "size" for the text
+   * Accepted values: see AVAILABLE_SIZES
+   *
+   * @type {string}
+   *
+   * @param size
+   */
+  get size() {
+    let { size = DEFAULT_SIZE } = this.args;
+
+    // let's be a bit forgiving with the consumers
+    if (typeof size === 'string') {
+      size = parseInt(size, 10);
+    }
+
+    assert(
+      `@size for "Hds::Text::Display" must be one of the following: ${AVAILABLE_SIZES.join(
+        ', '
+      )}; received: ${size}`,
+      AVAILABLE_SIZES.includes(size)
+    );
+
+    return size;
+  }
+
+  /**
+   * Sets the "weight" for the text
+   * Accepted values: see AVAILABLE_WEIGHTS_PER_SIZE
+   *
+   * @type {string}
+   *
+   * @param variant
+   */
+  get weight() {
+    let { weight } = this.args;
+
+    if (weight) {
+      const availableWeights = AVAILABLE_WEIGHTS_PER_SIZE[this.size];
+      assert(
+        `@weight for "Hds::Text::Display" with @size=${
+          this.size
+        } must be one of the following: ${availableWeights.join(
+          ', '
+        )}; received: ${weight}`,
+        availableWeights.includes(weight)
+      );
+    } else {
+      // use the default (first item in the array)
+      weight = AVAILABLE_WEIGHTS_PER_SIZE[this.size][0];
+    }
+
+    return weight;
+  }
+}

--- a/packages/components/addon/components/hds/text/index.hbs
+++ b/packages/components/addon/components/hds/text/index.hbs
@@ -1,0 +1,3 @@
+{{#let (element this.componentTag) as |Tag|}}
+  <Tag class={{this.classNames}} ...attributes>{{yield}}</Tag>
+{{/let}}

--- a/packages/components/addon/components/hds/text/index.js
+++ b/packages/components/addon/components/hds/text/index.js
@@ -1,0 +1,50 @@
+import Component from '@glimmer/component';
+
+export default class HdsTextIndexComponent extends Component {
+  /**
+   * Get a tag to render based on the `@tag` argument passed or the value of `this.size` (via mapping)
+   *
+   * @method #componentTag
+   * @return {string} The html tag to use in the dynamic render of the component
+   */
+  get componentTag() {
+    let { tag = 'span' } = this.args;
+
+    return tag;
+  }
+
+  /**
+   * Sets the "variant" (style) for the text
+   * Accepted values: see AVAILABLE_VARIANTS
+   *
+   * @type {string}
+   *
+   * @param variant
+   */
+  get variant() {
+    let { group, size } = this.args;
+
+    // notice: for performance reasons we don't do any other extra check on these values
+    // we assume they've already been validated by the "parent" components
+    return `${group}-${size}`;
+  }
+
+  /**
+   * Get the class names to apply to the component.
+   * @method #classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-text'];
+
+    // add a (helper) class based on the "group + size" variant
+    classes.push(`hds-typography-${this.variant}`);
+
+    // add a (helper) class based on the @weight argument
+    if (this.args.weight) {
+      classes.push(`hds-font-weight-${this.args.weight}`);
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/app/components/hds/text/body.js
+++ b/packages/components/app/components/hds/text/body.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/text/body';

--- a/packages/components/app/components/hds/text/code.js
+++ b/packages/components/app/components/hds/text/code.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/text/code';

--- a/packages/components/app/components/hds/text/display.js
+++ b/packages/components/app/components/hds/text/display.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/text/display';

--- a/packages/components/app/components/hds/text/index.js
+++ b/packages/components/app/components/hds/text/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/design-system-components/components/hds/text/index';

--- a/packages/components/tests/acceptance/percy-test.js
+++ b/packages/components/tests/acceptance/percy-test.js
@@ -128,6 +128,9 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/components/tag');
     await percySnapshot('Tag');
 
+    await visit('/components/text');
+    await percySnapshot('Text');
+
     await visit('/components/toast');
     await percySnapshot('Toast');
 

--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -56,6 +56,7 @@ Router.map(function () {
     this.route('stepper');
     this.route('table');
     this.route('tag');
+    this.route('text');
     this.route('toast');
     this.route('tabs');
     this.route('tooltip');

--- a/packages/components/tests/dummy/app/routes/components/text.js
+++ b/packages/components/tests/dummy/app/routes/components/text.js
@@ -1,0 +1,27 @@
+import Route from '@ember/routing/route';
+
+import {
+  AVAILABLE_SIZES as DISPLAY_AVAILABLE_SIZES,
+  AVAILABLE_WEIGHTS_PER_SIZE as DISPLAY_AVAILABLE_WEIGHTS_PER_SIZE,
+} from '@hashicorp/design-system-components/components/hds/text/display';
+import {
+  AVAILABLE_SIZES as BODY_AVAILABLE_SIZES,
+  AVAILABLE_WEIGHTS_PER_SIZE as BODY_AVAILABLE_WEIGHTS_PER_SIZE,
+} from '@hashicorp/design-system-components/components/hds/text/body';
+import {
+  AVAILABLE_SIZES as CODE_AVAILABLE_SIZES,
+  AVAILABLE_WEIGHTS_PER_SIZE as CODE_AVAILABLE_WEIGHTS_PER_SIZE,
+} from '@hashicorp/design-system-components/components/hds/text/code';
+
+export default class ComponentsTextRoute extends Route {
+  model() {
+    return {
+      DISPLAY_AVAILABLE_SIZES,
+      DISPLAY_AVAILABLE_WEIGHTS_PER_SIZE,
+      BODY_AVAILABLE_SIZES,
+      BODY_AVAILABLE_WEIGHTS_PER_SIZE,
+      CODE_AVAILABLE_SIZES,
+      CODE_AVAILABLE_WEIGHTS_PER_SIZE,
+    };
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/text.hbs
+++ b/packages/components/tests/dummy/app/templates/components/text.hbs
@@ -1,0 +1,60 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{page-title "Text component"}}
+
+<Shw::Text::H1>Text</Shw::Text::H1>
+
+<section data-test-percy>
+
+  <Shw::Text::H2>Variants</Shw::Text::H2>
+  <Shw::Text::Body><em>Notice: we are showing only the combinations of
+      <code>font-size</code>
+      ("style") and
+      <code>font-weight</code>
+      that the design system
+      <strong>suggests</strong>
+      to use.</em></Shw::Text::Body>
+
+  <Shw::Text::H4 @tag="h3">Text::Display</Shw::Text::H4>
+  <Shw::Flex @direction="column" as |SF|>
+    {{#each this.model.DISPLAY_AVAILABLE_SIZES as |size|}}
+      <SF.Item @label="size={{size}}">
+        {{#let (get this.model.DISPLAY_AVAILABLE_WEIGHTS_PER_SIZE size) as |weights|}}
+          {{#each weights as |weight|}}
+            <Hds::Text::Display @size={{size}} @tag="p" @weight={{weight}}>The fox jumped over the lazy dog ({{weight}})</Hds::Text::Display>
+          {{/each}}
+        {{/let}}
+      </SF.Item>
+    {{/each}}
+  </Shw::Flex>
+
+  <Shw::Text::H4 @tag="h3">Text::Body</Shw::Text::H4>
+  <Shw::Flex @direction="column" as |SF|>
+    {{#each this.model.BODY_AVAILABLE_SIZES as |size|}}
+      <SF.Item @label="size={{size}}">
+        {{#let (get this.model.BODY_AVAILABLE_WEIGHTS_PER_SIZE size) as |weights|}}
+          {{#each weights as |weight|}}
+            <Hds::Text::Body @size={{size}} @tag="p" @weight={{weight}}>The fox jumped over the lazy dog ({{weight}})</Hds::Text::Body>
+          {{/each}}
+        {{/let}}
+      </SF.Item>
+    {{/each}}
+  </Shw::Flex>
+
+  <Shw::Text::H4 @tag="h3">Text::Code</Shw::Text::H4>
+  <Shw::Flex @direction="column" as |SF|>
+    {{#each this.model.CODE_AVAILABLE_SIZES as |size|}}
+      <SF.Item @label="size={{size}}">
+        {{#let (get this.model.CODE_AVAILABLE_WEIGHTS_PER_SIZE size) as |weights|}}
+          {{#each weights as |weight|}}
+            <Hds::Text::Code @size={{size}} @tag="p" @weight={{weight}}>The fox jumped over the lazy dog ({{weight}})</Hds::Text::Code>
+          {{/each}}
+        {{/let}}
+      </SF.Item>
+    {{/each}}
+  </Shw::Flex>
+
+</section>

--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -202,6 +202,11 @@ SPDX-License-Identifier: MPL-2.0
         </LinkTo>
       </li>
       <li>
+        <LinkTo @route="components.text">
+          Text
+        </LinkTo>
+      </li>
+      <li>
         <LinkTo @route="components.toast">
           Toast
         </LinkTo>


### PR DESCRIPTION
### :pushpin: Summary

This is the first PR for the proposed `Text` component. It implements the following APIs:
- definition of the "variant" using the tag name + `@size` argument
- definition of the HTML tag to use (generic implementation) via the `@tag` argument
- definition of the "weight to use (with basic validation of correct combination) via the `@weight` argument

Other arguments related to alignment, color, etc will be handled in follow-up PRs.

**Preview** of the components in action: https://hds-showcase-git-text-component-2023-part-1-hashicorp.vercel.app/components/text

### :camera_flash: Screenshots

![localhost_3000_components_text](https://github.com/hashicorp/design-system/assets/686239/a696ca87-6990-496d-8d3f-69caf7017fee)

### :link: External links

Meeting notes: https://docs.google.com/document/d/12wk3VyH2aMCI-DMlrRfrmUhrQwUzRLUGydYlw3SPuiQ/
Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2168

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
