### PR TITLE
randomize flight export branch name

### DIFF
--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -35,6 +35,7 @@ jobs:
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
         with:
           branch: 'hds-icon-export'
+          branch-suffix: 'short-commit-hash'
           commit-message: 'sync & build of flight icons'
           title: 'Updated export of icons from Figma'
           body: ''


### PR DESCRIPTION
### :pushpin: Summary

Re-using the same branch name has created some (unnecessary) confusion, so this change uses the [branch-suffix](https://github.com/peter-evans/create-pull-request#alternative-strategy---always-create-a-new-pull-request-branch) option to randomize these moving forward.

Was `hds-icon-export`
Will be something like `hds-icon-export-6qj97jr`