### PR TITLE
Fix media-query "medium" naming in website

### DIFF
--- a/website/app/styles/breakpoints/index.scss
+++ b/website/app/styles/breakpoints/index.scss
@@ -18,11 +18,11 @@ $doc-breakpoint-for-sidebar: 880px;
   @media (max-width: calc(#{$doc-breakpoint-medium} - 1px)) { @content; }
 }
 
-@mixin medium {
+@mixin medium-only {
   @media (min-width: $doc-breakpoint-medium) and (max-width: calc(#{$doc-breakpoint-large} - 1px)) { @content; }
 }
 
-@mixin medium-and-above {
+@mixin medium {
   @media (min-width: $doc-breakpoint-medium) { @content; }
 }
 

--- a/website/app/styles/doc-components/font-helpers-list.scss
+++ b/website/app/styles/doc-components/font-helpers-list.scss
@@ -16,7 +16,7 @@
   padding: 0;
   list-style: none;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     display: grid;
     grid-template-columns: minmax(120px, max-content) auto;
   }
@@ -26,7 +26,7 @@
   display: flex;
   flex-direction: column;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     display: contents;
   }
 }
@@ -41,7 +41,7 @@
   border: 1px solid var(--doc-color-gray-500);
   border-radius: 3px 3px 0 0;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     justify-content: center;
     text-align: center;
     border-radius: 3px 0 0 3px;
@@ -55,7 +55,7 @@
   border-width: 0 1px 1px 1px;
   border-radius: 0 0 3px 3px;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     border-width: 1px 1px 1px 0;
     border-radius: 0 3px 3px 0;
   }

--- a/website/app/styles/doc-components/icons-list/index.scss
+++ b/website/app/styles/doc-components/icons-list/index.scss
@@ -76,7 +76,7 @@
   border: 1px solid var(--doc-color-gray-500);
   border-radius: 3px;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     flex-direction: row;
   }
 }
@@ -90,7 +90,7 @@
   height: 120px;
   border-bottom: 1px solid var(--doc-color-gray-500);
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     width: 120px;
     height: 100%;
     border-right: 1px solid var(--doc-color-gray-500);

--- a/website/app/styles/doc-components/tokens-list/index.scss
+++ b/website/app/styles/doc-components/tokens-list/index.scss
@@ -17,7 +17,7 @@
   padding: 0;
   list-style: none;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     display: grid;
     grid-template-columns: minmax(100px, max-content) auto;
   }
@@ -27,7 +27,7 @@
   display: flex;
   flex-direction: column;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     display: contents;
   }
 }
@@ -43,7 +43,7 @@
   border: 1px solid var(--doc-color-gray-500);
   border-radius: 3px 3px 0 0;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     justify-content: center;
     border-radius: 3px 0 0 3px;
   }
@@ -132,7 +132,7 @@
   border-width: 0 1px 1px 1px;
   border-radius: 0 0 3px 3px;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     border-width: 1px 1px 1px 0;
     border-radius: 0 3px 3px 0;
   }

--- a/website/app/styles/pages/about/principles.scss
+++ b/website/app/styles/pages/about/principles.scss
@@ -15,7 +15,7 @@
   padding: 0;
   list-style: none;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/website/app/styles/pages/application/cover.scss
+++ b/website/app/styles/pages/application/cover.scss
@@ -71,7 +71,7 @@
   overflow-y: hidden; // .doc-page-tabs__tab--is-current has an ::after pseudoelement that always overflows with 3px, so we disable the vertical scrollbar and rely on the horizontal one
   -webkit-overflow-scrolling: touch;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     position: absolute;
     bottom: 0;
     display: block;

--- a/website/app/styles/pages/application/error.scss
+++ b/website/app/styles/pages/application/error.scss
@@ -24,7 +24,7 @@
   min-width: 0;
   max-width: 320px;
 
-  @include breakpoint.medium-and-above () {
+  @include breakpoint.medium () {
     display: grid;
     grid-template-columns: auto 1fr;
     gap: 48px;

--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -26,7 +26,7 @@
   padding: 16px 24px;
   color: var(--doc-color-black);
 
-  @include breakpoint.medium-and-above() {
+  @include breakpoint.medium () {
     flex-direction: row;
     justify-content: space-between;
   }
@@ -35,7 +35,7 @@
     flex-direction: column-reverse;
     color: var(--doc-color-white);
 
-    @include breakpoint.medium-and-above() {
+    @include breakpoint.medium () {
       flex-direction: row-reverse;
     }
   }

--- a/website/app/styles/pages/application/header.scss
+++ b/website/app/styles/pages/application/header.scss
@@ -63,7 +63,7 @@
 .doc-page-header__nav-menu {
   display: none;
 
-  @include breakpoint.medium-and-above() {
+  @include breakpoint.medium () {
     display: block;
     flex: 1 0 auto;
     align-self: stretch;
@@ -157,7 +157,7 @@
 
   body.application.index & {
     // this is a special case: in homepage the top-level links in the header are still accessible at the "medium" viewport, so no need to show the burger menu
-    @include breakpoint.medium () {
+    @include breakpoint.medium-only () {
       display: none;
     }
   }

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -92,7 +92,7 @@ body.application:not(.index) {
       content: "";
     }
 
-    @include breakpoint.medium-and-above() {
+    @include breakpoint.medium () {
       display: none;
     }
   }

--- a/website/app/styles/pages/application/tabs.scss
+++ b/website/app/styles/pages/application/tabs.scss
@@ -44,7 +44,7 @@
       background-color: var(--doc-color-black);
       content: "";
 
-      @include breakpoint.medium-and-above () {
+      @include breakpoint.medium () {
         bottom: -1px;
       }
     }

--- a/website/app/styles/pages/home.scss
+++ b/website/app/styles/pages/home.scss
@@ -33,7 +33,7 @@ body.application.index {
   content: "";
   pointer-events: none;
 
-  @include breakpoint.medium-and-above() {
+  @include breakpoint.medium () {
     height: 40vw;
     max-height: 640px;
     background-image: url("/assets/illustrations/home-abstract.jpg");
@@ -126,7 +126,7 @@ body.application.index {
     font-size: var(--tagline-font-size);
     line-height: 1.55;
 
-    @include breakpoint.medium-and-above() {
+    @include breakpoint.medium () {
       max-width: 600px;
     }
   }
@@ -187,7 +187,7 @@ body.application.index {
   margin: 8px 0 12px 0;
   color: var(--doc-color-gray-500);
 
-  @include breakpoint.medium-and-above() {
+  @include breakpoint.medium () {
     margin: 16 0 24 0;
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

While working on the "related components" feature, I have realized that the `Deck` layout with 2 columns was broken, because of a wrong media query. This likely happened because of the confusing/inconsistent naming used for the "medium" breakpoint media query. 

### :hammer_and_wrench: Detailed description

In this PR I have:
- renamed some media queries (and fixed some declarations accordingly)

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
