### PR TITLE
Add /support redirect

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -20,5 +20,8 @@
     }
   ],
   "framework": "ember",
-  "rewrites": [{ "source": "/(.*)", "destination": "/_empty.html" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/_empty.html" }],
+  "redirects": [
+    { "source": "/support", "destination": "/about/support", "permanent": false }
+  ]
 }


### PR DESCRIPTION
### :pushpin: Summary

This PR adds a `/support` path that redirects to the actual support page which is nested under `/about/support`. The thinking here is that we could more easily link people to https://helios.hashicorp.design/support (or https://hds-website-git-br-support-redirect-hashicorp.vercel.app/support in the preview). 

I pulled this out of https://github.com/hashicorp/design-system/pull/1467 since it's related but ultimately a separate concern in my view and could be merged separately (or not if it doesn't seem valuable).

### :hammer_and_wrench: Detailed description

The changes uses vercel's [redirect logic](https://vercel.com/docs/concepts/projects/project-configuration#redirect-object-definition), and specifically the `permanent: false` option which gives this status code which seems appropriate for what we want to do here:

> 307 Temporary Redirect: Not cached by client, the method and body never changed. This type of redirect does not affect SEO and search engines will treat them as normal redirects.


<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2197](https://hashicorp.atlassian.net/browse/HDS-2197)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2197]: https://hashicorp.atlassian.net/browse/HDS-2197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ