### PR TITLE
Add example of a11y acceptance tests

### DIFF
--- a/packages/components/tests/acceptance/components/hds/accordion-test.js
+++ b/packages/components/tests/acceptance/components/hds/accordion-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from '../../../helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | Component | hds/accordion', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visit /components/accordion and check a11y', async function (assert) {
+    let axeOptions = {
+      rules: {
+        'duplicate-id': { enabled: false },
+      },
+    };
+
+    await visit('/components/accordion');
+
+    assert.strictEqual(currentURL(), '/components/accordion');
+
+    await a11yAudit(axeOptions);
+
+    assert.ok(true, 'no a11y errors found!');
+  });
+});

--- a/packages/components/tests/acceptance/components/hds/alert-test.js
+++ b/packages/components/tests/acceptance/components/hds/alert-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from '../../../helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/hds/alert', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visit /components/alert and check a11y', async function (assert) {
+    let axeOptions = {
+      rules: {
+        'duplicate-id': { enabled: false },
+      },
+    };
+    await visit('/components/alert');
+
+    assert.strictEqual(currentURL(), '/components/alert');
+
+    await a11yAudit(axeOptions);
+    assert.ok(true, 'no a11y errors found!');
+  });
+});

--- a/packages/components/tests/acceptance/components/hds/dropdown-test.js
+++ b/packages/components/tests/acceptance/components/hds/dropdown-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from '../../../helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | Components | hds/dropdown', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visit /components/dropdown and check a11y', async function (assert) {
+    let axeOptions = {
+      rules: {
+        'duplicate-id': { enabled: false },
+      },
+    };
+
+    await visit('/components/dropdown');
+
+    assert.strictEqual(currentURL(), '/components/dropdown');
+
+    await a11yAudit(axeOptions);
+
+    assert.ok(true, 'no a11y errors found!');
+  });
+});

--- a/packages/components/tests/acceptance/components/hds/pagination-test.js
+++ b/packages/components/tests/acceptance/components/hds/pagination-test.js
@@ -6,9 +6,26 @@
 import { module, test } from 'qunit';
 import { click, select, visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from '../../../helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | Component | hds/pagination', function (hooks) {
   setupApplicationTest(hooks);
+
+  test('visit components/pagination and check a11y', async function (assert) {
+    let axeOptions = {
+      rules: {
+        'duplicate-id': { enabled: false },
+      },
+    };
+
+    await visit('/components/pagination');
+
+    assert.strictEqual(currentURL(), '/components/pagination');
+
+    await a11yAudit(axeOptions);
+
+    assert.ok(true, 'no a11y errors found!');
+  });
 
   test('interacting with the demo of a "numbered" pagination with routing', async function (assert) {
     await visit('/components/pagination');


### PR DESCRIPTION
### :pushpin: Summary

This is a draft PR to demonstrate accessibility tests from `ember-a11y-testing` in acceptance tests, similar to how we do Percy tests. 

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
