### PR TITLE
Fix dropdown visibility in "How to use" documentation

### DIFF
--- a/website/app/styles/doc-components/code-block.scss
+++ b/website/app/styles/doc-components/code-block.scss
@@ -12,6 +12,7 @@
 
 .doc-code-block {
   position: relative;
+  z-index: 2;
   border-radius: 3px;
 
   .doc-copy-button {


### PR DESCRIPTION
### :pushpin: Summary

Not sure how we missed this before, or what change we introduced that caused this, but most of the "How to use" examples of the `Dropdown` were cut out by the sidebar navigation (see images below).

### :hammer_and_wrench: Detailed description

in this PR I have:
- assigned a `z-index` to the `Doc::CodeBlock` so that its content lays on top of the sidebar

### :camera_flash: Screenshots

<img width="281" alt="screenshot_2925" src="https://github.com/hashicorp/design-system/assets/686239/0e322382-7df5-4cd0-8086-f03e5df2a18b">
<img width="356" alt="screenshot_2924" src="https://github.com/hashicorp/design-system/assets/686239/a212473a-35a6-4754-9b07-1559e969b223">
<img width="419" alt="screenshot_2923" src="https://github.com/hashicorp/design-system/assets/686239/05342910-dc70-4cd4-8742-8b965dbbe372">

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
