### PR TITLE
Add support to TextInput for 'datetime-local' type

### DIFF
--- a/.changeset/modern-pandas-judge.md
+++ b/.changeset/modern-pandas-judge.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Form::TextInput` - Add support for datetime-local type

--- a/packages/components/addon/components/hds/form/text-input/base.js
+++ b/packages/components/addon/components/hds/form/text-input/base.js
@@ -16,6 +16,7 @@ export const TYPES = [
   'url',
   'date',
   'time',
+  'datetime-local',
   'search',
 ];
 

--- a/packages/components/app/styles/components/form/text-input.scss
+++ b/packages/components/app/styles/components/form/text-input.scss
@@ -88,7 +88,8 @@
   // DATE/TIME
 
   &[type="date"],
-  &[type="time"] {
+  &[type="time"],
+  &[type="datetime-local"] {
 
     // browsers set a specific width for these controls, we want to keep it
     width: initial;
@@ -108,7 +109,8 @@
 
   // we override the default icon with the Flight corresponding one
   // notice: the original in Chrome has two assets, one for light and one for dark mode, and uses a special syntax, but apparently it doesn't work if used in a stylesheet
-  &[type="date"] {
+  &[type="date"],
+  &[type="datetime-local"] {
     &::-webkit-calendar-picker-indicator {
       background-image: var(--token-form-text-input-background-image-data-url-date);
       background-position: center center;

--- a/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/text-input.hbs
@@ -111,6 +111,15 @@
                     @isInvalid={{if (eq variant "invalid") true}}
                   />
                 </SF.Item>
+                <SF.Item>
+                  <Hds::Form::TextInput::Base
+                    @type="datetime-local"
+                    @value="Lorem ipsum dolor"
+                    disabled={{if (eq variant "disabled") "disabled"}}
+                    readonly={{if (eq variant "readonly") "readonly"}}
+                    @isInvalid={{if (eq variant "invalid") true}}
+                  />
+                </SF.Item>
               </Shw::Flex>
             </SG.Item>
           {{/unless}}
@@ -151,6 +160,9 @@
             </SF.Item>
             <SF.Item {{style display=display}}>
               <Hds::Form::TextInput::Base @type="time" />
+            </SF.Item>
+            <SF.Item {{style display=display}}>
+              <Hds::Form::TextInput::Base @type="datetime-local" />
             </SF.Item>
           </Shw::Flex>
         </SG.Item>

--- a/packages/components/tests/integration/components/hds/form/text-input/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/base-test.js
@@ -27,10 +27,13 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
     assert.dom('#test-form-text-input').hasAttribute('type', 'text');
   });
   test('it should render the correct type depending on the @type prop', async function (assert) {
+    this.set('type', 'email');
     await render(
-      hbs`<Hds::Form::TextInput::Base @type="email" id="test-form-text-input" />`
+      hbs`<Hds::Form::TextInput::Base @type={{this.type}} id="test-form-text-input" />`
     );
     assert.dom('#test-form-text-input').hasAttribute('type', 'email');
+    this.set('type', 'datetime-local');
+    assert.dom('#test-form-text-input').hasAttribute('type', 'datetime-local');
   });
 
   // VALUE
@@ -88,7 +91,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {
     const errorMessage =
-      '@type for "Hds::Form::TextInput" must be one of the following: text, email, password, url, date, time, search; received: foo';
+      '@type for "Hds::Form::TextInput" must be one of the following: text, email, password, url, date, time, datetime-local, search; received: foo';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/website/docs/components/form/text-input/partials/code/component-api.md
+++ b/website/docs/components/form/text-input/partials/code/component-api.md
@@ -8,7 +8,7 @@ The Text Input component has two different variants with their own APIs:
 ### Form::TextInput::Base
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" }} @default="text">
+  <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" "datetime-local" }} @default="text">
     Sets the native HTML `type` of the `<input>`. See the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) for a full list of covered types.
   </C.Property>
   <C.Property @name="value" @type="string|number|date">
@@ -35,7 +35,7 @@ The Text Input component has two different variants with their own APIs:
 ### Form::TextInput::Field
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" }} @default="text">
+  <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" "datetime-local" }} @default="text">
     Sets the native HTML `type` of the `<input>`. See the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) for a full list of covered types.
   </C.Property>
   <C.Property @name="value" @type="string|number|date">

--- a/website/docs/components/form/text-input/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/text-input/partials/guidelines/guidelines.md
@@ -52,6 +52,10 @@ Date and time fields use the native browser functionality for the popovers. Some
   <F.Label>Time</F.Label>
 </Hds::Form::TextInput::Field>
 
+<Hds::Form::TextInput::Field @type="datetime-local" placeholder="mm/dd/yyT--:-- --" @width="150px" as |F|>
+  <F.Label>Datetime</F.Label>
+</Hds::Form::TextInput::Field>
+
 ## Required and optional
 
 For complex forms, indicate **required** fields. This is the most explicit and transparent method and ensures users don’t have to make assumptions. Read more about best practices for [marking required fields in forms](https://www.nngroup.com/articles/required-fields/).


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds support for `@type="datetime-local"` to the `TextInput` component.

- **Showcase:** https://hds-showcase-git-hds-2235-datetime-local-type-hashicorp.vercel.app/components/form/text-input
- **Web:** https://hds-website-git-hds-2235-datetime-local-type-hashicorp.vercel.app/components/form/text-input?tab=code#component-api

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

Component showcase:

https://github.com/hashicorp/design-system/assets/19582796/0fd54648-565a-4071-bd18-876911d802dd

Website docs:

https://github.com/hashicorp/design-system/assets/19582796/5ae6ac7f-4df1-42a1-98a5-300e14536d8f



### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2235

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
