### PR TITLE
`Hds::Tabs` - Fix missing tab indicator when used in Modal or Flyout

### DIFF
--- a/.changeset/fuzzy-socks-agree.md
+++ b/.changeset/fuzzy-socks-agree.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::Tabs` - Fix missing tab indicator when used in Modal or Flyout

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
+import { schedule } from '@ember/runloop';
 
 export default class HdsTabsIndexComponent extends Component {
   @tracked tabNodes = [];
@@ -28,7 +29,10 @@ export default class HdsTabsIndexComponent extends Component {
       }
     });
     this.selectedTabIndex = initialTabIndex;
-    this.setTabIndicator(initialTabIndex);
+
+    schedule('afterRender', () => {
+      this.setTabIndicator(initialTabIndex);
+    });
 
     assert('Only one tab may use isSelected argument', selectedCount <= 1);
 

--- a/packages/components/tests/dummy/app/controllers/components/modal.js
+++ b/packages/components/tests/dummy/app/controllers/components/modal.js
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 export default class ModalController extends Controller {
   @tracked basicModalActive = false;
   @tracked formModalActive = false;
+  @tracked tabsModalActive = false;
 
   @action
   activateModal(modal) {

--- a/packages/components/tests/dummy/app/templates/components/modal.hbs
+++ b/packages/components/tests/dummy/app/templates/components/modal.hbs
@@ -268,5 +268,35 @@
       </M.Footer>
     </Hds::Modal>
   {{/if}}
+
+  <button type="button" {{on "click" (fn this.activateModal "tabsModalActive")}}>Open tabs modal</button>
+
+  {{#if this.tabsModalActive}}
+    <Hds::Modal id="tabs-modal" @onClose={{fn this.deactivateModal "tabsModalActive"}} as |M|>
+      <M.Header>
+        Modal title
+      </M.Header>
+      <M.Body>
+        <Hds::Tabs as |T|>
+          <T.Tab>One</T.Tab>
+          <T.Tab>Two</T.Tab>
+          <T.Tab>Three</T.Tab>
+          <T.Panel>
+            <p class="hds-typography-body-300 hds-foreground-primary">Content 1</p>
+          </T.Panel>
+          <T.Panel>
+            <p class="hds-typography-body-300 hds-foreground-primary">Content 2</p>
+          </T.Panel>
+          <T.Panel>
+            <p class="hds-typography-body-300 hds-foreground-primary">Content 3</p>
+          </T.Panel>
+        </Hds::Tabs>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
+
 </section>
 {{! template-lint-enable no-autofocus-attribute }}


### PR DESCRIPTION
### :pushpin: Summary

`Hds::Tabs` - Fix missing tab indicator when used in Modal

### :hammer_and_wrench: Detailed description

The tab indicator is currently set on insert, which sometimes can happen before render so the parent node offset values become `0`, resulting in no indicator for the active tab. We change the code to operate the offset computations after render.

Added an example of Tabs in Modal to facilitate manual testing.

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![tabs-in-modal-before](https://github.com/hashicorp/design-system/assets/788096/2fa3fd06-40ea-4190-9b4d-3e3a35fa1af7)


</td><td>

![tabs-in-modal-after](https://github.com/hashicorp/design-system/assets/788096/e568b67c-d786-49d8-a82c-3ecdc4f29139)


</td></tr>
</table>


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2387](https://hashicorp.atlassian.net/browse/HDS-2387)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
