### PR TITLE
`TextInput` Example size change for `Datetime`

### DIFF
--- a/website/docs/components/form/text-input/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/text-input/partials/guidelines/guidelines.md
@@ -44,15 +44,15 @@ Text Input accepts [all native HTML types](https://developer.mozilla.org/en-US/d
 Date and time fields use the native browser functionality for the popovers. Some browsers do not display an icon or popover.
 !!!
 
-<Hds::Form::TextInput::Field @type="date" placeholder="mm/dd/yy" @width="150px" as |F|>
+<Hds::Form::TextInput::Field @type="date" placeholder="mm/dd/yy" @width="192px" as |F|>
   <F.Label>Date</F.Label>
 </Hds::Form::TextInput::Field>
 
-<Hds::Form::TextInput::Field @type="time" placeholder="--:-- --" @width="150px" as |F|>
+<Hds::Form::TextInput::Field @type="time" placeholder="--:-- --" @width="192px" as |F|>
   <F.Label>Time</F.Label>
 </Hds::Form::TextInput::Field>
 
-<Hds::Form::TextInput::Field @type="datetime-local" placeholder="mm/dd/yyT--:-- --" @width="150px" as |F|>
+<Hds::Form::TextInput::Field @type="datetime-local" placeholder="mm/dd/yyT--:-- --" @width="192px" as |F|>
   <F.Label>Datetime</F.Label>
 </Hds::Form::TextInput::Field>
 

--- a/website/docs/components/form/text-input/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/text-input/partials/guidelines/guidelines.md
@@ -44,15 +44,15 @@ Text Input accepts [all native HTML types](https://developer.mozilla.org/en-US/d
 Date and time fields use the native browser functionality for the popovers. Some browsers do not display an icon or popover.
 !!!
 
-<Hds::Form::TextInput::Field @type="date" placeholder="mm/dd/yy" @width="192px" as |F|>
+<Hds::Form::TextInput::Field @type="date" placeholder="mm/dd/yy" as |F|>
   <F.Label>Date</F.Label>
 </Hds::Form::TextInput::Field>
 
-<Hds::Form::TextInput::Field @type="time" placeholder="--:-- --" @width="192px" as |F|>
+<Hds::Form::TextInput::Field @type="time" placeholder="--:-- --" as |F|>
   <F.Label>Time</F.Label>
 </Hds::Form::TextInput::Field>
 
-<Hds::Form::TextInput::Field @type="datetime-local" placeholder="mm/dd/yyT--:-- --" @width="192px" as |F|>
+<Hds::Form::TextInput::Field @type="datetime-local" placeholder="mm/dd/yyT--:-- --" as |F|>
   <F.Label>Datetime</F.Label>
 </Hds::Form::TextInput::Field>
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will update the size of the datetime example to match the one in Figma

### :hammer_and_wrench: Detailed description

Removed @Width from examples 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2247](https://hashicorp.atlassian.net/browse/HDS-2247)


***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2247]: https://hashicorp.atlassian.net/browse/HDS-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ