### PR TITLE
`Link::Standalone`: Update font-weight (HDS-2437)

### DIFF
--- a/.changeset/new-garlics-vanish.md
+++ b/.changeset/new-garlics-vanish.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Change font-weight of `Hds::Link::Standalone` from 500 to 400 to match font-weight of `Hds::Button`.

--- a/packages/components/app/styles/components/link/standalone.scss
+++ b/packages/components/app/styles/components/link/standalone.scss
@@ -21,7 +21,7 @@ $hds-link-standalone-border-width: 1px;
   align-items: center;
   justify-content: center;
   width: fit-content;
-  font-weight: var(--token-typography-font-weight-medium);
+  font-weight: var(hds-font-weight-regular);
   font-family: var(--token-typography-font-stack-text);
   background-color: transparent; // needs to exist for a11y
   border: $hds-link-standalone-border-width solid transparent; // needs to exist AND be transparent for a11y

--- a/packages/components/app/styles/components/link/standalone.scss
+++ b/packages/components/app/styles/components/link/standalone.scss
@@ -21,7 +21,7 @@ $hds-link-standalone-border-width: 1px;
   align-items: center;
   justify-content: center;
   width: fit-content;
-  font-weight: var(--hds-font-weight-regular);
+  font-weight: var(--token-typography-font-weight-regular);
   font-family: var(--token-typography-font-stack-text);
   background-color: transparent; // needs to exist for a11y
   border: $hds-link-standalone-border-width solid transparent; // needs to exist AND be transparent for a11y

--- a/packages/components/app/styles/components/link/standalone.scss
+++ b/packages/components/app/styles/components/link/standalone.scss
@@ -21,7 +21,7 @@ $hds-link-standalone-border-width: 1px;
   align-items: center;
   justify-content: center;
   width: fit-content;
-  font-weight: var(hds-font-weight-regular);
+  font-weight: var(--hds-font-weight-regular);
   font-family: var(--token-typography-font-stack-text);
   background-color: transparent; // needs to exist for a11y
   border: $hds-link-standalone-border-width solid transparent; // needs to exist AND be transparent for a11y

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -1,5 +1,10 @@
 The Button component is used to trigger an action or event. For accessibility, Buttons should not be used to route to a URL; use a [Link](/components/link/standalone) instead.
 
+!!! Info
+
+Due to diferences in text rendering between Figma and web browsers, the `Button` and `Link::Standalone` Ember components use font-weight 400 vs. the Figma components which use font-weight 500.
+
+!!!
 ## How to use this component
 
 The basic invocation requires text to be passed:

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -2,7 +2,7 @@ The Button component is used to trigger an action or event. For accessibility, B
 
 !!! Info
 
-Due to diferences in text rendering between Figma and web browsers, the `Button` and `Link::Standalone` Ember components use font-weight 400 vs. the Figma components which use font-weight 500.
+Due to differences in text rendering between Figma and web browsers, the `Button` Ember component uses `font-weight` 400 vs. the Figma component which uses `font-weight` 500.
 
 !!!
 ## How to use this component

--- a/website/docs/components/link/standalone/partials/code/how-to-use.md
+++ b/website/docs/components/link/standalone/partials/code/how-to-use.md
@@ -3,6 +3,12 @@ The Standalone Link handles the generation of:
 - an HTML anchor element `<a>` that points to an external URL (when using a `@href` argument)
 - an [Ember component `<LinkTo>`](https://guides.emberjs.com/release/routing/linking-between-routes/#toc_the-linkto--component) that points to an internal application link or resource (when using a `@route` argument)
 
+!!! Info
+
+Due to diferences in text rendering between Figma and web browsers, the `Button` and `Link::Standalone` Ember components use font-weight 400 vs. the Figma components which use font-weight 500.
+
+!!!
+
 ## How to use this component
 
 The most basic invocation requires both `@icon` and `@text`, and either an `@href` or `@route` argument.

--- a/website/docs/components/link/standalone/partials/code/how-to-use.md
+++ b/website/docs/components/link/standalone/partials/code/how-to-use.md
@@ -5,7 +5,7 @@ The Standalone Link handles the generation of:
 
 !!! Info
 
-Due to diferences in text rendering between Figma and web browsers, the `Button` and `Link::Standalone` Ember components use font-weight 400 vs. the Figma components which use font-weight 500.
+Due to differences in text rendering between Figma and web browsers, the `Link::Standalone` Ember component uses `font-weight` 400 vs. the Figma component which uses `font-weight` 500.
 
 !!!
 


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will change the font weight of `Hds::Link::Standalone` from 500 (`--token-typography-font-weight-medium`) to 400 (`--token-typography-font-weight-regular`)

- **Showcase:** https://hds-showcase-git-hds-2437-update-standalone-link-hashicorp.vercel.app/components/link/standalone
- **Website:** https://hds-website-git-hds-2437-update-standalone-link-hashicorp.vercel.app/components/link/standalone

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?
-->

### :camera_flash: Screenshots
**Info banners:**
<img width="751" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/9147afb2-ed36-43b8-992f-3a97add044c8">
----
<img width="763" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/f99da36a-f32e-4cd4-923f-462a1b78185c">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2437](https://hashicorp.atlassian.net/browse/HDS-2437)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2437]: https://hashicorp.atlassian.net/browse/HDS-2437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ