### PR TITLE
`SideNav` - Fix (again!) the interactivity of the links when in “minimized" state

### DIFF
--- a/.changeset/good-ads-worry.md
+++ b/.changeset/good-ads-worry.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav` - Fixed issue with links still being interactive (even if visually hidden) when the navigation is "minimized"

--- a/packages/components/app/styles/components/side-nav/main.scss
+++ b/packages/components/app/styles/components/side-nav/main.scss
@@ -191,6 +191,19 @@
     visibility: hidden !important; // we need `!important` here to override the inline style applied to the single panels
     opacity: 0;
     transition: none;
+    // this is needed because, despite the element having `visibility: hidden`,
+    // the child elements ("panels") have their visibility dynamically managed via JS
+    // and when they have "visibility: visible" applied, they are not visually visible
+    // (because of the `opacity: 0` of the parent) but the user can still interact with them
+    // and click on the links inside the sidenav even if they're not visible at all,
+    // so we have to block the interactivity of the whole container
+    // for reference see these PRs:
+    // - https://github.com/hashicorp/design-system/pull/1338
+    // - https://github.com/hashicorp/design-system/pull/1388
+    // - https://github.com/hashicorp/design-system/pull/1516
+    // and this codepen with a redux of the problem:
+    // - https://codepen.io/didoo/pen/mdQKMJW?editors=1100
+    pointer-events: none;
   }
 
   .hds-side-nav--is-mobile.hds-side-nav--is-not-minimized &,


### PR DESCRIPTION
### :pushpin: Summary

This is another fix to the apparently never ending problem of visually hidden elements that remain interactive in the `SideNav` when in "minimized" state. See links to previous PRs for details of where the problem lays (TLDR: conflicting `visible` styles in the `SideNav` component, some handled by JS, some by CSS).

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a `pointer-events: none` declaration for the `hds-side-nav-hide-when-minimized` elements, to disable interactivity for its entire DOM subtree.
- added a long comment to explain why this is needed and reference to previous PRs for context

### :link: External links

Previous PRs related to this problem:

- https://github.com/hashicorp/design-system/pull/1338
- https://github.com/hashicorp/design-system/pull/1388

Slack thread: https://hashicorp.slack.com/archives/C054FFLHZKR/p1689821175976069

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
