### PR TITLE
`Stepper` - Remove useless CSS declarations

### DIFF
--- a/.changeset/warm-schools-serve.md
+++ b/.changeset/warm-schools-serve.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Stepper` - removed some CSS declarations that were not used/applied

--- a/packages/components/app/styles/components/stepper/step-indicator.scss
+++ b/packages/components/app/styles/components/stepper/step-indicator.scss
@@ -21,11 +21,6 @@ $hds-stepper-indicator-step-size: 24px;
   width: 100%;
   height: 100%;
   filter: drop-shadow(0 1px 1px rgba(101, 106, 118, 5%));
-
-  path {
-    fill: --status-fill-color;
-    stroke: --status-stroke-color;
-  }
 }
 
 .hds-stepper-indicator-step__status {
@@ -42,13 +37,11 @@ $hds-stepper-indicator-step-size: 24px;
 .hds-stepper-indicator-step__icon {
   width: 12px;
   height: 12px;
-  color: --status-text-color;
 }
 
 .hds-stepper-indicator-step__text {
   width: 20px;
   overflow: hidden;
-  color: --status-text-color;
   font-weight: var(--token-typography-font-weight-medium);
   font-size: 0.8125rem;
   font-family: var(--token-typography-font-stack-text);


### PR DESCRIPTION
### :pushpin: Summary

While working on a related issue, I noticed that there are some declarations in the CSS for the `Stepper` component that can  be safely removed (they're not used, and they are ignored by the browser because the syntax is not correct).

<img width="491" alt="screenshot_3061" src="https://github.com/hashicorp/design-system/assets/686239/e8c26cb3-18de-45d1-96bd-002750bdd1a5">

### :hammer_and_wrench: Detailed description

In this PR I have:
  - `Stepper` - removed some CSS declarations that were not used/applied

***

### 👀 Reviewer's checklist:

- [x] +1 Percy if applicable
- [x] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [x] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
