### PR TITLE
Document potential layout shift in `Modal` and `Flyout`

### DIFF
--- a/website/docs/components/flyout/partials/code/how-to-use.md
+++ b/website/docs/components/flyout/partials/code/how-to-use.md
@@ -4,7 +4,7 @@ The `Hds::Flyout` component leverages the `<dialog>` element which is [currently
 
 ## Page scroll
 
-When an `Hds::Flyout` component is open, the rest of the page is disabled (via `inert`). The page scrolling is also disabled by applying `overflow: hidden` to the `<body>` element, to make it clear to the user that the underlying elements are not interactive and to avoid confusion.
+When an `Hds::Flyout` component is open, the rest of the page is disabled (via `inert`). The page scrolling is also disabled by applying `overflow: hidden` to the `<body>` element, to make it clear to the user that the underlying elements are not interactive and to avoid confusion. Depending on users’ scroll bar settings, opening a Flyout may cause slight layout shifts on the horizontal axis.
 
 ## Positioning
 

--- a/website/docs/components/modal/partials/code/how-to-use.md
+++ b/website/docs/components/modal/partials/code/how-to-use.md
@@ -4,7 +4,7 @@ The Modal component leverages the `<dialog>` element which is currently supporte
 
 ## Page scroll
 
-When a Modal is open, the rest of the page is disabled (via `inert`). The page scrolling is also disabled by applying `overflow: hidden` to the `<body>` element, to make it clear to the user that the underlying elements are not interactive and to avoid confusion.
+When a Modal is open, the rest of the page is disabled (via `inert`). The page scrolling is also disabled by applying `overflow: hidden` to the `<body>` element, to make it clear to the user that the underlying elements are not interactive and to avoid confusion. Depending on users’ scroll bar settings, opening a Modal may cause slight layout shifts on the horizontal axis.
 
 ## Positioning
 


### PR DESCRIPTION
### :pushpin: Summary

If a user's scroll bar is set to appear always or an external device (such as a mouse or trackpad) is connected, opening a Modal/Flyout will result in a slight layout shift on the x-axis. We've been aware of this issue when developing the Modal component but considering no clear solution (to be read as non-hacky or without causing side effects) was found and acknowledging this as a common issue across the industry the issue was deemed as acceptable. Based on previous inquiries on this topic and following a conversation with @emlanctot during office hours we decided to document it so that our consumers are aware of this behavior/limitation.

### :camera_flash: Screenshots

Default settings on MacOSX

![modal-default](https://github.com/hashicorp/design-system/assets/788096/eb6edd8f-7330-48a4-972c-999db97078f4)


Scroll always visible/mouse connected on MacOSX (keep an eye on the right-side edge of the page)

![modal-scroll-visible](https://github.com/hashicorp/design-system/assets/788096/e45fda05-4484-4e3d-b95e-7a80e5cbde53)

