### PR TITLE
`Tabs` - Add use case for nested tabs in the showcase

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -98,6 +98,34 @@
     <T.Panel><Shw::Placeholder @text="Content three" @height="50" @background="#eee" /></T.Panel>
   </Hds::Tabs>
 
+  <Shw::Text::Body>Nested tabs</Shw::Text::Body>
+
+  <Hds::Tabs as |T|>
+    <T.Tab>One</T.Tab>
+    <T.Tab>Two</T.Tab>
+    <T.Tab>Three</T.Tab>
+
+    <T.Panel>
+      <Hds::Tabs as |T|>
+        <T.Tab>Tab One - Sub-tab A</T.Tab>
+        <T.Tab>Tab One - Sub-tab B</T.Tab>
+        <T.Tab>Tab One - Sub-tab C</T.Tab>
+        <T.Panel><Shw::Placeholder @text="Tab One - Content A" @height="50" @background="#eee" /></T.Panel>
+        <T.Panel><Shw::Placeholder @text="Tab One - Content B" @height="50" @background="#eee" /></T.Panel>
+        <T.Panel><Shw::Placeholder @text="Tab One - Content C" @height="50" @background="#eee" /></T.Panel>
+      </Hds::Tabs>
+    </T.Panel>
+    <T.Panel>
+      <Hds::Tabs as |T|>
+        <T.Tab>Tab Two - Sub-tab A</T.Tab>
+        <T.Tab>Tab Two - Sub-tab B</T.Tab>
+        <T.Panel><Shw::Placeholder @text="Tab Two - Content A" @height="50" @background="#eee" /></T.Panel>
+        <T.Panel><Shw::Placeholder @text="Tab Two - Content B" @height="50" @background="#eee" /></T.Panel>
+      </Hds::Tabs>
+    </T.Panel>
+    <T.Panel><Shw::Placeholder @text="Tab Three - Content" @height="50" @background="#eee" /></T.Panel>
+  </Hds::Tabs>
+
   <Shw::Divider />
 
   <Shw::Text::H2>Base elements</Shw::Text::H2>


### PR DESCRIPTION
### :pushpin: Summary

This PR adds a demo of nested tabs in the `Tabs` showcase.

Context: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1693256847934889

### :camera_flash: Screenshots

<img width="1041" alt="screenshot_3037" src="https://github.com/hashicorp/design-system/assets/686239/49791ccd-6630-401a-af20-cd05de1cebbf">

_Notice: the first tab in the first sub-tabs sets should be highlighted._

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
