### PR TITLE
`Text` component - Part 2 (extended API)

### DIFF
--- a/packages/components/addon/components/hds/text/body.hbs
+++ b/packages/components/addon/components/hds/text/body.hbs
@@ -8,6 +8,7 @@
   @size={{this.size}}
   @weight={{this.weight}}
   @align={{@align}}
+  @color={{@color}}
   @tag={{@tag}}
   ...attributes
 >{{yield}}</Hds::Text>

--- a/packages/components/addon/components/hds/text/body.hbs
+++ b/packages/components/addon/components/hds/text/body.hbs
@@ -3,4 +3,11 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<Hds::Text @group="body" @size={{this.size}} @weight={{this.weight}} @tag={{@tag}} ...attributes>{{yield}}</Hds::Text>
+<Hds::Text
+  @group="body"
+  @size={{this.size}}
+  @weight={{this.weight}}
+  @align={{@align}}
+  @tag={{@tag}}
+  ...attributes
+>{{yield}}</Hds::Text>

--- a/packages/components/addon/components/hds/text/code.hbs
+++ b/packages/components/addon/components/hds/text/code.hbs
@@ -3,4 +3,11 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<Hds::Text @group="code" @size={{this.size}} @weight={{this.weight}} @tag={{@tag}} ...attributes>{{yield}}</Hds::Text>
+<Hds::Text
+  @group="code"
+  @size={{this.size}}
+  @weight={{this.weight}}
+  @align={{@align}}
+  @tag={{@tag}}
+  ...attributes
+>{{yield}}</Hds::Text>

--- a/packages/components/addon/components/hds/text/code.hbs
+++ b/packages/components/addon/components/hds/text/code.hbs
@@ -8,6 +8,7 @@
   @size={{this.size}}
   @weight={{this.weight}}
   @align={{@align}}
+  @color={{@color}}
   @tag={{@tag}}
   ...attributes
 >{{yield}}</Hds::Text>

--- a/packages/components/addon/components/hds/text/display.hbs
+++ b/packages/components/addon/components/hds/text/display.hbs
@@ -8,6 +8,7 @@
   @size={{this.size}}
   @weight={{this.weight}}
   @align={{@align}}
+  @color={{@color}}
   @tag={{@tag}}
   ...attributes
 >{{yield}}</Hds::Text>

--- a/packages/components/addon/components/hds/text/display.hbs
+++ b/packages/components/addon/components/hds/text/display.hbs
@@ -7,6 +7,7 @@
   @group="display"
   @size={{this.size}}
   @weight={{this.weight}}
+  @align={{@align}}
   @tag={{@tag}}
   ...attributes
 >{{yield}}</Hds::Text>

--- a/packages/components/addon/components/hds/text/index.hbs
+++ b/packages/components/addon/components/hds/text/index.hbs
@@ -1,3 +1,3 @@
 {{#let (element this.componentTag) as |Tag|}}
-  <Tag class={{this.classNames}} ...attributes>{{yield}}</Tag>
+  <Tag class={{this.classNames}} {{style color=this.customColor}} ...attributes>{{yield}}</Tag>
 {{/let}}

--- a/packages/components/addon/components/hds/text/index.js
+++ b/packages/components/addon/components/hds/text/index.js
@@ -3,6 +3,29 @@ import { assert } from '@ember/debug';
 
 export const AVAILABLE_ALIGNS = ['left', 'center', 'right'];
 
+export const AVAILABLE_COLORS = [
+  'primary',
+  'strong',
+  'faint',
+  'disabled',
+  'high-contrast',
+  'action',
+  'action-hover',
+  'action-active',
+  'highlight',
+  'highlight-on-surface',
+  'highlight-high-contrast',
+  'success',
+  'success-on-surface',
+  'success-high-contrast',
+  'warning',
+  'warning-on-surface',
+  'warning-high-contrast',
+  'critical',
+  'critical-on-surface',
+  'critical-high-contrast',
+];
+
 export default class HdsTextIndexComponent extends Component {
   /**
    * Get a tag to render based on the `@tag` argument passed or the value of `this.size` (via mapping)
@@ -55,6 +78,41 @@ export default class HdsTextIndexComponent extends Component {
   }
 
   /**
+   * Sets the color of the text as pre-defined value
+   * Accepted values: see AVAILABLE_COLORS
+   *
+   * @param color
+   * @type {string}
+   */
+  get predefinedColor() {
+    let { color } = this.args;
+
+    console.log(color, AVAILABLE_COLORS.includes(color));
+
+    if (AVAILABLE_COLORS.includes(color)) {
+      return color;
+    } else {
+      return undefined;
+    }
+  }
+
+  /**
+   * Sets the color of the text as custom value (via inline style)
+   *
+   * @param color
+   * @type {string}
+   */
+  get customColor() {
+    let { color } = this.args;
+
+    if (!AVAILABLE_COLORS.includes(color)) {
+      return color;
+    } else {
+      return undefined;
+    }
+  }
+
+  /**
    * Get the class names to apply to the component.
    * @method #classNames
    * @return {string} The "class" attribute to apply to the component.
@@ -74,6 +132,10 @@ export default class HdsTextIndexComponent extends Component {
     if (this.align) {
       classes.push(`hds-text--align-${this.align}`);
     }
+
+    // add a (helper) class based on the @color argument (if pre-defined)
+    if (this.predefinedColor) {
+      classes.push(`hds-foreground-${this.predefinedColor}`);
     }
 
     return classes.join(' ');

--- a/packages/components/addon/components/hds/text/index.js
+++ b/packages/components/addon/components/hds/text/index.js
@@ -1,4 +1,7 @@
 import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+export const AVAILABLE_ALIGNS = ['left', 'center', 'right'];
 
 export default class HdsTextIndexComponent extends Component {
   /**
@@ -30,6 +33,28 @@ export default class HdsTextIndexComponent extends Component {
   }
 
   /**
+   * Sets the alignment of the text
+   * Accepted values: see AVAILABLE_ALIGNS
+   *
+   * @param align
+   * @type {string}
+   */
+  get align() {
+    let { align } = this.args;
+
+    if (align) {
+      assert(
+        `@align for "Hds::Text" must be one of the following: ${AVAILABLE_ALIGNS.join(
+          ', '
+        )}; received: ${align}`,
+        AVAILABLE_ALIGNS.includes(align)
+      );
+    }
+
+    return align;
+  }
+
+  /**
    * Get the class names to apply to the component.
    * @method #classNames
    * @return {string} The "class" attribute to apply to the component.
@@ -43,6 +68,12 @@ export default class HdsTextIndexComponent extends Component {
     // add a (helper) class based on the @weight argument
     if (this.args.weight) {
       classes.push(`hds-font-weight-${this.args.weight}`);
+    }
+
+    // add a class based on the @align argument
+    if (this.align) {
+      classes.push(`hds-text--align-${this.align}`);
+    }
     }
 
     return classes.join(' ');

--- a/packages/components/app/styles/@hashicorp/design-system-components.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-components.scss
@@ -41,6 +41,7 @@
 @use "../components/table";
 @use "../components/tabs";
 @use "../components/tag";
+@use "../components/text";
 @use "../components/toast";
 @use "../components/tooltip";
 // END COMPONENT CSS FILES IMPORTS

--- a/packages/components/app/styles/components/text.scss
+++ b/packages/components/app/styles/components/text.scss
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+//
+// TEXT
+//
+
+// .hds-text {}
+
+// ALIGNMENT
+
+.hds-text--align-left {
+  text-align: left;
+}
+
+.hds-text--align-center {
+  text-align: center;
+}
+
+.hds-text--align-right {
+  text-align: right;
+}
+

--- a/packages/components/tests/dummy/app/components/shw/flex/index.js
+++ b/packages/components/tests/dummy/app/components/shw/flex/index.js
@@ -14,6 +14,11 @@ export default class FlexIndexComponent extends Component {
     // add a class based on the @direction argument
     classes.push(`shw-flex--direction-${this.direction}`);
 
+    // add a class based on the @wrap argument
+    if (this.args.wrap) {
+      classes.push('shw-flex--wrap');
+    }
+
     return classes.join(' ');
   }
 }

--- a/packages/components/tests/dummy/app/routes/components/text.js
+++ b/packages/components/tests/dummy/app/routes/components/text.js
@@ -12,6 +12,9 @@ import {
   AVAILABLE_SIZES as CODE_AVAILABLE_SIZES,
   AVAILABLE_WEIGHTS_PER_SIZE as CODE_AVAILABLE_WEIGHTS_PER_SIZE,
 } from '@hashicorp/design-system-components/components/hds/text/code';
+import {
+  AVAILABLE_ALIGNS,
+} from '@hashicorp/design-system-components/components/hds/text/index';
 
 export default class ComponentsTextRoute extends Route {
   model() {
@@ -22,6 +25,7 @@ export default class ComponentsTextRoute extends Route {
       BODY_AVAILABLE_WEIGHTS_PER_SIZE,
       CODE_AVAILABLE_SIZES,
       CODE_AVAILABLE_WEIGHTS_PER_SIZE,
+      AVAILABLE_ALIGNS,
     };
   }
 }

--- a/packages/components/tests/dummy/app/routes/components/text.js
+++ b/packages/components/tests/dummy/app/routes/components/text.js
@@ -14,6 +14,7 @@ import {
 } from '@hashicorp/design-system-components/components/hds/text/code';
 import {
   AVAILABLE_ALIGNS,
+  AVAILABLE_COLORS,
 } from '@hashicorp/design-system-components/components/hds/text/index';
 
 export default class ComponentsTextRoute extends Route {
@@ -26,6 +27,7 @@ export default class ComponentsTextRoute extends Route {
       CODE_AVAILABLE_SIZES,
       CODE_AVAILABLE_WEIGHTS_PER_SIZE,
       AVAILABLE_ALIGNS,
+      AVAILABLE_COLORS,
     };
   }
 }

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -54,6 +54,7 @@
 @import "./showcase-pages/table";
 @import "./showcase-pages/tabs";
 @import "./showcase-pages/tag";
+@import "./showcase-pages/text";
 @import "./showcase-pages/tooltip";
 @import "./showcase-pages/typography";
 // END COMPONENT PAGES IMPORTS

--- a/packages/components/tests/dummy/app/styles/showcase-components/flex.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-components/flex.scss
@@ -12,6 +12,9 @@
   }
 }
 
+.shw-flex--wrap {
+  flex-wrap: wrap;
+}
 
 .shw-flex__items {
   display: flex;

--- a/packages/components/tests/dummy/app/styles/showcase-pages/text.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/text.scss
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// TEXT
+
+body.components-text {
+  .shw-component-text-sample-color--high-contrast {
+    background: #0c0c0e;
+    outline: 2px solid #0c0c0e;
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/text.hbs
+++ b/packages/components/tests/dummy/app/templates/components/text.hbs
@@ -79,4 +79,45 @@
     {{/each}}
   </Shw::Grid>
 
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H2>Color</Shw::Text::H2>
+
+  <Shw::Text::H4 tag="h3">Color inheritance</Shw::Text::H4>
+  <Shw::Flex @direction="row" @wrap={{true}} {{style gap="2rem"}} as |SF|>
+    <SF.Item @label="parent with no specific color">
+      <div>
+        <Hds::Text::Body @size="300" @tag="p">Lorem ipsum dolor</Hds::Text::Body>
+      </div>
+    </SF.Item>
+    <SF.Item @label="parent with #e91e63 color">
+      <div {{style color="#e91e63"}}>
+        <Hds::Text::Body @size="300" @tag="p">Lorem ipsum dolor</Hds::Text::Body>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Text::H4 tag="h3">Pre-defined colors</Shw::Text::H4>
+  <Shw::Flex @direction="row" @wrap={{true}} {{style gap="2rem"}} as |SF|>
+    {{#each this.model.AVAILABLE_COLORS as |color|}}
+      <SF.Item @label={{color}}>
+        <div class="shw-component-text-sample-color--{{color}}">
+          <Hds::Text::Body @size="300" @weight="semibold" @tag="p" @color={{color}}>Lorem ipsum dolor</Hds::Text::Body>
+          <Hds::Text::Body @size="300" @weight="medium" @tag="p" @color={{color}}>Lorem ipsum dolor</Hds::Text::Body>
+          <Hds::Text::Body @size="300" @tag="p" @color={{color}}>Lorem ipsum dolor</Hds::Text::Body>
+        </div>
+      </SF.Item>
+    {{/each}}
+  </Shw::Flex>
+
+  <Shw::Text::H4 tag="h3">Custom colors</Shw::Text::H4>
+  <Shw::Flex @direction="row" @wrap={{true}} {{style gap="2rem"}} as |SF|>
+    <SF.Item @label="text with #e91e63 color">
+      <Hds::Text::Body @size="300" @tag="p" @color="#e91e63">Lorem ipsum dolor</Hds::Text::Body>
+    </SF.Item>
+    <SF.Item @label="text with '--token-color-palette-purple-400' color">
+      <Hds::Text::Body @size="300" @tag="p" @color="var(--token-color-palette-purple-400)">Lorem ipsum dolor</Hds::Text::Body>
+    </SF.Item>
+  </Shw::Flex>
+
 </section>

--- a/packages/components/tests/dummy/app/templates/components/text.hbs
+++ b/packages/components/tests/dummy/app/templates/components/text.hbs
@@ -57,4 +57,26 @@
     {{/each}}
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H2>Alignment</Shw::Text::H2>
+  <Shw::Grid @columns={{3}} as |SG|>
+    {{#each this.model.AVAILABLE_ALIGNS as |alignment|}}
+      <SG.Item>
+        <Shw::Flex @direction="column" as |SF|>
+          <SF.Item @label="parent with text-align={{alignment}}">
+            <Shw::Outliner {{style text-align=alignment}}>
+              <Hds::Text::Body @size="200" @tag="p">The fox jumped over the lazy dog</Hds::Text::Body>
+            </Shw::Outliner>
+          </SF.Item>
+          <SF.Item @label="with @align={{alignment}}">
+            <Shw::Outliner>
+              <Hds::Text::Body @size="200" @tag="p" @align={{alignment}}>The fox jumped over the lazy dog</Hds::Text::Body>
+            </Shw::Outliner>
+          </SF.Item>
+        </Shw::Flex>
+      </SG.Item>
+    {{/each}}
+  </Shw::Grid>
+
 </section>


### PR DESCRIPTION
### :pushpin: Summary

This is the second PR for the proposed `Text` component (it follows https://github.com/hashicorp/design-system/pull/1457).
 
It implements the following APIs:
- definition of the "text alignment" using the `@align` argument
- definition of the "text color" using the `@color` argument
  - we accept both a color from a predefined list of "foreground" colors, as well as custom color in the form of a valid CSS string

From discussion within the working group, we have come to the conclusion not to add extra arguments to control the layout of the element (eg. `@display` or the text overflow/wrapping/truncation).

**Preview** of the component in action: https://hds-showcase-git-text-component-2023-part-2-hashicorp.vercel.app/components/text

### :camera_flash: Screenshots

<img width="1046" alt="screenshot_2896" src="https://github.com/hashicorp/design-system/assets/686239/37f3f66a-73a8-4976-9346-a6e4b09cc31e">
<img width="1025" alt="screenshot_2897" src="https://github.com/hashicorp/design-system/assets/686239/88b763a5-c54b-4840-8328-bc5e57059914">

### :link: External links

Meeting notes: https://docs.google.com/document/d/12wk3VyH2aMCI-DMlrRfrmUhrQwUzRLUGydYlw3SPuiQ/
Jira ticket: https://hashicorp.atlassian.net/browse/HDS-1946

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
