### PR TITLE
Fix frontmatter on `CopyButton` and `CopySnippet`

### DIFF
--- a/website/docs/components/copy/button/index.md
+++ b/website/docs/components/copy/button/index.md
@@ -5,6 +5,7 @@ caption: A button that copies the attached or associated text upon interaction.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=37400-71082&mode=design
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/copy/button
+related: ['components/copy/snippet', 'components/form/masked-input']
 previewImage: assets/illustrations/components/copy-button.jpg
 navigation:
   keywords: ['snippet', 'clipboard']

--- a/website/docs/components/copy/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/copy/button/partials/guidelines/guidelines.md
@@ -35,8 +35,3 @@ Placing a Copy Button close to the content explicitly communicates what is being
 
 ![Example of the copy button component using proper placement](/assets/components/copy/copy-button-placement-do.png)
 !!!
-
-## Related
-
-- [Copy Snippet](/components/copy/snippet)
-- [Masked Input](/components/form/masked-input)

--- a/website/docs/components/copy/snippet/index.md
+++ b/website/docs/components/copy/snippet/index.md
@@ -3,8 +3,9 @@ title: Copy Snippet
 description: A button that enables users to copy a snippet of code
 caption: A button that copies the text content of the button itself.
 links:
-figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=40399-101361&mode=design
-github:  https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/copy/snippet
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=40399-101361&mode=design
+  github:  https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/copy/snippet
+related: ['components/copy/button', 'components/button']
 previewImage: assets/illustrations/components/copy-snippet.jpg
 navigation:
   keywords: ['button', 'clipboard', 'code']

--- a/website/docs/components/copy/snippet/partials/guidelines/guidelines.md
+++ b/website/docs/components/copy/snippet/partials/guidelines/guidelines.md
@@ -53,8 +53,3 @@ Avoid truncating content too soon. For shorter snippets and where space allows, 
 ![Example of Copy Snippet component truncating too soon](/assets/components/copy/copy-snippet-truncation-dont.png)
 
 !!!
-
-## Related
-
-- [Copy Button](/components/copy/button)
-- [Button](/components/button)


### PR DESCRIPTION
### :pushpin: Summary

Fix frontmatter on `CopyButton` and `CopySnippet`:
 - use the new 'related' section
 - fix GitHub & Figma links

👉 Preview [Copy Button](https://hds-website-git-alex-ju-fix-frontmatter-on-cop-a852ac-hashicorp.vercel.app/components/copy/button) and [Copy Snippet](https://hds-website-git-alex-ju-fix-frontmatter-on-cop-a852ac-hashicorp.vercel.app/components/copy/snippet).

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
