### PR TITLE
Tidied up component tests for `a11yAudit`

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,7 +35,7 @@
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each",
     "test:ember:percy": "percy exec ember test",
-    "test:a11y": "ENABLE_A11Y_AUDIT=true ember test",
+    "test:a11y": "ENABLE_A11Y_AUDIT=true ember test --server",
     "test:a11y-report": "ENABLE_A11Y_MIDDLEWARE_REPORTER=true ember test"
   },
   "dependencies": {

--- a/packages/components/tests/integration/components/hds/alert/index-test.js
+++ b/packages/components/tests/integration/components/hds/alert/index-test.js
@@ -85,7 +85,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
 
   test('it should render an Hds::Button component yielded to the "actions" container', async function (assert) {
     await render(
-      hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Button @text="I am a button" @size="small" @color="secondary" /></Hds::Alert>`
+      hbs`<Hds::Alert @type="inline" aria-labelledby="test-alert-button" id="test-alert" as |A|><A.Button @text="I am a button" @size="small" @color="secondary" id="test-alert-button"/></Hds::Alert>`
     );
     assert
       .dom('#test-alert .hds-alert__actions button')
@@ -97,7 +97,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   });
   test('it should render an Hds::Link::Standalone component yielded to the "actions" container', async function (assert) {
     await render(
-      hbs`<Hds::Alert @type="inline" id="test-alert" as |A|><A.Link::Standalone @icon="plus" @text="I am a link" @href="#" @size="small" @color="secondary" /></Hds::Alert>`
+      hbs`<Hds::Alert @type="inline" aria-labelledby="test-alert-link" id="test-alert" as |A|><A.Link::Standalone @icon="plus" @text="I am a link" @href="#" @size="small" @color="secondary" id="test-alert-link" /></Hds::Alert>`
     );
     assert
       .dom('#test-alert .hds-alert__actions a')

--- a/packages/components/tests/integration/components/hds/breadcrumb/item-test.js
+++ b/packages/components/tests/integration/components/hds/breadcrumb/item-test.js
@@ -12,13 +12,15 @@ module('Integration | Component | hds/breadcrumb/item', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Breadcrumb::Item id="test-breadcrumb-item" />`);
+    await render(
+      hbs`<ul><Hds::Breadcrumb::Item id="test-breadcrumb-item" @text="test" /></ul>`
+    );
     assert.dom('#test-breadcrumb-item').hasClass('hds-breadcrumb__item');
   });
 
   test('it should render the correct style if the @maxWidth prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Breadcrumb::Item @maxWidth="200px" @text="test" id="test-breadcrumb-item" />`
+      hbs`<ul><Hds::Breadcrumb::Item @maxWidth="200px" @text="test" id="test-breadcrumb-item" /></ul>`
     );
     assert.dom('#test-breadcrumb-item').hasStyle({ 'max-width': '200px' });
   });
@@ -27,20 +29,20 @@ module('Integration | Component | hds/breadcrumb/item', function (hooks) {
 
   test('it should render a link by default', async function (assert) {
     await render(
-      hbs`<Hds::Breadcrumb::Item id="test-breadcrumb-item" @text="text renders" />`
+      hbs`<ul><Hds::Breadcrumb::Item id="test-breadcrumb-item" @text="text renders" /></ul>`
     );
     assert.dom('#test-breadcrumb-item > a').exists();
   });
   test('it should not render a if @current is true', async function (assert) {
     await render(
-      hbs`<Hds::Breadcrumb::Item id="test-breadcrumb-item" @text="text renders" @current={{true}} />`
+      hbs`<ul><Hds::Breadcrumb::Item id="test-breadcrumb-item" @text="text renders" @current={{true}} /></ul>`
     );
     assert.dom('#test-breadcrumb-item > a').doesNotExist();
     assert.dom('#test-breadcrumb-item .hds-breadcrumb__current').exists();
   });
   test('it should render the item with icon and text if @icon and @text are provided', async function (assert) {
     await render(
-      hbs`<Hds::Breadcrumb::Item id="test-breadcrumb-item" @text="text renders" @icon="activity" />`
+      hbs`<ul><Hds::Breadcrumb::Item id="test-breadcrumb-item" @text="text renders" @icon="activity" /></ul>`
     );
     assert.dom('.flight-icon.flight-icon-activity').exists();
     assert.dom('.hds-breadcrumb__text').hasText('text renders');
@@ -55,7 +57,7 @@ module('Integration | Component | hds/breadcrumb/item', function (hooks) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
     await render(
-      hbs`<Hds::Breadcrumb::Item @maxWidth="123" id="test-breadcrumb-item" />`
+      hbs`<ul><Hds::Breadcrumb::Item @maxWidth="123" id="test-breadcrumb-item" /></ul>`
     );
     assert.throws(function () {
       throw new Error(errorMessage);

--- a/packages/components/tests/integration/components/hds/breadcrumb/truncation-test.js
+++ b/packages/components/tests/integration/components/hds/breadcrumb/truncation-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | hds/breadcrumb/truncation', function (hooks) {
 
   test('it renders the breadcrumb truncation with an appropriate CSS class', async function (assert) {
     await render(
-      hbs`<Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" />`
+      hbs`<ul><Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" /></ul>`
     );
     assert
       .dom('#test-breadcrumb-truncation')
@@ -24,14 +24,14 @@ module('Integration | Component | hds/breadcrumb/truncation', function (hooks) {
 
   test('it should render a toggle button', async function (assert) {
     await render(
-      hbs`<Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" />`
+      hbs`<ul><Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" /></ul>`
     );
     assert.dom('#test-breadcrumb-truncation button').exists();
   });
 
   test('the toggle button should have an aria-label', async function (assert) {
     await render(
-      hbs`<Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" />`
+      hbs`<ul><Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" /></ul>`
     );
     assert.dom('#test-breadcrumb-truncation button').hasAttribute('aria-label');
   });
@@ -40,7 +40,7 @@ module('Integration | Component | hds/breadcrumb/truncation', function (hooks) {
 
   test('it should not render the content', async function (assert) {
     await render(
-      hbs`<Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" />`
+      hbs`<ul><Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" /></ul>`
     );
     assert
       .dom('#test-breadcrumb-truncation .hds-breadcrumb__truncation-content')
@@ -48,7 +48,7 @@ module('Integration | Component | hds/breadcrumb/truncation', function (hooks) {
   });
   test('it should yield (and render) the content', async function (assert) {
     await render(
-      hbs`<Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation"><a id="test-breadcrumb-truncation-link" href="#">test</a></Hds::Breadcrumb::Truncation>`
+      hbs`<ul><Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation"><li><a id="test-breadcrumb-truncation-link" href="#">test</a></li></Hds::Breadcrumb::Truncation></ul>`
     );
     await click('#test-breadcrumb-truncation button');
     assert.dom('.hds-breadcrumb__truncation-content').exists();
@@ -60,7 +60,7 @@ module('Integration | Component | hds/breadcrumb/truncation', function (hooks) {
 
   test('it should render with the correct aria-expanded attribute on the toggle element', async function (assert) {
     await render(
-      hbs`<Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" />`
+      hbs`<ul><Hds::Breadcrumb::Truncation id="test-breadcrumb-truncation" /></ul>`
     );
     assert
       .dom('#test-breadcrumb-truncation button')

--- a/packages/components/tests/integration/components/hds/button/index-test.js
+++ b/packages/components/tests/integration/components/hds/button/index-test.js
@@ -145,7 +145,9 @@ module('Integration | Component | hds/button/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Button @icon="clipboard-copy" />`);
+    await render(
+      hbs`<Hds::Button @icon="clipboard-copy" id="test-button-assertion" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -182,7 +184,7 @@ module('Integration | Component | hds/button/index', function (hooks) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
     await render(
-      hbs`<Hds::Button @icon="clipboard-copy" @text="copy to clipboard" @iconPosition="after" />`
+      hbs`<Hds::Button @text="copy to clipboard" @icon="clipboard-copy"  @iconPosition="after" id="test-is-flake" />`
     );
     assert.throws(function () {
       throw new Error(errorMessage);

--- a/packages/components/tests/integration/components/hds/disclosure-primitive/index-test.js
+++ b/packages/components/tests/integration/components/hds/disclosure-primitive/index-test.js
@@ -32,7 +32,7 @@ module(
       await render(hbs`
       <Hds::DisclosurePrimitive>
         <:toggle>
-          <button type="button" id="test-disclosure-primitive-button" />
+          <button type="button" id="test-disclosure-primitive-button">Click me</button>
         </:toggle>
       </Hds::DisclosurePrimitive>
     `);
@@ -44,10 +44,10 @@ module(
       await render(hbs`
       <Hds::DisclosurePrimitive>
         <:toggle as |t|>
-          <button type="button" id="test-disclosure-primitive-button" {{on "click" t.onClickToggle}} />
+          <button type="button" id="test-disclosure-primitive-button" style="padding:1rem;" {{on "click" t.onClickToggle}}>Click me</button>
         </:toggle>
         <:content>
-          <a id="test-disclosure-primitive-link" href="#">test</a>
+          <a id="test-disclosure-primitive-link" href="#" style="padding:1rem;">test</a>
         </:content>
       </Hds::DisclosurePrimitive>
     `);
@@ -57,15 +57,16 @@ module(
     });
 
     // CLOSE DISCLOSED CONTENT ON CLICK
+    // INLINE STYLE ADDED FOR A11YAUDIT
 
     test('it should hide the "content" when an interactive element triggers `close`', async function (assert) {
       await render(hbs`
       <Hds::DisclosurePrimitive id="test-disclosure-primitive">
         <:toggle as |t|>
-          <button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} />
+          <button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} style="padding:1rem;">Toggle</button>
         </:toggle>
         <:content as |c|>
-          <button id="test-content-button" {{on "click" c.close}}>test</button>
+          <button id="test-content-button" {{on "click" c.close}} style="padding:1rem;">test</button>
         </:content>
       </Hds::DisclosurePrimitive>
     `);

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
@@ -15,14 +15,14 @@ module(
 
     test('it renders the "list-item/checkbox"', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<ul><Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox></ul>`
       );
       assert.dom(this.element).exists();
     });
 
     test('it should render the "list-item/checkbox" as a <li> element with a CSS class that matches the component name', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<ul><Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox></ul>`
       );
       assert.dom('.hds-dropdown-list-item').hasTagName('li');
       assert
@@ -34,7 +34,7 @@ module(
 
     test('it should render the "list-item" with a checkbox control', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<ul><Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox></ul>`
       );
       assert.dom('.hds-form-checkbox').exists();
     });
@@ -43,7 +43,7 @@ module(
 
     test('it should forward the `id` and `value` arguments to the input control', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox @id="id" @value="value">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<ul><Hds::Dropdown::ListItem::Checkbox @id="id" @value="value">Checkbox item</Hds::Dropdown::ListItem::Checkbox></ul>`
       );
       assert.dom('.hds-form-checkbox').hasAttribute('id', 'id');
       assert.dom('.hds-form-checkbox').hasValue('value');
@@ -52,7 +52,7 @@ module(
     // CONTROL-LABEL ASSOCIATION
     test('it automatically creates the control-label relationship via generated id', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox @value="value">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<ul><Hds::Dropdown::ListItem::Checkbox @value="value">Checkbox item</Hds::Dropdown::ListItem::Checkbox></ul>`
       );
       let control = this.element.querySelector(
         '.hds-dropdown-list-item__control'
@@ -67,7 +67,7 @@ module(
 
     test('if an icon is declared the flight icon should render in the component', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox @icon="hexagon">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<ul><Hds::Dropdown::ListItem::Checkbox @icon="hexagon">Checkbox item</Hds::Dropdown::ListItem::Checkbox></ul>`
       );
       assert.dom('.flight-icon.flight-icon-hexagon').exists();
     });
@@ -76,7 +76,7 @@ module(
 
     test('it should render the content passed as block in a form label', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<ul><Hds::Dropdown::ListItem::Checkbox>Checkbox item</Hds::Dropdown::ListItem::Checkbox></ul>`
       );
       assert.dom('.hds-dropdown-list-item__control').exists();
       assert.dom('.hds-dropdown-list-item__label').hasText('Checkbox item');
@@ -86,7 +86,7 @@ module(
 
     test('it should render with a result count badge', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox @count="10">Checkbox item</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<ul><Hds::Dropdown::ListItem::Checkbox @count="10">Checkbox item</Hds::Dropdown::ListItem::Checkbox></ul>`
       );
       assert.dom('.hds-dropdown-list-item__count').hasText('10');
     });
@@ -95,7 +95,7 @@ module(
 
     test('it should render as checked if `checked` is true', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Checkbox checked={{true}}>Checkbox</Hds::Dropdown::ListItem::Checkbox>`
+        hbs`<ul><Hds::Dropdown::ListItem::Checkbox checked={{true}}>Checkbox</Hds::Dropdown::ListItem::Checkbox></ul>`
       );
       assert.dom('.hds-form-checkbox').isChecked();
     });

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/copy-item-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/copy-item-test.js
@@ -19,7 +19,7 @@ module(
 
     test('it should render the component as a <li> element with a CSS class that matches the component name', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::CopyItem @text="copy-item" id="test-list-item-copy-item" />`
+        hbs`<ul><Hds::Dropdown::ListItem::CopyItem @text="copy-item" id="test-list-item-copy-item" /></ul>`
       );
       assert.dom('#test-list-item-copy-item').hasTagName('li');
       assert
@@ -39,7 +39,9 @@ module(
       setupOnerror(function (error) {
         assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
       });
-      await render(hbs`<Hds::Dropdown::ListItem::CopyItem />`);
+      await render(
+        hbs`<Hds::Dropdown::ListItem::CopyItem id="test-valid-failure" />`
+      );
       assert.throws(function () {
         throw new Error(errorMessage);
       });

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/description-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/description-test.js
@@ -19,7 +19,7 @@ module(
 
     test('it should render the component as a <li> element with a CSS class that matches the component name', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Description @text="description" id="test-list-item-description" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Description @text="description" id="test-list-item-description" /></ul>`
       );
       assert.dom('#test-list-item-description').hasTagName('li');
       assert
@@ -39,7 +39,9 @@ module(
       setupOnerror(function (error) {
         assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
       });
-      await render(hbs`<Hds::Dropdown::ListItem::Description />`);
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Description id="test-valid-failure" />`
+      );
       assert.throws(function () {
         throw new Error(errorMessage);
       });

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/generic-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/generic-test.js
@@ -15,7 +15,7 @@ module(
 
     test('it should render the component as a <li> element with a CSS class that matches the component name', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Generic id="test-list-item-generic" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Generic id="test-list-item-generic" /></ul>`
       );
       assert.dom('#test-list-item-generic').hasTagName('li');
       assert.dom('#test-list-item-generic').hasClass('hds-dropdown-list-item');
@@ -28,7 +28,7 @@ module(
 
     test('it should render the yielded content', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Generic><pre>test</pre></Hds::Dropdown::ListItem::Generic>`
+        hbs`<ul><Hds::Dropdown::ListItem::Generic><pre>test</pre></Hds::Dropdown::ListItem::Generic></ul>`
       );
       assert.dom('.hds-dropdown-list-item--variant-generic > pre').exists();
       assert

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/interactive-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/interactive-test.js
@@ -23,7 +23,7 @@ module(
 
     test('it should render the component as a <li> element with a CSS class that matches the component name', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Interactive @text="interactive" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Interactive @text="interactive" /></ul>`
       );
       assert.dom('.hds-dropdown-list-item').hasTagName('li');
       assert
@@ -35,19 +35,19 @@ module(
 
     test('it should render the "list-item" with a button by default"', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Interactive @text="interactive" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Interactive @text="interactive" /></ul>`
       );
       assert.dom('.hds-dropdown-list-item > button').exists();
     });
     test('it should render the "list-item" with a link if it has a @route parameter"', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Interactive @text="interactive" @route="index" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Interactive @text="interactive" @route="index" /></ul>`
       );
       assert.dom('.hds-dropdown-list-item > a').exists();
     });
     test('it should render the "list-item" with a link if it has a @href argument"', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Interactive @text="interactive" @href="#" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Interactive @text="interactive" @href="#" /></ul>`
       );
       assert.dom('.hds-dropdown-list-item > a').exists();
     });
@@ -56,7 +56,7 @@ module(
 
     test('it should render the "action" color as the default if no color is declared"', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Interactive @text="interactive" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Interactive @text="interactive" /></ul>`
       );
       assert
         .dom('.hds-dropdown-list-item')
@@ -64,7 +64,7 @@ module(
     });
     test('it should render the correct CSS color class if the @color prop is declared', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Interactive @color="critical" @text="interactive" @icon="trash" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Interactive @color="critical" @text="interactive" @icon="trash" /></ul>`
       );
       assert
         .dom('.hds-dropdown-list-item')
@@ -75,7 +75,7 @@ module(
 
     test('if an icon is declared the flight icon should render in the component', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Interactive @icon="clipboard-copy" @text="interactive" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Interactive @icon="clipboard-copy" @text="interactive" /></ul>`
       );
       assert.dom('.flight-icon.flight-icon-clipboard-copy').exists();
     });
@@ -84,7 +84,7 @@ module(
 
     test('it should render the text passed as @text prop', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Interactive @text="interactive text" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Interactive @text="interactive text" /></ul>`
       );
       assert.dom('.hds-dropdown-list-item').hasText('interactive text');
     });
@@ -98,7 +98,9 @@ module(
       setupOnerror(function (error) {
         assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
       });
-      await render(hbs`<Hds::Dropdown::ListItem::Interactive />`);
+      await render(
+        hbs`<ul><Hds::Dropdown::ListItem::Interactive id="test-valid-failure" /></ul>`
+      );
       assert.throws(function () {
         throw new Error(errorMessage);
       });
@@ -111,7 +113,7 @@ module(
         assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
       });
       await render(
-        hbs`<Hds::Dropdown::ListItem::Interactive @text="interactive text" @color="foo" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Interactive @text="interactive text" @color="foo" /></ul>`
       );
       assert.throws(function () {
         throw new Error(errorMessage);

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/radio-test.js
@@ -15,14 +15,14 @@ module(
 
     test('it renders the "list-item/radio"', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio>`
+        hbs`<ul><Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio></ul>`
       );
       assert.dom(this.element).exists();
     });
 
     test('it should render the "list-item/radio" as a <li> element with a CSS class that matches the component name', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio>`
+        hbs`<ul><Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio></ul>`
       );
       assert.dom('.hds-dropdown-list-item').hasTagName('li');
       assert
@@ -34,7 +34,7 @@ module(
 
     test('it should render the "list-item" with a radio control', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio>`
+        hbs`<ul><Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio></ul>`
       );
       assert.dom('.hds-form-radio').exists();
     });
@@ -43,7 +43,7 @@ module(
 
     test('it should forward the `id` and `value` arguments to the input control', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio @id="id" @value="value">Radio item</Hds::Dropdown::ListItem::Radio>`
+        hbs`<ul><Hds::Dropdown::ListItem::Radio @id="id" @value="value">Radio item</Hds::Dropdown::ListItem::Radio></ul>`
       );
       assert.dom('.hds-form-radio').hasAttribute('id', 'id');
       assert.dom('.hds-form-radio').hasValue('value');
@@ -52,7 +52,7 @@ module(
     // CONTROL-LABEL ASSOCIATION
     test('it automatically creates the control-label relationship via generated id', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio @value="value">Checkbox item</Hds::Dropdown::ListItem::Radio>`
+        hbs`<ul><Hds::Dropdown::ListItem::Radio @value="value">Checkbox item</Hds::Dropdown::ListItem::Radio></ul>`
       );
       let control = this.element.querySelector(
         '.hds-dropdown-list-item__control'
@@ -67,7 +67,7 @@ module(
 
     test('if an icon is declared the flight icon should render in the component', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio @icon="hexagon">Radio item</Hds::Dropdown::ListItem::Radio>`
+        hbs`<ul><Hds::Dropdown::ListItem::Radio @icon="hexagon">Radio item</Hds::Dropdown::ListItem::Radio></ul>`
       );
       assert.dom('.flight-icon.flight-icon-hexagon').exists();
     });
@@ -76,7 +76,7 @@ module(
 
     test('it should render the content passed as block in a form label', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio>`
+        hbs`<ul><Hds::Dropdown::ListItem::Radio>Radio item</Hds::Dropdown::ListItem::Radio></ul>`
       );
       assert.dom('.hds-dropdown-list-item__control').exists();
       assert.dom('.hds-dropdown-list-item__label').hasText('Radio item');
@@ -86,7 +86,7 @@ module(
 
     test('it should render with a result count badge', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio @count="10">Radio item</Hds::Dropdown::ListItem::Radio>`
+        hbs`<ul><Hds::Dropdown::ListItem::Radio @count="10">Radio item</Hds::Dropdown::ListItem::Radio></ul>`
       );
       assert.dom('.hds-dropdown-list-item__count').hasText('10');
     });
@@ -95,7 +95,7 @@ module(
 
     test('it should render as checked if `checked` is true', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Radio checked={{true}}>Radio</Hds::Dropdown::ListItem::Radio>`
+        hbs`<ul><Hds::Dropdown::ListItem::Radio checked={{true}}>Radio</Hds::Dropdown::ListItem::Radio></ul>`
       );
       assert.dom('.hds-form-radio').isChecked();
     });

--- a/packages/components/tests/integration/components/hds/dropdown/list-item/title-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/list-item/title-test.js
@@ -19,7 +19,7 @@ module(
 
     test('it should render the component as a <li> element with a CSS class that matches the component name', async function (assert) {
       await render(
-        hbs`<Hds::Dropdown::ListItem::Title @text="title" id="test-list-item-title" />`
+        hbs`<ul><Hds::Dropdown::ListItem::Title @text="title" id="test-list-item-title" /></ul>`
       );
       assert.dom('#test-list-item-title').hasTagName('li');
       assert.dom('#test-list-item-title').hasClass('hds-dropdown-list-item');
@@ -37,7 +37,7 @@ module(
       setupOnerror(function (error) {
         assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
       });
-      await render(hbs`<Hds::Dropdown::ListItem::Title />`);
+      await render(hbs`<ul><Hds::Dropdown::ListItem::Title /></ul>`);
       assert.throws(function () {
         throw new Error(errorMessage);
       });

--- a/packages/components/tests/integration/components/hds/form/checkbox/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/base-test.js
@@ -12,12 +12,14 @@ module('Integration | Component | hds/form/checkbox/base', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" />`);
+    await render(
+      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" aria-label="test label" />`
+    );
     assert.dom('#test-form-checkbox').hasClass('hds-form-checkbox');
   });
   test('it should convert the `indeterminate` attribute into a property', async function (assert) {
     await render(
-      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" indeterminate={{true}} />`
+      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" indeterminate={{true}} aria-label="test label" />`
     );
     assert.dom('#test-form-checkbox').doesNotHaveAttribute('indeterminate');
     assert.dom('#test-form-checkbox').hasProperty('indeterminate', true);
@@ -27,7 +29,7 @@ module('Integration | Component | hds/form/checkbox/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" aria-label="test label" class="my-class" data-test1 data-test2="test" />`
     );
     assert.dom('#test-form-checkbox').hasClass('my-class');
     assert.dom('#test-form-checkbox').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
@@ -16,21 +16,25 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
   });
 
   test('it should render the component with the appropriate CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::Checkbox::Field />`);
+    await render(hbs`<Hds::Form::Checkbox::Field aria-label="test label" />`);
     assert.dom('.hds-form-field__control').exists();
   });
 
   // VALUE
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
-    await render(hbs`<Hds::Form::Checkbox::Field @value="abc123" />`);
+    await render(
+      hbs`<Hds::Form::Checkbox::Field @value="abc123" aria-label="test label" />`
+    );
     assert.dom('input').hasValue('abc123');
   });
 
   // ID
 
   test('it should render the input with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::Checkbox::Field @id="my-input" />`);
+    await render(
+      hbs`<Hds::Form::Checkbox::Field @id="my-input" aria-label="test label" />`
+    );
     assert.dom('input').hasAttribute('id', 'my-input');
   });
 
@@ -51,7 +55,7 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::Checkbox::Field />`);
+    await render(hbs`<Hds::Form::Checkbox::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -87,7 +91,7 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
   // we have added an extra assertion for the "name" attribute here, even if not strictly necessary, to make sure is not overwritten in any way
   test('it should spread all the attributes (including "name") passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" />`
+      hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" aria-label="test label" />`
     );
     assert.dom('input').hasClass('my-class');
     assert.dom('input').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
@@ -31,8 +31,8 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
       hbs`<Hds::Form::RadioCard::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.RadioCard/>
-            <G.RadioCard/>
+            <G.RadioCard aria-label="test label one" />
+            <G.RadioCard aria-label="test label two" />
             <G.Error>This is the group error</G.Error>
           </Hds::Form::RadioCard::Group>`
     );
@@ -61,8 +61,8 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
       hbs`<Hds::Form::RadioCard::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.RadioCard/>
-            <G.RadioCard/>
+            <G.RadioCard aria-label="test label one" />
+            <G.RadioCard aria-label="test label two" />
             <G.Error>This is the group error</G.Error>
           </Hds::Form::RadioCard::Group>`
     );
@@ -85,8 +85,8 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
       hbs`<Hds::Form::RadioCard::Group @name="test-name" @alignment="center" @controlPosition="left" @layout="fixed" as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.RadioCard @maxWidth="50%" data-test="first-control"/>
-            <G.RadioCard @maxWidth="50%" data-test="second-control"/>
+            <G.RadioCard @maxWidth="50%" data-test="first-control" aria-label="test label one" />
+            <G.RadioCard @maxWidth="50%" data-test="second-control" aria-label="test label two" />
             <G.Error>This is the group error</G.Error>
           </Hds::Form::RadioCard::Group>`
     );
@@ -111,7 +111,7 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
     await render(
       hbs`<Hds::Form::RadioCard::Group @isRequired={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
-            <G.RadioCard/>
+            <G.RadioCard aria-label="test label" />
           </Hds::Form::RadioCard::Group>`
     );
     assert.dom('legend .hds-form-indicator').exists();
@@ -121,7 +121,7 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
     await render(
       hbs`<Hds::Form::RadioCard::Group @isOptional={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
-            <G.RadioCard/>
+            <G.RadioCard aria-label="test label" />
           </Hds::Form::RadioCard::Group>`
     );
     assert.dom('legend .hds-form-indicator').exists();

--- a/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
@@ -12,18 +12,20 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::RadioCard/>`);
+    await render(hbs`<Hds::Form::RadioCard aria-label="test label" />`);
     assert.dom('label').hasClass('hds-form-radio-card');
   });
   test('it should render the input with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::RadioCard />`);
+    await render(hbs`<Hds::Form::RadioCard aria-label="test label" />`);
     assert.dom('input').hasClass('hds-form-radio-card__control');
   });
 
   // NAME, VALUE
 
   test('it should render the input with the arguments provided', async function (assert) {
-    await render(hbs`<Hds::Form::RadioCard @name="name" @value="value" />`);
+    await render(
+      hbs`<Hds::Form::RadioCard @name="name" @value="value" aria-label="test label" />`
+    );
     assert.dom('input').hasValue('value');
     assert.dom('input').hasAttribute('name', 'name');
   });
@@ -32,7 +34,7 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
 
   test('it should render the component with CSS classes that reflect the arguments provided', async function (assert) {
     await render(
-      hbs`<Hds::Form::RadioCard @checked="checked" @disabled="disabled" />`
+      hbs`<Hds::Form::RadioCard @checked="checked" @disabled="disabled" aria-label="test label" />`
     );
     assert.dom('label').hasClass('hds-form-radio-card--checked');
     assert.dom('label').hasClass('hds-form-radio-card--disabled');
@@ -57,7 +59,7 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     assert.dom('.custom').exists();
   });
   test('it does not render the contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::RadioCard />`);
+    await render(hbs`<Hds::Form::RadioCard aria-label="test label" />`);
     assert.dom('.flight-icon').doesNotExist();
     assert.dom('.hds-form-radio-card__label').doesNotExist();
     assert.dom('.hds-badge').doesNotExist();
@@ -69,7 +71,7 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::RadioCard id="my-id" name="my-name" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::RadioCard id="my-id" name="my-name" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('input').hasAttribute('id', 'my-id');
     assert.dom('input').hasAttribute('name', 'my-name');
@@ -87,7 +89,9 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Form::RadioCard @alignment="foo" />`);
+    await render(
+      hbs`<Hds::Form::RadioCard @alignment="foo" aria-label="test label" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -100,7 +104,9 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Form::RadioCard @controlPosition="foo" />`);
+    await render(
+      hbs`<Hds::Form::RadioCard @controlPosition="foo" aria-label="test label" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -113,7 +119,9 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Form::RadioCard @layout="foo" />`);
+    await render(
+      hbs`<Hds::Form::RadioCard @layout="foo" aria-label="test label" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -126,7 +134,9 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Form::RadioCard @layout="fixed" />`);
+    await render(
+      hbs`<Hds::Form::RadioCard @layout="fixed" aria-label="test label" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });

--- a/packages/components/tests/integration/components/hds/form/radio/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/base-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | hds/form/radio/base', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Base id="test-form-radio" />`);
+    await render(
+      hbs`<Hds::Form::Radio::Base id="test-form-radio" aria-label="test label" />`
+    );
     assert.dom('#test-form-radio').hasClass('hds-form-radio');
   });
 
@@ -20,7 +22,7 @@ module('Integration | Component | hds/form/radio/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Radio::Base id="test-form-radio" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Radio::Base id="test-form-radio" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('#test-form-radio').hasClass('my-class');
     assert.dom('#test-form-radio').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/radio/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/field-test.js
@@ -16,21 +16,25 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
   });
 
   test('it should render the component with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Field />`);
+    await render(hbs`<Hds::Form::Radio::Field aria-label="test label" />`);
     assert.dom('.hds-form-field__control').exists();
   });
 
   // VALUE
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Field @value="abc123" />`);
+    await render(
+      hbs`<Hds::Form::Radio::Field @value="abc123" aria-label="test label" />`
+    );
     assert.dom('input').hasValue('abc123');
   });
 
   // ID
 
   test('it should render the input with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Field @id="my-input" />`);
+    await render(
+      hbs`<Hds::Form::Radio::Field @id="my-input" aria-label="test label" />`
+    );
     assert.dom('input').hasAttribute('id', 'my-input');
   });
 
@@ -50,7 +54,7 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Field />`);
+    await render(hbs`<Hds::Form::Radio::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -84,9 +88,9 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
   // ATTRIBUTES
 
   // we have added an extra assertion for the "name" attribute here, even if not strictly necessary, to make sure is not overwritten in any way
-  test('it should spread all the attributes (includind "name") passed to the component on the input', async function (assert) {
+  test('it should spread all the attributes (including "name") passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" />`
+      hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" aria-label="test label" />`
     );
     assert.dom('input').hasClass('my-class');
     assert.dom('input').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/radio/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/group-test.js
@@ -16,7 +16,9 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
   });
 
   test('it should render the component', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Group id="test-form-radio" />`);
+    await render(
+      hbs`<Hds::Form::Radio::Group id="test-form-radio" aria-label="test label" />`
+    );
     assert.dom('#test-form-radio').hasClass('hds-form-group');
   });
 

--- a/packages/components/tests/integration/components/hds/form/select/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/base-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Base id="test-form-select" />`);
+    await render(
+      hbs`<Hds::Form::Select::Base id="test-form-select" aria-label="test label" />`
+    );
     assert.dom('#test-form-select').hasClass('hds-form-select');
   });
 
@@ -20,7 +22,7 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
 
   test('it should render the options passed via contextual component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Base id="test-form-select" as |C|><C.Options><option value="abc123">This is the option</option></C.Options></Hds::Form::Select::Base>`
+      hbs`<Hds::Form::Select::Base id="test-form-select" aria-label="test label" as |C|><C.Options><option value="abc123">This is the option</option></C.Options></Hds::Form::Select::Base>`
     );
     assert.dom('#test-form-select option').exists();
     assert.dom('#test-form-select option').hasText('This is the option');
@@ -31,7 +33,7 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
 
   test('it should render the select with a fixed width if a @width value is passed', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Base @width="248px" id="test-form-select" />`
+      hbs`<Hds::Form::Select::Base @width="248px" id="test-form-select" aria-label="test label" />`
     );
     assert.dom('#test-form-select').hasStyle({ width: '248px' });
   });
@@ -40,7 +42,7 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Base id="test-form-select" @isInvalid={{true}} />`
+      hbs`<Hds::Form::Select::Base id="test-form-select" @isInvalid={{true}} aria-label="test label" />`
     );
     assert.dom('#test-form-select').hasClass('hds-form-select--is-invalid');
   });
@@ -49,7 +51,7 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Base id="test-form-select" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Select::Base id="test-form-select" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('#test-form-select').hasClass('my-class');
     assert.dom('#test-form-select').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/select/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/field-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
   });
 
   test('it should render the component with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Field />`);
+    await render(hbs`<Hds::Form::Select::Field aria-label="test label" />`);
     assert.dom('.hds-form-field__control').exists();
   });
 
@@ -24,7 +24,7 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
 
   test('it should render the options passed via contextual component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Field id="test-form-select" as |F|><F.Options><option value="abc123">This is the option</option></F.Options></Hds::Form::Select::Field>`
+      hbs`<Hds::Form::Select::Field id="test-form-select" aria-label="test label" as |F|><F.Options><option value="abc123">This is the option</option></F.Options></Hds::Form::Select::Field>`
     );
     assert.dom('select option').exists();
     assert.dom('select option').hasText('This is the option');
@@ -34,21 +34,27 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
   // WIDTH
 
   test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Field @width="248px" />`);
+    await render(
+      hbs`<Hds::Form::Select::Field aria-label="test label" @width="248px" />`
+    );
     assert.dom('select').hasStyle({ width: '248px' });
   });
 
   // INVALID
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Field @isInvalid={{true}} />`);
+    await render(
+      hbs`<Hds::Form::Select::Field aria-label="test label" @isInvalid={{true}} />`
+    );
     assert.dom('select').hasClass('hds-form-select--is-invalid');
   });
 
   // ID
 
   test('it should render the select control with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Field @id="my-input" />`);
+    await render(
+      hbs`<Hds::Form::Select::Field aria-label="test label" @id="my-input" />`
+    );
     assert.dom('select').hasAttribute('id', 'my-input');
   });
 
@@ -68,7 +74,7 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Field />`);
+    await render(hbs`<Hds::Form::Select::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -134,7 +140,7 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Field class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Select::Field aria-label="test label" class="my-class" data-test1 data-test2="test" />`
     );
     assert.dom('select').hasClass('my-class');
     assert.dom('select').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/text-input/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/base-test.js
@@ -16,19 +16,23 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
   });
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Base id="test-form-text-input" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" aria-label="test label" />`
+    );
     assert.dom('#test-form-text-input').hasClass('hds-form-text-input');
   });
 
   // TYPE
 
   test('it should render the "text" type if no type is declared', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Base id="test-form-text-input" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" aria-label="test label" />`
+    );
     assert.dom('#test-form-text-input').hasAttribute('type', 'text');
   });
   test('it should render the correct type depending on the @type prop', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base @type="email" id="test-form-text-input" />`
+      hbs`<Hds::Form::TextInput::Base @type="email" id="test-form-text-input" aria-label="test label" />`
     );
     assert.dom('#test-form-text-input').hasAttribute('type', 'email');
   });
@@ -37,7 +41,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base @value="abc123" id="test-form-text-input" />`
+      hbs`<Hds::Form::TextInput::Base @value="abc123" id="test-form-text-input" aria-label="test label" />`
     );
     assert.dom('#test-form-text-input').hasValue('abc123');
   });
@@ -46,7 +50,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @isInvalid={{true}} />`
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @isInvalid={{true}} aria-label="test label" />`
     );
     assert
       .dom('#test-form-text-input')
@@ -57,7 +61,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should render the correct CSS class if the @isLoading prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @type="search" @isLoading={{true}} />`
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @type="search" @isLoading={{true}} aria-label="test label" />`
     );
     assert
       .dom('#test-form-text-input')
@@ -68,7 +72,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base @width="248px" id="test-form-text-input" />`
+      hbs`<Hds::Form::TextInput::Base @width="248px" id="test-form-text-input" aria-label="test label" />`
     );
     assert.dom('#test-form-text-input').hasStyle({ width: '248px' });
   });
@@ -77,7 +81,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('#test-form-text-input').hasClass('my-class');
     assert.dom('#test-form-text-input').hasAttribute('data-test1');
@@ -93,7 +97,9 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Form::TextInput::Base @type="foo" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Base @type="foo" aria-label="test label" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });

--- a/packages/components/tests/integration/components/hds/form/text-input/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/field-test.js
@@ -16,32 +16,38 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
   });
 
   test('it should render the component with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field />`);
+    await render(hbs`<Hds::Form::TextInput::Field aria-label="test label" />`);
     assert.dom('.hds-form-field__control').exists();
   });
 
   // TYPE
 
   test('it should render the "text" type if no type is declared', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field />`);
+    await render(hbs`<Hds::Form::TextInput::Field aria-label="test label" />`);
     assert.dom('input').hasAttribute('type', 'text');
   });
   test('it should render the correct type depending on the @type prop', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field @type="email" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Field @type="email" aria-label="test label" />`
+    );
     assert.dom('input').hasAttribute('type', 'email');
   });
 
   // VALUE
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field @value="abc123" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Field @value="abc123" aria-label="test label" />`
+    );
     assert.dom('input').hasValue('abc123');
   });
 
   // INVALID
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field @isInvalid={{true}} />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Field @isInvalid={{true}} aria-label="test label" />`
+    );
     assert.dom('input').hasClass('hds-form-text-input--is-invalid');
   });
 
@@ -49,7 +55,7 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
 
   test('it should render the correct CSS class if the @isLoading prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Field @type="search" @isLoading={{true}} />`
+      hbs`<Hds::Form::TextInput::Field @type="search" @isLoading={{true}} aria-label="test label" />`
     );
     assert.dom('input').hasClass('hds-form-text-input--is-loading');
   });
@@ -57,14 +63,18 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
   // WIDTH
 
   test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field @width="248px" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Field @width="248px" aria-label="test label" />`
+    );
     assert.dom('input').hasStyle({ width: '248px' });
   });
 
   // ID
 
   test('it should render the input with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field @id="my-input" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Field @id="my-input" aria-label="test label" />`
+    );
     assert.dom('input').hasAttribute('id', 'my-input');
   });
 
@@ -84,7 +94,7 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field />`);
+    await render(hbs`<Hds::Form::TextInput::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -150,7 +160,7 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Field class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::TextInput::Field class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('input').hasClass('my-class');
     assert.dom('input').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/textarea/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/base-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Base id="test-form-textarea" />`);
+    await render(
+      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" aria-label="test label" />`
+    );
     assert.dom('#test-form-textarea').hasClass('hds-form-textarea');
   });
 
@@ -20,7 +22,7 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
     await render(
-      hbs`<Hds::Form::Textarea::Base @value="abc123" id="test-form-textarea" />`
+      hbs`<Hds::Form::Textarea::Base @value="abc123" id="test-form-textarea" aria-label="test label" />`
     );
     assert.dom('#test-form-textarea').hasValue('abc123');
   });
@@ -28,11 +30,13 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
   // ROWS
 
   test('it should render the textarea with the default number of rows', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Base />`);
+    await render(hbs`<Hds::Form::Textarea::Base aria-label="test label" />`);
     assert.dom('textarea').hasAttribute('rows', '4');
   });
   test('it should render the textarea with a custom number of rows', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Base rows="2" />`);
+    await render(
+      hbs`<Hds::Form::Textarea::Base rows="2" aria-label="test label" />`
+    );
     assert.dom('textarea').hasAttribute('rows', '2');
   });
 
@@ -40,7 +44,7 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" @isInvalid={{true}} />`
+      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" @isInvalid={{true}} aria-label="test label" />`
     );
     assert.dom('#test-form-textarea').hasClass('hds-form-textarea--is-invalid');
   });
@@ -49,7 +53,7 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('#test-form-textarea').hasClass('my-class');
     assert.dom('#test-form-textarea').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/textarea/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/field-test.js
@@ -16,21 +16,25 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
   });
 
   test('it should render the component with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Field />`);
+    await render(hbs`<Hds::Form::Textarea::Field aria-label="test label" />`);
     assert.dom('.hds-form-field__control').exists();
   });
 
   // VALUE
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Field @value="abc123" />`);
+    await render(
+      hbs`<Hds::Form::Textarea::Field @value="abc123" aria-label="test label" />`
+    );
     assert.dom('textarea').hasValue('abc123');
   });
 
   // INVALID
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Field @isInvalid={{true}} />`);
+    await render(
+      hbs`<Hds::Form::Textarea::Field @isInvalid={{true}} aria-label="test label" />`
+    );
     assert.dom('textarea').hasClass('hds-form-textarea--is-invalid');
   });
 
@@ -38,13 +42,13 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
 
   test('it should render the textarea control with a fixed width if a @width value is passed', async function (assert) {
     await render(hbs`
-      <Hds::Form::Textarea::Field @width="248px" />
+      <Hds::Form::Textarea::Field @width="248px" aria-label="test label" />
     `);
     assert.dom('textarea').hasStyle({ width: '248px' });
   });
   test('it should render the textarea control with a fixed height if a @height value is passed', async function (assert) {
     await render(hbs`
-      <Hds::Form::Textarea::Field @height="248px" />
+      <Hds::Form::Textarea::Field @height="248px" aria-label="test label" />
     `);
     assert.dom('textarea').hasStyle({ height: '248px' });
   });
@@ -52,7 +56,9 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
   // ID
 
   test('it should render the textarea control with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Field @id="my-textarea" />`);
+    await render(
+      hbs`<Hds::Form::Textarea::Field @id="my-textarea" aria-label="test label" />`
+    );
     assert.dom('textarea').hasAttribute('id', 'my-textarea');
   });
 
@@ -72,7 +78,7 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Field />`);
+    await render(hbs`<Hds::Form::Textarea::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -140,7 +146,7 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::Textarea::Field class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Textarea::Field class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('textarea').hasClass('my-class');
     assert.dom('textarea').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/toggle/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/base-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Base id="test-form-toggle" />`);
+    await render(
+      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" aria-label="test label" />`
+    );
     // Notice: the "toggle" component has a slightly different DOM structure than the other form controls
     assert.dom('.hds-form-toggle').exists();
     assert.dom('.hds-form-toggle > #test-form-toggle').exists();
@@ -23,7 +25,7 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('#test-form-toggle').hasClass('my-class');
     assert.dom('#test-form-toggle').hasAttribute('data-test1');
@@ -33,7 +35,9 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
   // ACCESSIBILITY
 
   test('it should render with the correct role', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Base id="test-form-toggle" />`);
+    await render(
+      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" aria-label="test label" />`
+    );
     assert.dom('#test-form-toggle').hasAttribute('role', 'switch');
   });
   // role="switch"

--- a/packages/components/tests/integration/components/hds/form/toggle/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/field-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
   });
 
   test('it should render the component with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Field />`);
+    await render(hbs`<Hds::Form::Toggle::Field aria-label="test label" />`);
     // Notice: the "toggle" component has a slightly different DOM structure than the other form controls
     assert.dom('input').hasClass('hds-form-toggle__control');
   });
@@ -24,14 +24,18 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
   // VALUE
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Field @value="abc123" />`);
+    await render(
+      hbs`<Hds::Form::Toggle::Field @value="abc123" aria-label="test label" />`
+    );
     assert.dom('input').hasValue('abc123');
   });
 
   // ID
 
   test('it should render the input with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Field @id="my-input" />`);
+    await render(
+      hbs`<Hds::Form::Toggle::Field @id="my-input" aria-label="test label" />`
+    );
     assert.dom('input').hasAttribute('id', 'my-input');
   });
 
@@ -51,7 +55,7 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Field />`);
+    await render(hbs`<Hds::Form::Toggle::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -87,7 +91,7 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::Toggle::Field checked="checked" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Toggle::Field checked="checked" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('input').hasClass('my-class');
     assert.dom('input').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/interactive/index-test.js
+++ b/packages/components/tests/integration/components/hds/interactive/index-test.js
@@ -14,24 +14,28 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
   // notice: since this element can generate different HTML element, to make the tests even more solid, in the DOM selectors we prefix the #ID of the element with the tag name
 
   test('it renders the interactive container', async function (assert) {
-    await render(hbs`<Hds::Interactive />`);
+    await render(hbs`<Hds::Interactive>Interactive text</Hds::Interactive>`);
     assert.dom(this.element).exists();
   });
 
   // GENERATED ELEMENTS
 
   test('it should render a <button> if no @href or @route is passed (default)', async function (assert) {
-    await render(hbs`<Hds::Interactive id="test-interactive" />`);
+    await render(
+      hbs`<Hds::Interactive id="test-interactive">Interactive text</Hds::Interactive>`
+    );
     assert.dom('#test-interactive').hasTagName('button');
   });
   test('it should render a <a> link if @href is passed', async function (assert) {
-    await render(hbs`<Hds::Interactive @href="#" id="test-interactive" />`);
+    await render(
+      hbs`<Hds::Interactive @href="#" id="test-interactive">Interactive text</Hds::Interactive>`
+    );
     assert.dom('#test-interactive').hasTagName('a');
     assert.dom('#test-interactive').hasAttribute('href', '#');
   });
   test('it should render a <a> link if @route is passed', async function (assert) {
     await render(
-      hbs`<Hds::Interactive @route="utilities.interactive" id="test-interactive" />`
+      hbs`<Hds::Interactive @route="utilities.interactive" id="test-interactive">Link text</Hds::Interactive>`
     );
     assert.dom('#test-interactive').hasTagName('a');
     assert
@@ -42,20 +46,22 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
   // TARGET/REL ATTRIBUTES
 
   test('it should render a <a> link with the right "target" and "rel" attributes if @href is passed', async function (assert) {
-    await render(hbs`<Hds::Interactive @href="#" id="test-interactive" />`);
+    await render(
+      hbs`<Hds::Interactive @href="#" id="test-interactive">Link text</Hds::Interactive>`
+    );
     assert.dom('#test-interactive').hasAttribute('target', '_blank');
     assert.dom('#test-interactive').hasAttribute('rel', 'noopener noreferrer');
   });
   test('it should render a <a> link with custom "target" and "rel" attributes if they are passed as attributes', async function (assert) {
     await render(
-      hbs`<Hds::Interactive @href="#" id="test-interactive" target="test-target" rel="test-rel" />`
+      hbs`<Hds::Interactive @href="#" id="test-interactive" target="test-target" rel="test-rel">Interactive text</Hds::Interactive>`
     );
     assert.dom('#test-interactive').hasAttribute('target', 'test-target');
     assert.dom('#test-interactive').hasAttribute('rel', 'test-rel');
   });
-  test('it should render a <a> link withhout "target" and "rel" attributes if @isHrefExternal is false', async function (assert) {
+  test('it should render a <a> link without "target" and "rel" attributes if @isHrefExternal is false', async function (assert) {
     await render(
-      hbs`<Hds::Interactive @href="#" @isHrefExternal={{false}} id="test-interactive" />`
+      hbs`<Hds::Interactive @href="#" @isHrefExternal={{false}} id="test-interactive">Interactive text</Hds::Interactive>`
     );
     assert.dom('#test-interactive').doesNotHaveAttribute('target');
     assert.dom('#test-interactive').doesNotHaveAttribute('rel');
@@ -65,7 +71,7 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
 
   test('it should spread all the attributes passed to the <button> element', async function (assert) {
     await render(
-      hbs`<Hds::Interactive id="test-interactive" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Interactive id="test-interactive" class="my-class" data-test1 data-test2="test">Interactive text</Hds::Interactive>`
     );
     assert.dom('button#test-interactive').hasClass('my-class');
     assert.dom('button#test-interactive').hasAttribute('data-test1');
@@ -73,7 +79,7 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
   });
   test('it should spread all the attributes passed to the <a> element', async function (assert) {
     await render(
-      hbs`<Hds::Interactive @href="#" id="test-interactive" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Interactive @href="#" id="test-interactive" class="my-class" data-test1 data-test2="test">Interactive text</Hds::Interactive>`
     );
     assert.dom('a#test-interactive').hasClass('my-class');
     assert.dom('a#test-interactive').hasAttribute('data-test1');
@@ -81,7 +87,7 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
   });
   test('it should spread all the attributes passed to the <LinkTo> element', async function (assert) {
     await render(
-      hbs`<Hds::Interactive @route="index" id="test-interactive" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Interactive @route="index" id="test-interactive" class="my-class" data-test1 data-test2="test">Interactive text</Hds::Interactive>`
     );
     assert.dom('a#test-interactive').hasClass('my-class');
     assert.dom('a#test-interactive').hasAttribute('data-test1');
@@ -92,41 +98,46 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
 
   test('it should yield the children of the <button> element', async function (assert) {
     await render(
-      hbs`<Hds::Interactive id="test-interactive"><pre>test</pre></Hds::Interactive>`
+      hbs`<Hds::Interactive id="test-interactive"><span>Interactive text</span></Hds::Interactive>`
     );
-    assert.dom('button#test-interactive > pre').exists();
-    assert.dom('button#test-interactive > pre').hasText('test');
+    assert.dom('button#test-interactive > span').exists();
+    assert.dom('button#test-interactive > span').hasText('Interactive text');
   });
   test('it should yield the children of the <a> element', async function (assert) {
     await render(
-      hbs`<Hds::Interactive @href="#" id="test-interactive"><pre>test</pre></Hds::Interactive>`
+      hbs`<Hds::Interactive @href="#" id="test-interactive"><span>Interactive text</span></Hds::Interactive>`
     );
-    assert.dom('a#test-interactive > pre').exists();
-    assert.dom('a#test-interactive > pre').hasText('test');
+    assert.dom('a#test-interactive > span').exists();
+    assert.dom('a#test-interactive > span').hasText('Interactive text');
   });
   test('it should yield the children of the <LinkTo> element', async function (assert) {
     await render(
-      hbs`<Hds::Interactive @route="index" id="test-interactive"><pre>test</pre></Hds::Interactive>`
+      hbs`<Hds::Interactive @route="index" id="test-interactive"><span>Interactive text</span></Hds::Interactive>`
     );
-    assert.dom('a#test-interactive > pre').exists();
-    assert.dom('a#test-interactive > pre').hasText('test');
+    assert.dom('a#test-interactive > span').exists();
+    assert.dom('a#test-interactive > span').hasText('Interactive text');
   });
 
   // A11Y
 
   test('it should render with the correct button "type" by default', async function (assert) {
-    await render(hbs`<Hds::Interactive id="test-interactive" />`);
+    await render(
+      hbs`<Hds::Interactive id="test-interactive">Interactive text</Hds::Interactive>`
+    );
     assert.dom('button#test-interactive').hasAttribute('type', 'button');
   });
-  test('it should have a custom type if @type is set', async function (assert) {
-    await render(hbs`<Hds::Interactive id="test-interactive" type="submit" />`);
+  test('it should have a custom type if type attribute is set', async function (assert) {
+    await render(
+      hbs`<Hds::Interactive id="test-interactive" type="submit" >Interactive text</Hds::Interactive>`
+    );
     assert.dom('button#test-interactive').hasAttribute('type', 'submit');
   });
+
   test('it should dispatch a click event when pressing space key on a link', async function (assert) {
     let clicked = false;
     this.set('clickHandler', () => (clicked = true));
     await render(
-      hbs`<div {{on "click" this.clickHandler}}><Hds::Interactive @href="javascript:;" id="test-interactive"/></div>`
+      hbs`<div {{on "click" this.clickHandler}}><Hds::Interactive @href="javascript:;" id="test-interactive">Interactive text</Hds::Interactive></div>`
     );
     await triggerKeyEvent('#test-interactive', 'keyup', ' ');
     assert.ok(clicked);

--- a/packages/components/tests/integration/components/hds/link/inline-test.js
+++ b/packages/components/tests/integration/components/hds/link/inline-test.js
@@ -65,20 +65,22 @@ module('Integration | Component | hds/link/inline', function (hooks) {
   // TARGET/REL ATTRIBUTES
 
   test('it should render a <a> link with the right "target" and "rel" attributes if @href is passed', async function (assert) {
-    await render(hbs`<Hds::Link::Inline @href="/" id="test-link" />`);
+    await render(
+      hbs`<Hds::Link::Inline @href="/" id="test-link">Link text</Hds::Link::Inline>`
+    );
     assert.dom('#test-link').hasAttribute('target', '_blank');
     assert.dom('#test-link').hasAttribute('rel', 'noopener noreferrer');
   });
   test('it should render a <a> link with custom "target" and "rel" attributes if they are passed as attributes', async function (assert) {
     await render(
-      hbs`<Hds::Link::Inline @href="/" id="test-link" target="test-target" rel="test-rel" />`
+      hbs`<Hds::Link::Inline @href="/" id="test-link" target="test-target" rel="test-rel">Link text</Hds::Link::Inline>`
     );
     assert.dom('#test-link').hasAttribute('target', 'test-target');
     assert.dom('#test-link').hasAttribute('rel', 'test-rel');
   });
   test('it should render a <a> link withhout "target" and "rel" attributes if @isHrefExternal is false', async function (assert) {
     await render(
-      hbs`<Hds::Link::Inline @href="/" @isHrefExternal={{false}} id="test-link" />`
+      hbs`<Hds::Link::Inline @href="/" @isHrefExternal={{false}} id="test-link">Link text</Hds::Link::Inline>`
     );
     assert.dom('#test-link').doesNotHaveAttribute('target');
     assert.dom('#test-link').doesNotHaveAttribute('rel');

--- a/packages/components/tests/integration/components/hds/link/standalone-test.js
+++ b/packages/components/tests/integration/components/hds/link/standalone-test.js
@@ -120,7 +120,9 @@ module('Integration | Component | hds/link/standalone', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Link::Standalone @icon="film" @href="/" />`);
+    await render(
+      hbs`<Hds::Link::Standalone @icon="film" @href="/" id="test-valid-failure" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -132,7 +134,9 @@ module('Integration | Component | hds/link/standalone', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Link::Standalone @href="/" @text="watch video" />`);
+    await render(
+      hbs`<Hds::Link::Standalone @href="/" @text="watch video" id="test-valid-failure" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -173,7 +177,7 @@ module('Integration | Component | hds/link/standalone', function (hooks) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
     await render(
-      hbs`<Hds::Link::Standalone @icon="film" @text="watch video" @href="/" @color="foo" />`
+      hbs`<Hds::Link::Standalone @icon="film" @text="watch video" @href="/" @color="foo" id="test-valid-failure" />`
     );
     assert.throws(function () {
       throw new Error(errorMessage);

--- a/packages/components/tests/integration/components/hds/menu-primitive/index-test.js
+++ b/packages/components/tests/integration/components/hds/menu-primitive/index-test.js
@@ -32,7 +32,7 @@ module('Integration | Component | hds/menu-primitive/index', function (hooks) {
     await render(hbs`
       <Hds::MenuPrimitive>
         <:toggle>
-          <button type="button" id="test-menu-primitive-button" />
+          <Hds::Button type="button" id="test-menu-primitive-button" @text="Toggle button" />
         </:toggle>
       </Hds::MenuPrimitive>
     `);
@@ -44,10 +44,10 @@ module('Integration | Component | hds/menu-primitive/index', function (hooks) {
     await render(hbs`
       <Hds::MenuPrimitive>
         <:toggle as |t|>
-          <button type="button" id="test-menu-primitive-button" {{on "click" t.onClickToggle}} />
+          <Hds::Button type="button" id="test-menu-primitive-button" {{on "click" t.onClickToggle}} @text="Toggle button" />
         </:toggle>
         <:content>
-          <a id="test-menu-primitive-link" href="#">test</a>
+          <Hds::Link::Standalone id="test-menu-primitive-link" @icon="plus" @href="/" @text="Test interactive" />
         </:content>
       </Hds::MenuPrimitive>
     `);
@@ -62,10 +62,10 @@ module('Integration | Component | hds/menu-primitive/index', function (hooks) {
     await render(hbs`
       <Hds::MenuPrimitive id="test-menu-primitive">
         <:toggle as |t|>
-          <button type="button" id="test-menu-primitive-button" {{on "click" t.onClickToggle}} />
+          <Hds::Button type="button" id="test-menu-primitive-button" {{on "click" t.onClickToggle}} @text="Toggle button" />
         </:toggle>
         <:content>
-          <a id="test-menu-primitive-link" href="#">test</a>
+          <Hds::Link::Standalone id="test-menu-primitive-link"  @icon="plus" @href="/" @text="Test interactive" />
         </:content>
       </Hds::MenuPrimitive>
     `);
@@ -83,10 +83,10 @@ module('Integration | Component | hds/menu-primitive/index', function (hooks) {
     await render(hbs`
       <Hds::MenuPrimitive id="test-menu-primitive">
         <:toggle as |t|>
-          <button type="button" id="test-menu-primitive-button" {{on "click" t.onClickToggle}} />
+          <Hds::Button type="button" id="test-menu-primitive-button" {{on "click" t.onClickToggle}} @text="Toggle button" />
         </:toggle>
         <:content>
-          <a id="test-menu-primitive-link" href="#">test</a>
+          <Hds::Link::Standalone id="test-menu-primitive-link" @icon="plus" @href="/" @text="Test interactive" />
         </:content>
       </Hds::MenuPrimitive>
     `);
@@ -107,10 +107,10 @@ module('Integration | Component | hds/menu-primitive/index', function (hooks) {
     await render(hbs`
       <Hds::MenuPrimitive id="test-menu-primitive">
         <:toggle as |t|>
-          <button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} />
+          <Hds::Button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} @text="Toggle button" />
         </:toggle>
         <:content as |c|>
-          <button id="test-content-button" {{on "click" c.close}}>test</button>
+          <Hds::Button id="test-content-button" {{on "click" c.close}} @text="Interactive content element" />
         </:content>
       </Hds::MenuPrimitive>
     `);

--- a/packages/components/tests/integration/components/hds/reveal/index-test.js
+++ b/packages/components/tests/integration/components/hds/reveal/index-test.js
@@ -135,7 +135,9 @@ module('Integration | Component | hds/reveal/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Reveal>Additional content</Hds::Reveal>`);
+    await render(
+      hbs`<Hds::Reveal id="test-valid-failure">Additional content</Hds::Reveal>`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });

--- a/packages/components/tests/integration/components/hds/segmented-group/index-test.js
+++ b/packages/components/tests/integration/components/hds/segmented-group/index-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | hds/segmented-group/index', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::SegmentedGroup id="test-segmented-group" />`);
+    await render(
+      hbs`<Hds::SegmentedGroup id="test-segmented-group" data-test-valid-failure />`
+    );
     assert.dom('#test-segmented-group').hasClass('hds-segmented-group');
   });
 
@@ -26,8 +28,8 @@ module('Integration | Component | hds/segmented-group/index', function (hooks) {
               <DD.ToggleButton @color="secondary" @text="Toggle" />
               <DD.Interactive @href="#" @text="Dropdown Item" />
             </S.Dropdown>
-            <S.Select id="segmented-select"/>
-            <S.TextInput id="segmented-input" />
+            <S.Select id="segmented-select" aria-label="text select" />
+            <S.TextInput id="segmented-input" aria-label="test text input" />
             <S.Generic><span id="segmented-generic"></span></S.Generic/>
           </Hds::SegmentedGroup>`
     );

--- a/packages/components/tests/integration/components/hds/table/th-sort-test.js
+++ b/packages/components/tests/integration/components/hds/table/th-sort-test.js
@@ -35,7 +35,7 @@ module('Integration | Component | hds/table/th-sort', function (hooks) {
 
   test('it should add inline styles if `@width` is declared', async function (assert) {
     await render(
-      hbs`<Hds::Table::ThSort id="data-test-table-th-sort" @width="10%" />`
+      hbs`<Hds::Table::ThSort id="data-test-table-th-sort" @width="10%">Artist</Hds::Table::ThSort>`
     );
     assert
       .dom('#data-test-table-th-sort')

--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -43,13 +43,15 @@ setRunOptions({
       'best-practice',
     ],
   },
-  include: ['#ember-testing-container'],
-  exclude: ['.flight-sprite-container', '.shw-page-main'],
+  include: [['#ember-testing-container']],
+  exclude: [['.flight-sprite-container'], ['.shw-page-main']],
 });
 
-// This might not be needed since using the ENABLE_A11Y_AUDIT environment variable is used in the script that runs the audit 🤔
-// Also if `enableA11yAudit` is specified in the query param it will also force the audit already
-// So, think about whether or not there are valid use cases for this conditional.
+// This will be used by developers to run the tests locally
+// Either with the `enableA11yAudit` as a query param in the URL
+// or `yarn test:a11y` in the CLI
+// Note: if you want to filter what test is run from the start, use the --filter flag: `yarn test:a11y --filter="alert"`
+// Docs: https://guides.emberjs.com/release/testing/#toc_how-to-filter-tests
 if (shouldForceAudit()) {
   setEnableA11yAudit(true);
 }

--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -50,6 +50,7 @@ setRunOptions({
     ['#test-button-assertion'],
     ['#test-is-flake'],
     ['#test-valid-failure'],
+    ['[data-test-valid-failure]'],
   ],
 });
 

--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -44,7 +44,12 @@ setRunOptions({
     ],
   },
   include: [['#ember-testing-container']],
-  exclude: [['.flight-sprite-container'], ['.shw-page-main']],
+  exclude: [
+    ['.flight-sprite-container'],
+    ['.shw-page-main'],
+    ['#test-button-assertion'],
+    ['#test-is-flake'],
+  ],
 });
 
 // This will be used by developers to run the tests locally

--- a/packages/components/tests/test-helper.js
+++ b/packages/components/tests/test-helper.js
@@ -49,6 +49,7 @@ setRunOptions({
     ['.shw-page-main'],
     ['#test-button-assertion'],
     ['#test-is-flake'],
+    ['#test-valid-failure'],
   ],
 });
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR tidies up component tests for a11yAudit (accessibility automation tests) 

### :hammer_and_wrench: Detailed description

I've tried to separate out each change by commit since it felt appropriate to do in this case. 

I'm going to submit the `form` and `side-nav` test improvements each as their own PRs since they each have a lot of issues. 

The benefit of this work is that once it is complete, anyone on our team could go run the [appropriate github action](https://github.com/hashicorp/design-system/actions/workflows/ci-components-nightly.yml) and get the real state of accessibility automation results, and we'll know it's an accurate reflection of where our gaps are. 

Here are the issues that I've filed as a result of this work: 

- [HDS-2214](https://hashicorp.atlassian.net/browse/HDS-2214)
- [HDS-2213](https://hashicorp.atlassian.net/browse/HDS-2213)
- [HDS-2207](https://hashicorp.atlassian.net/browse/HDS-2207)
- [HDS-2206](https://hashicorp.atlassian.net/browse/HDS-2206)

### :camera_flash: Screenshots

This is internal only, it should not change anything rendered to the browser. 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2204](https://hashicorp.atlassian.net/browse/HDS-2204)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2204]: https://hashicorp.atlassian.net/browse/HDS-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HDS-2214]: https://hashicorp.atlassian.net/browse/HDS-2214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-2213]: https://hashicorp.atlassian.net/browse/HDS-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-2207]: https://hashicorp.atlassian.net/browse/HDS-2207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-2206]: https://hashicorp.atlassian.net/browse/HDS-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ