### PR TITLE
`Hds::IconTile` - remove comment on `assert`

### DIFF
--- a/packages/components/addon/components/hds/icon-tile/index.js
+++ b/packages/components/addon/components/hds/icon-tile/index.js
@@ -133,7 +133,6 @@ export default class HdsIconTileIndexComponent extends Component {
   get entity() {
     let entity;
 
-    // TODO: discuss if we want these kind of tests
     assert(
       `you can't pass both @logo and @icon properties to the "Hds::IconTile" component`,
       !(this.args.logo && this.args.icon)


### PR DESCRIPTION
### :pushpin: Summary

Remove comment on `assert` in `Hds::IconTile`; we seem to be using `assert` across the library, so there's likely no discussion to have around it.
