### PR TITLE
`Card` - change default value of overflow to visible (HDS-1976)

### DIFF
--- a/.changeset/blue-kangaroos-sip.md
+++ b/.changeset/blue-kangaroos-sip.md
@@ -2,6 +2,6 @@
 "@hashicorp/design-system-components": minor
 ---
 
-Update default value of `Card` `@overflow` argument to `"visible"` to address an area of consumer confusion and better support the most common use cases. 
+`Card` - Updated default value of `@overflow` argument to `"visible"` to address an area of consumer confusion and better support the most common use cases. 
 
 Technically, this is a breaking change as it will require consumers relying upon the previous `hidden` default value to now manually set the value. The result of not setting the a `"hidden"` value can cause square edges of some images to "stick out" and overlap the rounded corners of the Card itself. We considered this to be a fairly minor, low-impact issue however which would not affect functionality or usability.

--- a/.changeset/blue-kangaroos-sip.md
+++ b/.changeset/blue-kangaroos-sip.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": minor
 ---
 
-Update default value of `Card` `@overflow` argument to `visible` to address an area of consumer confusion and better support the most common use cases. Technically, this is a breaking change as it will require consumers relying upon the previous `hidden` default value to now manually set the value. The result of not setting the a `hidden` value can cause square edges of some images to "stick out" and overlap the rounded corners of the Card itself. We considered this to be a fairly minor, low-impact issue however which would not affect functionality or usability.
+Update default value of `Card` `@overflow` argument to `"visible"` to address an area of consumer confusion and better support the most common use cases. 
+
+Technically, this is a breaking change as it will require consumers relying upon the previous `hidden` default value to now manually set the value. The result of not setting the a `"hidden"` value can cause square edges of some images to "stick out" and overlap the rounded corners of the Card itself. We considered this to be a fairly minor, low-impact issue however which would not affect functionality or usability.

--- a/.changeset/blue-kangaroos-sip.md
+++ b/.changeset/blue-kangaroos-sip.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Update default value of `Card` `@overflow` argument to `visible` to address an area of consumer confusion and better support the most common use cases. Technically, this is a breaking change as it will require consumers relying upon the previous `hidden` default value to now manually set the value. The result of not setting the a `hidden` value can cause square edges of some images to "stick out" and overlap the rounded corners of the Card itself. We considered this to be a fairly minor, low-impact issue however which would not affect functionality or usability.

--- a/packages/components/addon/components/hds/card/container.js
+++ b/packages/components/addon/components/hds/card/container.js
@@ -8,7 +8,7 @@ import { assert } from '@ember/debug';
 
 export const DEFAULT_LEVEL = 'base';
 export const DEFAULT_BACKGROUND = 'neutral-primary';
-export const DEFAULT_OVERFLOW = 'hidden';
+export const DEFAULT_OVERFLOW = 'visible';
 export const LEVELS = ['base', 'mid', 'high'];
 export const BACKGROUNDS = ['neutral-primary', 'neutral-secondary'];
 export const OVERFLOWS = ['hidden', 'visible'];
@@ -106,7 +106,7 @@ export default class HdsCardContainerComponent extends Component {
    *
    * @param overflow
    * @type {string}
-   * @default 'hidden'
+   * @default 'visible'
    */
   get overflow() {
     let { overflow = DEFAULT_OVERFLOW } = this.args;

--- a/packages/components/tests/dummy/app/templates/components/card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/card.hbs
@@ -72,19 +72,19 @@
 
   <Shw::Text::H2>Overflow</Shw::Text::H2>
   <div class="shw-component-card-wrapper">
-    <Shw::Grid @columns={{2}} {{style width="fit-content"}} as |SG|>
+    <Shw::Grid @columns={{2}} {{style width="fit-content" gap="2rem"}} as |SG|>
       <SG.Item>
         <Hds::Card::Container @level="mid" @hasBorder={{true}}>
           <div class="shw-component-card-overflow__wrapper-relative">
-            <Shw::Placeholder @text="hidden (default)" @width="200" @height="200" @background="#e1f5fe" />
+            <Shw::Placeholder @text="visible (default)" @width="200" @height="200" @background="#e1f5fe" />
             <div class="shw-component-card-overflow__content-absolute"></div>
           </div>
         </Hds::Card::Container>
       </SG.Item>
       <SG.Item>
-        <Hds::Card::Container @level="mid" @hasBorder={{true}} @overflow="visible">
+        <Hds::Card::Container @level="mid" @hasBorder={{true}} @overflow="hidden">
           <div class="shw-component-card-overflow__wrapper-relative">
-            <Shw::Placeholder @text="visible" @width="200" @height="200" @background="#e1f5fe" />
+            <Shw::Placeholder @text="hidden" @width="200" @height="200" @background="#e1f5fe" />
             <div class="shw-component-card-overflow__content-absolute"></div>
           </div>
         </Hds::Card::Container>

--- a/packages/components/tests/integration/components/hds/card/container-test.js
+++ b/packages/components/tests/integration/components/hds/card/container-test.js
@@ -64,19 +64,19 @@ module('Integration | Component | hds/card/container', function (hooks) {
 
   // OVERFLOW
 
-  test('it should have the overflow hidden if no @overflow prop is declared', async function (assert) {
+  test('it should have the overflow visible if no @overflow prop is declared', async function (assert) {
     await render(hbs`<Hds::Card::Container id="test-card-container" />`);
     assert
       .dom('#test-card-container')
-      .hasClass('hds-card__container--overflow-hidden');
+      .hasClass('hds-card__container--overflow-visible');
   });
-  test('it should have the overflow visible if the @overflow prop is declared as "visible"', async function (assert) {
+  test('it should have the overflow hidden if the @overflow prop is declared as "hidden"', async function (assert) {
     await render(
-      hbs`<Hds::Card::Container id="test-card-container" @overflow="visible" />`
+      hbs`<Hds::Card::Container id="test-card-container" @overflow="hidden" />`
     );
     assert
       .dom('#test-card-container')
-      .hasClass('hds-card__container--overflow-visible');
+      .hasClass('hds-card__container--overflow-hidden');
   });
 
   // ASSERTIONS

--- a/website/docs/components/card/partials/code/component-api.md
+++ b/website/docs/components/card/partials/code/component-api.md
@@ -16,7 +16,7 @@
   <C.Property @name="hasBorder" @type="boolean" @default="false">
     Controls whether or not the Card has a visible external border.
   </C.Property>
-  <C.Property @name="overflow" @type="enum" @values={{array "hidden" "visible" }} @default="hidden">
+  <C.Property @name="overflow" @type="enum" @values={{array "visible" "hidden" }} @default="visible">
     Controls the "overflow" property for the component.
   </C.Property>
   <C.Property @name="...attributes">


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will change the default value of the `Hds::Card::Container` `@overflow` argument from `hidden` to `visible`

- **Showcase preview:** https://hds-showcase-git-hds-1976-card-overflow-update-hashicorp.vercel.app/components/card
- **Web preview:** https://hds-website-git-hds-1976-card-overflow-update-hashicorp.vercel.app/components/card?tab=code#component-api

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
- Jira ticket: [HDS-1976](https://hashicorp.atlassian.net/browse/HDS-1976)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1976]: https://hashicorp.atlassian.net/browse/HDS-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ