### PR TITLE
`Hds::PageHeader` – Set position to 'relative'

### DIFF
--- a/.changeset/calm-days-rescue.md
+++ b/.changeset/calm-days-rescue.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::PageHeader` – Set position to 'relative'

--- a/packages/components/app/styles/components/page-header.scss
+++ b/packages/components/app/styles/components/page-header.scss
@@ -8,6 +8,9 @@
 //
 
 .hds-page-header {
+  // `container-type: inline-size` creates a new stacking context; to control the position of Page Header content on the z-axis
+  // we set this element to `relative` to allow consumers to define the `z-index` value that works in their context
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 16px;

--- a/website/app/styles/doc-components/code-block.scss
+++ b/website/app/styles/doc-components/code-block.scss
@@ -22,6 +22,8 @@
 }
 
 .doc-code-block__code-rendered {
+  position: relative;
+  z-index: 1;
   padding: 16px;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 2'%3E%3Cpath d='M1 2V0h1v1H0v1z' fill-opacity='.05'/%3E%3C/svg%3E");
   // use this to fine tune the size of the checkered pattern

--- a/website/docs/components/page-header/partials/code/how-to-use.md
+++ b/website/docs/components/page-header/partials/code/how-to-use.md
@@ -16,6 +16,8 @@ The Page Header uses a number of contextual components that either yield their c
 
 The layout of this component is responsive and adjusts based on the width of its bounding container. The examples captured here may not be indicative of how the component will render within a specific application or layout.
 
+The responsive layout is achieved using [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_container_queries), which creates a new [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context). We recommend setting the appropriate `z-index` value to the Page Header (or its parent container) to make sure its content–for example a Dropdown–is not obscured by other elements on the page.
+
 !!!
 
 ```handlebars


### PR DESCRIPTION
### :pushpin: Summary

Set `Hds::PageHeader`'s position to 'relative' and recommend consumers to manage positioning using `z-index`.

### :hammer_and_wrench: Detailed description

Removing `position: relative` from other elements (such as `Hds::Tooltip`) is not an option as it is used in conjunction with a pseudoelement to generate the focus ring.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2114](https://hashicorp.atlassian.net/browse/HDS-2114)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2114]: https://hashicorp.atlassian.net/browse/HDS-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ