### PR TITLE
(nitpick) (non-blocking) Update component-api.md

### DIFF
--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -21,7 +21,7 @@ The Dropdown component is composed of different child components each with their
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the Dropdown List has a `min-width` of `200px` and a `max-width` of `400px`, so it adapts to the content size. If a `@width` parameter is provided then the list will have a fixed width.
   </C.Property>
-  <C.Property @name="height" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
+  <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
     If a `@height` parameter is provided then the list will have a fixed height.
   </C.Property>
   <C.Property @name="isInline" @type="boolean" @default="false">


### PR DESCRIPTION
Fix minor typo in documentation.

### :pushpin: Summary

Docs said width when it meant height.

### :hammer_and_wrench: Detailed description

Docs said width when it meant height.

### :camera_flash: Screenshots

<img width="714" alt="Screenshot 2023-09-05 at 5 29 30 PM" src="https://github.com/hashicorp/design-system/assets/707107/e98cb985-c9ee-45a5-b7e4-ca29bacd6cda">


### :link: External links

https://helios.hashicorp.design/components/dropdown?tab=code#dropdown

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
