### PR TITLE
use `@ember/test-waiters` to instruct Ember to wait for modal `close`

### DIFF
--- a/.changeset/pretty-ways-rule.md
+++ b/.changeset/pretty-ways-rule.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`HDS::Modal` - reduce test flakiness around closing modals when using @ember/test-helpers

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^2.0.5",
+    "@ember/test-waiters": "^3.0.2",
     "@hashicorp/design-system-tokens": "^1.7.0",
     "@hashicorp/ember-flight-icons": "^3.0.8",
     "dialog-polyfill": "^0.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,7 +2396,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ember/test-waiters@npm:^2.4.3 || ^3.0.0, @ember/test-waiters@npm:^3.0.0":
+"@ember/test-waiters@npm:^2.4.3 || ^3.0.0, @ember/test-waiters@npm:^3.0.0, @ember/test-waiters@npm:^3.0.2":
   version: 3.0.2
   resolution: "@ember/test-waiters@npm:3.0.2"
   dependencies:
@@ -2794,6 +2794,7 @@ __metadata:
     "@ember/render-modifiers": ^2.0.5
     "@ember/string": ^3.1.1
     "@ember/test-helpers": ^2.9.3
+    "@ember/test-waiters": ^3.0.2
     "@embroider/test-setup": ^2.1.1
     "@glimmer/component": ^1.1.2
     "@glimmer/tracking": ^1.1.2


### PR DESCRIPTION
### :pushpin: Summary

Makes tests less flakey in CI for consumers of the design system

### :hammer_and_wrench: Detailed description

This PR instructs Ember's test suite to wait for the `<dialog>`'s `close` event.

In one of our product's test suites, we were experiencing some flakiness with tests randomly failing when using modals in tests. This is due to Chrome/other browsers queing the `<dialog>`'s `close` event. From the [HTML Spec][1]:

> Queue an element task on the user interaction task source given the subject
> element to fire an event named close at subject.

This means that the `close` event could fire at the end of the current loop or at the beginning of the next turn of the event loop, or in other words, after our test code has run and waited for side effects. Because Ember is unaware of these events, Ember's test infrastructure isn't waiting for the `close` event to fire when using `await click(selector)`/etc from [@ember/test-helpers][2]. We can't depend on the browser to run these events in a particular order as other events may have been queued first.

In order to help consumers of the design system use this component successfully in their application without flakiness or manual polling logic, we can take advantage of Ember's [@ember/test-waiters library][3], which will [eventually become a standard part of Ember.js][4].

Before we close the `<dialog>` element, we register a `waiter` from `@ember/test-waiters` and then resolve it when the close event fires.

To reduce the impact on production builds, we use `ember-cli-babel`'s [General Purpose Env Flags][5] to strip out the instrumentation code during production builds.

[1]: https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-close
[2]: https://github.com/emberjs/ember-test-helpers
[3]: https://github.com/emberjs/ember-test-waiters
[4]: https://github.com/emberjs/rfcs/blob/master/text/0581-new-test-waiters.md
[5]: https://github.com/babel/ember-cli-babel#general-purpose-env-flags

### :camera_flash: Screenshots

N/A

### :link: External links

* https://hashicorp.slack.com/archives/C03JP1TCGQM/p1691097709962489

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
