### PR TITLE
`Hds::Form::Field` - Fix error message for unexpected `@layout` values

### DIFF
--- a/.changeset/weak-eagles-accept.md
+++ b/.changeset/weak-eagles-accept.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::Form::Field` - Fix error message for unexpected `@layout` values

--- a/packages/components/addon/components/hds/form/field/index.js
+++ b/packages/components/addon/components/hds/form/field/index.js
@@ -40,7 +40,7 @@ export default class HdsFormFieldIndexComponent extends Component {
     let { layout } = this.args;
 
     assert(
-      `@type for "Hds::Form::Field" must be one of the following: ${LAYOUT_TYPES.join(
+      `@layout for "Hds::Form::Field" must be one of the following: ${LAYOUT_TYPES.join(
         ', '
       )}; received: ${layout}`,
       LAYOUT_TYPES.includes(layout)

--- a/packages/components/tests/integration/components/hds/form/field/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/field/index-test.js
@@ -5,11 +5,15 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | hds/form/field/index', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
 
   test('it should render the component with a CSS class provided via the @contextualClass argument', async function (assert) {
     await render(
@@ -160,5 +164,20 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
     assert.dom('#test-form-field').hasClass('my-class');
     assert.dom('#test-form-field').hasAttribute('data-test1');
     assert.dom('#test-form-field').hasAttribute('data-test2', 'test');
+  });
+
+  // ASSERTIONS
+
+  test('it should throw an assertion if an incorrect value for @layout is provided', async function (assert) {
+    const errorMessage =
+      '@layout for "Hds::Form::Field" must be one of the following: vertical, flag; received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Form::Field @layout="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

Fix the assert message on `Form::Field` and add a test to cover it.

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
