### PR TITLE
Remove aria-hidden from optional span

### DIFF
--- a/.changeset/curvy-rice-watch.md
+++ b/.changeset/curvy-rice-watch.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Remove aria-hidden from the "optional" span in Form::Indicator

--- a/packages/components/addon/components/hds/form/indicator/index.hbs
+++ b/packages/components/addon/components/hds/form/indicator/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 {{#if @isOptional}}
-  <span aria-hidden="true" class={{this.classNames}}>(Optional)</span>
+  <span class={{this.classNames}}>(Optional)</span>
 {{/if}}
 {{#if @isRequired}}
   &nbsp;<Hds::Badge aria-hidden="true" class={{this.classNames}} @size="small" @color="neutral" @text="Required" />


### PR DESCRIPTION
### :pushpin: Summary

Removes `aria-hidden` from the optional span in `Form::Indicator` when `@isOptional` is true.

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

### :hammer_and_wrench: Detailed description

`aria-hidden` was added to the `@isRequired` badge because the input element itself is denoted as required and therefore having it on the badge too is repetitive for SRs and other AT. However, this is not true for the optional span. The aria-hidden attribute was likely added accidentally at the same time.

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
