### PR TITLE
`Dropdown::ListItem::CopyItem` - Update defaults for `@color` and `@isTruncated`

### DIFF
--- a/.changeset/little-ads-explain.md
+++ b/.changeset/little-ads-explain.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Dropdown::ListItem::CopyItem` - changed defaults for `@color` (now `secondary`) and `@isTruncated` (now `true`)
+

--- a/packages/components/addon/components/hds/dropdown/list-item/copy-item.hbs
+++ b/packages/components/addon/components/hds/dropdown/list-item/copy-item.hbs
@@ -8,5 +8,5 @@
       class="hds-dropdown-list-item__copy-item-title hds-typography-body-100 hds-font-weight-semibold"
     >{{@copyItemTitle}}</div>
   {{/if}}
-  <Hds::Copy::Snippet @textToCopy={{this.text}} @isTruncated={{@isTruncated}} />
+  <Hds::Copy::Snippet @color="secondary" @textToCopy={{this.text}} @isTruncated={{this.isTruncated}} />
 </li>

--- a/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
+++ b/packages/components/addon/components/hds/dropdown/list-item/copy-item.js
@@ -22,6 +22,19 @@ export default class HdsDropdownListItemCopyItemComponent extends Component {
 
     return text;
   }
+
+  /**
+   * @param isTruncated
+   * @type {boolean}
+   * @default true
+   * @description Indicates that the text should be truncated instead of wrapping and using multiple lines.
+   */
+  get isTruncated() {
+    let { isTruncated = true } = this.args;
+
+    return isTruncated;
+  }
+
   /**
    * Get the class names to apply to the component.
    * @method classNames

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -524,8 +524,17 @@
   <Shw::Text::H4>Content</Shw::Text::H4>
 
   <Shw::Flex as |SF|>
-    <SF.Item @label="Base">
+    <SF.Item @label="With short text">
       {{! Notice: we want to emulate the case of a fixed width list }}
+      {{! template-lint-disable no-inline-styles }}
+      <div class="hds-dropdown__content" style="width: 250px">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::CopyItem @text="Lorem ipsum" />
+        </ul>
+      </div>
+      {{! template-lint-enable no-inline-styles }}
+    </SF.Item>
+    <SF.Item @label="With long text">
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
@@ -534,7 +543,33 @@
       </div>
       {{! template-lint-enable no-inline-styles }}
     </SF.Item>
-    <SF.Item @label="With copyItemTitle defined">
+    <SF.Item @label="With long text + isTruncated=false">
+      {{! template-lint-disable no-inline-styles }}
+      <div class="hds-dropdown__content" style="width: 250px">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::CopyItem
+            @copyItemTitle="Lorem ipsum dolor"
+            @text="91ee1e8ef65b337f0e70d793f456c71d"
+            @isTruncated={{false}}
+          />
+        </ul>
+      </div>
+      {{! template-lint-enable no-inline-styles }}
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Short text + copyItemTitle">
+      {{! Notice: we want to emulate the case of a fixed width list }}
+      {{! template-lint-disable no-inline-styles }}
+      <div class="hds-dropdown__content" style="width: 250px">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::CopyItem @copyItemTitle="Lorem ipsum dolor" @text="Lorem ipsum" />
+        </ul>
+      </div>
+      {{! template-lint-enable no-inline-styles }}
+    </SF.Item>
+    <SF.Item @label="Long text + copyItemTitle">
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
@@ -546,14 +581,14 @@
       </div>
       {{! template-lint-enable no-inline-styles }}
     </SF.Item>
-    <SF.Item @label="With isTruncated">
+    <SF.Item @label="Long text + copyItemTitle + isTruncated=false">
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
           <Hds::Dropdown::ListItem::CopyItem
             @copyItemTitle="Lorem ipsum dolor"
             @text="91ee1e8ef65b337f0e70d793f456c71d"
-            @isTruncated={{true}}
+            @isTruncated={{false}}
           />
         </ul>
       </div>
@@ -580,7 +615,7 @@
       </div>
       {{! template-lint-enable no-inline-styles }}
     </SF.Item>
-    <SF.Item @label="With copyItemTitle defined">
+    <SF.Item @label="With copyItemTitle">
       {{! Notice: we want to emulate the case of a fixed width list }}
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
@@ -597,7 +632,7 @@
       </div>
       {{! template-lint-enable no-inline-styles }}
     </SF.Item>
-    <SF.Item @label="With copyItemTitle & isTruncated">
+    <SF.Item @label="With copyItemTitle + isTruncated=false">
       {{! Notice: we want to emulate the case of a fixed width list }}
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
@@ -606,7 +641,7 @@
             <Hds::Dropdown::ListItem::CopyItem
               @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r"
               @copyItemTitle="Lorem ipsumy dolor"
-              @isTruncated={{true}}
+              @isTruncated={{false}}
               mock-state-value={{state}}
               mock-state-selector="button"
             />

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -172,7 +172,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
     <br><br>
     _Notice: this argument is forwarded (as `textToCopy`) to the [`Copy::Snippet` component](/components/copy/snippet?tab=code#component-api)._
   </C.Property>
-  <C.Property @name="isTruncated" @type="boolean" @default="false">
+  <C.Property @name="isTruncated" @type="boolean" @default="true">
     Constrains text to one line and truncates it based on available width. Text will only be truncated if it does not fit within the available space.
     <br><br>
     There are accessibility concerns if using this feature. See the [Accessibility section](/components/copy/snippet?tab=accessibility) of the `Copy::Snippet` component for more information.

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -226,9 +226,7 @@ Pass the argument `@isLoading={{true}}` to the item. This will show a “loading
 
 ### ListItem::CopyItem
 
-To enable users to copy a snippet of code (eg. URLs, secrets, code blocks, etc.).
-
-Using the `@isTruncated` argument it is possible to constrain the text to one-line and truncate it if it does not fit the available space. Care should be taken in choosing to use this feature as there are [accessibility concerns](/components/copy/snippet?tab=accessibility).
+To enable users to copy a snippet of code (eg. URLs, secrets, code blocks, etc.) use `ListItem::CopyItem`.
 
 ```handlebars
 <Hds::Dropdown as |dd|>
@@ -236,9 +234,13 @@ Using the `@isTruncated` argument it is possible to constrain the text to one-li
   <dd.Title @text="Integrate with Terraform Cloud" />
   <dd.Description @text="Create a new run task in Terraform using the URL and key below." />
   <dd.CopyItem @text="https://api.cloud.hashicorp.com" @copyItemTitle="Endpoint URL" />
-  <dd.CopyItem @isTruncated={{true}} @text="91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d" @copyItemTitle="HMAC Key" />
+  <dd.CopyItem @text="91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d" @copyItemTitle="HMAC Key" />
+  <dd.CopyItem @isTruncated={{false}} @text="91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d" @copyItemTitle="HMAC Key (without truncation)" />
 </Hds::Dropdown>
 ```
+
+Using the `@isTruncated` argument is possible to disable the truncation constrain applied to the text (to be rendered on a single line, and truncate it if it does not fit the available space). Care should be taken in choosing how to use this feature as there are [accessibility concerns](/components/copy/snippet?tab=accessibility).
+
 ### ListItem::Checkmark
 
 For switching context (e.g., organization switchers, project switchers, etc.) use `ListItem::Checkmark`.


### PR DESCRIPTION
### :pushpin: Summary

While working on https://github.com/hashicorp/design-system/pull/1624 I noticed a couple of differences between the current vs the previous implementation (see screenshots). 
After a conversation with @heatherlarsen we agreed that the desired behaviour is:
- `color` variant should be `secondary`
- `truncation` should be on by default (but optionally can be turned off)

### :hammer_and_wrench: Detailed description

In this PR I have:
- changed defaults for `@color` (now `secondary`) and `@isTruncated` (now `true`)
- updated showcase for `Dropdown` component
- updated “How to use” and “Component API” documentation for `Dropdown::ListItem::CopyItem`

👉 👉 👉  **Previews**:
- showcase: https://hds-showcase-git-fix-dropdown-copy-item-defaults-hashicorp.vercel.app/components/dropdown
- documentation: https://hds-website-git-fix-dropdown-copy-item-defaults-hashicorp.vercel.app/components/dropdown?tab=code

### :camera_flash: Screenshots

**Before** (implementation before changes in #1488)
<img width="551" alt="before" src="https://github.com/hashicorp/design-system/assets/686239/cbaf1d17-8e1f-40e6-b014-4e67b39afbe1">

**After** (after changes in #1488)
<img width="824" alt="after" src="https://github.com/hashicorp/design-system/assets/686239/9d4c2dff-64d2-4bc4-841b-36c5ff8b4627">

**Current PR:**
<img width="811" alt="screenshot_3075" src="https://github.com/hashicorp/design-system/assets/686239/477914ed-d998-40d1-9bbf-9474b2c54503">


### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2490

***

### 👀 Reviewer's checklist:

- [ ] +1 Percy if applicable
- [ ] Confirm that PR has a changelog update via [Changesets](https://github.com/changesets/changesets) if needed
- [ ] Confirm that A11y tests have been run locally for this component

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
