### PR TITLE
`Copy` - Showcase tweaks

### DIFF
--- a/packages/components/tests/dummy/app/controllers/components/copy/button.js
+++ b/packages/components/tests/dummy/app/controllers/components/copy/button.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { scheduleOnce } from '@ember/runloop';
+
+function replaceMockCopyStatus() {
+  document.querySelectorAll('[mock-copy-status]').forEach((element) => {
+    const status = element.attributes['mock-copy-status'].value;
+    element.classList.remove('hds-copy-button--status-idle');
+    element.classList.add(`hds-copy-button--status-${status}`);
+    const icon = element.querySelector('svg use');
+    if (icon) {
+      if (status === 'success') {
+        // eg. href="#flight-clipboard-checked-16"
+        icon.setAttribute('href', `#flight-${this.model.SUCCESS_ICON}-16`);
+      } else if (status === 'error') {
+        icon.setAttribute('href', `#flight-${this.model.ERROR_ICON}-16`);
+      }
+    }
+  });
+}
+
+export default class CopyButtonController extends Controller {
+  @service router;
+
+  constructor() {
+    super(...arguments);
+    this.router.on('routeDidChange', this, 'routeDidChange');
+  }
+
+  routeDidChange() {
+    scheduleOnce('afterRender', this, replaceMockCopyStatus);
+  }
+}

--- a/packages/components/tests/dummy/app/controllers/components/copy/snippet.js
+++ b/packages/components/tests/dummy/app/controllers/components/copy/snippet.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { scheduleOnce } from '@ember/runloop';
+
+function replaceMockCopyStatus() {
+  document.querySelectorAll('[mock-copy-status]').forEach((element) => {
+    const status = element.attributes['mock-copy-status'].value;
+    element.classList.remove('hds-copy-snippet--status-idle');
+    element.classList.add(`hds-copy-snippet--status-${status}`);
+    const icon = element.querySelector('svg use');
+    if (icon) {
+      if (status === 'success') {
+        // eg. href="#flight-clipboard-checked-16"
+        icon.setAttribute('href', `#flight-${this.model.SUCCESS_ICON}-16`);
+      } else if (status === 'error') {
+        icon.setAttribute('href', `#flight-${this.model.ERROR_ICON}-16`);
+      }
+    }
+  });
+}
+
+export default class CopySnippetController extends Controller {
+  @service router;
+
+  constructor() {
+    super(...arguments);
+    this.router.on('routeDidChange', this, 'routeDidChange');
+  }
+
+  routeDidChange() {
+    scheduleOnce('afterRender', this, replaceMockCopyStatus);
+  }
+}

--- a/packages/components/tests/dummy/app/routes/components/copy/button.js
+++ b/packages/components/tests/dummy/app/routes/components/copy/button.js
@@ -4,13 +4,16 @@
  */
 
 import Route from '@ember/routing/route';
-import { SIZES } from '@hashicorp/design-system-components/components/hds/copy/button';
+import {
+  SIZES,
+  SUCCESS_ICON,
+  ERROR_ICON,
+} from '@hashicorp/design-system-components/components/hds/copy/button';
 
 export default class ComponentsCopyButtonRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
     const STATES = ['default', 'hover', 'active', 'focus'];
-    const STATUS = ['idle', 'success', 'error'];
-    return { SIZES, STATES, STATUS };
+    return { SIZES, STATES, SUCCESS_ICON, ERROR_ICON };
   }
 }

--- a/packages/components/tests/dummy/app/routes/components/copy/snippet.js
+++ b/packages/components/tests/dummy/app/routes/components/copy/snippet.js
@@ -4,13 +4,16 @@
  */
 
 import Route from '@ember/routing/route';
-import { COLORS } from '@hashicorp/design-system-components/components/hds/copy/snippet';
+import {
+  COLORS,
+  SUCCESS_ICON,
+  ERROR_ICON,
+} from '@hashicorp/design-system-components/components/hds/copy/snippet';
 
 export default class ComponentsCopySnippetRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
     const STATES = ['default', 'hover', 'active', 'focus'];
-    const STATUS = ['idle', 'success', 'error'];
-    return { COLORS, STATES, STATUS };
+    return { COLORS, STATES, SUCCESS_ICON, ERROR_ICON };
   }
 }

--- a/packages/components/tests/dummy/app/styles/showcase-components/grid.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-components/grid.scss
@@ -36,6 +36,10 @@
   .shw-grid--cols-6 > & {
     grid-template-columns: repeat(6, 1fr);
   }
+
+  .shw-grid--cols-7 > & {
+    grid-template-columns: repeat(7, 1fr);
+  }
 }
 
 .shw-grid__item--grow {

--- a/packages/components/tests/dummy/app/styles/showcase-pages/copy/button.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/copy/button.scss
@@ -12,6 +12,12 @@ body.components-copy-button {
     align-items: flex-start;
   }
 
+  .shw-component-copy-button-composition-masked-input-field {
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+  }
+
   .shw-component-copy-button-code-block {
     padding: 1rem;
     color: white;

--- a/packages/components/tests/dummy/app/styles/showcase-pages/copy/button.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/copy/button.scss
@@ -6,6 +6,12 @@
 // COPY > BUTTON
 
 body.components-copy-button {
+  .shw-component-copy-button-composition-masked-input-base {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+  }
+
   .shw-component-copy-button-code-block {
     padding: 1rem;
     color: white;

--- a/packages/components/tests/dummy/app/styles/showcase-pages/copy/button.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/copy/button.scss
@@ -5,9 +5,11 @@
 
 // COPY > BUTTON
 
-body.components-copy-button pre {
-  padding: 1rem;
-  color: white;
-  background-color: black;
-  border-radius: 5px;
+body.components-copy-button {
+  .shw-component-copy-button-code-block {
+    padding: 1rem;
+    color: white;
+    background-color: black;
+    border-radius: 5px;
+  }
 }

--- a/packages/components/tests/dummy/app/templates/components/copy/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/copy/button.hbs
@@ -100,6 +100,27 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Flex as |SF|>
+    <SF.Item @label="With MaskedInput::Field">
+      <div class="shw-component-copy-button-composition-masked-input-field">
+        <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+        </Hds::Form::MaskedInput::Field>
+        <Hds::Copy::Button @isIconOnly={{true}} @text="Copy" @textToCopy="Lorem ipsum dolor" />
+      </div>
+    </SF.Item>
+    <SF.Item @label="With MaskedInput::Field (multiline)">
+      <div class="shw-component-copy-button-composition-masked-input-field">
+        <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" @isMultiline={{true}} as |F|>
+          <F.Label>This is the label</F.Label>
+          <F.HelperText>This is the helper text</F.HelperText>
+        </Hds::Form::MaskedInput::Field>
+        <Hds::Copy::Button @isIconOnly={{true}} @text="Copy" @textToCopy="Lorem ipsum dolor" />
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Divider />
 
   <Shw::Text::H2>Demo</Shw::Text::H2>

--- a/packages/components/tests/dummy/app/templates/components/copy/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/copy/button.hbs
@@ -8,16 +8,6 @@
 <Shw::Text::H1>Copy::Button</Shw::Text::H1>
 
 <section data-test-percy>
-  <Shw::Text::H2>Generated element</Shw::Text::H2>
-
-  <Shw::Flex as |SF|>
-    <SF.Item class="shw-component-button-generated">
-      <Shw::Label>Default</Shw::Label>
-      <p class="shw-text shw-text-body" id="targetToCopy">This is the target element; the button will copy the text in
-        this target element.</p>
-      <Hds::Copy::Button @text="Copy" @targetToCopy="#targetToCopy" />
-    </SF.Item>
-  </Shw::Flex>
 
   <Shw::Text::H2>Content</Shw::Text::H2>
 
@@ -70,32 +60,63 @@
     {{/each}}
   </Shw::Flex>
 
-  <Shw::Text::H2>Some specific use cases for demo purposes</Shw::Text::H2>
-  <Shw::Flex as |SF|>
-    <SF.Item>
-      <Shw::Label>A code block</Shw::Label>
-      {{!-- prettier-ignore --}}
-      <pre><code id="targetToCopy3">&lt;h1&gt;A page header example&lt;/h1&gt;
-&lt;p&gt;Some paragraph text also&lt;/p&gt;
-      </code></pre>
-      <Hds::Copy::Button @text="Copy this code block" @targetToCopy="#targetToCopy3" />
-    </SF.Item>
-  </Shw::Flex>
-  <Shw::Flex as |SF|>
-    <SF.Item>
-      <Shw::Label>Copy an input value</Shw::Label>
-      <Hds::Form::TextInput::Field @value="036140285924" @name="test-input" @id="test-input" as |F|>
-        <F.Label>Input Label</F.Label>
-      </Hds::Form::TextInput::Field>
-      <br />
-      <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input" />
-    </SF.Item>
-  </Shw::Flex>
+  <Shw::Divider />
+
+  <Shw::Text::H2>Demo</Shw::Text::H2>
+
+  <Shw::Text::H4 @tag="h3">In memory</Shw::Text::H4>
 
   <Shw::Flex as |SF|>
     <SF.Item>
-      <Shw::Label>Use textToCopy instead of targetToCopy</Shw::Label>
       <Hds::Copy::Button @text="Copy your secret key" @textToCopy="someSecretThingGoesHere" />
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H4 @tag="h3">With target element</Shw::Text::H4>
+
+  <Shw::Grid {{style gap="2rem"}} @columns={{3}} as |SG|>
+    <SG.Item>
+      <Shw::Label>Text element</Shw::Label>
+      <Hds::Copy::Button @text="Copy the paragraph" @targetToCopy="#targetToCopy" />
+      <p class="shw-text shw-text-body" id="targetToCopy">This is the target element; the button will copy the text in
+        this target element.</p>
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>Code block</Shw::Label>
+      <Hds::Copy::Button @text="Copy the code block" @targetToCopy="#targetToCopy3" />
+      {{!-- prettier-ignore --}}
+      <pre class="shw-component-copy-button-code-block"><code id="targetToCopy3">&lt;h1&gt;A page header example&lt;/h1&gt;
+&lt;p&gt;Some paragraph text also&lt;/p&gt;</code></pre>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Grid {{style gap="2rem"}} @columns={{3}} as |SG|>
+    <SG.Item>
+      <Shw::Label>Input element</Shw::Label>
+      <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input" />
+      <br />
+      <Hds::Form::TextInput::Field @value="036140285924" @name="test-input" @id="test-input" as |F|>
+        <F.Label>Input Label</F.Label>
+      </Hds::Form::TextInput::Field>
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>Input element (readonly)</Shw::Label>
+      <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input-readonly" />
+      <br />
+      <Hds::Form::TextInput::Field readonly @value="036140285924-readonly" @name="test-input-readonly" @id="test-input-readonly" as |F|>
+        <F.Label>Input Label</F.Label>
+      </Hds::Form::TextInput::Field>
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>Input element (disabled)</Shw::Label>
+      <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input-disabled" />
+      <br />
+      <Hds::Form::TextInput::Field disabled @value="036140285924-disabled" @name="test-input-disabled" @id="test-input-disabled" as |F|>
+        <F.Label>Input Label</F.Label>
+      </Hds::Form::TextInput::Field>
+    </SG.Item>
+  </Shw::Grid>
+
 </section>

--- a/packages/components/tests/dummy/app/templates/components/copy/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/copy/button.hbs
@@ -56,6 +56,52 @@
 
   <Shw::Divider />
 
+  <Shw::Text::H2>Compositions</Shw::Text::H2>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="With MaskedInput::Base">
+      <div class="shw-component-copy-button-composition-masked-input-base">
+        <Hds::Form::MaskedInput::Base @value="Lorem ipsum dolor" />
+        <Hds::Copy::Button @isIconOnly={{true}} @text="Copy" @textToCopy="Lorem ipsum dolor" />
+      </div>
+    </SF.Item>
+    <SF.Item @label="With MaskedInput::Base (multiline)">
+      <div class="shw-component-copy-button-composition-masked-input-base">
+        <Hds::Form::MaskedInput::Base @isMultiline={{true}} @value="Lorem ipsum dolor" />
+        <Hds::Copy::Button @isIconOnly={{true}} @text="Copy" @textToCopy="Lorem ipsum dolor" />
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="With Form::Field + MaskedInput::Base">
+      <Hds::Form::Field @layout="vertical" as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Control>
+          <div class="shw-component-copy-button-composition-masked-input-base">
+            <Hds::Form::MaskedInput::Base @value="Lorem ipsum dolor" />
+            <Hds::Copy::Button @isIconOnly={{true}} @text="Copy" @textToCopy="Lorem ipsum dolor" />
+          </div>
+        </F.Control>
+      </Hds::Form::Field>
+    </SF.Item>
+    <SF.Item @label="With Form::Field + MaskedInput::Base (multiline)">
+      <Hds::Form::Field @layout="vertical" as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Control>
+          <div class="shw-component-copy-button-composition-masked-input-base">
+            <Hds::Form::MaskedInput::Base @isMultiline={{true}} @value="Lorem ipsum dolor" />
+            <Hds::Copy::Button @isIconOnly={{true}} @text="Copy" @textToCopy="Lorem ipsum dolor" />
+          </div>
+        </F.Control>
+      </Hds::Form::Field>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Divider />
+
   <Shw::Text::H2>Demo</Shw::Text::H2>
 
   <Shw::Text::H4 @tag="h3">In memory</Shw::Text::H4>

--- a/packages/components/tests/dummy/app/templates/components/copy/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/copy/button.hbs
@@ -37,28 +37,22 @@
 
   <Shw::Text::H2>States</Shw::Text::H2>
 
-  <Shw::Grid @columns={{4}} as |SG|>
+  <Shw::Grid @columns={{6}} as |SG|>
     {{#each @model.SIZES as |size|}}
       {{#each @model.STATES as |state|}}
-        <SG.Item @label="{{capitalize size}} / {{capitalize state}}">
+        <SG.Item @label={{if (eq size "small") (capitalize state)}}>
           <Hds::Copy::Button @text="Copy" @size={{size}} mock-state-value={{state}} @targetToCopy="#targetToCopy" />
         </SG.Item>
       {{/each}}
+      {{#let (array "success" "error") as |statuses|}}
+        {{#each statuses as |status|}}
+          <SG.Item @label={{if (eq size "small") (capitalize status)}}>
+            <Hds::Copy::Button @text="Copy" @size={{size}} @targetToCopy="#targetToCopy" mock-copy-status={{status}} />
+          </SG.Item>
+        {{/each}}
+      {{/let}}
     {{/each}}
   </Shw::Grid>
-  <Shw::Text::H2>Status</Shw::Text::H2>
-  <Shw::Flex as |SF|>
-    {{#each @model.STATUS as |status|}}
-      <SF.Item @label="{{capitalize status}}">
-        <Hds::Copy::Button
-          @text="Copy"
-          @targetToCopy="#targetToCopy"
-          @status={{status}}
-          class="hds-copy-button--{{status}}"
-        />
-      </SF.Item>
-    {{/each}}
-  </Shw::Flex>
 
   <Shw::Divider />
 
@@ -105,7 +99,13 @@
       <Shw::Label>Input element (readonly)</Shw::Label>
       <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input-readonly" />
       <br />
-      <Hds::Form::TextInput::Field readonly @value="036140285924-readonly" @name="test-input-readonly" @id="test-input-readonly" as |F|>
+      <Hds::Form::TextInput::Field
+        readonly
+        @value="036140285924-readonly"
+        @name="test-input-readonly"
+        @id="test-input-readonly"
+        as |F|
+      >
         <F.Label>Input Label</F.Label>
       </Hds::Form::TextInput::Field>
     </SG.Item>
@@ -113,7 +113,13 @@
       <Shw::Label>Input element (disabled)</Shw::Label>
       <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input-disabled" />
       <br />
-      <Hds::Form::TextInput::Field disabled @value="036140285924-disabled" @name="test-input-disabled" @id="test-input-disabled" as |F|>
+      <Hds::Form::TextInput::Field
+        disabled
+        @value="036140285924-disabled"
+        @name="test-input-disabled"
+        @id="test-input-disabled"
+        as |F|
+      >
         <F.Label>Input Label</F.Label>
       </Hds::Form::TextInput::Field>
     </SG.Item>

--- a/packages/components/tests/dummy/app/templates/components/copy/snippet.hbs
+++ b/packages/components/tests/dummy/app/templates/components/copy/snippet.hbs
@@ -8,19 +8,16 @@
 <Shw::Text::H1>Copy::Snippet</Shw::Text::H1>
 
 <section data-test-percy>
-  <Shw::Text::H2>Generated element</Shw::Text::H2>
+
+  <Shw::Text::H2>Content</Shw::Text::H2>
 
   <Shw::Flex as |SF|>
     <SF.Item>
-      <Shw::Label>Default</Shw::Label>
+      <Shw::Label>With short text</Shw::Label>
       <Hds::Copy::Snippet @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r" />
     </SF.Item>
-  </Shw::Flex>
-
-  <Shw::Text::H2>Widths</Shw::Text::H2>
-  <Shw::Flex as |SF|>
     <SF.Item>
-      <Shw::Label>Default (multi-line)</Shw::Label>
+      <Shw::Label>With long text (multi-line / default)</Shw::Label>
       <Shw::Outliner {{style width="300px"}}>
         <Hds::Copy::Snippet
           @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r with some really long text that should wrap and be multi-line"
@@ -28,7 +25,7 @@
       </Shw::Outliner>
     </SF.Item>
     <SF.Item>
-      <Shw::Label>@isTruncated</Shw::Label>
+      <Shw::Label>With long text (truncated)</Shw::Label>
       <Shw::Outliner {{style width="300px"}}>
         <Hds::Copy::Snippet
           @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r with a bunch of other long text that should force truncation if truncation is set to true"
@@ -37,20 +34,22 @@
       </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Text::H2>Full width</Shw::Text::H2>
   <Shw::Flex as |SF|>
     <SF.Item>
-      <Shw::Label>@isFullWidth with long text</Shw::Label>
+      <Shw::Label>With short text</Shw::Label>
+      <Shw::Outliner {{style width="500px"}}>
+        <Hds::Copy::Snippet @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r" @isFullWidth={{true}} />
+      </Shw::Outliner>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>With long text</Shw::Label>
       <Shw::Outliner {{style width="500px"}}>
         <Hds::Copy::Snippet
           @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r and some other text that should not matter because the element with is set to full width and hopefully people will not do this but in case they do we want to make sure that we still have the designed layout"
           @isFullWidth={{true}}
         />
-      </Shw::Outliner>
-    </SF.Item>
-    <SF.Item {{style width="100%"}}>
-      <Shw::Label>@isFullWidth with shorter text</Shw::Label>
-      <Shw::Outliner {{style width="500px"}}>
-        <Hds::Copy::Snippet @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r" @isFullWidth={{true}} />
       </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/dummy/app/templates/components/copy/snippet.hbs
+++ b/packages/components/tests/dummy/app/templates/components/copy/snippet.hbs
@@ -67,13 +67,24 @@
 
   <Shw::Text::H2>States</Shw::Text::H2>
 
-  <Shw::Grid @columns={{4}} as |SG|>
+  <Shw::Grid @columns={{6}} as |SG|>
     {{#each @model.COLORS as |color|}}
       {{#each @model.STATES as |state|}}
-        <SG.Item @label="{{capitalize color}} / {{capitalize state}}">
+        <SG.Item @label={{if (eq color "primary") (capitalize state)}}>
           <Hds::Copy::Snippet @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r" @color={{color}} mock-state-value={{state}} />
         </SG.Item>
       {{/each}}
+      {{#let (array "success" "error") as |statuses|}}
+        {{#each statuses as |status|}}
+          <SG.Item @label={{if (eq color "primary") (capitalize status)}}>
+            <Hds::Copy::Snippet
+              @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r"
+              @color={{color}}
+              mock-copy-status={{status}}
+            />
+          </SG.Item>
+        {{/each}}
+      {{/let}}
     {{/each}}
   </Shw::Grid>
 </section>


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of https://github.com/hashicorp/design-system/pull/1488 in which I agreed to implement a preview of the "success/error" visual states for the component in the showcase. In the process, I have reorganized a bit the content, and added a few use cases, that have highlighted possible issues (to be discussed with the team)

### :hammer_and_wrench: Detailed description

In this PR I have
- `Copy::Button`
  - reorganized content in showcase
  - implemented mocking of copy “states” in showcase
  - added a couple of examples of composition in showcase
- `Copy::Snippet`
  - reorganized content in showcase
  - implemented mocking of copy “states” in showcase

Previews:
- `Copy::Button`: https://hds-showcase-git-copy-showcase-tweaks-hashicorp.vercel.app/components/copy/button
- `Copy::Snippet`: https://hds-showcase-git-copy-showcase-tweaks-hashicorp.vercel.app/components/copy/snippet

### :camera_flash: Screenshots

<img width="1041" alt="screenshot_3011" src="https://github.com/hashicorp/design-system/assets/686239/68a26229-ef82-4ecc-a7bf-ccba7fb07600">

<img width="1039" alt="screenshot_3010" src="https://github.com/hashicorp/design-system/assets/686239/8e76c3db-0c97-4173-a220-f5c2c3a1e00f">

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
