### PR TITLE
Update error icon in copy components

### DIFF
--- a/.changeset/tender-cougars-report.md
+++ b/.changeset/tender-cougars-report.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Update error icon for copy components

--- a/packages/components/addon/components/hds/copy/button/index.js
+++ b/packages/components/addon/components/hds/copy/button/index.js
@@ -12,7 +12,7 @@ export const DEFAULT_SIZE = 'medium';
 export const SIZES = ['small', 'medium'];
 export const DEFAULT_ICON = 'clipboard-copy';
 export const SUCCESS_ICON = 'clipboard-checked';
-export const ERROR_ICON = 'clipboard';
+export const ERROR_ICON = 'clipboard-x';
 export const DEFAULT_STATUS = 'idle';
 
 export default class HdsCopyButtonComponent extends Component {

--- a/packages/components/addon/components/hds/copy/snippet/index.hbs
+++ b/packages/components/addon/components/hds/copy/snippet/index.hbs
@@ -5,7 +5,7 @@
 <button
   type="button"
   class={{this.classNames}}
-  {{clipboard text=@textToCopy onError=this.onError onSuccess=this.onSuccess}}
+  {{clipboard text=@textToCopy container=@container onError=this.onError onSuccess=this.onSuccess}}
   ...attributes
 >
   <span class="hds-copy-snippet__text hds-typography-code-100 {{if @isTruncated 'hds-copy-snippet__text--truncated'}}">

--- a/packages/components/addon/components/hds/copy/snippet/index.js
+++ b/packages/components/addon/components/hds/copy/snippet/index.js
@@ -12,7 +12,7 @@ export const DEFAULT_COLOR = 'primary';
 export const COLORS = ['primary', 'secondary'];
 export const DEFAULT_ICON = 'clipboard-copy';
 export const SUCCESS_ICON = 'clipboard-checked';
-export const ERROR_ICON = 'clipboard';
+export const ERROR_ICON = 'clipboard-x';
 export const DEFAULT_STATUS = 'idle';
 
 export default class HdsCopySnippetIndexComponent extends Component {

--- a/website/docs/components/copy/button/partials/code/component-api.md
+++ b/website/docs/components/copy/button/partials/code/component-api.md
@@ -20,7 +20,7 @@ This component uses [ember-cli-clipboard](https://github.com/jkusa/ember-cli-cli
      Selector string of element or action that returns an element from which to copy text.
   </C.Property>
   <C.Property @name="container" @type="string">
-     Selector string or element object of containing element, typically used in conjunction with modals; set the focused element as the container value".
+     Selector string or element object of containing element, typically used in conjunction with modals; set the focused element as the container value.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/copy/snippet/partials/code/component-api.md
+++ b/website/docs/components/copy/snippet/partials/code/component-api.md
@@ -3,12 +3,15 @@
 This component uses [ember-cli-clipboard](https://github.com/jkusa/ember-cli-clipboard) under the hood.
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="color" @type="enum" @values={{array "secondary" "tertiary" }} @default="tertiary"/>
+  <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
   <C.Property @name="isFullWidth" @type="boolean" @default="false">
     Indicates that the component should take up the full width of the parent container.
   </C.Property>
   <C.Property @name="textToCopy" @type="string" @required="true">
     String value or action that returns a string to be copied.
+  </C.Property>
+  <C.Property @name="container" @type="string">
+     Selector string or element object of containing element, typically used in conjunction with modals; set the focused element as the container value.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the copy components to use the new clipboard-x icon

### :hammer_and_wrench: Detailed description

- updated the error icon value in `Copy::Button`
- updated the error icon value in `Copy::Snippet`

### :camera_flash: Screenshots

<img width="382" alt="CleanShot 2023-08-10 at 00 30 00@2x" src="https://github.com/hashicorp/design-system/assets/4587451/e4c1ada0-6a31-41a6-99da-f13cce93d1e8">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2365](https://hashicorp.atlassian.net/browse/HDS-2365)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2365]: https://hashicorp.atlassian.net/browse/HDS-2365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ