### PR TITLE
Introduce a custom "copy to clipboard" library to replace `ember-cli-clipboard/clipboard.js` + Update `Copy::Button/Snippet` components

### DIFF
--- a/.changeset/strong-bears-kick.md
+++ b/.changeset/strong-bears-kick.md
@@ -1,0 +1,14 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+- removed `ember-cli-clipboard` as dependency and introduced a custom `hds-clipboard` modifier (using the web [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API))
+- `Copy::Button`
+  - replaced third-party `clipboard` modifier with `hds-clipboard`
+  - removed `@container` argument (not needed anymore)
+  - added `@onSuccess/onError` callbacks
+- `Copy::Snippet`
+  - replaced third-party `clipboard` modifier with `hds-clipboard`
+  - added `@onSuccess/onError` callbacks
+- `Dropdown::ListItem::CopyItem`
+  - the change to the underlying `Copy::Snippet` has fixed an issue with the focus being lost on copy (causing the dropdown to close on copy)

--- a/.changeset/strong-bears-kick.md
+++ b/.changeset/strong-bears-kick.md
@@ -1,11 +1,11 @@
 ---
-"@hashicorp/design-system-components": major
+"@hashicorp/design-system-components": minor
 ---
 
 - removed `ember-cli-clipboard` as dependency and introduced a custom `hds-clipboard` modifier (using the web [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API))
 - `Copy::Button`
   - replaced third-party `clipboard` modifier with `hds-clipboard`
-  - removed `@container` argument (not needed anymore)
+  - removed `@container` argument (not needed anymore, it was used in the third party library as a hack to account for focus trapping and focus shifting)
   - added `@onSuccess/onError` callbacks
 - `Copy::Snippet`
   - replaced third-party `clipboard` modifier with `hds-clipboard`

--- a/packages/components/addon/components/hds/copy/button/index.hbs
+++ b/packages/components/addon/components/hds/copy/button/index.hbs
@@ -11,6 +11,6 @@
   @isIconOnly={{@isIconOnly}}
   @color="secondary"
   @iconPosition="trailing"
-  {{clipboard text=@textToCopy target=@targetToCopy container=@container onError=this.onError onSuccess=this.onSuccess}}
+  {{hds-clipboard text=@textToCopy target=@targetToCopy onSuccess=this.onSuccess onError=this.onError}}
   ...attributes
 />

--- a/packages/components/addon/components/hds/copy/button/index.js
+++ b/packages/components/addon/components/hds/copy/button/index.js
@@ -70,26 +70,26 @@ export default class HdsCopyButtonComponent extends Component {
   }
 
   @action
-  onSuccess() {
+  onSuccess(args) {
     this.status = 'success';
     this.resetStatusDelayed();
 
     let { onSuccess } = this.args;
 
     if (typeof onSuccess === 'function') {
-      onSuccess();
+      onSuccess(args);
     }
   }
 
   @action
-  onError() {
+  onError(args) {
     this.status = 'error';
     this.resetStatusDelayed();
 
     let { onError } = this.args;
 
     if (typeof onError === 'function') {
-      onError();
+      onError(args);
     }
   }
 

--- a/packages/components/addon/components/hds/copy/button/index.js
+++ b/packages/components/addon/components/hds/copy/button/index.js
@@ -73,12 +73,24 @@ export default class HdsCopyButtonComponent extends Component {
   onSuccess() {
     this.status = 'success';
     this.resetStatusDelayed();
+
+    let { onSuccess } = this.args;
+
+    if (typeof onSuccess === 'function') {
+      onSuccess();
+    }
   }
 
   @action
   onError() {
     this.status = 'error';
     this.resetStatusDelayed();
+
+    let { onError } = this.args;
+
+    if (typeof onError === 'function') {
+      onError();
+    }
   }
 
   resetStatusDelayed() {

--- a/packages/components/addon/components/hds/copy/snippet/index.hbs
+++ b/packages/components/addon/components/hds/copy/snippet/index.hbs
@@ -5,7 +5,7 @@
 <button
   type="button"
   class={{this.classNames}}
-  {{clipboard text=@textToCopy container=@container onError=this.onError onSuccess=this.onSuccess}}
+  {{hds-clipboard text=@textToCopy onSuccess=this.onSuccess onError=this.onError}}
   ...attributes
 >
   <span class="hds-copy-snippet__text hds-typography-code-100 {{if @isTruncated 'hds-copy-snippet__text--truncated'}}">

--- a/packages/components/addon/components/hds/copy/snippet/index.js
+++ b/packages/components/addon/components/hds/copy/snippet/index.js
@@ -100,12 +100,24 @@ export default class HdsCopySnippetIndexComponent extends Component {
   onSuccess() {
     this.status = 'success';
     this.resetStatusDelayed();
+
+    let { onSuccess } = this.args;
+
+    if (typeof onSuccess === 'function') {
+      onSuccess();
+    }
   }
 
   @action
   onError() {
     this.status = 'error';
     this.resetStatusDelayed();
+
+    let { onError } = this.args;
+
+    if (typeof onError === 'function') {
+      onError();
+    }
   }
 
   resetStatusDelayed() {

--- a/packages/components/addon/components/hds/copy/snippet/index.js
+++ b/packages/components/addon/components/hds/copy/snippet/index.js
@@ -97,26 +97,26 @@ export default class HdsCopySnippetIndexComponent extends Component {
   }
 
   @action
-  onSuccess() {
+  onSuccess(args) {
     this.status = 'success';
     this.resetStatusDelayed();
 
     let { onSuccess } = this.args;
 
     if (typeof onSuccess === 'function') {
-      onSuccess();
+      onSuccess(args);
     }
   }
 
   @action
-  onError() {
+  onError(args) {
     this.status = 'error';
     this.resetStatusDelayed();
 
     let { onError } = this.args;
 
     if (typeof onError === 'function') {
-      onError();
+      onError(args);
     }
   }
 

--- a/packages/components/addon/modifiers/hds-clipboard.js
+++ b/packages/components/addon/modifiers/hds-clipboard.js
@@ -39,7 +39,7 @@ export const getTargetElement = (target) => {
       );
       return;
     }
-  } else if (target instanceof Node && target.nodeType === 1) {
+  } else if (target instanceof Node && target.nodeType === Node.ELEMENT_NODE) {
     targetElement = target;
   } else {
     if (target instanceof NodeList) {
@@ -57,7 +57,10 @@ export const getTargetElement = (target) => {
 
 export const getTextToCopyFromTargetElement = (targetElement) => {
   let textToCopy;
-  if (targetElement instanceof Node && targetElement.nodeType === 1) {
+  if (
+    targetElement instanceof Node &&
+    targetElement.nodeType === Node.ELEMENT_NODE
+  ) {
     if (
       targetElement instanceof HTMLInputElement || // targetElement.nodeName === 'INPUT' ||
       targetElement instanceof HTMLTextAreaElement || // targetElement.nodeName === 'TEXTAREA' ||
@@ -150,8 +153,8 @@ export default class HdsClipboardModifier extends Modifier {
   }
 
   // defines a new `copyToClipboard` action on each click event
-  async #onClick(e) {
-    const trigger = e.delegateTarget || e.currentTarget;
+  async #onClick(event) {
+    const trigger = event.currentTarget;
     const success = await copyToClipboard(this.text, this.target);
 
     // fire the `onSuccess/onError` callbacks (if provided)

--- a/packages/components/addon/modifiers/hds-clipboard.js
+++ b/packages/components/addon/modifiers/hds-clipboard.js
@@ -98,11 +98,9 @@ export const writeTextToClipboard = async (textToCopy) => {
     } catch (error) {
       // clipboard write failed
       // this probably never happens (see comment above) or happens only for very old browsers that don't for which `navigator.clipboard` is undefined
-      warn(
-        'copy action failed, please check your browser‘s permissions',
-        textToCopy,
-        error
-      );
+      warn('copy action failed, please check your browser‘s permissions', {
+        id: 'hds-clipboard.write-text-to-clipboard.catch-error',
+      });
       return false;
     }
   } else {

--- a/packages/components/addon/modifiers/hds-clipboard.js
+++ b/packages/components/addon/modifiers/hds-clipboard.js
@@ -4,7 +4,7 @@
  */
 
 import { modifier } from 'ember-modifier';
-import { assert } from '@ember/debug';
+import { assert, warn } from '@ember/debug';
 
 export const getTextToCopy = (text) => {
   let textToCopy;
@@ -97,8 +97,9 @@ export const writeTextToClipboard = async (textToCopy) => {
       return true;
     } catch (error) {
       // clipboard write failed
-      console.log(
-        '`hds-clipboard` modifier - an error occurred while writing to the clipboard - check your browser permissions',
+      // this probably never happens (see comment above) or happens only for very old browsers that don't for which `navigator.clipboard` is undefined
+      warn(
+        'copy action failed, please check your browser‘s permissions',
         textToCopy,
         error
       );

--- a/packages/components/addon/modifiers/hds-clipboard.js
+++ b/packages/components/addon/modifiers/hds-clipboard.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Modifier from 'ember-modifier';
+import { assert } from '@ember/debug';
+
+async function copyToClipboard(text, target) {
+  let textToCopy;
+
+  if (text) {
+    if (typeof text === 'string') {
+      textToCopy = text;
+    } else if (
+      // context: https://github.com/hashicorp/design-system/pull/1564
+      typeof text === 'number' ||
+      typeof text === 'bigint'
+    ) {
+      textToCopy = text.toString();
+    } else {
+      assert(
+        `\`hds-clipboard\` modifier - \`text\` argument must be a string - provided: ${typeof text}`
+      );
+    }
+  } else if (target) {
+    let targetElement;
+    if (typeof target === 'string') {
+      targetElement = document.querySelector(target);
+
+      assert(
+        '`hds-clipboard` modifier - `target` selector provided does not point to an existing DOM node, check your selector string',
+        targetElement
+      );
+    } else if (target instanceof Node && target.nodeType === 1) {
+      targetElement = target;
+    } else if (target instanceof NodeList) {
+      assert(
+        '`hds-clipboard` modifier - `target` argument must be a string or a DOM node - provided: a list of DOM nodes'
+      );
+    } else {
+      assert(
+        `\`hds-clipboard\` modifier - \`target\` argument must be a string or a DOM node - provided: ${typeof target}`
+      );
+    }
+
+    if (
+      targetElement instanceof HTMLInputElement || // targetElement.nodeName === 'INPUT' ||
+      targetElement instanceof HTMLTextAreaElement || // targetElement.nodeName === 'TEXTAREA' ||
+      targetElement instanceof HTMLSelectElement // targetElement.nodeName === 'SELECT'
+    ) {
+      textToCopy = targetElement.value;
+    } else {
+      // simplest approach
+      textToCopy = targetElement.innerText;
+
+      // approach based on text selection (left for backup just in case)
+      // var selection = window.getSelection();
+      // var range = document.createRange();
+      // selection.removeAllRanges();
+      // range.selectNodeContents(targetElement);
+      // selection.addRange(range);
+      // textToCopy = selection.toString();
+      // selection.removeAllRanges();
+    }
+  } else {
+    assert(
+      '`hds-clipboard` modifier - either a `text` or a `target` argument is required'
+    );
+  }
+
+  // finally copy the text to the clipboard using the Clipboard API
+  // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
+  if (textToCopy) {
+    try {
+      // notice: the "clipboard-write" permission is granted automatically to pages when they are in the active tab
+      // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/write
+      await navigator.clipboard.writeText(textToCopy);
+      // DEBUG uncomment this for easy debugging
+      // console.log('success', textToCopy);
+      return true;
+    } catch (error) {
+      // clipboard write failed
+      console.log(
+        '`hds-clipboard` modifier - an error occurred while writing to the clipboard - check your browser permissions',
+        textToCopy,
+        error
+      );
+      return false;
+    }
+  } else {
+    return false;
+  }
+}
+
+export default class HdsClipboardModifier extends Modifier {
+  didSetup = false;
+
+  modify(element, positional, named) {
+    assert(
+      '`hds-clipboard` modifier - the modifier must be applied to an element',
+      element
+    );
+
+    const { text, target, onSuccess, onError } = named;
+    this.text = text;
+    this.target = target;
+    this.onSuccess = onSuccess;
+    this.onError = onError;
+
+    if (!this.didSetup) {
+      this.#listenClick(element);
+      this.didSetup = true;
+    }
+  }
+
+  // add a "click" event listener to the element
+  #listenClick(element) {
+    this.listener = element.addEventListener('click', (e) => this.#onClick(e));
+  }
+
+  // defines a new `copyToClipboard` action on each click event
+  async #onClick(e) {
+    const trigger = e.delegateTarget || e.currentTarget;
+    const success = await copyToClipboard(this.text, this.target);
+
+    // fire the `onSuccess/onError` callbacks (if provided)
+    const args = {
+      triggger: trigger,
+      text: this.text,
+      target: this.target,
+    };
+    if (success) {
+      if (typeof this.onSuccess === 'function') {
+        this.onSuccess(args);
+      }
+    } else {
+      if (typeof this.onError === 'function') {
+        this.onError(args);
+      }
+    }
+  }
+
+  willDestroy() {
+    this.listener.destroy();
+  }
+}

--- a/packages/components/app/modifiers/hds-clipboard.js
+++ b/packages/components/app/modifiers/hds-clipboard.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export { default } from '@hashicorp/design-system-components/modifiers/hds-clipboard';

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -101,6 +101,7 @@
     "prettier": "^2.8.8",
     "qunit": "^2.19.4",
     "qunit-dom": "^2.0.0",
+    "sinon": "^15.2.0",
     "stylelint": "^15.10.1",
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard-scss": "^5.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,6 @@
     "ember-auto-import": "^2.6.3",
     "ember-cached-decorator-polyfill": "^0.1.4",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-clipboard": "^1.0.0",
     "ember-cli-htmlbars": "^6.2.0",
     "ember-cli-sass": "^10.0.1",
     "ember-composable-helpers": "^4.5.0",

--- a/packages/components/tests/dummy/app/controllers/components/copy/button.js
+++ b/packages/components/tests/dummy/app/controllers/components/copy/button.js
@@ -4,6 +4,8 @@
  */
 
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { scheduleOnce } from '@ember/runloop';
 
@@ -26,6 +28,7 @@ function replaceMockCopyStatus() {
 
 export default class CopyButtonController extends Controller {
   @service router;
+  @tracked isModalActive = false;
 
   constructor() {
     super(...arguments);
@@ -34,5 +37,28 @@ export default class CopyButtonController extends Controller {
 
   routeDidChange() {
     scheduleOnce('afterRender', this, replaceMockCopyStatus);
+  }
+
+  get bigIntNumber() {
+    let bigIntNumber = BigInt(12345678910);
+    return bigIntNumber;
+  }
+
+  get targetNodeElement() {
+    return document.querySelector('#test-target-node-element');
+  }
+
+  get targetMultipleNodeElements() {
+    return document.querySelectorAll('#test-target-node-elements');
+  }
+
+  @action
+  activateModal() {
+    this.isModalActive = true;
+  }
+
+  @action
+  deactivateModal() {
+    this.isModalActive = false;
   }
 }

--- a/packages/components/tests/dummy/app/controllers/components/copy/button.js
+++ b/packages/components/tests/dummy/app/controllers/components/copy/button.js
@@ -61,4 +61,17 @@ export default class CopyButtonController extends Controller {
   deactivateModal() {
     this.isModalActive = false;
   }
+
+  // DEBUG
+  // uncomment these if you need to debug the `onSuccess/onError` callback methods
+
+  // @action
+  // onSuccess({ trigger, text, target }) {
+  //   console.log('onSuccess invoked in the controller', trigger, text, target);
+  // }
+
+  // @action
+  // onError({ trigger, text, target }) {
+  //   console.log('onError invoked in the controller', trigger, text, target);
+  // }
 }

--- a/packages/components/tests/dummy/app/styles/showcase-pages/copy/button.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/copy/button.scss
@@ -18,10 +18,78 @@ body.components-copy-button {
     align-items: flex-end;
   }
 
+  .shw-component-copy-button-input-component {
+    .hds-copy-button {
+      margin-top: 8px;
+    }
+  }
+
+  .shw-component-copy-structured-content {
+    margin: 0;
+    padding: 16px;
+
+    li + li {
+      margin-top: 8px;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+
+  .shw-component-copy-button-display-none {
+    display: none;
+  }
+
+  .shw-component-copy-button-visibility-hidden {
+    visibility: hidden;
+  }
+
   .shw-component-copy-button-code-block {
     padding: 1rem;
     color: white;
     background-color: black;
     border-radius: 5px;
+  }
+
+  .shw-component-copy-button-flex-container {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .shw-component-copy-button-demo-container {
+    .shw-text-h4 {
+      margin: 16px  0 8px;
+    }
+
+    .shw-text-body {
+      margin: 8px  0;
+    }
+
+    .shw-divider {
+      margin: 24px 0;
+    }
+
+    .shw-component-copy-button-demo-paragraph {
+      @include shw-font-family("system sans");
+      margin: 0;
+      font-size: 1rem;
+
+      code { font-size: inherit; }
+    }
+
+    .shw-component-copy-button-code-block {
+      flex: 1;
+      min-width: 0;
+      margin: 0;
+    }
+  }
+
+  .shw-component-copy-button-demo-flex-container {
+    display: flex;
+    gap: 8px;
+    align-items: start;
+    margin-bottom: 16px;
   }
 }

--- a/packages/components/tests/dummy/app/styles/showcase-pages/copy/button.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/copy/button.scss
@@ -60,11 +60,11 @@ body.components-copy-button {
 
   .shw-component-copy-button-demo-container {
     .shw-text-h4 {
-      margin: 16px  0 8px;
+      margin: 16px 0 8px;
     }
 
     .shw-text-body {
-      margin: 8px  0;
+      margin: 8px 0;
     }
 
     .shw-divider {

--- a/packages/components/tests/dummy/app/templates/components/copy/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/copy/button.hbs
@@ -11,7 +11,7 @@
 
   <Shw::Text::H2>Content</Shw::Text::H2>
 
-  <input type="hidden" id="targetToCopy" value="This is some text stored in a hidden &lt;input&lt; element" />
+  <input type="hidden" id="targetToCopy" value="This is some text stored in a hidden &lt;input&gt; element" />
 
   <Shw::Flex as |SF|>
     <SF.Item @label="Default">

--- a/packages/components/tests/dummy/app/templates/components/copy/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/copy/button.hbs
@@ -11,6 +11,8 @@
 
   <Shw::Text::H2>Content</Shw::Text::H2>
 
+  <input type="hidden" id="targetToCopy" value="This is some text stored in a hidden &lt;input&lt; element" />
+
   <Shw::Flex as |SF|>
     <SF.Item @label="Default">
       <Hds::Copy::Button @text="Copy" @targetToCopy="#targetToCopy" />
@@ -125,51 +127,64 @@
 
   <Shw::Text::H2>Demo</Shw::Text::H2>
 
-  <Shw::Text::H4 @tag="h3">In memory</Shw::Text::H4>
+  <Shw::Text::H3>With <code>text</code> as argument</Shw::Text::H3>
 
   <Shw::Flex as |SF|>
     <SF.Item>
-      <Hds::Copy::Button @text="Copy your secret key" @textToCopy="someSecretThingGoesHere" />
+      <Hds::Copy::Button @text="Copy a secret key" @textToCopy="someSecretThingGoesHere" />
     </SF.Item>
     <SF.Item>
       {{! context: https://github.com/hashicorp/design-system/pull/1564 }}
       <Hds::Copy::Button @text="Copy a number" @textToCopy={{123456789}} />
     </SF.Item>
+    <SF.Item>
+      <Hds::Copy::Button @text="Copy a Bigint number" @textToCopy={{this.bigIntNumber}} />
+    </SF.Item>
   </Shw::Flex>
 
   <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H4 @tag="h3">With target element</Shw::Text::H4>
+  <Shw::Text::H3>With <code>target</code> element</Shw::Text::H3>
+
+  <Shw::Text::H4>Target types</Shw::Text::H4>
+
+  <Shw::Flex {{style gap="2rem"}} @columns={{3}} as |SF|>
+    <SF.Item>
+      <Shw::Label>Target as a CSS selector (`string`)</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <p class="shw-text-body" id="test-target-string">Lorem ipsum dolor</p>
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the content in the node"
+          @targetToCopy="#test-target-string"
+        />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>Target as a DOM element (`Node`)</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <p class="shw-text-body" id="test-target-node-element">Lorem ipsum dolor</p>
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the content in the node"
+          @targetToCopy={{this.targetNodeElement}}
+        />
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Text::H4>HDS components</Shw::Text::H4>
 
   <Shw::Grid {{style gap="2rem"}} @columns={{3}} as |SG|>
-    <SG.Item>
-      <Shw::Label>Text element</Shw::Label>
-      <Hds::Copy::Button @text="Copy the paragraph" @targetToCopy="#targetToCopy" />
-      <p class="shw-text shw-text-body" id="targetToCopy">This is the target element; the button will copy the text in
-        this target element.</p>
-    </SG.Item>
-    <SG.Item>
-      <Shw::Label>Code block</Shw::Label>
-      <Hds::Copy::Button @text="Copy the code block" @targetToCopy="#targetToCopy3" />
-      {{!-- prettier-ignore --}}
-      <pre class="shw-component-copy-button-code-block"><code id="targetToCopy3">&lt;h1&gt;A page header example&lt;/h1&gt;
-&lt;p&gt;Some paragraph text also&lt;/p&gt;</code></pre>
-    </SG.Item>
-  </Shw::Grid>
-
-  <Shw::Grid {{style gap="2rem"}} @columns={{3}} as |SG|>
-    <SG.Item>
-      <Shw::Label>Input element</Shw::Label>
-      <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input" />
-      <br />
+    <SG.Item class="shw-component-copy-button-input-component">
+      <Shw::Label>Input component</Shw::Label>
       <Hds::Form::TextInput::Field @value="036140285924" @name="test-input" @id="test-input" as |F|>
         <F.Label>Input Label</F.Label>
       </Hds::Form::TextInput::Field>
+      <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input" />
     </SG.Item>
-    <SG.Item>
-      <Shw::Label>Input element (readonly)</Shw::Label>
-      <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input-readonly" />
-      <br />
+    <SG.Item class="shw-component-copy-button-input-component">
+      <Shw::Label>Input component (readonly)</Shw::Label>
       <Hds::Form::TextInput::Field
         readonly
         @value="036140285924-readonly"
@@ -179,11 +194,10 @@
       >
         <F.Label>Input Label</F.Label>
       </Hds::Form::TextInput::Field>
+      <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input-readonly" />
     </SG.Item>
-    <SG.Item>
-      <Shw::Label>Input element (disabled)</Shw::Label>
-      <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input-disabled" />
-      <br />
+    <SG.Item class="shw-component-copy-button-input-component">
+      <Shw::Label>Input component (disabled)</Shw::Label>
       <Hds::Form::TextInput::Field
         disabled
         @value="036140285924-disabled"
@@ -193,7 +207,397 @@
       >
         <F.Label>Input Label</F.Label>
       </Hds::Form::TextInput::Field>
+      <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input-disabled" />
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>Textarea component</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <Hds::Form::Textarea::Base
+          @value="This is a normal
+multiline text
+that should be copied"
+          @name="test-textarea"
+          id="test-textarea"
+        />
+        <Hds::Copy::Button @isIconOnly={{true}} @text="Copy the textarea value" @targetToCopy="#test-textarea" />
+      </div>
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>Textarea component (readonly)</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <Hds::Form::Textarea::Base
+          readonly
+          @value="This is a redonly
+multiline text
+that should be copied"
+          @name="test-textarea-readonly"
+          id="test-textarea-readonly"
+        />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the textarea value"
+          @targetToCopy="#test-textarea-readonly"
+        />
+      </div>
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>Textarea component (disabled)</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <Hds::Form::Textarea::Base
+          disabled
+          @value="This is a disabled
+multiline text
+that should be copied"
+          @name="test-textarea-disabled"
+          id="test-textarea-disabled"
+        />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the textarea value"
+          @targetToCopy="#test-textarea-disabled"
+        />
+      </div>
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>Select component</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <Hds::Form::Select::Base @name="test-select" id="test-select" as |C|>
+          <C.Options>
+            <option>Lorem ipsum dolor</option>
+            <option selected>Sit amet</option>
+            <option>Consectetur adipiscing elit</option>
+          </C.Options>
+        </Hds::Form::Select::Base>
+        <Hds::Copy::Button @isIconOnly={{true}} @text="Copy the textarea value" @targetToCopy="#test-select" />
+      </div>
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>Select component (disabled)</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <Hds::Form::Select::Base disabled @name="test-select-disabled" id="test-select-disabled" as |C|>
+          <C.Options>
+            <option>Lorem ipsum dolor</option>
+            <option>Sit amet</option>
+            <option selected>Consectetur adipiscing elit</option>
+          </C.Options>
+        </Hds::Form::Select::Base>
+        <Hds::Copy::Button @isIconOnly={{true}} @text="Copy the textarea value" @targetToCopy="#test-select-disabled" />
+      </div>
     </SG.Item>
   </Shw::Grid>
+
+  <Shw::Grid {{style gap="2rem"}} @columns={{3}} as |SG|>
+    <SG.Item>
+      <Shw::Label>Within a Dropdown</Shw::Label>
+      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+        <dd.ToggleButton @text="Open menu" />
+        <dd.Generic>
+          <div class="shw-component-copy-button-demo-container">
+            <p class="shw-text-h4">With HDS components</p>
+            <p class="shw-text-body">Input</p>
+            <div class="shw-component-copy-button-demo-flex-container">
+              <Hds::Form::TextInput::Base
+                @name="test-dropdown-text-input"
+                id="test-dropdown-text-input"
+                @value="Lorem ipsum dolor"
+              />
+              <Hds::Copy::Button
+                @isIconOnly={{true}}
+                @text="Copy the text input value"
+                @targetToCopy="#test-dropdown-text-input"
+              />
+            </div>
+            <Shw::Divider @level={{2}} />
+            <p class="shw-text-h4">With HTML blocks</p>
+            <p class="shw-text-body">Structured content</p>
+            <div class="shw-component-copy-button-demo-flex-container">
+              <p class="shw-component-copy-button-demo-paragraph" id="test-dropdown-structured-content">This is the
+                <span><strong>some</strong>
+                  <em>structured</em></span>
+                content that will be
+                <a href="#">targeted</a>
+                by the
+                <code>button</code>.</p>
+              <Hds::Copy::Button
+                @isIconOnly={{true}}
+                @text="Copy the structured content"
+                @targetToCopy="#test-dropdown-structured-content"
+              />
+            </div>
+            <p class="shw-text-body">Code block with 'contentEditable'</p>
+            <div class="shw-component-copy-button-demo-flex-container">
+              {{!-- prettier-ignore --}}
+              <pre class="shw-component-copy-button-code-block"><code
+            id="test-dropdown-code-block-editable"
+            contenteditable="true"
+          >&lt;h1&gt;Lorem&lt;/h1&gt;
+&lt;p&gt;Ipsum dolor&lt;/p&gt;</code></pre>
+              <Hds::Copy::Button
+                @isIconOnly={{true}}
+                @text="Copy the code block content"
+                @targetToCopy="#test-dropdown-code-block-editable"
+              />
+            </div>
+          </div>
+        </dd.Generic>
+      </Hds::Dropdown>
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>Within a Modal</Shw::Label>
+      <Hds::Button @color="secondary" @text="Open modal" {{on "click" this.activateModal}} />
+
+      {{! template-lint-disable no-autofocus-attribute }}
+      {{#if this.isModalActive}}
+        <Hds::Modal id="test-copy-button-modal" @onClose={{this.deactivateModal}} as |M|>
+          <M.Header>
+            Lorem ipsum dolor
+          </M.Header>
+          <M.Body>
+            <form name="test-copy-button-modal-form" class="shw-component-copy-button-demo-container">
+              <p class="shw-text-h4">With HDS components</p>
+              <p class="shw-text-body">Input</p>
+              <div class="shw-component-copy-button-demo-flex-container">
+                <Hds::Form::TextInput::Base
+                  @name="test-modal-text-input"
+                  id="test-modal-text-input"
+                  @value="Lorem ipsum dolor"
+                />
+                <Hds::Copy::Button
+                  @isIconOnly={{true}}
+                  @text="Copy the text input value"
+                  @targetToCopy="#test-modal-text-input"
+                />
+              </div>
+              <Shw::Divider @level={{2}} />
+              <p class="shw-text-h4">With HTML blocks</p>
+              <p class="shw-text-body">Structured content</p>
+              <div class="shw-component-copy-button-demo-flex-container">
+                <p class="shw-component-copy-button-demo-paragraph" id="test-modal-structured-content">This is the
+                  <span><strong>some</strong>
+                    <em>structured</em></span>
+                  content that will be
+                  <a href="#">targeted</a>
+                  by the
+                  <code>button</code>.</p>
+                <Hds::Copy::Button
+                  @isIconOnly={{true}}
+                  @text="Copy the structured content"
+                  @targetToCopy="#test-modal-structured-content"
+                />
+              </div>
+              <p class="shw-text-body">Code block with 'contentEditable'</p>
+              <div class="shw-component-copy-button-demo-flex-container">
+                {{!-- prettier-ignore --}}
+                <pre class="shw-component-copy-button-code-block"><code
+              id="test-modal-code-block-editable"
+              contenteditable="true"
+            >&lt;h1&gt;Lorem&lt;/h1&gt;
+&lt;p&gt;Ipsum dolor&lt;/p&gt;</code></pre>
+                <Hds::Copy::Button
+                  @isIconOnly={{true}}
+                  @text="Copy the code block content"
+                  @targetToCopy="#test-modal-code-block-editable"
+                />
+              </div>
+            </form>
+          </M.Body>
+          <M.Footer as |F|>
+            <Hds::ButtonSet>
+              <Hds::Button type="submit" @text="OK" {{on "click" this.deactivateModal}} />
+              <Hds::Button type="button" @text="Cancel" @color="secondary" {{on "click" F.close}} />
+            </Hds::ButtonSet>
+          </M.Footer>
+        </Hds::Modal>
+      {{/if}}
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Text::H4>HTML blocks</Shw::Text::H4>
+
+  <Shw::Grid {{style gap="2rem"}} @columns={{2}} as |SG|>
+    <SG.Item>
+      <Shw::Label>Structured content</Shw::Label>
+      <Hds::Copy::Button @text="Copy the content below" @targetToCopy="#test-structured-content" />
+      <ul class="shw-component-copy-structured-content" id="test-structured-content">
+        <li class="shw-text-body">
+          <p>This whole list is the
+            <span><strong>target</strong>
+              <em>element</em></span></p>
+        </li>
+        <li class="shw-text-body">
+          <p>The button will
+            <code>copy</code>
+            the
+            <a href="#">text</a>
+            in this
+            <cite>target</cite>
+            element.</p>
+        </li>
+      </ul>
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>With hidden content</Shw::Label>
+      <Hds::Copy::Button @text="Copy the content below" @targetToCopy="#test-hidden-content" />
+      <p class="shw-text-body" id="test-hidden-content">This paragraph contains some
+        <strong class="shw-component-copy-button-display-none">not</strong>
+        hidden content
+        <strong class="shw-component-copy-button-visibility-hidden">, or not?</strong>
+      </p>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Grid {{style gap="2rem"}} @columns={{2}} as |SG|>
+    <SG.Item>
+      <Shw::Label>Code block</Shw::Label>
+      <Hds::Copy::Button @text="Copy the code block" @targetToCopy="#test-code-block" />
+      {{!-- prettier-ignore --}}
+      <pre class="shw-component-copy-button-code-block"><code id="test-code-block">&lt;h1&gt;A page header example&lt;/h1&gt;
+&lt;p&gt;Some paragraph text also&lt;/p&gt;</code></pre>
+    </SG.Item>
+    <SG.Item>
+      <Shw::Label>Code block with 'contenteditable'</Shw::Label>
+      <Hds::Copy::Button @text="Edit and copy the code block" @targetToCopy="#test-code-block-editable" />
+      {{!-- prettier-ignore --}}
+      <pre class="shw-component-copy-button-code-block"><code id="test-code-block-editable" contenteditable="true">&lt;h1&gt;A page header example&lt;/h1&gt;
+&lt;p&gt;Some paragraph text also&lt;/p&gt;</code></pre>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Text::H4>HTML input elements</Shw::Text::H4>
+
+  <Shw::Flex {{style gap="2rem"}} as |SF|>
+    <SF.Item>
+      <Shw::Label>Text input</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <input type="text" name="test-generic-input-text" id="test-generic-input-text" value="Lorem ipsum dolor" />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic input text value"
+          @targetToCopy="#test-generic-input-text"
+        />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>Password input</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <input
+          type="password"
+          name="test-generic-input-password"
+          id="test-generic-input-password"
+          value="Thisisapassword"
+        />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic input password value"
+          @targetToCopy="#test-generic-input-password"
+        />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>Number input</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <input type="number" name="test-generic-input-number" id="test-generic-input-number" value="123456" />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic input number value"
+          @targetToCopy="#test-generic-input-number"
+        />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>URL input</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <input type="url" name="test-generic-input-url" id="test-generic-input-url" value="https://www.hello.com" />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic input url value"
+          @targetToCopy="#test-generic-input-url"
+        />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>Email input</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <input type="email" name="test-generic-input-email" id="test-generic-input-email" value="info@hello.com" />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic input email value"
+          @targetToCopy="#test-generic-input-email"
+        />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>Date input</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <input type="date" name="test-generic-input-date" id="test-generic-input-date" value="2018-07-22" />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic input date value"
+          @targetToCopy="#test-generic-input-date"
+        />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>Time input</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <input type="time" name="test-generic-input-time" id="test-generic-input-time" value="23:59" />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic input time value"
+          @targetToCopy="#test-generic-input-time"
+        />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>Range input</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <input type="range" name="test-generic-input-range" id="test-generic-input-range" min="0" max="10" value="6" />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic input range value"
+          @targetToCopy="#test-generic-input-range"
+        />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>Color input</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <input type="color" name="test-generic-input-color" id="test-generic-input-color" value="#e66465" />
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic input color value"
+          @targetToCopy="#test-generic-input-color"
+        />
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+  <Shw::Flex {{style gap="2rem"}} as |SF|>
+    <SF.Item>
+      <Shw::Label>Textarea</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <textarea name="test-generic-textarea" id="test-generic-textarea" rows="3">Lorem ipsum dolor</textarea>
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic textarea value"
+          @targetToCopy="#test-generic-textarea"
+        />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <Shw::Label>Select</Shw::Label>
+      <div class="shw-component-copy-button-flex-container">
+        <select name="test-generic-select" id="test-generic-select">
+          <option>Lorem ipsum dolor</option>
+          <option>Sit amet</option>
+          <option>Consectetur adipiscing elit</option>
+        </select>
+        <Hds::Copy::Button
+          @isIconOnly={{true}}
+          @text="Copy the generic select value"
+          @targetToCopy="#test-generic-select"
+        />
+      </div>
+    </SF.Item>
+  </Shw::Flex>
 
 </section>

--- a/packages/components/tests/integration/components/hds/copy/button/index-test.js
+++ b/packages/components/tests/integration/components/hds/copy/button/index-test.js
@@ -5,32 +5,66 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import {
-  click,
-  render,
-  resetOnerror,
-  setupOnerror,
-  waitFor,
-} from '@ember/test-helpers';
+import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+function wait(timeout = 2000) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout);
+  });
+}
 
 module('Integration | Component | hds/copy/button/index', function (hooks) {
   setupRenderingTest(hooks);
 
+  // IMPORTANT: don't use an arrow function here or "this.set" will not be recognized
+  hooks.beforeEach(function () {
+    sinon.stub(window.navigator.clipboard, 'writeText').resolves();
+    this.success = undefined;
+    this.set('onSuccess', () => (this.success = true));
+    this.set('onError', () => (this.success = false));
+  });
+
   hooks.afterEach(() => {
     resetOnerror();
+    // we need to restore the "window.navigator" methods
+    sinon.restore();
+    this.success = undefined;
   });
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Button id="test-copy-button" @text="copy" @targetToCopy="#targetToCopy" />`
+      hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy your secret key" @textToCopy="someSecretThingGoesHere" />`
     );
     assert.dom('#test-copy-button').hasClass('hds-copy-button');
   });
 
+  // @TEXT ARGUMENT
+
+  test('it should allow to copy a `string` provided as `@text` argument', async function (assert) {
+    await render(
+      hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy your secret key" @textToCopy="someSecretThingGoesHere" @onSuccess={{this.onSuccess}} @onError={{this.onError}} />`
+    );
+    await click('button#test-copy-button');
+    assert.true(this.success);
+  });
+
+  // @TARGET ARGUMENT
+
+  test('it should allow to target an element using a `string` selector for the `@target` argument', async function (assert) {
+    await render(
+      hbs`<p id="test-copy-button-target">Hello world!</p><Hds::Copy::Button id="test-copy-button" @text="Copy your secret key" @targetToCopy="#test-copy-button-target" @onSuccess={{this.onSuccess}} @onError={{this.onError}} />`
+    );
+    await click('button#test-copy-button');
+    assert.true(this.success);
+  });
+
+  // VARIANTS
+
   test('it should render the correct default component variation: secondary color, medium size, idle status', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Button id="test-copy-button" @text="copy" @targetToCopy="#targetToCopy" />`
+      hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy your secret key" @textToCopy="someSecretThingGoesHere" />`
     );
     assert.dom('#test-copy-button').hasClass('hds-copy-button');
     assert.dom('#test-copy-button').hasClass('hds-button--size-medium');
@@ -40,11 +74,7 @@ module('Integration | Component | hds/copy/button/index', function (hooks) {
 
   test('it should only render an icon and also render an aria-label if isIconOnly is set to true', async function (assert) {
     await render(
-      hbs`<p id="clipboardTarget2">
-      The button will copy the text in this paragraph element.
-    </p>
-    <Hds::Copy::Button @text="Copy" @isIconOnly={{true}}
-    @targetToCopy="#clipboardTarget2" id="test-copy-button" />`
+      hbs`<Hds::Copy::Button @text="Copy" @isIconOnly={{true}} @textToCopy="someSecretThingGoesHere" id="test-copy-button" />`
     );
     assert.dom('#test-copy-button').doesNotIncludeText('Copy');
     assert.dom('#test-copy-button').hasAria('label', 'Copy');
@@ -52,40 +82,42 @@ module('Integration | Component | hds/copy/button/index', function (hooks) {
 
   test('it should render the small size if @size small is defined', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Button id="test-copy-button" @text="copy" @targetToCopy="#targetToCopy" @size="small" />`
+      hbs`<Hds::Copy::Button id="test-copy-button" @text="copy" @textToCopy="someSecretThingGoesHere" @size="small" />`
     );
     assert.dom('#test-copy-button').hasClass('hds-button--size-small');
   });
 
-  test('it always renders the text value', async function (assert) {
+  test('it always renders the text value, not the text to copy', async function (assert) {
     await render(
       hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy your secret key"
       @textToCopy="someSecretThingGoesHere" />`
     );
     assert.dom('#test-copy-button').hasText('Copy your secret key');
+    assert
+      .dom('#test-copy-button')
+      .doesNotIncludeText('someSecretThingGoesHere');
   });
 
   test('it should have the correct CSS class to support full-width size if @isFullWidth prop is true', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Button id="test-copy-button" @text="copy" @targetToCopy="#targetToCopy" @isFullWidth={{true}} />`
+      hbs`<Hds::Copy::Button id="test-copy-button" @text="copy" @textToCopy="someSecretThingGoesHere" @isFullWidth={{true}} />`
     );
     assert.dom('#test-copy-button').hasClass('hds-button--width-full');
   });
 
-  test('it should update the status to success if the copy operation was successful using targetToCopy', async function (assert) {
+  // COPY STATES
+
+  test('it should update the status to success if the copy operation was successful', async function (assert) {
     await render(
-      hbs`<p id="clipboardTarget2">
-      The button will copy the text in this paragraph element.
-    </p>
-    <Hds::Copy::Button @text="Copy" @isIconOnly={{true}}
-    @targetToCopy="#clipboardTarget2" id="test-copy-button" />`
+      hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy your secret key" @textToCopy="someSecretThingGoesHere" @onSuccess={{this.onSuccess}} @onError={{this.onError}} />`
     );
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
     await click('button#test-copy-button');
+    assert.true(this.success);
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-success');
   });
 
-  test('it should update the status to success if the copy operation was successful using textToCopy', async function (assert) {
+  test('it should update the status back to idle after success', async function (assert) {
     await render(
       hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy your secret key"
       @textToCopy="someSecretThingGoesHere" />`
@@ -93,41 +125,26 @@ module('Integration | Component | hds/copy/button/index', function (hooks) {
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
     await click('button#test-copy-button');
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-success');
+    await wait(); // wait for the status to revert to "idle" automatically
+    assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
   });
 
-  test('it should update the status back to idle after success while using targetToCopy', async function (assert) {
+  test('it should update the status to an error after a failed "copy" operation', async function (assert) {
+    sinon.restore();
+    sinon
+      .stub(window.navigator.clipboard, 'writeText')
+      .throws(
+        'Sinon throws (syntethic error)',
+        'this is a fake error message provided to the sinon.stub().throws() method'
+      );
     await render(
-      hbs`<p id="clipboardTarget2">
-      The button will copy the text in this paragraph element.
-    </p>
-    <Hds::Copy::Button @text="Copy" @isIconOnly={{true}}
-    @targetToCopy="#clipboardTarget2" id="test-copy-button" />`
+      hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy your secret key" @textToCopy="someSecretThingGoesHere" @onSuccess={{this.onSuccess}} @onError={{this.onError}} />`
     );
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
     await click('button#test-copy-button');
-    assert.dom('#test-copy-button').hasClass('hds-copy-button--status-success');
-    await waitFor('.hds-copy-button--status-idle', { timeout: 2000 });
-    assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
-  });
-
-  test('it should update the status back to idle after success while using textToCopy', async function (assert) {
-    await render(
-      hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy your secret key"
-      @textToCopy="someSecretThingGoesHere" />`
-    );
-    assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
-    await click('button#test-copy-button');
-    assert.dom('#test-copy-button').hasClass('hds-copy-button--status-success');
-    await waitFor('.hds-copy-button--status-idle', { timeout: 2000 });
-    assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
-  });
-
-  test('it should be able to copy a number', async function (assert) {
-    // context: https://github.com/hashicorp/design-system/pull/1564
-    await render(
-      hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy a number" textToCopy={{123456789}} />`
-    );
-    // if the `ember-cli-clipboard` addon fails it triggers a JS error
+    assert.false(this.success);
+    assert.dom('#test-copy-button').hasClass('hds-copy-button--status-error');
+    await wait(); // wait for the status to revert to "idle" automatically
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
   });
 

--- a/packages/components/tests/integration/components/hds/copy/snippet/index-test.js
+++ b/packages/components/tests/integration/components/hds/copy/snippet/index-test.js
@@ -5,32 +5,45 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import {
-  click,
-  render,
-  resetOnerror,
-  setupOnerror,
-  waitFor,
-} from '@ember/test-helpers';
+import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+function wait(timeout = 2000) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout);
+  });
+}
 
 module('Integration | Component | hds/copy/snippet/index', function (hooks) {
   setupRenderingTest(hooks);
 
+  // IMPORTANT: don't use an arrow function here or "this.set" will not be recognized
+  hooks.beforeEach(function () {
+    sinon.stub(window.navigator.clipboard, 'writeText').resolves();
+    this.success = undefined;
+    this.set('onSuccess', () => (this.success = true));
+    this.set('onError', () => (this.success = false));
+  });
+
   hooks.afterEach(() => {
     resetOnerror();
+    // we need to restore the "window.navigator" methods
+    sinon.restore();
   });
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="3423g-234525-h345346-f34rtf4" />`
+      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="someSecretThingGoesHere" />`
     );
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet');
   });
 
+  // VARIANTS
+
   test('it should render the correct default component variation: primary color, idle status', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="3423g-234525-h345346-f34rtf4" />`
+      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="someSecretThingGoesHere" />`
     );
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet');
     assert
@@ -41,7 +54,7 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
 
   test('it should render the secondary color if defined', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="3423g-234525-h345346-f34rtf4" @color="secondary" />`
+      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="someSecretThingGoesHere" @color="secondary" />`
     );
     assert
       .dom('#test-copy-snippet')
@@ -50,7 +63,7 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
 
   test('it should support truncation if @isTruncated is set to true', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="3423g-234525-h345346-f34rtf4" @isTruncated={{true}} />`
+      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="someSecretThingGoesHere" @isTruncated={{true}} />`
     );
     assert
       .dom('#test-copy-snippet > span')
@@ -59,17 +72,20 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
 
   test('it should have the correct CSS class to support full-width size if @isFullWidth prop is true', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="3423g-234525-h345346-f34rtf4" @isFullWidth={{true}} />`
+      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="someSecretThingGoesHere" @isFullWidth={{true}} />`
     );
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--width-full');
   });
 
+  // COPY STATES
+
   test('it should update the status to success if the copy operation was successful', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="3423g-234525-h345346-f34rtf4" @isFullWidth={{true}} />`
+      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="someSecretThingGoesHere" @onSuccess={{this.onSuccess}} @onError={{this.onError}} />`
     );
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
     await click('button#test-copy-snippet');
+    assert.true(this.success);
     assert
       .dom('#test-copy-snippet')
       .hasClass('hds-copy-snippet--status-success');
@@ -77,23 +93,33 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
 
   test('it should update the status back to idle after success', async function (assert) {
     await render(
-      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="3423g-234525-h345346-f34rtf4" @isFullWidth={{true}} />`
+      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="someSecretThingGoesHere" />`
     );
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
     await click('button#test-copy-snippet');
     assert
       .dom('#test-copy-snippet')
       .hasClass('hds-copy-snippet--status-success');
-    await waitFor('.hds-copy-snippet--status-idle', { timeout: 2000 });
+    await wait(); // wait for the status to revert to "idle" automatically
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
   });
 
-  test('it should be able to copy a number', async function (assert) {
-    // context: https://github.com/hashicorp/design-system/pull/1564
+  test('it should update the status to an error after a failed "copy" operation', async function (assert) {
+    sinon.restore();
+    sinon
+      .stub(window.navigator.clipboard, 'writeText')
+      .throws(
+        'Sinon throws (syntethic error)',
+        'this is a fake error message provided to the sinon.stub().throws() method'
+      );
     await render(
-      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy={{123456789}} />`
+      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="someSecretThingGoesHere" @onSuccess={{this.onSuccess}} @onError={{this.onError}} />`
     );
-    // if the `ember-cli-clipboard` addon fails it triggers a JS error
+    assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
+    await click('button#test-copy-snippet');
+    assert.false(this.success);
+    assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-error');
+    await wait(); // wait for the status to revert to "idle" automatically
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
   });
 
@@ -107,7 +133,7 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
     await render(
-      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="3423g-234525-h345346-f34rtf4" @color="tertiary" />`
+      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="someSecretThingGoesHere" @color="tertiary" />`
     );
     assert.throws(function () {
       throw new Error(errorMessage);

--- a/packages/components/tests/integration/modifiers/hds-clipboard-test.js
+++ b/packages/components/tests/integration/modifiers/hds-clipboard-test.js
@@ -1,0 +1,338 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import {
+  click,
+  render,
+  find,
+  findAll,
+  fillIn,
+  resetOnerror,
+} from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+import {
+  getTextToCopy,
+  getTargetElement,
+  getTextToCopyFromTargetElement,
+  writeTextToClipboard,
+  copyToClipboard,
+} from '@hashicorp/design-system-components/modifiers/hds-clipboard';
+
+//
+// ================================================================
+//
+// NOTICE:
+// we're collecting both _unit_ and _integration_ tests
+// in a single file for simplicity / ease of maintainance
+//
+// ================================================================
+//
+
+module('Unit | Modifier | hds-clipboard - getTextToCopy()', function () {
+  test('returns the string that is passed as argument', async function (assert) {
+    assert.deepEqual(getTextToCopy('test'), 'test');
+  });
+  test('returns the number that is passed as argument as a string', async function (assert) {
+    assert.deepEqual(getTextToCopy(1234), '1234');
+  });
+  test('it should throw an assertion if the argument provided is not a string/number', async function (assert) {
+    const arg = {};
+    assert.throws(function () {
+      getTextToCopy(arg);
+    });
+  });
+});
+
+module(
+  'Unit | Modifier | hds-clipboard - getTargetElement()',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    test('returns the DOM element identified by a CSS selector string passed as argument', async function (assert) {
+      await render(hbs`<pre id="test-target">Test</pre>`);
+      this.target = find('#test-target');
+      assert.deepEqual(await this.target, await find('#test-target'));
+    });
+    test('returns the same DOM element passed as argument', async function (assert) {
+      await render(hbs`<pre id="test-target">Test</pre>`);
+      this.node = await find('#test-target');
+      this.target = find('#test-target');
+      assert.deepEqual(await this.target, this.node);
+    });
+    test('it should throw an assertion if the argument provided is a list of DOM nodes', async function (assert) {
+      await render(
+        hbs`<pre class="test-target">Test 1</pre><pre class="test-target">Test 2</pre>`
+      );
+      const arg = await findAll('.test-target');
+      assert.throws(function () {
+        getTargetElement(arg);
+      });
+    });
+    test('it should throw an assertion if the argument provided is not a string/node', async function (assert) {
+      await render(
+        hbs`<pre class="test-target">Test 1</pre><pre class="test-target">Test 2</pre>`
+      );
+      const arg = {};
+      assert.throws(function () {
+        getTargetElement(arg);
+      });
+    });
+  }
+);
+
+module(
+  'Unit | Modifier | hds-clipboard - getTextToCopyFromTargetElement()',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    const cases = [
+      ['text', 'test'],
+      ['number', 1234],
+      ['date', '2022-12-08'], // you can't pass a Date() object to the <input type="date">, it will not work
+      ['time', '23:59'], // same for the date
+      ['range', 6],
+      ['color', '#e66465'],
+    ];
+
+    test.each(
+      'returns the value of an <input> element (with "type") passed as `target` argument',
+      cases,
+      async function (assert, [type, value]) {
+        this.set('type', type);
+        this.set('value', value);
+        await render(
+          hbs`<input id="test-target" type={{this.type}} value={{this.value}} />`
+        );
+        this.target = find('#test-target');
+        assert.equal(
+          this.value,
+          getTextToCopyFromTargetElement(this.target),
+          `input type="${type}"`
+        );
+      }
+    );
+
+    test('returns the value of a <textarea> passed as `target` argument', async function (assert) {
+      this.set('value', `hello\nworld<br>!`);
+      await render(hbs`<textarea id="test-target">{{this.value}}</textarea>`);
+      this.target = find('#test-target');
+      assert.deepEqual(this.value, getTextToCopyFromTargetElement(this.target));
+    });
+
+    test('returns the value of a <select> element passed as `target` argument', async function (assert) {
+      this.set('option1', `option1`);
+      this.set('option2', `option2`);
+      this.set('option3', `option3`);
+      await render(hbs`<select id="test-target">
+        <option>{{this.option1}}</option>
+        <option>{{this.option2}}</option>
+        <option>{{this.option3}}</option>
+      </select>`);
+      this.target = find('#test-target');
+      assert.deepEqual(
+        this.option1,
+        getTextToCopyFromTargetElement(this.target)
+      );
+    });
+
+    test('returns the value of the selected option of a <select> element passed as `target` argument', async function (assert) {
+      this.set('option1', `option1`);
+      this.set('option2', `option2`);
+      this.set('option3', `option3`);
+      await render(hbs`<select id="test-target">
+        <option>{{this.option1}}</option>
+        <option selected>{{this.option2}}</option>
+        <option>{{this.option3}}</option>
+      </select>`);
+      this.target = find('#test-target');
+      assert.deepEqual(
+        this.option2,
+        getTextToCopyFromTargetElement(this.target)
+      );
+      await fillIn(this.target, this.option3);
+      assert.deepEqual(
+        this.option3,
+        getTextToCopyFromTargetElement(this.target)
+      );
+    });
+
+    test('returns the innerText of DOM element passed as `target` argument', async function (assert) {
+      await render(hbs`<ul id="test-target">
+        <li><p>Lorem <span><strong>Ipsum</strong> <em>dolor</em></span></p></li>
+        <li><p><code>Sit</code> <a href="#">Amet</a></p><pre>Some<br/>Code</pre></li>
+      </ul>`);
+      this.target = find('#test-target');
+      assert.deepEqual(
+        getTextToCopyFromTargetElement(this.target),
+        `Lorem Ipsum dolor\n\nSit Amet\n\nSome\nCode`
+      );
+    });
+
+    test('returns the innerText of DOM element passed as `target` argument without including hidden elements', async function (assert) {
+      await render(hbs`<p id="test-target">Lorem
+      <span style="display: none">Ipsum</span>
+      <span style="visibility: hidden">Dolor</span>
+    </p>`);
+      this.target = find('#test-target');
+      assert.deepEqual(getTextToCopyFromTargetElement(this.target), 'Lorem ');
+    });
+  }
+);
+
+module(
+  'Unit | Modifier | hds-clipboard - writeTextToClipboard()',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.afterEach(() => {
+      // we need to restore the "window.navigator" methods
+      sinon.restore();
+    });
+
+    test('returns `true` as response if the `navigator.writeText` operation succeeds', async function (assert) {
+      // we need to mock this call, otherwise it will fail in a testing environment (with error: DOMException: Document is not focused)
+      // this is because the "Document is not"
+      // see: https://github.com/cypress-io/cypress/issues/18198
+      // see: https://stackoverflow.com/questions/69425289/javascript-prompt-cause-document-is-not-focused
+      sinon.stub(window.navigator.clipboard, 'writeText').resolves();
+      const success = await writeTextToClipboard('test');
+      assert.true(success);
+    });
+    test('returns `false` as response if the `navigator.writeText` operation fails', async function (assert) {
+      // we need to mock the "catch" in the `try/catch`
+      sinon
+        .stub(window.navigator.clipboard, 'writeText')
+        .throws(
+          'Sinon throws (syntethic error)',
+          'this is a fake error message provided to the sinon.stub().throws() method'
+        );
+      const success = await writeTextToClipboard('test');
+      assert.false(success);
+    });
+    test('returns `false` as response if no `textToCopy` argument is provided', async function (assert) {
+      assert.false(await writeTextToClipboard());
+    });
+  }
+);
+
+module(
+  'Unit | Modifier | hds-clipboard - copyToClipboard()', // for this one we test only the assertion (the functionality is tested in the integration tests below)
+  function (hooks) {
+    setupRenderingTest(hooks);
+    // not sure why it's not working...
+    skip('it should throw an assertion if no `text` or `target` argument is provided', async function (assert) {
+      assert.throws(async function () {
+        await copyToClipboard();
+      });
+    });
+  }
+);
+
+module('Integration | Modifier | hds-clipboard', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // IMPORTANT: don't use an arrow function here or "this.set" will not be recognized
+  hooks.beforeEach(function () {
+    sinon.stub(window.navigator.clipboard, 'writeText').resolves();
+    this.success = undefined;
+    this.set('onSuccess', () => (this.success = true));
+    this.set('onError', () => (this.success = false));
+  });
+
+  hooks.afterEach(() => {
+    resetOnerror();
+    // we need to restore the "window.navigator" methods
+    sinon.restore();
+    this.success = undefined;
+  });
+
+  // @TEXT ARGUMENT
+
+  test('it should allow to copy a `string` provided as `@text` argument', async function (assert) {
+    await render(
+      hbs`<button id="test-button" {{hds-clipboard
+        text="Hello world!"
+        onSuccess=this.onSuccess
+        onError=this.onError
+      }}>Test</button>`
+    );
+    await click('button#test-button');
+    assert.true(this.success);
+  });
+
+  // context: https://github.com/hashicorp/design-system/pull/1564
+  test('it should allow to copy an `integer` provided as `@text` argument', async function (assert) {
+    await render(
+      hbs`<button id="test-button" {{hds-clipboard
+        text=1234
+        onSuccess=this.onSuccess
+        onError=this.onError
+      }}>Test</button>`
+    );
+    await click('button#test-button');
+    assert.true(this.success);
+  });
+
+  // @TARGET ARGUMENT
+
+  test('it should allow to target an element using a `string` selector for the `@target` argument', async function (assert) {
+    await render(
+      hbs`<p id="test-target">Hello world!</p><button id="test-button" {{hds-clipboard
+        target="#test-target"
+        onSuccess=this.onSuccess
+        onError=this.onError
+      }}>Test</button>`
+    );
+    await click('button#test-button');
+    assert.true(this.success);
+  });
+
+  test('it should allow to target an element using a DOM node', async function (assert) {
+    await render(hbs`<p id="test-target">Hello world!</p><button id="test-button" {{hds-clipboard
+        target=this.target
+        onSuccess=this.onSuccess
+        onError=this.onError
+      }}>Test</button>`);
+    this.set('target', find('#test-target'));
+    await click('button#test-button');
+    assert.true(this.success);
+  });
+
+  // ONSUCCESS/ONERROR CALLBACKS
+
+  test('it should invoke the `onSuccess` callback on a successful "copy" action', async function (assert) {
+    await render(
+      hbs`<button id="test-button" {{hds-clipboard
+        text="Hello world!"
+        onSuccess=this.onSuccess
+        onError=this.onError
+      }}>Test</button>`
+    );
+    await click('button#test-button');
+    assert.true(this.success);
+  });
+
+  test('it should invoke the `onError` callback on a failed "copy" action', async function (assert) {
+    sinon.restore();
+    sinon
+      .stub(window.navigator.clipboard, 'writeText')
+      .throws(
+        'Sinon throws (syntethic error)',
+        'this is a fake error message provided to the sinon.stub().throws() method'
+      );
+    await render(
+      hbs`<button id="test-button" {{hds-clipboard
+        text="Hello world!"
+        onSuccess=this.onSuccess
+        onError=this.onError
+      }}>Test</button>`
+    );
+    await click('button#test-button');
+    assert.false(this.success);
+  });
+});

--- a/website/docs/components/copy/button/partials/code/component-api.md
+++ b/website/docs/components/copy/button/partials/code/component-api.md
@@ -1,6 +1,6 @@
 ## Component API
 
-This component uses [ember-cli-clipboard](https://github.com/jkusa/ember-cli-clipboard) under the hood.
+This component uses the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) under the hood.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" }} @default="medium"/>
@@ -19,8 +19,11 @@ This component uses [ember-cli-clipboard](https://github.com/jkusa/ember-cli-cli
   <C.Property @name="targetToCopy" @type="string | function">
      Selector string of element or action that returns an element from which to copy text.
   </C.Property>
-  <C.Property @name="container" @type="string">
-     Selector string or element object of containing element, typically used in conjunction with modals; set the focused element as the container value.
+  <C.Property @name="onSuccess" @type="function">
+    Callback function invoked (if provided) when the "copy" action succeeds.
+  </C.Property>
+  <C.Property @name="onError" @type="function">
+    Callback function invoked (if provided) when the "copy" action fails.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/copy/snippet/partials/code/component-api.md
+++ b/website/docs/components/copy/snippet/partials/code/component-api.md
@@ -1,6 +1,6 @@
 ## Component API
 
-This component uses [ember-cli-clipboard](https://github.com/jkusa/ember-cli-clipboard) under the hood.
+This component uses the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) under the hood.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
@@ -10,13 +10,16 @@ This component uses [ember-cli-clipboard](https://github.com/jkusa/ember-cli-cli
   <C.Property @name="textToCopy" @type="string" @required="true">
     String value or action that returns a string to be copied.
   </C.Property>
-  <C.Property @name="container" @type="string">
-     Selector string or element object of containing element, typically used in conjunction with modals; set the focused element as the container value.
-  </C.Property>
   <C.Property @name="isTruncated" @type="boolean" @default="false">
     Constrains text to one line and truncates it based on available width. Text will only be truncated if it does not fit within the available space.
     <br><br>
     There are accessibility concerns if using this feature. See the [Accessibility section](/components/copy/snippet?tab=accessibility) for more information.
+  </C.Property>
+  <C.Property @name="onSuccess" @type="function">
+    Callback function invoked (if provided) when the "copy" action succeeds.
+  </C.Property>
+  <C.Property @name="onError" @type="function">
+    Callback function invoked (if provided) when the "copy" action fails.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/yarn.lock
+++ b/yarn.lock
@@ -2849,6 +2849,7 @@ __metadata:
     qunit: ^2.19.4
     qunit-dom: ^2.0.0
     sass: ^1.62.1
+    sinon: ^15.2.0
     stylelint: ^15.10.1
     stylelint-config-rational-order: ^0.1.2
     stylelint-config-standard-scss: ^5.0.0
@@ -3530,6 +3531,51 @@ __metadata:
   version: 0.14.0
   resolution: "@sindresorhus/is@npm:0.14.0"
   checksum: 971e0441dd44ba3909b467219a5e242da0fc584048db5324cfb8048148fa8dcc9d44d71e3948972c4f6121d24e5da402ef191420d1266a95f713bb6d6e59c98a
+  languageName: node
+  linkType: hard
+
+"@sinonjs/commons@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@sinonjs/commons@npm:2.0.0"
+  dependencies:
+    type-detect: 4.0.8
+  checksum: 5023ba17edf2b85ed58262313b8e9b59e23c6860681a9af0200f239fe939e2b79736d04a260e8270ddd57196851dde3ba754d7230be5c5234e777ae2ca8af137
+  languageName: node
+  linkType: hard
+
+"@sinonjs/commons@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@sinonjs/commons@npm:3.0.0"
+  dependencies:
+    type-detect: 4.0.8
+  checksum: b4b5b73d4df4560fb8c0c7b38c7ad4aeabedd362f3373859d804c988c725889cde33550e4bcc7cd316a30f5152a2d1d43db71b6d0c38f5feef71fd8d016763f8
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^10.0.2, @sinonjs/fake-timers@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "@sinonjs/fake-timers@npm:10.3.0"
+  dependencies:
+    "@sinonjs/commons": ^3.0.0
+  checksum: 614d30cb4d5201550c940945d44c9e0b6d64a888ff2cd5b357f95ad6721070d6b8839cd10e15b76bf5e14af0bcc1d8f9ec00d49a46318f1f669a4bec1d7f3148
+  languageName: node
+  linkType: hard
+
+"@sinonjs/samsam@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@sinonjs/samsam@npm:8.0.0"
+  dependencies:
+    "@sinonjs/commons": ^2.0.0
+    lodash.get: ^4.4.2
+    type-detect: ^4.0.8
+  checksum: 95e40d0bb9f7288e27c379bee1b03c3dc51e7e78b9d5ea6aef66a690da7e81efc4715145b561b449cefc5361a171791e3ce30fb1a46ab247d4c0766024c60a60
+  languageName: node
+  linkType: hard
+
+"@sinonjs/text-encoding@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "@sinonjs/text-encoding@npm:0.7.2"
+  checksum: fe690002a32ba06906cf87e2e8fe84d1590294586f2a7fd180a65355b53660c155c3273d8011a5f2b77209b819aa7306678ae6e4aea0df014bd7ffd4bbbcf1ab
   languageName: node
   linkType: hard
 
@@ -14435,6 +14481,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"just-extend@npm:^4.0.2":
+  version: 4.2.1
+  resolution: "just-extend@npm:4.2.1"
+  checksum: ff9fdede240fad313efeeeb68a660b942e5586d99c0058064c78884894a2690dc09bba44c994ad4e077e45d913fef01a9240c14a72c657b53687ac58de53b39c
+  languageName: node
+  linkType: hard
+
 "keyv@npm:^3.0.0":
   version: 3.1.0
   resolution: "keyv@npm:3.1.0"
@@ -14875,6 +14928,13 @@ __metadata:
   version: 4.5.0
   resolution: "lodash.foreach@npm:4.5.0"
   checksum: a940386b158ca0d62994db41fc16529eb8ae67138f29ced38e91f912cb5435d1b0ed34b18e6f7b9ddfc32ab676afc6dfec60d1e22633d8e3e4b33413402ab4ad
+  languageName: node
+  linkType: hard
+
+"lodash.get@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.get@npm:4.4.2"
+  checksum: e403047ddb03181c9d0e92df9556570e2b67e0f0a930fcbbbd779370972368f5568e914f913e93f3b08f6d492abc71e14d4e9b7a18916c31fa04bd2306efe545
   languageName: node
   linkType: hard
 
@@ -15923,6 +15983,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nise@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "nise@npm:5.1.4"
+  dependencies:
+    "@sinonjs/commons": ^2.0.0
+    "@sinonjs/fake-timers": ^10.0.2
+    "@sinonjs/text-encoding": ^0.7.1
+    just-extend: ^4.0.2
+    path-to-regexp: ^1.7.0
+  checksum: bc57c10eaec28a6a7ddfb2e1e9b21d5e1fe22710e514f8858ae477cf9c7e9c891475674d5241519193403db43d16c3675f4207bc094a7a27b7e4f56584a78c1b
+  languageName: node
+  linkType: hard
+
 "no-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "no-case@npm:3.0.4"
@@ -16858,6 +16931,15 @@ __metadata:
   version: 0.1.7
   resolution: "path-to-regexp@npm:0.1.7"
   checksum: 69a14ea24db543e8b0f4353305c5eac6907917031340e5a8b37df688e52accd09e3cebfe1660b70d76b6bd89152f52183f28c74813dbf454ba1a01c82a38abce
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^1.7.0":
+  version: 1.8.0
+  resolution: "path-to-regexp@npm:1.8.0"
+  dependencies:
+    isarray: 0.0.1
+  checksum: 709f6f083c0552514ef4780cb2e7e4cf49b0cc89a97439f2b7cc69a608982b7690fb5d1720a7473a59806508fc2dae0be751ba49f495ecf89fd8fbc62abccbcd
   languageName: node
   linkType: hard
 
@@ -18950,6 +19032,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sinon@npm:^15.2.0":
+  version: 15.2.0
+  resolution: "sinon@npm:15.2.0"
+  dependencies:
+    "@sinonjs/commons": ^3.0.0
+    "@sinonjs/fake-timers": ^10.3.0
+    "@sinonjs/samsam": ^8.0.0
+    diff: ^5.1.0
+    nise: ^5.1.4
+    supports-color: ^7.2.0
+  checksum: 1641b9af8a73ba57c73c9b6fd955a2d062a5d78cce719887869eca45faf33b0fd20cabfeffdfd856bb35bfbd3d49debb2d954ff6ae5e9825a3da5ff4f604ab6c
+  languageName: node
+  linkType: hard
+
 "slash@npm:^1.0.0":
   version: 1.0.0
   resolution: "slash@npm:1.0.0"
@@ -19901,7 +19997,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
+"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -20641,6 +20737,13 @@ __metadata:
   dependencies:
     prelude-ls: ~1.1.2
   checksum: dd3b1495642731bc0e1fc40abe5e977e0263005551ac83342ecb6f4f89551d106b368ec32ad3fb2da19b3bd7b2d1f64330da2ea9176d8ddbfe389fb286eb5124
+  languageName: node
+  linkType: hard
+
+"type-detect@npm:4.0.8, type-detect@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "type-detect@npm:4.0.8"
+  checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,7 +2812,6 @@ __metadata:
     ember-cached-decorator-polyfill: ^0.1.4
     ember-cli: ~4.12.1
     ember-cli-babel: ^7.26.11
-    ember-cli-clipboard: ^1.0.0
     ember-cli-dependency-checker: ^3.3.1
     ember-cli-deprecation-workflow: ^2.1.0
     ember-cli-htmlbars: ^6.2.0


### PR DESCRIPTION
### :pushpin: Summary

This PR is a porting (cleanup/squash) of the branch in #1620.
In that spike I have explored how to fix an issue with the `Copy::Snippet` component, used in the `Dropdown::LIstItem::CopyItem` that was causing the dropdown to close immediately after the user clicked on the copy button.

For details about the issue see [this ticket](https://hashicorp.atlassian.net/browse/HDS-2348), and for an analysis of the root cause of the issue see [this comment in the ticket](https://hashicorp.atlassian.net/browse/HDS-2348?focusedCommentId=314288).

### :hammer_and_wrench: Detailed description

in this PR I have:
- removed `ember-cli-clipboard` as dependency
- implemented `hds-clipboard` modifier
    - I've started from `ember-cli-clipboard` + `clipboard.js` as reference, but along the way I've completely refactored and rewrote the entire code and overall logic/architecture, using the web Clipboard API for copying to clipboard
- added “integration” + “unit” tests for the `hds-clipboard` modifier
- changed `Copy::Button/Snippet` components to use our internal `hds-clipboard` helper/modifier
   - in the process I've also added `onSuccess/onError` callbacks
   - notice: I've removed the `@container` argument from the `Button` template code, because it’s not needed anymore, the focus is not moved away by the copy action in the browser now
- updated/fixed integration tests for `Copy::Button/Snippet`
    - I've had to add back the `Sinon` package (as “dev” dependency) to stub `window.navigator.writeText`
- updated showcase for `Copy::Button` to cover more use cases (see link below)
- updated the website documentation for `Copy::Button/Snippet`

🙏 🙏 🙏 **Please reviewers:** 
- check thoroughly the code, possibly line by line
- check that the implementation of the `hds-clipboard` modifier is idiomatic to Ember and follows similar implementations (eg. in Cloud UI)
- question everything, challenge everything I've done
- double check that I've covered all the use cases (positive/negative outcomes, edge cases, etc)
- think if I've missed something, something is not covered

We need to make sure there are no regressions when we release this update

👉 👉 👉 **Previews**:
- [showcase for `Copy::Button`](https://hds-showcase-git-fix-copy-snippet-blur-in-dropdown-hashicorp.vercel.app/components/copy/button)
- [showcase for `Copy::Snippet`](https://hds-showcase-git-fix-copy-snippet-blur-in-dropdown-hashicorp.vercel.app/components/copy/snippet)
- [documentation page for `Copy::Button`](https://hds-website-git-fix-copy-snippet-blur-in-dropdown-hashicorp.vercel.app/components/copy/button?tab=code#component-api)
- [documentation page for `Copy::Snippet`](https://hds-website-git-fix-copy-snippet-blur-in-dropdown-hashicorp.vercel.app/components/copy/snippet?tab=code#component-api)
- documentation page for `Dropdown` - see [this example](https://hds-website-git-fix-copy-snippet-blur-in-dropdown-hashicorp.vercel.app/components/dropdown?tab=code#listitemgeneric) (open the menu and copy one of the values; then compare this with [the same page/example currently in production](https://helios.hashicorp.design/components/dropdown?tab=code#listitemgeneric))

### ⚠️ TODOs
- [x] Check everything works as expected in HCP/Cloud UI
    - Ticket: https://hashicorp.atlassian.net/browse/HDS-2484
    - Test PR: https://github.com/hashicorp/cloud-ui/pull/7480
- [x] Check everything works as expected in Terraform/Atlas
    - Ticket: https://hashicorp.atlassian.net/browse/HDS-2485
    - Test PR: https://github.com/hashicorp/atlas/pull/17025

### :link: External links

- Jira ticket for the issue: https://hashicorp.atlassian.net/browse/HDS-2348
    - analysis of root cause of the issue: https://hashicorp.atlassian.net/browse/HDS-2348?focusedCommentId=314288
- Jira ticket for this fix: https://hashicorp.atlassian.net/browse/HDS-2467

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
