### PR TITLE
`Hds::Form::RadioCard` - changes to `@layout` property

### DIFF
--- a/.changeset/yellow-monkeys-wave.md
+++ b/.changeset/yellow-monkeys-wave.md
@@ -1,0 +1,10 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+`Form::RadioCard` - remove the `@layout` property
+`Form::RadioCard::Group` - repurpose the `@layout` property to either `horizontal` (default) or `vertical`
+
+To migrate `Form::RadioCard` and `Form::RadioCard::Group` instances without encountering visual changes:
+ - make sure all instances with `@layout="fixed"` have a `@maxWidth` defined, then remove the `@layout="fixed"` definition
+ - remove all `@layout="fluid"` definitions

--- a/packages/components/addon/components/hds/form/radio-card/group.hbs
+++ b/packages/components/addon/components/hds/form/radio-card/group.hbs
@@ -4,7 +4,7 @@
 }}
 <Hds::Form::Fieldset
   class="hds-form-group--radio-cards"
-  @layout="horizontal"
+  @layout={{if (eq @layout "vertical") "vertical" "horizontal"}}
   @name={{@name}}
   @isRequired={{@isRequired}}
   @isOptional={{@isOptional}}
@@ -22,7 +22,6 @@
           name=@name
           alignment=@alignment
           controlPosition=@controlPosition
-          layout=@layout
           extraAriaDescribedBy=F.ariaDescribedBy
         )
       )

--- a/packages/components/addon/components/hds/form/radio-card/index.js
+++ b/packages/components/addon/components/hds/form/radio-card/index.js
@@ -84,7 +84,9 @@ export default class HdsFormRadioCardIndexComponent extends Component {
       classes.push('hds-form-radio-card--disabled');
     }
     if (this.args.maxWidth) {
-      classes.push('hds-form-radio-card--fixed-width');
+      classes.push('hds-form-radio-card--has-fixed-width');
+    } else {
+      classes.push('hds-form-radio-card--has-fluid-width');
     }
 
     // add a class based on the @controlPosition argument

--- a/packages/components/addon/components/hds/form/radio-card/index.js
+++ b/packages/components/addon/components/hds/form/radio-card/index.js
@@ -12,10 +12,8 @@ import { setAriaDescribedBy } from '@hashicorp/design-system-components/utils/hd
 
 export const DEFAULT_CONTROL_POSITION = 'bottom';
 export const DEFAULT_ALIGNMENT = 'left';
-export const DEFAULT_LAYOUT = 'fluid';
 export const CONTROL_POSITIONS = ['bottom', 'left'];
 export const ALIGNMENTS = ['left', 'center'];
-export const LAYOUTS = ['fluid', 'fixed'];
 
 export default class HdsFormRadioCardIndexComponent extends Component {
   @tracked ariaDescribedBy = this.args.extraAriaDescribedBy;
@@ -72,34 +70,6 @@ export default class HdsFormRadioCardIndexComponent extends Component {
   }
 
   /**
-   * Sets the layout of the card within the group
-   * Accepted values: fluid, fixed
-   *
-   * @param layout
-   * @type {string}
-   * @default 'fluid'
-   */
-  get layout() {
-    let { layout = DEFAULT_LAYOUT } = this.args;
-
-    assert(
-      `@layout for "Hds::Form::RadioCard" must be one of the following: ${LAYOUTS.join(
-        ', '
-      )}; received: ${layout}`,
-      LAYOUTS.includes(layout)
-    );
-
-    // if the `@layout` is set to 'fixed' we need a `@maxWidth` value to constrain the card to
-    if (layout === 'fixed') {
-      assert(
-        `@maxWidth for "Hds::Form::RadioCard" with @layout "fixed" is required`,
-        this.args.maxWidth
-      );
-    }
-    return layout;
-  }
-
-  /**
    * Get the class names to apply to the component.
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
@@ -113,15 +83,15 @@ export default class HdsFormRadioCardIndexComponent extends Component {
     if (this.args.disabled) {
       classes.push('hds-form-radio-card--disabled');
     }
+    if (this.args.maxWidth) {
+      classes.push('hds-form-radio-card--fixed-width');
+    }
 
     // add a class based on the @controlPosition argument
     classes.push(`hds-form-radio-card--control-${this.controlPosition}`);
 
     // add a class based on the @alignment argument
     classes.push(`hds-form-radio-card--align-${this.alignment}`);
-
-    // add a class based on the @layout argument
-    classes.push(`hds-form-radio-card--layout-${this.layout}`);
 
     return classes.join(' ');
   }

--- a/packages/components/app/styles/components/form/group.scss
+++ b/packages/components/app/styles/components/form/group.scss
@@ -29,13 +29,13 @@
 }
 
 .hds-form-group--layout-vertical {
-  .hds-form-group__control-field + .hds-form-group__control-field {
-    margin-top: 12px;
-  }
-
   .hds-form-group__control-fields-wrapper {
     display: flex;
     flex-direction: column;
+  }
+
+  .hds-form-group__control-field + .hds-form-group__control-field {
+    margin-top: 12px;
   }
 }
 

--- a/packages/components/app/styles/components/form/group.scss
+++ b/packages/components/app/styles/components/form/group.scss
@@ -32,6 +32,11 @@
   .hds-form-group__control-field + .hds-form-group__control-field {
     margin-top: 12px;
   }
+
+  .hds-form-group__control-fields-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 .hds-form-group--layout-horizontal {

--- a/packages/components/app/styles/components/form/radio-card.scss
+++ b/packages/components/app/styles/components/form/radio-card.scss
@@ -20,11 +20,14 @@
   }
 
   .hds-form-radio-card {
-    flex: 1 0 0;
     margin: calc(var(--token-form-radiocard-group-gap) / 2);
   }
 
-  .hds-form-radio-card--fixed-width {
+  .hds-form-radio-card--has-fluid-width {
+    flex: 1 0 0;
+  }
+
+  .hds-form-radio-card--has-fixed-width {
     flex: 1 0 100%;
   }
 }

--- a/packages/components/app/styles/components/form/radio-card.scss
+++ b/packages/components/app/styles/components/form/radio-card.scss
@@ -20,16 +20,11 @@
   }
 
   .hds-form-radio-card {
+    flex: 1 0 0;
     margin: calc(var(--token-form-radiocard-group-gap) / 2);
   }
 
-  // LAYOUT
-
-  .hds-form-radio-card--layout-fluid {
-    flex: 1 0 0;
-  }
-
-  .hds-form-radio-card--layout-fixed {
+  .hds-form-radio-card--fixed-width {
     flex: 1 0 100%;
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -92,6 +92,8 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Control position</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
@@ -123,6 +125,8 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Card alignment</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
@@ -153,6 +157,8 @@
       </Hds::Form::RadioCard::Group>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>Card width</Shw::Text::H3>
 
@@ -203,6 +209,8 @@
       </Hds::Form::RadioCard::Group>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>Group content</Shw::Text::H3>
 
@@ -258,6 +266,8 @@
       </Hds::Form::RadioCard::Group>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>Group layout</Shw::Text::H3>
 

--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -293,5 +293,29 @@
         {{/each}}
       </Hds::Form::RadioCard::Group>
     </SF.Item>
+    <SF.Item @label="Vertical, fixed width">
+      <Hds::Form::RadioCard::Group
+        @name="radio-card-layout-vertical-fixed"
+        @controlPosition="left"
+        @layout="vertical"
+        as |G|
+      >
+        <G.Legend>Group legend</G.Legend>
+        {{#each @model.RADIOCARDS as |item|}}
+          <G.RadioCard
+            @maxWidth="330px"
+            @checked={{item.checked}}
+            @value={{item.value}}
+            {{on "change" this.onChange}}
+            as |R|
+          >
+            <R.Icon @name="hexagon" />
+            <R.Label>{{item.label}}</R.Label>
+            <R.Badge @text={{item.badge}} />
+            <R.Description>{{item.description}}</R.Description>
+          </G.RadioCard>
+        {{/each}}
+      </Hds::Form::RadioCard::Group>
+    </SF.Item>
   </Shw::Flex>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -69,7 +69,7 @@
       </Hds::Form::RadioCard::Group>
     </SF.Item>
     <SF.Item @label="With different content height">
-      <Hds::Form::RadioCard::Group @name="radio-card-group-custom" @layout="fixed" as |G|>
+      <Hds::Form::RadioCard::Group @name="radio-card-group-custom" as |G|>
         <G.Legend>Group legend</G.Legend>
         <G.RadioCard @maxWidth="330px" @checked={{true}} {{on "change" this.onChange}} as |R|>
           <R.Icon @name="hexagon" />
@@ -154,26 +154,26 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H3>Group layout</Shw::Text::H3>
+  <Shw::Text::H3>Card width</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
-    <SF.Item @label="Fluid">
-      <Hds::Form::RadioCard::Group @name="radio-card-layout-fluid" @layout="fluid" as |G|>
+    <SF.Item @label="Flexible width (default)">
+      <Hds::Form::RadioCard::Group @name="radio-card-width-flexible" as |G|>
         <G.Legend>Group legend</G.Legend>
-        <G.RadioCard @maxWidth="50%" @checked={{true}} {{on "change" this.onChange}} as |R|>
+        <G.RadioCard @checked={{true}} {{on "change" this.onChange}} as |R|>
           <R.Icon @name="hexagon" />
           <R.Label>Radio card label 1</R.Label>
           <R.Description>This is the radio card description text.</R.Description>
         </G.RadioCard>
-        <G.RadioCard @maxWidth="50%" {{on "change" this.onChange}} as |R|>
+        <G.RadioCard {{on "change" this.onChange}} as |R|>
           <R.Icon @name="hexagon" />
           <R.Label>Radio card label 2</R.Label>
           <R.Description>This is the radio card description text.</R.Description>
         </G.RadioCard>
       </Hds::Form::RadioCard::Group>
     </SF.Item>
-    <SF.Item @label="Fixed">
-      <Hds::Form::RadioCard::Group @name="radio-card-layout-fixed" @layout="fixed" as |G|>
+    <SF.Item @label="Fixed width">
+      <Hds::Form::RadioCard::Group @name="radio-card-width-fixed" as |G|>
         <G.Legend>Group legend</G.Legend>
         <G.RadioCard @maxWidth="244px" @checked={{true}} {{on "change" this.onChange}} as |R|>
           <R.Icon @name="hexagon" />
@@ -252,6 +252,42 @@
           <G.RadioCard @checked={{item.checked}} @value={{item.value}} {{on "change" this.onChange}} as |R|>
             <R.Icon @name="hexagon" />
             <R.Label>{{item.label}}</R.Label>
+            <R.Description>{{item.description}}</R.Description>
+          </G.RadioCard>
+        {{/each}}
+      </Hds::Form::RadioCard::Group>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Text::H3>Group layout</Shw::Text::H3>
+
+  <Shw::Flex @direction="column" as |SF|>
+    <SF.Item @label="Horizontal (default)">
+      <Hds::Form::RadioCard::Group
+        @name="radio-card-layout-horizontal"
+        @controlPosition="left"
+        @layout="horizontal"
+        as |G|
+      >
+        <G.Legend>Group legend</G.Legend>
+        {{#each @model.RADIOCARDS as |item|}}
+          <G.RadioCard @checked={{item.checked}} @value={{item.value}} {{on "change" this.onChange}} as |R|>
+            <R.Icon @name="hexagon" />
+            <R.Label>{{item.label}}</R.Label>
+            <R.Badge @text={{item.badge}} />
+            <R.Description>{{item.description}}</R.Description>
+          </G.RadioCard>
+        {{/each}}
+      </Hds::Form::RadioCard::Group>
+    </SF.Item>
+    <SF.Item @label="Vertical">
+      <Hds::Form::RadioCard::Group @name="radio-card-layout-vertical" @controlPosition="left" @layout="vertical" as |G|>
+        <G.Legend>Group legend</G.Legend>
+        {{#each @model.RADIOCARDS as |item|}}
+          <G.RadioCard @checked={{item.checked}} @value={{item.value}} {{on "change" this.onChange}} as |R|>
+            <R.Icon @name="hexagon" />
+            <R.Label>{{item.label}}</R.Label>
+            <R.Badge @text={{item.badge}} />
             <R.Description>{{item.description}}</R.Description>
           </G.RadioCard>
         {{/each}}

--- a/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
 
   // LAYOUT
 
-  test('it should render the component with CSS classes that reflect the arguments provided', async function (assert) {
+  test('it should render the component with CSS classes that reflect the `@layout` argument provided', async function (assert) {
     await render(
       hbs`<Hds::Form::RadioCard::Group id="test-radio-card-group-layout" @layout="vertical" />`
     );

--- a/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
@@ -24,6 +24,17 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
       .hasClass('hds-form-group--radio-cards');
   });
 
+  // LAYOUT
+
+  test('it should render the component with CSS classes that reflect the arguments provided', async function (assert) {
+    await render(
+      hbs`<Hds::Form::RadioCard::Group id="test-radio-card-group-layout" @layout="vertical" />`
+    );
+    assert
+      .dom('#test-radio-card-group-layout')
+      .hasClass('hds-form-group--layout-vertical');
+  });
+
   // CONTEXTUAL COMPONENTS
 
   test('it renders the contextual components', async function (assert) {
@@ -80,9 +91,9 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
 
   // ARGUMENT FORWARDING: NAME, ALIGNMENT, CONTROL POSITION, LAYOUT
 
-  test('it should render the component with CSS classes that reflect the arguments provided', async function (assert) {
+  test('it should render the contextual components with CSS classes that reflect the arguments provided', async function (assert) {
     await render(
-      hbs`<Hds::Form::RadioCard::Group @name="test-name" @alignment="center" @controlPosition="left" @layout="fixed" as |G|>
+      hbs`<Hds::Form::RadioCard::Group @name="test-name" @alignment="center" @controlPosition="left" as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
             <G.RadioCard @maxWidth="50%" data-test="first-control"/>
@@ -100,9 +111,6 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
     assert
       .dom('.hds-form-radio-card')
       .hasClass('hds-form-radio-card--control-left');
-    assert
-      .dom('.hds-form-radio-card')
-      .hasClass('hds-form-radio-card--layout-fixed');
   });
 
   // REQUIRED AND OPTIONAL

--- a/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
@@ -32,11 +32,22 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
 
   test('it should render the component with CSS classes that reflect the arguments provided', async function (assert) {
     await render(
-      hbs`<Hds::Form::RadioCard @checked="checked" @disabled="disabled" @maxWidth="25%" />`
+      hbs`<Hds::Form::RadioCard @checked="checked" @disabled="disabled" />`
     );
     assert.dom('label').hasClass('hds-form-radio-card--checked');
     assert.dom('label').hasClass('hds-form-radio-card--disabled');
-    assert.dom('label').hasClass('hds-form-radio-card--fixed-width');
+  });
+
+  // WIDTH
+
+  test('it should render the default class, resulting in a fluid width', async function (assert) {
+    await render(hbs`<Hds::Form::RadioCard />`);
+    assert.dom('label').hasClass('hds-form-radio-card--has-fluid-width');
+  });
+
+  test('it should render the correct class if `@maxWidth` is set', async function (assert) {
+    await render(hbs`<Hds::Form::RadioCard @maxWidth="25%" />`);
+    assert.dom('label').hasClass('hds-form-radio-card--has-fixed-width');
   });
 
   // CONTEXTUAL COMPONENTS

--- a/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
@@ -28,14 +28,15 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     assert.dom('input').hasAttribute('name', 'name');
   });
 
-  // CHECKED, DISABLED
+  // CHECKED, DISABLED, MAX-WIDTH
 
   test('it should render the component with CSS classes that reflect the arguments provided', async function (assert) {
     await render(
-      hbs`<Hds::Form::RadioCard @checked="checked" @disabled="disabled" />`
+      hbs`<Hds::Form::RadioCard @checked="checked" @disabled="disabled" @maxWidth="25%" />`
     );
     assert.dom('label').hasClass('hds-form-radio-card--checked');
     assert.dom('label').hasClass('hds-form-radio-card--disabled');
+    assert.dom('label').hasClass('hds-form-radio-card--fixed-width');
   });
 
   // CONTEXTUAL COMPONENTS
@@ -88,32 +89,6 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
     await render(hbs`<Hds::Form::RadioCard @controlPosition="foo" />`);
-    assert.throws(function () {
-      throw new Error(errorMessage);
-    });
-  });
-
-  test('it should throw an assertion if an incorrect value for @layout is provided', async function (assert) {
-    const errorMessage =
-      '@layout for "Hds::Form::RadioCard" must be one of the following: fluid, fixed; received: foo';
-    assert.expect(2);
-    setupOnerror(function (error) {
-      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
-    });
-    await render(hbs`<Hds::Form::RadioCard @layout="foo" />`);
-    assert.throws(function () {
-      throw new Error(errorMessage);
-    });
-  });
-
-  test('it should throw an assertion if @layout is fixed and no @maxWidth value is provided', async function (assert) {
-    const errorMessage =
-      '@maxWidth for "Hds::Form::RadioCard" with @layout "fixed" is required';
-    assert.expect(2);
-    setupOnerror(function (error) {
-      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
-    });
-    await render(hbs`<Hds::Form::RadioCard @layout="fixed" />`);
     assert.throws(function () {
       throw new Error(errorMessage);
     });

--- a/website/docs/components/form/radio-card/partials/code/component-api.md
+++ b/website/docs/components/form/radio-card/partials/code/component-api.md
@@ -21,11 +21,9 @@
   <C.Property @name="alignment" @type="enum" @values={{array "left" "center" }} @default="left">
     Sets the alignment of the Radio Card content.
   </C.Property>
-  <C.Property @name="layout" @type="enum" @values={{array "fluid" "fixed" }} @default="fluid">
-    By default, the Radio Card will expand to fit the parent container. When used in a group, the cards will equally share the width to fit the available space. If the `@layout` parameter is set to `fixed`, a `@maxWidth` value must be specified to constrain the card.
-  </C.Property>
   <C.Property @name="maxWidth" @type="string" @valueNote="any valid CSS width (%, vw, etc)">
-    When used with a `fluid` layout, this parameter will determine the number of Radio Cards shown per row (for example `25%` will result in 4 cards). When used with a `fixed` layout, this parameter will preserve the width of the card and wrap cards on multiple rows if necessary.
+    This parameter will set the width of the card, wrapping cards on multiple rows if necessary.
+    You can use it to define the number of Radio Cards shown per row (for example `25%` will result in 4 cards).
   </C.Property>
   <C.Property @name="extraAriaDescribedBy" @type="string">
     An additional ID attribute to be added to the `aria-describedby` HTML attribute.
@@ -84,8 +82,8 @@
   <C.Property @name="isRequired" @type="boolean" @default="false">
     Appends a `Required` indicator next to the legend text and sets the `required` attribute on the controls when user input is required.
   </C.Property>
-  <C.Property @name="layout" @type="string" @values={{array "fluid" "fixed" }} @default="fluid">
-    By default, the Radio Cards will expand to fit the parent container and will equally share the width to fit the available space. If the `@layout` parameter is set to `fixed`, a `@maxWidth` value must be specified for each `RadioCard` to constrain them.
+  <C.Property @name="layout" @type="string" @values={{array "horizontal" "vertical" }} @default="horizontal">
+    By default, the Radio Cards will be layed out horizontally, one next to another. Set this property to `vertical` to stack them one underneath each other.
   </C.Property>
 </Doc::ComponentApi>
 

--- a/website/docs/components/form/radio-card/partials/code/how-to-use.md
+++ b/website/docs/components/form/radio-card/partials/code/how-to-use.md
@@ -39,7 +39,7 @@ The `@name` argument offers an easy way to provide the same name for all the rad
 
 ### Custom content
 
-Customizable options include: 
+Customizable options include:
 
 - Defining custom content using the `Generic` block
 - Defining a custom width using the `maxWidth` argument
@@ -71,6 +71,32 @@ Customizable options include:
         <li class="hds-typography-display-100">250 free requests/month</li>
       </ul>
     </R.Generic>
+  </G.RadioCard>
+</Hds::Form::RadioCard::Group>
+```
+
+### Layout and control position
+
+To change how the cards are layed out in a group set the `@layout` argument to `vertical`. To change the position of the control elements within a card set the `@controlPosition` argument to `left`.
+
+```handlebars
+<Hds::Form::RadioCard::Group
+  @name="radio-card-layout-vertical"
+  @layout="vertical"
+  @controlPosition="left" as |G|
+>
+  <G.Legend>Allow this source connect to the destination</G.Legend>
+  <G.RadioCard @checked={{true}} {{on "change" this.onChange}} as |R|>
+    <R.Label>Admin</R.Label>
+    <R.Description>Grants full admin capabilities for this project and all workspaces within. Team members can edit and delete this project, manage the team access level, and create and move workspaces.</R.Description>
+  </G.RadioCard>
+  <G.RadioCard {{on "change" this.onChange}} as |R|>
+    <R.Label>Read</R.Label>
+    <R.Description>Grants full admin capabilities for this project and all workspaces within. Team members can manage the team access level, and create and move workspaces.</R.Description>
+  </G.RadioCard>
+  <G.RadioCard {{on "change" this.onChange}} as |R|>
+    <R.Label>Write</R.Label>
+    <R.Description>Grants full admin capabilities for this project and all workspaces within. Team members can edit this project, manage the team access level, and create and move workspaces.</R.Description>
   </G.RadioCard>
 </Hds::Form::RadioCard::Group>
 ```

--- a/website/docs/components/form/radio-card/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/radio-card/partials/guidelines/guidelines.md
@@ -55,6 +55,49 @@ In most cases, we recommend using the bottom position. Still, we offer Radio Car
   </G.RadioCard>
 </Hds::Form::RadioCard::Group>
 
+## Layout
+
+In most cases, use the horizontal layout to maximize the real estate available. Use the vertical layout intentionally when assembled with other components within limited horizontal space, or when needing to create a vertical options list with radio cards.
+
+### Horizontal
+
+<Hds::Form::RadioCard::Group @name="radio-card-horizontal-layout" as |G|>
+  <G.Legend>Allow this source connect to the destination</G.Legend>
+  <G.RadioCard @checked={{true}} {{on "change" this.onChange}} as |R|>
+    <R.Icon @name="arrow-right" @color="var(--token-color-foreground-success)" />
+    <R.Label>Allow</R.Label>
+    <R.Description>The source service will be allowed to connect to the destination.</R.Description>
+  </G.RadioCard>
+  <G.RadioCard {{on "change" this.onChange}} as |R|>
+    <R.Icon @name="skip" @color="var(--token-color-foreground-critical)" />
+    <R.Label>Deny</R.Label>
+    <R.Description>The source service will not be allowed to connect to the destination.</R.Description>
+  </G.RadioCard>
+  <G.RadioCard {{on "change" this.onChange}} as |R|>
+    <R.Icon @name="layers" @color="var(--token-color-foreground-primary)" />
+    <R.Label>Application aware</R.Label>
+    <R.Description>The source may or may not connect to the destination service via unique permissions based on Layer 7 criteria: path, header, or method.</R.Description>
+  </G.RadioCard>
+</Hds::Form::RadioCard::Group>
+
+### Vertical
+
+<Hds::Form::RadioCard::Group @name="radio-card-vertical-layout" @controlPosition="left" @layout="vertical" as |G|>
+  <G.Legend>Allow this source connect to the destination</G.Legend>
+  <G.RadioCard @checked={{true}} {{on "change" this.onChange}} as |R|>
+    <R.Label>Admin</R.Label>
+    <R.Description>Grants full admin capabilities for this project and all workspaces within. Team members can edit and delete this project, manage the team access level, and create and move workspaces.</R.Description>
+  </G.RadioCard>
+  <G.RadioCard {{on "change" this.onChange}} as |R|>
+    <R.Label>Read</R.Label>
+    <R.Description>Grants full admin capabilities for this project and all workspaces within. Team members can manage the team access level, and create and move workspaces.</R.Description>
+  </G.RadioCard>
+  <G.RadioCard {{on "change" this.onChange}} as |R|>
+    <R.Label>Write</R.Label>
+    <R.Description>Grants full admin capabilities for this project and all workspaces within. Team members can edit this project, manage the team access level, and create and move workspaces.</R.Description>
+  </G.RadioCard>
+</Hds::Form::RadioCard::Group>
+
 ## Nested badge
 
 Badges can be used in radio cards to display additional information and context. To ensure proper usage of the badge component, refer to the [guidelines](/components/badge).


### PR DESCRIPTION
:warning: This PR awaits to be released in the next major version :warning:

### :pushpin: Summary

In this PR we are removing the `@layout` property on `Hds::Form::RadioCard` and introducing changes to the `@layout` property on `Hds::Form::RadioCard::Group`. 

### :hammer_and_wrench: Detailed description

#### Removing the `@layout` property on `Hds::Form::RadioCard`

This change is motivated by alignment with the Figma counterpart of this component and alignment with other form components using the `@layout` argument to define the direction of the layout and not the width constraints.

To achieve fixed width Radio Cards, in the current implementation, a consumer would have to set `@layout` to `fixed` and define a `@maxWidth` value. We changed the `Hds::Form::RadioCard` API so that only the `@maxWidth` is required.

#### Changing to the `@layout` property on `Hds::Form::RadioCard::Group`

`@layout` property on `Hds::Form::RadioCard::Group` was used as a way to define the Radio Card `@layout` (`fluid` or `fixed`) in a single place and apply it to each Radio Card. We are changing the purpose of this property so that it defines the way Radio Cards are positioned/stacked in a group (`horizontal`, `vertical`).

### 🧑‍💻 Impact on consumers

If a `Hds::Form::RadioCard` has a `@maxWidth` value, the card will be displayed as 'fixed'.

If a `Hds::Form::RadioCard::Group` has the `@layout` defined as `fluid` or `fixed` (or anything else than `vertical`), it will fall back to `horizontal` without affecting the layout of the group.

Overall, this change _should_ not have visual impacts on existing invocations however, it is a breaking change as we retire an argument and we change the purpose of another one.

Currently, there are 3 instances of Radio Cards with `@layout="fixed"` in our consumers' codebases (Nomad, Atlas and Cloud UI each having one).

[👉 Preview showcase](https://hds-showcase-git-alex-ju-radio-card-layout-hashicorp.vercel.app/components/form/radio-card)

[👉 Preview doc website](https://hds-website-git-alex-ju-radio-card-layout-hashicorp.vercel.app/components/form/radio-card?tab=code)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2264](https://hashicorp.atlassian.net/browse/HDS-2264)

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2264]: https://hashicorp.atlassian.net/browse/HDS-2264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ