### PR TITLE
Update aria-label for pagination nav element

### DIFF
--- a/packages/components/addon/components/hds/pagination/compact/index.js
+++ b/packages/components/addon/components/hds/pagination/compact/index.js
@@ -50,10 +50,10 @@ export default class HdsPaginationCompactIndexComponent extends Component {
   /**
    * @param ariaLabel
    * @type {string}
-   * @default 'Pagination navigation'
+   * @default 'Pagination'
    */
   get ariaLabel() {
-    return this.args.ariaLabel ?? 'Pagination navigation';
+    return this.args.ariaLabel ?? 'Pagination';
   }
 
   get routeQueryParams() {

--- a/packages/components/addon/components/hds/pagination/numbered/index.js
+++ b/packages/components/addon/components/hds/pagination/numbered/index.js
@@ -130,10 +130,10 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   /**
    * @param ariaLabel
    * @type {string}
-   * @default 'Pagination navigation'
+   * @default 'Pagination'
    */
   get ariaLabel() {
-    return this.args.ariaLabel ?? 'Pagination navigation';
+    return this.args.ariaLabel ?? 'Pagination';
   }
 
   // This very specific `get/set` pattern is used to handle the two different use cases of the component

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -22,7 +22,7 @@ These Pagination sub-elements may be used directly if you need to cover a very s
 ### Pagination::Numbered
 
 <Doc::ComponentApi as |C|>
-<C.Property @name="ariaLabel" @type="string" @default="Pagination navigation">
+<C.Property @name="ariaLabel" @type="string" @default="Pagination">
     Accepts a localized string.
 </C.Property>
 <C.Property @name="totalItems" @required="true" @type="number">
@@ -66,7 +66,7 @@ This component supports use of [`...attributes`](https://guides.emberjs.com/rele
 ### Pagination::Compact
 
 <Doc::ComponentApi as |C|>
-<C.Property @name="ariaLabel" @type="string" @default="Pagination navigation">
+<C.Property @name="ariaLabel" @type="string" @default="Pagination">
     Accepts a localized string.
 </C.Property>
 <C.Property @name="route/model/models/replace">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes the `aria-label` attribute on the pagination component.

### :hammer_and_wrench: Detailed description

- changed "pagination navigation" to just "pagination" because the screen-reader will identify that it is a navigation element (we were getting "pagination navigation navigation")
- updated website API docs for the same


### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
