### PR TITLE
Remove testing for “splattributes” from integration tests

### DIFF
--- a/packages/components/tests/integration/components/hds/accordion/index-test.js
+++ b/packages/components/tests/integration/components/hds/accordion/index-test.js
@@ -56,7 +56,7 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
         <Hds::Accordion as |A|>
           <A.Item>
             <:toggle>Item one</:toggle>
-            <:content>Additional content</:content> 
+            <:content>Additional content</:content>
           </A.Item>
         </Hds::Accordion>
       `
@@ -76,7 +76,7 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
         <Hds::Accordion as |A|>
           <A.Item>
             <:toggle>Item one</:toggle>
-            <:content>Additional content</:content> 
+            <:content>Additional content</:content>
           </A.Item>
         </Hds::Accordion>
       `
@@ -105,7 +105,7 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
         <Hds::Accordion as |A|>
           <A.Item @isOpen={{true}}>
             <:toggle>Item one</:toggle>
-            <:content>Additional content</:content> 
+            <:content>Additional content</:content>
           </A.Item>
         </Hds::Accordion>
       `
@@ -127,11 +127,11 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
         <Hds::Accordion as |A|>
           <A.Item id="test-contains-interactive--false">
             <:toggle>Item one</:toggle>
-            <:content>Additional content</:content> 
+            <:content>Additional content</:content>
           </A.Item>
           <A.Item @containsInteractive={{true}} id="test-contains-interactive--true">
             <:toggle>Item one</:toggle>
-            <:content>Additional content</:content> 
+            <:content>Additional content</:content>
           </A.Item>
         </Hds::Accordion>
       `
@@ -142,29 +142,5 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
     assert
       .dom('#test-contains-interactive--true')
       .hasClass('hds-accordion-item--contains-interactive');
-  });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`
-        <Hds::Accordion id="test-accordion" class="my-class" data-test1 data-test2="test" as |A|>
-          <A.Item id="test-accordion-item" class="my-class" data-test1 data-test2="test">
-            <:toggle>Item one</:toggle>
-            <:content>Additional content</:content> 
-          </A.Item>
-        </Hds::Accordion>
-      `
-    );
-    // Accordion:
-    assert.dom('#test-accordion').hasClass('my-class');
-    assert.dom('#test-accordion').hasAttribute('data-test1');
-    assert.dom('#test-accordion').hasAttribute('data-test2', 'test');
-
-    // AccordionItem:
-    assert.dom('#test-accordion-item').hasClass('my-class');
-    assert.dom('#test-accordion-item').hasAttribute('data-test1');
-    assert.dom('#test-accordion-item').hasAttribute('data-test2', 'test');
   });
 });

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -144,17 +144,6 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown #test-list-item-interactive').doesNotExist();
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Dropdown id="test-dropdown" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-dropdown').hasClass('my-class');
-    assert.dom('#test-dropdown').hasAttribute('data-test1');
-    assert.dom('#test-dropdown').hasAttribute('data-test2', 'test');
-  });
-
   // ACCESSIBILITY
 
   test('it should render a list of items without a role if no selectable items are passed in', async function (assert) {

--- a/packages/components/tests/integration/components/hds/flyout/index-test.js
+++ b/packages/components/tests/integration/components/hds/flyout/index-test.js
@@ -151,28 +151,6 @@ module('Integration | Component | hds/flyout/index', function (hooks) {
     assert.dom('button.hds-flyout__dismiss').isFocused();
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component and subcomponents', async function (assert) {
-    await render(
-      hbs`<Hds::Flyout id="test-flyout" class="flyout-class" data-test-flyout1 data-test-flyout2="test" as |F|>
-            <F.Header id="test-flyout-header" data-test-flyout-header1 data-test-flyout-header2="test-header">Title</F.Header>
-            <F.Body id="test-flyout-body" data-test-flyout-body1 data-test-flyout-body2="test-body">Body</F.Body>
-          </Hds::Flyout>`
-    );
-    assert.dom('#test-flyout').hasClass('flyout-class');
-    assert.dom('#test-flyout').hasAttribute('data-test-flyout1');
-    assert.dom('#test-flyout').hasAttribute('data-test-flyout2', 'test');
-    assert.dom('#test-flyout-header').hasAttribute('data-test-flyout-header1');
-    assert
-      .dom('#test-flyout-header')
-      .hasAttribute('data-test-flyout-header2', 'test-header');
-    assert.dom('#test-flyout-body').hasAttribute('data-test-flyout-body1');
-    assert
-      .dom('#test-flyout-body')
-      .hasAttribute('data-test-flyout-body2', 'test-body');
-  });
-
   // CALLBACKS
 
   test('it should call `onOpen` function if provided', async function (assert) {

--- a/packages/components/tests/integration/components/hds/form/checkbox/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/base-test.js
@@ -22,15 +22,4 @@ module('Integration | Component | hds/form/checkbox/base', function (hooks) {
     assert.dom('#test-form-checkbox').doesNotHaveAttribute('indeterminate');
     assert.dom('#test-form-checkbox').hasProperty('indeterminate', true);
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Checkbox::Base id="test-form-checkbox" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-checkbox').hasClass('my-class');
-    assert.dom('#test-form-checkbox').hasAttribute('data-test1');
-    assert.dom('#test-form-checkbox').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/field-test.js
@@ -81,17 +81,4 @@ module('Integration | Component | hds/form/checkbox/field', function (hooks) {
       .dom('.hds-form-field__error')
       .hasAttribute('id', `error-${controlId}`);
   });
-
-  // ATTRIBUTES
-
-  // we have added an extra assertion for the "name" attribute here, even if not strictly necessary, to make sure is not overwritten in any way
-  test('it should spread all the attributes (including "name") passed to the component on the input', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Checkbox::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" />`
-    );
-    assert.dom('input').hasClass('my-class');
-    assert.dom('input').hasAttribute('data-test1');
-    assert.dom('input').hasAttribute('data-test2', 'test');
-    assert.dom('input').hasAttribute('name', 'test-name');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/checkbox/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/group-test.js
@@ -151,15 +151,4 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
     assert.dom('legend .hds-form-indicator').exists();
     assert.dom('legend .hds-form-indicator').hasText('(Optional)');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Checkbox::Group id="test-form-checkbox" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-checkbox').hasClass('my-class');
-    assert.dom('#test-form-checkbox').hasAttribute('data-test1');
-    assert.dom('#test-form-checkbox').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/error/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/error/index-test.js
@@ -51,20 +51,12 @@ module('Integration | Component | hds/form/error/index', function (hooks) {
       .hasText('First error message');
   });
 
-  // ATTRIBUTES
+  // ID
 
   test('it renders an error with the correct "id" attribute if the @controlId argument is provided', async function (assert) {
     await render(
       hbs`<Hds::Form::Error @controlId="my-control-id">This is the error</Hds::Form::Error>`
     );
     assert.dom('#error-my-control-id').exists();
-  });
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Error id="test-form-error" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-error').hasClass('my-class');
-    assert.dom('#test-form-error').hasAttribute('data-test1');
-    assert.dom('#test-form-error').hasAttribute('data-test2', 'test');
   });
 });

--- a/packages/components/tests/integration/components/hds/form/field/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/field/index-test.js
@@ -155,17 +155,6 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
     assert.dom('label .hds-form-indicator').hasText('(Optional)');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Field id="test-form-field" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-field').hasClass('my-class');
-    assert.dom('#test-form-field').hasAttribute('data-test1');
-    assert.dom('#test-form-field').hasAttribute('data-test2', 'test');
-  });
-
   // ASSERTIONS
 
   test('it should throw an assertion if an incorrect value for @layout is provided', async function (assert) {

--- a/packages/components/tests/integration/components/hds/form/fieldset/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/fieldset/index-test.js
@@ -95,15 +95,4 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
     assert.dom('legend .hds-form-indicator').exists();
     assert.dom('legend .hds-form-indicator').hasText('(Optional)');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Fieldset id="test-form-fieldset" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-fieldset').hasClass('my-class');
-    assert.dom('#test-form-fieldset').hasAttribute('data-test1');
-    assert.dom('#test-form-fieldset').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/helper-text/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/helper-text/index-test.js
@@ -42,21 +42,13 @@ module(
         .hasText('This is an HTML element inside the helper text');
     });
 
-    // ATTRIBUTES
+    // ID
 
     test('it renders a helper text with the correct "id" attribute if the @controlId argument is provided', async function (assert) {
       await render(
         hbs`<Hds::Form::HelperText @controlId="my-control-id">This is the helper text</Hds::Form::HelperText>`
       );
       assert.dom('#helper-text-my-control-id').exists();
-    });
-    test('it should spread all the attributes passed to the component', async function (assert) {
-      await render(
-        hbs`<Hds::Form::HelperText id="test-form-helper-text" class="my-class" data-test1 data-test2="test" />`
-      );
-      assert.dom('#test-form-helper-text').hasClass('my-class');
-      assert.dom('#test-form-helper-text').hasAttribute('data-test1');
-      assert.dom('#test-form-helper-text').hasAttribute('data-test2', 'test');
     });
   }
 );

--- a/packages/components/tests/integration/components/hds/form/label/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/label/index-test.js
@@ -57,20 +57,12 @@ module('Integration | Component | hds/form/label/index', function (hooks) {
     assert.dom('#test-form-label .hds-form-indicator').hasText('(Optional)');
   });
 
-  // ATTRIBUTES
+  // FOR
 
   test('it renders a label with the "for" attribute if the @controlId argument is provided', async function (assert) {
     await render(
       hbs`<Hds::Form::Label @controlId="my-control-id" id="test-form-label">This is the label</Hds::Form::Label>`
     );
     assert.dom('#test-form-label').hasAttribute('for', 'my-control-id');
-  });
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Label id="test-form-label" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-label').hasClass('my-class');
-    assert.dom('#test-form-label').hasAttribute('data-test1');
-    assert.dom('#test-form-label').hasAttribute('data-test2', 'test');
   });
 });

--- a/packages/components/tests/integration/components/hds/form/legend/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/legend/index-test.js
@@ -60,15 +60,4 @@ module('Integration | Component | hds/form/legend/index', function (hooks) {
     assert.dom('#test-form-legend > .hds-form-indicator').exists();
     assert.dom('#test-form-legend .hds-form-indicator').hasText('(Optional)');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Legend id="test-form-legend" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-legend').hasClass('my-class');
-    assert.dom('#test-form-legend').hasAttribute('data-test1');
-    assert.dom('#test-form-legend').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/masked-input/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/masked-input/base-test.js
@@ -114,16 +114,5 @@ module(
       );
       assert.dom('textarea#test-form-masked-input').exists();
     });
-
-    // ATTRIBUTES
-
-    test('it should spread all the attributes passed to the component on the input', async function (assert) {
-      await render(
-        hbs`<Hds::Form::MaskedInput::Base class="my-class" data-test1 data-test2="test" />`
-      );
-      assert.dom('input').hasClass('my-class');
-      assert.dom('input').hasAttribute('data-test1');
-      assert.dom('input').hasAttribute('data-test2', 'test');
-    });
   }
 );

--- a/packages/components/tests/integration/components/hds/form/masked-input/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/masked-input/field-test.js
@@ -140,16 +140,5 @@ module(
       assert.dom('input').hasAttribute('required');
       assert.dom('label .hds-form-indicator').doesNotExist();
     });
-
-    // ATTRIBUTES
-
-    test('it should spread all the attributes passed to the component on the input', async function (assert) {
-      await render(
-        hbs`<Hds::Form::MaskedInput::Field class="my-class" data-test1 data-test2="test" />`
-      );
-      assert.dom('input').hasClass('my-class');
-      assert.dom('input').hasAttribute('data-test1');
-      assert.dom('input').hasAttribute('data-test2', 'test');
-    });
   }
 );

--- a/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/group-test.js
@@ -127,15 +127,4 @@ module('Integration | Component | hds/form/radio-card/group', function (hooks) {
     assert.dom('legend .hds-form-indicator').exists();
     assert.dom('legend .hds-form-indicator').hasText('(Optional)');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::Form::RadioCard::Group id="test-radio-card-group" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-radio-card-group').hasClass('my-class');
-    assert.dom('#test-radio-card-group').hasAttribute('data-test1');
-    assert.dom('#test-radio-card-group').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio-card/index-test.js
@@ -65,19 +65,6 @@ module('Integration | Component | hds/form/radio-card/index', function (hooks) {
     assert.dom('.custom').doesNotExist();
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    await render(
-      hbs`<Hds::Form::RadioCard id="my-id" name="my-name" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('input').hasAttribute('id', 'my-id');
-    assert.dom('input').hasAttribute('name', 'my-name');
-    assert.dom('input').hasClass('my-class');
-    assert.dom('input').hasAttribute('data-test1');
-    assert.dom('input').hasAttribute('data-test2', 'test');
-  });
-
   // ASSERTIONS: ALIGNMENT, CONTROL POSITION, LAYOUT
 
   test('it should throw an assertion if an incorrect value for @alignment is provided', async function (assert) {

--- a/packages/components/tests/integration/components/hds/form/radio/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/base-test.js
@@ -15,15 +15,4 @@ module('Integration | Component | hds/form/radio/base', function (hooks) {
     await render(hbs`<Hds::Form::Radio::Base id="test-form-radio" />`);
     assert.dom('#test-form-radio').hasClass('hds-form-radio');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Radio::Base id="test-form-radio" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-radio').hasClass('my-class');
-    assert.dom('#test-form-radio').hasAttribute('data-test1');
-    assert.dom('#test-form-radio').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/radio/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/field-test.js
@@ -80,17 +80,4 @@ module('Integration | Component | hds/form/radio/field', function (hooks) {
       .dom('.hds-form-field__error')
       .hasAttribute('id', `error-${controlId}`);
   });
-
-  // ATTRIBUTES
-
-  // we have added an extra assertion for the "name" attribute here, even if not strictly necessary, to make sure is not overwritten in any way
-  test('it should spread all the attributes (includind "name") passed to the component on the input', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Radio::Field checked="checked" class="my-class" data-test1 data-test2="test" name="test-name" />`
-    );
-    assert.dom('input').hasClass('my-class');
-    assert.dom('input').hasAttribute('data-test1');
-    assert.dom('input').hasAttribute('data-test2', 'test');
-    assert.dom('input').hasAttribute('name', 'test-name');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/radio/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/group-test.js
@@ -151,15 +151,4 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
     assert.dom('legend .hds-form-indicator').exists();
     assert.dom('legend .hds-form-indicator').hasText('(Optional)');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Radio::Group id="test-form-radio" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-radio').hasClass('my-class');
-    assert.dom('#test-form-radio').hasAttribute('data-test1');
-    assert.dom('#test-form-radio').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/select/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/base-test.js
@@ -44,15 +44,4 @@ module('Integration | Component | hds/form/select/base', function (hooks) {
     );
     assert.dom('#test-form-select').hasClass('hds-form-select--is-invalid');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Select::Base id="test-form-select" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-select').hasClass('my-class');
-    assert.dom('#test-form-select').hasAttribute('data-test1');
-    assert.dom('#test-form-select').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/select/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/select/field-test.js
@@ -129,15 +129,4 @@ module('Integration | Component | hds/form/select/field', function (hooks) {
     assert.dom('select').hasAttribute('required');
     assert.dom('label .hds-form-indicator').doesNotExist();
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Select::Field class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('select').hasClass('my-class');
-    assert.dom('select').hasAttribute('data-test1');
-    assert.dom('select').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/text-input/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/base-test.js
@@ -76,17 +76,6 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
     assert.dom('#test-form-text-input').hasStyle({ width: '248px' });
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::TextInput::Base id="test-form-text-input" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-text-input').hasClass('my-class');
-    assert.dom('#test-form-text-input').hasAttribute('data-test1');
-    assert.dom('#test-form-text-input').hasAttribute('data-test2', 'test');
-  });
-
   // ASSERTIONS
 
   test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {

--- a/packages/components/tests/integration/components/hds/form/text-input/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/text-input/field-test.js
@@ -145,15 +145,4 @@ module('Integration | Component | hds/form/text-input/field', function (hooks) {
     assert.dom('input').hasAttribute('required');
     assert.dom('label .hds-form-indicator').doesNotExist();
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    await render(
-      hbs`<Hds::Form::TextInput::Field class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('input').hasClass('my-class');
-    assert.dom('input').hasAttribute('data-test1');
-    assert.dom('input').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/textarea/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/base-test.js
@@ -44,15 +44,4 @@ module('Integration | Component | hds/form/textarea/base', function (hooks) {
     );
     assert.dom('#test-form-textarea').hasClass('hds-form-textarea--is-invalid');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Textarea::Base id="test-form-textarea" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-textarea').hasClass('my-class');
-    assert.dom('#test-form-textarea').hasAttribute('data-test1');
-    assert.dom('#test-form-textarea').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/textarea/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/textarea/field-test.js
@@ -135,15 +135,4 @@ module('Integration | Component | hds/form/textarea/field', function (hooks) {
     assert.dom('textarea').hasAttribute('required');
     assert.dom('label .hds-form-indicator').doesNotExist();
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Textarea::Field class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('textarea').hasClass('my-class');
-    assert.dom('textarea').hasAttribute('data-test1');
-    assert.dom('textarea').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/toggle/base-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/base-test.js
@@ -19,17 +19,6 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
     assert.dom('#test-form-toggle').hasClass('hds-form-toggle__control');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Toggle::Base id="test-form-toggle" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-toggle').hasClass('my-class');
-    assert.dom('#test-form-toggle').hasAttribute('data-test1');
-    assert.dom('#test-form-toggle').hasAttribute('data-test2', 'test');
-  });
-
   // ACCESSIBILITY
 
   test('it should render with the correct role', async function (assert) {

--- a/packages/components/tests/integration/components/hds/form/toggle/field-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/field-test.js
@@ -82,15 +82,4 @@ module('Integration | Component | hds/form/toggle/field', function (hooks) {
       .dom('.hds-form-field__error')
       .hasAttribute('id', `error-${controlId}`);
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the input', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Toggle::Field checked="checked" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('input').hasClass('my-class');
-    assert.dom('input').hasAttribute('data-test1');
-    assert.dom('input').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/form/toggle/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/group-test.js
@@ -129,15 +129,4 @@ module('Integration | Component | hds/form/toggle/group', function (hooks) {
     assert.dom('legend .hds-form-indicator').exists();
     assert.dom('legend .hds-form-indicator').hasText('(Optional)');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::Form::Toggle::Group id="test-form-toggle" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-form-toggle').hasClass('my-class');
-    assert.dom('#test-form-toggle').hasAttribute('data-test1');
-    assert.dom('#test-form-toggle').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/interactive/index-test.js
+++ b/packages/components/tests/integration/components/hds/interactive/index-test.js
@@ -61,33 +61,6 @@ module('Integration | Component | hds/interactive/index', function (hooks) {
     assert.dom('#test-interactive').doesNotHaveAttribute('rel');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the <button> element', async function (assert) {
-    await render(
-      hbs`<Hds::Interactive id="test-interactive" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('button#test-interactive').hasClass('my-class');
-    assert.dom('button#test-interactive').hasAttribute('data-test1');
-    assert.dom('button#test-interactive').hasAttribute('data-test2', 'test');
-  });
-  test('it should spread all the attributes passed to the <a> element', async function (assert) {
-    await render(
-      hbs`<Hds::Interactive @href="#" id="test-interactive" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('a#test-interactive').hasClass('my-class');
-    assert.dom('a#test-interactive').hasAttribute('data-test1');
-    assert.dom('a#test-interactive').hasAttribute('data-test2', 'test');
-  });
-  test('it should spread all the attributes passed to the <LinkTo> element', async function (assert) {
-    await render(
-      hbs`<Hds::Interactive @route="index" id="test-interactive" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('a#test-interactive').hasClass('my-class');
-    assert.dom('a#test-interactive').hasAttribute('data-test1');
-    assert.dom('a#test-interactive').hasAttribute('data-test2', 'test');
-  });
-
   // YIELDING
 
   test('it should yield the children of the <button> element', async function (assert) {

--- a/packages/components/tests/integration/components/hds/modal/index-test.js
+++ b/packages/components/tests/integration/components/hds/modal/index-test.js
@@ -161,33 +161,6 @@ module('Integration | Component | hds/modal/index', function (hooks) {
     assert.dom('button.hds-modal__dismiss').isFocused();
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component and subcomponents', async function (assert) {
-    await render(
-      hbs`<Hds::Modal id="test-modal" class="modal-class" data-test-modal1 data-test-modal2="test" as |M|>
-            <M.Header id="test-modal-header" data-test-modal-header1 data-test-modal-header2="test-header">Title</M.Header>
-            <M.Body id="test-modal-body" data-test-modal-body1 data-test-modal-body2="test-body">Body</M.Body>
-            <M.Footer id="test-modal-footer" data-test-modal-footer1 data-test-modal-footer2="test-footer">Footer</M.Footer>
-          </Hds::Modal>`
-    );
-    assert.dom('#test-modal').hasClass('modal-class');
-    assert.dom('#test-modal').hasAttribute('data-test-modal1');
-    assert.dom('#test-modal').hasAttribute('data-test-modal2', 'test');
-    assert.dom('#test-modal-header').hasAttribute('data-test-modal-header1');
-    assert
-      .dom('#test-modal-header')
-      .hasAttribute('data-test-modal-header2', 'test-header');
-    assert.dom('#test-modal-body').hasAttribute('data-test-modal-body1');
-    assert
-      .dom('#test-modal-body')
-      .hasAttribute('data-test-modal-body2', 'test-body');
-    assert.dom('#test-modal-footer').hasAttribute('data-test-modal-footer1');
-    assert
-      .dom('#test-modal-footer')
-      .hasAttribute('data-test-modal-footer2', 'test-footer');
-  });
-
   // CALLBACKS
 
   test('it should call `onOpen` function if provided', async function (assert) {

--- a/packages/components/tests/integration/components/hds/pagination/compact-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/compact-test.js
@@ -63,17 +63,6 @@ module('Integration | Component | hds/pagination/compact', function (hooks) {
       .hasAttribute('disabled');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::Pagination::Compact id="test-pagination-compact" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-pagination-compact').hasClass('my-class');
-    assert.dom('#test-pagination-compact').hasAttribute('data-test1');
-    assert.dom('#test-pagination-compact').hasAttribute('data-test2', 'test');
-  });
-
   // EVENTS
 
   test('it should invoke the onPageChange callback and return the value of the new page number and page size', async function (assert) {

--- a/packages/components/tests/integration/components/hds/pagination/nav/arrow-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/nav/arrow-test.js
@@ -70,17 +70,6 @@ module('Integration | Component | hds/pagination/nav/arrow', function (hooks) {
     assert.dom('.hds-pagination-nav__control').hasAttribute('disabled');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::Pagination::Nav::Arrow @direction="next" id="test-pagination-arrow" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-pagination-arrow').hasClass('my-class');
-    assert.dom('#test-pagination-arrow').hasAttribute('data-test1');
-    assert.dom('#test-pagination-arrow').hasAttribute('data-test2', 'test');
-  });
-
   // EVENTS
 
   test('it should call the onClick handler with the value of the direction of the button', async function (assert) {

--- a/packages/components/tests/integration/components/hds/pagination/nav/ellipsis-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/nav/ellipsis-test.js
@@ -19,18 +19,5 @@ module(
     `);
       assert.dom('#test-nav-ellipsis').hasClass('hds-pagination-nav__ellipsis');
     });
-
-    // ATTRIBUTES
-
-    test('it should spread all the attributes passed to the component on the element', async function (assert) {
-      await render(
-        hbs`<Hds::Pagination::Nav::Ellipsis id="test-pagination-ellipsis" class="my-class" data-test1 data-test2="test" />`
-      );
-      assert.dom('#test-pagination-ellipsis').hasClass('my-class');
-      assert.dom('#test-pagination-ellipsis').hasAttribute('data-test1');
-      assert
-        .dom('#test-pagination-ellipsis')
-        .hasAttribute('data-test2', 'test');
-    });
   }
 );

--- a/packages/components/tests/integration/components/hds/pagination/nav/number-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/nav/number-test.js
@@ -51,17 +51,6 @@ module('Integration | Component | hds/pagination/nav/number', function (hooks) {
       .doesNotHaveAttribute('aria-current', 'page');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::Pagination::Nav::Number @page={{3}} id="test-pagination-number" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-pagination-number').hasClass('my-class');
-    assert.dom('#test-pagination-number').hasAttribute('data-test1');
-    assert.dom('#test-pagination-number').hasAttribute('data-test2', 'test');
-  });
-
   // EVENTS
 
   test('it should call the onClick handler with the value of the page number', async function (assert) {

--- a/packages/components/tests/integration/components/hds/pagination/numbered-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/numbered-test.js
@@ -276,17 +276,6 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
     assert.dom('.hds-pagination-nav__arrow--direction-next').isDisabled();
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::Pagination::Numbered @totalItems={{100}} id="test-pagination-numbered" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-pagination-numbered').hasClass('my-class');
-    assert.dom('#test-pagination-numbered').hasAttribute('data-test1');
-    assert.dom('#test-pagination-numbered').hasAttribute('data-test2', 'test');
-  });
-
   // INTERACTION
 
   test('it should select the activated page number', async function (assert) {

--- a/packages/components/tests/integration/components/hds/pagination/size-selector-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/size-selector-test.js
@@ -81,19 +81,6 @@ module(
       assert.dom('.hds-pagination-size-selector label').hasText('Custom text');
     });
 
-    // ATTRIBUTES
-
-    test('it should spread all the attributes passed to the component on the element', async function (assert) {
-      await render(
-        hbs`<Hds::Pagination::SizeSelector @pageSizes={{array 10 30 50}} id="test-pagination-size-selector" class="my-class" data-test1 data-test2="test" />`
-      );
-      assert.dom('#test-pagination-size-selector').hasClass('my-class');
-      assert.dom('#test-pagination-size-selector').hasAttribute('data-test1');
-      assert
-        .dom('#test-pagination-size-selector')
-        .hasAttribute('data-test2', 'test');
-    });
-
     // EVENTS
 
     test('it should call the onClick handler with the value of the page number', async function (assert) {

--- a/packages/components/tests/integration/components/hds/reveal/index-test.js
+++ b/packages/components/tests/integration/components/hds/reveal/index-test.js
@@ -113,20 +113,6 @@ module('Integration | Component | hds/reveal/index', function (hooks) {
     assert.dom('.hds-reveal__toggle-button').hasText('Close me');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`
-      <Hds::Reveal @text="More options" id="test-reveal" class="my-class" data-test1 data-test2="test">
-        Additional content
-      </Hds::Reveal>`
-    );
-    assert.dom('#test-reveal').hasClass('my-class');
-    assert.dom('#test-reveal').hasAttribute('data-test1');
-    assert.dom('#test-reveal').hasAttribute('data-test2', 'test');
-  });
-
   // ASSERTIONS
 
   test('it should throw an assertion if @text is missing/has no value', async function (assert) {

--- a/packages/components/tests/integration/components/hds/side-nav/base-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/base-test.js
@@ -40,15 +40,4 @@ module('Integration | Component | hds/side-nav/base', function (hooks) {
     assert.dom('#test-side-nav-body').exists();
     assert.dom('#test-side-nav-footer').exists();
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav::Base id="test-side-nav" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-side-nav').hasClass('my-class');
-    assert.dom('#test-side-nav').hasAttribute('data-test1');
-    assert.dom('#test-side-nav').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/side-nav/header/home-link-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/header/home-link-test.js
@@ -44,17 +44,6 @@ module('Integration | Component | hds/side-nav/home-link', function (hooks) {
       .hasAttribute('fill', 'var(--token-color-boundary-brand)');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="Hashicorp" id="test-side-nav-homelink" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-side-nav-homelink').hasClass('my-class');
-    assert.dom('#test-side-nav-homelink').hasAttribute('data-test1');
-    assert.dom('#test-side-nav-homelink').hasAttribute('data-test2', 'test');
-  });
-
   // ASSERTIONS
 
   test('it should throw an assertion if @ariaLabel is missing/has no value', async function (assert) {

--- a/packages/components/tests/integration/components/hds/side-nav/header/icon-button-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/header/icon-button-test.js
@@ -62,17 +62,6 @@ module('Integration | Component | hds/side-nav/icon-button', function (hooks) {
       .hasAttribute('href', '/utilities/interactive');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" id="test-side-nav-button" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-side-nav-button').hasClass('my-class');
-    assert.dom('#test-side-nav-button').hasAttribute('data-test1');
-    assert.dom('#test-side-nav-button').hasAttribute('data-test2', 'test');
-  });
-
   // ASSERTIONS
 
   test('it should throw an assertion if @ariaLabel is missing/has no value', async function (assert) {

--- a/packages/components/tests/integration/components/hds/side-nav/header/index-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/header/index-test.js
@@ -32,15 +32,4 @@ module('Integration | Component | hds/side-nav/header', function (hooks) {
     assert.dom('#test-side-nav-logo').exists();
     assert.dom('#test-side-nav-actions').exists();
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav::Header id="test-side-nav-header" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-side-nav-header').hasClass('my-class');
-    assert.dom('#test-side-nav-header').hasAttribute('data-test1');
-    assert.dom('#test-side-nav-header').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/side-nav/index-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/index-test.js
@@ -178,17 +178,6 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
       .doesNotHaveAttribute('data-test-minimized');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav id="test-side-nav" class="my-class" data-test1 data-test2="test" @hasA11yRefocus={{false}} />`
-    );
-    assert.dom('#test-side-nav').hasClass('my-class');
-    assert.dom('#test-side-nav').hasAttribute('data-test1');
-    assert.dom('#test-side-nav').hasAttribute('data-test2', 'test');
-  });
-
   // CALLBACKS
 
   test('it should call `onToggleMinimizedStatus` function if provided', async function (assert) {

--- a/packages/components/tests/integration/components/hds/side-nav/list/back-link-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/list/back-link-test.js
@@ -64,16 +64,5 @@ module(
         .hasTagName('a')
         .hasAttribute('href', '/utilities/interactive');
     });
-
-    // ATTRIBUTES
-
-    test('it should spread all the attributes passed to the component on the element', async function (assert) {
-      await render(
-        hbs`<Hds::SideNav::List::BackLink id="test-side-nav-backlink" class="my-class" data-test1 data-test2="test" />`
-      );
-      assert.dom('#test-side-nav-backlink').hasClass('my-class');
-      assert.dom('#test-side-nav-backlink').hasAttribute('data-test1');
-      assert.dom('#test-side-nav-backlink').hasAttribute('data-test2', 'test');
-    });
   }
 );

--- a/packages/components/tests/integration/components/hds/side-nav/list/index-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/list/index-test.js
@@ -44,15 +44,4 @@ module('Integration | Component | hds/side-nav/list/index', function (hooks) {
     `);
     assert.dom('.hds-side-nav__list').hasAttribute('role', 'list');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav::List id="test-side-nav-list" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-side-nav-list').hasClass('my-class');
-    assert.dom('#test-side-nav-list').hasAttribute('data-test1');
-    assert.dom('#test-side-nav-list').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/side-nav/list/item-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/list/item-test.js
@@ -30,15 +30,4 @@ module('Integration | Component | hds/side-nav/list/item', function (hooks) {
     `);
     assert.dom('#test-custom-content').exists();
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav::List::Item id="test-side-nav-item" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-side-nav-item').hasClass('my-class');
-    assert.dom('#test-side-nav-item').hasAttribute('data-test1');
-    assert.dom('#test-side-nav-item').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/side-nav/list/link-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/list/link-test.js
@@ -78,15 +78,4 @@ module('Integration | Component | hds/side-nav/list/link', function (hooks) {
       .hasTagName('a')
       .hasAttribute('href', '/utilities/interactive');
   });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav::List::Link id="test-side-nav-link" class="my-class" data-test1 data-test2="test" />`
-    );
-    assert.dom('#test-side-nav-link').hasClass('my-class');
-    assert.dom('#test-side-nav-link').hasAttribute('data-test1');
-    assert.dom('#test-side-nav-link').hasAttribute('data-test2', 'test');
-  });
 });

--- a/packages/components/tests/integration/components/hds/side-nav/portal/index-test.js
+++ b/packages/components/tests/integration/components/hds/side-nav/portal/index-test.js
@@ -75,28 +75,6 @@ module('Integration | Component | hds/side-nav/portal', function (hooks) {
     assert.dom('#test-side-nav-list-link').hasText('Link');
   });
 
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the portals on the rendered elements', async function (assert) {
-    await render(hbs`
-      <Hds::SideNav::Portal::Target id="test-side-nav-portal-target" class="my-class" data-test1 data-test2="test" />
-      <Hds::SideNav::Portal id="test-side-nav-portal" class="my-class" data-test1 data-test2="test">
-        <div/>
-      </Hds::SideNav::Portal>
-    `);
-    assert.dom('#test-side-nav-portal-target').exists();
-    assert.dom('#test-side-nav-portal-target').hasClass('my-class');
-    assert.dom('#test-side-nav-portal-target').hasAttribute('data-test1');
-    assert
-      .dom('#test-side-nav-portal-target')
-      .hasAttribute('data-test2', 'test');
-
-    assert.dom('#test-side-nav-portal').exists();
-    assert.dom('#test-side-nav-portal').hasClass('my-class');
-    assert.dom('#test-side-nav-portal').hasAttribute('data-test1');
-    assert.dom('#test-side-nav-portal').hasAttribute('data-test2', 'test');
-  });
-
   // A11Y
 
   test('it should render with the correct aria-label attribute passed down to the "list" parent', async function (assert) {

--- a/packages/components/tests/integration/components/hds/tooltip/tooltip-button-test.js
+++ b/packages/components/tests/integration/components/hds/tooltip/tooltip-button-test.js
@@ -36,9 +36,9 @@ module('Integration | Component | hds/tooltip/index', function (hooks) {
   test('when allowHTML to true is passed in as an extraTippyOption, it renders rich HTML and text content passed into the tooltip', async function (assert) {
     await render(
       hbs`
-        <Hds::TooltipButton 
+        <Hds::TooltipButton
           @extraTippyOptions={{hash allowHTML=true}}
-          @text="<em>em</em> <strong>strong</strong>" 
+          @text="<em>em</em> <strong>strong</strong>"
           id="test-tooltip-button"
         >info</Hds::TooltipButton>
       `
@@ -127,19 +127,6 @@ module('Integration | Component | hds/tooltip/index', function (hooks) {
       hbs`<Hds::TooltipButton @text="More info." @isInline={{false}} id="test-tooltip-button">info</Hds::TooltipButton>`
     );
     assert.dom('#test-tooltip-button').hasClass('hds-tooltip-button--is-block');
-  });
-
-  // ATTRIBUTES
-
-  test('it should spread all the attributes passed to the component on the element', async function (assert) {
-    await render(
-      hbs`
-      <Hds::TooltipButton @text="Here is more info." id="test-tooltip-button" class="my-class" data-test1 data-test2="test">info</Hds::TooltipButton>
-      `
-    );
-    assert.dom('#test-tooltip-button').hasClass('my-class');
-    assert.dom('#test-tooltip-button').hasAttribute('data-test1');
-    assert.dom('#test-tooltip-button').hasAttribute('data-test2', 'test');
   });
 
   // ASSERTIONS


### PR DESCRIPTION
### :pushpin: Summary

Per our [discussion and decision today](https://docs.google.com/document/d/1twnk39hZ7p8oZYrld_FYsdiuUb6yn_weA46KnhF4nu4/edit#heading=h.d767m4xoyzww), I've removed all the instances of tests in which we were testing the correct application of "splattributes" on components/subcomponents.

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
