### PR TITLE
`Hds::Form::MaskedInput` - Add `hasCopyButton` argument

### DIFF
--- a/.changeset/silly-buckets-pay.md
+++ b/.changeset/silly-buckets-pay.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Hds::Form::MaskedInput` - Add `hasCopyButton` argument

--- a/packages/components/addon/components/hds/form/masked-input/base.hbs
+++ b/packages/components/addon/components/hds/form/masked-input/base.hbs
@@ -2,33 +2,38 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class={{this.classNames}} {{style width=@width}}>
-  {{#if @isMultiline}}
-    <Hds::Form::Textarea::Base
-      class="hds-form-masked-input__control"
-      @value={{@value}}
-      @isInvalid={{@isInvalid}}
-      @height={{@height}}
-      id={{this.id}}
-      ...attributes
-    />
-  {{else}}
-    <Hds::Form::TextInput::Base
-      class="hds-form-masked-input__control"
-      @value={{@value}}
-      @isInvalid={{@isInvalid}}
-      id={{this.id}}
-      ...attributes
-    />
+<div class="hds-form-masked-input__wrapper">
+  <div class={{this.classNames}} {{style width=@width}}>
+    {{#if @isMultiline}}
+      <Hds::Form::Textarea::Base
+        class="hds-form-masked-input__control"
+        @value={{@value}}
+        @isInvalid={{@isInvalid}}
+        @height={{@height}}
+        id={{this.id}}
+        ...attributes
+      />
+    {{else}}
+      <Hds::Form::TextInput::Base
+        class="hds-form-masked-input__control"
+        @value={{@value}}
+        @isInvalid={{@isInvalid}}
+        id={{this.id}}
+        ...attributes
+      />
+    {{/if}}
+    <button
+      class="hds-form-masked-input__toggle-button"
+      type="button"
+      aria-label={{this.ariaLabel}}
+      aria-controls={{this.id}}
+      {{on "click" this.onClickToggle}}
+    >
+      <FlightIcon @name={{if this.isMasked "eye" "eye-off"}} @size="16" @isInlineBlock={{false}} />
+      <span class="sr-only" aria-live="polite">{{this.ariaMessageText}}</span>
+    </button>
+  </div>
+  {{#if @hasCopyButton}}
+    <Hds::Copy::Button @text="Copy masked content" @isIconOnly={{true}} @textToCopy="{{@value}}" />
   {{/if}}
-  <button
-    class="hds-form-masked-input__toggle-button"
-    type="button"
-    aria-label={{this.ariaLabel}}
-    aria-controls={{this.id}}
-    {{on "click" this.onClickToggle}}
-  >
-    <FlightIcon @name={{if this.isMasked "eye" "eye-off"}} @size="16" @isInlineBlock={{false}} />
-    <span class="sr-only" aria-live="polite">{{this.ariaMessageText}}</span>
-  </button>
 </div>

--- a/packages/components/addon/components/hds/form/masked-input/base.hbs
+++ b/packages/components/addon/components/hds/form/masked-input/base.hbs
@@ -34,7 +34,7 @@
   {{#if @hasCopyButton}}
     <Hds::Copy::Button
       class="hds-form-masked-input__copy-button"
-      @text="Copy masked content"
+      @text={{this.copyButtonText}}
       @isIconOnly={{true}}
       @textToCopy="{{@value}}"
     />

--- a/packages/components/addon/components/hds/form/masked-input/base.hbs
+++ b/packages/components/addon/components/hds/form/masked-input/base.hbs
@@ -2,38 +2,41 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class="hds-form-masked-input__wrapper">
-  <div class={{this.classNames}} {{style width=@width}}>
-    {{#if @isMultiline}}
-      <Hds::Form::Textarea::Base
-        class="hds-form-masked-input__control"
-        @value={{@value}}
-        @isInvalid={{@isInvalid}}
-        @height={{@height}}
-        id={{this.id}}
-        ...attributes
-      />
-    {{else}}
-      <Hds::Form::TextInput::Base
-        class="hds-form-masked-input__control"
-        @value={{@value}}
-        @isInvalid={{@isInvalid}}
-        id={{this.id}}
-        ...attributes
-      />
-    {{/if}}
-    <button
-      class="hds-form-masked-input__toggle-button"
-      type="button"
-      aria-label={{this.ariaLabel}}
-      aria-controls={{this.id}}
-      {{on "click" this.onClickToggle}}
-    >
-      <FlightIcon @name={{if this.isMasked "eye" "eye-off"}} @size="16" @isInlineBlock={{false}} />
-      <span class="sr-only" aria-live="polite">{{this.ariaMessageText}}</span>
-    </button>
-  </div>
+<div class={{this.classNames}} {{style width=@width}}>
+  {{#if @isMultiline}}
+    <Hds::Form::Textarea::Base
+      class="hds-form-masked-input__control"
+      @value={{@value}}
+      @isInvalid={{@isInvalid}}
+      @height={{@height}}
+      id={{this.id}}
+      ...attributes
+    />
+  {{else}}
+    <Hds::Form::TextInput::Base
+      class="hds-form-masked-input__control"
+      @value={{@value}}
+      @isInvalid={{@isInvalid}}
+      id={{this.id}}
+      ...attributes
+    />
+  {{/if}}
+  <button
+    class="hds-form-masked-input__toggle-button"
+    type="button"
+    aria-label={{this.ariaLabel}}
+    aria-controls={{this.id}}
+    {{on "click" this.onClickToggle}}
+  >
+    <FlightIcon @name={{if this.isMasked "eye" "eye-off"}} @size="16" @isInlineBlock={{false}} />
+    <span class="sr-only" aria-live="polite">{{this.ariaMessageText}}</span>
+  </button>
   {{#if @hasCopyButton}}
-    <Hds::Copy::Button @text="Copy masked content" @isIconOnly={{true}} @textToCopy="{{@value}}" />
+    <Hds::Copy::Button
+      class="hds-form-masked-input__copy-button"
+      @text="Copy masked content"
+      @isIconOnly={{true}}
+      @textToCopy="{{@value}}"
+    />
   {{/if}}
 </div>

--- a/packages/components/addon/components/hds/form/masked-input/base.js
+++ b/packages/components/addon/components/hds/form/masked-input/base.js
@@ -41,7 +41,7 @@ export default class HdsFormMaskedInputBaseComponent extends Component {
   /**
    * @param ariaMessageText
    * @type {string}
-   * @default ''
+   * @default 'Input content is now hidden'
    */
   get ariaMessageText() {
     if (this.args.ariaMessageText) {
@@ -50,6 +50,19 @@ export default class HdsFormMaskedInputBaseComponent extends Component {
       return 'Input content is now hidden';
     } else {
       return 'Input content is now visible';
+    }
+  }
+
+  /**
+   * @param copyButtonText
+   * @type {string}
+   * @default 'Copy masked content'
+   */
+  get copyButtonText() {
+    if (this.args.copyButtonText) {
+      return this.args.copyButtonText;
+    } else {
+      return 'Copy masked content';
     }
   }
 

--- a/packages/components/addon/components/hds/form/masked-input/field.hbs
+++ b/packages/components/addon/components/hds/form/masked-input/field.hbs
@@ -15,6 +15,7 @@
   {{yield (hash HelperText=F.HelperText Error=F.Error)}}
   <F.Control>
     <Hds::Form::MaskedInput::Base
+      @hasCopyButton={{@hasCopyButton}}
       @isMultiline={{@isMultiline}}
       @isMasked={{@isMasked}}
       @value={{@value}}

--- a/packages/components/app/styles/components/form/masked-input.scss
+++ b/packages/components/app/styles/components/form/masked-input.scss
@@ -9,17 +9,15 @@
 
 $hds-form-masked-input-button-size: 24px;
 
-.hds-form-masked-input__wrapper {
-  display: flex;
-  gap: 8px;
-  align-items: flex-start;
-}
-
 .hds-form-masked-input {
   position: relative;
+  display: grid;
+  grid-column-gap: 8px;
+  grid-template-columns: auto min-content;
   width: 100%;
 
   .hds-form-masked-input__control {
+    grid-area: 1 / 1 / 2 / 2;
     padding-right: calc(var(--token-form-control-padding) + $hds-form-masked-input-button-size);
   }
 }
@@ -42,6 +40,7 @@ $hds-form-masked-input-button-size: 24px;
   position: absolute;
   top: calc(var(--token-form-control-padding) - var(--token-form-control-border-width));
   right: calc(var(--token-form-control-padding) - var(--token-form-control-border-width));
+  grid-area: 1 / 1 / 2 / 2;
   width: $hds-form-masked-input-button-size;
   height: $hds-form-masked-input-button-size;
   padding: 2px;
@@ -49,4 +48,9 @@ $hds-form-masked-input-button-size: 24px;
   background-color: transparent;
   border-color: transparent;
   cursor: pointer;
+}
+
+.hds-form-masked-input__copy-button {
+  grid-area: 1 / 2 / 2 / 3;
+  align-self: flex-start;
 }

--- a/packages/components/app/styles/components/form/masked-input.scss
+++ b/packages/components/app/styles/components/form/masked-input.scss
@@ -13,7 +13,7 @@ $hds-form-masked-input-button-size: 24px;
   position: relative;
   display: grid;
   grid-template-areas: "input copy-button";
-  grid-template-columns: auto min-content;
+  grid-template-columns: 1fr auto;
   width: 100%;
 
   .hds-form-masked-input__control {

--- a/packages/components/app/styles/components/form/masked-input.scss
+++ b/packages/components/app/styles/components/form/masked-input.scss
@@ -12,7 +12,6 @@ $hds-form-masked-input-button-size: 24px;
 .hds-form-masked-input {
   position: relative;
   display: grid;
-  grid-column-gap: 8px;
   grid-template-columns: auto min-content;
   width: 100%;
 
@@ -53,4 +52,5 @@ $hds-form-masked-input-button-size: 24px;
 .hds-form-masked-input__copy-button {
   grid-area: 1 / 2 / 2 / 3;
   align-self: flex-start;
+  margin-left: 8px;
 }

--- a/packages/components/app/styles/components/form/masked-input.scss
+++ b/packages/components/app/styles/components/form/masked-input.scss
@@ -12,11 +12,12 @@ $hds-form-masked-input-button-size: 24px;
 .hds-form-masked-input {
   position: relative;
   display: grid;
+  grid-template-areas: "input copy-button";
   grid-template-columns: auto min-content;
   width: 100%;
 
   .hds-form-masked-input__control {
-    grid-area: 1 / 1 / 2 / 2;
+    grid-area: input;
     padding-right: calc(var(--token-form-control-padding) + $hds-form-masked-input-button-size);
   }
 }
@@ -39,7 +40,7 @@ $hds-form-masked-input-button-size: 24px;
   position: absolute;
   top: calc(var(--token-form-control-padding) - var(--token-form-control-border-width));
   right: calc(var(--token-form-control-padding) - var(--token-form-control-border-width));
-  grid-area: 1 / 1 / 2 / 2;
+  grid-area: input;
   width: $hds-form-masked-input-button-size;
   height: $hds-form-masked-input-button-size;
   padding: 2px;
@@ -50,7 +51,7 @@ $hds-form-masked-input-button-size: 24px;
 }
 
 .hds-form-masked-input__copy-button {
-  grid-area: 1 / 2 / 2 / 3;
+  grid-area: copy-button;
   align-self: flex-start;
   margin-left: 8px;
 }

--- a/packages/components/app/styles/components/form/masked-input.scss
+++ b/packages/components/app/styles/components/form/masked-input.scss
@@ -9,6 +9,12 @@
 
 $hds-form-masked-input-button-size: 24px;
 
+.hds-form-masked-input__wrapper {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
 .hds-form-masked-input {
   position: relative;
   width: 100%;

--- a/packages/components/tests/dummy/app/templates/components/form/masked-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/masked-input.hbs
@@ -87,7 +87,7 @@
           <SG.Item
             @label="{{capitalize variant}} / {{capitalize state}}"
             mock-state-value={{state}}
-            mock-state-selector="input"
+            mock-state-selector="textarea"
           >
             <Shw::Flex @direction="column" as |SF|>
               <SF.Item>
@@ -147,7 +147,7 @@
           <SG.Item
             @label="{{capitalize variant}} / {{capitalize state}}"
             mock-state-value={{state}}
-            mock-state-selector="input"
+            mock-state-selector="textarea"
           >
             <Shw::Flex @direction="column" as |SF|>
               <SF.Item>

--- a/packages/components/tests/dummy/app/templates/components/form/masked-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/masked-input.hbs
@@ -106,6 +106,67 @@
     {{/each}}
   {{/let}}
 
+  <Shw::Divider @level="2" />
+
+  <Shw::Text::H3>Copy button</Shw::Text::H3>
+
+  <Shw::Text::H4>Single line</Shw::Text::H4>
+
+  {{#let (array "base" "invalid" "readonly") as |variants|}}
+    {{#each variants as |variant|}}
+      <Shw::Grid @columns={{3}} as |SG|>
+        {{#each @model.STATES as |state|}}
+          <SG.Item
+            @label="{{capitalize variant}} / {{capitalize state}}"
+            mock-state-value={{state}}
+            mock-state-selector="input"
+          >
+            <Shw::Flex @direction="column" as |SF|>
+              <SF.Item>
+                <Hds::Form::MaskedInput::Base
+                  disabled={{if (eq variant "disabled") "disabled"}}
+                  readonly={{if (eq variant "readonly") "readonly"}}
+                  @hasCopyButton={{true}}
+                  @value="Lorem ipsum dolor"
+                  @isInvalid={{if (eq variant "invalid") true}}
+                />
+              </SF.Item>
+            </Shw::Flex>
+          </SG.Item>
+        {{/each}}
+      </Shw::Grid>
+    {{/each}}
+  {{/let}}
+
+  <Shw::Text::H4>Multiline</Shw::Text::H4>
+
+  {{#let (array "base" "invalid" "readonly") as |variants|}}
+    {{#each variants as |variant|}}
+      <Shw::Grid @columns={{3}} as |SG|>
+        {{#each @model.STATES as |state|}}
+          <SG.Item
+            @label="{{capitalize variant}} / {{capitalize state}}"
+            mock-state-value={{state}}
+            mock-state-selector="input"
+          >
+            <Shw::Flex @direction="column" as |SF|>
+              <SF.Item>
+                <Hds::Form::MaskedInput::Base
+                  disabled={{if (eq variant "disabled") "disabled"}}
+                  readonly={{if (eq variant "readonly") "readonly"}}
+                  @isMultiline={{true}}
+                  @hasCopyButton={{true}}
+                  @value="Lorem ipsum dolor"
+                  @isInvalid={{if (eq variant "invalid") true}}
+                />
+              </SF.Item>
+            </Shw::Flex>
+          </SG.Item>
+        {{/each}}
+      </Shw::Grid>
+    {{/each}}
+  {{/let}}
+
   <Shw::Divider />
 
   <Shw::Text::H2>"Field" control</Shw::Text::H2>
@@ -126,8 +187,13 @@
         <F.HelperText>This is the helper text</F.HelperText>
       </Hds::Form::MaskedInput::Field>
     </SG.Item>
-    {{! left empty on purpose }}
-    <SG.Item />
+    <SG.Item @label="Label + Helper text + Copy Button + Error">
+      <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" @isInvalid={{true}} @hasCopyButton={{true}} as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Error>This is the error</F.Error>
+      </Hds::Form::MaskedInput::Field>
+    </SG.Item>
     <SG.Item @label="Label + Error">
       <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" @isInvalid={{true}} as |F|>
         <F.Label>This is the label</F.Label>
@@ -167,8 +233,19 @@
         <F.HelperText>This is the helper text</F.HelperText>
       </Hds::Form::MaskedInput::Field>
     </SG.Item>
-    {{! left empty on purpose }}
-    <SG.Item />
+    <SG.Item @label="Label + Helper text + Copy Button + Error">
+      <Hds::Form::MaskedInput::Field
+        @isMultiline={{true}}
+        @value="Lorem ipsum dolor"
+        @isInvalid={{true}}
+        @hasCopyButton={{true}}
+        as |F|
+      >
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Error>This is the error</F.Error>
+      </Hds::Form::MaskedInput::Field>
+    </SG.Item>
     <SG.Item @label="Label + Error">
       <Hds::Form::MaskedInput::Field @isMultiline={{true}} @value="Lorem ipsum dolor" @isInvalid={{true}} as |F|>
         <F.Label>This is the label</F.Label>

--- a/website/docs/components/copy/button/index.md
+++ b/website/docs/components/copy/button/index.md
@@ -5,7 +5,7 @@ caption: A button that copies the attached or associated text upon interaction.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=37400-71082&mode=design
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/copy/button
-related: ['components/copy/snippet', 'components/form/masked-input']
+related: ['components/copy/snippet']
 previewImage: assets/illustrations/components/copy-button.jpg
 navigation:
   keywords: ['snippet', 'clipboard']

--- a/website/docs/components/form/masked-input/partials/code/component-api.md
+++ b/website/docs/components/form/masked-input/partials/code/component-api.md
@@ -20,6 +20,9 @@ The Masked Input component has two different variants with their own APIs:
   <C.Property @name="isInvalid" @type="boolean" @default="false">
     Applies an “invalid” appearance to the control but doesn’t modify its logical validity.
   </C.Property>
+  <C.Property @name="hasCopyButton" @type="boolean" @default="false">
+    If set to `true` it renders a [`Copy::Button`](/components/copy/button) next to the form control allowing the value of the input to be copied to clipboard.
+  </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the input fills the parent container. If a `@width` parameter is provided, the control will have a fixed width.
   </C.Property>
@@ -55,6 +58,9 @@ The Masked Input component has two different variants with their own APIs:
   </C.Property>
   <C.Property @name="isOptional" @type="boolean" @default="false">
     Appends an `Optional` indicator next to the label text when user input is optional.
+  </C.Property>
+  <C.Property @name="hasCopyButton" @type="boolean" @default="false">
+    If set to `true` it renders a [`Copy::Button`](/components/copy/button) next to the form control allowing the value of the input to be copied to clipboard.
   </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the input fills the parent container. If a `@width` parameter is provided, the control will have a fixed width. This width will only be applied to the control, not the other elements of the field.

--- a/website/docs/components/form/masked-input/partials/code/component-api.md
+++ b/website/docs/components/form/masked-input/partials/code/component-api.md
@@ -23,6 +23,9 @@ The Masked Input component has two different variants with their own APIs:
   <C.Property @name="hasCopyButton" @type="boolean" @default="false">
     If set to `true`, it renders a [`Copy::Button`](/components/copy/button) next to the form control allowing the value of the input to be copied to the clipboard.
   </C.Property>
+  <C.Property @name="copyButtonText" @type="string" @default="Copy masked content">
+    Override this value to provide a meaninful `aria-label` for the [`Copy::Button`](/components/copy/button) component.
+  </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the input fills the parent container. If a `@width` parameter is provided, the control will have a fixed width.
   </C.Property>
@@ -61,6 +64,9 @@ The Masked Input component has two different variants with their own APIs:
   </C.Property>
   <C.Property @name="hasCopyButton" @type="boolean" @default="false">
     If set to `true`, it renders a [`Copy::Button`](/components/copy/button) next to the form control allowing the value of the input to be copied to the clipboard.
+  </C.Property>
+  <C.Property @name="copyButtonText" @type="string" @default="Copy masked content">
+    Override this value to provide a meaninful `aria-label` for the [`Copy::Button`](/components/copy/button) component.
   </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the input fills the parent container. If a `@width` parameter is provided, the control will have a fixed width. This width will only be applied to the control, not the other elements of the field.

--- a/website/docs/components/form/masked-input/partials/code/component-api.md
+++ b/website/docs/components/form/masked-input/partials/code/component-api.md
@@ -27,7 +27,7 @@ The Masked Input component has two different variants with their own APIs:
     Override this value to provide a meaninful `aria-label` for the [`Copy::Button`](/components/copy/button) component.
   </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
-    By default, the input fills the parent container. If a `@width` parameter is provided, the control will have a fixed width. When `hasCopyButton` is `true` the width includes the associated copy button.
+    By default, the input fills the parent container. If a `@width` parameter is provided, the control will have a fixed width. When `hasCopyButton` is `true`, the width includes the associated copy button.
   </C.Property>
   <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
     Only available if `@isMultiline` is `true`. By default, the `<textarea>` has a `height` determined by the browser to accommodate 4 lines of text. If a custom `@height` value is provided, the control will have a fixed height.

--- a/website/docs/components/form/masked-input/partials/code/component-api.md
+++ b/website/docs/components/form/masked-input/partials/code/component-api.md
@@ -27,7 +27,7 @@ The Masked Input component has two different variants with their own APIs:
     Override this value to provide a meaninful `aria-label` for the [`Copy::Button`](/components/copy/button) component.
   </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
-    By default, the input fills the parent container. If a `@width` parameter is provided, the control will have a fixed width.
+    By default, the input fills the parent container. If a `@width` parameter is provided, the control will have a fixed width. When `hasCopyButton` is `true` the width includes the associated copy button.
   </C.Property>
   <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
     Only available if `@isMultiline` is `true`. By default, the `<textarea>` has a `height` determined by the browser to accommodate 4 lines of text. If a custom `@height` value is provided, the control will have a fixed height.

--- a/website/docs/components/form/masked-input/partials/code/component-api.md
+++ b/website/docs/components/form/masked-input/partials/code/component-api.md
@@ -21,7 +21,7 @@ The Masked Input component has two different variants with their own APIs:
     Applies an “invalid” appearance to the control but doesn’t modify its logical validity.
   </C.Property>
   <C.Property @name="hasCopyButton" @type="boolean" @default="false">
-    If set to `true` it renders a [`Copy::Button`](/components/copy/button) next to the form control allowing the value of the input to be copied to clipboard.
+    If set to `true`, it renders a [`Copy::Button`](/components/copy/button) next to the form control allowing the value of the input to be copied to the clipboard.
   </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the input fills the parent container. If a `@width` parameter is provided, the control will have a fixed width.
@@ -60,7 +60,7 @@ The Masked Input component has two different variants with their own APIs:
     Appends an `Optional` indicator next to the label text when user input is optional.
   </C.Property>
   <C.Property @name="hasCopyButton" @type="boolean" @default="false">
-    If set to `true` it renders a [`Copy::Button`](/components/copy/button) next to the form control allowing the value of the input to be copied to clipboard.
+    If set to `true`, it renders a [`Copy::Button`](/components/copy/button) next to the form control allowing the value of the input to be copied to the clipboard.
   </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the input fills the parent container. If a `@width` parameter is provided, the control will have a fixed width. This width will only be applied to the control, not the other elements of the field.

--- a/website/docs/components/form/masked-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/masked-input/partials/code/how-to-use.md
@@ -79,7 +79,7 @@ Something to keep in mind when designing and implementing functionality that mak
 
 #### Copy button
 
-To allow users to copy the input value to their clipboard set the `@hasCopyButton` argument to `true`.
+To allow users to copy the input value to their clipboard, set the `@hasCopyButton` argument to `true`.
 
 ```handlebars
 <Hds::Form::MaskedInput::Field @hasCopyButton={{true}} @value="036215df4996ca649928d8864b4df9e42cba0d6d" as |F|>

--- a/website/docs/components/form/masked-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/masked-input/partials/code/how-to-use.md
@@ -77,6 +77,15 @@ Something to keep in mind when designing and implementing functionality that mak
 
 !!!
 
+#### Copy button
+
+To allow users to copy the input value to their clipboard set the `@hasCopyButton` argument to `true`.
+
+```handlebars
+<Hds::Form::MaskedInput::Field @hasCopyButton={{true}} @value="036215df4996ca649928d8864b4df9e42cba0d6d" as |F|>
+  <F.Label>Terraform Cloud team token</F.Label>
+</Hds::Form::MaskedInput::Field>
+```
 
 #### Helper text
 

--- a/website/docs/components/form/masked-input/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/masked-input/partials/guidelines/guidelines.md
@@ -68,6 +68,19 @@ For shorter, simpler forms, indicate optional fields instead.
   <F.Label>Label</F.Label>
 </Hds::Form::MaskedInput::Field>
 
+## Copying the Masked Input value
+
+Setting the `hasCopyButton` property to `true` will display a [Copy Button](/components/copy/copy-button) adjacent to the Masked Input, allowing users to copy the value in the Masked Input to their clipboard. Refer to the [Copy Button](/components/copy/copy-button) usage guidelines for more details around copying content. 
+
+<Doc::Layout @spacing="16px">
+  <Hds::Form::MaskedInput::Field @value="0362df4996ca864b4df9e42cba0d6d" @width="300px" @hasCopyButton={{true}} as |F|>
+    <F.Label>Label</F.Label>
+  </Hds::Form::MaskedInput::Field>
+  <Hds::Form::MaskedInput::Field @value="0362df4996ca864b4df9e42cba0d6d" @isMultiline={{true}} @width="300px" @hasCopyButton={{true}} as |F|>
+    <F.Label>Label</F.Label>
+  </Hds::Form::MaskedInput::Field>
+</Doc::Layout>
+
 ## Error validation
 
 For error validation recommendations, refer to the [Form patterns](/patterns/form-patterns) documentation.


### PR DESCRIPTION
### :pushpin: Summary

Allow `Hds::Copy::Button` on `Hds::Form::MaskedInput::Base` and `Hds::Form::MaskedInput::Field`

### :hammer_and_wrench: Detailed description

To be able to manage the layout (placing the `Hds::Copy::Button` next to the `Hds::Form::MaskedInput::Base` with `8px` spacing) we needed to introduce an additional wrapper element (`hds-form-masked-input__wrapper`). I was not able to avoid this, but very much open to ideas.

### 🧑‍💻 Impact on consumers

There are no instances of `Hds::Form::MaskedInput` in our consumers' codebases.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2320](https://hashicorp.atlassian.net/browse/HDS-2320)
Figma file: https://www.figma.com/file/j3b8rHoknu1WX3LLaRZCkj/Copyable-masked-input?type=design&node-id=39498-83754&mode=design&t=bMiZcWFNBp1jYOMz-4
[Related PR with guidelines](https://github.com/hashicorp/design-system/pull/1581)

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2320]: https://hashicorp.atlassian.net/browse/HDS-2320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ