### PR TITLE
Updated test:a11y script

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,7 +35,7 @@
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each",
     "test:ember:percy": "percy exec ember test",
-    "test:a11y": "ENABLE_A11Y_AUDIT=true ember test",
+    "test:a11y": "ENABLE_A11Y_AUDIT=true ember test --server",
     "test:a11y-report": "ENABLE_A11Y_MIDDLEWARE_REPORTER=true ember test"
   },
   "dependencies": {

--- a/packages/components/tests/integration/components/hds/alert/index-test.js
+++ b/packages/components/tests/integration/components/hds/alert/index-test.js
@@ -85,7 +85,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
 
   test('it should render an Hds::Button component yielded to the "actions" container', async function (assert) {
     await render(
-      hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Button @text="I am a button" @size="small" @color="secondary" /></Hds::Alert>`
+      hbs`<Hds::Alert @type="inline" aria-labelledby="test-alert-button" id="test-alert" as |A|><A.Button @text="I am a button" @size="small" @color="secondary" id="test-alert-button"/></Hds::Alert>`
     );
     assert
       .dom('#test-alert .hds-alert__actions button')
@@ -97,7 +97,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   });
   test('it should render an Hds::Link::Standalone component yielded to the "actions" container', async function (assert) {
     await render(
-      hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Link::Standalone @icon="plus" @text="I am a link" @href="#" @size="small" @color="secondary" /></Hds::Alert>`
+      hbs`<Hds::Alert @type="inline" aria-labelledby="test-alert-link" id="test-alert" as |A|><A.Link::Standalone @icon="plus" @text="I am a link" @href="#" @size="small" @color="secondary" id="test-alert-link" /></Hds::Alert>`
     );
     assert
       .dom('#test-alert .hds-alert__actions a')

--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -43,13 +43,15 @@ setRunOptions({
       'best-practice',
     ],
   },
-  include: ['#ember-testing-container'],
-  exclude: ['.flight-sprite-container', '.shw-page-main'],
+  include: [['#ember-testing-container']],
+  exclude: [['.flight-sprite-container'], ['.shw-page-main']],
 });
 
-// This might not be needed since using the ENABLE_A11Y_AUDIT environment variable is used in the script that runs the audit 🤔
-// Also if `enableA11yAudit` is specified in the query param it will also force the audit already
-// So, think about whether or not there are valid use cases for this conditional.
+// This will be used by developers to run the tests locally
+// Either with the `enableA11yAudit` as a query param in the URL
+// or `yarn test:a11y` in the CLI
+// Note: if you want to filter what test is run from the start, use the --filter flag: `yarn test:a11y --filter="alert"`
+// Docs: https://guides.emberjs.com/release/testing/#toc_how-to-filter-tests
 if (shouldForceAudit()) {
   setEnableA11yAudit(true);
 }


### PR DESCRIPTION
### :pushpin: Summary
 
If merged, this PR updates the `yarn test:a11y` invocation and adds instructions for use. This would negate the need to add a specific `a11yAudit` invocation to individual components.

### :hammer_and_wrench: Detailed description

- updates `test:a11y` invocation
- adds comments to the `test-helper.js` file so devs know how to invoke the a11yAudit locally 
- updated the alert component related tests so they pass the a11y audit as an example by using the `yarn test:a11y --filter="alert"` invocation in the terminal.

### :camera_flash: Screenshots

Tests pass
![20 passing tests for alert component](https://github.com/hashicorp/design-system/assets/4587451/b0613c6d-5421-4b37-bb9d-f1ead6736880)


### :link: External links

Jira ticket: [HDS-2204](https://hashicorp.atlassian.net/browse/HDS-2204)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2204]: https://hashicorp.atlassian.net/browse/HDS-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ