### PR TITLE
`SideNav` - Add missing "Component API" docs and warning about refocusing behaviour

### DIFF
--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -15,26 +15,26 @@ This is the full-fledged component (responsive and animated).
     A named block where the content for the “footer” section of the SideNav is rendered. It yields the value of `isMinimized` too.
   </C.Property>
   <C.Property @name="isResponsive" @type="boolean" @default="true">
-    Controls whether the SideNav is responsive to viewport changes. It can be programmatically turned off passing `false`.
+    Controls whether the SideNav is responsive to viewport changes. It can be programmatically turned off by passing `false`.
     <br>
-    <em>Notice: even if the @isResponsive parameter is set to false, some JavaScript is executed anyway in the background, and events listeners are attached to some DOM elements (even if these functionality are not used).</em>
+    <em>Notice: even if the @isResponsive parameter is set to false, some JavaScript is executed anyway in the background, and event listeners are attached to some DOM elements (even if this functionality is not used).</em>
   </C.Property>
   <C.Property @name="hasA11yRefocus" @type="boolean" @default="true">
-    Controls whether a "navigator narrator" and a "skip link" are added to the navigation (provided by the [`ember-a11y-refocus` Ember addon](https://github.com/ember-a11y/ember-a11y-refocus)). It can be programmatically turned off passing `false`.
+    Controls whether a "navigator narrator" and a "skip link" are added to the navigation (provided by the [`ember-a11y-refocus` Ember addon](https://github.com/ember-a11y/ember-a11y-refocus)). It can be programmatically turned off by passing `false`.
     <br><br>
     <em>For details about the addon behaviour and functionality, refer to the [official documentation](https://github.com/ember-a11y/ember-a11y-refocus#readme).</em>
     <Doc::ComponentApi as |C|>
       <C.Property @name="a11yRefocusSkipTo" @type="string">
-        Pass through property for the `skipTo` argument - The element ID that should receive focus on skip.
+        Pass-through property for the `skipTo` argument - The element ID that should receive focus on skip.
       </C.Property>
       <C.Property @name="a11yRefocusSkipText" @type="string">
-        Pass through property for the `skipText` argument - The text passed in the skip link; defaults to "Skip to main content".
+        Pass-through property for the `skipText` argument - The text passed in the skip link; defaults to "Skip to main content".
       </C.Property>
       <C.Property @name="a11yRefocusNavigationText" @type="string">
-        Pass through property for the `navigationText` argument - The text used as navigation message. Defaults to "The page navigation is complete. You may now navigate the page content as you wish.".
+        Pass-through property for the `navigationText` argument - The text used as navigation message. Defaults to "The page navigation is complete. You may now navigate the page content as you wish.".
       </C.Property>
       <C.Property @name="a11yRefocusRouteChangeValidator" @type="string">
-        Pass through property for the `routeChangeValidator` argument - Custom function used to define which route changes should trigger the refocusing behavior for the navigator narrator. - For details see [Customizing the definition of a route change](https://github.com/ember-a11y/ember-a11y-refocus#customizing-the-definition-of-a-route-change).
+        Pass-through property for the `routeChangeValidator` argument - Custom function used to define which route changes should trigger the refocusing behavior for the navigator narrator. - For details see [Customizing the definition of a route change](https://github.com/ember-a11y/ember-a11y-refocus#customizing-the-definition-of-a-route-change).
       </C.Property>
     </Doc::ComponentApi>
   </C.Property>

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -20,7 +20,7 @@ This is the full-fledged component (responsive and animated).
     <em>Notice: even if the @isResponsive parameter is set to false, some JavaScript is executed anyway in the background, and event listeners are attached to some DOM elements (even if this functionality is not used).</em>
   </C.Property>
   <C.Property @name="hasA11yRefocus" @type="boolean" @default="true">
-    Controls whether a "navigator narrator" and a "skip link" are added to the navigation (provided by the [`ember-a11y-refocus` Ember addon](https://github.com/ember-a11y/ember-a11y-refocus)). It can be programmatically turned off by passing `false`.
+    Controls whether a "navigator narrator" and a "skip link" are added to the navigation (provided by the [`ember-a11y-refocus` Ember addon](https://github.com/ember-a11y/ember-a11y-refocus)). It can be programmatically turned off by passing `false`. Warning: if it is set to false, then it will fail Bypass Blocks, [Success Criteria 2.4.1](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html). Since this component appears on every page, the application will not be considered conformant.
     <br><br>
     <em>For details about the addon behaviour and functionality, refer to the [official documentation](https://github.com/ember-a11y/ember-a11y-refocus#readme).</em>
     <Doc::ComponentApi as |C|>

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -14,6 +14,30 @@ This is the full-fledged component (responsive and animated).
   <C.Property @name="<:footer>" @type="named block">
     A named block where the content for the “footer” section of the SideNav is rendered. It yields the value of `isMinimized` too.
   </C.Property>
+  <C.Property @name="isResponsive" @type="boolean" @default="true">
+    Controls whether the SideNav is responsive to viewport changes. It can be programmatically turned off passing `false`.
+    <br>
+    <em>Notice: even if the @isResponsive parameter is set to false, some JavaScript is executed anyway in the background, and events listeners are attached to some DOM elements (even if these functionality are not used).</em>
+  </C.Property>
+  <C.Property @name="hasA11yRefocus" @type="boolean" @default="true">
+    Controls whether a "navigator narrator" and a "skip link" are added to the navigation (provided by the [`ember-a11y-refocus` Ember addon](https://github.com/ember-a11y/ember-a11y-refocus)). It can be programmatically turned off passing `false`.
+    <br><br>
+    <em>For details about the addon behaviour and functionality, refer to the [official documentation](https://github.com/ember-a11y/ember-a11y-refocus#readme).</em>
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="a11yRefocusSkipTo" @type="string">
+        Pass through property for the `skipTo` argument - The element ID that should receive focus on skip.
+      </C.Property>
+      <C.Property @name="a11yRefocusSkipText" @type="string">
+        Pass through property for the `skipText` argument - The text passed in the skip link; defaults to "Skip to main content".
+      </C.Property>
+      <C.Property @name="a11yRefocusNavigationText" @type="string">
+        Pass through property for the `navigationText` argument - The text used as navigation message. Defaults to "The page navigation is complete. You may now navigate the page content as you wish.".
+      </C.Property>
+      <C.Property @name="a11yRefocusRouteChangeValidator" @type="string">
+        Pass through property for the `routeChangeValidator` argument - Custom function used to define which route changes should trigger the refocusing behavior for the navigator narrator. - For details see [Customizing the definition of a route change](https://github.com/ember-a11y/ember-a11y-refocus#customizing-the-definition-of-a-route-change).
+      </C.Property>
+    </Doc::ComponentApi>
+  </C.Property>
   <C.Property @name="ariaLabel" @type="string">
     Accepts a localized string; the fallback is set to `Open menu` if the menu is closed, and `Close menu` if the menu is open.
   </C.Property>

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -452,6 +452,14 @@ If you find yourself in the situation of wanting/needing to customize or change 
 
 By default the component uses the [ember-a11y-refocus](https://github.com/ember-a11y/ember-a11y-refocus) addon to provide a "navigator narrator" and a "Skip Link" to the navigation (see [the addon documentation for details)](https://github.com/ember-a11y/ember-a11y-refocus#what-this-addon-does).
 
+!!! Critical
+
+**Notice**
+
+The addon introduces a refocusing behavior **on route changes** that may interfere with the hosting application (eg. unfocusing an active element). For details on how to control this behaviour, see [Customizing the definition of a route change](https://github.com/ember-a11y/ember-a11y-refocus#customizing-the-definition-of-a-route-change).
+
+!!!
+
 This functionality can be disabled using the `@hasA11yRefocus=\{{false}}` argument, if that is necessary.
 
 #### `aria` attributes

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -456,7 +456,7 @@ By default, the component uses the [ember-a11y-refocus](https://github.com/ember
 
 **Notice**
 
-The addon introduces a refocusing behavior **on route changes** that may interfere with the hosting application (eg. unfocusing an active element). For details on how to control this behaviour, see [Customizing the definition of a route change](https://github.com/ember-a11y/ember-a11y-refocus#customizing-the-definition-of-a-route-change).
+The addon introduces a refocusing behavior **on route changes** that may interfere with the hosting application (eg. unfocusing an active element). For details on how to control this behavior, see the section about [customizing the definition of a route change](https://github.com/ember-a11y/ember-a11y-refocus#customizing-the-definition-of-a-route-change).
 
 !!!
 

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -450,7 +450,7 @@ If you find yourself in the situation of wanting/needing to customize or change 
 
 #### `ember-a11y-refocus`
 
-By default the component uses the [ember-a11y-refocus](https://github.com/ember-a11y/ember-a11y-refocus) addon to provide a "navigator narrator" and a "Skip Link" to the navigation (see [the addon documentation for details)](https://github.com/ember-a11y/ember-a11y-refocus#what-this-addon-does).
+By default, the component uses the [ember-a11y-refocus](https://github.com/ember-a11y/ember-a11y-refocus) addon to provide a "navigator narrator" and a "Skip Link" to the navigation (see [the addon documentation for details)](https://github.com/ember-a11y/ember-a11y-refocus#what-this-addon-does).
 
 !!! Critical
 


### PR DESCRIPTION
### :pushpin: Summary

This PR intends to address a couple of points raised in [this slack thread](https://hashicorp.slack.com/archives/C11JCBJTW/p1691088873427389):

- some `SideNav` APIs/arguments related to the `ember-a11y-refocus` are not documented
- the [refocus behaviour](https://github.com/ember-a11y/ember-a11y-refocus#customizing-the-definition-of-a-route-change) of the `ember-a11y-refocus` addon is not documented

### :hammer_and_wrench: Detailed description

In this PR I have:

- added missing arguments to the “Component API” for the `SideNav` component
- added warning about refocusing behaviour of the `ember-a11y-refocus` addon used in the `SideNav` component

👉 👉 👉 **Preview:** https://hds-website-git-sidenav-add-missing-component-876339-hashicorp.vercel.app/components/side-nav?tab=code#sidenav

### :link: External links

- https://hashicorp.slack.com/archives/C11JCBJTW/p1691158980192609?thread_ts=1691088873.427389&cid=C11JCBJTW
- https://hashicorp.atlassian.net/browse/IPL-4528?focusedCommentId=289640
  - https://github.com/hashicorp/atlas/compare/deanmarano/search-focus-updates?expand=1

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
