### PR TITLE
Adding more context around link usage in buttons

### DIFF
--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -1,10 +1,9 @@
-The Button component is used to trigger an action or event. For accessibility, Buttons should not be used to route to a URL; use a [Link](/components/link/standalone) instead.
-
 !!! Info
 
 Due to differences in text rendering between Figma and web browsers, the `Button` Ember component uses `font-weight` 400 vs. the Figma component which uses `font-weight` 500.
 
 !!!
+
 ## How to use this component
 
 The basic invocation requires text to be passed:
@@ -98,14 +97,16 @@ Read the Ember.js guides for more information: [Patterns for Actions](https://gu
 
 ### Links
 
-You can generate a link with the visual appearance of a button, by passing an `@href` or a `@route` argument to the component.
+!!! Insight
 
-If you’re passing an `@href` or a `@route` argument to the component, this will generate an `<a>` link, not a `<button>`. In this case, no `type` is needed.
-
-!!! Info
+While we support using links within buttons, please strive for the correct semantic use. Learn more about [how semantic use helps make our products more conformant](/components/button?tab=accessibility#button-vs-link).
 
 The `Hds::Button` component uses the generic `Hds::Interactive` component. For more details about how this utility component works, please refer to [its documentation page](/utilities/interactive).
 !!!
+
+You can generate a link with the visual appearance of a button, by passing an `@href` or a `@route` argument to the component.
+
+If you’re passing an `@href` or a `@route` argument to the component, this will generate an `<a>` link, not a `<button>`. In this case, no `type` is needed.
 
 #### With @href
 

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -97,16 +97,14 @@ Read the Ember.js guides for more information: [Patterns for Actions](https://gu
 
 ### Links
 
-!!! Insight
-
-While we support using links as buttons, please strive for the correct semantic use. Learn more about [how semantic use helps make our products more conformant](/components/button?tab=accessibility#button-vs-link).
-
-The `Hds::Button` component uses the generic `Hds::Interactive` component. For more details about how this utility component works, please refer to [its documentation page](/utilities/interactive).
-!!!
-
 You can generate a link with the visual appearance of a button, by passing an `@href` or a `@route` argument to the component.
 
 If you’re passing an `@href` or a `@route` argument to the component, this will generate an `<a>` link, not a `<button>`. In this case, no `type` is needed.
+
+!!! Info
+
+The `Hds::Button` component uses the generic `Hds::Interactive` component. For more details about how this utility component works, please refer to [its documentation page](/utilities/interactive).
+!!!
 
 #### With @href
 

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -99,7 +99,7 @@ Read the Ember.js guides for more information: [Patterns for Actions](https://gu
 
 !!! Insight
 
-While we support using links within buttons, please strive for the correct semantic use. Learn more about [how semantic use helps make our products more conformant](/components/button?tab=accessibility#button-vs-link).
+While we support using links as buttons, please strive for the correct semantic use. Learn more about [how semantic use helps make our products more conformant](/components/button?tab=accessibility#button-vs-link).
 
 The `Hds::Button` component uses the generic `Hds::Interactive` component. For more details about how this utility component works, please refer to [its documentation page](/utilities/interactive).
 !!!

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -118,11 +118,6 @@ Use `external-link` when using the Button for external links. In most cases, con
 
 ## Links as Buttons
 
-!!! Insight
-
-While we support using links within buttons, please strive for the correct semantic use. Learn more about [how semantic use helps make our products more conformant](/components/button?tab=accessibility#button-vs-link).
-!!!
-
 The Button component accepts an `@href` or `@route` argument, which results in a link with the visual appearance of a button. While in general, we advise against this approach because it can cause confusion for keyboard-only users, there are a few instances where this may be appropriate for improved visual hierarchy, such as:
 
 For links that require more prominence and CTAs (calls-to-action).
@@ -144,6 +139,8 @@ For links that are part of an [inverse button group](/patterns/button-organizati
   <Hds::Button @color="primary" @text="Submit" />
   <Hds::Button @color="secondary" @text="Cancel" @href="#" />
 </Hds::ButtonSet>
+
+Learn more about [how semantic use helps make our products more conformant](/components/button?tab=accessibility#button-vs-link).
 
 ## Button set
 

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -3,22 +3,17 @@
 ### When to use
 
 - To trigger an action or event, like a form submission.
+- For links that require more prominence, such as CTAs (calls-to-action), see [Links in Buttons](/components/button#links-in-buttons).
+- For links that are part of an [inverse button group](/patterns/button-organization#grouping), see [Links in Buttons](/components/button#links-in-buttons).
 
 ### When not to use
 
-- When navigating to another destination, consider [Inline](/components/link/inline) or [Standalone](/components/link/standalone) link.
+- For links that are not CTAs or part of an [inverse button group](/patterns/button-organization#grouping), consider [Inline](/components/link/inline) or [Standalone](/components/link/standalone) link.
 - To display multiple actions under a single button, use [Dropdown](/components/dropdown).
 
 ## Sizes
 
 Medium is the preferred size, but use a Button size that best fits the UI (e.g., don’t use a `large` button in a table).
-
-!!! Insight
-
-**Migration tip** 
-
-Medium buttons are the same size as default Structure buttons. Small buttons are the same size as compact Structure buttons.
-!!!
 
 <Doc::Layout @spacing="16px">
   <Hds::Button @size="small" @text="Small" />
@@ -121,13 +116,42 @@ Use `external-link` when using the Button for external links. In most cases, con
 
 <Hds::Button @color="secondary" @text="Authenticate with GitHub" @icon="external-link" @iconPosition="trailing" @href="https://hashicorp.com" />
 
-## Button set
+## Links in Buttons
 
-[ButtonSets](/components/button-set) are patterns when multiple Buttons need to be displayed in a single row.
+!!! Insight
+
+While we support using links within buttons, please strive for the correct semantic use. Learn more about [how semantic use helps make our products more conformant](/components/button?tab=accessibility#button-vs-link).
+!!!
+
+The Button component accepts an `@href` or `@route` argument, which results in a link with the visual appearance of a button. While we advise against this approach because it can cause confusion for keyboard-only users, there are a few instances where this may be appropriate for improved visual hierarchy, such as:
+
+For links that require more prominence and CTAs (calls-to-action).
+
+<Hds::Button @color="primary" @text="Sign up for free" @size="large" @href="#" />
+
+<Hds::Alert @type="inline" @color="neutral" as |A|>
+  <A.Title>Modifying user permissions</A.Title>
+  <A.Description>
+    This page displays all users in the organization that have permissions in this project. A user must be invited to the org first before you can change the user’s role at the project level.
+  </A.Description>
+  <A.Button @text="Go to HCP Design Sandbox" @color="secondary" @href="#" />
+  <A.Link::Standalone @text="View documentation" @color="primary" @icon="docs-link" @iconPosition="trailing" @href="#" />
+</Hds::Alert>
+
+For links that are part of an [inverse button group](/patterns/button-organization#grouping).
 
 <Hds::ButtonSet>
   <Hds::Button @color="primary" @text="Submit" />
-  <Hds::Button @color="secondary" @text="Cancel" />
+  <Hds::Button @color="secondary" @text="Cancel" @href="#" />
+</Hds::ButtonSet>
+
+## Button set
+
+ButtonSet is a layout component that provides proper spacing between multiple Buttons. Refer to the [ButtonSet](/components/button-set) documentation to learn more. ButtonSet is only available in code.
+
+<Hds::ButtonSet>
+  <Hds::Button @color="primary" @text="Edit cluster" />
+  <Hds::Button @color="secondary" @text="Create cluster" />
 </Hds::ButtonSet>
 
 More detailed examples and guidance on button organization can be found in the [button organization](/patterns/button-organization) pattern documentation.

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -3,8 +3,8 @@
 ### When to use
 
 - To trigger an action or event, like a form submission.
-- For links that require more prominence, such as CTAs (calls-to-action), see [Links in Buttons](/components/button#links-in-buttons).
-- For links that are part of an [inverse button group](/patterns/button-organization#grouping), see [Links in Buttons](/components/button#links-in-buttons).
+- For links that require more prominence, such as CTAs (calls-to-action), see [Links as Buttons](/components/button#links-as-buttons).
+- For links that are part of an [inverse button group](/patterns/button-organization#grouping), see [Links as Buttons](/components/button#links-as-buttons).
 
 ### When not to use
 
@@ -116,14 +116,14 @@ Use `external-link` when using the Button for external links. In most cases, con
 
 <Hds::Button @color="secondary" @text="Authenticate with GitHub" @icon="external-link" @iconPosition="trailing" @href="https://hashicorp.com" />
 
-## Links in Buttons
+## Links as Buttons
 
 !!! Insight
 
 While we support using links within buttons, please strive for the correct semantic use. Learn more about [how semantic use helps make our products more conformant](/components/button?tab=accessibility#button-vs-link).
 !!!
 
-The Button component accepts an `@href` or `@route` argument, which results in a link with the visual appearance of a button. While we advise against this approach because it can cause confusion for keyboard-only users, there are a few instances where this may be appropriate for improved visual hierarchy, such as:
+The Button component accepts an `@href` or `@route` argument, which results in a link with the visual appearance of a button. While in general, we advise against this approach because it can cause confusion for keyboard-only users, there are a few instances where this may be appropriate for improved visual hierarchy, such as:
 
 For links that require more prominence and CTAs (calls-to-action).
 
@@ -132,7 +132,7 @@ For links that require more prominence and CTAs (calls-to-action).
 <Hds::Alert @type="inline" @color="neutral" as |A|>
   <A.Title>Modifying user permissions</A.Title>
   <A.Description>
-    This page displays all users in the organization that have permissions in this project. A user must be invited to the org first before you can change the user’s role at the project level.
+    This page displays all users in the organization who have permissions in this project. A user must be invited to the org first before you can change the user’s role at the project level.
   </A.Description>
   <A.Button @text="Go to HCP Design Sandbox" @color="secondary" @href="#" />
   <A.Link::Standalone @text="View documentation" @color="primary" @icon="docs-link" @iconPosition="trailing" @href="#" />

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -144,7 +144,7 @@ Learn more about [how semantic use helps make our products more conformant](/com
 
 ## Button set
 
-ButtonSet is a layout component that provides proper spacing between multiple Buttons. Refer to the [ButtonSet](/components/button-set) documentation to learn more. ButtonSet is only available in code.
+ButtonSet is a layout component that provides consistent spacing between multiple Buttons. Refer to the [ButtonSet](/components/button-set) documentation to learn more. ButtonSet is only available in code.
 
 <Hds::ButtonSet>
   <Hds::Button @color="primary" @text="Edit cluster" />


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds context around when to use links in buttons.

**👉🏻 Preview link:** https://hds-website-git-hl-button-docs-update-hashicorp.vercel.app/components/button

### :hammer_and_wrench: Detailed description

The following updates were made: 
- Summarized when to use a link within a button in the Usage section.
- Added a new section called "Links in Buttons" which further expands on the summarized content and adds example use cases.
- Moved content about links in buttons in the Code page to the appropriate section.
- Removed an outdated migration tip (_unrelated to Jira ticket_).
- Clarified some language and changed the example in Button set section (_unrelated to Jira ticket_).

### :camera_flash: Screenshots

<img width="1510" alt="Screenshot 2023-09-11 at 3 41 37 PM" src="https://github.com/hashicorp/design-system/assets/8553306/28be7f84-d968-4eb5-9f37-11a20fd4b4dd">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2492](https://hashicorp.atlassian.net/browse/HDS-2492)

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2492]: https://hashicorp.atlassian.net/browse/HDS-2492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ