### PR TITLE
Update usage info for FlightIcon component

### DIFF
--- a/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
+++ b/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
@@ -2,7 +2,7 @@
 
 Icons can be used in many ways. The package can be installed as an [Ember addon](#using-icons-in-ember-apps) for the convenience of using a component with strong defaults. It can also be [consumed in React applications](#using-icons-in-react-apps) via direct import of the SVG file or as a standalone React/SVG icon component.
 
-### Using icons in Ember apps
+### Adding icons to Ember apps
 
 Install the `ember-flight-icons` addon.
 
@@ -14,7 +14,6 @@ yarn add @hashicorp/ember-flight-icons
 
 Because this addon exposes a `data-test-icon` helper, we recommend installing [`ember-test-selectors`](https://github.com/simplabs/ember-test-selectors) which strips out all `data-test-*` attributes for production builds.
 !!!
-
 
 #### Deferred loading
 
@@ -34,9 +33,9 @@ module.exports = function(environment) {
 
 For more information on why this may be helpful in certain scenarios, see [DS-049 - Improve Ember Flight Icons Loading Performance](https://go.hashi.co/rfc/ds-049).
 
-### Using icons in React apps
+### Adding icons to React apps
 
-To use icons in a React application, install the `@hashicorp/flight-icons` package and import the icons as either inline SVGs or as a standalone React/SVG component. 
+To use icons in a React application, install the `@hashicorp/flight-icons` package and import the icons as either inline SVGs or as a standalone React/SVG component.
 
 !!! Info
 
@@ -108,6 +107,16 @@ It renders to this (where the `id` will be unique each time):
 >
     <use href="/@hashicorp/ember-flight-icons/icons/sprite.svg#alert-circle-16"></use>
 </svg>
+```
+
+Because the icons are hidden to assistive technology, they cannot be used on their own and must be used inside of an element with an accessible name.
+
+The [Hds::Button](/components/button?tab=code#icon-only-button) component automatically provides this support, but if you make a custom element, or want to use a FlightIcon inside of a native HTML element like your own button element, ensure that an `aria-label` attribute is added, like this:
+
+```handlebars
+<button type="button" aria-label="add a new thing">
+  <FlightIcon @name="plus" />
+</button>
 ```
 
 ### Color

--- a/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
+++ b/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
@@ -111,7 +111,7 @@ It renders to this (where the `id` will be unique each time):
 
 Because the icons are hidden to assistive technology, they cannot be used on their own and must be used inside of an element with an accessible name.
 
-The [Hds::Button](/components/button?tab=code#icon-only-button) component automatically provides this support, but if you make a custom element, or want to use a FlightIcon inside of a native HTML element like your own button element, ensure that an `aria-label` attribute is added, like this:
+The [Hds::Button](/components/button?tab=code#icon-only-button) component automatically provides this support, but if you make a custom element, or want to use a `FlightIcon` inside of a native HTML element like your own button element, ensure that an `aria-label` attribute is added, like this:
 
 ```handlebars
 <button type="button" aria-label="add a new thing">

--- a/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
+++ b/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
@@ -35,7 +35,7 @@ For more information on why this may be helpful in certain scenarios, see [DS-04
 
 ### Adding icons to React apps
 
-To use icons in a React application, install the `@hashicorp/flight-icons` package and import the icons as either inline SVGs or as a standalone React/SVG component.
+To add icons to a React application, install the `@hashicorp/flight-icons` package and import the icons as either inline SVGs or as a standalone React/SVG component.
 
 !!! Info
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves the issue where the website docs for the icon usage were unclear and resulting in misuse in consumer codebases.

### :hammer_and_wrench: Detailed description

- changed "using" to "adding" in the first part of the instructions so it is clearer
- added extra section in "using" that explains accessible use for custom elements (and links to Hds::Button icon-only use)

### :camera_flash: Screenshots

Added a section about accessible use:
<img width="901" alt="CleanShot 2023-08-09 at 23 57 38@2x" src="https://github.com/hashicorp/design-system/assets/4587451/88720f02-9f5d-4be8-8014-95c2db52dc29">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2282](https://hashicorp.atlassian.net/browse/HDS-2282)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2282]: https://hashicorp.atlassian.net/browse/HDS-2282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ