### PR TITLE
Improve documentation for the `Dropdown::ListItem::CopyItem`

### DIFF
--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -164,9 +164,20 @@ If the Dropdown content exceeds the height of the container, the header and foot
 ### ListItem::CopyItem
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="copyItemTitle" @type="string"/>
+  <C.Property @name="copyItemTitle" @type="string">
+    Displays a title above the text to be copied.
+  </C.Property>
   <C.Property @name="text" @required="true" @type="string">
     Text to be copied. If no text value is defined, an error will be thrown.
+    <br><br>
+    _Notice: this argument is forwarded (as `textToCopy`) to the [`Copy::Snippet` component](/components/copy/snippet?tab=code#component-api)._
+  </C.Property>
+  <C.Property @name="isTruncated" @type="boolean" @default="false">
+    Constrains text to one line and truncates it based on available width. Text will only be truncated if it does not fit within the available space.
+    <br><br>
+    There are accessibility concerns if using this feature. See the [Accessibility section](/components/copy/snippet?tab=accessibility) of the `Copy::Snippet` component for more information.
+    <br><br>
+    _Notice: this argument is forwarded to the [`Copy::Snippet` component](/components/copy/snippet?tab=code#component-api)._
   </C.Property>
 </Doc::ComponentApi>
 

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -224,6 +224,21 @@ Pass the argument `@isLoading={{true}}` to the item. This will show a “loading
 </Hds::Dropdown>
 ```
 
+### ListItem::CopyItem
+
+To enable users to copy a snippet of code (eg. URLs, secrets, code blocks, etc.).
+
+Using the `@isTruncated` argument is possible to constrain the text to one-line and truncate it if it does not fit the available space. Care should be taken in choosing to use this feature as there are [accessibility concerns](/components/copy/snippet?tab=accessibility).
+
+```handlebars
+<Hds::Dropdown as |dd|>
+  <dd.ToggleButton @listPosition="bottom-left" @text="Create run task" @color="secondary" />
+  <dd.Title @text="Integrate with Terraform Cloud" />
+  <dd.Description @text="Create a new run task in Terraform using the URL and key below." />
+  <dd.CopyItem @text="https://api.cloud.hashicorp.com" @copyItemTitle="Endpoint URL" />
+  <dd.CopyItem @isTruncated={{true}} @text="91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d" @copyItemTitle="HMAC Key" />
+</Hds::Dropdown>
+```
 ### ListItem::Checkmark
 
 For switching context (e.g., organization switchers, project switchers, etc.) use `ListItem::Checkmark`.
@@ -283,14 +298,12 @@ When using the “generic” ListItem, the product team is responsible for imple
 `ListItem::Generic` allows you to pass custom elements to the Dropdown.
 
 ```handlebars
-<Hds::Dropdown as |dd|>
+<Hds::Dropdown @listPosition="bottom-left" as |dd|>
   <dd.ToggleButton @text="Text Toggle" @color="secondary" />
   <dd.Title @text="Integrate with Terraform Cloud" />
   <dd.Description @text="Create a new run task in Terraform using the URL and key below." />
   <dd.Generic>
     <Hds::Link::Standalone @text="Watch tutorial video" @icon="film" @href="/" />
   </dd.Generic>
-  <dd.CopyItem @text="https://api.cloud.hashicorp.com" @copyItemTitle="Endpoint URL" />
-  <dd.CopyItem @text="91ee1e8ef65b337f0e70d793f456c71d" @copyItemTitle="HMAC Key" />
 </Hds::Dropdown>
 ```

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -228,7 +228,7 @@ Pass the argument `@isLoading={{true}}` to the item. This will show a “loading
 
 To enable users to copy a snippet of code (eg. URLs, secrets, code blocks, etc.).
 
-Using the `@isTruncated` argument is possible to constrain the text to one-line and truncate it if it does not fit the available space. Care should be taken in choosing to use this feature as there are [accessibility concerns](/components/copy/snippet?tab=accessibility).
+Using the `@isTruncated` argument it is possible to constrain the text to one-line and truncate it if it does not fit the available space. Care should be taken in choosing to use this feature as there are [accessibility concerns](/components/copy/snippet?tab=accessibility).
 
 ```handlebars
 <Hds::Dropdown as |dd|>


### PR DESCRIPTION
### :pushpin: Summary

This PR intends to improve the documentation for the `Dropdown::ListItem::CopyItem`, in particular around the possibility of using `@isTruncated` as argument (forwarded to the `Copy::Snippet` component). This follows [a previous conversation](https://hashicorp.slack.com/archives/C02526PLZ9D/p1693307182523119?thread_ts=1693214133.191979&cid=C02526PLZ9D) with @jgwhite.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the “Component API” documentation for the `Dropdown::ListItem::CopyItem` subcomponent
- added an example of `Dropdown::ListItem::CopyItem` (also with truncation) to the “How to use” section

 👉👉 👉 Preview:
- How to use: https://hds-website-git-update-dropdown-listitem-copyi-a8da7c-hashicorp.vercel.app/components/dropdown?tab=code#listitemcopyitem
- Component API: https://hds-website-git-update-dropdown-listitem-copyi-a8da7c-hashicorp.vercel.app/components/dropdown?tab=code#listitemcopyitem-1

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2449

***

### 👀 Reviewer's checklist:

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
