### PR TITLE
Remove `ember-named-blocks-polyfill`

### DIFF
--- a/.changeset/ninety-nails-report.md
+++ b/.changeset/ninety-nails-report.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Remove `ember-named-blocks-polyfill` as all consumers of HDS are on Ember 3.25 or later now. This can be installed locally if it is still needed.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,6 @@
     "ember-composable-helpers": "^4.5.0",
     "ember-focus-trap": "^1.0.2",
     "ember-keyboard": "^8.2.0",
-    "ember-named-blocks-polyfill": "^0.2.5",
     "ember-stargate": "^0.4.3",
     "ember-style-modifier": "^3.0.1",
     "ember-truth-helpers": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2826,7 +2826,6 @@ __metadata:
     ember-focus-trap: ^1.0.2
     ember-keyboard: ^8.2.0
     ember-load-initializers: ^2.1.2
-    ember-named-blocks-polyfill: ^0.2.5
     ember-page-title: ^7.0.0
     ember-power-select: ^6.0.1
     ember-qunit: ^6.2.0
@@ -10339,16 +10338,6 @@ __metadata:
     ember-cli-typescript: ^5.0.0
     ember-compatibility-helpers: ^1.2.5
   checksum: 2e96d9ec3939de178a9ce704d5a9360fd73f0276ffa4a9cce9f100a4087fdc8fae4a8b28bf1be22b05a4d1c61e1bb1ab93ca60576810c6556bc4d9323864c66a
-  languageName: node
-  linkType: hard
-
-"ember-named-blocks-polyfill@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "ember-named-blocks-polyfill@npm:0.2.5"
-  dependencies:
-    ember-cli-babel: ^7.19.0
-    ember-cli-version-checker: ^5.1.1
-  checksum: f3ca8eeb61a208bf4690d423806b35371b5f01c58028404c9065d7d6e289d2220f40232756718a784fe0d0a65ed9c5a66a3df76f4abd222d07fca35886f5c583
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: Summary

Remove `ember-named-blocks-polyfill` as all internal consumers of HDS are on Ember 3.25 or later now


### :link: External links

* [Docs](https://github.com/ember-polyfills/ember-named-blocks-polyfill/tree/main#ember-named-blocks-polyfill)

> This addon provides a polyfill for the [Yieldable Named Blocks](https://github.com/emberjs/rfcs/blob/master/text/0460-yieldable-named-blocks.md) feature. **On Ember.js versions with native support for the feature (3.25+), this addon is inert**.

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
