### PR TITLE
`Hds::Textarea` – Fix border and text color for readonly state

### DIFF
--- a/.changeset/gorgeous-rocks-brake.md
+++ b/.changeset/gorgeous-rocks-brake.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::Textarea` – Fix border and text color for readonly state

--- a/packages/components/app/styles/components/form/textarea.scss
+++ b/packages/components/app/styles/components/form/textarea.scss
@@ -48,9 +48,9 @@
   // READONLY
 
   &:read-only {
-    color: var(--token-form-control-disabled-foreground-color);
+    color: var(--token-form-control-readonly-foreground-color);
     background-color: var(--token-form-control-readonly-surface-color);
-    border-color: var(--token-form-control-disabled-border-color);
+    border-color: var(--token-form-control-readonly-border-color);
     box-shadow: none;
   }
 

--- a/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/textarea.hbs
@@ -101,7 +101,7 @@
               <Hds::Form::Textarea::Base @value="Default width" />
             </SF.Item>
             <SF.Item @grow={{true}} {{style display=display}}>
-              <Hds::Form::Textarea::Base @value="Custom width" @width="248px" />
+              <Hds::Form::Textarea::Base @value="Custom width and height" @width="248px" @height="150px" />
             </SF.Item>
           </Shw::Flex>
         </SG.Item>
@@ -201,7 +201,13 @@
               </Hds::Form::Textarea::Field>
             </SF.Item>
             <SF.Item @grow={{true}} {{style display=display}}>
-              <Hds::Form::Textarea::Field @value="Custom width" @width="248px" @isInvalid={{true}} as |F|>
+              <Hds::Form::Textarea::Field
+                @value="Custom width and height"
+                @width="248px"
+                @height="150px"
+                @isInvalid={{true}}
+                as |F|
+              >
                 <F.Label>This is the label</F.Label>
                 <F.HelperText>This is the helper text</F.HelperText>
                 <F.Error>This is the error</F.Error>


### PR DESCRIPTION
### :pushpin: Summary

Fix border and text color for readonly state

### :hammer_and_wrench: Detailed description

While working on #1468 I discovered that we're probably not using the correct tokens on the readonly textarea.

Updated the readonly tokens and added a custom `@height` example for visual regression testing.

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="444" alt="Screenshot 2023-07-04 at 12 34 00" src="https://github.com/hashicorp/design-system/assets/788096/1ed45c85-27a8-4632-85a7-4d058ee6872c">

</td><td>

<img width="443" alt="Screenshot 2023-07-04 at 12 34 15" src="https://github.com/hashicorp/design-system/assets/788096/aea016bb-7500-4439-b349-4106755f385d">


</td></tr>
</table>

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
