### PR TITLE
Render `DocCards` in equal heights

### DIFF
--- a/website/app/styles/doc-components/cards/deck.scss
+++ b/website/app/styles/doc-components/cards/deck.scss
@@ -10,6 +10,7 @@
 
 .doc-cards-deck {
   display: grid;
+  grid-auto-rows: 1fr;
   gap: 32px; // TODO maybe different gaps via a prop?
   margin: 0;
   padding: 0;


### PR DESCRIPTION
### :pushpin: Summary

Following up on the great work done in #1508, this PR proposes equal heights for rows in the CSS grid layout used to render the related components.

It results in equal-in-height `DocCards` (as shown in the screen captures below). Unfortunately, they are equal on the same page, but not across the website.

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![related-components-before](https://github.com/hashicorp/design-system/assets/788096/3209a708-041c-468b-a266-50c913caea53)


</td><td>

![related-components-after](https://github.com/hashicorp/design-system/assets/788096/9fd4bbb1-7df8-4f46-8004-08295ad2d0fe)


</td></tr>
</table>

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
