### PR TITLE
Fix styles for right-aligned text in ThSort

### DIFF
--- a/.changeset/young-waves-deny.md
+++ b/.changeset/young-waves-deny.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Resolved issue where ThSort was not supporting right-aligned text properly

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -163,7 +163,6 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
   justify-content: flex-end;
 }
 
-
 .hds-table__th-sort--text-center,
 .hds-table__th--text-center,
 .hds-table__td--text-center {

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -159,6 +159,12 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
   text-align: right;
 }
 
+// Due to the structure of the ThSort button content, we need to add some extra alignment support but this should be cleaned up in HDS-2363
+.hds-table__th-sort.hds-table__th-sort--text-right button .hds-table__th-sort--button-content {
+  justify-content: flex-end;
+}
+
+
 .hds-table__th-sort--text-center,
 .hds-table__th--text-center,
 .hds-table__td--text-center {

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -159,8 +159,7 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
   text-align: right;
 }
 
-// Due to the structure of the ThSort button content, we need to add some extra alignment support but this should be cleaned up in HDS-2363
-.hds-table__th-sort.hds-table__th-sort--text-right button .hds-table__th-sort--button-content {
+.hds-table__th-sort--text-right .hds-table__th-sort--button-content {
   justify-content: flex-end;
 }
 

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -224,6 +224,25 @@
     </:body>
   </Hds::Table>
 
+  <Shw::Text::H4>Sortable table, one column right-aligned</Shw::Text::H4>
+
+  <Hds::Table
+    @model={{this.model.music}}
+    @columns={{array
+      (hash key="artist" label="Artist" isSortable="true")
+      (hash key="album" label="Album" isSortable="true")
+      (hash key="year" label="Release Year" isSortable="true" align="right")
+    }}
+  >
+    <:body as |B|>
+      <B.Tr>
+        <B.Td>{{B.data.artist}}</B.Td>
+        <B.Td>{{B.data.album}}</B.Td>
+        <B.Td @align="right">{{B.data.year}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+
   <Shw::Text::H4>Sortable table, some columns sortable, artist column pre-sorted.</Shw::Text::H4>
 
   <Hds::Table


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR provides a hotfix for right-aligned text style support in the `ThSort` component.

### :hammer_and_wrench: Detailed description

- had to add some very nested CSS to get to the text alignment
- wrote a follow-up issue ([HDS-2363](https://hashicorp.atlassian.net/browse/HDS-2363)) to get the component markup tidied up a bit and adjust the CSS appropriately
- added an example to the preview page so we can make sure this doesn't regress
- added patch changeset

### :camera_flash: Screenshots

Year column is right-aligned:
<img width="873" alt="CleanShot 2023-08-09 at 23 26 39@2x" src="https://github.com/hashicorp/design-system/assets/4587451/7b033fa1-bb73-4080-9ed2-2cf9f8e56050">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2362](https://hashicorp.atlassian.net/browse/HDS-2362)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2363]: https://hashicorp.atlassian.net/browse/HDS-2363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-2362]: https://hashicorp.atlassian.net/browse/HDS-2362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ