### PR TITLE
Fix link pointing to "Hiding/Disabling" recommendations in the documentation

### DIFF
--- a/website/docs/components/dropdown/partials/specifications/states.md
+++ b/website/docs/components/dropdown/partials/specifications/states.md
@@ -2,9 +2,9 @@
 
 !!! Info
 
-**A note on disabled states** 
+**A note on disabled states**
 
-Because disabled states completely remove the interactive function of an element, it can be challenging for a user to understand why it has been disabled and/or why they cannot interact with that element. In an effort to avoid this confusion, we opt for using methods like enabling or hiding the element and, thus, are not offering disabled states for the Dropdown. Read more about [when to enable vs hide](https://docs.google.com/document/d/1fqsXjjPnz5HK2NcY1buh5RcI5S6XCgQwfr8GP3kClv0/edit#heading=h.52ub6bvbvcb7).
+Because disabled states completely remove the interactive function of an element, it can be challenging for a user to understand why it has been disabled and/or why they cannot interact with that element. In an effort to avoid this confusion, we opt for using methods like enabling or hiding the element and, thus, are not offering disabled states for the Dropdown. Read more about [when to enable vs hide](https://hashicorp.atlassian.net/wiki/spaces/DES/pages/2678685874/Hiding+Disabling).
 !!!
 
 ### Toggle


### PR DESCRIPTION
### :pushpin: Summary

While reading [this thread](https://hashicorp.slack.com/archives/C7KTUHNUS/p1689725427620269?thread_ts=1689725223.494769&cid=C7KTUHNUS) and following the link in the "info" block in the documentation, I've noticed that the GDocs document is deprecated and replaced with a wiki page in Confluence.

This small PR simply updates the link to point to the wiki page directly.

### :camera_flash: Screenshots

<img width="883" alt="modified" src="https://github.com/hashicorp/design-system/assets/686239/50cfe60e-a92a-4e3c-ac3e-dc6c3faad7ab">

### :link: External links

Old document: https://docs.google.com/document/d/1fqsXjjPnz5HK2NcY1buh5RcI5S6XCgQwfr8GP3kClv0/edit#heading=h.52ub6bvbvcb7
Confluence page: https://hashicorp.atlassian.net/wiki/spaces/DES/pages/2678685874/Hiding+Disabling

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
