### PR TITLE
add config and initializer to defer loading of icon sprite

### DIFF
--- a/.changeset/pretty-jobs-destroy.md
+++ b/.changeset/pretty-jobs-destroy.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/ember-flight-icons": minor
+---
+
+Add opt in flag to allow consumers to move sprite loading out of index.html

--- a/packages/components/tests/dummy/config/environment.js
+++ b/packages/components/tests/dummy/config/environment.js
@@ -18,6 +18,10 @@ module.exports = function (environment) {
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
       },
     },
+    // enabled here to aid in testing this feature within our component library
+    emberFlightIcons: {
+      lazyEmbed: true,
+    },
 
     APP: {
       // Here you can pass flags/options to your application instance

--- a/packages/components/tests/index.html
+++ b/packages/components/tests/index.html
@@ -29,8 +29,6 @@
     <div id="qunit-fixture">
       <div id="ember-testing-container">
         <div id="ember-testing">
-          <!-- this is used to inject the SVG sprite -->
-          {{content-for "ember-testing-sprite-embed"}}
         </div>
       </div>
     </div>

--- a/packages/ember-flight-icons/addon/instance-initializers/load-sprite.js
+++ b/packages/ember-flight-icons/addon/instance-initializers/load-sprite.js
@@ -3,7 +3,15 @@ import config from 'ember-get-config';
 
 export function initialize() {
   if (config.emberFlightIcons?.lazyEmbed) {
-    window.document.body.insertAdjacentHTML('beforeend', svgSprite);
+    // in test environments we can inject the sprite directly into the ember testing container
+    // to avoid issues with tools like Percy that only consider content inside that element
+    if (config.environment === 'test') {
+      window.document
+        .getElementById('ember-testing')
+        .insertAdjacentHTML('afterbegin', svgSprite);
+    } else {
+      window.document.body.insertAdjacentHTML('beforeend', svgSprite);
+    }
   }
 }
 

--- a/packages/ember-flight-icons/addon/instance-initializers/load-sprite.js
+++ b/packages/ember-flight-icons/addon/instance-initializers/load-sprite.js
@@ -1,0 +1,12 @@
+import * as svgSprite from '@hashicorp/flight-icons/svg-sprite/svg-sprite-module';
+import config from 'ember-get-config';
+
+export function initialize() {
+  if (config.emberFlightIcons?.lazyEmbed) {
+    window.document.body.insertAdjacentHTML('beforeend', svgSprite);
+  }
+}
+
+export default {
+  initialize,
+};

--- a/packages/ember-flight-icons/app/instance-initializers/load-sprite.js
+++ b/packages/ember-flight-icons/app/instance-initializers/load-sprite.js
@@ -1,0 +1,4 @@
+export {
+  default,
+  initialize,
+} from '@hashicorp/ember-flight-icons/instance-initializers/load-sprite';

--- a/packages/ember-flight-icons/index.js
+++ b/packages/ember-flight-icons/index.js
@@ -11,15 +11,7 @@ module.exports = {
   name: require('./package').name,
 
   contentFor(type, config) {
-    // notice: the "body-footer" is used in the normal app, while the "ember-testing-sprite-embed" is used
-    // in the testing environment to inject the sprite in the #ember-testing "app root element" (ENV.APP.rootElement)
-    // otherwise the @percy/ember package ignores everything else and the SVG sprite is not added to the DOM
-    // see thread: https://hashicorp.slack.com/archives/C11JCBJTW/p1633978558343000
-    // see: https://github.com/percy/percy-ember/blob/ab3b8ebb272fb6479e1185b8ef6e11dab3d6d9b0/addon-test-support/%40percy/ember/index.js#L53
-    if (
-      !config.emberFlightIcons?.lazyEmbed &&
-      (type === 'body-footer' || type === 'ember-testing-sprite-embed')
-    ) {
+    if (!config.emberFlightIcons?.lazyEmbed && type === 'body-footer') {
       return flightIconSprite;
     }
   },

--- a/packages/ember-flight-icons/index.js
+++ b/packages/ember-flight-icons/index.js
@@ -10,13 +10,16 @@ const flightIconSprite = require('@hashicorp/flight-icons/svg-sprite/svg-sprite-
 module.exports = {
   name: require('./package').name,
 
-  contentFor(type) {
+  contentFor(type, config) {
     // notice: the "body-footer" is used in the normal app, while the "ember-testing-sprite-embed" is used
     // in the testing environment to inject the sprite in the #ember-testing "app root element" (ENV.APP.rootElement)
     // otherwise the @percy/ember package ignores everything else and the SVG sprite is not added to the DOM
     // see thread: https://hashicorp.slack.com/archives/C11JCBJTW/p1633978558343000
     // see: https://github.com/percy/percy-ember/blob/ab3b8ebb272fb6479e1185b8ef6e11dab3d6d9b0/addon-test-support/%40percy/ember/index.js#L53
-    if (type === 'body-footer' || type === 'ember-testing-sprite-embed') {
+    if (
+      !config.emberFlightIcons?.lazyEmbed &&
+      (type === 'body-footer' || type === 'ember-testing-sprite-embed')
+    ) {
       return flightIconSprite;
     }
   },

--- a/packages/ember-flight-icons/tests/index.html
+++ b/packages/ember-flight-icons/tests/index.html
@@ -29,8 +29,6 @@
     <div id="qunit-fixture">
       <div id="ember-testing-container">
         <div id="ember-testing">
-          <!-- this is used to inject the SVG sprite -->
-          {{content-for "ember-testing-sprite-embed"}}
         </div>
       </div>
     </div>

--- a/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
+++ b/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
@@ -15,6 +15,25 @@ yarn add @hashicorp/ember-flight-icons
 Because this addon exposes a `data-test-icon` helper, we recommend installing [`ember-test-selectors`](https://github.com/simplabs/ember-test-selectors) which strips out all `data-test-*` attributes for production builds.
 !!!
 
+
+#### Deferred loading
+
+By default, the SVG sprite will be injected into your application's `index.html` file. If you would like this to happen later as part of your app bundle you can set the `lazyEmbed` flag to `true` in the `emberFlightIcons` object in your app's `config/environment.js` file:
+
+```js
+module.exports = function(environment) {
+  const ENV = {
+    // your other config
+    ...
+    emberFlightIcons: {
+      lazyEmbed: true,
+    },
+  };
+}
+```
+
+For more information on why this may be helpful in certain scenarios, see [DS-049 - Improve Ember Flight Icons Loading Performance](https://go.hashi.co/rfc/ds-049).
+
 ### Using icons in React apps
 
 To use icons in a React application, install the `@hashicorp/flight-icons` package and import the icons as either inline SVGs or as a standalone React/SVG component. 


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR will offer a new way to "lazy" load the ember-flight-icon sprite _not_ in the index.html as it does currently.

[Updated docs](https://hds-website-git-br-efi-sprite-hashicorp.vercel.app/icons/usage-guidelines?tab=code#deferred-loading)

### :hammer_and_wrench: Detailed description

There is a more context in the linked RFC below, but effectively what this PR does is introduce a backwards compatible change that allows a consumer to opt into loading the sprite as part of their app bundle vs having it included in the index.html file. It was specifically implemented in a way that if we were to want to remove this feature it would not break any consuming code (those users would revert to the default).

A critical detail for why we don't make this new way the only option is that it doesn't work in fastboot mode which adversely impacts the Helios website.

### Testing
To verify the change you can inspect the showcase and website preview apps and see the difference:

* Showcase: sprite is loaded as part of a `chunk.js` file
* Website: sprite is loaded in index.html

**In both cases you should see `flight-sprite-container` in the DOM only once.**


#### Percy

~~For testing purposes I have included a commit that demonstrates this in action in our showcase app. Because this breaks our Percy tests for reasons out of scope for this PR, I will remove it before merging. _Ideally_ we could use this as a way to implicitly test that this behavior continues to work with future changes, but I was unable to think of a way around this that didn't involve introducing logic to solve this problem in the code we ship for the addon which felt undesirable to me.~~

I was able to solve this and fix the flakey test problem at the same time.

### :link: External links

<!-- Issues, RFC, etc. -->
* Jira ticket: [HDS-2159](https://hashicorp.atlassian.net/browse/HDS-2159)
* [DS-049](https://docs.google.com/document/d/1V9plDdEMuLxrJOOqNUVEIl63uyV2__pq785EZKn_VL8/edit)

***

### 👀 Reviewer's checklist:

- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2159]: https://hashicorp.atlassian.net/browse/HDS-2159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ