### PR TITLE
`HDS::Flyout` - reduce test flakiness around closing Flyout when using `@ember/test-helpers`

### DIFF
--- a/.changeset/strange-shoes-jam.md
+++ b/.changeset/strange-shoes-jam.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`HDS::Flyout` - reduce test flakiness around closing Flyout when using `@ember/test-helpers`

--- a/packages/components/addon/components/hds/flyout/index.js
+++ b/packages/components/addon/components/hds/flyout/index.js
@@ -8,6 +8,15 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import { getElementId } from '@hashicorp/design-system-components/utils/hds-get-element-id';
+import { buildWaiter } from '@ember/test-waiters';
+import { DEBUG } from '@glimmer/env';
+
+let waiter;
+
+// Notice: this code will get stripped out in production builds (DEBUG evaluates to `true` in dev/test builds, but `false` in prod builds)
+if (DEBUG) {
+  waiter = buildWaiter('@hashicorp/design-system-components:flyout');
+}
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_HAS_OVERLAY = true;
@@ -115,7 +124,19 @@ export default class HdsFlyoutIndexComponent extends Component {
   }
 
   @action
-  onDismiss() {
+  async onDismiss() {
+    // allow ember test helpers to be aware of when the `close` event fires
+    // when using `click` or other helpers from '@ember/test-helpers'
+    // Notice: this code will get stripped out in production builds (DEBUG evaluates to `true` in dev/test builds, but `false` in prod builds)
+    if (DEBUG && this.element.open) {
+      let token = waiter.beginAsync();
+      let listener = () => {
+        waiter.endAsync(token);
+        this.element.removeEventListener('close', listener);
+      };
+      this.element.addEventListener('close', listener);
+    }
+
     // Make flyout dialog invisible using the native `close` method
     this.element.close();
 


### PR DESCRIPTION
### :pushpin: Summary

Replicating in Flyout the logic introduced in #1549 for the Modal, as they use a very similar codebase.

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
