### PR TITLE
Add conformance statement for link components

### DIFF
--- a/website/docs/components/link/inline/partials/accessibility/accessibility.md
+++ b/website/docs/components/link/inline/partials/accessibility/accessibility.md
@@ -1,4 +1,9 @@
-<!-- TODO: Add conformance rating -->
+## Conformance rating
+
+<Doc::Badge @type="success">Conformant</Doc::Badge>
+
+When used as recommended, there should not be any WCAG conformance issues with this component.
+
 ## Best Practices
 
 ### Annotations in design
@@ -11,7 +16,7 @@ Include annotations of the non-visual experience in your handoff notes. For exam
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "2.1.1" "1.3.3" "1.4.1" "2.4.7" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "2.1.1" "1.4.1" "2.4.7" }} />
 
 ---
 

--- a/website/docs/components/link/standalone/partials/accessibility/accessibility.md
+++ b/website/docs/components/link/standalone/partials/accessibility/accessibility.md
@@ -1,4 +1,9 @@
-<!-- TODO: Add conformance rating -->
+## Conformance rating
+
+<Doc::Badge @type="success">Conformant</Doc::Badge>
+
+When used as recommended, there should not be any WCAG conformance issues with this component.
+
 ## Best Practices
 
 ### Annotations in design
@@ -15,7 +20,7 @@ Animations or transitions will not take place if the user has `prefers-reduced-m
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "2.1.1" "1.3.3" "1.4.1" "2.4.7" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "2.1.1" "1.4.1" "2.4.7" }} />
 
 ---
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the a11y info for the link components

Preview:
- [standalone](https://hds-website-git-melsumner-link-a11y-statements-hashicorp.vercel.app/components/link/standalone?tab=accessibility)
- [inline](https://hds-website-git-melsumner-link-a11y-statements-hashicorp.vercel.app/components/link/inline)

### :hammer_and_wrench: Detailed description

- add standalone link conformance rating
- add inline link conformance rating
- removes SC 1.3.3 from both components


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2228](https://hashicorp.atlassian.net/browse/HDS-2228)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2228]: https://hashicorp.atlassian.net/browse/HDS-2228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ