### PR TITLE
silence ember-string.add-package deprecation

### DIFF
--- a/website/config/deprecation-workflow.js
+++ b/website/config/deprecation-workflow.js
@@ -10,6 +10,7 @@ self.deprecationWorkflow.config = {
   workflow: [
     { handler: "silence", matchId: "remove-owner-inject" },
     { handler: "silence", matchId: "ember-modifier.function-based-options" },
-    { handler: "throw", matchId: "deprecate-auto-location" }
+    { handler: "throw", matchId: "deprecate-auto-location" },
+    { handler: "silence", matchId: "ember-string.add-package" }
   ]
 };


### PR DESCRIPTION
### :pushpin: Summary

Per https://github.com/emberjs/ember-string/issues/370#issuecomment-1518493689 silencing seems to be the best way to "fix" this issue in the short term. There's nothing broken per se and this avoids having deprecation spew in our terminals.

This can be tested locally and see the terminal is happy again.

[HDS-2189](https://hashicorp.atlassian.net/browse/HDS-2180)
