### PR TITLE
Update copy-item to use copy/snippet

### DIFF
--- a/packages/components/addon/components/hds/dropdown/list-item/copy-item.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/copy-item.hbs
@@ -8,13 +8,5 @@
       class="hds-dropdown-list-item__copy-item-title hds-typography-body-100 hds-font-weight-semibold"
     >{{@copyItemTitle}}</div>
   {{/if}}
-  <button type="button" class="{{if this.isSuccess 'is-success'}}" {{on "click" this.copyCode}}>
-    <div class="hds-dropdown-list-item__copy-item-text hds-typography-code-100">
-      {{this.text}}
-    </div>
-    <FlightIcon
-      @name="{{if this.isSuccess 'clipboard-checked' 'clipboard-copy'}}"
-      class="hds-dropdown-list-item__copy-item-icon"
-    />
-  </button>
+  <Hds::Copy::Snippet @textToCopy={{this.text}} />
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
@@ -4,10 +4,23 @@
  */
 
 import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
 
 export default class HdsDropdownListItemCopyItemComponent extends Component {
+  /**
+   * @param text
+   * @type {string}
+   * @description The text of the item. If no text value is defined an error will be thrown
+   */
   get text() {
-    return this.args.text;
+    let { text } = this.args;
+
+    assert(
+      '@text for "Hds::Dropdown::ListItem::CopyItem" must have a valid value',
+      text !== undefined
+    );
+
+    return text;
   }
   /**
    * Get the class names to apply to the component.

--- a/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
@@ -4,29 +4,11 @@
  */
 
 import Component from '@glimmer/component';
-import { assert } from '@ember/debug';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 
 export default class HdsDropdownListItemCopyItemComponent extends Component {
-  @tracked isSuccess = false;
-
-  /**
-   * @param text
-   * @type {string}
-   * @description The text of the item. If no text value is defined an error will be thrown
-   */
   get text() {
-    let { text } = this.args;
-
-    assert(
-      '@text for "Hds::Dropdown::ListItem::CopyItem" must have a valid value',
-      text !== undefined
-    );
-
-    return text;
+    return this.args.text;
   }
-
   /**
    * Get the class names to apply to the component.
    * @method classNames
@@ -39,30 +21,5 @@ export default class HdsDropdownListItemCopyItemComponent extends Component {
     ];
 
     return classes.join(' ');
-  }
-
-  @action
-  async copyCode() {
-    // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
-    await navigator.clipboard.writeText(this.args.text);
-
-    if (navigator.clipboard.readText) {
-      const result = await navigator.clipboard.readText();
-
-      if (result === this.args.text) {
-        this.isSuccess = true;
-      }
-    } else {
-      // assume that it works so Firefox can show the success state
-      // doesn't confirm that you'll get the correct pasted text
-      // but we accept this as a reasonable tradeoff
-      // since users can always copy/paste manually.
-      this.isSuccess = true;
-    }
-
-    // make it fade back to the default state
-    setTimeout(() => {
-      this.isSuccess = false;
-    }, 1000);
   }
 }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -278,61 +278,17 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 
 .hds-dropdown-list-item--variant-copy-item {
   width: 100%;
+  max-width: 100%;
   padding: 10px 16px 12px;
 
-  button {
-    display: flex;
-    justify-content: space-between;
+  .hds-copy-snippet {
     width: 100%;
-    padding: 12px 8px;
-    color: var(--token-color-foreground-primary);
-    background-color: transparent;
-    border: 1px solid var(--token-color-border-primary);
-    border-radius: 5px;
-
-    &:hover,
-    &.mock-hover {
-      background-color: var(--token-color-surface-interactive-hover);
-      cursor: pointer;
-    }
-
-    @include hds-focus-ring-basic();
-
-    &:focus,
-    &.mock-focus {
-      // TODO this focus is just way too complex
-      background-color: var(--token-color-surface-action);
-      border-color: var(--token-color-focus-action-internal);
-    }
-
-    &:active,
-    &.mock-active {
-      background-color: var(--token-color-surface-interactive-active);
-    }
-
-    &.is-success {
-      background-color: var(--token-color-surface-success);
-      border-color: var(--token-color-border-success);
-
-      .hds-dropdown-list-item__copy-item-icon {
-        color: var(--token-color-foreground-success);
-      }
-    }
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
 }
 
-.hds-dropdown-list-item__copy-item-text {
-  overflow: hidden;
-  white-space: nowrap;
-  text-align: left;
-  text-overflow: ellipsis;
-}
-
-.hds-dropdown-list-item__copy-item-icon {
-  flex: none;
-  margin-left: 8px;
-  color: var(--token-color-foreground-action);
-}
 
 // HDS::DROPDOWN::LIST-ITEM::DESCRIPTION
 

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -534,7 +534,7 @@
       </div>
       {{! template-lint-enable no-inline-styles }}
     </SF.Item>
-    <SF.Item @label="With 'copyItemTitle'">
+    <SF.Item @label="With copyItemTitle defined">
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
@@ -548,27 +548,38 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H4>States</Shw::Text::H4>
+  <Shw::Text::H3>States</Shw::Text::H3>
 
   <Shw::Flex as |SF|>
-    <SF.Item>
+    <SF.Item @label="Base">
       {{! Notice: we want to emulate the case of a fixed width list }}
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
             <Hds::Dropdown::ListItem::CopyItem
-              @text="{{state}}: 91ee1e8ef65b337f0e70d793f456c71d"
+              @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r"
               mock-state-value={{state}}
               mock-state-selector="button"
             />
           {{/each}}
-          <Hds::Dropdown::ListItem::CopyItem
-            @text="success: 91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d"
-            @isSuccess={{true}}
-            mock-state-value="success"
-            mock-state-selector="button"
-          />
+        </ul>
+      </div>
+      {{! template-lint-enable no-inline-styles }}
+    </SF.Item>
+    <SF.Item @label="With copyItemTitle defined">
+      {{! Notice: we want to emulate the case of a fixed width list }}
+      {{! template-lint-disable no-inline-styles }}
+      <div class="hds-dropdown__content" style="width: 250px">
+        <ul class="hds-dropdown__list">
+          {{#each @model.ITEM_STATES as |state|}}
+            <Hds::Dropdown::ListItem::CopyItem
+              @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r"
+              @copyItemTitle="Lorem ipsumy dolor"
+              mock-state-value={{state}}
+              mock-state-selector="button"
+            />
+          {{/each}}
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this would update the dropdown/copy-item to use the copy/snippet. 

I made this a separate PR because we are still on the fence about what to do, so we can still ship the rest of the copy component w/o this if we want to.

So it's not so much about reviewing the code at this point since it would get merged into the copy-component branch; it's more about answering our open question about shipping this change as well. 

### :hammer_and_wrench: Detailed description

Nothing changes for the consumer's invocation, but the styles are updated to match copy/snippet (see screenshot)

### :camera_flash: Screenshots

![CleanShot 2023-07-17 at 16 42 12](https://github.com/hashicorp/design-system/assets/4587451/4cf5b09c-4310-4800-9a03-741357ad19ad)


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
