### PR TITLE
Remove unnecessary export of `hds/copy/index.js`

### DIFF
--- a/.changeset/eight-vans-yawn.md
+++ b/.changeset/eight-vans-yawn.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Remove unnecessary export of `hds/copy/index.js`

--- a/packages/components/app/components/hds/copy/index.js
+++ b/packages/components/app/components/hds/copy/index.js
@@ -1,6 +1,0 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
-export { default } from '@hashicorp/design-system-components/components/hds/copy/index';


### PR DESCRIPTION
### :pushpin: Summary

The history was squashed so it's not possible to gather context for why this was added, but there isn't a corresponding `addon` file for this so removing it seems safe.


### :hammer_and_wrench: Detailed description

@WenInCode reported this was causing embroider to fail
```bash
ERROR in ./components/hds/copy/index.js 6:0-113
Module not found: Error: Can't resolve '../../../../node_modules/@hashicorp/design-system-components/components/hds/copy/index' in '$TMPDIR/embroider/b11a20/documentation/components/hds/copy'
resolve '../../../../node_modules/@hashicorp/design-system-components/components/hds/copy/index' in '$TMPDIR/embroider/b11a20/documentation/components/hds/copy'
  using description file: $TMPDIR/embroider/b11a20/documentation/package.json (relative path: ./components/hds/copy)
```


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2381](https://hashicorp.atlassian.net/browse/HDS-2381)


***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2381]: https://hashicorp.atlassian.net/browse/HDS-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ