### PR TITLE
Fix layout of `SideNav` list title

### DIFF
--- a/.changeset/silver-cougars-return.md
+++ b/.changeset/silver-cougars-return.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+- `SideNav` - updated layout styling for the `SideNav::List::Title` element

--- a/packages/components/app/styles/components/side-nav/content.scss
+++ b/packages/components/app/styles/components/side-nav/content.scss
@@ -34,9 +34,9 @@
 .hds-side-nav__list-title {
   display: flex;
   align-items: center;
-  min-height: 34px;
+  min-height: var(--token-side-nav-body-list-item-height);
   margin-top: var(--token-side-nav-body-list-margin-vertical);
-  padding: 0 var(--token-side-nav-body-list-item-padding-horizontal);
+  padding: 9px var(--token-side-nav-body-list-item-padding-horizontal); // 8px = (min-height - body-100-line-height) / 2
   color: var(--token-side-nav-color-foreground-faint);
 
   // Remove margin from title at top of all list-items & lists

--- a/packages/components/tests/dummy/app/templates/components/side-nav.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav.hbs
@@ -485,11 +485,17 @@
     <SF.Item @label="Base">
       <ul class="shw-component-sim-side-nav-body">
         <Hds::SideNav::List::Title>Group title</Hds::SideNav::List::Title>
+        <Hds::SideNav::List::Item>
+          <Shw::Placeholder @height="108px" @text="following content" @background="#e4e4e4" />
+        </Hds::SideNav::List::Item>
       </ul>
     </SF.Item>
     <SF.Item @label="With very long text">
       <ul class="shw-component-sim-side-nav-body">
         <Hds::SideNav::List::Title>This is a long text that should go on two lines</Hds::SideNav::List::Title>
+        <Hds::SideNav::List::Item>
+          <Shw::Placeholder @height="108px" @text="following content" @background="#e4e4e4" />
+        </Hds::SideNav::List::Item>
       </ul>
     </SF.Item>
   </Shw::Flex>


### PR DESCRIPTION
### :pushpin: Summary

While adopting the `SideNav` in TFC the UI engineers have noticed that - in the "list title" - when the text is very long and goes on multiple lines, the spacing between the "title" and the following content is not maintained.

Context: https://hashicorp.slack.com/archives/C02T2JTKF7D/p1689289668365859

<img width="400" alt="screenshot" src="https://github.com/hashicorp/design-system/assets/686239/fcdf27f7-9a12-41ad-b5c0-ab3c3a79c8ac">

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated layout styling for `Hds::SideNav::List::Title`
- updated showcase for `Hds::SideNav::List::Title` so that it's easier to spot regressions

👉 **Preview**: https://hds-showcase-git-fix-sidenav-list-title-hashicorp.vercel.app/components/side-nav

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
