### PR TITLE
`Hds::SegmentedGroup` - fix `border-radius`

### DIFF
--- a/.changeset/thin-bears-tap.md
+++ b/.changeset/thin-bears-tap.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::SegmentedGroup` - prevent `border-radius` from interfering with underlying elements

--- a/packages/components/app/styles/components/segmented-group.scss
+++ b/packages/components/app/styles/components/segmented-group.scss
@@ -10,10 +10,10 @@
 .hds-segmented-group {
   display: inline-flex;
 
-  .hds-button,
-  .hds-dropdown,
-  .hds-form-select,
-  .hds-form-text-input {
+  > .hds-button,
+  > .hds-dropdown,
+  > .hds-form-select,
+  > .hds-form-text-input {
     &:first-child {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;

--- a/packages/components/tests/dummy/app/templates/components/segmented-group.hbs
+++ b/packages/components/tests/dummy/app/templates/components/segmented-group.hbs
@@ -111,6 +111,9 @@
         <S.Button @color="secondary" @text="Button" />
         <S.Dropdown as |DD|>
           <DD.ToggleButton @color="secondary" @text="Dropdown" />
+          <DD.Header @hasDivider={{true}}>
+            <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
+          </DD.Header>
           <DD.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</DD.Checkbox>
           <DD.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</DD.Checkbox>
           <DD.Checkbox name="checkbox-item-dropdown" @count="10">docker</DD.Checkbox>
@@ -129,6 +132,9 @@
         <S.TextInput aria-label="segmented-input-dropdown-button" />
         <S.Dropdown as |DD|>
           <DD.ToggleButton @color="secondary" @text="Dropdown" />
+          <DD.Header @hasDivider={{true}}>
+            <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
+          </DD.Header>
           <DD.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</DD.Checkbox>
           <DD.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</DD.Checkbox>
           <DD.Checkbox name="checkbox-item-dropdown" @count="10">docker</DD.Checkbox>
@@ -175,6 +181,9 @@
         </S.Select>
         <S.Dropdown as |DD|>
           <DD.ToggleButton @color="secondary" @text="Dropdown" />
+          <DD.Header @hasDivider={{true}}>
+            <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
+          </DD.Header>
           <DD.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</DD.Checkbox>
           <DD.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</DD.Checkbox>
           <DD.Checkbox name="checkbox-item-dropdown" @count="10">docker</DD.Checkbox>

--- a/packages/components/tests/dummy/app/templates/components/segmented-group.hbs
+++ b/packages/components/tests/dummy/app/templates/components/segmented-group.hbs
@@ -111,7 +111,16 @@
         <S.Button @color="secondary" @text="Button" />
         <S.Dropdown as |DD|>
           <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
+          <DD.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</DD.Checkbox>
+          <DD.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</DD.Checkbox>
+          <DD.Checkbox name="checkbox-item-dropdown" @count="10">docker</DD.Checkbox>
+          <DD.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</DD.Checkbox>
+          <DD.Footer @hasDivider={{true}}>
+            <Hds::ButtonSet>
+              <Hds::Button @text="Apply" @isFullWidth={{true}} @size="small" />
+              <Hds::Button @text="Cancel" @color="secondary" @isFullWidth={{true}} @size="small" />
+            </Hds::ButtonSet>
+          </DD.Footer>
         </S.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
@@ -120,7 +129,16 @@
         <S.TextInput aria-label="segmented-input-dropdown-button" />
         <S.Dropdown as |DD|>
           <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
+          <DD.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</DD.Checkbox>
+          <DD.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</DD.Checkbox>
+          <DD.Checkbox name="checkbox-item-dropdown" @count="10">docker</DD.Checkbox>
+          <DD.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</DD.Checkbox>
+          <DD.Footer @hasDivider={{true}}>
+            <Hds::ButtonSet>
+              <Hds::Button @text="Apply" @isFullWidth={{true}} @size="small" />
+              <Hds::Button @text="Cancel" @color="secondary" @isFullWidth={{true}} @size="small" />
+            </Hds::ButtonSet>
+          </DD.Footer>
         </S.Dropdown>
         <S.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
@@ -157,7 +175,16 @@
         </S.Select>
         <S.Dropdown as |DD|>
           <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
+          <DD.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</DD.Checkbox>
+          <DD.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</DD.Checkbox>
+          <DD.Checkbox name="checkbox-item-dropdown" @count="10">docker</DD.Checkbox>
+          <DD.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</DD.Checkbox>
+          <DD.Footer @hasDivider={{true}}>
+            <Hds::ButtonSet>
+              <Hds::Button @text="Apply" @isFullWidth={{true}} @size="small" />
+              <Hds::Button @text="Cancel" @color="secondary" @isFullWidth={{true}} @size="small" />
+            </Hds::ButtonSet>
+          </DD.Footer>
         </S.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>


### PR DESCRIPTION
### :pushpin: Summary

Prevent `border-radius` in `Hds::SegmentedGroup` from interfering with underlying elements.

### :hammer_and_wrench: Detailed description

Fixed by adding the child combinator to only apply `border-radius` adjustments to direct children of a Segmented Group.
Update examples in the showcase to use a more relevant use case, including buttons.

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="357" alt="Screenshot 2023-08-08 at 11 08 59" src="https://github.com/hashicorp/design-system/assets/788096/599e9bac-9b5e-4518-b54c-14037f490b2d">


</td><td>

<img width="360" alt="Screenshot 2023-08-08 at 11 08 22" src="https://github.com/hashicorp/design-system/assets/788096/13889059-3eb9-42d6-8f4d-4e682a95ac1d">


</td></tr>
</table>


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2326](https://hashicorp.atlassian.net/browse/HDS-2326)

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2326]: https://hashicorp.atlassian.net/browse/HDS-2326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ