### PR TITLE
Update percy reference to permalink

### DIFF
--- a/packages/ember-flight-icons/index.js
+++ b/packages/ember-flight-icons/index.js
@@ -15,7 +15,7 @@ module.exports = {
     // in the testing environment to inject the sprite in the #ember-testing "app root element" (ENV.APP.rootElement)
     // otherwise the @percy/ember package ignores everything else and the SVG sprite is not added to the DOM
     // see thread: https://hashicorp.slack.com/archives/C11JCBJTW/p1633978558343000
-    // see: https://github.com/percy/percy-ember/blob/master/addon-test-support/%40percy/ember/index.js#L33
+    // see: https://github.com/percy/percy-ember/blob/ab3b8ebb272fb6479e1185b8ef6e11dab3d6d9b0/addon-test-support/%40percy/ember/index.js#L53
     if (type === 'body-footer' || type === 'ember-testing-sprite-embed') {
       return flightIconSprite;
     }


### PR DESCRIPTION
The previous link was attached to a line that has moved over time, so this uses GitHub's permalink feature to anchor to the line we care about which is specifically about the testing container

