### PR TITLE
`Text` component replacements

### DIFF
--- a/.changeset/silver-dodos-retire.md
+++ b/.changeset/silver-dodos-retire.md
@@ -1,0 +1,15 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+- `Accordion` - replaced internal text styling (using `Text` component)
+- `ApplicationState` - replaced internal text styling (using `Text` component)
+- `Copy::Snippet` - replaced internal text styling (using `Text` component)
+- `Dropdown` - replaced internal text styling (using `Text` component)
+- `Form:**` - replaced internal text styling (using `Text` component)
+- `Flyout` - replaced internal text styling (using `Text` component)
+- `Modal` - replaced internal text styling (using `Text` component)
+- `PageHeader` - replaced internal text styling (using `Text` component)
+- `Pagination` - replaced internal text styling (using `Text` component)
+- `Stepper` - replaced internal text styling (using `Text` component)
+- `Tag` - replaced internal text styling (using `Text` component)

--- a/packages/components/addon/components/hds/accordion/item/index.hbs
+++ b/packages/components/addon/components/hds/accordion/item/index.hbs
@@ -14,17 +14,28 @@
         @parentContainsInteractive={{this.containsInteractive}}
       />
 
-      <div
-        class="hds-accordion-item__toggle-content hds-typography-display-200 hds-foreground-strong hds-font-weight-semibold"
+      <Hds::Text::Display
+        @tag="div"
+        @size="200"
+        @weight="semibold"
+        @color="strong"
+        class="hds-accordion-item__toggle-content"
       >
         {{yield to="toggle"}}
-      </div>
+      </Hds::Text::Display>
     </div>
   </:toggle>
 
   <:content>
-    <div class="hds-accordion-item__content hds-typography-body-200 hds-foreground-primary" id={{this.contentId}}>
+    <Hds::Text::Body
+      class="hds-accordion-item__content"
+      @tag="div"
+      @size="200"
+      @weight="regular"
+      @color="primary"
+      id={{this.contentId}}
+    >
       {{yield to="content"}}
-    </div>
+    </Hds::Text::Body>
   </:content>
 </Hds::DisclosurePrimitive>

--- a/packages/components/addon/components/hds/application-state/body.hbs
+++ b/packages/components/addon/components/hds/application-state/body.hbs
@@ -6,8 +6,8 @@
   {{#if (has-block)}}
     {{yield}}
   {{else}}
-    <p class="hds-application-state__body-text hds-typography-body-300">
+    <Hds::Text::Body class="hds-application-state__body-text" @tag="p" @size="300">
       {{@text}}
-    </p>
+    </Hds::Text::Body>
   {{/if}}
 </div>

--- a/packages/components/addon/components/hds/application-state/header.hbs
+++ b/packages/components/addon/components/hds/application-state/header.hbs
@@ -8,13 +8,13 @@
       <FlightIcon @name={{@icon}} @size="24" />
     </div>
   {{/if}}
-  <div class="hds-application-state__title hds-typography-display-400 hds-font-weight-semibold">
+  <Hds::Text::Display class="hds-application-state__title" @tag="div" @size="400" @weight="semibold">
     {{@title}}
-  </div>
+  </Hds::Text::Display>
   {{#if @errorCode}}
-    <div class="hds-application-state__error-code hds-typography-body-100 hds-font-weight-medium">
+    <Hds::Text::Body class="hds-application-state__error-code" @tag="div" @size="100" @weight="medium">
       Error
       {{@errorCode}}
-    </div>
+    </Hds::Text::Body>
   {{/if}}
 </div>

--- a/packages/components/addon/components/hds/copy/snippet/index.hbs
+++ b/packages/components/addon/components/hds/copy/snippet/index.hbs
@@ -8,8 +8,12 @@
   {{clipboard text=@textToCopy container=@container onError=this.onError onSuccess=this.onSuccess}}
   ...attributes
 >
-  <span class="hds-copy-snippet__text hds-typography-code-100 {{if @isTruncated 'hds-copy-snippet__text--truncated'}}">
+  <Hds::Text::Code
+    class="hds-copy-snippet__text {{if @isTruncated 'hds-copy-snippet__text--truncated'}}"
+    @tag="span"
+    @size="100"
+  >
     {{@textToCopy}}
-  </span>
+  </Hds::Text::Code>
   <FlightIcon @name={{this.icon}} class="hds-copy-snippet__icon" />
 </button>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkmark.hbs
@@ -24,11 +24,17 @@
         <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
       </div>
     {{/if}}
-    <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
+    <Hds::Text::Body @tag="div" @size="200" @weight="medium" class="hds-dropdown-list-item__interactive-text">
       {{yield}}
-    </div>
+    </Hds::Text::Body>
     {{#if @count}}
-      <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
+      <Hds::Text::Body
+        class="hds-dropdown-list-item__count"
+        @tag="span"
+        @size="100"
+        @weight="medium"
+        @color="faint"
+      >{{@count}}</Hds::Text::Body>
     {{/if}}
     <span class="hds-dropdown-list-item__checkmark">
       {{#if @selected}}

--- a/packages/components/addon/components/hds/dropdown/list-item/copy-item.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/copy-item.hbs
@@ -4,9 +4,13 @@
 }}
 <li class={{this.classNames}} ...attributes>
   {{#if @copyItemTitle}}
-    <div
-      class="hds-dropdown-list-item__copy-item-title hds-typography-body-100 hds-font-weight-semibold"
-    >{{@copyItemTitle}}</div>
+    <Hds::Text::Body
+      class="hds-dropdown-list-item__copy-item-title"
+      @tag="div"
+      @size="100"
+      @weight="semibold"
+      @color="faint"
+    >{{@copyItemTitle}}</Hds::Text::Body>
   {{/if}}
   <Hds::Copy::Snippet @textToCopy={{this.text}} @isTruncated={{@isTruncated}} />
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/description.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/description.hbs
@@ -2,6 +2,13 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<li class={{this.classNames}} ...attributes>
+<Hds::Text::Body
+  class="hds-dropdown-list-item hds-dropdown-list-item--variant-description"
+  @tag="li"
+  @size="100"
+  @weight="regular"
+  @color="faint"
+  ...attributes
+>
   {{this.text}}
-</li>
+</Hds::Text::Body>

--- a/packages/components/addon/components/hds/dropdown/list-item/description.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/description.js
@@ -22,22 +22,4 @@ export default class HdsDropdownListItemDescriptionComponent extends Component {
 
     return text;
   }
-
-  /**
-   * Get the class names to apply to the component.
-   * @method classNames
-   * @return {string} The "class" attribute to apply to the component.
-   */
-  get classNames() {
-    let classes = [
-      'hds-dropdown-list-item',
-      'hds-dropdown-list-item--variant-description',
-    ];
-
-    // add classes for the typographic style
-    classes.push('hds-typography-body-100');
-    classes.push('hds-font-weight-regular');
-
-    return classes.join(' ');
-  }
 }

--- a/packages/components/addon/components/hds/dropdown/list-item/interactive.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/interactive.hbs
@@ -8,9 +8,9 @@
       <div class="hds-dropdown-list-item__interactive-icon">
         <FlightIcon @name="loading" @isInlineBlock={{false}} />
       </div>
-      <div class="hds-dropdown-list-item__interactive-text hds-typography-body-100 hds-font-weight-regular">
+      <Hds::Text::Body @tag="div" @size="100" @weight="regular" class="hds-dropdown-list-item__interactive-text">
         {{this.text}}
-      </div>
+      </Hds::Text::Body>
     </div>
   {{else}}
     <Hds::Interactive
@@ -29,9 +29,9 @@
           <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
         </div>
       {{/if}}
-      <div class="hds-dropdown-list-item__interactive-text hds-typography-body-200 hds-font-weight-medium">
+      <Hds::Text::Body class="hds-dropdown-list-item__interactive-text" @tag="div" @size="200" @weight="medium">
         {{this.text}}
-      </div>
+      </Hds::Text::Body>
     </Hds::Interactive>
   {{/if}}
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
@@ -14,7 +14,12 @@
     <span class="hds-dropdown-list-item__text-content">{{yield}}</span>
 
     {{#if @count}}
-      <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
+      <Hds::Text::Body
+        class="hds-dropdown-list-item__count"
+        @tag="span"
+        @size="100"
+        @weight="medium"
+      >{{@count}}</Hds::Text::Body>
     {{/if}}
   </label>
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/title.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/title.hbs
@@ -2,6 +2,13 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<li class={{this.classNames}} ...attributes>
+<Hds::Text::Body
+  class="hds-dropdown-list-item hds-dropdown-list-item--variant-title"
+  @tag="li"
+  @size="100"
+  @weight="semibold"
+  @color="strong"
+  ...attributes
+>
   {{this.text}}
-</li>
+</Hds::Text::Body>

--- a/packages/components/addon/components/hds/dropdown/list-item/title.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/title.js
@@ -22,22 +22,4 @@ export default class HdsDropdownListItemTitleComponent extends Component {
 
     return text;
   }
-
-  /**
-   * Get the class names to apply to the component.
-   * @method classNames
-   * @return {string} The "class" attribute to apply to the component.
-   */
-  get classNames() {
-    let classes = [
-      'hds-dropdown-list-item',
-      'hds-dropdown-list-item--variant-title',
-    ];
-
-    // add classes for the typographic style
-    classes.push('hds-typography-body-100');
-    classes.push('hds-font-weight-semibold');
-
-    return classes.join(' ');
-  }
 }

--- a/packages/components/addon/components/hds/flyout/description.hbs
+++ b/packages/components/addon/components/hds/flyout/description.hbs
@@ -2,6 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class="hds-flyout__description hds-typography-body-200" ...attributes>
+<Hds::Text::Body class="hds-flyout__description" @tag="div" @size="200" @color="primary" ...attributes>
   {{yield}}
-</div>
+</Hds::Text::Body>

--- a/packages/components/addon/components/hds/flyout/header.hbs
+++ b/packages/components/addon/components/hds/flyout/header.hbs
@@ -6,13 +6,13 @@
   {{#if @icon}}
     <FlightIcon class="hds-flyout__icon" @name={{@icon}} @size="24" @isInlineBlock={{false}} />
   {{/if}}
-  <div class="hds-flyout__title hds-typography-display-300 hds-font-weight-semibold" id={{@id}}>
+  <Hds::Text::Display class="hds-flyout__title" @tag="div" @size="300" @weight="semibold" id={{@id}}>
     {{#if @tagline}}
-      <div class="hds-flyout__tagline hds-typography-body-100 hds-font-weight-regular">
+      <Hds::Text::Body class="hds-flyout__tagline" @tag="div" @size="100" @weight="regular" @color="faint">
         {{@tagline}}
-      </div>
+      </Hds::Text::Body>
     {{/if}}
     {{yield}}
-  </div>
+  </Hds::Text::Display>
   <Hds::DismissButton class="hds-flyout__dismiss" {{on "click" @onDismiss}} />
 </div>

--- a/packages/components/addon/components/hds/form/error/index.hbs
+++ b/packages/components/addon/components/hds/form/error/index.hbs
@@ -4,7 +4,7 @@
 }}
 <div class={{this.classNames}} id={{this.id}} {{did-insert this.onInsert}} ...attributes>
   <FlightIcon class="hds-form-error__icon" @name="alert-diamond-fill" />
-  <div class="hds-form-error__content">
+  <Hds::Text::Body class="hds-form-error__content" @tag="div" @size="100" @weight="medium">
     {{yield (hash Message=(component "hds/form/error/message"))}}
-  </div>
+  </Hds::Text::Body>
 </div>

--- a/packages/components/addon/components/hds/form/error/index.js
+++ b/packages/components/addon/components/hds/form/error/index.js
@@ -46,9 +46,6 @@ export default class HdsFormErrorIndexComponent extends Component {
   get classNames() {
     let classes = ['hds-form-error'];
 
-    // add typographic classes
-    classes.push('hds-typography-body-100', 'hds-font-weight-medium');
-
     // add a class based on the @contextualClass argument
     // notice: this will *not* be documented for public use
     // the reason for this is that the contextual component declarations don't pass attributes to the component

--- a/packages/components/addon/components/hds/form/error/message.hbs
+++ b/packages/components/addon/components/hds/form/error/message.hbs
@@ -2,6 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<p class="hds-form-error__message" ...attributes>
+<Hds::Text::Body class="hds-form-error__message" @tag="p" @size="100" @weight="medium" ...attributes>
   {{yield}}
-</p>
+</Hds::Text::Body>

--- a/packages/components/addon/components/hds/form/helper-text/index.hbs
+++ b/packages/components/addon/components/hds/form/helper-text/index.hbs
@@ -2,6 +2,14 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class={{this.classNames}} id={{this.id}} {{did-insert this.onInsert}} ...attributes>
+<Hds::Text::Body
+  class={{this.classNames}}
+  @tag="div"
+  @size="100"
+  @weight="regular"
+  id={{this.id}}
+  {{did-insert this.onInsert}}
+  ...attributes
+>
   {{yield}}
-</div>
+</Hds::Text::Body>

--- a/packages/components/addon/components/hds/form/helper-text/index.js
+++ b/packages/components/addon/components/hds/form/helper-text/index.js
@@ -46,9 +46,6 @@ export default class HdsFormHelperTextIndexComponent extends Component {
   get classNames() {
     let classes = ['hds-form-helper-text'];
 
-    // add typographic classes
-    classes.push('hds-typography-body-100', 'hds-font-weight-regular');
-
     // add a class based on the @contextualClass argument
     // notice: this will *not* be documented for public use
     // the reason for this is that the contextual component declarations don't pass attributes to the component

--- a/packages/components/addon/components/hds/form/indicator/index.hbs
+++ b/packages/components/addon/components/hds/form/indicator/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 {{#if @isOptional}}
-  <span class={{this.classNames}}>(Optional)</span>
+  <Hds::Text::Body class={{this.classNames}} tag="span" @size="100" @weight="regular">(Optional)</Hds::Text::Body>
 {{/if}}
 {{#if @isRequired}}
   &nbsp;<Hds::Badge aria-hidden="true" class={{this.classNames}} @size="small" @color="neutral" @text="Required" />

--- a/packages/components/addon/components/hds/form/indicator/index.js
+++ b/packages/components/addon/components/hds/form/indicator/index.js
@@ -17,9 +17,6 @@ export default class HdsFormIndicatorIndexComponent extends Component {
     if (this.args.isOptional) {
       // add speficic class for "optional" indicator
       classes.push('hds-form-indicator--optional');
-
-      // add typographic classes
-      classes.push('hds-typography-body-100', 'hds-font-weight-regular');
     }
 
     return classes.join(' ');

--- a/packages/components/addon/components/hds/form/radio-card/description.hbs
+++ b/packages/components/addon/components/hds/form/radio-card/description.hbs
@@ -2,4 +2,9 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<span class="hds-form-radio-card__description hds-typography-body-100" ...attributes>{{yield}}</span>
+<Hds::Text::Body
+  class="hds-form-radio-card__description"
+  @tag="span"
+  @size="100"
+  ...attributes
+>{{yield}}</Hds::Text::Body>

--- a/packages/components/addon/components/hds/form/radio-card/label.hbs
+++ b/packages/components/addon/components/hds/form/radio-card/label.hbs
@@ -2,4 +2,10 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<span class="hds-form-radio-card__label hds-typography-display-300 hds-font-weight-bold" ...attributes>{{yield}}</span>
+<Hds::Text::Display
+  class="hds-form-radio-card__label"
+  @tag="span"
+  @size="300"
+  @weight="bold"
+  ...attributes
+>{{yield}}</Hds::Text::Display>

--- a/packages/components/addon/components/hds/modal/header.hbs
+++ b/packages/components/addon/components/hds/modal/header.hbs
@@ -6,13 +6,13 @@
   {{#if @icon}}
     <FlightIcon class="hds-modal__icon" @name={{@icon}} @size="24" @isInlineBlock={{false}} />
   {{/if}}
-  <div class="hds-modal__title hds-typography-display-300 hds-font-weight-semibold" id={{@id}}>
+  <Hds::Text::Display class="hds-modal__title" @tag="div" @size="300" @weight="semibold" id={{@id}}>
     {{#if @tagline}}
-      <div class="hds-modal__tagline hds-typography-body-100 hds-font-weight-regular">
+      <Hds::Text::Body class="hds-modal__tagline" @tag="div" @size="100" @weight="regular">
         {{@tagline}}
-      </div>
+      </Hds::Text::Body>
     {{/if}}
     {{yield}}
-  </div>
+  </Hds::Text::Display>
   <Hds::DismissButton class="hds-modal__dismiss" {{on "click" @onDismiss}} />
 </div>

--- a/packages/components/addon/components/hds/page-header/description.hbs
+++ b/packages/components/addon/components/hds/page-header/description.hbs
@@ -2,4 +2,10 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<p class="hds-foreground-primary hds-typography-body-200 hds-page-header__description" ...attributes>{{yield}}</p>
+<Hds::Text::Body
+  class="hds-page-header__description"
+  @tag="p"
+  @size="200"
+  @color="primary"
+  ...attributes
+>{{yield}}</Hds::Text::Body>

--- a/packages/components/addon/components/hds/page-header/subtitle.hbs
+++ b/packages/components/addon/components/hds/page-header/subtitle.hbs
@@ -2,4 +2,10 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<p class="hds-foreground-faint hds-typography-body-200 hds-page-header__subtitle" ...attributes>{{yield}}</p>
+<Hds::Text::Body
+  class="hds-page-header__subtitle"
+  @tag="p"
+  @size="200"
+  @color="faint"
+  ...attributes
+>{{yield}}</Hds::Text::Body>

--- a/packages/components/addon/components/hds/page-header/title.hbs
+++ b/packages/components/addon/components/hds/page-header/title.hbs
@@ -2,4 +2,10 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<h1 class="hds-foreground-strong hds-typography-display-500 hds-page-header__title" ...attributes>{{yield}}</h1>
+<Hds::Text::Display
+  class="hds-page-header__title"
+  @tag="h1"
+  @size="500"
+  @color="strong"
+  ...attributes
+>{{yield}}</Hds::Text::Display>

--- a/packages/components/addon/components/hds/pagination/info/index.hbs
+++ b/packages/components/addon/components/hds/pagination/info/index.hbs
@@ -2,10 +2,10 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class="hds-pagination-info hds-typography-body-100 hds-font-weight-medium" ...attributes>
+<Hds::Text::Body class="hds-pagination-info" @tag="div" @size="100" @weight="medium" ...attributes>
   {{@itemsRangeStart}}–{{@itemsRangeEnd}}
   {{#if this.showTotalItems}}
     of
     {{@totalItems}}
   {{/if}}
-</div>
+</Hds::Text::Body>

--- a/packages/components/addon/components/hds/pagination/nav/arrow.hbs
+++ b/packages/components/addon/components/hds/pagination/nav/arrow.hbs
@@ -6,9 +6,15 @@
   <Hds::Interactive class={{this.classNames}} aria-label={{this.content.ariaLabel}} disabled={{true}} ...attributes>
     <FlightIcon @name={{this.content.icon}} />
     {{#if this.showLabel}}
-      <span class="hds-pagination-nav__arrow-label" aria-hidden="true">
+      <Hds::Text::Body
+        class="hds-pagination-nav__arrow-label"
+        @tag="span"
+        @size="100"
+        @weight="medium"
+        aria-hidden="true"
+      >
         {{this.content.label}}
-      </span>
+      </Hds::Text::Body>
     {{/if}}
   </Hds::Interactive>
 {{else}}
@@ -24,9 +30,15 @@
   >
     <FlightIcon @name={{this.content.icon}} />
     {{#if this.showLabel}}
-      <span class="hds-pagination-nav__arrow-label" aria-hidden="true">
+      <Hds::Text::Body
+        class="hds-pagination-nav__arrow-label"
+        @tag="span"
+        @size="100"
+        @weight="medium"
+        aria-hidden="true"
+      >
         {{this.content.label}}
-      </span>
+      </Hds::Text::Body>
     {{/if}}
   </Hds::Interactive>
 {{/if}}

--- a/packages/components/addon/components/hds/pagination/nav/arrow.js
+++ b/packages/components/addon/components/hds/pagination/nav/arrow.js
@@ -61,8 +61,6 @@ export default class HdsPaginationControlArrowComponent extends Component {
       'hds-pagination-nav__control',
       'hds-pagination-nav__arrow',
       `hds-pagination-nav__arrow--direction-${this.args.direction}`,
-      'hds-typography-body-100',
-      'hds-font-weight-medium',
     ];
 
     return classes.join(' ');

--- a/packages/components/addon/components/hds/pagination/nav/number.hbs
+++ b/packages/components/addon/components/hds/pagination/nav/number.hbs
@@ -12,5 +12,6 @@
   ...attributes
   aria-current={{if @isSelected "page" null}}
 >
-  <span class="sr-only">page </span>{{this.page}}
+  <Hds::Text::Body @tag="span" @size="100" @weight="medium"><span class="sr-only">page
+    </span>{{this.page}}</Hds::Text::Body>
 </Hds::Interactive>

--- a/packages/components/addon/components/hds/pagination/nav/number.js
+++ b/packages/components/addon/components/hds/pagination/nav/number.js
@@ -25,12 +25,7 @@ export default class HdsPaginationControlNumberComponent extends Component {
    * @return {string} The "class" attribute to apply to the component.
    */
   get classNames() {
-    let classes = [
-      'hds-pagination-nav__control',
-      'hds-pagination-nav__number',
-      'hds-typography-body-100',
-      'hds-font-weight-medium"',
-    ];
+    let classes = ['hds-pagination-nav__control', 'hds-pagination-nav__number'];
 
     if (this.args.isSelected) {
       classes.push(`hds-pagination-nav__number--is-selected`);

--- a/packages/components/addon/components/hds/stepper/step/indicator.hbs
+++ b/packages/components/addon/components/hds/stepper/step/indicator.hbs
@@ -17,7 +17,12 @@
     {{else if (eq @status "complete")}}
       <FlightIcon class="hds-stepper-indicator-step__icon" @name="check" @size="16" />
     {{else}}
-      <span class="hds-stepper-indicator-step__text">{{@text}}</span>
+      <Hds::Text::Body
+        class="hds-stepper-indicator-step__text"
+        @tag="span"
+        @size="100"
+        @weight="medium"
+      >{{@text}}</Hds::Text::Body>
     {{/if}}
   </div>
 </div>

--- a/packages/components/addon/components/hds/tag/index.hbs
+++ b/packages/components/addon/components/hds/tag/index.hbs
@@ -2,7 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<span class={{this.classNames}} ...attributes>
+<Hds::Text::Body class={{this.classNames}} @tag="span" @size="100" @weight="medium" @color="primary" ...attributes>
   {{#if this.onDismiss}}
     <button class="hds-tag__dismiss" type="button" aria-label={{this.ariaLabel}} {{on "click" this.onDismiss}}>
       <FlightIcon class="hds-tag__dismiss-icon" @name="x" @size="16" @isInlineBlock={{false}} />
@@ -27,4 +27,4 @@
       {{this.text}}
     </span>
   {{/if}}
-</span>
+</Hds::Text::Body>

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -547,7 +547,6 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   .hds-dropdown-list-item__icon {
     margin-top: 2px;
     margin-right: 4px;
-    color: var(--token-color-foreground-primary);
   }
 }
 

--- a/packages/components/app/styles/components/flyout.scss
+++ b/packages/components/app/styles/components/flyout.scss
@@ -70,7 +70,6 @@
 
 .hds-flyout__tagline {
   margin-bottom: 4px;
-  color: var(--token-color-foreground-faint);
 }
 
 .hds-flyout__dismiss {
@@ -79,7 +78,6 @@
 
 .hds-flyout__description {
   padding: 0 24px 16px;
-  color: var(--token-color-foreground-primary);
 }
 
 .hds-flyout__body {

--- a/packages/components/app/styles/components/stepper/step-indicator.scss
+++ b/packages/components/app/styles/components/stepper/step-indicator.scss
@@ -42,9 +42,6 @@ $hds-stepper-indicator-step-size: 24px;
 .hds-stepper-indicator-step__text {
   width: 20px;
   overflow: hidden;
-  font-weight: var(--token-typography-font-weight-medium);
-  font-size: 0.8125rem;
-  font-family: var(--token-typography-font-stack-text);
   white-space: nowrap;
   text-align: center;
   user-select: none;

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -15,11 +15,7 @@ $hds-tag-border-radius: 50px;
 .hds-tag {
   display: inline-flex;
   align-items: stretch;
-  color: var(--token-color-foreground-primary);
-  font-weight: var(--token-typography-font-weight-medium);
-  font-size: 0.8125rem; // 13px
-  font-family: var(--token-typography-font-stack-text);
-  line-height: 1rem; // 16px
+  line-height: 1rem; // 16px - override `body-100`
   vertical-align: middle;
   background-color: var(--token-color-surface-interactive);
   border: 1px solid var(--token-color-border-strong);

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -148,7 +148,7 @@
       <Hds::Form::Error>This is a simple error message</Hds::Form::Error>
     </SF.Item>
     <SF.Item @label="With text that spans multiple lines">
-      <Shw::Outliner class="shw-component-form-base-elements-container-with-badge">
+      <Shw::Outliner {{style width="250px"}}>
         <Hds::Form::Error>This is a very long error message that should span on multiple lines</Hds::Form::Error>
       </Shw::Outliner>
     </SF.Item>


### PR DESCRIPTION
### :pushpin: Summary

This PR follows the introduction of the `Text` component in #1490, and intends to replace the usage of `.hds-typography` classes or `token-font` tokens, where a `Text` component would work.

As agreed during the last HDS Engineering Sync meeting, I've replaced only purely textual elements, leaving out any semantic element (eg. `button`, `label`, etc).

### :hammer_and_wrench: Detailed description

In this PR I have replaced the typographic styling in the following components, to use the `Text` component where possible:

- `Accordion`
- `ApplicationState`
- `Copy::Snippet`
- `Dropdown`
- `Form`
- `Flyout`
- `Modal`
- `PageHeader`
- `Pagination`
- `Stepper`
- `Tag`

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2354

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
