### PR TITLE
`Hds::Tabs` - Fix tabs and panels misbehaving on route change

### DIFF
--- a/.changeset/large-melons-allow.md
+++ b/.changeset/large-melons-allow.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::Tabs` - Fix tabs and panels misbehaving on route change

--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -11,6 +11,7 @@
           Tab=(component
             "hds/tabs/tab"
             didInsertNode=this.didInsertTab
+            willDestroyNode=this.willDestroyTab
             tabIds=this.tabIds
             panelIds=this.panelIds
             selectedTabIndex=this.selectedTabIndex
@@ -28,6 +29,7 @@
       Panel=(component
         "hds/tabs/panel"
         didInsertNode=this.didInsertPanel
+        willDestroyNode=this.willDestroyPanel
         tabIds=this.tabIds
         panelIds=this.panelIds
         selectedTabIndex=this.selectedTabIndex

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -45,9 +45,21 @@ export default class HdsTabsIndexComponent extends Component {
   }
 
   @action
+  willDestroyTab(element) {
+    this.tabNodes = this.tabNodes.filter((node) => node.id !== element.id);
+    this.tabIds = this.tabIds.filter((tabId) => tabId !== element.id);
+  }
+
+  @action
   didInsertPanel(panelId, element) {
     this.panelNodes = [...this.panelNodes, element];
     this.panelIds = [...this.panelIds, panelId];
+  }
+
+  @action
+  willDestroyPanel(element) {
+    this.panelNodes = this.panelNodes.filter((node) => node.id !== element.id);
+    this.panelIds = this.panelIds.filter((panelId) => panelId !== element.id);
   }
 
   @action

--- a/packages/components/addon/components/hds/tabs/panel.hbs
+++ b/packages/components/addon/components/hds/tabs/panel.hbs
@@ -10,6 +10,7 @@
   id={{this.panelId}}
   hidden={{not this.isSelected}}
   {{did-insert this.didInsertNode}}
+  {{will-destroy this.willDestroyNode}}
 >
   {{yield}}
 </section>

--- a/packages/components/addon/components/hds/tabs/panel.js
+++ b/packages/components/addon/components/hds/tabs/panel.js
@@ -42,4 +42,13 @@ export default class HdsTabsIndexComponent extends Component {
       didInsertNode(this.elementId, ...arguments);
     }
   }
+
+  @action
+  willDestroyNode() {
+    let { willDestroyNode } = this.args;
+
+    if (typeof willDestroyNode === 'function') {
+      willDestroyNode(...arguments);
+    }
+  }
 }

--- a/packages/components/addon/components/hds/tabs/tab.hbs
+++ b/packages/components/addon/components/hds/tabs/tab.hbs
@@ -13,6 +13,7 @@
     tabindex={{unless this.isSelected "-1"}}
     data-is-selected={{this.isInitialTab}}
     {{did-insert this.didInsertNode}}
+    {{will-destroy this.willDestroyNode}}
     {{on "click" this.onClick}}
     {{on "keyup" this.onKeyUp}}
   >

--- a/packages/components/addon/components/hds/tabs/tab.js
+++ b/packages/components/addon/components/hds/tabs/tab.js
@@ -55,6 +55,15 @@ export default class HdsTabsIndexComponent extends Component {
   }
 
   @action
+  willDestroyNode() {
+    let { willDestroyNode } = this.args;
+
+    if (typeof willDestroyNode === 'function') {
+      willDestroyNode(...arguments);
+    }
+  }
+
+  @action
   onClick() {
     let { onClick } = this.args;
 


### PR DESCRIPTION
### :pushpin: Summary

`Hds::Tabs` - Fix tabs and panels misbehaving on route change

### :hammer_and_wrench: Detailed description

In a very simplified illustration, a tabs component with two items would look as follows:
```
Hds::Tabs (size=2)
├── Hds::Tabs::Tab (id=tab-ember-1, index=0)
├── Hds::Tabs::Tab (id=tab-ember-2, index=1)
├── Hds::Tabs::Panel (id=panel-ember-3, index=0)
└── Hds::Tabs::Panel (id=panel-ember-4, index=1)
```

#### Before
On route change, the above component would become:
```
Hds::Tabs (size=4, out of which 2 were removed from the DOM)
├── Hds::Tabs::Tab (id=tab-ember-5, index=2)
├── Hds::Tabs::Tab (id=tab-ember-6, index=3)
├── Hds::Tabs::Panel (id=panel-ember-7, index=2)
└── Hds::Tabs::Panel (id=panel-ember-8, index=3)
```

The index values are increasing because `Tab`s and `Panel`s are always appended to `Hds::Tabs` (never removed). As the component tries to preserve the active index (either `0` or `1`, depending on selection) the route change action results in no active `Tab` or `Panel`.

[Debug 'before' in a dummy app](https://hds-showcase-hfrvg1es3-hashicorp.vercel.app/demo-app/submodules/submodel-1)

#### After
With this change, we manage `Tab`s and `Panel`s destructions (and their removal from stored indexes), with the following output on route change:
```
Hds::Tabs (size=2)
├── Hds::Tabs::Tab (id=tab-ember-5, index=0)
├── Hds::Tabs::Tab (id=tab-ember-6, index=1)
├── Hds::Tabs::Panel (id=panel-ember-7, index=0)
└── Hds::Tabs::Panel (id=panel-ember-8, index=1)
```

This means the active index is preserved on route change. Notice the `Tab`s and `Panel`s are still recreated (as you can see from their `id`s) however we consider this to be the desired outcome as their content may change with a route change.

[Debug 'after' in a dummy app](https://hds-showcase-mi7cjdmp1-hashicorp.vercel.app/demo-app/submodules/submodule-1)

### :camera_flash: Screenshots

#### Before

![tabs-route-before](https://github.com/hashicorp/design-system/assets/788096/a00e3cb8-b7f9-48a7-80b5-19f86210f0a8)


#### After

![tabs-route-after](https://github.com/hashicorp/design-system/assets/788096/0c7f665e-6c51-430a-8316-c8211952b024)


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2372](https://hashicorp.atlassian.net/browse/HDS-2372)
Related PR: https://github.com/hashicorp/atlas/pull/16525

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2372]: https://hashicorp.atlassian.net/browse/HDS-2372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ