### PR TITLE
Update the layout and styling of the "Component API" docs component

### DIFF
--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -14,31 +14,29 @@
     {{/if}}
   </div>
   {{#if (or @values @valueNote)}}
-    <div class="doc-component-api__property-values">
-      {{#if @values}}
-        <ul class="doc-component-api__property-values" role="list">
-          {{#each @values as |value|}}
-            <li
-              class="doc-component-api__property-value
-                {{if (eq @default value) 'doc-component-api__property-value--default'}}"
-            >
-              {{value}}{{#if (eq @default value)}} <span class="doc-sr-only">(default)</span>{{/if}}
-            </li>
-          {{/each}}
-        </ul>
-      {{else if @valueNote}}
-        {{@valueNote}}
-      {{/if}}
-    </div>
-  {{else if @default}}
-    <div class="doc-component-api__property-values">
+    {{#if @values}}
       <ul class="doc-component-api__property-values" role="list">
-        <li class="doc-component-api__property-value doc-component-api__property-value--default">
-          {{@default}}
-          <span class="doc-sr-only">(default)</span>
-        </li>
+        {{#each @values as |value|}}
+          <li
+            class="doc-component-api__property-value
+              {{if (eq @default value) 'doc-component-api__property-value--default'}}"
+          >
+            {{value}}{{#if (eq @default value)}} <span class="doc-sr-only">(default)</span>{{/if}}
+          </li>
+        {{/each}}
       </ul>
-    </div>
+    {{else if @valueNote}}
+      <div class="doc-component-api__property-values">
+        {{@valueNote}}
+      </div>
+    {{/if}}
+  {{else if @default}}
+    <ul class="doc-component-api__property-values" role="list">
+      <li class="doc-component-api__property-value doc-component-api__property-value--default">
+        {{@default}}
+        <span class="doc-sr-only">(default)</span>
+      </li>
+    </ul>
   {{/if}}
   {{#if (has-block)}}
     <div class="doc-component-api__property-description">

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -3,30 +3,25 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<dl class="doc-component-api__property">
-  <dt class="doc-component-api__term doc-component-api__term--name">Name</dt>
-  <dd class="doc-component-api__description doc-component-api__description--name">
+<div class="doc-component-api__property">
+  <div class="doc-component-api__property-info">
     <code class="doc-component-api__property-name">{{@name}}</code>
-  </dd>
-  {{#if @type}}
-    <dt class="doc-component-api__term doc-component-api__term--type">Type</dt>
-    <dd class="doc-component-api__description doc-component-api__description--type">
+    {{#if @type}}
       <code class="doc-component-api__property-type">{{@type}}</code>
-    </dd>
-  {{/if}}
-  {{#if @required}}
-    <dt class="doc-component-api__term doc-component-api__term--required">Required</dt>
-    <dd class="doc-component-api__description doc-component-api__description--required">
-      <Doc::Badge @type="outlined">Required</Doc::Badge>
-    </dd>
-  {{/if}}
+    {{/if}}
+    {{#if @required}}
+      <code class="doc-component-api__property-required">required</code>
+    {{/if}}
+  </div>
   {{#if (or @values @valueNote)}}
-    <dt class="doc-component-api__term doc-component-api__term--values">Values</dt>
-    <dd class="doc-component-api__description doc-component-api__description--values">
+    <div class="doc-component-api__property-values">
       {{#if @values}}
         <ul class="doc-component-api__property-values" role="list">
           {{#each @values as |value|}}
-            <li class="doc-component-api__property-value{{if (eq @default value) '--default'}}">
+            <li
+              class="doc-component-api__property-value
+                {{if (eq @default value) 'doc-component-api__property-value--default'}}"
+            >
               {{value}}{{#if (eq @default value)}} <span class="doc-sr-only">(default)</span>{{/if}}
             </li>
           {{/each}}
@@ -34,22 +29,20 @@
       {{else if @valueNote}}
         {{@valueNote}}
       {{/if}}
-    </dd>
+    </div>
   {{else if @default}}
-    <dt class="doc-component-api__term doc-component-api__term--values">Default</dt>
-    <dd class="doc-component-api__description doc-component-api__description--values">
+    <div class="doc-component-api__property-values">
       <ul class="doc-component-api__property-values" role="list">
-        <li class="doc-component-api__property-value--default">
+        <li class="doc-component-api__property-value doc-component-api__property-value--default">
           {{@default}}
           <span class="doc-sr-only">(default)</span>
         </li>
       </ul>
-    </dd>
+    </div>
   {{/if}}
   {{#if (has-block)}}
-    <dt class="doc-component-api__term doc-component-api__term--description">Description</dt>
-    <dd class="doc-component-api__description doc-component-api__description--description">
+    <div class="doc-component-api__property-description">
       {{yield}}
-    </dd>
+    </div>
   {{/if}}
-</dl>
+</div>

--- a/website/app/styles/doc-components/component-api.scss
+++ b/website/app/styles/doc-components/component-api.scss
@@ -103,8 +103,11 @@
 
 .doc-component-api__property-description {
   .doc-component-api {
-    margin: 16px 0;
+    margin: 16px 0 16px 8px;
+    padding-right: 16px;
+    padding-left: 16px;
     border: none;
+    border-left: 2px solid var(--doc-color-feedback-information-300);
     border-radius: 0;
 
     &:last-child {
@@ -113,14 +116,14 @@
   }
 
   .doc-component-api__property {
-    padding-top: 16px;
-    padding-bottom: 16px;
-    padding-left: 12px;
-  }
+    padding-left: 0;
 
-  .doc-component-api__property-values,
-  .doc-component-api__property-description {
-    padding-left: 12px;
-    border-left: 2px solid var(--doc-color-feedback-information-300);
+    &:first-child {
+      padding-top: 12px;
+    }
+
+    &:last-child {
+      padding-bottom: 12px;
+    }
   }
 }

--- a/website/app/styles/doc-components/component-api.scss
+++ b/website/app/styles/doc-components/component-api.scss
@@ -68,18 +68,18 @@
 // second row - values
 
 .doc-component-api__property-values {
-  margin: 24px 0 0 0;
-  padding: 0;
+  @include doc-font-family("mono"); // custom font styling
+  margin: 12px 0 0 0;
+  padding: 12px 0 0 0;
+  font-size: 13px;
+  line-height: 1.714;
 }
 
 .doc-component-api__property-value {
-  @include doc-font-family("mono"); // custom font styling
   display: inline-block;
   margin-bottom: 8px;
   padding: 0 6px;
   color: var(--doc-color-gray-200);
-  font-size: 13px;
-  line-height: 1.714;
   background-color: var(--doc-color-gray-600);
   border: 1px solid transparent;
   border-radius: 3px;
@@ -95,7 +95,7 @@
 
 .doc-component-api__property-description {
   @include doc-font-style-body-small ();
-  margin: 20px 0 0 0;
+  padding: 20px 0 0 0;
 }
 
 
@@ -105,7 +105,6 @@
   .doc-component-api {
     margin: 16px 0;
     border: none;
-    border-left: 2px solid var(--doc-color-feedback-information-300);
     border-radius: 0;
 
     &:last-child {
@@ -116,5 +115,12 @@
   .doc-component-api__property {
     padding-top: 16px;
     padding-bottom: 16px;
+    padding-left: 12px;
+  }
+
+  .doc-component-api__property-values,
+  .doc-component-api__property-description {
+    padding-left: 12px;
+    border-left: 2px solid var(--doc-color-feedback-information-300);
   }
 }

--- a/website/app/styles/doc-components/component-api.scss
+++ b/website/app/styles/doc-components/component-api.scss
@@ -5,118 +5,51 @@
 
 // COMPONENT API
 
-// Property grid areas
-// | 1 | 3 | 5 |
-// | 2 | 4 | 5 |
-// | 6 | 6 | 6 |
-// | 7 | 7 | 7 |
-// | 8 | 8 | 8 |
-// | 9 | 9 | 9 |
-
 @use "../breakpoints" as breakpoint;
 @use "../typography/mixins";
 
 
+// SET OF PROPERTIES
+
 .doc-component-api {
   margin-bottom: 24px;
+  border: 1px solid var(--doc-color-gray-500);
+  border-radius: 3px;
 }
+
+
+// SINGLE PROPERTY "ITEM"
 
 .doc-component-api__property {
   position: relative;
-  display: grid;
-  grid-template-rows: repeat(6, auto);
-  grid-template-columns: repeat(3, 1fr);
   margin: 0;
   padding: 24px 16px;
   border-bottom: 1px solid var(--doc-color-gray-500);
 
-  @include breakpoint.small () {
-    display: block;
-  }
-}
-
-.doc-component-api__term {
-  @include doc-font-style-label();
-  margin: 0;
-  margin-bottom: 8px;
-  padding: 0;
-  color: var(--doc-color-gray-300);
-
-  &--name {
-    grid-area: 1 / 1 / 2 / 2;
-  }
-
-  &--type {
-    grid-area: 1 / 2 / 2 / 3;
-    padding-left: 8px;
-
-    @include breakpoint.small () {
-      padding-left: 0;
-    }
-  }
-
-  &--required {
-    display: none;
-  }
-
-  &--values {
-    grid-area: 3 / 1 / 4 / 4;
-  }
-
-  &--description {
-    grid-area: 5 / 1 / 6 / 4;
-  }
-}
-
-.doc-component-api__description {
-  @include doc-font-style-body-small ();
-  margin: 0 0 16px;
-  padding: 0;
-
-  &--name {
-    grid-area: 2 / 1 / 3 / 2;
-  }
-
-  &--type {
-    grid-area: 2 / 2 / 3 / 3;
-    padding-left: 8px;
-
-    @include breakpoint.small () {
-      padding-left: 0;
-    }
-  }
-
-  &--required {
-    grid-area: 1 / 3 / 3 / 4;
-    text-align: right;
-
-    @include breakpoint.small () {
-      position: absolute;
-      top: 24px;
-      right: 16px;
-    }
-  }
-
-  &--values {
-    grid-area: 4 / 1 / 5 / 4;
-  }
-
-  &--description {
-    grid-area: 6 / 1 / 7 / 4;
-  }
-
   &:last-child {
-    margin: 0;
+    border-bottom: none;
   }
+}
+
+// first row - info
+
+.doc-component-api__property-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: flex-start;
 }
 
 .doc-component-api__property-name {
-  @include doc-font-style-code ();
+  @include doc-font-family("mono"); // custom font styling
   display: inline-block;
   padding: 0 7px;
-  color: var(--doc-color-white);
+  color: var(--doc-color-feedback-information-100);
   font-weight: 700;
-  background-color: var(--doc-color-gray-200);
+  font-size: 17px;
+  line-height: 1.714;
+  background-color: var(--doc-color-feedback-information-400);
   border-radius: 3px;
 }
 
@@ -126,43 +59,62 @@
   color: var(--doc-color-gray-100);
 }
 
-.doc-component-api__property-values {
+.doc-component-api__property-required {
   @include doc-font-style-code ();
-  margin: 0;
+  display: inline-block;
+  color: #f25054; // it's an HDS color, so we use its corresponding hex value
+}
+
+// second row - values
+
+.doc-component-api__property-values {
+  margin: 24px 0 0 0;
   padding: 0;
 }
 
 .doc-component-api__property-value {
+  @include doc-font-family("mono"); // custom font styling
   display: inline-block;
   margin-bottom: 8px;
-  padding: 0 7px;
-  color: var(--doc-color-feedback-information-200);
-  background-color: var(--doc-color-feedback-information-400);
+  padding: 0 6px;
+  color: var(--doc-color-gray-200);
+  font-size: 13px;
+  line-height: 1.714;
+  background-color: var(--doc-color-gray-600);
+  border: 1px solid transparent;
   border-radius: 3px;
 }
 
 .doc-component-api__property-value--default {
-  display: inline-block;
-  padding: 0 7px;
-  color: var(--doc-color-white);
+  color: var(--doc-color-gray-100);
   font-weight: 700;
-  background-color: var(--doc-color-feedback-information-200);
-  border-radius: 3px;
+  background-color: var(--doc-color-gray-500);
 }
 
-// Nested instances
+// third row - description
 
-.doc-component-api__description {
+.doc-component-api__property-description {
+  @include doc-font-style-body-small ();
+  margin: 20px 0 0 0;
+}
+
+
+// NESTED INSTANCES
+
+.doc-component-api__property-description {
   .doc-component-api {
     margin: 16px 0;
-    border-left: 2px solid var(--doc-color-gray-500);
+    border: none;
+    border-left: 2px solid var(--doc-color-feedback-information-300);
+    border-radius: 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   .doc-component-api__property {
-    padding: 16px;
-
-    &:last-child {
-      border-bottom: none;
-    }
+    padding-top: 16px;
+    padding-bottom: 16px;
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

This PR implements the refreshed "Component API" component for the documentation.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the `Doc::ComponentApi::Property` component
  - used simple `<div>` elements instead of `<dl>` elements (I don't think it's possible to maintain the same semantic structure now)
  - removed all the extra labels from the content
  - removed all the extra `<div>` containers (not needed anymore)
- updated the `Doc::ComponentApi::Property` styling
  - removed the grid layout, now normal stacking of elements works fine
  - followed the new design specs for `name/type/required/values`

👉 👉 👉 **Previews:**  
- https://hds-website-git-componen-api-refresh-hashicorp.vercel.app/components/alert?tab=code#component-api
- - https://hds-website-git-componen-api-refresh-hashicorp.vercel.app/components/table?tab=code#component-api

### :camera_flash: Screenshots

![Alert-Helios-Design-System](https://github.com/hashicorp/design-system/assets/686239/1ba5c891-52ea-4f69-a834-ec237e048394)

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2195
Figma file: https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?type=design&node-id=3342%3A89190&mode=design&t=TAwEC01tainr46sv-1

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
