### PR TITLE
Fix Embroider warnings caused by incorrect export of internal utility functions

### DIFF
--- a/.changeset/serious-ravens-promise.md
+++ b/.changeset/serious-ravens-promise.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix Embroider warnings caused by incorrect export of internal utility functions

--- a/packages/components/app/utils/hds-get-element-id.js
+++ b/packages/components/app/utils/hds-get-element-id.js
@@ -1,6 +1,0 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
-export { default } from '@hashicorp/design-system-components/utils/hds-get-element-id';

--- a/packages/components/app/utils/hds-set-aria-described-by.js
+++ b/packages/components/app/utils/hds-set-aria-described-by.js
@@ -1,6 +1,0 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
-export { default } from '@hashicorp/design-system-components/utils/hds-set-aria-described-by';


### PR DESCRIPTION
### :pushpin: Summary

Fix Embroider warnings caused by incorrect export of internal utility functions.

Initially, I was tempted to fix this by adding defaults to the utility functions, but then I realized these functions should not be part of the public API of the library (as they are designed for internal use only) so I decided to remove them from the API instead.

Remove `app/utils` exports as they cause the following embroider warnings in the consumer codebase:

```
WARNING in ../rewritten-packages/@hashicorp/design-system-components.4bc2410c/_app_/utils/hds-get-element-id.js 6:0-87
export 'default' (reexported as 'default') was not found in '@hashicorp/design-system-components/utils/hds-get-element-id' (possible exports: getElementId)
 @ ./assets/hcp.js 215:13-55

WARNING in ../rewritten-packages/@hashicorp/design-system-components.4bc2410c/_app_/utils/hds-set-aria-described-by.js 6:0-94
export 'default' (reexported as 'default') was not found in '@hashicorp/design-system-components/utils/hds-set-aria-described-by' (possible exports: setAriaDescribedBy)
 @ ./assets/hcp.js 218:13-62
```

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2275](https://hashicorp.atlassian.net/browse/HDS-2275)

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2275]: https://hashicorp.atlassian.net/browse/HDS-2275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ