### PR TITLE
`Copy::Snippet` - Update `width` behaviour implementation

### DIFF
--- a/.changeset/strange-birds-juggle.md
+++ b/.changeset/strange-birds-juggle.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Copy::Snippet` - Fixed the way in which “width/full-width” is applied to the component + Internal update to the “truncation” implementation.
+- the component is not full-width by default (the width now fits the content); use `@isFullWidth={{true}}` to have a full-width layout
+- the internal class name `hds-copy-snippet__text--truncated` has been changed to `hds-copy-snippet--is-truncated` (and moved)

--- a/packages/components/addon/components/hds/copy/snippet/index.hbs
+++ b/packages/components/addon/components/hds/copy/snippet/index.hbs
@@ -8,11 +8,7 @@
   {{hds-clipboard text=@textToCopy onSuccess=this.onSuccess onError=this.onError}}
   ...attributes
 >
-  <Hds::Text::Code
-    class="hds-copy-snippet__text {{if @isTruncated 'hds-copy-snippet__text--truncated'}}"
-    @tag="span"
-    @size="100"
-  >
+  <Hds::Text::Code class="hds-copy-snippet__text" @tag="span" @size="100">
     {{@textToCopy}}
   </Hds::Text::Code>
   <FlightIcon @name={{this.icon}} class="hds-copy-snippet__icon" />

--- a/packages/components/addon/components/hds/copy/snippet/index.js
+++ b/packages/components/addon/components/hds/copy/snippet/index.js
@@ -88,6 +88,11 @@ export default class HdsCopySnippetIndexComponent extends Component {
     // add a class based on the tracked status (idle/success/error)
     classes.push(`hds-copy-snippet--status-${this.status}`);
 
+    // add a class based on the @isTruncated argument
+    if (this.isTruncated) {
+      classes.push('hds-copy-snippet--is-truncated');
+    }
+
     // add a class based on the @isFullWidth argument
     if (this.isFullWidth) {
       classes.push('hds-copy-snippet--width-full');

--- a/packages/components/app/styles/components/copy/snippet.scss
+++ b/packages/components/app/styles/components/copy/snippet.scss
@@ -97,8 +97,13 @@
   max-width: 100%;
 }
 
-.hds-copy-snippet__text--truncated {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+.hds-copy-snippet--is-truncated {
+  width: 100%;
+  max-width: 100%;
+
+  .hds-copy-snippet__text {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 }

--- a/packages/components/app/styles/components/copy/snippet.scss
+++ b/packages/components/app/styles/components/copy/snippet.scss
@@ -15,11 +15,8 @@
   gap: 8px;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
   padding: 6px 4px;
-  white-space: normal;
   text-align: left;
-  overflow-wrap: anywhere;
   border: 1px solid transparent;
   border-radius: 5px;
   cursor: pointer;
@@ -89,7 +86,6 @@
 
 .hds-copy-snippet__text {
   flex: 1 0 0;
-  max-width: calc(100% - 24px);
 }
 
 .hds-copy-snippet__icon {
@@ -97,11 +93,8 @@
 }
 
 .hds-copy-snippet--width-full {
-  justify-content: center;
-
-  .hds-copy-snippet__text {
-    flex: 0 0 auto;
-  }
+  width: 100%;
+  max-width: 100%;
 }
 
 .hds-copy-snippet__text--truncated {

--- a/packages/components/tests/dummy/app/components/shw/grid/item.js
+++ b/packages/components/tests/dummy/app/components/shw/grid/item.js
@@ -14,6 +14,11 @@ export default class GridItemComponent extends Component {
       classes.push('shw-grid__item--grow');
     }
 
+    // add a class based on the @forceMinWidth argument
+    if (this.args.forceMinWidth === true) {
+      classes.push('shw-grid__item--force-min-width');
+    }
+
     return classes.join(' ');
   }
 }

--- a/packages/components/tests/dummy/app/styles/showcase-components/grid.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-components/grid.scss
@@ -46,6 +46,10 @@
   grid-column: 1/-1;
 }
 
+.shw-grid__item--force-min-width {
+  min-width: 0;
+}
+
 
 // DEBUG
 

--- a/packages/components/tests/dummy/app/styles/showcase-pages/button.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/button.scss
@@ -11,4 +11,10 @@ body.components-button {
       margin-top: 8px;
     }
   }
+
+  .shw-component-button-containers-divider {
+    display: block;
+    margin: 4px 0;
+    border: none;
+  }
 }

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -102,33 +102,51 @@
 
   <Shw::Text::H2>Containers</Shw::Text::H2>
 
-  <Shw::Flex as |SF|>
-    <SF.Item>
+  <Shw::Grid @columns={{4}} as |SG|>
+    <SG.Item @forceMinWidth={{true}}>
       <Shw::Label>Parent with <code>display: inline-block</code></Shw::Label>
       <div {{style display="inline-block"}}>
         <Hds::Button @icon="plus" @iconPosition="leading" @text="Lorem ipsum" />
       </div>
-    </SF.Item>
-    <SF.Item>
+      <hr class="shw-component-button-containers-divider" />
+      <div {{style display="inline-block"}}>
+        <Hds::Button @icon="plus" @text="This is a very long text that should go on multiple lines" />
+      </div>
+    </SG.Item>
+    <SG.Item @forceMinWidth={{true}}>
       <Shw::Label>Parent with <code>display: inline-flex</code></Shw::Label>
       <div {{style display="inline-flex"}}>
         <Hds::Button @icon="plus" @iconPosition="leading" @text="Lorem ipsum" />
       </div>
-    </SF.Item>
-    <SF.Item>
+      <hr class="shw-component-button-containers-divider" />
+      <div {{style display="inline-flex"}}>
+        <Hds::Button @icon="plus" @text="This is a very long text that should go on multiple lines" />
+      </div>
+    </SG.Item>
+    <SG.Item @forceMinWidth={{true}}>
       <Shw::Label>Parent with <code>flex-grow: 0</code></Shw::Label>
       <div {{style display="flex"}}>
         <div {{style flex-grow="0"}}>
           <Hds::Button @icon="plus" @iconPosition="leading" @text="Lorem ipsum" />
         </div>
       </div>
-    </SF.Item>
-    <SF.Item>
+      <hr class="shw-component-button-containers-divider" />
+      <div {{style display="flex"}}>
+        <div {{style flex-grow="0"}}>
+          <Hds::Button @icon="plus" @text="This is a very long text that should go on multiple lines" />
+        </div>
+      </div>
+    </SG.Item>
+    <SG.Item @forceMinWidth={{true}}>
       <Shw::Label>Parent with <code>max-width: fit-content</code></Shw::Label>
       <div {{style max-width="fit-content"}}>
         <Hds::Button @icon="plus" @iconPosition="leading" @text="Lorem ipsum" />
       </div>
-    </SF.Item>
-  </Shw::Flex>
+      <hr class="shw-component-button-containers-divider" />
+      <div {{style max-width="fit-content"}}>
+        <Hds::Button @icon="plus" @text="This is a very long text that should go on multiple lines" />
+      </div>
+    </SG.Item>
+  </Shw::Grid>
 
 </section>

--- a/packages/components/tests/dummy/app/templates/components/copy/snippet.hbs
+++ b/packages/components/tests/dummy/app/templates/components/copy/snippet.hbs
@@ -19,16 +19,14 @@
     <SF.Item>
       <Shw::Label>With long text (multi-line / default)</Shw::Label>
       <Shw::Outliner {{style width="300px"}}>
-        <Hds::Copy::Snippet
-          @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r with some really long text that should wrap and be multi-line"
-        />
+        <Hds::Copy::Snippet @textToCopy="With some really long text that should wrap and be multi-line" />
       </Shw::Outliner>
     </SF.Item>
     <SF.Item>
       <Shw::Label>With long text (truncated)</Shw::Label>
       <Shw::Outliner {{style width="300px"}}>
         <Hds::Copy::Snippet
-          @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r with a bunch of other long text that should force truncation if truncation is set to true"
+          @textToCopy="With some really long text that should be truncated because `isTruncated` is set to `true`"
           @isTruncated={{true}}
         />
       </Shw::Outliner>
@@ -72,6 +70,8 @@
     {{/each}}
   </Shw::Flex>
 
+  <Shw::Divider />
+
   <Shw::Text::H2>States</Shw::Text::H2>
 
   <Shw::Grid @columns={{6}} as |SG|>
@@ -94,4 +94,88 @@
       {{/let}}
     {{/each}}
   </Shw::Grid>
+
+  <Shw::Divider />
+
+  <Shw::Text::H2>Containers</Shw::Text::H2>
+
+  <Shw::Grid @columns={{3}} as |SG|>
+    {{#let (array "block" "flex" "grid") as |displays|}}
+      {{#each displays as |display|}}
+        <SG.Item @forceMinWidth={{true}}>
+          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+          <div {{style display=display overflow="hidden"}}>
+            <Hds::Copy::Snippet @textToCopy="With short text" />
+          </div>
+          <div {{style display=display overflow="hidden"}}>
+            <Hds::Copy::Snippet @textToCopy="With some really long text that should wrap and be multi-line" />
+          </div>
+          <div {{style display=display overflow="hidden"}}>
+            <Hds::Copy::Snippet
+              @textToCopy="With some really long text that should be truncated"
+              @isTruncated={{true}}
+            />
+          </div>
+        </SG.Item>
+      {{/each}}
+    {{/let}}
+  </Shw::Grid>
+
+  <Shw::Flex @label="Within a table" as |SF|>
+    <SF.Item @grow={{true}}>
+      <Hds::Table
+        @isStriped={{true}}
+        @isFixedLayout={{true}}
+        @caption="Static table used to demo different use cases of the Copy::Snippet component"
+      >
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Use case</H.Th>
+            <H.Th>Cluster partition</H.Th>
+            <H.Th>Imported services</H.Th>
+            <H.Th>Exported services</H.Th>
+            <H.Th {{style width="250px"}}>Secret key</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
+          <B.Tr>
+            <B.Th>With short text</B.Th>
+            <B.Td>cluster-2 / partition-2</B.Td>
+            <B.Td>10</B.Td>
+            <B.Td>10</B.Td>
+            <B.Td><Hds::Copy::Snippet @textToCopy="With short text" @color="secondary" /></B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Th>With short text + Full width</B.Th>
+            <B.Td>cluster-3 / partition-3</B.Td>
+            <B.Td>10</B.Td>
+            <B.Td>10</B.Td>
+            <B.Td><Hds::Copy::Snippet @textToCopy="With short text" @color="secondary" @isFullWidth={{true}} /></B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Th>With long text (wrapping)</B.Th>
+            <B.Td>cluster-3 / partition-3</B.Td>
+            <B.Td>10</B.Td>
+            <B.Td>10</B.Td>
+            <B.Td><Hds::Copy::Snippet
+                @textToCopy="With some really long text that should wrap and be multi-line"
+                @color="secondary"
+              /></B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Th>With long text + Truncation</B.Th>
+            <B.Td>cluster-3 / partition-3</B.Td>
+            <B.Td>10</B.Td>
+            <B.Td>10</B.Td>
+            <B.Td><Hds::Copy::Snippet
+                @textToCopy="With some really long text that should be truncated"
+                @color="secondary"
+                @isTruncated={{true}}
+              /></B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
+    </SF.Item>
+  </Shw::Flex>
+
 </section>

--- a/packages/components/tests/integration/components/hds/copy/snippet/index-test.js
+++ b/packages/components/tests/integration/components/hds/copy/snippet/index-test.js
@@ -65,9 +65,7 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
     await render(
       hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="someSecretThingGoesHere" @isTruncated={{true}} />`
     );
-    assert
-      .dom('#test-copy-snippet > span')
-      .hasClass('hds-copy-snippet__text--truncated');
+    assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--is-truncated');
   });
 
   test('it should have the correct CSS class to support full-width size if @isFullWidth prop is true', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

In a meeting dedicated to discuss the width/full-width behaviour of the `Code::Snippet` ([notes here](https://docs.google.com/document/d/1x6PXkwy4xtBvScZqeo8taj-n5FaAn5pVjvLfRk2Ck_M/edit))  we have decided:

- Width set to hug the contents (automatically max at 100%, since it’a a block element)
- `@isFullWidth` (default = `false`) - update to be a full-width (100%) variant 
    - (content should **not** be centered, but align to the left)
- `@isTruncated` (default = `false`) - truncates text (if true) otherwise the text wraps (if not set, or set to false)

### :hammer_and_wrench: Detailed description

In this PR I have:
- fixed the way in which “width/full-width” is applied to the `Code::Snippet`
- changed the way in which “truncation” is applied to its content
    - renamed (and moved) class name from `hds-copy-snippet__text--truncated`  to `hds-copy-snippet--is-truncated`
- updated integration tests for `Copy::Snippet`
- updated showcase for `Code::Snippet` to include “Containers” section
     - added option to the `Shw::Grid::Item` to force a `min-width` value (instead of `auto`)
     - updated “Containers” demo in showcase for `Button` elements to follow the `Copy::Snippet` one

👉 👉 👉 **Preview**: https://hds-showcase-git-update-copy-snippet-width-behaviour-hashicorp.vercel.app/components/copy/snippet

### :link: External links

Jira ticket: [TODO](https://hashicorp.atlassian.net/browse/HDS-2366)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
