### PR TITLE
Update `Button` examples to not use copy functionality

### DIFF
--- a/website/docs/components/button/index.js
+++ b/website/docs/components/button/index.js
@@ -11,4 +11,9 @@ export default class Index extends Component {
   copyToClipboard() {
     console.log('Clicked "Copy to clipboard" button!');
   }
+
+  @action
+  alertOnClick() {
+    alert('Hello from Helios!');
+  }
 }

--- a/website/docs/components/button/index.js
+++ b/website/docs/components/button/index.js
@@ -8,11 +8,6 @@ import { action } from '@ember/object';
 
 export default class Index extends Component {
   @action
-  copyToClipboard() {
-    console.log('Clicked "Copy to clipboard" button!');
-  }
-
-  @action
   alertOnClick() {
     alert('Hello from Helios!');
   }

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -70,7 +70,7 @@ There are three sizes available for the Button: `small`, `medium`, and `large`. 
 This indicates that the Button should take up the full-width of the parent container. It’s set to `false` by default.
 
 ```handlebars
-<Hds::Button @text="Copy to clipboard" @isFullWidth={{true}} />
+<Hds::Button @text="Full width button" @isFullWidth={{true}} />
 ```
 
 ### Type

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -132,5 +132,5 @@ If using an `@href` or `@route` and needing to disable the component, you’ll n
 !!!
 
 ```handlebars
-<Hds::Button @text="Alert me" disabled />
+<Hds::Button @text="Alert me" disabled {{on "click" this.alertOnClick}} />
 ```

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -5,7 +5,7 @@ The Button component is used to trigger an action or event. For accessibility, B
 The basic invocation requires text to be passed:
 
 ```handlebars
-<Hds::Button @text="Copy to clipboard" />
+<Hds::Button @text="Basic button" />
 ```
 
 ### Add an icon
@@ -13,7 +13,7 @@ The basic invocation requires text to be passed:
 To add an icon to your Button, give the `@icon` any [icon](/icons/library) name:
 
 ```handlebars
-<Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" />
+<Hds::Button @text="Create cluster" @icon="plus" />
 ```
 
 ### Icon position
@@ -21,7 +21,7 @@ To add an icon to your Button, give the `@icon` any [icon](/icons/library) name:
 By default, if you define an icon, it is placed in the leading position (before the text). If you need to position the icon in the trailing position (after the text), define `@iconPosition`:
 
 ```handlebars
-<Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" @iconPosition="trailing" />
+<Hds::Button @text="Next step" @icon="arrow-right" @iconPosition="trailing" />
 ```
 
 ### Icon-only Button
@@ -34,7 +34,7 @@ To add a tooltip to an icon-only Button, here’s an example of how to do it in 
 If you would like to create an icon-only Button, set `@isIconOnly` to `true`. Note that you still have to define the `@text` value; it will be used as the `aria-label` attribute value on the `Button` element.
 
 ```handlebars
-<Hds::Button @text="Copy to clipboard" @icon="clipboard-copy" @isIconOnly={{true}} />
+<Hds::Button @text="Create cluster" @icon="plus" @isIconOnly={{true}} />
 ```
 
 ### Color
@@ -88,7 +88,7 @@ Define the action in your route or controller, and add it to the component invoc
 Read the Ember.js guides for more information: [Patterns for Actions](https://guides.emberjs.com/release/in-depth-topics/patterns-for-actions/) .
 
 ```handlebars
-<Hds::Button @text="Copy to clipboard" {{on "click" this.copyToClipboard}} />
+<Hds::Button @text="Alert me" {{on "click" this.alertOnClick}} />
 ```
 
 ### Links
@@ -132,5 +132,5 @@ If using an `@href` or `@route` and needing to disable the component, you’ll n
 !!!
 
 ```handlebars
-<Hds::Button @text="Copy to clipboard" disabled />
+<Hds::Button @text="Alert me" disabled />
 ```


### PR DESCRIPTION
### :pushpin: Summary

In working on something else, I noticed the "How to use" examples for the `Button` showcase "copy" functionality and copying to the clipboard. Since we've released the copy components recently, it seems like these examples might guide users in the wrong direction and use the `Button` component with some custom logic to hook into the clipboard.

So I updated them to some real-ish world examples.

One additional change I made as part of the backing class was to change the `console.log` to a browser alert. Open to feedback whether this is annoying or not, but it seemed liked slightly more explicit and realistic example.

**Question:** Does it make sense to link to the Copy button somewhere in here?

### :camera_flash: Screenshots

Before
<img width="801" alt="Screenshot 2023-08-08 at 4 26 33 PM" src="https://github.com/hashicorp/design-system/assets/2200899/20214d36-349f-4a75-9e6c-5211b355b2ea">

After
<img width="832" alt="Screenshot 2023-08-08 at 4 27 02 PM" src="https://github.com/hashicorp/design-system/assets/2200899/7ba53eff-555f-4515-8d7b-0bb8391904b5">

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
