### PR TITLE
Fix event name typo

### DIFF
--- a/website/docs/components/form/select/partials/code/how-to-use.md
+++ b/website/docs/components/form/select/partials/code/how-to-use.md
@@ -210,7 +210,7 @@ Similarly, you can pass HTML attributes to the `<option/optgroup>` elements.
 
 #### Event handling
 
-Because this component supports use of `...attributes`, you can use all the usual Ember techniques for event handling (e.g., `blue`, `change`), validation, etc.
+Because this component supports use of `...attributes`, you can use all the usual Ember techniques for event handling (e.g., `blur`, `change`), validation, etc.
 
 ```handlebars
 <Hds::Form::Select::Field {{on "blur" this.yourOnBlurFunction}} as |F|>

--- a/website/docs/components/form/text-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/text-input/partials/code/how-to-use.md
@@ -158,7 +158,7 @@ This component supports use of `...attributes`. This means you can use all the s
 
 #### Events handling
 
-Because this component supports use of `...attributes`, you can use all the usual Ember techniques for event handling (e.g., `input`, `blue`, `change`), validation, etc.
+Because this component supports use of `...attributes`, you can use all the usual Ember techniques for event handling (e.g., `input`, `blur`, `change`), validation, etc.
 
 ```handlebars
 <Hds::Form::TextInput::Field @type="email" placeholder="eg. name.surname@email.com" {{on "blur" this.yourOnBlurFunction}} as |F|>

--- a/website/docs/components/form/textarea/partials/code/how-to-use.md
+++ b/website/docs/components/form/textarea/partials/code/how-to-use.md
@@ -146,7 +146,7 @@ This component supports use of `...attributes`. This means you can use all the s
 
 #### Events handling
 
-Because this component supports use of `...attributes`, you can use all the usual Ember techniques for event handling (e.g., `input`, `blue`, `change`), validation, etc.
+Because this component supports use of `...attributes`, you can use all the usual Ember techniques for event handling (e.g., `input`, `blur`, `change`), validation, etc.
 
 ```handlebars
 <Hds::Form::Textarea::Field placeholder="Workspace description" {{on "blur" this.yourOnBlurFunction}} as |F|>


### PR DESCRIPTION
### :pushpin: Summary

Fix event name typo: `blue`→ `blur`

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
