### PR TITLE
`Alert`: Fix link colors (HDS-2396)

### DIFF
--- a/packages/components/app/styles/components/alert.scss
+++ b/packages/components/app/styles/components/alert.scss
@@ -63,9 +63,9 @@
     border-radius: 5px;
   }
 
-  // Notice: in the future this may become a "Link::Inline" component (for now we declare directly the same styles here)
-  a {
-    color: var(--token-color-foreground-action);
+  // Default styling for bare HTML links not using HDS::Link components
+  a:not([class*="hds-"]) {
+    color: var(--token-color-foreground-strong);
 
     &:focus,
     &:focus-visible {
@@ -75,11 +75,11 @@
     }
 
     &:hover {
-      color: var(--token-color-foreground-action-hover);
+      color: var(--token-color-foreground-primary);
     }
 
     &:active {
-      color: var(--token-color-foreground-action-active);
+      color: var(--token-color-foreground-faint);
     }
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -140,6 +140,55 @@
             </A.Generic>
           </Hds::Alert>
         </SF.Item>
+
+        <SF.Item>
+          <Hds::Alert @type="inline" @color="success" as |A|>
+            <A.Title>An alert with an HTML link compared to the <code>Hds::Link</code> in the description</A.Title>
+            <A.Description>
+              <p>Description with an <a href="#">HTML link</a>.</p>
+              <p>
+                Compared with a
+                <Hds::Link::Inline @href="#">Primary Hds::Link::Inline</Hds::Link::Inline>, and a
+                <Hds::Link::Standalone @icon="hashicorp" @text="Primary Hds::Link::Standalone with an icon" @href="#" />
+              </p>
+              <p>
+                Also compared with a
+                <Hds::Link::Inline @href="#" @color="secondary">Secondary Hds::Link::Inline</Hds::Link::Inline>, and a
+                <Hds::Link::Standalone
+                  @icon="hashicorp"
+                  @color="secondary"
+                  @text="Primary Hds::Link::Standalone with an icon"
+                  @href="#"
+                />
+              </p>
+            </A.Description>
+          </Hds::Alert>
+        </SF.Item>
+
+        <SF.Item>
+          <Hds::Alert @type="compact" @color="success" as |A|>
+            <A.Title>An alert with an HTML link compared to the <code>Hds::Link</code> in the description</A.Title>
+            <A.Description>
+              Compact alert with an
+              <a href="#">HTML link</a>.
+              <p>
+                Compared with a
+                <Hds::Link::Inline @href="#">Primary Hds::Link::Inline</Hds::Link::Inline>, and a
+                <Hds::Link::Standalone @icon="hashicorp" @text="Primary Hds::Link::Standalone with an icon" @href="#" />
+              </p>
+              <p>
+                Also compared with a
+                <Hds::Link::Inline @href="#" @color="secondary">Secondary Hds::Link::Inline</Hds::Link::Inline>, and a
+                <Hds::Link::Standalone
+                  @icon="hashicorp"
+                  @color="secondary"
+                  @text="Primary Hds::Link::Standalone with an icon"
+                  @href="#"
+                />
+              </p>
+            </A.Description>
+          </Hds::Alert>
+        </SF.Item>
       </Shw::Flex>
     </SG.Item>
   </Shw::Grid>

--- a/website/docs/components/alert/partials/guidelines/guidelines.md
+++ b/website/docs/components/alert/partials/guidelines/guidelines.md
@@ -67,7 +67,7 @@ Use the Alert to communicate validation errors. For more details, refer to the [
     <A.Description>Correct the formatting of the following fields to update your user profile:
     </A.Description>
     <A.Description>
-    <Hds::Link::Inline @href="...">Email address</Hds::Link::Inline>
+    <Hds::Link::Inline @href="..." @color="secondary">Email address</Hds::Link::Inline>
     </A.Description>
   </Hds::Alert>
 !!!


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will:
* Fix a bug overriding the set color of `Hds::Link` in `Alert`
* Change the default color of plain HTML links to use "secondary" colors
* Update Showcase to add examples of links as content in regular and compact Alert
* Change an example `Link` in the Website to use "secondary" color.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2396](https://hashicorp.atlassian.net/browse/HDS-2396)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
