### PR TITLE
🧪 [SPIKE] - Styling `input[type=file]`

### DIFF
--- a/packages/components/addon/components/hds/form/file-input/index.hbs
+++ b/packages/components/addon/components/hds/form/file-input/index.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<input type="file" class={{this.classNames}} ...attributes />

--- a/packages/components/addon/components/hds/form/file-input/index.js
+++ b/packages/components/addon/components/hds/form/file-input/index.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+
+export default class HdsFormFileInputIndexComponent extends Component {
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-form-file-input'];
+
+    // add a class based on the @extraClass argument
+    // classes.push(`hds-form-file-input--variant-${this.args.extraClass}`);
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/app/components/hds/form/file-input/index.js
+++ b/packages/components/app/components/hds/form/file-input/index.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export { default } from '@hashicorp/design-system-components/components/hds/form/file-input/index';

--- a/packages/components/app/styles/@hashicorp/design-system-components.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-components.scss
@@ -27,6 +27,7 @@
 @use "../components/dropdown";
 @use "../components/flyout";
 @use "../components/form"; // multiple components
+@use "../components/form/file-input";
 @use "../components/icon-tile";
 @use "../components/link"; // multiple components
 @use "../components/menu-primitive";

--- a/packages/components/app/styles/components/form/file-input.scss
+++ b/packages/components/app/styles/components/form/file-input.scss
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+//
+// FORM > FILE-INPUT
+//
+
+@use "../../mixins/button" as *;
+
+.hds-form-file-input { // this can work as container ??
+  margin: -1px;
+  font-family: var(--token-typography-font-stack-text);
+  border: 1px solid transparent;
+  border-radius: calc($hds-button-border-radius + 1px);
+  // font-size: 1.875rem; // we may want to use this to tweak the size of the text that contains the name of the file?
+
+  &:focus,
+  &:focus-visible {
+    border-color: var(--token-color-focus-action-internal);
+    outline: 3px solid var(--token-color-focus-action-external);
+    outline-offset: 0;
+  }
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/::file-selector-button
+// https://caniuse.com/?search=file-selector-button
+
+.hds-form-file-input::file-selector-button {
+  min-height: 2.25rem;
+  margin-inline-end: 16px;
+  margin-right: 16px;
+  padding: 0.5625rem 0.9375rem;
+  padding-left: 38px; // override for the icon
+  color: var(--token-color-foreground-primary);
+  font-size: 0.875rem;
+  font-family: var(--token-typography-font-stack-text);
+  line-height: 1rem;
+  text-decoration: none;
+  background-color: var(--token-color-surface-faint);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cg fill='%233b3d45'%3E%3Cpath d='M4.24 5.8a.75.75 0 001.06-.04l1.95-2.1v6.59a.75.75 0 001.5 0V3.66l1.95 2.1a.75.75 0 101.1-1.02l-3.25-3.5a.75.75 0 00-1.101.001L4.2 4.74a.75.75 0 00.04 1.06z'/%3E%3Cpath d='M1.75 9a.75.75 0 01.75.75v3c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75v-3a.75.75 0 011.5 0v3A2.25 2.25 0 0112.75 15h-9.5A2.25 2.25 0 011 12.75v-3A.75.75 0 011.75 9z'/%3E%3C/g%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: 16px 50%;
+  background-size: var(--token-form-text-input-background-image-size);
+  border: $hds-button-border-width solid transparent;
+  border-color: var(--token-color-border-strong);
+  border-radius: $hds-button-border-radius;
+  // box-shadow: var(--token-elevation-low-box-shadow); // the overflow is not visible so better to remove it
+  cursor: pointer;
+}
+
+.hds-form-file-input::file-selector-button:hover,
+.hds-form-file-input.mock-hover::file-selector-button {
+  color: var(--token-color-foreground-primary);
+  background-color: var(--token-color-surface-primary);
+  border-color: var(--token-color-border-strong);
+}
+
+.hds-form-file-input::file-selector-button:focus,
+.hds-form-file-input.mock-focus::file-selector-button {
+  color: var(--token-color-foreground-primary);
+  background-color: var(--token-color-surface-faint);
+  border-color: var(--token-color-focus-action-internal);
+}
+
+.hds-form-file-input::file-selector-button:active,
+.hds-form-file-input.mock-active::file-selector-button {
+  color: var(--token-color-foreground-primary);
+  background-color: var(--token-color-surface-interactive-active);
+  border-color: var(--token-color-border-strong);
+  // box-shadow: none;
+}

--- a/packages/components/tests/acceptance/percy-test.js
+++ b/packages/components/tests/acceptance/percy-test.js
@@ -143,6 +143,10 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/utilities/dismiss-button');
     await percySnapshot('DismissButton');
 
+    // MOVE THIS BLOCK IN THE RIGHT POSITION
+    await visit('/components/form-file-input');
+    await percySnapshot('Form/fileInput');
+
     // DO NOT REMOVE – PERCY SNAPSHOTS END
 
     assert.ok(true);

--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -40,6 +40,7 @@ Router.map(function () {
       this.route('textarea');
       this.route('toggle');
       this.route('radio-card');
+      this.route('file-input');
     });
     this.route('icon-tile');
     this.route('link', function () {

--- a/packages/components/tests/dummy/app/routes/components/form/file-input.js
+++ b/packages/components/tests/dummy/app/routes/components/form/file-input.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+
+export default class ComponentsFormFileInputRoute extends Route {}

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -38,6 +38,7 @@
 @import "./showcase-pages/flyout";
 @import "./showcase-pages/form/base-elements";
 @import "./showcase-pages/form/checkbox";
+@import "./showcase-pages/form/file-input";
 @import "./showcase-pages/form/radio";
 @import "./showcase-pages/form/select";
 @import "./showcase-pages/form/text-input";

--- a/packages/components/tests/dummy/app/styles/showcase-pages/form/file-input.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/form/file-input.scss
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// FORM > FILE-INPUT

--- a/packages/components/tests/dummy/app/templates/components/form/file-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/file-input.hbs
@@ -1,0 +1,21 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{page-title "Form::FileInput Component"}}
+
+<Shw::Text::H1>Form::FileInput</Shw::Text::H1>
+
+<section data-test-percy>
+
+  <Shw::Text::Body><code>Hds::Button[@color=secondary]</code> (used as visual reference)</Shw::Text::Body>
+  <Hds::Button @icon="upload" @text="Choose file" @color="secondary" />
+
+  <Shw::Text::Body><code>Input[type=file]</code>
+    (styled via
+    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::file-selector-button"><code
+      >::file-selector-button</code></a>)</Shw::Text::Body>
+  <Hds::Form::FileInput />
+
+</section>

--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -117,6 +117,11 @@ SPDX-License-Identifier: MPL-2.0
         </LinkTo>
       </li>
       <li>
+        <LinkTo @route="components.form.file-input">
+          Form::FileInput
+        </LinkTo>
+      </li>
+      <li>
         <LinkTo @route="components.form.text-input">
           Form::TextInput
         </LinkTo>

--- a/packages/components/tests/integration/components/hds/form/file-input/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/file-input/index-test.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | hds/form/file-input/index',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it should render the component with a CSS class that matches the component name', async function (assert) {
+      await render(
+        hbs`<Hds::Form::FileInput id="test-form-file-input" />`
+      );
+      assert
+        .dom('#test-form-file-input')
+        .hasClass('hds-form-file-input');
+    });
+  }
+);


### PR DESCRIPTION
### :pushpin: Summary

Context: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1688592284604109

### :camera_flash: Screenshots
<img width="490" alt="screenshot_2890" src="https://github.com/hashicorp/design-system/assets/686239/f3920447-2633-4e73-a207-297d47f30dfe">
