### PR TITLE
feat: add json output format

### DIFF
--- a/.changeset/wild-trains-decide.md
+++ b/.changeset/wild-trains-decide.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-tokens": minor
+---
+
+Add JSON output format

--- a/packages/tokens/dist/devdot/tokens.json
+++ b/packages/tokens/dist/devdot/tokens.json
@@ -1,0 +1,7917 @@
+{
+  "color": {
+    "palette": {
+      "blue-500": {
+        "value": "#1c345f",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#1c345f",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-500"
+        ]
+      },
+      "blue-400": {
+        "value": "#0046d1",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#0046d1",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-400"
+        ]
+      },
+      "blue-300": {
+        "value": "#0c56e9",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#0c56e9",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-300"
+        ]
+      },
+      "blue-200": {
+        "value": "#1060ff",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#1060ff",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-200"
+        ]
+      },
+      "blue-100": {
+        "value": "#cce3fe",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#cce3fe",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-100"
+        ]
+      },
+      "blue-50": {
+        "value": "#f2f8ff",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#f2f8ff",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-50"
+        ]
+      },
+      "purple-500": {
+        "value": "#42215b",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#42215b",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-500"
+        ]
+      },
+      "purple-400": {
+        "value": "#7b00db",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#7b00db",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-400"
+        ]
+      },
+      "purple-300": {
+        "value": "#911ced",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#911ced",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-300"
+        ]
+      },
+      "purple-200": {
+        "value": "#a737ff",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#a737ff",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-200"
+        ]
+      },
+      "purple-100": {
+        "value": "#ead2fe",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#ead2fe",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-100"
+        ]
+      },
+      "purple-50": {
+        "value": "#f9f2ff",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#f9f2ff",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-50"
+        ]
+      },
+      "green-500": {
+        "value": "#054220",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#054220",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-500"
+        ]
+      },
+      "green-400": {
+        "value": "#006619",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#006619",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-400"
+        ]
+      },
+      "green-300": {
+        "value": "#00781e",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#00781e",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-300"
+        ]
+      },
+      "green-200": {
+        "value": "#008a22",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#008a22",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-200"
+        ]
+      },
+      "green-100": {
+        "value": "#cceeda",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#cceeda",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-100"
+        ]
+      },
+      "green-50": {
+        "value": "#f2fbf6",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#f2fbf6",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-50"
+        ]
+      },
+      "amber-500": {
+        "value": "#542800",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#542800",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-500"
+        ]
+      },
+      "amber-400": {
+        "value": "#803d00",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#803d00",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-400"
+        ]
+      },
+      "amber-300": {
+        "value": "#9e4b00",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#9e4b00",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-300"
+        ]
+      },
+      "amber-200": {
+        "value": "#bb5a00",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#bb5a00",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-200"
+        ]
+      },
+      "amber-100": {
+        "value": "#fbeabf",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#fbeabf",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-100"
+        ]
+      },
+      "amber-50": {
+        "value": "#fff9e8",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#fff9e8",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-50"
+        ]
+      },
+      "red-500": {
+        "value": "#51130a",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#51130a",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-500"
+        ]
+      },
+      "red-400": {
+        "value": "#940004",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#940004",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-400"
+        ]
+      },
+      "red-300": {
+        "value": "#c00005",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#c00005",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-300"
+        ]
+      },
+      "red-200": {
+        "value": "#e52228",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#e52228",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-200"
+        ]
+      },
+      "red-100": {
+        "value": "#fbd4d4",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#fbd4d4",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-100"
+        ]
+      },
+      "red-50": {
+        "value": "#fff5f5",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#fff5f5",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-50"
+        ]
+      },
+      "neutral-700": {
+        "value": "#0c0c0e",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#0c0c0e",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-700",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-700"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-700"
+        ]
+      },
+      "neutral-600": {
+        "value": "#3b3d45",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#3b3d45",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-600",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-600"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-600"
+        ]
+      },
+      "neutral-500": {
+        "value": "#656a76",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#656a76",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-500"
+        ]
+      },
+      "neutral-400": {
+        "value": "#8c909c",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#8c909c",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-400"
+        ]
+      },
+      "neutral-300": {
+        "value": "#c2c5cb",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#c2c5cb",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-300"
+        ]
+      },
+      "neutral-200": {
+        "value": "#dedfe3",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#dedfe3",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-200"
+        ]
+      },
+      "neutral-100": {
+        "value": "#f1f2f3",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#f1f2f3",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-100"
+        ]
+      },
+      "neutral-50": {
+        "value": "#fafafa",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#fafafa",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-50"
+        ]
+      },
+      "neutral-0": {
+        "value": "#ffffff",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#ffffff",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-0",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-0"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-0"
+        ]
+      },
+      "alpha-300": {
+        "value": "#3b3d4566",
+        "alpha": "0.4",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-600.value}",
+          "alpha": "0.4",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-alpha-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "alpha-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "alpha-300"
+        ]
+      },
+      "alpha-200": {
+        "value": "#656a7633",
+        "alpha": "0.2",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-500.value}",
+          "alpha": "0.2",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-alpha-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "alpha-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "alpha-200"
+        ]
+      },
+      "alpha-100": {
+        "value": "#656a761a",
+        "alpha": "0.1",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-500.value}",
+          "alpha": "0.1",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-alpha-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "alpha-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "alpha-100"
+        ]
+      }
+    },
+    "border": {
+      "primary": {
+        "value": "#656a7633",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.alpha-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-primary",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "primary"
+        },
+        "path": [
+          "color",
+          "border",
+          "primary"
+        ]
+      },
+      "faint": {
+        "value": "#656a761a",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.alpha-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-faint",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "faint"
+        },
+        "path": [
+          "color",
+          "border",
+          "faint"
+        ]
+      },
+      "strong": {
+        "value": "#3b3d4566",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.alpha-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-strong",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "strong"
+        },
+        "path": [
+          "color",
+          "border",
+          "strong"
+        ]
+      },
+      "action": {
+        "value": "#cce3fe",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.blue-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-action",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "action"
+        },
+        "path": [
+          "color",
+          "border",
+          "action"
+        ]
+      },
+      "highlight": {
+        "value": "#ead2fe",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-highlight",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "highlight"
+        },
+        "path": [
+          "color",
+          "border",
+          "highlight"
+        ]
+      },
+      "success": {
+        "value": "#cceeda",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.green-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-success",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "success"
+        },
+        "path": [
+          "color",
+          "border",
+          "success"
+        ]
+      },
+      "warning": {
+        "value": "#fbeabf",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.amber-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-warning",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "warning"
+        },
+        "path": [
+          "color",
+          "border",
+          "warning"
+        ]
+      },
+      "critical": {
+        "value": "#fbd4d4",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-critical",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "critical"
+        },
+        "path": [
+          "color",
+          "border",
+          "critical"
+        ]
+      }
+    },
+    "focus": {
+      "action": {
+        "internal": {
+          "value": "#0c56e9",
+          "type": "color",
+          "group": "semantic",
+          "filePath": "src/global/color/semantic-focus.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.palette.blue-300.value}",
+            "type": "color",
+            "group": "semantic"
+          },
+          "name": "token-color-focus-action-internal",
+          "attributes": {
+            "category": "color",
+            "type": "focus",
+            "item": "action",
+            "subitem": "internal"
+          },
+          "path": [
+            "color",
+            "focus",
+            "action",
+            "internal"
+          ]
+        },
+        "external": {
+          "value": "#5990ff",
+          "type": "color",
+          "group": "semantic",
+          "comment": "this is a special color used only for the focus style, to pass color contrast for a11y purpose",
+          "filePath": "src/global/color/semantic-focus.json",
+          "isSource": true,
+          "original": {
+            "value": "#5990ff",
+            "type": "color",
+            "group": "semantic",
+            "comment": "this is a special color used only for the focus style, to pass color contrast for a11y purpose"
+          },
+          "name": "token-color-focus-action-external",
+          "attributes": {
+            "category": "color",
+            "type": "focus",
+            "item": "action",
+            "subitem": "external"
+          },
+          "path": [
+            "color",
+            "focus",
+            "action",
+            "external"
+          ]
+        }
+      },
+      "critical": {
+        "internal": {
+          "value": "#c00005",
+          "type": "color",
+          "group": "semantic",
+          "filePath": "src/global/color/semantic-focus.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.palette.red-300.value}",
+            "type": "color",
+            "group": "semantic"
+          },
+          "name": "token-color-focus-critical-internal",
+          "attributes": {
+            "category": "color",
+            "type": "focus",
+            "item": "critical",
+            "subitem": "internal"
+          },
+          "path": [
+            "color",
+            "focus",
+            "critical",
+            "internal"
+          ]
+        },
+        "external": {
+          "value": "#dd7578",
+          "type": "color",
+          "group": "semantic",
+          "comment": "this is a special color used only for the focus style, to pass color contrast for a11y purpose",
+          "filePath": "src/global/color/semantic-focus.json",
+          "isSource": true,
+          "original": {
+            "value": "#dd7578",
+            "type": "color",
+            "group": "semantic",
+            "comment": "this is a special color used only for the focus style, to pass color contrast for a11y purpose"
+          },
+          "name": "token-color-focus-critical-external",
+          "attributes": {
+            "category": "color",
+            "type": "focus",
+            "item": "critical",
+            "subitem": "external"
+          },
+          "path": [
+            "color",
+            "focus",
+            "critical",
+            "external"
+          ]
+        }
+      }
+    },
+    "foreground": {
+      "strong": {
+        "value": "#0c0c0e",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-700.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-strong",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "strong"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "strong"
+        ]
+      },
+      "primary": {
+        "value": "#3b3d45",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-600.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-primary",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "primary"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "primary"
+        ]
+      },
+      "faint": {
+        "value": "#656a76",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-500.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-faint",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "faint"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "faint"
+        ]
+      },
+      "high-contrast": {
+        "value": "#ffffff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-0.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-high-contrast",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "high-contrast"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "high-contrast"
+        ]
+      },
+      "disabled": {
+        "value": "#8c909c",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-400.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-disabled",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "disabled"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "disabled"
+        ]
+      },
+      "action": {
+        "value": "#1060ff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.blue-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-action",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "action"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "action"
+        ]
+      },
+      "action-hover": {
+        "value": "#0c56e9",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.blue-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-action-hover",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "action-hover"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "action-hover"
+        ]
+      },
+      "action-active": {
+        "value": "#0046d1",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.blue-400.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-action-active",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "action-active"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "action-active"
+        ]
+      },
+      "highlight": {
+        "value": "#a737ff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-highlight",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "highlight"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "highlight"
+        ]
+      },
+      "highlight-on-surface": {
+        "value": "#911ced",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-highlight-on-surface",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "highlight-on-surface"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "highlight-on-surface"
+        ]
+      },
+      "highlight-high-contrast": {
+        "value": "#42215b",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-500.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-highlight-high-contrast",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "highlight-high-contrast"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "highlight-high-contrast"
+        ]
+      },
+      "success": {
+        "value": "#008a22",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.green-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-success",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "success"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "success"
+        ]
+      },
+      "success-on-surface": {
+        "value": "#00781e",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.green-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-success-on-surface",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "success-on-surface"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "success-on-surface"
+        ]
+      },
+      "success-high-contrast": {
+        "value": "#054220",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.green-500.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-success-high-contrast",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "success-high-contrast"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "success-high-contrast"
+        ]
+      },
+      "warning": {
+        "value": "#bb5a00",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.amber-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-warning",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "warning"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "warning"
+        ]
+      },
+      "warning-on-surface": {
+        "value": "#9e4b00",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.amber-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-warning-on-surface",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "warning-on-surface"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "warning-on-surface"
+        ]
+      },
+      "warning-high-contrast": {
+        "value": "#542800",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.amber-500.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-warning-high-contrast",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "warning-high-contrast"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "warning-high-contrast"
+        ]
+      },
+      "critical": {
+        "value": "#e52228",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-critical",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "critical"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "critical"
+        ]
+      },
+      "critical-on-surface": {
+        "value": "#c00005",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-critical-on-surface",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "critical-on-surface"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "critical-on-surface"
+        ]
+      },
+      "critical-high-contrast": {
+        "value": "#51130a",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-500.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-critical-high-contrast",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "critical-high-contrast"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "critical-high-contrast"
+        ]
+      },
+      "action-visited": {
+        "value": "#a737ff",
+        "type": "color",
+        "group": "semantic",
+        "comment": "This extra color is unique for the DevDot platform (the 'visited' state of a link is not differentiated in the products applications).",
+        "filePath": "src/devdot/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-200.value}",
+          "type": "color",
+          "group": "semantic",
+          "comment": "This extra color is unique for the DevDot platform (the 'visited' state of a link is not differentiated in the products applications)."
+        },
+        "name": "token-color-foreground-action-visited",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "action-visited"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "action-visited"
+        ]
+      },
+      "action-visited-hover": {
+        "value": "#7b00db",
+        "type": "color",
+        "group": "semantic",
+        "comment": "This extra color is unique for the DevDot platform (the 'visited+hover' state of a link is not differentiated in the products applications).",
+        "filePath": "src/devdot/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-400.value}",
+          "type": "color",
+          "group": "semantic",
+          "comment": "This extra color is unique for the DevDot platform (the 'visited+hover' state of a link is not differentiated in the products applications)."
+        },
+        "name": "token-color-foreground-action-visited-hover",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "action-visited-hover"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "action-visited-hover"
+        ]
+      }
+    },
+    "page": {
+      "primary": {
+        "value": "#ffffff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-page.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-0.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-page-primary",
+        "attributes": {
+          "category": "color",
+          "type": "page",
+          "item": "primary"
+        },
+        "path": [
+          "color",
+          "page",
+          "primary"
+        ]
+      },
+      "faint": {
+        "value": "#fafafa",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-page.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-page-faint",
+        "attributes": {
+          "category": "color",
+          "type": "page",
+          "item": "faint"
+        },
+        "path": [
+          "color",
+          "page",
+          "faint"
+        ]
+      }
+    },
+    "surface": {
+      "primary": {
+        "value": "#ffffff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-0.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-primary",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "primary"
+        },
+        "path": [
+          "color",
+          "surface",
+          "primary"
+        ]
+      },
+      "faint": {
+        "value": "#fafafa",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-faint",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "faint"
+        },
+        "path": [
+          "color",
+          "surface",
+          "faint"
+        ]
+      },
+      "strong": {
+        "value": "#f1f2f3",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-strong",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "strong"
+        },
+        "path": [
+          "color",
+          "surface",
+          "strong"
+        ]
+      },
+      "interactive": {
+        "value": "#ffffff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-0.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-interactive",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "interactive"
+        },
+        "path": [
+          "color",
+          "surface",
+          "interactive"
+        ]
+      },
+      "interactive-hover": {
+        "value": "#f1f2f3",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-interactive-hover",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "interactive-hover"
+        },
+        "path": [
+          "color",
+          "surface",
+          "interactive-hover"
+        ]
+      },
+      "interactive-active": {
+        "value": "#dedfe3",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-interactive-active",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "interactive-active"
+        },
+        "path": [
+          "color",
+          "surface",
+          "interactive-active"
+        ]
+      },
+      "interactive-disabled": {
+        "value": "#fafafa",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-interactive-disabled",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "interactive-disabled"
+        },
+        "path": [
+          "color",
+          "surface",
+          "interactive-disabled"
+        ]
+      },
+      "action": {
+        "value": "#f2f8ff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.blue-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-action",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "action"
+        },
+        "path": [
+          "color",
+          "surface",
+          "action"
+        ]
+      },
+      "highlight": {
+        "value": "#f9f2ff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-highlight",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "highlight"
+        },
+        "path": [
+          "color",
+          "surface",
+          "highlight"
+        ]
+      },
+      "success": {
+        "value": "#f2fbf6",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.green-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-success",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "success"
+        },
+        "path": [
+          "color",
+          "surface",
+          "success"
+        ]
+      },
+      "warning": {
+        "value": "#fff9e8",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.amber-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-warning",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "warning"
+        },
+        "path": [
+          "color",
+          "surface",
+          "warning"
+        ]
+      },
+      "critical": {
+        "value": "#fff5f5",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-critical",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "critical"
+        },
+        "path": [
+          "color",
+          "surface",
+          "critical"
+        ]
+      }
+    },
+    "hashicorp": {
+      "brand": {
+        "value": "#000000",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-company.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.hashicorp-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-hashicorp-brand",
+        "attributes": {
+          "category": "color",
+          "type": "hashicorp",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "hashicorp",
+          "brand"
+        ]
+      }
+    },
+    "boundary": {
+      "brand": {
+        "value": "#f24c53",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-boundary.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.boundary-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-boundary-brand",
+        "attributes": {
+          "category": "color",
+          "type": "boundary",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "boundary",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#cf2d32",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-boundary.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.boundary-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-boundary-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "boundary",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "boundary",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#ffecec",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-boundary.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.boundary-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-boundary-surface",
+        "attributes": {
+          "category": "color",
+          "type": "boundary",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "boundary",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#fbd7d8",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-boundary.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.boundary-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-boundary-border",
+        "attributes": {
+          "category": "color",
+          "type": "boundary",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "boundary",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#f97076",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-boundary.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.boundary-300.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-boundary-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "boundary",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "boundary",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#db363b",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-boundary.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.boundary-400.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-boundary-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "boundary",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "boundary",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#fffafa",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'boundary-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-boundary.json",
+            "isSource": true,
+            "original": {
+              "value": "#fffafa",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'boundary-50' value at 25% opacity on white"
+            },
+            "name": "token-color-boundary-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "boundary",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "boundary",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#ffecec",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-boundary.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.boundary-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-boundary-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "boundary",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "boundary",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "consul": {
+      "brand": {
+        "value": "#e03875",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-consul.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.consul-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-consul-brand",
+        "attributes": {
+          "category": "color",
+          "type": "consul",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "consul",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#d01c5b",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-consul.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.consul-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-consul-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "consul",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "consul",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#ffe9f1",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-consul.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.consul-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-consul-surface",
+        "attributes": {
+          "category": "color",
+          "type": "consul",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "consul",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#ffcede",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-consul.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.consul-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-consul-border",
+        "attributes": {
+          "category": "color",
+          "type": "consul",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "consul",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#ff99be",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-consul.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.consul-300.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-consul-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "consul",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "consul",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#da306e",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-consul.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.consul-400.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-consul-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "consul",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "consul",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#fff9fb",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'consul-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-consul.json",
+            "isSource": true,
+            "original": {
+              "value": "#fff9fb",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'consul-50' value at 25% opacity on white"
+            },
+            "name": "token-color-consul-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "consul",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "consul",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#ffe9f1",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-consul.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.consul-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-consul-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "consul",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "consul",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "hcp": {
+      "brand": {
+        "value": "#000000",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-hcp.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.hcp-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-hcp-brand",
+        "attributes": {
+          "category": "color",
+          "type": "hcp",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "hcp",
+          "brand"
+        ]
+      }
+    },
+    "nomad": {
+      "brand": {
+        "value": "#06d092",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-nomad.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.nomad-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-nomad-brand",
+        "attributes": {
+          "category": "color",
+          "type": "nomad",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "nomad",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#008661",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-nomad.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.nomad-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-nomad-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "nomad",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "nomad",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#d3fdeb",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-nomad.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.nomad-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-nomad-surface",
+        "attributes": {
+          "category": "color",
+          "type": "nomad",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "nomad",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#bff3dd",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-nomad.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.nomad-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-nomad-border",
+        "attributes": {
+          "category": "color",
+          "type": "nomad",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "nomad",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#bff3dd",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-nomad.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.nomad-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-nomad-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "nomad",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "nomad",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#60dea9",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-nomad.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.nomad-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-nomad-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "nomad",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "nomad",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#f3fff9",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'nomad-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-nomad.json",
+            "isSource": true,
+            "original": {
+              "value": "#f3fff9",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'nomad-50' value at 25% opacity on white"
+            },
+            "name": "token-color-nomad-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "nomad",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "nomad",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#d3fdeb",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-nomad.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.nomad-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-nomad-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "nomad",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "nomad",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "packer": {
+      "brand": {
+        "value": "#02a8ef",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-packer.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.packer-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-packer-brand",
+        "attributes": {
+          "category": "color",
+          "type": "packer",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "packer",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#007eb4",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-packer.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.packer-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-packer-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "packer",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "packer",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#d4f2ff",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-packer.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.packer-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-packer-surface",
+        "attributes": {
+          "category": "color",
+          "type": "packer",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "packer",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#b4e4ff",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-packer.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.packer-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-packer-border",
+        "attributes": {
+          "category": "color",
+          "type": "packer",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "packer",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#b4e4ff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-packer.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.packer-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-packer-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "packer",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "packer",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#63d0ff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-packer.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.packer-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-packer-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "packer",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "packer",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#f3fcff",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'packer-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-packer.json",
+            "isSource": true,
+            "original": {
+              "value": "#F3FCFF",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'packer-50' value at 25% opacity on white"
+            },
+            "name": "token-color-packer-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "packer",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "packer",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#d4f2ff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-packer.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.packer-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-packer-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "packer",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "packer",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "terraform": {
+      "brand": {
+        "value": "#7b42bc",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-terraform.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.terraform-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-terraform-brand",
+        "attributes": {
+          "category": "color",
+          "type": "terraform",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "terraform",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#773cb4",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-terraform.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.terraform-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-terraform-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "terraform",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "terraform",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#f4ecff",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-terraform.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.terraform-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-terraform-surface",
+        "attributes": {
+          "category": "color",
+          "type": "terraform",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "terraform",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#ebdbfc",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-terraform.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.terraform-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-terraform-border",
+        "attributes": {
+          "category": "color",
+          "type": "terraform",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "terraform",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#bb8deb",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-terraform.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.terraform-300.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-terraform-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "terraform",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "terraform",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#844fba",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-terraform.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.terraform-400.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-terraform-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "terraform",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "terraform",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#fcfaff",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'terraform-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-terraform.json",
+            "isSource": true,
+            "original": {
+              "value": "#fcfaff",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'terraform-50' value at 25% opacity on white"
+            },
+            "name": "token-color-terraform-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "terraform",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "terraform",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#f4ecff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-terraform.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.terraform-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-terraform-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "terraform",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "terraform",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "vagrant": {
+      "brand": {
+        "value": "#1868f2",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vagrant-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vagrant-brand",
+        "attributes": {
+          "category": "color",
+          "type": "vagrant",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "vagrant",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#1c61d8",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vagrant-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vagrant-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "vagrant",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "vagrant",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#d6ebff",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vagrant-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vagrant-surface",
+        "attributes": {
+          "category": "color",
+          "type": "vagrant",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "vagrant",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#c7dbfc",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vagrant-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vagrant-border",
+        "attributes": {
+          "category": "color",
+          "type": "vagrant",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "vagrant",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#c7dbfc",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vagrant-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vagrant-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "vagrant",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vagrant",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#7dadff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vagrant-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vagrant-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vagrant",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vagrant",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#f4faff",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'vagrant-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+            "isSource": true,
+            "original": {
+              "value": "#f4faff",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'vagrant-50' value at 25% opacity on white"
+            },
+            "name": "token-color-vagrant-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "vagrant",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vagrant",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#d6ebff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vagrant-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vagrant-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vagrant",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vagrant",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "vault": {
+      "brand": {
+        "value": "#ffd814",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-brand",
+        "attributes": {
+          "category": "color",
+          "type": "vault",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "vault",
+          "brand"
+        ]
+      },
+      "brand-alt": {
+        "value": "#000000",
+        "type": "color",
+        "group": "branding",
+        "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work",
+        "filePath": "src/products/shared/color/semantic-product-vault.json",
+        "isSource": true,
+        "original": {
+          "value": "#000",
+          "type": "color",
+          "group": "branding",
+          "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work"
+        },
+        "name": "token-color-vault-brand-alt",
+        "attributes": {
+          "category": "color",
+          "type": "vault",
+          "item": "brand-alt"
+        },
+        "path": [
+          "color",
+          "vault",
+          "brand-alt"
+        ]
+      },
+      "foreground": {
+        "value": "#9a6f00",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "vault",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "vault",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#fff9cf",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-surface",
+        "attributes": {
+          "category": "color",
+          "type": "vault",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "vault",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#feec7b",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-border",
+        "attributes": {
+          "category": "color",
+          "type": "vault",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "vault",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#feec7b",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "vault",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vault",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#ffe543",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vault",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vault",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#fffdf2",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'vault-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-vault.json",
+            "isSource": true,
+            "original": {
+              "value": "#fffdf2",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'vault-50' value at 25% opacity on white"
+            },
+            "name": "token-color-vault-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "vault",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vault",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#fff9cf",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vault",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vault",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "waypoint": {
+      "brand": {
+        "value": "#14c6cb",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.waypoint-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-waypoint-brand",
+        "attributes": {
+          "category": "color",
+          "type": "waypoint",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "waypoint",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#008196",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.waypoint-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-waypoint-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "waypoint",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "waypoint",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#e0fcff",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.waypoint-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-waypoint-surface",
+        "attributes": {
+          "category": "color",
+          "type": "waypoint",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "waypoint",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#cbf1f3",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.waypoint-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-waypoint-border",
+        "attributes": {
+          "category": "color",
+          "type": "waypoint",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "waypoint",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#cbf1f3",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.waypoint-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-waypoint-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "waypoint",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "waypoint",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#62d4dc",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.waypoint-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-waypoint-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "waypoint",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "waypoint",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#f6feff",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'waypoint-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+            "isSource": true,
+            "original": {
+              "value": "#f6feff",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'waypoint-50' value at 25% opacity on white"
+            },
+            "name": "token-color-waypoint-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "waypoint",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "waypoint",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#e0fcff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.waypoint-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-waypoint-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "waypoint",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "waypoint",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "elevation": {
+    "inset": {
+      "box-shadow": {
+        "value": "inset 0px 1px 2px 1px #656a761a",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.inset.box-shadow-01.value}"
+        },
+        "name": "token-elevation-inset-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "inset",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "inset",
+          "box-shadow"
+        ]
+      }
+    },
+    "low": {
+      "box-shadow": {
+        "value": "0px 1px 1px 0px #656a760d, 0px 2px 2px 0px #656a760d",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.low.box-shadow-01.value}, {elevation.low.box-shadow-02.value}"
+        },
+        "name": "token-elevation-low-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "low",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "low",
+          "box-shadow"
+        ]
+      }
+    },
+    "mid": {
+      "box-shadow": {
+        "value": "0px 2px 3px 0px #656a761a, 0px 8px 16px -10px #656a7633",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.mid.box-shadow-01.value}, {elevation.mid.box-shadow-02.value}"
+        },
+        "name": "token-elevation-mid-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "mid",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "mid",
+          "box-shadow"
+        ]
+      }
+    },
+    "high": {
+      "box-shadow": {
+        "value": "0px 2px 3px 0px #656a7626, 0px 16px 16px -10px #656a7633",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.high.box-shadow-01.value}, {elevation.high.box-shadow-02.value}"
+        },
+        "name": "token-elevation-high-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "high",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "high",
+          "box-shadow"
+        ]
+      }
+    },
+    "higher": {
+      "box-shadow": {
+        "value": "0px 2px 3px 0px #656a761a, 0px 12px 28px 0px #656a7640",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.higher.box-shadow-01.value}, {elevation.higher.box-shadow-02.value}"
+        },
+        "name": "token-elevation-higher-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "higher",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "higher",
+          "box-shadow"
+        ]
+      }
+    },
+    "overlay": {
+      "box-shadow": {
+        "value": "0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.overlay.box-shadow-01.value}, {elevation.overlay.box-shadow-02.value}"
+        },
+        "name": "token-elevation-overlay-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "overlay",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "overlay",
+          "box-shadow"
+        ]
+      }
+    }
+  },
+  "surface": {
+    "inset": {
+      "box-shadow": {
+        "value": "inset 0 0 0 1px #656a764d, inset 0px 1px 2px 1px #656a761a",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.inset.box-shadow-border.value}, {elevation.inset.box-shadow.value}"
+        },
+        "name": "token-surface-inset-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "inset",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "inset",
+          "box-shadow"
+        ]
+      }
+    },
+    "base": {
+      "box-shadow": {
+        "value": "0 0 0 1px #656a7633",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.base.box-shadow-border.value}"
+        },
+        "name": "token-surface-base-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "base",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "base",
+          "box-shadow"
+        ]
+      }
+    },
+    "low": {
+      "box-shadow": {
+        "value": "0 0 0 1px #656a7626, 0px 1px 1px 0px #656a760d, 0px 2px 2px 0px #656a760d",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.low.box-shadow-border.value}, {elevation.low.box-shadow.value}"
+        },
+        "name": "token-surface-low-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "low",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "low",
+          "box-shadow"
+        ]
+      }
+    },
+    "mid": {
+      "box-shadow": {
+        "value": "0 0 0 1px #656a7626, 0px 2px 3px 0px #656a761a, 0px 8px 16px -10px #656a7633",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.mid.box-shadow-border.value}, {elevation.mid.box-shadow.value}"
+        },
+        "name": "token-surface-mid-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "mid",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "mid",
+          "box-shadow"
+        ]
+      }
+    },
+    "high": {
+      "box-shadow": {
+        "value": "0 0 0 1px #656a7640, 0px 2px 3px 0px #656a7626, 0px 16px 16px -10px #656a7633",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.high.box-shadow-border.value}, {elevation.high.box-shadow.value}"
+        },
+        "name": "token-surface-high-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "high",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "high",
+          "box-shadow"
+        ]
+      }
+    },
+    "higher": {
+      "box-shadow": {
+        "value": "0 0 0 1px #656a7633, 0px 2px 3px 0px #656a761a, 0px 12px 28px 0px #656a7640",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.higher.box-shadow-border.value}, {elevation.higher.box-shadow.value}"
+        },
+        "name": "token-surface-higher-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "higher",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "higher",
+          "box-shadow"
+        ]
+      }
+    },
+    "overlay": {
+      "box-shadow": {
+        "value": "0 0 0 1px #3b3d4540, 0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.overlay.box-shadow-border.value}, {elevation.overlay.box-shadow.value}"
+        },
+        "name": "token-surface-overlay-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "overlay",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "overlay",
+          "box-shadow"
+        ]
+      }
+    }
+  },
+  "focus-ring": {
+    "action": {
+      "box-shadow": {
+        "value": "inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff",
+        "filePath": "src/global/focus-ring.json",
+        "isSource": true,
+        "original": {
+          "value": "{focus-ring.action.internal-box-shadow.value}, {focus-ring.action.external-box-shadow.value}"
+        },
+        "name": "token-focus-ring-action-box-shadow",
+        "attributes": {
+          "category": "focus-ring",
+          "type": "action",
+          "item": "box-shadow"
+        },
+        "path": [
+          "focus-ring",
+          "action",
+          "box-shadow"
+        ]
+      }
+    },
+    "critical": {
+      "box-shadow": {
+        "value": "inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578",
+        "filePath": "src/global/focus-ring.json",
+        "isSource": true,
+        "original": {
+          "value": "{focus-ring.critical.internal-box-shadow.value}, {focus-ring.critical.external-box-shadow.value}"
+        },
+        "name": "token-focus-ring-critical-box-shadow",
+        "attributes": {
+          "category": "focus-ring",
+          "type": "critical",
+          "item": "box-shadow"
+        },
+        "path": [
+          "focus-ring",
+          "critical",
+          "box-shadow"
+        ]
+      }
+    }
+  },
+  "form": {
+    "label": {
+      "color": {
+        "value": "#0c0c0e",
+        "type": "color",
+        "group": "components",
+        "filePath": "src/products/shared/form/base-elements.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.foreground.strong.value}",
+          "type": "color",
+          "group": "components"
+        },
+        "name": "token-form-label-color",
+        "attributes": {
+          "category": "form",
+          "type": "label",
+          "item": "color"
+        },
+        "path": [
+          "form",
+          "label",
+          "color"
+        ]
+      }
+    },
+    "legend": {
+      "color": {
+        "value": "#0c0c0e",
+        "type": "color",
+        "group": "components",
+        "filePath": "src/products/shared/form/base-elements.json",
+        "isSource": true,
+        "original": {
+          "value": "{form.label.color.value}",
+          "type": "color",
+          "group": "components"
+        },
+        "name": "token-form-legend-color",
+        "attributes": {
+          "category": "form",
+          "type": "legend",
+          "item": "color"
+        },
+        "path": [
+          "form",
+          "legend",
+          "color"
+        ]
+      }
+    },
+    "helper-text": {
+      "color": {
+        "value": "#656a76",
+        "type": "color",
+        "group": "components",
+        "filePath": "src/products/shared/form/base-elements.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.foreground.faint.value}",
+          "type": "color",
+          "group": "components"
+        },
+        "name": "token-form-helper-text-color",
+        "attributes": {
+          "category": "form",
+          "type": "helper-text",
+          "item": "color"
+        },
+        "path": [
+          "form",
+          "helper-text",
+          "color"
+        ]
+      }
+    },
+    "indicator": {
+      "optional": {
+        "color": {
+          "value": "#656a76",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/base-elements.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.foreground.faint.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-indicator-optional-color",
+          "attributes": {
+            "category": "form",
+            "type": "indicator",
+            "item": "optional",
+            "subitem": "color"
+          },
+          "path": [
+            "form",
+            "indicator",
+            "optional",
+            "color"
+          ]
+        }
+      }
+    },
+    "error": {
+      "color": {
+        "value": "#c00005",
+        "type": "color",
+        "group": "components",
+        "filePath": "src/products/shared/form/base-elements.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-300.value}",
+          "type": "color",
+          "group": "components"
+        },
+        "name": "token-form-error-color",
+        "attributes": {
+          "category": "form",
+          "type": "error",
+          "item": "color"
+        },
+        "path": [
+          "form",
+          "error",
+          "color"
+        ]
+      },
+      "icon-size": {
+        "value": "14px",
+        "type": "size",
+        "filePath": "src/products/shared/form/base-elements.json",
+        "isSource": true,
+        "original": {
+          "value": "14",
+          "type": "size"
+        },
+        "name": "token-form-error-icon-size",
+        "attributes": {
+          "category": "form",
+          "type": "error",
+          "item": "icon-size"
+        },
+        "path": [
+          "form",
+          "error",
+          "icon-size"
+        ]
+      }
+    },
+    "checkbox": {
+      "size": {
+        "value": "16px",
+        "type": "size",
+        "filePath": "src/products/shared/form/checkbox.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "size"
+        },
+        "name": "token-form-checkbox-size",
+        "attributes": {
+          "category": "form",
+          "type": "checkbox",
+          "item": "size"
+        },
+        "path": [
+          "form",
+          "checkbox",
+          "size"
+        ]
+      },
+      "border": {
+        "radius": {
+          "value": "3px",
+          "type": "size",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "3",
+            "type": "size"
+          },
+          "name": "token-form-checkbox-border-radius",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "border",
+            "subitem": "radius"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "border",
+            "radius"
+          ]
+        },
+        "width": {
+          "value": "1px",
+          "type": "size",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "1",
+            "type": "size"
+          },
+          "name": "token-form-checkbox-border-width",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "border",
+            "subitem": "width"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "background-image": {
+        "size": {
+          "value": "12px",
+          "type": "size",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "12",
+            "type": "size"
+          },
+          "name": "token-form-checkbox-background-image-size",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "background-image",
+            "subitem": "size"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "background-image",
+            "size"
+          ]
+        },
+        "data-url": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%23FFF'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'tick' color is hardcoded here!",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%23FFF'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'tick' color is hardcoded here!"
+          },
+          "name": "token-form-checkbox-background-image-data-url",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "background-image",
+            "subitem": "data-url"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "background-image",
+            "data-url"
+          ]
+        },
+        "data-url-indeterminate": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='m2.03125,6a0.66146,0.75 0 0 1 0.66146,-0.75l6.61458,0a0.66146,0.75 0 0 1 0,1.5l-6.61458,0a0.66146,0.75 0 0 1 -0.66146,-0.75z' fill='%23FFF'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'dash' color is hardcoded here!",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='m2.03125,6a0.66146,0.75 0 0 1 0.66146,-0.75l6.61458,0a0.66146,0.75 0 0 1 0,1.5l-6.61458,0a0.66146,0.75 0 0 1 -0.66146,-0.75z' fill='%23FFF'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'dash' color is hardcoded here!"
+          },
+          "name": "token-form-checkbox-background-image-data-url-indeterminate",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "background-image",
+            "subitem": "data-url-indeterminate"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "background-image",
+            "data-url-indeterminate"
+          ]
+        },
+        "data-url-disabled": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%238C909C'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'tick' color is hardcoded here!",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%238C909C'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'tick' color is hardcoded here!"
+          },
+          "name": "token-form-checkbox-background-image-data-url-disabled",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "background-image",
+            "subitem": "data-url-disabled"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "background-image",
+            "data-url-disabled"
+          ]
+        },
+        "data-url-indeterminate-disabled": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='m2.03125,6a0.66146,0.75 0 0 1 0.66146,-0.75l6.61458,0a0.66146,0.75 0 0 1 0,1.5l-6.61458,0a0.66146,0.75 0 0 1 -0.66146,-0.75z' fill='%238C909C'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'dash' color is hardcoded here!",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='m2.03125,6a0.66146,0.75 0 0 1 0.66146,-0.75l6.61458,0a0.66146,0.75 0 0 1 0,1.5l-6.61458,0a0.66146,0.75 0 0 1 -0.66146,-0.75z' fill='%238C909C'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'dash' color is hardcoded here!"
+          },
+          "name": "token-form-checkbox-background-image-data-url-indeterminate-disabled",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "background-image",
+            "subitem": "data-url-indeterminate-disabled"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "background-image",
+            "data-url-indeterminate-disabled"
+          ]
+        }
+      }
+    },
+    "control": {
+      "base": {
+        "foreground": {
+          "value-color": {
+            "value": "#0c0c0e",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.foreground.strong.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-foreground-value-color",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "foreground",
+              "state": "value-color"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "foreground",
+              "value-color"
+            ]
+          },
+          "placeholder-color": {
+            "value": "#656a76",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.foreground.faint.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-foreground-placeholder-color",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "foreground",
+              "state": "placeholder-color"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "foreground",
+              "placeholder-color"
+            ]
+          }
+        },
+        "surface-color": {
+          "default": {
+            "value": "#ffffff",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.surface.interactive.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-surface-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "surface-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "surface-color",
+              "default"
+            ]
+          },
+          "hover": {
+            "value": "#f1f2f3",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.surface.interactive-hover.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-surface-color-hover",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "surface-color",
+              "state": "hover"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "surface-color",
+              "hover"
+            ]
+          }
+        },
+        "border-color": {
+          "default": {
+            "value": "#8c909c",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.neutral-400.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-border-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "border-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "border-color",
+              "default"
+            ]
+          },
+          "hover": {
+            "value": "#656a76",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.neutral-500.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-border-color-hover",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "border-color",
+              "state": "hover"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "border-color",
+              "hover"
+            ]
+          }
+        }
+      },
+      "checked": {
+        "foreground-color": {
+          "value": "#ffffff",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.foreground.high-contrast.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-checked-foreground-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "checked",
+            "subitem": "foreground-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "checked",
+            "foreground-color"
+          ]
+        },
+        "surface-color": {
+          "default": {
+            "value": "#1060ff",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.blue-200.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-checked-surface-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "checked",
+              "subitem": "surface-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "control",
+              "checked",
+              "surface-color",
+              "default"
+            ]
+          },
+          "hover": {
+            "value": "#0c56e9",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.blue-300.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-checked-surface-color-hover",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "checked",
+              "subitem": "surface-color",
+              "state": "hover"
+            },
+            "path": [
+              "form",
+              "control",
+              "checked",
+              "surface-color",
+              "hover"
+            ]
+          }
+        },
+        "border-color": {
+          "default": {
+            "value": "#0c56e9",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.blue-300.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-checked-border-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "checked",
+              "subitem": "border-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "control",
+              "checked",
+              "border-color",
+              "default"
+            ]
+          },
+          "hover": {
+            "value": "#0046d1",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.blue-400.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-checked-border-color-hover",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "checked",
+              "subitem": "border-color",
+              "state": "hover"
+            },
+            "path": [
+              "form",
+              "control",
+              "checked",
+              "border-color",
+              "hover"
+            ]
+          }
+        }
+      },
+      "invalid": {
+        "border-color": {
+          "default": {
+            "value": "#c00005",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.red-300.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-invalid-border-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "invalid",
+              "subitem": "border-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "control",
+              "invalid",
+              "border-color",
+              "default"
+            ]
+          },
+          "hover": {
+            "value": "#940004",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.red-400.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-invalid-border-color-hover",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "invalid",
+              "subitem": "border-color",
+              "state": "hover"
+            },
+            "path": [
+              "form",
+              "control",
+              "invalid",
+              "border-color",
+              "hover"
+            ]
+          }
+        }
+      },
+      "readonly": {
+        "foreground-color": {
+          "value": "#3b3d45",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.foreground.primary.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-readonly-foreground-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "readonly",
+            "subitem": "foreground-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "readonly",
+            "foreground-color"
+          ]
+        },
+        "surface-color": {
+          "value": "#f1f2f3",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.surface.strong.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-readonly-surface-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "readonly",
+            "subitem": "surface-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "readonly",
+            "surface-color"
+          ]
+        },
+        "border-color": {
+          "value": "#656a761a",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.border.faint.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-readonly-border-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "readonly",
+            "subitem": "border-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "readonly",
+            "border-color"
+          ]
+        }
+      },
+      "disabled": {
+        "foreground-color": {
+          "value": "#8c909c",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.foreground.disabled.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-disabled-foreground-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "disabled",
+            "subitem": "foreground-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "disabled",
+            "foreground-color"
+          ]
+        },
+        "surface-color": {
+          "value": "#fafafa",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.surface.interactive-disabled.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-disabled-surface-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "disabled",
+            "subitem": "surface-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "disabled",
+            "surface-color"
+          ]
+        },
+        "border-color": {
+          "value": "#656a7633",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.border.primary.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-disabled-border-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "disabled",
+            "subitem": "border-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "disabled",
+            "border-color"
+          ]
+        }
+      },
+      "padding": {
+        "value": "7px",
+        "type": "size",
+        "comment": "Notice: we have to take in account the border, so it's 1px less than in Figma.",
+        "filePath": "src/products/shared/form/generic-control/sizing.json",
+        "isSource": true,
+        "original": {
+          "value": "7",
+          "type": "size",
+          "comment": "Notice: we have to take in account the border, so it's 1px less than in Figma."
+        },
+        "name": "token-form-control-padding",
+        "attributes": {
+          "category": "form",
+          "type": "control",
+          "item": "padding"
+        },
+        "path": [
+          "form",
+          "control",
+          "padding"
+        ]
+      },
+      "border": {
+        "radius": {
+          "value": "5px",
+          "type": "size",
+          "filePath": "src/products/shared/form/generic-control/sizing.json",
+          "isSource": true,
+          "original": {
+            "value": "5",
+            "type": "size"
+          },
+          "name": "token-form-control-border-radius",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "border",
+            "subitem": "radius"
+          },
+          "path": [
+            "form",
+            "control",
+            "border",
+            "radius"
+          ]
+        },
+        "width": {
+          "value": "1px",
+          "type": "size",
+          "filePath": "src/products/shared/form/generic-control/sizing.json",
+          "isSource": true,
+          "original": {
+            "value": "1",
+            "type": "size"
+          },
+          "name": "token-form-control-border-width",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "border",
+            "subitem": "width"
+          },
+          "path": [
+            "form",
+            "control",
+            "border",
+            "width"
+          ]
+        }
+      }
+    },
+    "radio": {
+      "size": {
+        "value": "16px",
+        "type": "size",
+        "filePath": "src/products/shared/form/radio.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "size"
+        },
+        "name": "token-form-radio-size",
+        "attributes": {
+          "category": "form",
+          "type": "radio",
+          "item": "size"
+        },
+        "path": [
+          "form",
+          "radio",
+          "size"
+        ]
+      },
+      "border": {
+        "width": {
+          "value": "1px",
+          "type": "size",
+          "filePath": "src/products/shared/form/radio.json",
+          "isSource": true,
+          "original": {
+            "value": "1",
+            "type": "size"
+          },
+          "name": "token-form-radio-border-width",
+          "attributes": {
+            "category": "form",
+            "type": "radio",
+            "item": "border",
+            "subitem": "width"
+          },
+          "path": [
+            "form",
+            "radio",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "background-image": {
+        "size": {
+          "value": "12px",
+          "type": "size",
+          "filePath": "src/products/shared/form/radio.json",
+          "isSource": true,
+          "original": {
+            "value": "12",
+            "type": "size"
+          },
+          "name": "token-form-radio-background-image-size",
+          "attributes": {
+            "category": "form",
+            "type": "radio",
+            "item": "background-image",
+            "subitem": "size"
+          },
+          "path": [
+            "form",
+            "radio",
+            "background-image",
+            "size"
+          ]
+        },
+        "data-url": {
+          "value": "url(\"data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%23ffffff'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'dot' color is hardcoded here!",
+          "filePath": "src/products/shared/form/radio.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%23ffffff'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'dot' color is hardcoded here!"
+          },
+          "name": "token-form-radio-background-image-data-url",
+          "attributes": {
+            "category": "form",
+            "type": "radio",
+            "item": "background-image",
+            "subitem": "data-url"
+          },
+          "path": [
+            "form",
+            "radio",
+            "background-image",
+            "data-url"
+          ]
+        },
+        "data-url-disabled": {
+          "value": "url(\"data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%238C909C'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'dot' color is hardcoded here!",
+          "filePath": "src/products/shared/form/radio.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%238C909C'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'dot' color is hardcoded here!"
+          },
+          "name": "token-form-radio-background-image-data-url-disabled",
+          "attributes": {
+            "category": "form",
+            "type": "radio",
+            "item": "background-image",
+            "subitem": "data-url-disabled"
+          },
+          "path": [
+            "form",
+            "radio",
+            "background-image",
+            "data-url-disabled"
+          ]
+        }
+      }
+    },
+    "radiocard-group": {
+      "gap": {
+        "value": "16px",
+        "type": "size",
+        "filePath": "src/products/shared/form/radiocard.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "size"
+        },
+        "name": "token-form-radiocard-group-gap",
+        "attributes": {
+          "category": "form",
+          "type": "radiocard-group",
+          "item": "gap"
+        },
+        "path": [
+          "form",
+          "radiocard-group",
+          "gap"
+        ]
+      }
+    },
+    "radiocard": {
+      "border": {
+        "width": {
+          "value": "1px",
+          "type": "size",
+          "filePath": "src/products/shared/form/radiocard.json",
+          "isSource": true,
+          "original": {
+            "value": "1",
+            "type": "size"
+          },
+          "name": "token-form-radiocard-border-width",
+          "attributes": {
+            "category": "form",
+            "type": "radiocard",
+            "item": "border",
+            "subitem": "width"
+          },
+          "path": [
+            "form",
+            "radiocard",
+            "border",
+            "width"
+          ]
+        },
+        "radius": {
+          "value": "6px",
+          "type": "size",
+          "filePath": "src/products/shared/form/radiocard.json",
+          "isSource": true,
+          "original": {
+            "value": "6",
+            "type": "size"
+          },
+          "name": "token-form-radiocard-border-radius",
+          "attributes": {
+            "category": "form",
+            "type": "radiocard",
+            "item": "border",
+            "subitem": "radius"
+          },
+          "path": [
+            "form",
+            "radiocard",
+            "border",
+            "radius"
+          ]
+        }
+      },
+      "content-padding": {
+        "value": "24px",
+        "type": "size",
+        "filePath": "src/products/shared/form/radiocard.json",
+        "isSource": true,
+        "original": {
+          "value": "24",
+          "type": "size"
+        },
+        "name": "token-form-radiocard-content-padding",
+        "attributes": {
+          "category": "form",
+          "type": "radiocard",
+          "item": "content-padding"
+        },
+        "path": [
+          "form",
+          "radiocard",
+          "content-padding"
+        ]
+      },
+      "control-padding": {
+        "value": "8px",
+        "type": "size",
+        "filePath": "src/products/shared/form/radiocard.json",
+        "isSource": true,
+        "original": {
+          "value": "8",
+          "type": "size"
+        },
+        "name": "token-form-radiocard-control-padding",
+        "attributes": {
+          "category": "form",
+          "type": "radiocard",
+          "item": "control-padding"
+        },
+        "path": [
+          "form",
+          "radiocard",
+          "control-padding"
+        ]
+      },
+      "transition": {
+        "duration": {
+          "value": "0.2s",
+          "type": "time",
+          "unit": "s",
+          "filePath": "src/products/shared/form/radiocard.json",
+          "isSource": true,
+          "original": {
+            "value": "0.2",
+            "type": "time",
+            "unit": "s"
+          },
+          "name": "token-form-radiocard-transition-duration",
+          "attributes": {
+            "category": "form",
+            "type": "radiocard",
+            "item": "transition",
+            "subitem": "duration"
+          },
+          "path": [
+            "form",
+            "radiocard",
+            "transition",
+            "duration"
+          ]
+        }
+      }
+    },
+    "select": {
+      "background-image": {
+        "size": {
+          "value": "16px",
+          "type": "size",
+          "filePath": "src/products/shared/form/select.json",
+          "isSource": true,
+          "original": {
+            "value": "16",
+            "type": "size"
+          },
+          "name": "token-form-select-background-image-size",
+          "attributes": {
+            "category": "form",
+            "type": "select",
+            "item": "background-image",
+            "subitem": "size"
+          },
+          "path": [
+            "form",
+            "select",
+            "background-image",
+            "size"
+          ]
+        },
+        "position-right-x": {
+          "value": "7px",
+          "type": "size",
+          "filePath": "src/products/shared/form/select.json",
+          "isSource": true,
+          "original": {
+            "value": "{form.control.padding.value}",
+            "type": "size"
+          },
+          "name": "token-form-select-background-image-position-right-x",
+          "attributes": {
+            "category": "form",
+            "type": "select",
+            "item": "background-image",
+            "subitem": "position-right-x"
+          },
+          "path": [
+            "form",
+            "select",
+            "background-image",
+            "position-right-x"
+          ]
+        },
+        "position-top-y": {
+          "value": "9px",
+          "type": "size",
+          "filePath": "src/products/shared/form/select.json",
+          "isSource": true,
+          "original": {
+            "value": "9",
+            "type": "size"
+          },
+          "name": "token-form-select-background-image-position-top-y",
+          "attributes": {
+            "category": "form",
+            "type": "select",
+            "item": "background-image",
+            "subitem": "position-top-y"
+          },
+          "path": [
+            "form",
+            "select",
+            "background-image",
+            "position-top-y"
+          ]
+        },
+        "data-url": {
+          "value": "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.55 2.24a.75.75 0 0 0-1.1 0L4.2 5.74a.75.75 0 1 0 1.1 1.02L8 3.852l2.7 2.908a.75.75 0 1 0 1.1-1.02l-3.25-3.5Zm-1.1 11.52a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02L8 12.148 5.3 9.24a.75.75 0 0 0-1.1 1.02l3.25 3.5Z' fill='%23656A76'/%3E%3C/svg%3E\")",
+          "comment": "notice: the 'caret' color is hardcoded here!",
+          "filePath": "src/products/shared/form/select.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.55 2.24a.75.75 0 0 0-1.1 0L4.2 5.74a.75.75 0 1 0 1.1 1.02L8 3.852l2.7 2.908a.75.75 0 1 0 1.1-1.02l-3.25-3.5Zm-1.1 11.52a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02L8 12.148 5.3 9.24a.75.75 0 0 0-1.1 1.02l3.25 3.5Z' fill='%23656A76'/%3E%3C/svg%3E\")",
+            "comment": "notice: the 'caret' color is hardcoded here!"
+          },
+          "name": "token-form-select-background-image-data-url",
+          "attributes": {
+            "category": "form",
+            "type": "select",
+            "item": "background-image",
+            "subitem": "data-url"
+          },
+          "path": [
+            "form",
+            "select",
+            "background-image",
+            "data-url"
+          ]
+        },
+        "data-url-disabled": {
+          "value": "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.55 2.24a.75.75 0 0 0-1.1 0L4.2 5.74a.75.75 0 1 0 1.1 1.02L8 3.852l2.7 2.908a.75.75 0 1 0 1.1-1.02l-3.25-3.5Zm-1.1 11.52a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02L8 12.148 5.3 9.24a.75.75 0 0 0-1.1 1.02l3.25 3.5Z' fill='%238C909C'/%3E%3C/svg%3E\")",
+          "comment": "notice: the 'caret' color is hardcoded here!",
+          "filePath": "src/products/shared/form/select.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.55 2.24a.75.75 0 0 0-1.1 0L4.2 5.74a.75.75 0 1 0 1.1 1.02L8 3.852l2.7 2.908a.75.75 0 1 0 1.1-1.02l-3.25-3.5Zm-1.1 11.52a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02L8 12.148 5.3 9.24a.75.75 0 0 0-1.1 1.02l3.25 3.5Z' fill='%238C909C'/%3E%3C/svg%3E\")",
+            "comment": "notice: the 'caret' color is hardcoded here!"
+          },
+          "name": "token-form-select-background-image-data-url-disabled",
+          "attributes": {
+            "category": "form",
+            "type": "select",
+            "item": "background-image",
+            "subitem": "data-url-disabled"
+          },
+          "path": [
+            "form",
+            "select",
+            "background-image",
+            "data-url-disabled"
+          ]
+        }
+      }
+    },
+    "text-input": {
+      "background-image": {
+        "size": {
+          "value": "16px",
+          "type": "size",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "16",
+            "type": "size"
+          },
+          "name": "token-form-text-input-background-image-size",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "size"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "size"
+          ]
+        },
+        "position-x": {
+          "value": "7px",
+          "type": "size",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "{form.control.padding.value}",
+            "type": "size"
+          },
+          "name": "token-form-text-input-background-image-position-x",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "position-x"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "position-x"
+          ]
+        },
+        "data-url-date": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M11.5.75a.75.75 0 00-1.5 0V1H6V.75a.75.75 0 00-1.5 0V1H3.25A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1H11.5V.75zm-7 2.5V2.5H3.25a.75.75 0 00-.75.75V5h11V3.25a.75.75 0 00-.75-.75H11.5v.75a.75.75 0 01-1.5 0V2.5H6v.75a.75.75 0 01-1.5 0zm9 3.25h-11v6.25c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V6.5z' fill-rule='evenodd' clip-rule='evenodd' fill='%233B3D45'/%3e%3c/svg%3e\")",
+          "comment": "notice: the icon color is hardcoded here!",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M11.5.75a.75.75 0 00-1.5 0V1H6V.75a.75.75 0 00-1.5 0V1H3.25A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1H11.5V.75zm-7 2.5V2.5H3.25a.75.75 0 00-.75.75V5h11V3.25a.75.75 0 00-.75-.75H11.5v.75a.75.75 0 01-1.5 0V2.5H6v.75a.75.75 0 01-1.5 0zm9 3.25h-11v6.25c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V6.5z' fill-rule='evenodd' clip-rule='evenodd' fill='%233B3D45'/%3e%3c/svg%3e\")",
+            "comment": "notice: the icon color is hardcoded here!"
+          },
+          "name": "token-form-text-input-background-image-data-url-date",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "data-url-date"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "data-url-date"
+          ]
+        },
+        "data-url-time": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%233B3D45'%3e%3cpath d='M8.5 3.75a.75.75 0 00-1.5 0V8c0 .284.16.544.415.67l2.5 1.25a.75.75 0 10.67-1.34L8.5 7.535V3.75z'/%3e%3cpath d='M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e\")",
+          "comment": "notice: the icon color is hardcoded here!",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%233B3D45'%3e%3cpath d='M8.5 3.75a.75.75 0 00-1.5 0V8c0 .284.16.544.415.67l2.5 1.25a.75.75 0 10.67-1.34L8.5 7.535V3.75z'/%3e%3cpath d='M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e\")",
+            "comment": "notice: the icon color is hardcoded here!"
+          },
+          "name": "token-form-text-input-background-image-data-url-time",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "data-url-time"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "data-url-time"
+          ]
+        },
+        "data-url-search": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%23656A76'%3e%3cpath d='M7.25 2a5.25 5.25 0 103.144 9.455l2.326 2.325a.75.75 0 101.06-1.06l-2.325-2.326A5.25 5.25 0 007.25 2zM3.5 7.25a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e\")",
+          "comment": "notice: the icon color is hardcoded here!",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%23656A76'%3e%3cpath d='M7.25 2a5.25 5.25 0 103.144 9.455l2.326 2.325a.75.75 0 101.06-1.06l-2.325-2.326A5.25 5.25 0 007.25 2zM3.5 7.25a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e\")",
+            "comment": "notice: the icon color is hardcoded here!"
+          },
+          "name": "token-form-text-input-background-image-data-url-search",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "data-url-search"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "data-url-search"
+          ]
+        },
+        "data-url-search-cancel": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3e%3c/svg%3e\")",
+          "comment": "notice: the icon color is hardcoded here!",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3e%3c/svg%3e\")",
+            "comment": "notice: the icon color is hardcoded here!"
+          },
+          "name": "token-form-text-input-background-image-data-url-search-cancel",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "data-url-search-cancel"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "data-url-search-cancel"
+          ]
+        },
+        "data-url-search-loading": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e\")",
+          "comment": "notice: the icon color and animation are hardcoded here!",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e\")",
+            "comment": "notice: the icon color and animation are hardcoded here!"
+          },
+          "name": "token-form-text-input-background-image-data-url-search-loading",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "data-url-search-loading"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "data-url-search-loading"
+          ]
+        }
+      }
+    },
+    "toggle": {
+      "width": {
+        "value": "32px",
+        "type": "size",
+        "filePath": "src/products/shared/form/toggle.json",
+        "isSource": true,
+        "original": {
+          "value": "32",
+          "type": "size"
+        },
+        "name": "token-form-toggle-width",
+        "attributes": {
+          "category": "form",
+          "type": "toggle",
+          "item": "width"
+        },
+        "path": [
+          "form",
+          "toggle",
+          "width"
+        ]
+      },
+      "height": {
+        "value": "16px",
+        "type": "size",
+        "filePath": "src/products/shared/form/toggle.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "size"
+        },
+        "name": "token-form-toggle-height",
+        "attributes": {
+          "category": "form",
+          "type": "toggle",
+          "item": "height"
+        },
+        "path": [
+          "form",
+          "toggle",
+          "height"
+        ]
+      },
+      "base": {
+        "surface-color": {
+          "default": {
+            "value": "#f1f2f3",
+            "type": "color",
+            "group": "components",
+            "comment": "the toggle has a different base surface color, compared to the other controls",
+            "filePath": "src/products/shared/form/toggle.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.surface.strong.value}",
+              "type": "color",
+              "group": "components",
+              "comment": "the toggle has a different base surface color, compared to the other controls"
+            },
+            "name": "token-form-toggle-base-surface-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "toggle",
+              "item": "base",
+              "subitem": "surface-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "toggle",
+              "base",
+              "surface-color",
+              "default"
+            ]
+          }
+        }
+      },
+      "border": {
+        "radius": {
+          "value": "3px",
+          "type": "size",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "3",
+            "type": "size"
+          },
+          "name": "token-form-toggle-border-radius",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "border",
+            "subitem": "radius"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "border",
+            "radius"
+          ]
+        },
+        "width": {
+          "value": "1px",
+          "type": "size",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "1",
+            "type": "size"
+          },
+          "name": "token-form-toggle-border-width",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "border",
+            "subitem": "width"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "background-image": {
+        "size": {
+          "value": "12px",
+          "type": "size",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "12",
+            "type": "size"
+          },
+          "name": "token-form-toggle-background-image-size",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "background-image",
+            "subitem": "size"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "background-image",
+            "size"
+          ]
+        },
+        "position-x": {
+          "value": "2px",
+          "type": "size",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "2",
+            "type": "size"
+          },
+          "name": "token-form-toggle-background-image-position-x",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "background-image",
+            "subitem": "position-x"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "background-image",
+            "position-x"
+          ]
+        },
+        "data-url": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%23FFF'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'tick' color is hardcoded here!",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%23FFF'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'tick' color is hardcoded here!"
+          },
+          "name": "token-form-toggle-background-image-data-url",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "background-image",
+            "subitem": "data-url"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "background-image",
+            "data-url"
+          ]
+        },
+        "data-url-disabled": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%238C909C'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'tick' color is hardcoded here!",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%238C909C'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'tick' color is hardcoded here!"
+          },
+          "name": "token-form-toggle-background-image-data-url-disabled",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "background-image",
+            "subitem": "data-url-disabled"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "background-image",
+            "data-url-disabled"
+          ]
+        }
+      },
+      "transition": {
+        "duration": {
+          "value": "0.2s",
+          "type": "time",
+          "unit": "s",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "0.2",
+            "type": "time",
+            "unit": "s"
+          },
+          "name": "token-form-toggle-transition-duration",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "transition",
+            "subitem": "duration"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "transition",
+            "duration"
+          ]
+        },
+        "timing-function": {
+          "value": "cubic-bezier(0.68, -0.2, 0.265, 1.15)",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "cubic-bezier(0.68, -0.2, 0.265, 1.15)"
+          },
+          "name": "token-form-toggle-transition-timing-function",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "transition",
+            "subitem": "timing-function"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "transition",
+            "timing-function"
+          ]
+        }
+      },
+      "thumb-size": {
+        "value": "16px",
+        "type": "size",
+        "filePath": "src/products/shared/form/toggle.json",
+        "isSource": true,
+        "original": {
+          "value": "{form.toggle.height.value}",
+          "type": "size"
+        },
+        "name": "token-form-toggle-thumb-size",
+        "attributes": {
+          "category": "form",
+          "type": "toggle",
+          "item": "thumb-size"
+        },
+        "path": [
+          "form",
+          "toggle",
+          "thumb-size"
+        ]
+      }
+    }
+  },
+  "pagination": {
+    "nav": {
+      "control": {
+        "height": {
+          "value": "36px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "36",
+            "type": "size"
+          },
+          "name": "token-pagination-nav-control-height",
+          "attributes": {
+            "category": "pagination",
+            "type": "nav",
+            "item": "control",
+            "subitem": "height"
+          },
+          "path": [
+            "pagination",
+            "nav",
+            "control",
+            "height"
+          ]
+        },
+        "padding": {
+          "horizontal": {
+            "value": "12px",
+            "type": "size",
+            "filePath": "src/products/shared/pagination.json",
+            "isSource": true,
+            "original": {
+              "value": "12",
+              "type": "size"
+            },
+            "name": "token-pagination-nav-control-padding-horizontal",
+            "attributes": {
+              "category": "pagination",
+              "type": "nav",
+              "item": "control",
+              "subitem": "padding",
+              "state": "horizontal"
+            },
+            "path": [
+              "pagination",
+              "nav",
+              "control",
+              "padding",
+              "horizontal"
+            ]
+          }
+        },
+        "focus-inset": {
+          "value": "4px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "4",
+            "type": "size"
+          },
+          "name": "token-pagination-nav-control-focus-inset",
+          "attributes": {
+            "category": "pagination",
+            "type": "nav",
+            "item": "control",
+            "subitem": "focus-inset"
+          },
+          "path": [
+            "pagination",
+            "nav",
+            "control",
+            "focus-inset"
+          ]
+        },
+        "icon-spacing": {
+          "value": "6px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "6",
+            "type": "size"
+          },
+          "name": "token-pagination-nav-control-icon-spacing",
+          "attributes": {
+            "category": "pagination",
+            "type": "nav",
+            "item": "control",
+            "subitem": "icon-spacing"
+          },
+          "path": [
+            "pagination",
+            "nav",
+            "control",
+            "icon-spacing"
+          ]
+        }
+      },
+      "indicator": {
+        "height": {
+          "value": "2px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "2",
+            "type": "size"
+          },
+          "name": "token-pagination-nav-indicator-height",
+          "attributes": {
+            "category": "pagination",
+            "type": "nav",
+            "item": "indicator",
+            "subitem": "height"
+          },
+          "path": [
+            "pagination",
+            "nav",
+            "indicator",
+            "height"
+          ]
+        },
+        "spacing": {
+          "value": "6px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "6",
+            "type": "size"
+          },
+          "name": "token-pagination-nav-indicator-spacing",
+          "attributes": {
+            "category": "pagination",
+            "type": "nav",
+            "item": "indicator",
+            "subitem": "spacing"
+          },
+          "path": [
+            "pagination",
+            "nav",
+            "indicator",
+            "spacing"
+          ]
+        }
+      }
+    },
+    "child": {
+      "spacing": {
+        "vertical": {
+          "value": "8px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "8",
+            "type": "size"
+          },
+          "name": "token-pagination-child-spacing-vertical",
+          "attributes": {
+            "category": "pagination",
+            "type": "child",
+            "item": "spacing",
+            "subitem": "vertical"
+          },
+          "path": [
+            "pagination",
+            "child",
+            "spacing",
+            "vertical"
+          ]
+        },
+        "horizontal": {
+          "value": "20px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "20",
+            "type": "size"
+          },
+          "name": "token-pagination-child-spacing-horizontal",
+          "attributes": {
+            "category": "pagination",
+            "type": "child",
+            "item": "spacing",
+            "subitem": "horizontal"
+          },
+          "path": [
+            "pagination",
+            "child",
+            "spacing",
+            "horizontal"
+          ]
+        }
+      }
+    }
+  },
+  "side-nav": {
+    "wrapper": {
+      "padding": {
+        "horizontal": {
+          "value": "16px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "16",
+            "type": "size"
+          },
+          "name": "token-side-nav-wrapper-padding-horizontal",
+          "attributes": {
+            "category": "side-nav",
+            "type": "wrapper",
+            "item": "padding",
+            "subitem": "horizontal"
+          },
+          "path": [
+            "side-nav",
+            "wrapper",
+            "padding",
+            "horizontal"
+          ]
+        },
+        "vertical": {
+          "value": "16px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "16",
+            "type": "size"
+          },
+          "name": "token-side-nav-wrapper-padding-vertical",
+          "attributes": {
+            "category": "side-nav",
+            "type": "wrapper",
+            "item": "padding",
+            "subitem": "vertical"
+          },
+          "path": [
+            "side-nav",
+            "wrapper",
+            "padding",
+            "vertical"
+          ]
+        }
+      }
+    },
+    "header": {
+      "home-link": {
+        "padding": {
+          "value": "4px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "4",
+            "type": "size"
+          },
+          "name": "token-side-nav-header-home-link-padding",
+          "attributes": {
+            "category": "side-nav",
+            "type": "header",
+            "item": "home-link",
+            "subitem": "padding"
+          },
+          "path": [
+            "side-nav",
+            "header",
+            "home-link",
+            "padding"
+          ]
+        },
+        "logo-size": {
+          "value": "48px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "48",
+            "type": "size"
+          },
+          "name": "token-side-nav-header-home-link-logo-size",
+          "attributes": {
+            "category": "side-nav",
+            "type": "header",
+            "item": "home-link",
+            "subitem": "logo-size"
+          },
+          "path": [
+            "side-nav",
+            "header",
+            "home-link",
+            "logo-size"
+          ]
+        }
+      },
+      "actions": {
+        "spacing": {
+          "value": "8px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "8",
+            "type": "size"
+          },
+          "name": "token-side-nav-header-actions-spacing",
+          "attributes": {
+            "category": "side-nav",
+            "type": "header",
+            "item": "actions",
+            "subitem": "spacing"
+          },
+          "path": [
+            "side-nav",
+            "header",
+            "actions",
+            "spacing"
+          ]
+        }
+      }
+    },
+    "body": {
+      "list": {
+        "margin-vertical": {
+          "value": "24px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "24",
+            "type": "size"
+          },
+          "name": "token-side-nav-body-list-margin-vertical",
+          "attributes": {
+            "category": "side-nav",
+            "type": "body",
+            "item": "list",
+            "subitem": "margin-vertical"
+          },
+          "path": [
+            "side-nav",
+            "body",
+            "list",
+            "margin-vertical"
+          ]
+        }
+      },
+      "list-item": {
+        "height": {
+          "value": "36px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "36",
+            "type": "size"
+          },
+          "name": "token-side-nav-body-list-item-height",
+          "attributes": {
+            "category": "side-nav",
+            "type": "body",
+            "item": "list-item",
+            "subitem": "height"
+          },
+          "path": [
+            "side-nav",
+            "body",
+            "list-item",
+            "height"
+          ]
+        },
+        "padding": {
+          "horizontal": {
+            "value": "8px",
+            "type": "size",
+            "filePath": "src/products/shared/side-nav.json",
+            "isSource": true,
+            "original": {
+              "value": "8",
+              "type": "size"
+            },
+            "name": "token-side-nav-body-list-item-padding-horizontal",
+            "attributes": {
+              "category": "side-nav",
+              "type": "body",
+              "item": "list-item",
+              "subitem": "padding",
+              "state": "horizontal"
+            },
+            "path": [
+              "side-nav",
+              "body",
+              "list-item",
+              "padding",
+              "horizontal"
+            ]
+          },
+          "vertical": {
+            "value": "4px",
+            "type": "size",
+            "filePath": "src/products/shared/side-nav.json",
+            "isSource": true,
+            "original": {
+              "value": "4",
+              "type": "size"
+            },
+            "name": "token-side-nav-body-list-item-padding-vertical",
+            "attributes": {
+              "category": "side-nav",
+              "type": "body",
+              "item": "list-item",
+              "subitem": "padding",
+              "state": "vertical"
+            },
+            "path": [
+              "side-nav",
+              "body",
+              "list-item",
+              "padding",
+              "vertical"
+            ]
+          }
+        },
+        "spacing-vertical": {
+          "value": "2px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "2",
+            "type": "size"
+          },
+          "name": "token-side-nav-body-list-item-spacing-vertical",
+          "attributes": {
+            "category": "side-nav",
+            "type": "body",
+            "item": "list-item",
+            "subitem": "spacing-vertical"
+          },
+          "path": [
+            "side-nav",
+            "body",
+            "list-item",
+            "spacing-vertical"
+          ]
+        },
+        "content-spacing-horizontal": {
+          "value": "8px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "8",
+            "type": "size"
+          },
+          "name": "token-side-nav-body-list-item-content-spacing-horizontal",
+          "attributes": {
+            "category": "side-nav",
+            "type": "body",
+            "item": "list-item",
+            "subitem": "content-spacing-horizontal"
+          },
+          "path": [
+            "side-nav",
+            "body",
+            "list-item",
+            "content-spacing-horizontal"
+          ]
+        },
+        "border-radius": {
+          "value": "5px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "5",
+            "type": "size"
+          },
+          "name": "token-side-nav-body-list-item-border-radius",
+          "attributes": {
+            "category": "side-nav",
+            "type": "body",
+            "item": "list-item",
+            "subitem": "border-radius"
+          },
+          "path": [
+            "side-nav",
+            "body",
+            "list-item",
+            "border-radius"
+          ]
+        }
+      }
+    },
+    "color": {
+      "foreground": {
+        "primary": {
+          "value": "#dedfe3",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#dedfe3",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-side-nav-color-foreground-primary",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "foreground",
+            "subitem": "primary"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "foreground",
+            "primary"
+          ]
+        },
+        "strong": {
+          "value": "#fff",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#fff",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-side-nav-color-foreground-strong",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "foreground",
+            "subitem": "strong"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "foreground",
+            "strong"
+          ]
+        },
+        "faint": {
+          "value": "#8c909c",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#8c909c",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-side-nav-color-foreground-faint",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "foreground",
+            "subitem": "faint"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "foreground",
+            "faint"
+          ]
+        }
+      },
+      "surface": {
+        "primary": {
+          "value": "#0c0c0e",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#0c0c0e",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-side-nav-color-surface-primary",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "surface",
+            "subitem": "primary"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "surface",
+            "primary"
+          ]
+        },
+        "interactive-hover": {
+          "value": "#3b3d45",
+          "type": "color",
+          "group": "semantic",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#3b3d45",
+            "type": "color",
+            "group": "semantic"
+          },
+          "name": "token-side-nav-color-surface-interactive-hover",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "surface",
+            "subitem": "interactive-hover"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "surface",
+            "interactive-hover"
+          ]
+        },
+        "interactive-active": {
+          "value": "#656a76",
+          "type": "color",
+          "group": "semantic",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#656a76",
+            "type": "color",
+            "group": "semantic"
+          },
+          "name": "token-side-nav-color-surface-interactive-active",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "surface",
+            "subitem": "interactive-active"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "surface",
+            "interactive-active"
+          ]
+        }
+      }
+    }
+  },
+  "tabs": {
+    "tab": {
+      "height": {
+        "value": "36px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "36",
+          "type": "size"
+        },
+        "name": "token-tabs-tab-height",
+        "attributes": {
+          "category": "tabs",
+          "type": "tab",
+          "item": "height"
+        },
+        "path": [
+          "tabs",
+          "tab",
+          "height"
+        ]
+      },
+      "padding": {
+        "horizontal": {
+          "value": "12px",
+          "type": "size",
+          "filePath": "src/products/shared/tabs.json",
+          "isSource": true,
+          "original": {
+            "value": "12",
+            "type": "size"
+          },
+          "name": "token-tabs-tab-padding-horizontal",
+          "attributes": {
+            "category": "tabs",
+            "type": "tab",
+            "item": "padding",
+            "subitem": "horizontal"
+          },
+          "path": [
+            "tabs",
+            "tab",
+            "padding",
+            "horizontal"
+          ]
+        },
+        "vertical": {
+          "value": "0px",
+          "type": "size",
+          "filePath": "src/products/shared/tabs.json",
+          "isSource": true,
+          "original": {
+            "value": "0",
+            "type": "size"
+          },
+          "name": "token-tabs-tab-padding-vertical",
+          "attributes": {
+            "category": "tabs",
+            "type": "tab",
+            "item": "padding",
+            "subitem": "vertical"
+          },
+          "path": [
+            "tabs",
+            "tab",
+            "padding",
+            "vertical"
+          ]
+        }
+      },
+      "border-radius": {
+        "value": "5px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "5",
+          "type": "size"
+        },
+        "name": "token-tabs-tab-border-radius",
+        "attributes": {
+          "category": "tabs",
+          "type": "tab",
+          "item": "border-radius"
+        },
+        "path": [
+          "tabs",
+          "tab",
+          "border-radius"
+        ]
+      },
+      "focus-inset": {
+        "value": "6px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "6",
+          "type": "size"
+        },
+        "name": "token-tabs-tab-focus-inset",
+        "attributes": {
+          "category": "tabs",
+          "type": "tab",
+          "item": "focus-inset"
+        },
+        "path": [
+          "tabs",
+          "tab",
+          "focus-inset"
+        ]
+      },
+      "gutter": {
+        "value": "6px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "6",
+          "type": "size"
+        },
+        "name": "token-tabs-tab-gutter",
+        "attributes": {
+          "category": "tabs",
+          "type": "tab",
+          "item": "gutter"
+        },
+        "path": [
+          "tabs",
+          "tab",
+          "gutter"
+        ]
+      }
+    },
+    "indicator": {
+      "height": {
+        "value": "3px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "3",
+          "type": "size"
+        },
+        "name": "token-tabs-indicator-height",
+        "attributes": {
+          "category": "tabs",
+          "type": "indicator",
+          "item": "height"
+        },
+        "path": [
+          "tabs",
+          "indicator",
+          "height"
+        ]
+      },
+      "transition": {
+        "function": {
+          "value": "cubic-bezier(0.5, 1, 0.89, 1)",
+          "filePath": "src/products/shared/tabs.json",
+          "isSource": true,
+          "original": {
+            "value": "cubic-bezier(0.5, 1, 0.89, 1)"
+          },
+          "name": "token-tabs-indicator-transition-function",
+          "attributes": {
+            "category": "tabs",
+            "type": "indicator",
+            "item": "transition",
+            "subitem": "function"
+          },
+          "path": [
+            "tabs",
+            "indicator",
+            "transition",
+            "function"
+          ]
+        },
+        "duration": {
+          "value": "0.6s",
+          "type": "time",
+          "unit": "s",
+          "filePath": "src/products/shared/tabs.json",
+          "isSource": true,
+          "original": {
+            "value": "0.6",
+            "type": "time",
+            "unit": "s"
+          },
+          "name": "token-tabs-indicator-transition-duration",
+          "attributes": {
+            "category": "tabs",
+            "type": "indicator",
+            "item": "transition",
+            "subitem": "duration"
+          },
+          "path": [
+            "tabs",
+            "indicator",
+            "transition",
+            "duration"
+          ]
+        }
+      }
+    },
+    "divider": {
+      "height": {
+        "value": "1px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "1",
+          "type": "size"
+        },
+        "name": "token-tabs-divider-height",
+        "attributes": {
+          "category": "tabs",
+          "type": "divider",
+          "item": "height"
+        },
+        "path": [
+          "tabs",
+          "divider",
+          "height"
+        ]
+      }
+    }
+  },
+  "tooltip": {
+    "border-radius": {
+      "value": "5px",
+      "type": "size",
+      "filePath": "src/products/shared/tooltip.json",
+      "isSource": true,
+      "original": {
+        "value": "5",
+        "type": "size"
+      },
+      "name": "token-tooltip-border-radius",
+      "attributes": {
+        "category": "tooltip",
+        "type": "border-radius"
+      },
+      "path": [
+        "tooltip",
+        "border-radius"
+      ]
+    },
+    "color": {
+      "foreground": {
+        "primary": {
+          "value": "var(--token-color-foreground-high-contrast)",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/tooltip.json",
+          "isSource": true,
+          "original": {
+            "value": "var(--token-color-foreground-high-contrast)",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-tooltip-color-foreground-primary",
+          "attributes": {
+            "category": "tooltip",
+            "type": "color",
+            "item": "foreground",
+            "subitem": "primary"
+          },
+          "path": [
+            "tooltip",
+            "color",
+            "foreground",
+            "primary"
+          ]
+        }
+      },
+      "surface": {
+        "primary": {
+          "value": "var(--token-color-palette-neutral-700)",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/tooltip.json",
+          "isSource": true,
+          "original": {
+            "value": "var(--token-color-palette-neutral-700)",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-tooltip-color-surface-primary",
+          "attributes": {
+            "category": "tooltip",
+            "type": "color",
+            "item": "surface",
+            "subitem": "primary"
+          },
+          "path": [
+            "tooltip",
+            "color",
+            "surface",
+            "primary"
+          ]
+        }
+      }
+    },
+    "focus-offset": {
+      "value": "-2px",
+      "type": "size",
+      "filePath": "src/products/shared/tooltip.json",
+      "isSource": true,
+      "original": {
+        "value": "-2",
+        "type": "size"
+      },
+      "name": "token-tooltip-focus-offset",
+      "attributes": {
+        "category": "tooltip",
+        "type": "focus-offset"
+      },
+      "path": [
+        "tooltip",
+        "focus-offset"
+      ]
+    },
+    "max-width": {
+      "value": "280px",
+      "type": "size",
+      "filePath": "src/products/shared/tooltip.json",
+      "isSource": true,
+      "original": {
+        "value": "280",
+        "type": "size"
+      },
+      "name": "token-tooltip-max-width",
+      "attributes": {
+        "category": "tooltip",
+        "type": "max-width"
+      },
+      "path": [
+        "tooltip",
+        "max-width"
+      ]
+    },
+    "padding": {
+      "horizontal": {
+        "value": "12px",
+        "type": "size",
+        "filePath": "src/products/shared/tooltip.json",
+        "isSource": true,
+        "original": {
+          "value": "12",
+          "type": "size"
+        },
+        "name": "token-tooltip-padding-horizontal",
+        "attributes": {
+          "category": "tooltip",
+          "type": "padding",
+          "item": "horizontal"
+        },
+        "path": [
+          "tooltip",
+          "padding",
+          "horizontal"
+        ]
+      },
+      "vertical": {
+        "value": "8px",
+        "type": "size",
+        "filePath": "src/products/shared/tooltip.json",
+        "isSource": true,
+        "original": {
+          "value": "8",
+          "type": "size"
+        },
+        "name": "token-tooltip-padding-vertical",
+        "attributes": {
+          "category": "tooltip",
+          "type": "padding",
+          "item": "vertical"
+        },
+        "path": [
+          "tooltip",
+          "padding",
+          "vertical"
+        ]
+      }
+    },
+    "transition": {
+      "function": {
+        "value": "cubic-bezier(0.54, 1.5, 0.38, 1.11)",
+        "filePath": "src/products/shared/tooltip.json",
+        "isSource": true,
+        "original": {
+          "value": "cubic-bezier(0.54, 1.5, 0.38, 1.11)"
+        },
+        "name": "token-tooltip-transition-function",
+        "attributes": {
+          "category": "tooltip",
+          "type": "transition",
+          "item": "function"
+        },
+        "path": [
+          "tooltip",
+          "transition",
+          "function"
+        ]
+      }
+    }
+  },
+  "typography": {
+    "font-stack": {
+      "display": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.sans.display.macOS.value}, {typography.font-stack.sans.display.windows.value}, {typography.font-stack.sans.display.sans.value}, {typography.font-stack.sans.display.emoji.value}"
+        },
+        "name": "token-typography-font-stack-display",
+        "attributes": {
+          "category": "typography",
+          "type": "font-stack",
+          "item": "display"
+        },
+        "path": [
+          "typography",
+          "font-stack",
+          "display"
+        ]
+      },
+      "text": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.sans.text.macOS.value}, {typography.font-stack.sans.text.windows.value}, {typography.font-stack.sans.display.sans.value}, {typography.font-stack.sans.text.emoji.value}"
+        },
+        "name": "token-typography-font-stack-text",
+        "attributes": {
+          "category": "typography",
+          "type": "font-stack",
+          "item": "text"
+        },
+        "path": [
+          "typography",
+          "font-stack",
+          "text"
+        ]
+      },
+      "code": {
+        "value": "ui-monospace, Menlo, Consolas, monospace",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.monospace.code.macOS.value}, {typography.font-stack.monospace.code.windows.value}, monospace"
+        },
+        "name": "token-typography-font-stack-code",
+        "attributes": {
+          "category": "typography",
+          "type": "font-stack",
+          "item": "code"
+        },
+        "path": [
+          "typography",
+          "font-stack",
+          "code"
+        ]
+      }
+    },
+    "font-weight": {
+      "regular": {
+        "value": "400",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "400"
+        },
+        "name": "token-typography-font-weight-regular",
+        "attributes": {
+          "category": "typography",
+          "type": "font-weight",
+          "item": "regular"
+        },
+        "path": [
+          "typography",
+          "font-weight",
+          "regular"
+        ]
+      },
+      "medium": {
+        "value": "500",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "500"
+        },
+        "name": "token-typography-font-weight-medium",
+        "attributes": {
+          "category": "typography",
+          "type": "font-weight",
+          "item": "medium"
+        },
+        "path": [
+          "typography",
+          "font-weight",
+          "medium"
+        ]
+      },
+      "semibold": {
+        "value": "600",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "600"
+        },
+        "name": "token-typography-font-weight-semibold",
+        "attributes": {
+          "category": "typography",
+          "type": "font-weight",
+          "item": "semibold"
+        },
+        "path": [
+          "typography",
+          "font-weight",
+          "semibold"
+        ]
+      },
+      "bold": {
+        "value": "700",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "700"
+        },
+        "name": "token-typography-font-weight-bold",
+        "attributes": {
+          "category": "typography",
+          "type": "font-weight",
+          "item": "bold"
+        },
+        "path": [
+          "typography",
+          "font-weight",
+          "bold"
+        ]
+      }
+    },
+    "display-500": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.display.value}"
+        },
+        "name": "token-typography-display-500-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "display-500",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "display-500",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1.875rem",
+        "type": "font-size",
+        "comment": "30px/1.875rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "30",
+          "type": "font-size",
+          "comment": "30px/1.875rem"
+        },
+        "name": "token-typography-display-500-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "display-500",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "display-500",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.2666",
+        "comment": "38px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.2666",
+          "comment": "38px"
+        },
+        "name": "token-typography-display-500-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "display-500",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "display-500",
+          "line-height"
+        ]
+      }
+    },
+    "display-400": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.display.value}"
+        },
+        "name": "token-typography-display-400-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "display-400",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "display-400",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1.5rem",
+        "type": "font-size",
+        "comment": "24px/1.5rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "24",
+          "type": "font-size",
+          "comment": "24px/1.5rem"
+        },
+        "name": "token-typography-display-400-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "display-400",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "display-400",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.3333",
+        "comment": "32px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.3333",
+          "comment": "32px"
+        },
+        "name": "token-typography-display-400-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "display-400",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "display-400",
+          "line-height"
+        ]
+      }
+    },
+    "display-300": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.text.value}"
+        },
+        "name": "token-typography-display-300-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "display-300",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "display-300",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1.125rem",
+        "type": "font-size",
+        "comment": "18px/1.125rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "18",
+          "type": "font-size",
+          "comment": "18px/1.125rem"
+        },
+        "name": "token-typography-display-300-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "display-300",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "display-300",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.3333",
+        "comment": "24px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.3333",
+          "comment": "24px"
+        },
+        "name": "token-typography-display-300-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "display-300",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "display-300",
+          "line-height"
+        ]
+      },
+      "letter-spacing": {
+        "value": "-0.5px",
+        "comment": "this is `tracking`",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "-0.5px",
+          "comment": "this is `tracking`"
+        },
+        "name": "token-typography-display-300-letter-spacing",
+        "attributes": {
+          "category": "typography",
+          "type": "display-300",
+          "item": "letter-spacing"
+        },
+        "path": [
+          "typography",
+          "display-300",
+          "letter-spacing"
+        ]
+      }
+    },
+    "display-200": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.display.value}"
+        },
+        "name": "token-typography-display-200-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "display-200",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "display-200",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1rem",
+        "type": "font-size",
+        "comment": "16px/1rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "font-size",
+          "comment": "16px/1rem"
+        },
+        "name": "token-typography-display-200-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "display-200",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "display-200",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.5",
+        "comment": "24px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.5",
+          "comment": "24px"
+        },
+        "name": "token-typography-display-200-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "display-200",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "display-200",
+          "line-height"
+        ]
+      },
+      "letter-spacing": {
+        "value": "-0.5px",
+        "comment": "this is `tracking`",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "-0.5px",
+          "comment": "this is `tracking`"
+        },
+        "name": "token-typography-display-200-letter-spacing",
+        "attributes": {
+          "category": "typography",
+          "type": "display-200",
+          "item": "letter-spacing"
+        },
+        "path": [
+          "typography",
+          "display-200",
+          "letter-spacing"
+        ]
+      }
+    },
+    "display-100": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.text.value}"
+        },
+        "name": "token-typography-display-100-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "display-100",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "display-100",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "0.8125rem",
+        "type": "font-size",
+        "comment": "13px/0.8125rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "13",
+          "type": "font-size",
+          "comment": "13px/0.8125rem"
+        },
+        "name": "token-typography-display-100-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "display-100",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "display-100",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.3846",
+        "comment": "18px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.3846",
+          "comment": "18px"
+        },
+        "name": "token-typography-display-100-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "display-100",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "display-100",
+          "line-height"
+        ]
+      }
+    },
+    "body-300": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.text.value}"
+        },
+        "name": "token-typography-body-300-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "body-300",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "body-300",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1rem",
+        "type": "font-size",
+        "comment": "16px/1rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "font-size",
+          "comment": "16px/1rem"
+        },
+        "name": "token-typography-body-300-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "body-300",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "body-300",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.5",
+        "comment": "24px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.5",
+          "comment": "24px"
+        },
+        "name": "token-typography-body-300-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "body-300",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "body-300",
+          "line-height"
+        ]
+      }
+    },
+    "body-200": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.text.value}"
+        },
+        "name": "token-typography-body-200-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "body-200",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "body-200",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "0.875rem",
+        "type": "font-size",
+        "comment": "14px/0.875rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "14",
+          "type": "font-size",
+          "comment": "14px/0.875rem"
+        },
+        "name": "token-typography-body-200-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "body-200",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "body-200",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.4286",
+        "comment": "20px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.4286",
+          "comment": "20px"
+        },
+        "name": "token-typography-body-200-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "body-200",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "body-200",
+          "line-height"
+        ]
+      }
+    },
+    "body-100": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.text.value}"
+        },
+        "name": "token-typography-body-100-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "body-100",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "body-100",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "0.8125rem",
+        "type": "font-size",
+        "comment": "13px/0.8125rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "13",
+          "type": "font-size",
+          "comment": "13px/0.8125rem"
+        },
+        "name": "token-typography-body-100-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "body-100",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "body-100",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.3846",
+        "comment": "18px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.3846",
+          "comment": "18px"
+        },
+        "name": "token-typography-body-100-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "body-100",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "body-100",
+          "line-height"
+        ]
+      }
+    },
+    "code-100": {
+      "font-family": {
+        "value": "ui-monospace, Menlo, Consolas, monospace",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.code.value}"
+        },
+        "name": "token-typography-code-100-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "code-100",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "code-100",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "0.8125rem",
+        "type": "font-size",
+        "comment": "13px/0.8125rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "13",
+          "type": "font-size",
+          "comment": "13px/0.8125rem"
+        },
+        "name": "token-typography-code-100-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "code-100",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "code-100",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.23",
+        "comment": "16px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.23",
+          "comment": "16px"
+        },
+        "name": "token-typography-code-100-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "code-100",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "code-100",
+          "line-height"
+        ]
+      }
+    },
+    "code-200": {
+      "font-family": {
+        "value": "ui-monospace, Menlo, Consolas, monospace",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.code.value}"
+        },
+        "name": "token-typography-code-200-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "code-200",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "code-200",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "0.875rem",
+        "type": "font-size",
+        "comment": "14px/0.875rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "14",
+          "type": "font-size",
+          "comment": "14px/0.875rem"
+        },
+        "name": "token-typography-code-200-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "code-200",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "code-200",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.125",
+        "comment": "18px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.125",
+          "comment": "18px"
+        },
+        "name": "token-typography-code-200-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "code-200",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "code-200",
+          "line-height"
+        ]
+      }
+    },
+    "code-300": {
+      "font-family": {
+        "value": "ui-monospace, Menlo, Consolas, monospace",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.code.value}"
+        },
+        "name": "token-typography-code-300-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "code-300",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "code-300",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1rem",
+        "type": "font-size",
+        "comment": "16px/1rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "font-size",
+          "comment": "16px/1rem"
+        },
+        "name": "token-typography-code-300-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "code-300",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "code-300",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.25",
+        "comment": "20px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.25",
+          "comment": "20px"
+        },
+        "name": "token-typography-code-300-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "code-300",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "code-300",
+          "line-height"
+        ]
+      }
+    }
+  }
+}

--- a/packages/tokens/dist/products/tokens.json
+++ b/packages/tokens/dist/products/tokens.json
@@ -1,0 +1,7867 @@
+{
+  "color": {
+    "palette": {
+      "blue-500": {
+        "value": "#1c345f",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#1c345f",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-500"
+        ]
+      },
+      "blue-400": {
+        "value": "#0046d1",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#0046d1",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-400"
+        ]
+      },
+      "blue-300": {
+        "value": "#0c56e9",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#0c56e9",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-300"
+        ]
+      },
+      "blue-200": {
+        "value": "#1060ff",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#1060ff",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-200"
+        ]
+      },
+      "blue-100": {
+        "value": "#cce3fe",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#cce3fe",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-100"
+        ]
+      },
+      "blue-50": {
+        "value": "#f2f8ff",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#f2f8ff",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-blue-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "blue-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "blue-50"
+        ]
+      },
+      "purple-500": {
+        "value": "#42215b",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#42215b",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-500"
+        ]
+      },
+      "purple-400": {
+        "value": "#7b00db",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#7b00db",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-400"
+        ]
+      },
+      "purple-300": {
+        "value": "#911ced",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#911ced",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-300"
+        ]
+      },
+      "purple-200": {
+        "value": "#a737ff",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#a737ff",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-200"
+        ]
+      },
+      "purple-100": {
+        "value": "#ead2fe",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#ead2fe",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-100"
+        ]
+      },
+      "purple-50": {
+        "value": "#f9f2ff",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#f9f2ff",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-purple-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "purple-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "purple-50"
+        ]
+      },
+      "green-500": {
+        "value": "#054220",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#054220",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-500"
+        ]
+      },
+      "green-400": {
+        "value": "#006619",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#006619",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-400"
+        ]
+      },
+      "green-300": {
+        "value": "#00781e",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#00781e",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-300"
+        ]
+      },
+      "green-200": {
+        "value": "#008a22",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#008a22",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-200"
+        ]
+      },
+      "green-100": {
+        "value": "#cceeda",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#cceeda",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-100"
+        ]
+      },
+      "green-50": {
+        "value": "#f2fbf6",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#f2fbf6",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-green-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "green-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "green-50"
+        ]
+      },
+      "amber-500": {
+        "value": "#542800",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#542800",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-500"
+        ]
+      },
+      "amber-400": {
+        "value": "#803d00",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#803d00",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-400"
+        ]
+      },
+      "amber-300": {
+        "value": "#9e4b00",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#9e4b00",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-300"
+        ]
+      },
+      "amber-200": {
+        "value": "#bb5a00",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#bb5a00",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-200"
+        ]
+      },
+      "amber-100": {
+        "value": "#fbeabf",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#fbeabf",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-100"
+        ]
+      },
+      "amber-50": {
+        "value": "#fff9e8",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#fff9e8",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-amber-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "amber-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "amber-50"
+        ]
+      },
+      "red-500": {
+        "value": "#51130a",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#51130a",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-500"
+        ]
+      },
+      "red-400": {
+        "value": "#940004",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#940004",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-400"
+        ]
+      },
+      "red-300": {
+        "value": "#c00005",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#c00005",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-300"
+        ]
+      },
+      "red-200": {
+        "value": "#e52228",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#e52228",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-200"
+        ]
+      },
+      "red-100": {
+        "value": "#fbd4d4",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#fbd4d4",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-100"
+        ]
+      },
+      "red-50": {
+        "value": "#fff5f5",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-accents.json",
+        "isSource": true,
+        "original": {
+          "value": "#fff5f5",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-red-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "red-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "red-50"
+        ]
+      },
+      "neutral-700": {
+        "value": "#0c0c0e",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#0c0c0e",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-700",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-700"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-700"
+        ]
+      },
+      "neutral-600": {
+        "value": "#3b3d45",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#3b3d45",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-600",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-600"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-600"
+        ]
+      },
+      "neutral-500": {
+        "value": "#656a76",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#656a76",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-500",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-500"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-500"
+        ]
+      },
+      "neutral-400": {
+        "value": "#8c909c",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#8c909c",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-400",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-400"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-400"
+        ]
+      },
+      "neutral-300": {
+        "value": "#c2c5cb",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#c2c5cb",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-300"
+        ]
+      },
+      "neutral-200": {
+        "value": "#dedfe3",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#dedfe3",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-200"
+        ]
+      },
+      "neutral-100": {
+        "value": "#f1f2f3",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#f1f2f3",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-100"
+        ]
+      },
+      "neutral-50": {
+        "value": "#fafafa",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#fafafa",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-50",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-50"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-50"
+        ]
+      },
+      "neutral-0": {
+        "value": "#ffffff",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "#ffffff",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-neutral-0",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "neutral-0"
+        },
+        "path": [
+          "color",
+          "palette",
+          "neutral-0"
+        ]
+      },
+      "alpha-300": {
+        "value": "#3b3d4566",
+        "alpha": "0.4",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-600.value}",
+          "alpha": "0.4",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-alpha-300",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "alpha-300"
+        },
+        "path": [
+          "color",
+          "palette",
+          "alpha-300"
+        ]
+      },
+      "alpha-200": {
+        "value": "#656a7633",
+        "alpha": "0.2",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-500.value}",
+          "alpha": "0.2",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-alpha-200",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "alpha-200"
+        },
+        "path": [
+          "color",
+          "palette",
+          "alpha-200"
+        ]
+      },
+      "alpha-100": {
+        "value": "#656a761a",
+        "alpha": "0.1",
+        "type": "color",
+        "group": "palette",
+        "filePath": "src/global/color/palette-neutrals.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-500.value}",
+          "alpha": "0.1",
+          "type": "color",
+          "group": "palette"
+        },
+        "name": "token-color-palette-alpha-100",
+        "attributes": {
+          "category": "color",
+          "type": "palette",
+          "item": "alpha-100"
+        },
+        "path": [
+          "color",
+          "palette",
+          "alpha-100"
+        ]
+      }
+    },
+    "border": {
+      "primary": {
+        "value": "#656a7633",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.alpha-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-primary",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "primary"
+        },
+        "path": [
+          "color",
+          "border",
+          "primary"
+        ]
+      },
+      "faint": {
+        "value": "#656a761a",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.alpha-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-faint",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "faint"
+        },
+        "path": [
+          "color",
+          "border",
+          "faint"
+        ]
+      },
+      "strong": {
+        "value": "#3b3d4566",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.alpha-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-strong",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "strong"
+        },
+        "path": [
+          "color",
+          "border",
+          "strong"
+        ]
+      },
+      "action": {
+        "value": "#cce3fe",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.blue-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-action",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "action"
+        },
+        "path": [
+          "color",
+          "border",
+          "action"
+        ]
+      },
+      "highlight": {
+        "value": "#ead2fe",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-highlight",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "highlight"
+        },
+        "path": [
+          "color",
+          "border",
+          "highlight"
+        ]
+      },
+      "success": {
+        "value": "#cceeda",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.green-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-success",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "success"
+        },
+        "path": [
+          "color",
+          "border",
+          "success"
+        ]
+      },
+      "warning": {
+        "value": "#fbeabf",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.amber-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-warning",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "warning"
+        },
+        "path": [
+          "color",
+          "border",
+          "warning"
+        ]
+      },
+      "critical": {
+        "value": "#fbd4d4",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-border.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-border-critical",
+        "attributes": {
+          "category": "color",
+          "type": "border",
+          "item": "critical"
+        },
+        "path": [
+          "color",
+          "border",
+          "critical"
+        ]
+      }
+    },
+    "focus": {
+      "action": {
+        "internal": {
+          "value": "#0c56e9",
+          "type": "color",
+          "group": "semantic",
+          "filePath": "src/global/color/semantic-focus.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.palette.blue-300.value}",
+            "type": "color",
+            "group": "semantic"
+          },
+          "name": "token-color-focus-action-internal",
+          "attributes": {
+            "category": "color",
+            "type": "focus",
+            "item": "action",
+            "subitem": "internal"
+          },
+          "path": [
+            "color",
+            "focus",
+            "action",
+            "internal"
+          ]
+        },
+        "external": {
+          "value": "#5990ff",
+          "type": "color",
+          "group": "semantic",
+          "comment": "this is a special color used only for the focus style, to pass color contrast for a11y purpose",
+          "filePath": "src/global/color/semantic-focus.json",
+          "isSource": true,
+          "original": {
+            "value": "#5990ff",
+            "type": "color",
+            "group": "semantic",
+            "comment": "this is a special color used only for the focus style, to pass color contrast for a11y purpose"
+          },
+          "name": "token-color-focus-action-external",
+          "attributes": {
+            "category": "color",
+            "type": "focus",
+            "item": "action",
+            "subitem": "external"
+          },
+          "path": [
+            "color",
+            "focus",
+            "action",
+            "external"
+          ]
+        }
+      },
+      "critical": {
+        "internal": {
+          "value": "#c00005",
+          "type": "color",
+          "group": "semantic",
+          "filePath": "src/global/color/semantic-focus.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.palette.red-300.value}",
+            "type": "color",
+            "group": "semantic"
+          },
+          "name": "token-color-focus-critical-internal",
+          "attributes": {
+            "category": "color",
+            "type": "focus",
+            "item": "critical",
+            "subitem": "internal"
+          },
+          "path": [
+            "color",
+            "focus",
+            "critical",
+            "internal"
+          ]
+        },
+        "external": {
+          "value": "#dd7578",
+          "type": "color",
+          "group": "semantic",
+          "comment": "this is a special color used only for the focus style, to pass color contrast for a11y purpose",
+          "filePath": "src/global/color/semantic-focus.json",
+          "isSource": true,
+          "original": {
+            "value": "#dd7578",
+            "type": "color",
+            "group": "semantic",
+            "comment": "this is a special color used only for the focus style, to pass color contrast for a11y purpose"
+          },
+          "name": "token-color-focus-critical-external",
+          "attributes": {
+            "category": "color",
+            "type": "focus",
+            "item": "critical",
+            "subitem": "external"
+          },
+          "path": [
+            "color",
+            "focus",
+            "critical",
+            "external"
+          ]
+        }
+      }
+    },
+    "foreground": {
+      "strong": {
+        "value": "#0c0c0e",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-700.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-strong",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "strong"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "strong"
+        ]
+      },
+      "primary": {
+        "value": "#3b3d45",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-600.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-primary",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "primary"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "primary"
+        ]
+      },
+      "faint": {
+        "value": "#656a76",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-500.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-faint",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "faint"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "faint"
+        ]
+      },
+      "high-contrast": {
+        "value": "#ffffff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-0.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-high-contrast",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "high-contrast"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "high-contrast"
+        ]
+      },
+      "disabled": {
+        "value": "#8c909c",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-400.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-disabled",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "disabled"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "disabled"
+        ]
+      },
+      "action": {
+        "value": "#1060ff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.blue-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-action",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "action"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "action"
+        ]
+      },
+      "action-hover": {
+        "value": "#0c56e9",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.blue-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-action-hover",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "action-hover"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "action-hover"
+        ]
+      },
+      "action-active": {
+        "value": "#0046d1",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.blue-400.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-action-active",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "action-active"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "action-active"
+        ]
+      },
+      "highlight": {
+        "value": "#a737ff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-highlight",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "highlight"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "highlight"
+        ]
+      },
+      "highlight-on-surface": {
+        "value": "#911ced",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-highlight-on-surface",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "highlight-on-surface"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "highlight-on-surface"
+        ]
+      },
+      "highlight-high-contrast": {
+        "value": "#42215b",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-500.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-highlight-high-contrast",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "highlight-high-contrast"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "highlight-high-contrast"
+        ]
+      },
+      "success": {
+        "value": "#008a22",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.green-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-success",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "success"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "success"
+        ]
+      },
+      "success-on-surface": {
+        "value": "#00781e",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.green-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-success-on-surface",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "success-on-surface"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "success-on-surface"
+        ]
+      },
+      "success-high-contrast": {
+        "value": "#054220",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.green-500.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-success-high-contrast",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "success-high-contrast"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "success-high-contrast"
+        ]
+      },
+      "warning": {
+        "value": "#bb5a00",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.amber-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-warning",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "warning"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "warning"
+        ]
+      },
+      "warning-on-surface": {
+        "value": "#9e4b00",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.amber-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-warning-on-surface",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "warning-on-surface"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "warning-on-surface"
+        ]
+      },
+      "warning-high-contrast": {
+        "value": "#542800",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.amber-500.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-warning-high-contrast",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "warning-high-contrast"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "warning-high-contrast"
+        ]
+      },
+      "critical": {
+        "value": "#e52228",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-critical",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "critical"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "critical"
+        ]
+      },
+      "critical-on-surface": {
+        "value": "#c00005",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-300.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-critical-on-surface",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "critical-on-surface"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "critical-on-surface"
+        ]
+      },
+      "critical-high-contrast": {
+        "value": "#51130a",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-foreground.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-500.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-foreground-critical-high-contrast",
+        "attributes": {
+          "category": "color",
+          "type": "foreground",
+          "item": "critical-high-contrast"
+        },
+        "path": [
+          "color",
+          "foreground",
+          "critical-high-contrast"
+        ]
+      }
+    },
+    "page": {
+      "primary": {
+        "value": "#ffffff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-page.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-0.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-page-primary",
+        "attributes": {
+          "category": "color",
+          "type": "page",
+          "item": "primary"
+        },
+        "path": [
+          "color",
+          "page",
+          "primary"
+        ]
+      },
+      "faint": {
+        "value": "#fafafa",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-page.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-page-faint",
+        "attributes": {
+          "category": "color",
+          "type": "page",
+          "item": "faint"
+        },
+        "path": [
+          "color",
+          "page",
+          "faint"
+        ]
+      }
+    },
+    "surface": {
+      "primary": {
+        "value": "#ffffff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-0.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-primary",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "primary"
+        },
+        "path": [
+          "color",
+          "surface",
+          "primary"
+        ]
+      },
+      "faint": {
+        "value": "#fafafa",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-faint",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "faint"
+        },
+        "path": [
+          "color",
+          "surface",
+          "faint"
+        ]
+      },
+      "strong": {
+        "value": "#f1f2f3",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-strong",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "strong"
+        },
+        "path": [
+          "color",
+          "surface",
+          "strong"
+        ]
+      },
+      "interactive": {
+        "value": "#ffffff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-0.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-interactive",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "interactive"
+        },
+        "path": [
+          "color",
+          "surface",
+          "interactive"
+        ]
+      },
+      "interactive-hover": {
+        "value": "#f1f2f3",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-100.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-interactive-hover",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "interactive-hover"
+        },
+        "path": [
+          "color",
+          "surface",
+          "interactive-hover"
+        ]
+      },
+      "interactive-active": {
+        "value": "#dedfe3",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-200.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-interactive-active",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "interactive-active"
+        },
+        "path": [
+          "color",
+          "surface",
+          "interactive-active"
+        ]
+      },
+      "interactive-disabled": {
+        "value": "#fafafa",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.neutral-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-interactive-disabled",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "interactive-disabled"
+        },
+        "path": [
+          "color",
+          "surface",
+          "interactive-disabled"
+        ]
+      },
+      "action": {
+        "value": "#f2f8ff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.blue-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-action",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "action"
+        },
+        "path": [
+          "color",
+          "surface",
+          "action"
+        ]
+      },
+      "highlight": {
+        "value": "#f9f2ff",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.purple-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-highlight",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "highlight"
+        },
+        "path": [
+          "color",
+          "surface",
+          "highlight"
+        ]
+      },
+      "success": {
+        "value": "#f2fbf6",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.green-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-success",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "success"
+        },
+        "path": [
+          "color",
+          "surface",
+          "success"
+        ]
+      },
+      "warning": {
+        "value": "#fff9e8",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.amber-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-warning",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "warning"
+        },
+        "path": [
+          "color",
+          "surface",
+          "warning"
+        ]
+      },
+      "critical": {
+        "value": "#fff5f5",
+        "type": "color",
+        "group": "semantic",
+        "filePath": "src/global/color/semantic-surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-50.value}",
+          "type": "color",
+          "group": "semantic"
+        },
+        "name": "token-color-surface-critical",
+        "attributes": {
+          "category": "color",
+          "type": "surface",
+          "item": "critical"
+        },
+        "path": [
+          "color",
+          "surface",
+          "critical"
+        ]
+      }
+    },
+    "hashicorp": {
+      "brand": {
+        "value": "#000000",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-company.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.hashicorp-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-hashicorp-brand",
+        "attributes": {
+          "category": "color",
+          "type": "hashicorp",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "hashicorp",
+          "brand"
+        ]
+      }
+    },
+    "boundary": {
+      "brand": {
+        "value": "#f24c53",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-boundary.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.boundary-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-boundary-brand",
+        "attributes": {
+          "category": "color",
+          "type": "boundary",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "boundary",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#cf2d32",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-boundary.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.boundary-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-boundary-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "boundary",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "boundary",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#ffecec",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-boundary.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.boundary-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-boundary-surface",
+        "attributes": {
+          "category": "color",
+          "type": "boundary",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "boundary",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#fbd7d8",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-boundary.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.boundary-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-boundary-border",
+        "attributes": {
+          "category": "color",
+          "type": "boundary",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "boundary",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#f97076",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-boundary.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.boundary-300.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-boundary-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "boundary",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "boundary",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#db363b",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-boundary.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.boundary-400.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-boundary-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "boundary",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "boundary",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#fffafa",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'boundary-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-boundary.json",
+            "isSource": true,
+            "original": {
+              "value": "#fffafa",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'boundary-50' value at 25% opacity on white"
+            },
+            "name": "token-color-boundary-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "boundary",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "boundary",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#ffecec",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-boundary.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.boundary-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-boundary-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "boundary",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "boundary",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "consul": {
+      "brand": {
+        "value": "#e03875",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-consul.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.consul-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-consul-brand",
+        "attributes": {
+          "category": "color",
+          "type": "consul",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "consul",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#d01c5b",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-consul.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.consul-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-consul-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "consul",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "consul",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#ffe9f1",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-consul.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.consul-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-consul-surface",
+        "attributes": {
+          "category": "color",
+          "type": "consul",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "consul",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#ffcede",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-consul.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.consul-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-consul-border",
+        "attributes": {
+          "category": "color",
+          "type": "consul",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "consul",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#ff99be",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-consul.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.consul-300.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-consul-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "consul",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "consul",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#da306e",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-consul.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.consul-400.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-consul-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "consul",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "consul",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#fff9fb",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'consul-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-consul.json",
+            "isSource": true,
+            "original": {
+              "value": "#fff9fb",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'consul-50' value at 25% opacity on white"
+            },
+            "name": "token-color-consul-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "consul",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "consul",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#ffe9f1",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-consul.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.consul-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-consul-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "consul",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "consul",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "hcp": {
+      "brand": {
+        "value": "#000000",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-hcp.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.hcp-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-hcp-brand",
+        "attributes": {
+          "category": "color",
+          "type": "hcp",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "hcp",
+          "brand"
+        ]
+      }
+    },
+    "nomad": {
+      "brand": {
+        "value": "#06d092",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-nomad.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.nomad-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-nomad-brand",
+        "attributes": {
+          "category": "color",
+          "type": "nomad",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "nomad",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#008661",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-nomad.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.nomad-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-nomad-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "nomad",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "nomad",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#d3fdeb",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-nomad.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.nomad-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-nomad-surface",
+        "attributes": {
+          "category": "color",
+          "type": "nomad",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "nomad",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#bff3dd",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-nomad.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.nomad-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-nomad-border",
+        "attributes": {
+          "category": "color",
+          "type": "nomad",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "nomad",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#bff3dd",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-nomad.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.nomad-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-nomad-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "nomad",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "nomad",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#60dea9",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-nomad.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.nomad-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-nomad-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "nomad",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "nomad",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#f3fff9",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'nomad-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-nomad.json",
+            "isSource": true,
+            "original": {
+              "value": "#f3fff9",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'nomad-50' value at 25% opacity on white"
+            },
+            "name": "token-color-nomad-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "nomad",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "nomad",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#d3fdeb",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-nomad.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.nomad-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-nomad-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "nomad",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "nomad",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "packer": {
+      "brand": {
+        "value": "#02a8ef",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-packer.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.packer-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-packer-brand",
+        "attributes": {
+          "category": "color",
+          "type": "packer",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "packer",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#007eb4",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-packer.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.packer-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-packer-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "packer",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "packer",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#d4f2ff",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-packer.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.packer-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-packer-surface",
+        "attributes": {
+          "category": "color",
+          "type": "packer",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "packer",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#b4e4ff",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-packer.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.packer-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-packer-border",
+        "attributes": {
+          "category": "color",
+          "type": "packer",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "packer",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#b4e4ff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-packer.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.packer-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-packer-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "packer",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "packer",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#63d0ff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-packer.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.packer-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-packer-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "packer",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "packer",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#f3fcff",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'packer-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-packer.json",
+            "isSource": true,
+            "original": {
+              "value": "#F3FCFF",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'packer-50' value at 25% opacity on white"
+            },
+            "name": "token-color-packer-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "packer",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "packer",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#d4f2ff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-packer.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.packer-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-packer-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "packer",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "packer",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "terraform": {
+      "brand": {
+        "value": "#7b42bc",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-terraform.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.terraform-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-terraform-brand",
+        "attributes": {
+          "category": "color",
+          "type": "terraform",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "terraform",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#773cb4",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-terraform.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.terraform-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-terraform-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "terraform",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "terraform",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#f4ecff",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-terraform.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.terraform-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-terraform-surface",
+        "attributes": {
+          "category": "color",
+          "type": "terraform",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "terraform",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#ebdbfc",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-terraform.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.terraform-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-terraform-border",
+        "attributes": {
+          "category": "color",
+          "type": "terraform",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "terraform",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#bb8deb",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-terraform.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.terraform-300.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-terraform-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "terraform",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "terraform",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#844fba",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-terraform.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.terraform-400.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-terraform-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "terraform",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "terraform",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#fcfaff",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'terraform-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-terraform.json",
+            "isSource": true,
+            "original": {
+              "value": "#fcfaff",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'terraform-50' value at 25% opacity on white"
+            },
+            "name": "token-color-terraform-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "terraform",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "terraform",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#f4ecff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-terraform.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.terraform-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-terraform-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "terraform",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "terraform",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "vagrant": {
+      "brand": {
+        "value": "#1868f2",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vagrant-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vagrant-brand",
+        "attributes": {
+          "category": "color",
+          "type": "vagrant",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "vagrant",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#1c61d8",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vagrant-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vagrant-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "vagrant",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "vagrant",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#d6ebff",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vagrant-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vagrant-surface",
+        "attributes": {
+          "category": "color",
+          "type": "vagrant",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "vagrant",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#c7dbfc",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vagrant-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vagrant-border",
+        "attributes": {
+          "category": "color",
+          "type": "vagrant",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "vagrant",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#c7dbfc",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vagrant-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vagrant-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "vagrant",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vagrant",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#7dadff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vagrant-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vagrant-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vagrant",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vagrant",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#f4faff",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'vagrant-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+            "isSource": true,
+            "original": {
+              "value": "#f4faff",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'vagrant-50' value at 25% opacity on white"
+            },
+            "name": "token-color-vagrant-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "vagrant",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vagrant",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#d6ebff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vagrant.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vagrant-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vagrant-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vagrant",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vagrant",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "vault": {
+      "brand": {
+        "value": "#ffd814",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-brand",
+        "attributes": {
+          "category": "color",
+          "type": "vault",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "vault",
+          "brand"
+        ]
+      },
+      "brand-alt": {
+        "value": "#000000",
+        "type": "color",
+        "group": "branding",
+        "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work",
+        "filePath": "src/products/shared/color/semantic-product-vault.json",
+        "isSource": true,
+        "original": {
+          "value": "#000",
+          "type": "color",
+          "group": "branding",
+          "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work"
+        },
+        "name": "token-color-vault-brand-alt",
+        "attributes": {
+          "category": "color",
+          "type": "vault",
+          "item": "brand-alt"
+        },
+        "path": [
+          "color",
+          "vault",
+          "brand-alt"
+        ]
+      },
+      "foreground": {
+        "value": "#9a6f00",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "vault",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "vault",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#fff9cf",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-surface",
+        "attributes": {
+          "category": "color",
+          "type": "vault",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "vault",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#feec7b",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-border",
+        "attributes": {
+          "category": "color",
+          "type": "vault",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "vault",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#feec7b",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "vault",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vault",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#ffe543",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vault",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vault",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#fffdf2",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'vault-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-vault.json",
+            "isSource": true,
+            "original": {
+              "value": "#fffdf2",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'vault-50' value at 25% opacity on white"
+            },
+            "name": "token-color-vault-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "vault",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vault",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#fff9cf",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vault",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vault",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
+    "waypoint": {
+      "brand": {
+        "value": "#14c6cb",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.waypoint-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-waypoint-brand",
+        "attributes": {
+          "category": "color",
+          "type": "waypoint",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "waypoint",
+          "brand"
+        ]
+      },
+      "foreground": {
+        "value": "#008196",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.waypoint-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-waypoint-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "waypoint",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "waypoint",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#e0fcff",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.waypoint-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-waypoint-surface",
+        "attributes": {
+          "category": "color",
+          "type": "waypoint",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "waypoint",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#cbf1f3",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.waypoint-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-waypoint-border",
+        "attributes": {
+          "category": "color",
+          "type": "waypoint",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "waypoint",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#cbf1f3",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.waypoint-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-waypoint-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "waypoint",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "waypoint",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#62d4dc",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.waypoint-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-waypoint-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "waypoint",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "waypoint",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#f6feff",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'waypoint-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+            "isSource": true,
+            "original": {
+              "value": "#f6feff",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'waypoint-50' value at 25% opacity on white"
+            },
+            "name": "token-color-waypoint-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "waypoint",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "waypoint",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#e0fcff",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-waypoint.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.waypoint-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-waypoint-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "waypoint",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "waypoint",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "elevation": {
+    "inset": {
+      "box-shadow": {
+        "value": "inset 0px 1px 2px 1px #656a761a",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.inset.box-shadow-01.value}"
+        },
+        "name": "token-elevation-inset-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "inset",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "inset",
+          "box-shadow"
+        ]
+      }
+    },
+    "low": {
+      "box-shadow": {
+        "value": "0px 1px 1px 0px #656a760d, 0px 2px 2px 0px #656a760d",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.low.box-shadow-01.value}, {elevation.low.box-shadow-02.value}"
+        },
+        "name": "token-elevation-low-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "low",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "low",
+          "box-shadow"
+        ]
+      }
+    },
+    "mid": {
+      "box-shadow": {
+        "value": "0px 2px 3px 0px #656a761a, 0px 8px 16px -10px #656a7633",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.mid.box-shadow-01.value}, {elevation.mid.box-shadow-02.value}"
+        },
+        "name": "token-elevation-mid-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "mid",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "mid",
+          "box-shadow"
+        ]
+      }
+    },
+    "high": {
+      "box-shadow": {
+        "value": "0px 2px 3px 0px #656a7626, 0px 16px 16px -10px #656a7633",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.high.box-shadow-01.value}, {elevation.high.box-shadow-02.value}"
+        },
+        "name": "token-elevation-high-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "high",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "high",
+          "box-shadow"
+        ]
+      }
+    },
+    "higher": {
+      "box-shadow": {
+        "value": "0px 2px 3px 0px #656a761a, 0px 12px 28px 0px #656a7640",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.higher.box-shadow-01.value}, {elevation.higher.box-shadow-02.value}"
+        },
+        "name": "token-elevation-higher-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "higher",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "higher",
+          "box-shadow"
+        ]
+      }
+    },
+    "overlay": {
+      "box-shadow": {
+        "value": "0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559",
+        "filePath": "src/global/elevation/elevation.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.overlay.box-shadow-01.value}, {elevation.overlay.box-shadow-02.value}"
+        },
+        "name": "token-elevation-overlay-box-shadow",
+        "attributes": {
+          "category": "elevation",
+          "type": "overlay",
+          "item": "box-shadow"
+        },
+        "path": [
+          "elevation",
+          "overlay",
+          "box-shadow"
+        ]
+      }
+    }
+  },
+  "surface": {
+    "inset": {
+      "box-shadow": {
+        "value": "inset 0 0 0 1px #656a764d, inset 0px 1px 2px 1px #656a761a",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.inset.box-shadow-border.value}, {elevation.inset.box-shadow.value}"
+        },
+        "name": "token-surface-inset-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "inset",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "inset",
+          "box-shadow"
+        ]
+      }
+    },
+    "base": {
+      "box-shadow": {
+        "value": "0 0 0 1px #656a7633",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.base.box-shadow-border.value}"
+        },
+        "name": "token-surface-base-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "base",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "base",
+          "box-shadow"
+        ]
+      }
+    },
+    "low": {
+      "box-shadow": {
+        "value": "0 0 0 1px #656a7626, 0px 1px 1px 0px #656a760d, 0px 2px 2px 0px #656a760d",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.low.box-shadow-border.value}, {elevation.low.box-shadow.value}"
+        },
+        "name": "token-surface-low-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "low",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "low",
+          "box-shadow"
+        ]
+      }
+    },
+    "mid": {
+      "box-shadow": {
+        "value": "0 0 0 1px #656a7626, 0px 2px 3px 0px #656a761a, 0px 8px 16px -10px #656a7633",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.mid.box-shadow-border.value}, {elevation.mid.box-shadow.value}"
+        },
+        "name": "token-surface-mid-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "mid",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "mid",
+          "box-shadow"
+        ]
+      }
+    },
+    "high": {
+      "box-shadow": {
+        "value": "0 0 0 1px #656a7640, 0px 2px 3px 0px #656a7626, 0px 16px 16px -10px #656a7633",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.high.box-shadow-border.value}, {elevation.high.box-shadow.value}"
+        },
+        "name": "token-surface-high-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "high",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "high",
+          "box-shadow"
+        ]
+      }
+    },
+    "higher": {
+      "box-shadow": {
+        "value": "0 0 0 1px #656a7633, 0px 2px 3px 0px #656a761a, 0px 12px 28px 0px #656a7640",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.higher.box-shadow-border.value}, {elevation.higher.box-shadow.value}"
+        },
+        "name": "token-surface-higher-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "higher",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "higher",
+          "box-shadow"
+        ]
+      }
+    },
+    "overlay": {
+      "box-shadow": {
+        "value": "0 0 0 1px #3b3d4540, 0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559",
+        "filePath": "src/global/elevation/surface.json",
+        "isSource": true,
+        "original": {
+          "value": "{elevation.overlay.box-shadow-border.value}, {elevation.overlay.box-shadow.value}"
+        },
+        "name": "token-surface-overlay-box-shadow",
+        "attributes": {
+          "category": "surface",
+          "type": "overlay",
+          "item": "box-shadow"
+        },
+        "path": [
+          "surface",
+          "overlay",
+          "box-shadow"
+        ]
+      }
+    }
+  },
+  "focus-ring": {
+    "action": {
+      "box-shadow": {
+        "value": "inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff",
+        "filePath": "src/global/focus-ring.json",
+        "isSource": true,
+        "original": {
+          "value": "{focus-ring.action.internal-box-shadow.value}, {focus-ring.action.external-box-shadow.value}"
+        },
+        "name": "token-focus-ring-action-box-shadow",
+        "attributes": {
+          "category": "focus-ring",
+          "type": "action",
+          "item": "box-shadow"
+        },
+        "path": [
+          "focus-ring",
+          "action",
+          "box-shadow"
+        ]
+      }
+    },
+    "critical": {
+      "box-shadow": {
+        "value": "inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578",
+        "filePath": "src/global/focus-ring.json",
+        "isSource": true,
+        "original": {
+          "value": "{focus-ring.critical.internal-box-shadow.value}, {focus-ring.critical.external-box-shadow.value}"
+        },
+        "name": "token-focus-ring-critical-box-shadow",
+        "attributes": {
+          "category": "focus-ring",
+          "type": "critical",
+          "item": "box-shadow"
+        },
+        "path": [
+          "focus-ring",
+          "critical",
+          "box-shadow"
+        ]
+      }
+    }
+  },
+  "form": {
+    "label": {
+      "color": {
+        "value": "#0c0c0e",
+        "type": "color",
+        "group": "components",
+        "filePath": "src/products/shared/form/base-elements.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.foreground.strong.value}",
+          "type": "color",
+          "group": "components"
+        },
+        "name": "token-form-label-color",
+        "attributes": {
+          "category": "form",
+          "type": "label",
+          "item": "color"
+        },
+        "path": [
+          "form",
+          "label",
+          "color"
+        ]
+      }
+    },
+    "legend": {
+      "color": {
+        "value": "#0c0c0e",
+        "type": "color",
+        "group": "components",
+        "filePath": "src/products/shared/form/base-elements.json",
+        "isSource": true,
+        "original": {
+          "value": "{form.label.color.value}",
+          "type": "color",
+          "group": "components"
+        },
+        "name": "token-form-legend-color",
+        "attributes": {
+          "category": "form",
+          "type": "legend",
+          "item": "color"
+        },
+        "path": [
+          "form",
+          "legend",
+          "color"
+        ]
+      }
+    },
+    "helper-text": {
+      "color": {
+        "value": "#656a76",
+        "type": "color",
+        "group": "components",
+        "filePath": "src/products/shared/form/base-elements.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.foreground.faint.value}",
+          "type": "color",
+          "group": "components"
+        },
+        "name": "token-form-helper-text-color",
+        "attributes": {
+          "category": "form",
+          "type": "helper-text",
+          "item": "color"
+        },
+        "path": [
+          "form",
+          "helper-text",
+          "color"
+        ]
+      }
+    },
+    "indicator": {
+      "optional": {
+        "color": {
+          "value": "#656a76",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/base-elements.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.foreground.faint.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-indicator-optional-color",
+          "attributes": {
+            "category": "form",
+            "type": "indicator",
+            "item": "optional",
+            "subitem": "color"
+          },
+          "path": [
+            "form",
+            "indicator",
+            "optional",
+            "color"
+          ]
+        }
+      }
+    },
+    "error": {
+      "color": {
+        "value": "#c00005",
+        "type": "color",
+        "group": "components",
+        "filePath": "src/products/shared/form/base-elements.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.red-300.value}",
+          "type": "color",
+          "group": "components"
+        },
+        "name": "token-form-error-color",
+        "attributes": {
+          "category": "form",
+          "type": "error",
+          "item": "color"
+        },
+        "path": [
+          "form",
+          "error",
+          "color"
+        ]
+      },
+      "icon-size": {
+        "value": "14px",
+        "type": "size",
+        "filePath": "src/products/shared/form/base-elements.json",
+        "isSource": true,
+        "original": {
+          "value": "14",
+          "type": "size"
+        },
+        "name": "token-form-error-icon-size",
+        "attributes": {
+          "category": "form",
+          "type": "error",
+          "item": "icon-size"
+        },
+        "path": [
+          "form",
+          "error",
+          "icon-size"
+        ]
+      }
+    },
+    "checkbox": {
+      "size": {
+        "value": "16px",
+        "type": "size",
+        "filePath": "src/products/shared/form/checkbox.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "size"
+        },
+        "name": "token-form-checkbox-size",
+        "attributes": {
+          "category": "form",
+          "type": "checkbox",
+          "item": "size"
+        },
+        "path": [
+          "form",
+          "checkbox",
+          "size"
+        ]
+      },
+      "border": {
+        "radius": {
+          "value": "3px",
+          "type": "size",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "3",
+            "type": "size"
+          },
+          "name": "token-form-checkbox-border-radius",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "border",
+            "subitem": "radius"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "border",
+            "radius"
+          ]
+        },
+        "width": {
+          "value": "1px",
+          "type": "size",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "1",
+            "type": "size"
+          },
+          "name": "token-form-checkbox-border-width",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "border",
+            "subitem": "width"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "background-image": {
+        "size": {
+          "value": "12px",
+          "type": "size",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "12",
+            "type": "size"
+          },
+          "name": "token-form-checkbox-background-image-size",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "background-image",
+            "subitem": "size"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "background-image",
+            "size"
+          ]
+        },
+        "data-url": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%23FFF'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'tick' color is hardcoded here!",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%23FFF'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'tick' color is hardcoded here!"
+          },
+          "name": "token-form-checkbox-background-image-data-url",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "background-image",
+            "subitem": "data-url"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "background-image",
+            "data-url"
+          ]
+        },
+        "data-url-indeterminate": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='m2.03125,6a0.66146,0.75 0 0 1 0.66146,-0.75l6.61458,0a0.66146,0.75 0 0 1 0,1.5l-6.61458,0a0.66146,0.75 0 0 1 -0.66146,-0.75z' fill='%23FFF'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'dash' color is hardcoded here!",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='m2.03125,6a0.66146,0.75 0 0 1 0.66146,-0.75l6.61458,0a0.66146,0.75 0 0 1 0,1.5l-6.61458,0a0.66146,0.75 0 0 1 -0.66146,-0.75z' fill='%23FFF'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'dash' color is hardcoded here!"
+          },
+          "name": "token-form-checkbox-background-image-data-url-indeterminate",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "background-image",
+            "subitem": "data-url-indeterminate"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "background-image",
+            "data-url-indeterminate"
+          ]
+        },
+        "data-url-disabled": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%238C909C'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'tick' color is hardcoded here!",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%238C909C'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'tick' color is hardcoded here!"
+          },
+          "name": "token-form-checkbox-background-image-data-url-disabled",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "background-image",
+            "subitem": "data-url-disabled"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "background-image",
+            "data-url-disabled"
+          ]
+        },
+        "data-url-indeterminate-disabled": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='m2.03125,6a0.66146,0.75 0 0 1 0.66146,-0.75l6.61458,0a0.66146,0.75 0 0 1 0,1.5l-6.61458,0a0.66146,0.75 0 0 1 -0.66146,-0.75z' fill='%238C909C'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'dash' color is hardcoded here!",
+          "filePath": "src/products/shared/form/checkbox.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='m2.03125,6a0.66146,0.75 0 0 1 0.66146,-0.75l6.61458,0a0.66146,0.75 0 0 1 0,1.5l-6.61458,0a0.66146,0.75 0 0 1 -0.66146,-0.75z' fill='%238C909C'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'dash' color is hardcoded here!"
+          },
+          "name": "token-form-checkbox-background-image-data-url-indeterminate-disabled",
+          "attributes": {
+            "category": "form",
+            "type": "checkbox",
+            "item": "background-image",
+            "subitem": "data-url-indeterminate-disabled"
+          },
+          "path": [
+            "form",
+            "checkbox",
+            "background-image",
+            "data-url-indeterminate-disabled"
+          ]
+        }
+      }
+    },
+    "control": {
+      "base": {
+        "foreground": {
+          "value-color": {
+            "value": "#0c0c0e",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.foreground.strong.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-foreground-value-color",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "foreground",
+              "state": "value-color"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "foreground",
+              "value-color"
+            ]
+          },
+          "placeholder-color": {
+            "value": "#656a76",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.foreground.faint.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-foreground-placeholder-color",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "foreground",
+              "state": "placeholder-color"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "foreground",
+              "placeholder-color"
+            ]
+          }
+        },
+        "surface-color": {
+          "default": {
+            "value": "#ffffff",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.surface.interactive.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-surface-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "surface-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "surface-color",
+              "default"
+            ]
+          },
+          "hover": {
+            "value": "#f1f2f3",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.surface.interactive-hover.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-surface-color-hover",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "surface-color",
+              "state": "hover"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "surface-color",
+              "hover"
+            ]
+          }
+        },
+        "border-color": {
+          "default": {
+            "value": "#8c909c",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.neutral-400.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-border-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "border-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "border-color",
+              "default"
+            ]
+          },
+          "hover": {
+            "value": "#656a76",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.neutral-500.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-base-border-color-hover",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "base",
+              "subitem": "border-color",
+              "state": "hover"
+            },
+            "path": [
+              "form",
+              "control",
+              "base",
+              "border-color",
+              "hover"
+            ]
+          }
+        }
+      },
+      "checked": {
+        "foreground-color": {
+          "value": "#ffffff",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.foreground.high-contrast.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-checked-foreground-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "checked",
+            "subitem": "foreground-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "checked",
+            "foreground-color"
+          ]
+        },
+        "surface-color": {
+          "default": {
+            "value": "#1060ff",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.blue-200.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-checked-surface-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "checked",
+              "subitem": "surface-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "control",
+              "checked",
+              "surface-color",
+              "default"
+            ]
+          },
+          "hover": {
+            "value": "#0c56e9",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.blue-300.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-checked-surface-color-hover",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "checked",
+              "subitem": "surface-color",
+              "state": "hover"
+            },
+            "path": [
+              "form",
+              "control",
+              "checked",
+              "surface-color",
+              "hover"
+            ]
+          }
+        },
+        "border-color": {
+          "default": {
+            "value": "#0c56e9",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.blue-300.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-checked-border-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "checked",
+              "subitem": "border-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "control",
+              "checked",
+              "border-color",
+              "default"
+            ]
+          },
+          "hover": {
+            "value": "#0046d1",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.blue-400.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-checked-border-color-hover",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "checked",
+              "subitem": "border-color",
+              "state": "hover"
+            },
+            "path": [
+              "form",
+              "control",
+              "checked",
+              "border-color",
+              "hover"
+            ]
+          }
+        }
+      },
+      "invalid": {
+        "border-color": {
+          "default": {
+            "value": "#c00005",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.red-300.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-invalid-border-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "invalid",
+              "subitem": "border-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "control",
+              "invalid",
+              "border-color",
+              "default"
+            ]
+          },
+          "hover": {
+            "value": "#940004",
+            "type": "color",
+            "group": "components",
+            "filePath": "src/products/shared/form/generic-control/colors.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.red-400.value}",
+              "type": "color",
+              "group": "components"
+            },
+            "name": "token-form-control-invalid-border-color-hover",
+            "attributes": {
+              "category": "form",
+              "type": "control",
+              "item": "invalid",
+              "subitem": "border-color",
+              "state": "hover"
+            },
+            "path": [
+              "form",
+              "control",
+              "invalid",
+              "border-color",
+              "hover"
+            ]
+          }
+        }
+      },
+      "readonly": {
+        "foreground-color": {
+          "value": "#3b3d45",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.foreground.primary.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-readonly-foreground-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "readonly",
+            "subitem": "foreground-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "readonly",
+            "foreground-color"
+          ]
+        },
+        "surface-color": {
+          "value": "#f1f2f3",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.surface.strong.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-readonly-surface-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "readonly",
+            "subitem": "surface-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "readonly",
+            "surface-color"
+          ]
+        },
+        "border-color": {
+          "value": "#656a761a",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.border.faint.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-readonly-border-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "readonly",
+            "subitem": "border-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "readonly",
+            "border-color"
+          ]
+        }
+      },
+      "disabled": {
+        "foreground-color": {
+          "value": "#8c909c",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.foreground.disabled.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-disabled-foreground-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "disabled",
+            "subitem": "foreground-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "disabled",
+            "foreground-color"
+          ]
+        },
+        "surface-color": {
+          "value": "#fafafa",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.surface.interactive-disabled.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-disabled-surface-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "disabled",
+            "subitem": "surface-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "disabled",
+            "surface-color"
+          ]
+        },
+        "border-color": {
+          "value": "#656a7633",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/form/generic-control/colors.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.border.primary.value}",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-form-control-disabled-border-color",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "disabled",
+            "subitem": "border-color"
+          },
+          "path": [
+            "form",
+            "control",
+            "disabled",
+            "border-color"
+          ]
+        }
+      },
+      "padding": {
+        "value": "7px",
+        "type": "size",
+        "comment": "Notice: we have to take in account the border, so it's 1px less than in Figma.",
+        "filePath": "src/products/shared/form/generic-control/sizing.json",
+        "isSource": true,
+        "original": {
+          "value": "7",
+          "type": "size",
+          "comment": "Notice: we have to take in account the border, so it's 1px less than in Figma."
+        },
+        "name": "token-form-control-padding",
+        "attributes": {
+          "category": "form",
+          "type": "control",
+          "item": "padding"
+        },
+        "path": [
+          "form",
+          "control",
+          "padding"
+        ]
+      },
+      "border": {
+        "radius": {
+          "value": "5px",
+          "type": "size",
+          "filePath": "src/products/shared/form/generic-control/sizing.json",
+          "isSource": true,
+          "original": {
+            "value": "5",
+            "type": "size"
+          },
+          "name": "token-form-control-border-radius",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "border",
+            "subitem": "radius"
+          },
+          "path": [
+            "form",
+            "control",
+            "border",
+            "radius"
+          ]
+        },
+        "width": {
+          "value": "1px",
+          "type": "size",
+          "filePath": "src/products/shared/form/generic-control/sizing.json",
+          "isSource": true,
+          "original": {
+            "value": "1",
+            "type": "size"
+          },
+          "name": "token-form-control-border-width",
+          "attributes": {
+            "category": "form",
+            "type": "control",
+            "item": "border",
+            "subitem": "width"
+          },
+          "path": [
+            "form",
+            "control",
+            "border",
+            "width"
+          ]
+        }
+      }
+    },
+    "radio": {
+      "size": {
+        "value": "16px",
+        "type": "size",
+        "filePath": "src/products/shared/form/radio.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "size"
+        },
+        "name": "token-form-radio-size",
+        "attributes": {
+          "category": "form",
+          "type": "radio",
+          "item": "size"
+        },
+        "path": [
+          "form",
+          "radio",
+          "size"
+        ]
+      },
+      "border": {
+        "width": {
+          "value": "1px",
+          "type": "size",
+          "filePath": "src/products/shared/form/radio.json",
+          "isSource": true,
+          "original": {
+            "value": "1",
+            "type": "size"
+          },
+          "name": "token-form-radio-border-width",
+          "attributes": {
+            "category": "form",
+            "type": "radio",
+            "item": "border",
+            "subitem": "width"
+          },
+          "path": [
+            "form",
+            "radio",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "background-image": {
+        "size": {
+          "value": "12px",
+          "type": "size",
+          "filePath": "src/products/shared/form/radio.json",
+          "isSource": true,
+          "original": {
+            "value": "12",
+            "type": "size"
+          },
+          "name": "token-form-radio-background-image-size",
+          "attributes": {
+            "category": "form",
+            "type": "radio",
+            "item": "background-image",
+            "subitem": "size"
+          },
+          "path": [
+            "form",
+            "radio",
+            "background-image",
+            "size"
+          ]
+        },
+        "data-url": {
+          "value": "url(\"data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%23ffffff'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'dot' color is hardcoded here!",
+          "filePath": "src/products/shared/form/radio.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%23ffffff'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'dot' color is hardcoded here!"
+          },
+          "name": "token-form-radio-background-image-data-url",
+          "attributes": {
+            "category": "form",
+            "type": "radio",
+            "item": "background-image",
+            "subitem": "data-url"
+          },
+          "path": [
+            "form",
+            "radio",
+            "background-image",
+            "data-url"
+          ]
+        },
+        "data-url-disabled": {
+          "value": "url(\"data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%238C909C'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'dot' color is hardcoded here!",
+          "filePath": "src/products/shared/form/radio.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='6' cy='6' r='2.5' fill='%238C909C'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'dot' color is hardcoded here!"
+          },
+          "name": "token-form-radio-background-image-data-url-disabled",
+          "attributes": {
+            "category": "form",
+            "type": "radio",
+            "item": "background-image",
+            "subitem": "data-url-disabled"
+          },
+          "path": [
+            "form",
+            "radio",
+            "background-image",
+            "data-url-disabled"
+          ]
+        }
+      }
+    },
+    "radiocard-group": {
+      "gap": {
+        "value": "16px",
+        "type": "size",
+        "filePath": "src/products/shared/form/radiocard.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "size"
+        },
+        "name": "token-form-radiocard-group-gap",
+        "attributes": {
+          "category": "form",
+          "type": "radiocard-group",
+          "item": "gap"
+        },
+        "path": [
+          "form",
+          "radiocard-group",
+          "gap"
+        ]
+      }
+    },
+    "radiocard": {
+      "border": {
+        "width": {
+          "value": "1px",
+          "type": "size",
+          "filePath": "src/products/shared/form/radiocard.json",
+          "isSource": true,
+          "original": {
+            "value": "1",
+            "type": "size"
+          },
+          "name": "token-form-radiocard-border-width",
+          "attributes": {
+            "category": "form",
+            "type": "radiocard",
+            "item": "border",
+            "subitem": "width"
+          },
+          "path": [
+            "form",
+            "radiocard",
+            "border",
+            "width"
+          ]
+        },
+        "radius": {
+          "value": "6px",
+          "type": "size",
+          "filePath": "src/products/shared/form/radiocard.json",
+          "isSource": true,
+          "original": {
+            "value": "6",
+            "type": "size"
+          },
+          "name": "token-form-radiocard-border-radius",
+          "attributes": {
+            "category": "form",
+            "type": "radiocard",
+            "item": "border",
+            "subitem": "radius"
+          },
+          "path": [
+            "form",
+            "radiocard",
+            "border",
+            "radius"
+          ]
+        }
+      },
+      "content-padding": {
+        "value": "24px",
+        "type": "size",
+        "filePath": "src/products/shared/form/radiocard.json",
+        "isSource": true,
+        "original": {
+          "value": "24",
+          "type": "size"
+        },
+        "name": "token-form-radiocard-content-padding",
+        "attributes": {
+          "category": "form",
+          "type": "radiocard",
+          "item": "content-padding"
+        },
+        "path": [
+          "form",
+          "radiocard",
+          "content-padding"
+        ]
+      },
+      "control-padding": {
+        "value": "8px",
+        "type": "size",
+        "filePath": "src/products/shared/form/radiocard.json",
+        "isSource": true,
+        "original": {
+          "value": "8",
+          "type": "size"
+        },
+        "name": "token-form-radiocard-control-padding",
+        "attributes": {
+          "category": "form",
+          "type": "radiocard",
+          "item": "control-padding"
+        },
+        "path": [
+          "form",
+          "radiocard",
+          "control-padding"
+        ]
+      },
+      "transition": {
+        "duration": {
+          "value": "0.2s",
+          "type": "time",
+          "unit": "s",
+          "filePath": "src/products/shared/form/radiocard.json",
+          "isSource": true,
+          "original": {
+            "value": "0.2",
+            "type": "time",
+            "unit": "s"
+          },
+          "name": "token-form-radiocard-transition-duration",
+          "attributes": {
+            "category": "form",
+            "type": "radiocard",
+            "item": "transition",
+            "subitem": "duration"
+          },
+          "path": [
+            "form",
+            "radiocard",
+            "transition",
+            "duration"
+          ]
+        }
+      }
+    },
+    "select": {
+      "background-image": {
+        "size": {
+          "value": "16px",
+          "type": "size",
+          "filePath": "src/products/shared/form/select.json",
+          "isSource": true,
+          "original": {
+            "value": "16",
+            "type": "size"
+          },
+          "name": "token-form-select-background-image-size",
+          "attributes": {
+            "category": "form",
+            "type": "select",
+            "item": "background-image",
+            "subitem": "size"
+          },
+          "path": [
+            "form",
+            "select",
+            "background-image",
+            "size"
+          ]
+        },
+        "position-right-x": {
+          "value": "7px",
+          "type": "size",
+          "filePath": "src/products/shared/form/select.json",
+          "isSource": true,
+          "original": {
+            "value": "{form.control.padding.value}",
+            "type": "size"
+          },
+          "name": "token-form-select-background-image-position-right-x",
+          "attributes": {
+            "category": "form",
+            "type": "select",
+            "item": "background-image",
+            "subitem": "position-right-x"
+          },
+          "path": [
+            "form",
+            "select",
+            "background-image",
+            "position-right-x"
+          ]
+        },
+        "position-top-y": {
+          "value": "9px",
+          "type": "size",
+          "filePath": "src/products/shared/form/select.json",
+          "isSource": true,
+          "original": {
+            "value": "9",
+            "type": "size"
+          },
+          "name": "token-form-select-background-image-position-top-y",
+          "attributes": {
+            "category": "form",
+            "type": "select",
+            "item": "background-image",
+            "subitem": "position-top-y"
+          },
+          "path": [
+            "form",
+            "select",
+            "background-image",
+            "position-top-y"
+          ]
+        },
+        "data-url": {
+          "value": "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.55 2.24a.75.75 0 0 0-1.1 0L4.2 5.74a.75.75 0 1 0 1.1 1.02L8 3.852l2.7 2.908a.75.75 0 1 0 1.1-1.02l-3.25-3.5Zm-1.1 11.52a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02L8 12.148 5.3 9.24a.75.75 0 0 0-1.1 1.02l3.25 3.5Z' fill='%23656A76'/%3E%3C/svg%3E\")",
+          "comment": "notice: the 'caret' color is hardcoded here!",
+          "filePath": "src/products/shared/form/select.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.55 2.24a.75.75 0 0 0-1.1 0L4.2 5.74a.75.75 0 1 0 1.1 1.02L8 3.852l2.7 2.908a.75.75 0 1 0 1.1-1.02l-3.25-3.5Zm-1.1 11.52a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02L8 12.148 5.3 9.24a.75.75 0 0 0-1.1 1.02l3.25 3.5Z' fill='%23656A76'/%3E%3C/svg%3E\")",
+            "comment": "notice: the 'caret' color is hardcoded here!"
+          },
+          "name": "token-form-select-background-image-data-url",
+          "attributes": {
+            "category": "form",
+            "type": "select",
+            "item": "background-image",
+            "subitem": "data-url"
+          },
+          "path": [
+            "form",
+            "select",
+            "background-image",
+            "data-url"
+          ]
+        },
+        "data-url-disabled": {
+          "value": "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.55 2.24a.75.75 0 0 0-1.1 0L4.2 5.74a.75.75 0 1 0 1.1 1.02L8 3.852l2.7 2.908a.75.75 0 1 0 1.1-1.02l-3.25-3.5Zm-1.1 11.52a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02L8 12.148 5.3 9.24a.75.75 0 0 0-1.1 1.02l3.25 3.5Z' fill='%238C909C'/%3E%3C/svg%3E\")",
+          "comment": "notice: the 'caret' color is hardcoded here!",
+          "filePath": "src/products/shared/form/select.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.55 2.24a.75.75 0 0 0-1.1 0L4.2 5.74a.75.75 0 1 0 1.1 1.02L8 3.852l2.7 2.908a.75.75 0 1 0 1.1-1.02l-3.25-3.5Zm-1.1 11.52a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02L8 12.148 5.3 9.24a.75.75 0 0 0-1.1 1.02l3.25 3.5Z' fill='%238C909C'/%3E%3C/svg%3E\")",
+            "comment": "notice: the 'caret' color is hardcoded here!"
+          },
+          "name": "token-form-select-background-image-data-url-disabled",
+          "attributes": {
+            "category": "form",
+            "type": "select",
+            "item": "background-image",
+            "subitem": "data-url-disabled"
+          },
+          "path": [
+            "form",
+            "select",
+            "background-image",
+            "data-url-disabled"
+          ]
+        }
+      }
+    },
+    "text-input": {
+      "background-image": {
+        "size": {
+          "value": "16px",
+          "type": "size",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "16",
+            "type": "size"
+          },
+          "name": "token-form-text-input-background-image-size",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "size"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "size"
+          ]
+        },
+        "position-x": {
+          "value": "7px",
+          "type": "size",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "{form.control.padding.value}",
+            "type": "size"
+          },
+          "name": "token-form-text-input-background-image-position-x",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "position-x"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "position-x"
+          ]
+        },
+        "data-url-date": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M11.5.75a.75.75 0 00-1.5 0V1H6V.75a.75.75 0 00-1.5 0V1H3.25A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1H11.5V.75zm-7 2.5V2.5H3.25a.75.75 0 00-.75.75V5h11V3.25a.75.75 0 00-.75-.75H11.5v.75a.75.75 0 01-1.5 0V2.5H6v.75a.75.75 0 01-1.5 0zm9 3.25h-11v6.25c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V6.5z' fill-rule='evenodd' clip-rule='evenodd' fill='%233B3D45'/%3e%3c/svg%3e\")",
+          "comment": "notice: the icon color is hardcoded here!",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M11.5.75a.75.75 0 00-1.5 0V1H6V.75a.75.75 0 00-1.5 0V1H3.25A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1H11.5V.75zm-7 2.5V2.5H3.25a.75.75 0 00-.75.75V5h11V3.25a.75.75 0 00-.75-.75H11.5v.75a.75.75 0 01-1.5 0V2.5H6v.75a.75.75 0 01-1.5 0zm9 3.25h-11v6.25c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V6.5z' fill-rule='evenodd' clip-rule='evenodd' fill='%233B3D45'/%3e%3c/svg%3e\")",
+            "comment": "notice: the icon color is hardcoded here!"
+          },
+          "name": "token-form-text-input-background-image-data-url-date",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "data-url-date"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "data-url-date"
+          ]
+        },
+        "data-url-time": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%233B3D45'%3e%3cpath d='M8.5 3.75a.75.75 0 00-1.5 0V8c0 .284.16.544.415.67l2.5 1.25a.75.75 0 10.67-1.34L8.5 7.535V3.75z'/%3e%3cpath d='M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e\")",
+          "comment": "notice: the icon color is hardcoded here!",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%233B3D45'%3e%3cpath d='M8.5 3.75a.75.75 0 00-1.5 0V8c0 .284.16.544.415.67l2.5 1.25a.75.75 0 10.67-1.34L8.5 7.535V3.75z'/%3e%3cpath d='M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e\")",
+            "comment": "notice: the icon color is hardcoded here!"
+          },
+          "name": "token-form-text-input-background-image-data-url-time",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "data-url-time"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "data-url-time"
+          ]
+        },
+        "data-url-search": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%23656A76'%3e%3cpath d='M7.25 2a5.25 5.25 0 103.144 9.455l2.326 2.325a.75.75 0 101.06-1.06l-2.325-2.326A5.25 5.25 0 007.25 2zM3.5 7.25a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e\")",
+          "comment": "notice: the icon color is hardcoded here!",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%23656A76'%3e%3cpath d='M7.25 2a5.25 5.25 0 103.144 9.455l2.326 2.325a.75.75 0 101.06-1.06l-2.325-2.326A5.25 5.25 0 007.25 2zM3.5 7.25a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e\")",
+            "comment": "notice: the icon color is hardcoded here!"
+          },
+          "name": "token-form-text-input-background-image-data-url-search",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "data-url-search"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "data-url-search"
+          ]
+        },
+        "data-url-search-cancel": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3e%3c/svg%3e\")",
+          "comment": "notice: the icon color is hardcoded here!",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z'/%3e%3c/svg%3e\")",
+            "comment": "notice: the icon color is hardcoded here!"
+          },
+          "name": "token-form-text-input-background-image-data-url-search-cancel",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "data-url-search-cancel"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "data-url-search-cancel"
+          ]
+        },
+        "data-url-search-loading": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e\")",
+          "comment": "notice: the icon color and animation are hardcoded here!",
+          "filePath": "src/products/shared/form/text-input.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' %3e%3cg fill='%23656A76' fill-rule='evenodd' clip-rule='evenodd'%3e%3canimateTransform attributeName='transform' type='rotate' dur='0.9s' from='0 8 8' to='360 8 8' repeatCount='indefinite'/%3e%3cpath d='M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z' opacity='.2'/%3e%3cpath d='M7.25.75A.75.75 0 018 0a8 8 0 018 8 .75.75 0 01-1.5 0A6.5 6.5 0 008 1.5a.75.75 0 01-.75-.75z'/%3e%3c/g%3e%3c/svg%3e\")",
+            "comment": "notice: the icon color and animation are hardcoded here!"
+          },
+          "name": "token-form-text-input-background-image-data-url-search-loading",
+          "attributes": {
+            "category": "form",
+            "type": "text-input",
+            "item": "background-image",
+            "subitem": "data-url-search-loading"
+          },
+          "path": [
+            "form",
+            "text-input",
+            "background-image",
+            "data-url-search-loading"
+          ]
+        }
+      }
+    },
+    "toggle": {
+      "width": {
+        "value": "32px",
+        "type": "size",
+        "filePath": "src/products/shared/form/toggle.json",
+        "isSource": true,
+        "original": {
+          "value": "32",
+          "type": "size"
+        },
+        "name": "token-form-toggle-width",
+        "attributes": {
+          "category": "form",
+          "type": "toggle",
+          "item": "width"
+        },
+        "path": [
+          "form",
+          "toggle",
+          "width"
+        ]
+      },
+      "height": {
+        "value": "16px",
+        "type": "size",
+        "filePath": "src/products/shared/form/toggle.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "size"
+        },
+        "name": "token-form-toggle-height",
+        "attributes": {
+          "category": "form",
+          "type": "toggle",
+          "item": "height"
+        },
+        "path": [
+          "form",
+          "toggle",
+          "height"
+        ]
+      },
+      "base": {
+        "surface-color": {
+          "default": {
+            "value": "#f1f2f3",
+            "type": "color",
+            "group": "components",
+            "comment": "the toggle has a different base surface color, compared to the other controls",
+            "filePath": "src/products/shared/form/toggle.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.surface.strong.value}",
+              "type": "color",
+              "group": "components",
+              "comment": "the toggle has a different base surface color, compared to the other controls"
+            },
+            "name": "token-form-toggle-base-surface-color-default",
+            "attributes": {
+              "category": "form",
+              "type": "toggle",
+              "item": "base",
+              "subitem": "surface-color",
+              "state": "default"
+            },
+            "path": [
+              "form",
+              "toggle",
+              "base",
+              "surface-color",
+              "default"
+            ]
+          }
+        }
+      },
+      "border": {
+        "radius": {
+          "value": "3px",
+          "type": "size",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "3",
+            "type": "size"
+          },
+          "name": "token-form-toggle-border-radius",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "border",
+            "subitem": "radius"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "border",
+            "radius"
+          ]
+        },
+        "width": {
+          "value": "1px",
+          "type": "size",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "1",
+            "type": "size"
+          },
+          "name": "token-form-toggle-border-width",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "border",
+            "subitem": "width"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "background-image": {
+        "size": {
+          "value": "12px",
+          "type": "size",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "12",
+            "type": "size"
+          },
+          "name": "token-form-toggle-background-image-size",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "background-image",
+            "subitem": "size"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "background-image",
+            "size"
+          ]
+        },
+        "position-x": {
+          "value": "2px",
+          "type": "size",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "2",
+            "type": "size"
+          },
+          "name": "token-form-toggle-background-image-position-x",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "background-image",
+            "subitem": "position-x"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "background-image",
+            "position-x"
+          ]
+        },
+        "data-url": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%23FFF'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'tick' color is hardcoded here!",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%23FFF'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'tick' color is hardcoded here!"
+          },
+          "name": "token-form-toggle-background-image-data-url",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "background-image",
+            "subitem": "data-url"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "background-image",
+            "data-url"
+          ]
+        },
+        "data-url-disabled": {
+          "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%238C909C'/%3e%3c/svg%3e\")",
+          "comment": "notice: the 'tick' color is hardcoded here!",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "url(\"data:image/svg+xml,%3csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L5.28033 8.78033C4.98744 9.07322 4.51256 9.07322 4.21967 8.78033L2.21967 6.78033C1.92678 6.48744 1.92678 6.01256 2.21967 5.71967C2.51256 5.42678 2.98744 5.42678 3.28033 5.71967L4.75 7.18934L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967Z' fill='%238C909C'/%3e%3c/svg%3e\")",
+            "comment": "notice: the 'tick' color is hardcoded here!"
+          },
+          "name": "token-form-toggle-background-image-data-url-disabled",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "background-image",
+            "subitem": "data-url-disabled"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "background-image",
+            "data-url-disabled"
+          ]
+        }
+      },
+      "transition": {
+        "duration": {
+          "value": "0.2s",
+          "type": "time",
+          "unit": "s",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "0.2",
+            "type": "time",
+            "unit": "s"
+          },
+          "name": "token-form-toggle-transition-duration",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "transition",
+            "subitem": "duration"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "transition",
+            "duration"
+          ]
+        },
+        "timing-function": {
+          "value": "cubic-bezier(0.68, -0.2, 0.265, 1.15)",
+          "filePath": "src/products/shared/form/toggle.json",
+          "isSource": true,
+          "original": {
+            "value": "cubic-bezier(0.68, -0.2, 0.265, 1.15)"
+          },
+          "name": "token-form-toggle-transition-timing-function",
+          "attributes": {
+            "category": "form",
+            "type": "toggle",
+            "item": "transition",
+            "subitem": "timing-function"
+          },
+          "path": [
+            "form",
+            "toggle",
+            "transition",
+            "timing-function"
+          ]
+        }
+      },
+      "thumb-size": {
+        "value": "16px",
+        "type": "size",
+        "filePath": "src/products/shared/form/toggle.json",
+        "isSource": true,
+        "original": {
+          "value": "{form.toggle.height.value}",
+          "type": "size"
+        },
+        "name": "token-form-toggle-thumb-size",
+        "attributes": {
+          "category": "form",
+          "type": "toggle",
+          "item": "thumb-size"
+        },
+        "path": [
+          "form",
+          "toggle",
+          "thumb-size"
+        ]
+      }
+    }
+  },
+  "pagination": {
+    "nav": {
+      "control": {
+        "height": {
+          "value": "36px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "36",
+            "type": "size"
+          },
+          "name": "token-pagination-nav-control-height",
+          "attributes": {
+            "category": "pagination",
+            "type": "nav",
+            "item": "control",
+            "subitem": "height"
+          },
+          "path": [
+            "pagination",
+            "nav",
+            "control",
+            "height"
+          ]
+        },
+        "padding": {
+          "horizontal": {
+            "value": "12px",
+            "type": "size",
+            "filePath": "src/products/shared/pagination.json",
+            "isSource": true,
+            "original": {
+              "value": "12",
+              "type": "size"
+            },
+            "name": "token-pagination-nav-control-padding-horizontal",
+            "attributes": {
+              "category": "pagination",
+              "type": "nav",
+              "item": "control",
+              "subitem": "padding",
+              "state": "horizontal"
+            },
+            "path": [
+              "pagination",
+              "nav",
+              "control",
+              "padding",
+              "horizontal"
+            ]
+          }
+        },
+        "focus-inset": {
+          "value": "4px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "4",
+            "type": "size"
+          },
+          "name": "token-pagination-nav-control-focus-inset",
+          "attributes": {
+            "category": "pagination",
+            "type": "nav",
+            "item": "control",
+            "subitem": "focus-inset"
+          },
+          "path": [
+            "pagination",
+            "nav",
+            "control",
+            "focus-inset"
+          ]
+        },
+        "icon-spacing": {
+          "value": "6px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "6",
+            "type": "size"
+          },
+          "name": "token-pagination-nav-control-icon-spacing",
+          "attributes": {
+            "category": "pagination",
+            "type": "nav",
+            "item": "control",
+            "subitem": "icon-spacing"
+          },
+          "path": [
+            "pagination",
+            "nav",
+            "control",
+            "icon-spacing"
+          ]
+        }
+      },
+      "indicator": {
+        "height": {
+          "value": "2px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "2",
+            "type": "size"
+          },
+          "name": "token-pagination-nav-indicator-height",
+          "attributes": {
+            "category": "pagination",
+            "type": "nav",
+            "item": "indicator",
+            "subitem": "height"
+          },
+          "path": [
+            "pagination",
+            "nav",
+            "indicator",
+            "height"
+          ]
+        },
+        "spacing": {
+          "value": "6px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "6",
+            "type": "size"
+          },
+          "name": "token-pagination-nav-indicator-spacing",
+          "attributes": {
+            "category": "pagination",
+            "type": "nav",
+            "item": "indicator",
+            "subitem": "spacing"
+          },
+          "path": [
+            "pagination",
+            "nav",
+            "indicator",
+            "spacing"
+          ]
+        }
+      }
+    },
+    "child": {
+      "spacing": {
+        "vertical": {
+          "value": "8px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "8",
+            "type": "size"
+          },
+          "name": "token-pagination-child-spacing-vertical",
+          "attributes": {
+            "category": "pagination",
+            "type": "child",
+            "item": "spacing",
+            "subitem": "vertical"
+          },
+          "path": [
+            "pagination",
+            "child",
+            "spacing",
+            "vertical"
+          ]
+        },
+        "horizontal": {
+          "value": "20px",
+          "type": "size",
+          "filePath": "src/products/shared/pagination.json",
+          "isSource": true,
+          "original": {
+            "value": "20",
+            "type": "size"
+          },
+          "name": "token-pagination-child-spacing-horizontal",
+          "attributes": {
+            "category": "pagination",
+            "type": "child",
+            "item": "spacing",
+            "subitem": "horizontal"
+          },
+          "path": [
+            "pagination",
+            "child",
+            "spacing",
+            "horizontal"
+          ]
+        }
+      }
+    }
+  },
+  "side-nav": {
+    "wrapper": {
+      "padding": {
+        "horizontal": {
+          "value": "16px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "16",
+            "type": "size"
+          },
+          "name": "token-side-nav-wrapper-padding-horizontal",
+          "attributes": {
+            "category": "side-nav",
+            "type": "wrapper",
+            "item": "padding",
+            "subitem": "horizontal"
+          },
+          "path": [
+            "side-nav",
+            "wrapper",
+            "padding",
+            "horizontal"
+          ]
+        },
+        "vertical": {
+          "value": "16px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "16",
+            "type": "size"
+          },
+          "name": "token-side-nav-wrapper-padding-vertical",
+          "attributes": {
+            "category": "side-nav",
+            "type": "wrapper",
+            "item": "padding",
+            "subitem": "vertical"
+          },
+          "path": [
+            "side-nav",
+            "wrapper",
+            "padding",
+            "vertical"
+          ]
+        }
+      }
+    },
+    "header": {
+      "home-link": {
+        "padding": {
+          "value": "4px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "4",
+            "type": "size"
+          },
+          "name": "token-side-nav-header-home-link-padding",
+          "attributes": {
+            "category": "side-nav",
+            "type": "header",
+            "item": "home-link",
+            "subitem": "padding"
+          },
+          "path": [
+            "side-nav",
+            "header",
+            "home-link",
+            "padding"
+          ]
+        },
+        "logo-size": {
+          "value": "48px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "48",
+            "type": "size"
+          },
+          "name": "token-side-nav-header-home-link-logo-size",
+          "attributes": {
+            "category": "side-nav",
+            "type": "header",
+            "item": "home-link",
+            "subitem": "logo-size"
+          },
+          "path": [
+            "side-nav",
+            "header",
+            "home-link",
+            "logo-size"
+          ]
+        }
+      },
+      "actions": {
+        "spacing": {
+          "value": "8px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "8",
+            "type": "size"
+          },
+          "name": "token-side-nav-header-actions-spacing",
+          "attributes": {
+            "category": "side-nav",
+            "type": "header",
+            "item": "actions",
+            "subitem": "spacing"
+          },
+          "path": [
+            "side-nav",
+            "header",
+            "actions",
+            "spacing"
+          ]
+        }
+      }
+    },
+    "body": {
+      "list": {
+        "margin-vertical": {
+          "value": "24px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "24",
+            "type": "size"
+          },
+          "name": "token-side-nav-body-list-margin-vertical",
+          "attributes": {
+            "category": "side-nav",
+            "type": "body",
+            "item": "list",
+            "subitem": "margin-vertical"
+          },
+          "path": [
+            "side-nav",
+            "body",
+            "list",
+            "margin-vertical"
+          ]
+        }
+      },
+      "list-item": {
+        "height": {
+          "value": "36px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "36",
+            "type": "size"
+          },
+          "name": "token-side-nav-body-list-item-height",
+          "attributes": {
+            "category": "side-nav",
+            "type": "body",
+            "item": "list-item",
+            "subitem": "height"
+          },
+          "path": [
+            "side-nav",
+            "body",
+            "list-item",
+            "height"
+          ]
+        },
+        "padding": {
+          "horizontal": {
+            "value": "8px",
+            "type": "size",
+            "filePath": "src/products/shared/side-nav.json",
+            "isSource": true,
+            "original": {
+              "value": "8",
+              "type": "size"
+            },
+            "name": "token-side-nav-body-list-item-padding-horizontal",
+            "attributes": {
+              "category": "side-nav",
+              "type": "body",
+              "item": "list-item",
+              "subitem": "padding",
+              "state": "horizontal"
+            },
+            "path": [
+              "side-nav",
+              "body",
+              "list-item",
+              "padding",
+              "horizontal"
+            ]
+          },
+          "vertical": {
+            "value": "4px",
+            "type": "size",
+            "filePath": "src/products/shared/side-nav.json",
+            "isSource": true,
+            "original": {
+              "value": "4",
+              "type": "size"
+            },
+            "name": "token-side-nav-body-list-item-padding-vertical",
+            "attributes": {
+              "category": "side-nav",
+              "type": "body",
+              "item": "list-item",
+              "subitem": "padding",
+              "state": "vertical"
+            },
+            "path": [
+              "side-nav",
+              "body",
+              "list-item",
+              "padding",
+              "vertical"
+            ]
+          }
+        },
+        "spacing-vertical": {
+          "value": "2px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "2",
+            "type": "size"
+          },
+          "name": "token-side-nav-body-list-item-spacing-vertical",
+          "attributes": {
+            "category": "side-nav",
+            "type": "body",
+            "item": "list-item",
+            "subitem": "spacing-vertical"
+          },
+          "path": [
+            "side-nav",
+            "body",
+            "list-item",
+            "spacing-vertical"
+          ]
+        },
+        "content-spacing-horizontal": {
+          "value": "8px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "8",
+            "type": "size"
+          },
+          "name": "token-side-nav-body-list-item-content-spacing-horizontal",
+          "attributes": {
+            "category": "side-nav",
+            "type": "body",
+            "item": "list-item",
+            "subitem": "content-spacing-horizontal"
+          },
+          "path": [
+            "side-nav",
+            "body",
+            "list-item",
+            "content-spacing-horizontal"
+          ]
+        },
+        "border-radius": {
+          "value": "5px",
+          "type": "size",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "5",
+            "type": "size"
+          },
+          "name": "token-side-nav-body-list-item-border-radius",
+          "attributes": {
+            "category": "side-nav",
+            "type": "body",
+            "item": "list-item",
+            "subitem": "border-radius"
+          },
+          "path": [
+            "side-nav",
+            "body",
+            "list-item",
+            "border-radius"
+          ]
+        }
+      }
+    },
+    "color": {
+      "foreground": {
+        "primary": {
+          "value": "#dedfe3",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#dedfe3",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-side-nav-color-foreground-primary",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "foreground",
+            "subitem": "primary"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "foreground",
+            "primary"
+          ]
+        },
+        "strong": {
+          "value": "#fff",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#fff",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-side-nav-color-foreground-strong",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "foreground",
+            "subitem": "strong"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "foreground",
+            "strong"
+          ]
+        },
+        "faint": {
+          "value": "#8c909c",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#8c909c",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-side-nav-color-foreground-faint",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "foreground",
+            "subitem": "faint"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "foreground",
+            "faint"
+          ]
+        }
+      },
+      "surface": {
+        "primary": {
+          "value": "#0c0c0e",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#0c0c0e",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-side-nav-color-surface-primary",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "surface",
+            "subitem": "primary"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "surface",
+            "primary"
+          ]
+        },
+        "interactive-hover": {
+          "value": "#3b3d45",
+          "type": "color",
+          "group": "semantic",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#3b3d45",
+            "type": "color",
+            "group": "semantic"
+          },
+          "name": "token-side-nav-color-surface-interactive-hover",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "surface",
+            "subitem": "interactive-hover"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "surface",
+            "interactive-hover"
+          ]
+        },
+        "interactive-active": {
+          "value": "#656a76",
+          "type": "color",
+          "group": "semantic",
+          "filePath": "src/products/shared/side-nav.json",
+          "isSource": true,
+          "original": {
+            "value": "#656a76",
+            "type": "color",
+            "group": "semantic"
+          },
+          "name": "token-side-nav-color-surface-interactive-active",
+          "attributes": {
+            "category": "side-nav",
+            "type": "color",
+            "item": "surface",
+            "subitem": "interactive-active"
+          },
+          "path": [
+            "side-nav",
+            "color",
+            "surface",
+            "interactive-active"
+          ]
+        }
+      }
+    }
+  },
+  "tabs": {
+    "tab": {
+      "height": {
+        "value": "36px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "36",
+          "type": "size"
+        },
+        "name": "token-tabs-tab-height",
+        "attributes": {
+          "category": "tabs",
+          "type": "tab",
+          "item": "height"
+        },
+        "path": [
+          "tabs",
+          "tab",
+          "height"
+        ]
+      },
+      "padding": {
+        "horizontal": {
+          "value": "12px",
+          "type": "size",
+          "filePath": "src/products/shared/tabs.json",
+          "isSource": true,
+          "original": {
+            "value": "12",
+            "type": "size"
+          },
+          "name": "token-tabs-tab-padding-horizontal",
+          "attributes": {
+            "category": "tabs",
+            "type": "tab",
+            "item": "padding",
+            "subitem": "horizontal"
+          },
+          "path": [
+            "tabs",
+            "tab",
+            "padding",
+            "horizontal"
+          ]
+        },
+        "vertical": {
+          "value": "0px",
+          "type": "size",
+          "filePath": "src/products/shared/tabs.json",
+          "isSource": true,
+          "original": {
+            "value": "0",
+            "type": "size"
+          },
+          "name": "token-tabs-tab-padding-vertical",
+          "attributes": {
+            "category": "tabs",
+            "type": "tab",
+            "item": "padding",
+            "subitem": "vertical"
+          },
+          "path": [
+            "tabs",
+            "tab",
+            "padding",
+            "vertical"
+          ]
+        }
+      },
+      "border-radius": {
+        "value": "5px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "5",
+          "type": "size"
+        },
+        "name": "token-tabs-tab-border-radius",
+        "attributes": {
+          "category": "tabs",
+          "type": "tab",
+          "item": "border-radius"
+        },
+        "path": [
+          "tabs",
+          "tab",
+          "border-radius"
+        ]
+      },
+      "focus-inset": {
+        "value": "6px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "6",
+          "type": "size"
+        },
+        "name": "token-tabs-tab-focus-inset",
+        "attributes": {
+          "category": "tabs",
+          "type": "tab",
+          "item": "focus-inset"
+        },
+        "path": [
+          "tabs",
+          "tab",
+          "focus-inset"
+        ]
+      },
+      "gutter": {
+        "value": "6px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "6",
+          "type": "size"
+        },
+        "name": "token-tabs-tab-gutter",
+        "attributes": {
+          "category": "tabs",
+          "type": "tab",
+          "item": "gutter"
+        },
+        "path": [
+          "tabs",
+          "tab",
+          "gutter"
+        ]
+      }
+    },
+    "indicator": {
+      "height": {
+        "value": "3px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "3",
+          "type": "size"
+        },
+        "name": "token-tabs-indicator-height",
+        "attributes": {
+          "category": "tabs",
+          "type": "indicator",
+          "item": "height"
+        },
+        "path": [
+          "tabs",
+          "indicator",
+          "height"
+        ]
+      },
+      "transition": {
+        "function": {
+          "value": "cubic-bezier(0.5, 1, 0.89, 1)",
+          "filePath": "src/products/shared/tabs.json",
+          "isSource": true,
+          "original": {
+            "value": "cubic-bezier(0.5, 1, 0.89, 1)"
+          },
+          "name": "token-tabs-indicator-transition-function",
+          "attributes": {
+            "category": "tabs",
+            "type": "indicator",
+            "item": "transition",
+            "subitem": "function"
+          },
+          "path": [
+            "tabs",
+            "indicator",
+            "transition",
+            "function"
+          ]
+        },
+        "duration": {
+          "value": "0.6s",
+          "type": "time",
+          "unit": "s",
+          "filePath": "src/products/shared/tabs.json",
+          "isSource": true,
+          "original": {
+            "value": "0.6",
+            "type": "time",
+            "unit": "s"
+          },
+          "name": "token-tabs-indicator-transition-duration",
+          "attributes": {
+            "category": "tabs",
+            "type": "indicator",
+            "item": "transition",
+            "subitem": "duration"
+          },
+          "path": [
+            "tabs",
+            "indicator",
+            "transition",
+            "duration"
+          ]
+        }
+      }
+    },
+    "divider": {
+      "height": {
+        "value": "1px",
+        "type": "size",
+        "filePath": "src/products/shared/tabs.json",
+        "isSource": true,
+        "original": {
+          "value": "1",
+          "type": "size"
+        },
+        "name": "token-tabs-divider-height",
+        "attributes": {
+          "category": "tabs",
+          "type": "divider",
+          "item": "height"
+        },
+        "path": [
+          "tabs",
+          "divider",
+          "height"
+        ]
+      }
+    }
+  },
+  "tooltip": {
+    "border-radius": {
+      "value": "5px",
+      "type": "size",
+      "filePath": "src/products/shared/tooltip.json",
+      "isSource": true,
+      "original": {
+        "value": "5",
+        "type": "size"
+      },
+      "name": "token-tooltip-border-radius",
+      "attributes": {
+        "category": "tooltip",
+        "type": "border-radius"
+      },
+      "path": [
+        "tooltip",
+        "border-radius"
+      ]
+    },
+    "color": {
+      "foreground": {
+        "primary": {
+          "value": "var(--token-color-foreground-high-contrast)",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/tooltip.json",
+          "isSource": true,
+          "original": {
+            "value": "var(--token-color-foreground-high-contrast)",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-tooltip-color-foreground-primary",
+          "attributes": {
+            "category": "tooltip",
+            "type": "color",
+            "item": "foreground",
+            "subitem": "primary"
+          },
+          "path": [
+            "tooltip",
+            "color",
+            "foreground",
+            "primary"
+          ]
+        }
+      },
+      "surface": {
+        "primary": {
+          "value": "var(--token-color-palette-neutral-700)",
+          "type": "color",
+          "group": "components",
+          "filePath": "src/products/shared/tooltip.json",
+          "isSource": true,
+          "original": {
+            "value": "var(--token-color-palette-neutral-700)",
+            "type": "color",
+            "group": "components"
+          },
+          "name": "token-tooltip-color-surface-primary",
+          "attributes": {
+            "category": "tooltip",
+            "type": "color",
+            "item": "surface",
+            "subitem": "primary"
+          },
+          "path": [
+            "tooltip",
+            "color",
+            "surface",
+            "primary"
+          ]
+        }
+      }
+    },
+    "focus-offset": {
+      "value": "-2px",
+      "type": "size",
+      "filePath": "src/products/shared/tooltip.json",
+      "isSource": true,
+      "original": {
+        "value": "-2",
+        "type": "size"
+      },
+      "name": "token-tooltip-focus-offset",
+      "attributes": {
+        "category": "tooltip",
+        "type": "focus-offset"
+      },
+      "path": [
+        "tooltip",
+        "focus-offset"
+      ]
+    },
+    "max-width": {
+      "value": "280px",
+      "type": "size",
+      "filePath": "src/products/shared/tooltip.json",
+      "isSource": true,
+      "original": {
+        "value": "280",
+        "type": "size"
+      },
+      "name": "token-tooltip-max-width",
+      "attributes": {
+        "category": "tooltip",
+        "type": "max-width"
+      },
+      "path": [
+        "tooltip",
+        "max-width"
+      ]
+    },
+    "padding": {
+      "horizontal": {
+        "value": "12px",
+        "type": "size",
+        "filePath": "src/products/shared/tooltip.json",
+        "isSource": true,
+        "original": {
+          "value": "12",
+          "type": "size"
+        },
+        "name": "token-tooltip-padding-horizontal",
+        "attributes": {
+          "category": "tooltip",
+          "type": "padding",
+          "item": "horizontal"
+        },
+        "path": [
+          "tooltip",
+          "padding",
+          "horizontal"
+        ]
+      },
+      "vertical": {
+        "value": "8px",
+        "type": "size",
+        "filePath": "src/products/shared/tooltip.json",
+        "isSource": true,
+        "original": {
+          "value": "8",
+          "type": "size"
+        },
+        "name": "token-tooltip-padding-vertical",
+        "attributes": {
+          "category": "tooltip",
+          "type": "padding",
+          "item": "vertical"
+        },
+        "path": [
+          "tooltip",
+          "padding",
+          "vertical"
+        ]
+      }
+    },
+    "transition": {
+      "function": {
+        "value": "cubic-bezier(0.54, 1.5, 0.38, 1.11)",
+        "filePath": "src/products/shared/tooltip.json",
+        "isSource": true,
+        "original": {
+          "value": "cubic-bezier(0.54, 1.5, 0.38, 1.11)"
+        },
+        "name": "token-tooltip-transition-function",
+        "attributes": {
+          "category": "tooltip",
+          "type": "transition",
+          "item": "function"
+        },
+        "path": [
+          "tooltip",
+          "transition",
+          "function"
+        ]
+      }
+    }
+  },
+  "typography": {
+    "font-stack": {
+      "display": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.sans.display.macOS.value}, {typography.font-stack.sans.display.windows.value}, {typography.font-stack.sans.display.sans.value}, {typography.font-stack.sans.display.emoji.value}"
+        },
+        "name": "token-typography-font-stack-display",
+        "attributes": {
+          "category": "typography",
+          "type": "font-stack",
+          "item": "display"
+        },
+        "path": [
+          "typography",
+          "font-stack",
+          "display"
+        ]
+      },
+      "text": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.sans.text.macOS.value}, {typography.font-stack.sans.text.windows.value}, {typography.font-stack.sans.display.sans.value}, {typography.font-stack.sans.text.emoji.value}"
+        },
+        "name": "token-typography-font-stack-text",
+        "attributes": {
+          "category": "typography",
+          "type": "font-stack",
+          "item": "text"
+        },
+        "path": [
+          "typography",
+          "font-stack",
+          "text"
+        ]
+      },
+      "code": {
+        "value": "ui-monospace, Menlo, Consolas, monospace",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.monospace.code.macOS.value}, {typography.font-stack.monospace.code.windows.value}, monospace"
+        },
+        "name": "token-typography-font-stack-code",
+        "attributes": {
+          "category": "typography",
+          "type": "font-stack",
+          "item": "code"
+        },
+        "path": [
+          "typography",
+          "font-stack",
+          "code"
+        ]
+      }
+    },
+    "font-weight": {
+      "regular": {
+        "value": "400",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "400"
+        },
+        "name": "token-typography-font-weight-regular",
+        "attributes": {
+          "category": "typography",
+          "type": "font-weight",
+          "item": "regular"
+        },
+        "path": [
+          "typography",
+          "font-weight",
+          "regular"
+        ]
+      },
+      "medium": {
+        "value": "500",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "500"
+        },
+        "name": "token-typography-font-weight-medium",
+        "attributes": {
+          "category": "typography",
+          "type": "font-weight",
+          "item": "medium"
+        },
+        "path": [
+          "typography",
+          "font-weight",
+          "medium"
+        ]
+      },
+      "semibold": {
+        "value": "600",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "600"
+        },
+        "name": "token-typography-font-weight-semibold",
+        "attributes": {
+          "category": "typography",
+          "type": "font-weight",
+          "item": "semibold"
+        },
+        "path": [
+          "typography",
+          "font-weight",
+          "semibold"
+        ]
+      },
+      "bold": {
+        "value": "700",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "700"
+        },
+        "name": "token-typography-font-weight-bold",
+        "attributes": {
+          "category": "typography",
+          "type": "font-weight",
+          "item": "bold"
+        },
+        "path": [
+          "typography",
+          "font-weight",
+          "bold"
+        ]
+      }
+    },
+    "display-500": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.display.value}"
+        },
+        "name": "token-typography-display-500-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "display-500",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "display-500",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1.875rem",
+        "type": "font-size",
+        "comment": "30px/1.875rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "30",
+          "type": "font-size",
+          "comment": "30px/1.875rem"
+        },
+        "name": "token-typography-display-500-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "display-500",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "display-500",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.2666",
+        "comment": "38px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.2666",
+          "comment": "38px"
+        },
+        "name": "token-typography-display-500-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "display-500",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "display-500",
+          "line-height"
+        ]
+      }
+    },
+    "display-400": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.display.value}"
+        },
+        "name": "token-typography-display-400-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "display-400",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "display-400",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1.5rem",
+        "type": "font-size",
+        "comment": "24px/1.5rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "24",
+          "type": "font-size",
+          "comment": "24px/1.5rem"
+        },
+        "name": "token-typography-display-400-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "display-400",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "display-400",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.3333",
+        "comment": "32px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.3333",
+          "comment": "32px"
+        },
+        "name": "token-typography-display-400-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "display-400",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "display-400",
+          "line-height"
+        ]
+      }
+    },
+    "display-300": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.text.value}"
+        },
+        "name": "token-typography-display-300-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "display-300",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "display-300",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1.125rem",
+        "type": "font-size",
+        "comment": "18px/1.125rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "18",
+          "type": "font-size",
+          "comment": "18px/1.125rem"
+        },
+        "name": "token-typography-display-300-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "display-300",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "display-300",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.3333",
+        "comment": "24px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.3333",
+          "comment": "24px"
+        },
+        "name": "token-typography-display-300-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "display-300",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "display-300",
+          "line-height"
+        ]
+      },
+      "letter-spacing": {
+        "value": "-0.5px",
+        "comment": "this is `tracking`",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "-0.5px",
+          "comment": "this is `tracking`"
+        },
+        "name": "token-typography-display-300-letter-spacing",
+        "attributes": {
+          "category": "typography",
+          "type": "display-300",
+          "item": "letter-spacing"
+        },
+        "path": [
+          "typography",
+          "display-300",
+          "letter-spacing"
+        ]
+      }
+    },
+    "display-200": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.display.value}"
+        },
+        "name": "token-typography-display-200-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "display-200",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "display-200",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1rem",
+        "type": "font-size",
+        "comment": "16px/1rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "font-size",
+          "comment": "16px/1rem"
+        },
+        "name": "token-typography-display-200-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "display-200",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "display-200",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.5",
+        "comment": "24px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.5",
+          "comment": "24px"
+        },
+        "name": "token-typography-display-200-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "display-200",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "display-200",
+          "line-height"
+        ]
+      },
+      "letter-spacing": {
+        "value": "-0.5px",
+        "comment": "this is `tracking`",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "-0.5px",
+          "comment": "this is `tracking`"
+        },
+        "name": "token-typography-display-200-letter-spacing",
+        "attributes": {
+          "category": "typography",
+          "type": "display-200",
+          "item": "letter-spacing"
+        },
+        "path": [
+          "typography",
+          "display-200",
+          "letter-spacing"
+        ]
+      }
+    },
+    "display-100": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.text.value}"
+        },
+        "name": "token-typography-display-100-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "display-100",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "display-100",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "0.8125rem",
+        "type": "font-size",
+        "comment": "13px/0.8125rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "13",
+          "type": "font-size",
+          "comment": "13px/0.8125rem"
+        },
+        "name": "token-typography-display-100-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "display-100",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "display-100",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.3846",
+        "comment": "18px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.3846",
+          "comment": "18px"
+        },
+        "name": "token-typography-display-100-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "display-100",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "display-100",
+          "line-height"
+        ]
+      }
+    },
+    "body-300": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.text.value}"
+        },
+        "name": "token-typography-body-300-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "body-300",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "body-300",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1rem",
+        "type": "font-size",
+        "comment": "16px/1rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "font-size",
+          "comment": "16px/1rem"
+        },
+        "name": "token-typography-body-300-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "body-300",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "body-300",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.5",
+        "comment": "24px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.5",
+          "comment": "24px"
+        },
+        "name": "token-typography-body-300-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "body-300",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "body-300",
+          "line-height"
+        ]
+      }
+    },
+    "body-200": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.text.value}"
+        },
+        "name": "token-typography-body-200-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "body-200",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "body-200",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "0.875rem",
+        "type": "font-size",
+        "comment": "14px/0.875rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "14",
+          "type": "font-size",
+          "comment": "14px/0.875rem"
+        },
+        "name": "token-typography-body-200-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "body-200",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "body-200",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.4286",
+        "comment": "20px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.4286",
+          "comment": "20px"
+        },
+        "name": "token-typography-body-200-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "body-200",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "body-200",
+          "line-height"
+        ]
+      }
+    },
+    "body-100": {
+      "font-family": {
+        "value": "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.text.value}"
+        },
+        "name": "token-typography-body-100-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "body-100",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "body-100",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "0.8125rem",
+        "type": "font-size",
+        "comment": "13px/0.8125rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "13",
+          "type": "font-size",
+          "comment": "13px/0.8125rem"
+        },
+        "name": "token-typography-body-100-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "body-100",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "body-100",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.3846",
+        "comment": "18px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.3846",
+          "comment": "18px"
+        },
+        "name": "token-typography-body-100-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "body-100",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "body-100",
+          "line-height"
+        ]
+      }
+    },
+    "code-100": {
+      "font-family": {
+        "value": "ui-monospace, Menlo, Consolas, monospace",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.code.value}"
+        },
+        "name": "token-typography-code-100-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "code-100",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "code-100",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "0.8125rem",
+        "type": "font-size",
+        "comment": "13px/0.8125rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "13",
+          "type": "font-size",
+          "comment": "13px/0.8125rem"
+        },
+        "name": "token-typography-code-100-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "code-100",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "code-100",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.23",
+        "comment": "16px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.23",
+          "comment": "16px"
+        },
+        "name": "token-typography-code-100-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "code-100",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "code-100",
+          "line-height"
+        ]
+      }
+    },
+    "code-200": {
+      "font-family": {
+        "value": "ui-monospace, Menlo, Consolas, monospace",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.code.value}"
+        },
+        "name": "token-typography-code-200-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "code-200",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "code-200",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "0.875rem",
+        "type": "font-size",
+        "comment": "14px/0.875rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "14",
+          "type": "font-size",
+          "comment": "14px/0.875rem"
+        },
+        "name": "token-typography-code-200-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "code-200",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "code-200",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.125",
+        "comment": "18px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.125",
+          "comment": "18px"
+        },
+        "name": "token-typography-code-200-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "code-200",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "code-200",
+          "line-height"
+        ]
+      }
+    },
+    "code-300": {
+      "font-family": {
+        "value": "ui-monospace, Menlo, Consolas, monospace",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "{typography.font-stack.code.value}"
+        },
+        "name": "token-typography-code-300-font-family",
+        "attributes": {
+          "category": "typography",
+          "type": "code-300",
+          "item": "font-family"
+        },
+        "path": [
+          "typography",
+          "code-300",
+          "font-family"
+        ]
+      },
+      "font-size": {
+        "value": "1rem",
+        "type": "font-size",
+        "comment": "16px/1rem",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "16",
+          "type": "font-size",
+          "comment": "16px/1rem"
+        },
+        "name": "token-typography-code-300-font-size",
+        "attributes": {
+          "category": "typography",
+          "type": "code-300",
+          "item": "font-size"
+        },
+        "path": [
+          "typography",
+          "code-300",
+          "font-size"
+        ]
+      },
+      "line-height": {
+        "value": "1.25",
+        "comment": "20px",
+        "filePath": "src/products/shared/typography.json",
+        "isSource": true,
+        "original": {
+          "value": "1.25",
+          "comment": "20px"
+        },
+        "name": "token-typography-code-300-line-height",
+        "attributes": {
+          "category": "typography",
+          "type": "code-300",
+          "item": "line-height"
+        },
+        "path": [
+          "typography",
+          "code-300",
+          "line-height"
+        ]
+      }
+    }
+  }
+}

--- a/packages/tokens/scripts/build.ts
+++ b/packages/tokens/scripts/build.ts
@@ -179,6 +179,21 @@ function getStyleDictionaryConfig({ target }: { target: string }) {
                         },
                     }
                 ]
+            },
+            "json": {
+                "transformGroup": targets[target].transformGroup,
+                "buildPath": `dist/${target}/`,
+                "prefix": "token",
+                "basePxFontSize": 16,
+                "files": [
+                    {
+                        "destination": "tokens.json",
+                        "format": "json",
+                        "filter": function(token: DesignToken) {
+                            return !token.private;
+                        },
+                    }
+                ]
             }
         }
     };
@@ -197,8 +212,7 @@ Object.keys(targets).forEach(target => {
     const StyleDictionary = StyleDictionaryPackage.extend(getStyleDictionaryConfig({ target }));
 
     console.log(`\nProcessing target "${target}"...`);
-    StyleDictionary.buildPlatform('web/css-variables');
-    StyleDictionary.buildPlatform('docs/json');
+    StyleDictionary.buildAllPlatforms()
     console.log('\nEnd processing');
 })
 


### PR DESCRIPTION
### :pushpin: Summary

Adds a new output format that generates a JSON file that can be re-consumed by other Style Dictionary instances.

### :hammer_and_wrench: Detailed description

As part of marketing's adoption of HDS, we want to generate a set of tokens that build upon the existing tokens of HDS. There are a handful of instances where we take a color value and perform modifications on it (such as lighten/darken) that are only possible if we have access to the underlying token value. For example:

```json5
{
  "color": {
    "vault": {
      "button": {
        // ...
        "background-color-hover": {
          "type": "color",
          "value": "{color.vault.brand}",
          "modify": [
            { "type": "mix", "args": ["black", 0.06, { "space": "srgb" }] }
          ]
        },
        // ...
        "border-color-focus": {
          "type": "color",
          "value": "{color.vault.foreground}",
          "alpha": "0.1"
        }
      }
    }
  }
}
```

Currently, we maintain an entire fork of the tokens package to accomplish this, but have realized that if we could pass the HDS tokens into another instance of Style Dictionary, then we could reduce our fork to just our custom tokens.

This PR adds a third output format using the [built-in `json` format](https://amzn.github.io/style-dictionary/#/formats?id=json). For simplicity, it doesn't configure a custom formatter to remove unnecessary properties, but that's a weak opinion loosely held.

This JSON file can then be passed into Style Dictionary like so:

```ts
const config: Config = {
  source: ['src/marketing/**/*.json'],
  include: [
    require.resolve(
      '@hashicorp/design-system-tokens/dist/products/tokens.json',
    ),
  ],
  platforms: {
    'web/css-variables': {
      transformGroup: 'marketing/web',
      buildPath: 'dist/marketing/css/',
      prefix: 'hdsplus',
      basePxFontSize: 16,
      files: [
        {
          destination: 'tokens.css',
          format: 'css/variables',
          filter(token: DesignToken) {
            return token.isSource
          },
        },
      ],
    },
  },
}
```

This configuration will generate a new set of tokens that have access to the underlying token values from HDS, but won't overwrite them given it uses a different prefix.

### :camera_flash: Screenshots

N/A

### :link: External links

HashiCorp Slack link: https://hashicorp.slack.com/archives/C05CBQ2J6J3/p1689625431482409

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
