### PR TITLE
Remove references to patterns roadmap

### DIFF
--- a/website/app/templates/patterns.hbs
+++ b/website/app/templates/patterns.hbs
@@ -9,11 +9,6 @@
   <Doc::Page::Cover @title="Patterns" />
   <Doc::Page::Content @breakthrough={{true}}>
     <Doc::Cards::Deck @cols="4" @cards={{this.cards.patterns}} />
-    <h2 class="doc-text-h2">Pattern roadmap</h2>
-    <p class="doc-text-body">We've spent much of the past year building lower level components, and therefore provide
-      limited support for patterns. See which patterns we plan to work on in the
-      <a class="doc-link-generic" href="https://go.hashi.co/hds-rollout">Helios roadmap</a>.
-    </p>
     <h2 class="doc-text-h2">Request a pattern</h2>
     <p class="doc-text-body">If you find yourself building the same pattern often or know of a pattern being used across
       products,


### PR DESCRIPTION
### :pushpin: Summary

It was pointed out in a review today that this is not terribly accurate (there is no discernible patterns information on our roadmap). For now I think it makes sense to remove this and bring it back if/when we have a more clear roadmap to share.