### PR TITLE
`CopySnippet`: Add web docs for `@isTruncated` (HDS-2444)

### DIFF
--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -27,8 +27,9 @@
 @import "pages/home"; // homepage (index)
 @import "pages/about/principles";
 @import "pages/foundations/landing";
-@import "pages/components/accordion";
 @import "pages/foundations/icon";
+@import "pages/components/accordion";
+@import "pages/components/copy-snippet";
 @import "pages/components/dropdown";
 @import "pages/components/flyout";
 @import "pages/components/landing";

--- a/website/app/styles/pages/components/copy-snippet.scss
+++ b/website/app/styles/pages/components/copy-snippet.scss
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+// COMPONENTS > COPY/COPY-SNIPPET
+
+.doc-page-constrain-copy-snippet-width {
+  max-width: 10em;
+}

--- a/website/app/styles/pages/components/copy-snippet.scss
+++ b/website/app/styles/pages/components/copy-snippet.scss
@@ -6,6 +6,6 @@
 
 // COMPONENTS > COPY/COPY-SNIPPET
 
-.doc-page-constrain-copy-snippet-width {
-  max-width: 10em;
+#show-content-components-copy-snippet {
+  .doc-copy-snippet-demo-constrain-width { max-width: 10em; }
 }

--- a/website/docs/components/copy/snippet/partials/code/component-api.md
+++ b/website/docs/components/copy/snippet/partials/code/component-api.md
@@ -13,6 +13,11 @@ This component uses [ember-cli-clipboard](https://github.com/jkusa/ember-cli-cli
   <C.Property @name="container" @type="string">
      Selector string or element object of containing element, typically used in conjunction with modals; set the focused element as the container value.
   </C.Property>
+  <C.Property @name="isTruncated" @type="boolean" @default="false">
+    Constrains text to one line and truncates it based on available width. Text will only be truncated if it does not fit within the available space within a page layout.
+    <br><br>
+    There are accessibility concerns if using this feature. See the [Accessibility section](/components/copy/snippet?tab=accessibility) for more information.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/components/copy/snippet/partials/code/component-api.md
+++ b/website/docs/components/copy/snippet/partials/code/component-api.md
@@ -14,7 +14,7 @@ This component uses [ember-cli-clipboard](https://github.com/jkusa/ember-cli-cli
      Selector string or element object of containing element, typically used in conjunction with modals; set the focused element as the container value.
   </C.Property>
   <C.Property @name="isTruncated" @type="boolean" @default="false">
-    Constrains text to one line and truncates it based on available width. Text will only be truncated if it does not fit within the available space within a page layout.
+    Constrains text to one line and truncates it based on available width. Text will only be truncated if it does not fit within the available space.
     <br><br>
     There are accessibility concerns if using this feature. See the [Accessibility section](/components/copy/snippet?tab=accessibility) for more information.
   </C.Property>

--- a/website/docs/components/copy/snippet/partials/code/how-to-use.md
+++ b/website/docs/components/copy/snippet/partials/code/how-to-use.md
@@ -24,10 +24,10 @@ This indicates that the component should take up the full-width of the parent co
 ```
 
 ### isTruncated
+
 When set to `true`, this constrains text to one-line and truncates it if it does not fit the available space.
 
 Care should be taken in choosing to use this feature as there are [accessibility concerns](/components/copy/snippet?tab=accessibility).
-
 
 ```handlebars
 <div class="doc-page-constrain-copy-snippet-width">

--- a/website/docs/components/copy/snippet/partials/code/how-to-use.md
+++ b/website/docs/components/copy/snippet/partials/code/how-to-use.md
@@ -30,7 +30,7 @@ When set to `true`, this constrains text to one-line and truncates it if it does
 Care should be taken in choosing to use this feature as there are [accessibility concerns](/components/copy/snippet?tab=accessibility).
 
 ```handlebars
-<div class="doc-page-constrain-copy-snippet-width">
+<div class="doc-copy-snippet-demo-constrain-width">
   <Hds::Copy::Snippet
     @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r with a bunch of other long text that should force truncation if truncation is set to true"
     @isTruncated={{true}}

--- a/website/docs/components/copy/snippet/partials/code/how-to-use.md
+++ b/website/docs/components/copy/snippet/partials/code/how-to-use.md
@@ -22,3 +22,18 @@ This indicates that the component should take up the full-width of the parent co
 ```handlebars
 <Hds::Copy::Snippet @textToCopy="e4rt-yg80-39kt" @isFullWidth={{true}} />
 ```
+
+### isTruncated
+When set to `true`, this constrains text to one-line and truncates it if it does not fit the available space.
+
+Care should be taken in choosing to use this feature as there are [accessibility concerns](/components/copy/snippet?tab=accessibility).
+
+
+```handlebars
+<div class="doc-page-constrain-copy-snippet-width">
+  <Hds::Copy::Snippet
+    @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r with a bunch of other long text that should force truncation if truncation is set to true"
+    @isTruncated={{true}}
+  />
+</div>
+```


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will add documentation for `@isTruncated` to the `CopySnippet`

**Web docs:** https://hds-website-git-hds-2444-document-copysnippet-179bfd-hashicorp.vercel.app/components/copy/snippet?tab=code

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->

- Jira ticket: [HDS-2444](https://hashicorp.atlassian.net/browse/HDS-2444)
- Slack thread: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1692735495406229

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2444]: https://hashicorp.atlassian.net/browse/HDS-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ