### PR TITLE
Add explicit `font-weight` in the `button` mixin

### DIFF
--- a/.changeset/wild-hornets-dream.md
+++ b/.changeset/wild-hornets-dream.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Set the `font-weight` of the `button` mixin explicitly to `regular` instead of relying on inheritance (components using this mixin: `Button`, `Dropdown::ToggleButton` and soon `Accordion`) - No visual difference expected

--- a/packages/components/app/styles/mixins/_button.scss
+++ b/packages/components/app/styles/mixins/_button.scss
@@ -40,6 +40,12 @@ $size-props: (
   align-items: center;
   justify-content: center;
   width: auto;
+  // notice: we set the font-weight of the button text to "regular" (on purpose)
+  // because of the antialising of the browser that renders the text quite different
+  // from what it looks like in Figma, so we prefer to have them visually similar
+  // even if they differ in their internal implementation (in Figma the font-weight is medium/500)
+  // for more context about this decision: https://hashicorp.atlassian.net/browse/HDS-2099
+  font-weight: var(--token-typography-font-weight-regular);
   font-family: var(--token-typography-font-stack-text);
   text-decoration: none;
   border: $hds-button-border-width solid transparent; // We need this to be transparent for a11y


### PR DESCRIPTION
### :pushpin: Summary

Context: 
- https://hashicorp.slack.com/archives/C7KTUHNUS/p1686934749993519
- https://hashicorp.atlassian.net/browse/HDS-2099

### :hammer_and_wrench: Detailed description

In this PR I have:
- set the `font-weight` of the `button` mixin explicitly to `regular` instead of relying on inheritance
  - components using this mixin: `Button`, `Dropdown::ToggleButton` and soon `Accordion`
- added a comment in code for future reference about this decision

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2099

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
