### PR TITLE
Fix website failing in SSR

### DIFF
--- a/website/app/components/doc/page/banner.js
+++ b/website/app/components/doc/page/banner.js
@@ -13,17 +13,24 @@ export default class DocPageBannerComponent extends Component {
   @tracked isVisible = !this.isDismissed;
 
   get isDismissed() {
-    const hasCookie =
-      document.cookie
-        .split('; ')
-        .findIndex((cookie) => cookie.startsWith(COOKIE_NAME)) >= 0;
+    let hasCookie = false;
+    // safeguarding as in SSR `ember-fastboot` doesn't have a `document` to operate on
+    if (typeof document !== 'undefined') {
+      hasCookie =
+        document.cookie
+          .split('; ')
+          .findIndex((cookie) => cookie.startsWith(COOKIE_NAME)) >= 0;
+    }
     return hasCookie;
   }
 
   @action
   onClose() {
     this.isVisible = false;
-    // we let it expire in two days (we want more impressions over two week's time)
-    document.cookie = `${COOKIE_NAME}=true; max-age=${60 * 60 * 24 * 2};`;
+    // safeguarding as in SSR `ember-fastboot` doesn't have a `document` to operate on
+    if (typeof document !== 'undefined') {
+      // we let it expire in two days (we want more impressions over two week's time)
+      document.cookie = `${COOKIE_NAME}=true; max-age=${60 * 60 * 24 * 2};`;
+    }
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

Add safeguarding to `document.cookie` operations

### :hammer_and_wrench: Detailed description

In server-side rendering `ember-fastboot` doesn't have a `document` to operate on, failing to render the page. By adding safeguards, aside from preventing the error from happening, for the server-side rendered version we show [the survey banner](https://github.com/hashicorp/design-system/pull/1544) and allow its dismissal but without the persistence offered by cookies.

### :link: External links

[Slack thread](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1692204668836639)
