### PR TITLE
Update `Button` icon guidelines

### DIFF
--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -116,12 +116,12 @@ Use `chevron-right` to indicate moving forward in a multi-step flow.
 
 Use `arrow-right` when using the Button for internal links. In most cases, consider using the [Standalone Link](/components/link/standalone) instead. For more details, please refer to the [code documentation](/components/button?tab=code#links).
 
-<Hds::Button @color="secondary" @text="Continue with HCP account" @icon="arrow-right" @iconPosition="trailing" />
+<Hds::Button @color="secondary" @text="Continue with HCP account" @icon="arrow-right" @iconPosition="trailing" @href="https://hashicorp.com" />
 
 
 Use `external-link` when using the Button for external links. In most cases, consider using the [Standalone Link](/components/link/standalone) instead. For more details, please refer to the [code documentation](/components/button?tab=code#links).
 
-<Hds::Button @color="secondary" @text="Authenticate with GitHub" @icon="external-link" @iconPosition="trailing" />
+<Hds::Button @color="secondary" @text="Authenticate with GitHub" @icon="external-link" @iconPosition="trailing" @href="https://hashicorp.com" />
 
 ## Button set
 

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -90,7 +90,6 @@ In most cases, use leading icons. Choose icons that add meaning and clarity to t
 
 <Hds::ButtonSet>
   <Hds::Button @color="secondary" @text="Unlock" @icon="unlock" @iconPosition="leading" />
-  <Hds::Button @color="secondary" @text="Show more results" @icon="eye" @iconPosition="leading" />
   <Hds::Button @color="critical" @text="Delete" @icon="trash" @iconPosition="leading" />
   <Hds::Button @color="tertiary" @text="Previous" @icon="chevron-left" @iconPosition="leading" />
 </Hds::ButtonSet>

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -86,7 +86,7 @@ Buttons used for a Dropdown (with the chevron icon) can be found in [Dropdown](/
 
 ### Leading
 
-In most cases, use leading icons. Choose icons that add meaning and clarity to the action described in the link’s text.
+In most cases, use leading icons. Choose icons that add meaning and clarity to the action described in the button’s text.
 
 <Hds::ButtonSet>
   <Hds::Button @color="secondary" @text="Unlock" @icon="unlock" @iconPosition="leading" />

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -107,17 +107,17 @@ Use the leading position when creating or adding a new object.
 
 ### Trailing
 
-Consider trailing icons when there’s no other meaningful icon or when guiding the user forward through the product.
+Consider trailing icons when guiding the user forward through the product or when using the Button for links.
 
 Use `chevron-right` to indicate moving forward in a multi-step flow.
 
 <Hds::Button @color="primary" @text="Next" @icon="chevron-right" @iconPosition="trailing" />
 
-Use `arrow-right` when using the Button for internal links. In most cases, consider using the [Standalone Link](/components/link/standalone) instead. For more details, please refer to the [code documentation](/components/button?tab=code#links).
+Use `arrow-right` when using the Button for internal links. In most cases, consider using a [Standalone Link](/components/link/standalone) instead. For more details, please refer to the [code documentation](/components/button?tab=code#links).
 
 <Hds::Button @color="secondary" @text="Continue with HCP account" @icon="arrow-right" @iconPosition="trailing" @href="https://hashicorp.com" />
 
-Use `external-link` when using the Button for external links. In most cases, consider using the [Standalone Link](/components/link/standalone) instead. For more details, please refer to the [code documentation](/components/button?tab=code#links).
+Use `external-link` when using the Button for external links. In most cases, consider using a [Standalone Link](/components/link/standalone) instead. For more details, please refer to the [code documentation](/components/button?tab=code#links).
 
 <Hds::Button @color="secondary" @text="Authenticate with GitHub" @icon="external-link" @iconPosition="trailing" @href="https://hashicorp.com" />
 

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -118,7 +118,6 @@ Use `arrow-right` when using the Button for internal links. In most cases, consi
 
 <Hds::Button @color="secondary" @text="Continue with HCP account" @icon="arrow-right" @iconPosition="trailing" @href="https://hashicorp.com" />
 
-
 Use `external-link` when using the Button for external links. In most cases, consider using the [Standalone Link](/components/link/standalone) instead. For more details, please refer to the [code documentation](/components/button?tab=code#links).
 
 <Hds::Button @color="secondary" @text="Authenticate with GitHub" @icon="external-link" @iconPosition="trailing" @href="https://hashicorp.com" />

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -107,7 +107,7 @@ Use the leading position when creating or adding a new object.
 
 ### Trailing
 
-Consider trailing icons when guiding the user forward through the product or when using the Button for links.
+Consider trailing icons when guiding the user forward through the product.
 
 Use `chevron-right` to indicate moving forward in a multi-step flow.
 

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -84,6 +84,45 @@ Buttons used for a Dropdown (with the chevron icon) can be found in [Dropdown](/
   <Hds::Button @color="secondary" @text="No text" @icon="plus" @isIconOnly={{true}} />
 </Hds::ButtonSet>
 
+### Leading
+
+In most cases, use leading icons. Choose icons that add meaning and clarity to the action described in the link’s text.
+
+<Hds::ButtonSet>
+  <Hds::Button @color="secondary" @text="Unlock" @icon="unlock" @iconPosition="leading" />
+  <Hds::Button @color="secondary" @text="Show more results" @icon="eye" @iconPosition="leading" />
+  <Hds::Button @color="critical" @text="Delete" @icon="trash" @iconPosition="leading" />
+  <Hds::Button @color="tertiary" @text="Previous" @icon="chevron-left" @iconPosition="leading" />
+</Hds::ButtonSet>
+
+!!! Do
+
+Use the leading position when creating or adding a new object.
+
+<Hds::ButtonSet>
+  <Hds::Button @color="primary" @text="Create variable" @icon="plus" @iconPosition="leading" />
+  <Hds::Button @color="secondary" @text="Add repository" @icon="plus" @iconPosition="leading" />
+</Hds::ButtonSet>
+
+!!!
+
+### Trailing
+
+Consider trailing icons when there’s no other meaningful icon or when guiding the user forward through the product.
+
+Use `chevron-right` to indicate moving forward in a multi-step flow.
+
+<Hds::Button @color="primary" @text="Next" @icon="chevron-right" @iconPosition="trailing" />
+
+Use `arrow-right` when using the Button for internal links. In most cases, consider using the [Standalone Link](/components/link/standalone) instead. For more details, please refer to the [code documentation](/components/button?tab=code#links).
+
+<Hds::Button @color="secondary" @text="Continue with HCP account" @icon="arrow-right" @iconPosition="trailing" />
+
+
+Use `external-link` when using the Button for external links. In most cases, consider using the [Standalone Link](/components/link/standalone) instead. For more details, please refer to the [code documentation](/components/button?tab=code#links).
+
+<Hds::Button @color="secondary" @text="Authenticate with GitHub" @icon="external-link" @iconPosition="trailing" />
+
 ## Button set
 
 [ButtonSets](/components/button-set) are patterns when multiple Buttons need to be displayed in a single row.


### PR DESCRIPTION
### :pushpin: Summary

This branch updates the icon position section and adds guidelines and recommendations for leading and trailing icons for different use cases.

Preview 👉 https://hds-website-git-cv-update-button-docs-hashicorp.vercel.app/components/button#icon-position

### :camera_flash: Screenshots

<img width="600" alt="Screen Shot 2023-07-20 at 2 39 52 PM" src="https://github.com/hashicorp/design-system/assets/2142312/a432d351-4a1f-4ce4-8d88-103e9fa3f49a">

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1552](https://hashicorp.atlassian.net/browse/HDS-1552)

***
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1552]: https://hashicorp.atlassian.net/browse/HDS-1552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ