### PR TITLE
use node 20 in CI

### DIFF
--- a/.github/workflows/ci-components-nightly.yml
+++ b/.github/workflows/ci-components-nightly.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: '16.x'
+  NODE_VERSION: '20.x'
 
 concurrency:
    group: ci-components-nightly-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -7,7 +7,7 @@ on:
   pull_request: {}
 
 env:
-  NODE_VERSION: '16.x'
+  NODE_VERSION: '20.x'
 
 concurrency:
    group: ci-components-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci-ember-flight-icons.yml
+++ b/.github/workflows/ci-ember-flight-icons.yml
@@ -7,7 +7,7 @@ on:
   pull_request: {}
 
 env:
-  NODE_VERSION: '16.x'
+  NODE_VERSION: '20.x'
 
 concurrency:
    group: ci-ember-flight-icons-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -7,7 +7,7 @@ on:
   pull_request: {}
 
 env:
-  NODE_VERSION: '16.x'
+  NODE_VERSION: '20.x'
 
 concurrency:
   group: ci-website-${{ github.head_ref || github.ref }}

--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: '16.x'
+  NODE_VERSION: '20.x'
 
 jobs:
   sync_iconset:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  NODE_VERSION: '20.x'
+
 jobs:
   release:
     name: Release
@@ -16,10 +19,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 16.x
+          node-version: ${{ env.NODE_VERSION }}
           cache-dependency-path: yarn.lock
 
       - name: Install Dependencies

--- a/website/package.json
+++ b/website/package.json
@@ -104,7 +104,7 @@
     "yaml-front-matter": "^4.1.1"
   },
   "engines": {
-    "node": "16.* || 18.*"
+    "node": "16.* || 18.* || 20.*"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
### :pushpin: Summary

[Node 16 is EOL next month](https://github.com/nodejs/release#release-schedule).

We're free to also do this locally as well, but note that our current version of ember-cli will display a warning that this version of node is not supported. This warning [has been removed](https://github.com/ember-cli/ember-cli/pull/10187) from future versions of ember-cli as in practice these versions should work as long as the underlying `engines` declarations allow them (and CI and the apps still work)

This change _only_ impacts our local testing environment and doesn't change anything for consumers of our apps.