### PR TITLE
remove `~` from closing comments in copywrite headers

### DIFF
--- a/.changeset/hot-dolphins-battle.md
+++ b/.changeset/hot-dolphins-battle.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Adjusted closing brace on copywrite headers to avoid terminal noise

--- a/packages/components/addon/components/hds/accordion/item/button.hbs
+++ b/packages/components/addon/components/hds/accordion/item/button.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <button
   class={{this.classNames}}

--- a/packages/components/addon/components/hds/accordion/item/index.hbs
+++ b/packages/components/addon/components/hds/accordion/item/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <Hds::DisclosurePrimitive class={{this.classNames}} @isOpen={{@isOpen}} ...attributes>
   <:toggle as |t|>


### PR DESCRIPTION
### :pushpin: Summary

It's not totally clear _why_ or even 100% _if_ this is the issue, but it does seem logical that given these were only changed and then released very recently they could be the cause of noise like this. These are the only two headers like this that I could find.

```bash
⠼ building... [Babel: @hashicorp/design-system-components > applyPatches]unexpectedly found "\n  Copyright (c) HashiCorp, Inc.\n  SPDX-License-Identifier: MPL-2.0\n~" when slicing source, but expected "\n  Copyright (c) HashiCorp, Inc.\n  SPDX-License-Identifier: MPL-2.0\n"
⠴ building... [Babel: @hashicorp/design-system-components > applyPatches]unexpectedly found "\n  Copyright (c) HashiCorp, Inc.\n  SPDX-License-Identifier: MPL-2.0\n~" when slicing source, but expected "\n  Copyright (c) HashiCorp, Inc.\n  SPDX-License-Identifier: MPL-2.0\n"
```

I have a followup to figure out why this change is happening in the automation that writes these headers.