### PR TITLE
`Dropdown`: checkbox gap fix (HDS-2332)

### DIFF
--- a/.changeset/honest-stingrays-whisper.md
+++ b/.changeset/honest-stingrays-whisper.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Refactor the layout of `Dropdown` checkbox and radio inputs to make the gap between the inputs and associated text, icon, and count clickable.
+Refactor the layout of the `Dropdown` checkbox and radio inputs to make the gap between the inputs and the associated text, as well as the icon and count, clickable.

--- a/.changeset/honest-stingrays-whisper.md
+++ b/.changeset/honest-stingrays-whisper.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Refactor the layout of `Dropdown` checkbox and radio inputs to make the gap between the inputs and associated text, including icons in front of the text, clickable.

--- a/.changeset/honest-stingrays-whisper.md
+++ b/.changeset/honest-stingrays-whisper.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Refactor the layout of `Dropdown` checkbox and radio inputs to make the gap between the inputs and associated text, including icons in front of the text, clickable.
+Refactor the layout of `Dropdown` checkbox and radio inputs to make the gap between the inputs and associated text, icon, and count clickable.

--- a/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
@@ -4,14 +4,14 @@
 }}
 
 <li class="hds-dropdown-list-item hds-dropdown-list-item--variant-checkbox">
-  <Hds::Form::Checkbox::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
-  {{#if @icon}}
-    <div class="hds-dropdown-list-item__icon">
-      <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
-    </div>
-  {{/if}}
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>
-    {{yield}}
+    <Hds::Form::Checkbox::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
+    {{#if @icon}}
+      <span class="hds-dropdown-list-item__icon">
+        <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
+      </span>
+    {{/if}}
+    <span class="hds-dropdown-list-item__text-content">{{yield}}</span>
   </label>
   {{#if @count}}
     <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>

--- a/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/checkbox.hbs
@@ -12,8 +12,9 @@
       </span>
     {{/if}}
     <span class="hds-dropdown-list-item__text-content">{{yield}}</span>
+
+    {{#if @count}}
+      <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
+    {{/if}}
   </label>
-  {{#if @count}}
-    <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
-  {{/if}}
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
@@ -4,13 +4,15 @@
 }}
 
 <li class="hds-dropdown-list-item hds-dropdown-list-item--variant-radio">
-  <Hds::Form::Radio::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
-  {{#if @icon}}
-    <div class="hds-dropdown-list-item__icon">
-      <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
-    </div>
-  {{/if}}
-  <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>{{yield}}</label>
+  <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>
+    <Hds::Form::Radio::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
+    {{#if @icon}}
+      <div class="hds-dropdown-list-item__icon">
+        <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
+      </div>
+    {{/if}}
+    <span class="hds-dropdown-list-item__text-content">{{yield}}</span>
+  </label>
   {{#if @count}}
     <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
   {{/if}}

--- a/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/radio.hbs
@@ -12,8 +12,9 @@
       </div>
     {{/if}}
     <span class="hds-dropdown-list-item__text-content">{{yield}}</span>
+
+    {{#if @count}}
+      <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
+    {{/if}}
   </label>
-  {{#if @count}}
-    <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
-  {{/if}}
 </li>

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -530,7 +530,6 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
     margin-top: 2px;
     margin-right: 8px;
 
-    &[disabled] ~ .hds-dropdown-list-item__label,
     &[disabled] ~ .hds-dropdown-list-item__icon,
     &[disabled] ~ .hds-dropdown-list-item__count,
     &[disabled] ~ .hds-dropdown-list-item__text-content {

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -553,7 +553,8 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 
 // COUNT
 .hds-dropdown-list-item__count {
-  margin-left: 8px;
+  margin-left: auto;
+  padding-left: 8px;
   color: var(--token-color-foreground-faint);
   line-height: 20px; // replicating the resulted height of the list item
 }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -538,7 +538,9 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   }
 
   .hds-dropdown-list-item__label {
+    display: flex;
     flex-grow: 1;
+    align-items: flex-start;
     color: var(--token-color-foreground-primary);
   }
 

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -532,7 +532,8 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 
     &[disabled] ~ .hds-dropdown-list-item__label,
     &[disabled] ~ .hds-dropdown-list-item__icon,
-    &[disabled] ~ .hds-dropdown-list-item__count {
+    &[disabled] ~ .hds-dropdown-list-item__count,
+    &[disabled] ~ .hds-dropdown-list-item__text-content {
       color: var(--token-color-foreground-disabled);
     }
   }


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR refactors the DOM and layout styles for checkboxes and radio buttons within the `Dropdown` component so that the gap between input and text as well as icons in front of text are clickable.

- **Showcase:** https://hds-showcase-git-hds-2332-dropdown-checkbox-gap-fix-hashicorp.vercel.app/components/dropdown

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2332](https://hashicorp.atlassian.net/browse/HDS-2332)

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2332]: https://hashicorp.atlassian.net/browse/HDS-2332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ