### PR TITLE
`SideNav` - updated banner type in documentation for "How to use / Accessibility / ember-a11y-refocus"

### DIFF
--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -452,7 +452,7 @@ If you find yourself in the situation of wanting/needing to customize or change 
 
 By default, the component uses the [ember-a11y-refocus](https://github.com/ember-a11y/ember-a11y-refocus) addon to provide a "navigator narrator" and a "Skip Link" to the navigation (see [the addon documentation for details)](https://github.com/ember-a11y/ember-a11y-refocus#what-this-addon-does).
 
-!!! Critical
+!!! Info
 
 **Notice**
 


### PR DESCRIPTION
### :pushpin: Summary

During our engineering sync we have discussed and [decided](https://docs.google.com/document/d/1twnk39hZ7p8oZYrld_FYsdiuUb6yn_weA46KnhF4nu4/edit#heading=h.m498uqhd7p5q) to lower the "gravity" of the banner related to the `ember-a11y-refocus` addon, to avoid communicating that it's a problem to use the addon.

### :camera_flash: Screenshots

**Before:**
<img width="900" alt="screenshot_3041" src="https://github.com/hashicorp/design-system/assets/686239/3caaa934-ca7b-491b-94cb-b398e3252e21">

**After:**
<img width="904" alt="screenshot_3042" src="https://github.com/hashicorp/design-system/assets/686239/24dbbbbb-bc76-4bf8-9754-bb1bbabec6f1">

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
