### PR TITLE
`Hds::Dropdown` - remove deprecated `@listPositions` values

### DIFF
--- a/.changeset/shy-ads-care.md
+++ b/.changeset/shy-ads-care.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+`Hds::Dropdown` – remove `@listPosition` `left` and `right` (use `bottom-left` and `bottom-right`, repsectively)

--- a/.changeset/shy-ads-care.md
+++ b/.changeset/shy-ads-care.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": major
 ---
 
-`Hds::Dropdown` – remove `@listPosition` `left` and `right` (use `bottom-left` and `bottom-right`, repsectively)
+`Hds::Dropdown` – remove `@listPosition` `left` and `right` (use `bottom-left` and `bottom-right`, respectively)

--- a/packages/components/addon/components/hds/dropdown/index.js
+++ b/packages/components/addon/components/hds/dropdown/index.js
@@ -8,10 +8,7 @@ import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
 export const DEFAULT_POSITION = 'bottom-right';
-// TODO: retire 'right' and 'left' in favor of `bottom-right` and `bottom-left` https://github.com/hashicorp/design-system/pull/1262
 export const POSITIONS = [
-  'right',
-  'left',
   'bottom-left',
   'bottom-right',
   'top-left',

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -190,16 +190,14 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   max-width: initial;
 }
 
-.hds-dropdown__content--position-bottom-right,
-.hds-dropdown__content--position-right {
+.hds-dropdown__content--position-bottom-right {
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
   z-index: 2;
 }
 
-.hds-dropdown__content--position-bottom-left,
-.hds-dropdown__content--position-left {
+.hds-dropdown__content--position-bottom-left {
   position: absolute;
   top: calc(100% + 4px);
   left: 0;

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -767,7 +767,7 @@
   </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
-      <Hds::Dropdown @listPosition="left" as |dd|>
+      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
         <dd.ToggleButton @text="Checkmark" @color="secondary" />
         <dd.Checkmark @count="11">virtualbox</dd.Checkmark>
         <dd.Checkmark @count="1" @selected={{true}}>vmware</dd.Checkmark>
@@ -925,7 +925,7 @@
   </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
-      <Hds::Dropdown @listPosition="left" as |dd|>
+      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
         <dd.ToggleButton @text="Checkbox" @color="secondary" />
         <dd.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</dd.Checkbox>
         <dd.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</dd.Checkbox>
@@ -1083,7 +1083,7 @@
   </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
-      <Hds::Dropdown @listPosition="left" as |dd|>
+      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
         <dd.ToggleButton @text="Radio" @color="secondary" />
         <dd.Radio name="radio-item-dropdown" @count="11">virtualbox</dd.Radio>
         <dd.Radio name="radio-item-dropdown" @count="1" checked>vmware</dd.Radio>

--- a/packages/components/tests/dummy/app/templates/components/side-nav.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav.hbs
@@ -109,7 +109,7 @@
                     <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
                   </:logo>
                   <:actions>
-                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
                       <dd.ToggleIcon @icon="help" @text="help menu" />
                       <dd.Title @text="Help & Support" />
                       <dd.Interactive @text="Documentation" @href="#" />
@@ -120,7 +120,7 @@
                       <dd.Interactive @text="Create support ticket" @href="#" />
                       <dd.Interactive @text="Give feedback" @href="#" />
                     </Hds::Dropdown>
-                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
                       <dd.ToggleIcon @icon="user" @text="user menu" />
                       <dd.Title @text="Signed In" />
                       <dd.Description @text="email@domain.com" />
@@ -173,7 +173,7 @@
                   </:logo>
                   <:actions>
                     <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
-                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
                       <dd.ToggleIcon @icon="help" @text="help menu" />
                       <dd.Title @text="Help & Support" />
                       <dd.Interactive @text="Documentation" @href="#" />
@@ -184,7 +184,7 @@
                       <dd.Interactive @text="Create support ticket" @href="#" />
                       <dd.Interactive @text="Give feedback" @href="#" />
                     </Hds::Dropdown>
-                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+                    <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
                       <dd.ToggleIcon @icon="user" @text="user menu" />
                       <dd.Title @text="Signed In" />
                       <dd.Description @text="email@domain.com" />
@@ -288,7 +288,7 @@
             <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
           </:logo>
           <:actions>
-            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
               <dd.ToggleIcon @icon="help" @text="help menu" />
               <dd.Title @text="Help & Support" />
               <dd.Interactive @text="Documentation" @href="#" />
@@ -299,7 +299,7 @@
               <dd.Interactive @text="Create support ticket" @href="#" />
               <dd.Interactive @text="Give feedback" @href="#" />
             </Hds::Dropdown>
-            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
               <dd.ToggleIcon @icon="user" @text="user menu" />
               <dd.Title @text="Signed In" />
               <dd.Description @text="email@domain.com" />
@@ -317,7 +317,7 @@
           </:logo>
           <:actions>
             <Hds::SideNav::Header::IconButton @icon="terminal-screen" @ariaLabel="Terminal" />
-            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
               <dd.ToggleButton @text="Help" />
               <dd.Title @text="Help & Support" />
               <dd.Interactive @text="Documentation" @href="#" />

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -933,7 +933,7 @@
           <B.Tr>
             <B.Th>Dropdown (with inline container)</B.Th>
             <B.Td @align="left">
-              <Hds::Dropdown @isInline={{true}} @listPosition="right" as |dd|>
+              <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
                 <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
                 <dd.Interactive @route="components.table" @text="Dropdown" />
               </Hds::Dropdown>

--- a/packages/components/tests/integration/components/hds/dropdown/index-test.js
+++ b/packages/components/tests/integration/components/hds/dropdown/index-test.js
@@ -93,9 +93,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
       .dom('#test-dropdown .hds-dropdown__content')
       .hasClass('hds-dropdown__content--position-bottom-right');
   });
-  test('it should render the content aligned on the left if the value of @listPosition is "left"', async function (assert) {
+  test('it should render the content aligned on the left if the value of @listPosition is "bottom-left"', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" @listPosition="left" as |dd|>
+      <Hds::Dropdown id="test-dropdown" @listPosition="bottom-left" as |dd|>
         <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
         <dd.Interactive @route="components.dropdown" @text="interactive" />
       </Hds::Dropdown>
@@ -103,7 +103,7 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     await click('button#test-toggle-button');
     assert
       .dom('#test-dropdown .hds-dropdown__content')
-      .hasClass('hds-dropdown__content--position-left');
+      .hasClass('hds-dropdown__content--position-bottom-left');
   });
   test('it should render the element as `inline` if the value of @isInline is "true"', async function (assert) {
     await render(hbs`

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -138,7 +138,7 @@ Here is an example of some possible actions:
         </:logo>
         <:actions>
           <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
-          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
             <dd.ToggleIcon @icon="help" @text="settings menu" />
             <dd.Title @text="Help & Support" />
             <dd.Interactive @text="Documentation" @href="#" />
@@ -149,7 +149,7 @@ Here is an example of some possible actions:
             <dd.Interactive @text="Create support ticket" @href="#" />
             <dd.Interactive @text="Give feedback" @href="#" />
           </Hds::Dropdown>
-          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
@@ -277,7 +277,7 @@ but in your app they will probably need to be set to `true` (or omitted to rely 
           <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
         </:logo>
         <:actions>
-          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
             <dd.Interactive @text="Documentation" @href="#" />
@@ -288,7 +288,7 @@ but in your app they will probably need to be set to `true` (or omitted to rely 
             <dd.Interactive @text="Create support ticket" @href="#" />
             <dd.Interactive @text="Give feedback" @href="#" />
           </Hds::Dropdown>
-          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />


### PR DESCRIPTION
:warning: This PR awaits to be released in the next major version :warning:

### :pushpin: Summary

We deprecated `left` and `right` values for `@listPositions` in [@hashicorp/design-system-components@2.0.0](https://github.com/hashicorp/design-system/pull/1273), and replaced them with `bottom-left` and `bottom-right`.

### 🧑‍💻 Impact on consumers

There are ~15 instanced of `@listPosition="left"` (which used to be the default value) and ~20 instances of `@listPosition="right"` across our consumers' codebases. Not sure when is the _right_ time for this to go out (maybe in the next major release) but didn't want to lose track of it.

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
