### PR TITLE
Tidied up form component tests for a11yAudit

### DIFF
--- a/packages/components/tests/integration/components/hds/form/checkbox/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/base-test.js
@@ -12,12 +12,14 @@ module('Integration | Component | hds/form/checkbox/base', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" />`);
+    await render(
+      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" aria-label="test label" />`
+    );
     assert.dom('#test-form-checkbox').hasClass('hds-form-checkbox');
   });
   test('it should convert the `indeterminate` attribute into a property', async function (assert) {
     await render(
-      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" indeterminate={{true}} />`
+      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" indeterminate={{true}} aria-label="test label" />`
     );
     assert.dom('#test-form-checkbox').doesNotHaveAttribute('indeterminate');
     assert.dom('#test-form-checkbox').hasProperty('indeterminate', true);
@@ -27,7 +29,7 @@ module('Integration | Component | hds/form/checkbox/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" aria-label="test label" class="my-class" data-test1 data-test2="test" />`
     );
     assert.dom('#test-form-checkbox').hasClass('my-class');
     assert.dom('#test-form-checkbox').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
@@ -16,21 +16,25 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
   });
 
   test('it should render the component with the appropriate CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::Checkbox::Field />`);
+    await render(hbs`<Hds::Form::Checkbox::Field aria-label="test label" />`);
     assert.dom('.hds-form-field__control').exists();
   });
 
   // VALUE
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
-    await render(hbs`<Hds::Form::Checkbox::Field @value="abc123" />`);
+    await render(
+      hbs`<Hds::Form::Checkbox::Field @value="abc123" aria-label="test label" />`
+    );
     assert.dom('input').hasValue('abc123');
   });
 
   // ID
 
   test('it should render the input with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::Checkbox::Field @id="my-input" />`);
+    await render(
+      hbs`<Hds::Form::Checkbox::Field @id="my-input" aria-label="test label" />`
+    );
     assert.dom('input').hasAttribute('id', 'my-input');
   });
 
@@ -51,7 +55,7 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::Checkbox::Field />`);
+    await render(hbs`<Hds::Form::Checkbox::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -87,7 +91,7 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
   // we have added an extra assertion for the "name" attribute here, even if not strictly necessary, to make sure is not overwritten in any way
   test('it should spread all the attributes (including "name") passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" />`
+      hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" aria-label="test label" />`
     );
     assert.dom('input').hasClass('my-class');
     assert.dom('input').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
@@ -31,8 +31,8 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
       hbs`<Hds::Form::RadioCard::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.RadioCard/>
-            <G.RadioCard/>
+            <G.RadioCard aria-label="test label one" />
+            <G.RadioCard aria-label="test label two" />
             <G.Error>This is the group error</G.Error>
           </Hds::Form::RadioCard::Group>`
     );
@@ -61,8 +61,8 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
       hbs`<Hds::Form::RadioCard::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.RadioCard/>
-            <G.RadioCard/>
+            <G.RadioCard aria-label="test label one" />
+            <G.RadioCard aria-label="test label two" />
             <G.Error>This is the group error</G.Error>
           </Hds::Form::RadioCard::Group>`
     );
@@ -85,8 +85,8 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
       hbs`<Hds::Form::RadioCard::Group @name="test-name" @alignment="center" @controlPosition="left" @layout="fixed" as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.RadioCard @maxWidth="50%" data-test="first-control"/>
-            <G.RadioCard @maxWidth="50%" data-test="second-control"/>
+            <G.RadioCard @maxWidth="50%" data-test="first-control" aria-label="test label one" />
+            <G.RadioCard @maxWidth="50%" data-test="second-control" aria-label="test label two" />
             <G.Error>This is the group error</G.Error>
           </Hds::Form::RadioCard::Group>`
     );
@@ -111,7 +111,7 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
     await render(
       hbs`<Hds::Form::RadioCard::Group @isRequired={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
-            <G.RadioCard/>
+            <G.RadioCard aria-label="test label" />
           </Hds::Form::RadioCard::Group>`
     );
     assert.dom('legend .hds-form-indicator').exists();
@@ -121,7 +121,7 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
     await render(
       hbs`<Hds::Form::RadioCard::Group @isOptional={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
-            <G.RadioCard/>
+            <G.RadioCard aria-label="test label" />
           </Hds::Form::RadioCard::Group>`
     );
     assert.dom('legend .hds-form-indicator').exists();

--- a/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
@@ -12,18 +12,20 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::RadioCard/>`);
+    await render(hbs`<Hds::Form::RadioCard aria-label="test label" />`);
     assert.dom('label').hasClass('hds-form-radio-card');
   });
   test('it should render the input with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::RadioCard />`);
+    await render(hbs`<Hds::Form::RadioCard aria-label="test label" />`);
     assert.dom('input').hasClass('hds-form-radio-card__control');
   });
 
   // NAME, VALUE
 
   test('it should render the input with the arguments provided', async function (assert) {
-    await render(hbs`<Hds::Form::RadioCard @name="name" @value="value" />`);
+    await render(
+      hbs`<Hds::Form::RadioCard @name="name" @value="value" aria-label="test label" />`
+    );
     assert.dom('input').hasValue('value');
     assert.dom('input').hasAttribute('name', 'name');
   });
@@ -32,7 +34,7 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
 
   test('it should render the component with CSS classes that reflect the arguments provided', async function (assert) {
     await render(
-      hbs`<Hds::Form::RadioCard @checked="checked" @disabled="disabled" />`
+      hbs`<Hds::Form::RadioCard @checked="checked" @disabled="disabled" aria-label="test label" />`
     );
     assert.dom('label').hasClass('hds-form-radio-card--checked');
     assert.dom('label').hasClass('hds-form-radio-card--disabled');
@@ -57,7 +59,7 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     assert.dom('.custom').exists();
   });
   test('it does not render the contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::RadioCard />`);
+    await render(hbs`<Hds::Form::RadioCard aria-label="test label" />`);
     assert.dom('.flight-icon').doesNotExist();
     assert.dom('.hds-form-radio-card__label').doesNotExist();
     assert.dom('.hds-badge').doesNotExist();
@@ -69,7 +71,7 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::RadioCard id="my-id" name="my-name" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::RadioCard id="my-id" name="my-name" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('input').hasAttribute('id', 'my-id');
     assert.dom('input').hasAttribute('name', 'my-name');
@@ -87,7 +89,9 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Form::RadioCard @alignment="foo" />`);
+    await render(
+      hbs`<Hds::Form::RadioCard @alignment="foo" aria-label="test label" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -100,7 +104,9 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Form::RadioCard @controlPosition="foo" />`);
+    await render(
+      hbs`<Hds::Form::RadioCard @controlPosition="foo" aria-label="test label" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -113,7 +119,9 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Form::RadioCard @layout="foo" />`);
+    await render(
+      hbs`<Hds::Form::RadioCard @layout="foo" aria-label="test label" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });
@@ -126,7 +134,9 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Form::RadioCard @layout="fixed" />`);
+    await render(
+      hbs`<Hds::Form::RadioCard @layout="fixed" aria-label="test label" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });

--- a/packages/components/tests/integration/components/hds/form/radio/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/base-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | hds/form/radio/base', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Base id="test-form-radio" />`);
+    await render(
+      hbs`<Hds::Form::Radio::Base id="test-form-radio" aria-label="test label" />`
+    );
     assert.dom('#test-form-radio').hasClass('hds-form-radio');
   });
 
@@ -20,7 +22,7 @@ module('Integration | Component | hds/form/radio/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Radio::Base id="test-form-radio" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Radio::Base id="test-form-radio" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('#test-form-radio').hasClass('my-class');
     assert.dom('#test-form-radio').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/radio/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/field-test.js
@@ -16,21 +16,25 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
   });
 
   test('it should render the component with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Field />`);
+    await render(hbs`<Hds::Form::Radio::Field aria-label="test label" />`);
     assert.dom('.hds-form-field__control').exists();
   });
 
   // VALUE
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Field @value="abc123" />`);
+    await render(
+      hbs`<Hds::Form::Radio::Field @value="abc123" aria-label="test label" />`
+    );
     assert.dom('input').hasValue('abc123');
   });
 
   // ID
 
   test('it should render the input with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Field @id="my-input" />`);
+    await render(
+      hbs`<Hds::Form::Radio::Field @id="my-input" aria-label="test label" />`
+    );
     assert.dom('input').hasAttribute('id', 'my-input');
   });
 
@@ -50,7 +54,7 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Field />`);
+    await render(hbs`<Hds::Form::Radio::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -84,9 +88,9 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
   // ATTRIBUTES
 
   // we have added an extra assertion for the "name" attribute here, even if not strictly necessary, to make sure is not overwritten in any way
-  test('it should spread all the attributes (includind "name") passed to the component on the input', async function (assert) {
+  test('it should spread all the attributes (including "name") passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" />`
+      hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" aria-label="test label" />`
     );
     assert.dom('input').hasClass('my-class');
     assert.dom('input').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/radio/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/group-test.js
@@ -16,7 +16,9 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
   });
 
   test('it should render the component', async function (assert) {
-    await render(hbs`<Hds::Form::Radio::Group id="test-form-radio" />`);
+    await render(
+      hbs`<Hds::Form::Radio::Group id="test-form-radio" aria-label="test label" />`
+    );
     assert.dom('#test-form-radio').hasClass('hds-form-group');
   });
 

--- a/packages/components/tests/integration/components/hds/form/select/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/base-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Base id="test-form-select" />`);
+    await render(
+      hbs`<Hds::Form::Select::Base id="test-form-select" aria-label="test label" />`
+    );
     assert.dom('#test-form-select').hasClass('hds-form-select');
   });
 
@@ -20,7 +22,7 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
 
   test('it should render the options passed via contextual component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Base id="test-form-select" as |C|><C.Options><option value="abc123">This is the option</option></C.Options></Hds::Form::Select::Base>`
+      hbs`<Hds::Form::Select::Base id="test-form-select" aria-label="test label" as |C|><C.Options><option value="abc123">This is the option</option></C.Options></Hds::Form::Select::Base>`
     );
     assert.dom('#test-form-select option').exists();
     assert.dom('#test-form-select option').hasText('This is the option');
@@ -31,7 +33,7 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
 
   test('it should render the select with a fixed width if a @width value is passed', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Base @width="248px" id="test-form-select" />`
+      hbs`<Hds::Form::Select::Base @width="248px" id="test-form-select" aria-label="test label" />`
     );
     assert.dom('#test-form-select').hasStyle({ width: '248px' });
   });
@@ -40,7 +42,7 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Base id="test-form-select" @isInvalid={{true}} />`
+      hbs`<Hds::Form::Select::Base id="test-form-select" @isInvalid={{true}} aria-label="test label" />`
     );
     assert.dom('#test-form-select').hasClass('hds-form-select--is-invalid');
   });
@@ -49,7 +51,7 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Base id="test-form-select" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Select::Base id="test-form-select" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('#test-form-select').hasClass('my-class');
     assert.dom('#test-form-select').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/select/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/field-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
   });
 
   test('it should render the component with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Field />`);
+    await render(hbs`<Hds::Form::Select::Field aria-label="test label" />`);
     assert.dom('.hds-form-field__control').exists();
   });
 
@@ -24,7 +24,7 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
 
   test('it should render the options passed via contextual component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Field id="test-form-select" as |F|><F.Options><option value="abc123">This is the option</option></F.Options></Hds::Form::Select::Field>`
+      hbs`<Hds::Form::Select::Field id="test-form-select" aria-label="test label" as |F|><F.Options><option value="abc123">This is the option</option></F.Options></Hds::Form::Select::Field>`
     );
     assert.dom('select option').exists();
     assert.dom('select option').hasText('This is the option');
@@ -34,21 +34,27 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
   // WIDTH
 
   test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Field @width="248px" />`);
+    await render(
+      hbs`<Hds::Form::Select::Field aria-label="test label" @width="248px" />`
+    );
     assert.dom('select').hasStyle({ width: '248px' });
   });
 
   // INVALID
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Field @isInvalid={{true}} />`);
+    await render(
+      hbs`<Hds::Form::Select::Field aria-label="test label" @isInvalid={{true}} />`
+    );
     assert.dom('select').hasClass('hds-form-select--is-invalid');
   });
 
   // ID
 
   test('it should render the select control with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Field @id="my-input" />`);
+    await render(
+      hbs`<Hds::Form::Select::Field aria-label="test label" @id="my-input" />`
+    );
     assert.dom('select').hasAttribute('id', 'my-input');
   });
 
@@ -68,7 +74,7 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::Select::Field />`);
+    await render(hbs`<Hds::Form::Select::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -134,7 +140,7 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::Select::Field class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Select::Field aria-label="test label" class="my-class" data-test1 data-test2="test" />`
     );
     assert.dom('select').hasClass('my-class');
     assert.dom('select').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/text-input/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/base-test.js
@@ -16,19 +16,23 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
   });
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Base id="test-form-text-input" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" aria-label="test label" />`
+    );
     assert.dom('#test-form-text-input').hasClass('hds-form-text-input');
   });
 
   // TYPE
 
   test('it should render the "text" type if no type is declared', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Base id="test-form-text-input" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" aria-label="test label" />`
+    );
     assert.dom('#test-form-text-input').hasAttribute('type', 'text');
   });
   test('it should render the correct type depending on the @type prop', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base @type="email" id="test-form-text-input" />`
+      hbs`<Hds::Form::TextInput::Base @type="email" id="test-form-text-input" aria-label="test label" />`
     );
     assert.dom('#test-form-text-input').hasAttribute('type', 'email');
   });
@@ -37,7 +41,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base @value="abc123" id="test-form-text-input" />`
+      hbs`<Hds::Form::TextInput::Base @value="abc123" id="test-form-text-input" aria-label="test label" />`
     );
     assert.dom('#test-form-text-input').hasValue('abc123');
   });
@@ -46,7 +50,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @isInvalid={{true}} />`
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @isInvalid={{true}} aria-label="test label" />`
     );
     assert
       .dom('#test-form-text-input')
@@ -57,7 +61,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should render the correct CSS class if the @isLoading prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @type="search" @isLoading={{true}} />`
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" @type="search" @isLoading={{true}} aria-label="test label" />`
     );
     assert
       .dom('#test-form-text-input')
@@ -68,7 +72,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base @width="248px" id="test-form-text-input" />`
+      hbs`<Hds::Form::TextInput::Base @width="248px" id="test-form-text-input" aria-label="test label" />`
     );
     assert.dom('#test-form-text-input').hasStyle({ width: '248px' });
   });
@@ -77,7 +81,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('#test-form-text-input').hasClass('my-class');
     assert.dom('#test-form-text-input').hasAttribute('data-test1');
@@ -93,7 +97,9 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Form::TextInput::Base @type="foo" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Base @type="foo" aria-label="test label" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });

--- a/packages/components/tests/integration/components/hds/form/text-input/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/field-test.js
@@ -16,32 +16,38 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
   });
 
   test('it should render the component with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field />`);
+    await render(hbs`<Hds::Form::TextInput::Field aria-label="test label" />`);
     assert.dom('.hds-form-field__control').exists();
   });
 
   // TYPE
 
   test('it should render the "text" type if no type is declared', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field />`);
+    await render(hbs`<Hds::Form::TextInput::Field aria-label="test label" />`);
     assert.dom('input').hasAttribute('type', 'text');
   });
   test('it should render the correct type depending on the @type prop', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field @type="email" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Field @type="email" aria-label="test label" />`
+    );
     assert.dom('input').hasAttribute('type', 'email');
   });
 
   // VALUE
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field @value="abc123" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Field @value="abc123" aria-label="test label" />`
+    );
     assert.dom('input').hasValue('abc123');
   });
 
   // INVALID
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field @isInvalid={{true}} />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Field @isInvalid={{true}} aria-label="test label" />`
+    );
     assert.dom('input').hasClass('hds-form-text-input--is-invalid');
   });
 
@@ -49,7 +55,7 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
 
   test('it should render the correct CSS class if the @isLoading prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Field @type="search" @isLoading={{true}} />`
+      hbs`<Hds::Form::TextInput::Field @type="search" @isLoading={{true}} aria-label="test label" />`
     );
     assert.dom('input').hasClass('hds-form-text-input--is-loading');
   });
@@ -57,14 +63,18 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
   // WIDTH
 
   test('it should render the input with a fixed width if a @width value is passed', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field @width="248px" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Field @width="248px" aria-label="test label" />`
+    );
     assert.dom('input').hasStyle({ width: '248px' });
   });
 
   // ID
 
   test('it should render the input with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field @id="my-input" />`);
+    await render(
+      hbs`<Hds::Form::TextInput::Field @id="my-input" aria-label="test label" />`
+    );
     assert.dom('input').hasAttribute('id', 'my-input');
   });
 
@@ -84,7 +94,7 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::TextInput::Field />`);
+    await render(hbs`<Hds::Form::TextInput::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -150,7 +160,7 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::TextInput::Field class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::TextInput::Field class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('input').hasClass('my-class');
     assert.dom('input').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/textarea/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/base-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Base id="test-form-textarea" />`);
+    await render(
+      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" aria-label="test label" />`
+    );
     assert.dom('#test-form-textarea').hasClass('hds-form-textarea');
   });
 
@@ -20,7 +22,7 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
     await render(
-      hbs`<Hds::Form::Textarea::Base @value="abc123" id="test-form-textarea" />`
+      hbs`<Hds::Form::Textarea::Base @value="abc123" id="test-form-textarea" aria-label="test label" />`
     );
     assert.dom('#test-form-textarea').hasValue('abc123');
   });
@@ -28,11 +30,13 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
   // ROWS
 
   test('it should render the textarea with the default number of rows', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Base />`);
+    await render(hbs`<Hds::Form::Textarea::Base aria-label="test label" />`);
     assert.dom('textarea').hasAttribute('rows', '4');
   });
   test('it should render the textarea with a custom number of rows', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Base rows="2" />`);
+    await render(
+      hbs`<Hds::Form::Textarea::Base rows="2" aria-label="test label" />`
+    );
     assert.dom('textarea').hasAttribute('rows', '2');
   });
 
@@ -40,7 +44,7 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
     await render(
-      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" @isInvalid={{true}} />`
+      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" @isInvalid={{true}} aria-label="test label" />`
     );
     assert.dom('#test-form-textarea').hasClass('hds-form-textarea--is-invalid');
   });
@@ -49,7 +53,7 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('#test-form-textarea').hasClass('my-class');
     assert.dom('#test-form-textarea').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/textarea/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/field-test.js
@@ -16,21 +16,25 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
   });
 
   test('it should render the component with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Field />`);
+    await render(hbs`<Hds::Form::Textarea::Field aria-label="test label" />`);
     assert.dom('.hds-form-field__control').exists();
   });
 
   // VALUE
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Field @value="abc123" />`);
+    await render(
+      hbs`<Hds::Form::Textarea::Field @value="abc123" aria-label="test label" />`
+    );
     assert.dom('textarea').hasValue('abc123');
   });
 
   // INVALID
 
   test('it should render the correct CSS class if the @isInvalid prop is declared', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Field @isInvalid={{true}} />`);
+    await render(
+      hbs`<Hds::Form::Textarea::Field @isInvalid={{true}} aria-label="test label" />`
+    );
     assert.dom('textarea').hasClass('hds-form-textarea--is-invalid');
   });
 
@@ -38,13 +42,13 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
 
   test('it should render the textarea control with a fixed width if a @width value is passed', async function (assert) {
     await render(hbs`
-      <Hds::Form::Textarea::Field @width="248px" />
+      <Hds::Form::Textarea::Field @width="248px" aria-label="test label" />
     `);
     assert.dom('textarea').hasStyle({ width: '248px' });
   });
   test('it should render the textarea control with a fixed height if a @height value is passed', async function (assert) {
     await render(hbs`
-      <Hds::Form::Textarea::Field @height="248px" />
+      <Hds::Form::Textarea::Field @height="248px" aria-label="test label" />
     `);
     assert.dom('textarea').hasStyle({ height: '248px' });
   });
@@ -52,7 +56,9 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
   // ID
 
   test('it should render the textarea control with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Field @id="my-textarea" />`);
+    await render(
+      hbs`<Hds::Form::Textarea::Field @id="my-textarea" aria-label="test label" />`
+    );
     assert.dom('textarea').hasAttribute('id', 'my-textarea');
   });
 
@@ -72,7 +78,7 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::Textarea::Field />`);
+    await render(hbs`<Hds::Form::Textarea::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -140,7 +146,7 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::Textarea::Field class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Textarea::Field class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('textarea').hasClass('my-class');
     assert.dom('textarea').hasAttribute('data-test1');

--- a/packages/components/tests/integration/components/hds/form/toggle/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/base-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Base id="test-form-toggle" />`);
+    await render(
+      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" aria-label="test label" />`
+    );
     // Notice: the "toggle" component has a slightly different DOM structure than the other form controls
     assert.dom('.hds-form-toggle').exists();
     assert.dom('.hds-form-toggle > #test-form-toggle').exists();
@@ -23,7 +25,7 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
 
   test('it should spread all the attributes passed to the component', async function (assert) {
     await render(
-      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('#test-form-toggle').hasClass('my-class');
     assert.dom('#test-form-toggle').hasAttribute('data-test1');
@@ -33,7 +35,9 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
   // ACCESSIBILITY
 
   test('it should render with the correct role', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Base id="test-form-toggle" />`);
+    await render(
+      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" aria-label="test label" />`
+    );
     assert.dom('#test-form-toggle').hasAttribute('role', 'switch');
   });
   // role="switch"

--- a/packages/components/tests/integration/components/hds/form/toggle/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/field-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
   });
 
   test('it should render the component with a specific CSS class', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Field />`);
+    await render(hbs`<Hds::Form::Toggle::Field aria-label="test label" />`);
     // Notice: the "toggle" component has a slightly different DOM structure than the other form controls
     assert.dom('input').hasClass('hds-form-toggle__control');
   });
@@ -24,14 +24,18 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
   // VALUE
 
   test('it should render the input with the value provided via @value argument', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Field @value="abc123" />`);
+    await render(
+      hbs`<Hds::Form::Toggle::Field @value="abc123" aria-label="test label" />`
+    );
     assert.dom('input').hasValue('abc123');
   });
 
   // ID
 
   test('it should render the input with a custom @id', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Field @id="my-input" />`);
+    await render(
+      hbs`<Hds::Form::Toggle::Field @id="my-input" aria-label="test label" />`
+    );
     assert.dom('input').hasAttribute('id', 'my-input');
   });
 
@@ -51,7 +55,7 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
     assert.dom('.hds-form-field__error').exists();
   });
   test('it does not render the yielded contextual components if not provided', async function (assert) {
-    await render(hbs`<Hds::Form::Toggle::Field />`);
+    await render(hbs`<Hds::Form::Toggle::Field data-test-valid-failure />`);
     assert.dom('.hds-form-field__label').doesNotExist();
     assert.dom('.hds-form-field__helper-text').doesNotExist();
     assert.dom('.hds-form-field__error').doesNotExist();
@@ -87,7 +91,7 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
 
   test('it should spread all the attributes passed to the component on the input', async function (assert) {
     await render(
-      hbs`<Hds::Form::Toggle::Field checked="checked" class="my-class" data-test1 data-test2="test" />`
+      hbs`<Hds::Form::Toggle::Field checked="checked" class="my-class" data-test1 data-test2="test" aria-label="test label" />`
     );
     assert.dom('input').hasClass('my-class');
     assert.dom('input').hasAttribute('data-test1');


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR tidies up component tests for a11yAudit (accessibility automation tests) for the form components

### :hammer_and_wrench: Detailed description

There were no issues filed as the result of this work. 


### :camera_flash: Screenshots

This should not change anything that is rendered to the browser. 


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2204](https://hashicorp.atlassian.net/browse/HDS-2204)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2204]: https://hashicorp.atlassian.net/browse/HDS-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ