### PR TITLE
`Dropdown`: modify  @height to use max-height (HDS-2513)

### DIFF
--- a/.changeset/red-comics-laugh.md
+++ b/.changeset/red-comics-laugh.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Change `Dropdown` `@height` property to use `max-height` instead of a fixed height.

--- a/.changeset/red-comics-laugh.md
+++ b/.changeset/red-comics-laugh.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Change `Dropdown` `@height` property to use `max-height` instead of a fixed height.
+`Dropdown`: changed`@height` property to use `max-height` instead of a fixed height.

--- a/packages/components/addon/components/hds/dropdown/index.hbs
+++ b/packages/components/addon/components/hds/dropdown/index.hbs
@@ -12,7 +12,7 @@
     }}
   </:toggle>
   <:content as |c|>
-    <div class={{this.classNamesContent}} {{style width=@width height=@height}}>
+    <div class={{this.classNamesContent}} {{style width=@width max-height=@height}}>
       {{yield (hash Header=(component "hds/dropdown/header"))}}
       <ul class="hds-dropdown__list" {{did-insert this.didInsertList}}>
         {{yield

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -22,7 +22,7 @@ The Dropdown component is composed of different child components each with their
     By default, the Dropdown List has a `min-width` of `200px` and a `max-width` of `400px`, so it adapts to the content size. If a `@width` parameter is provided then the list will have a fixed width.
   </C.Property>
   <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
-    If a `@height` parameter is provided then the list will have a fixed height.
+    If a `@height` parameter is provided then the list will have a max-height.
   </C.Property>
   <C.Property @name="isInline" @type="boolean" @default="false">
     If a `@isInline` parameter is provided then the element will be displayed as `inline-block` (useful to achieve specific layouts like in a container with right alignment). Otherwise it will be have a `block` layout.

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -126,6 +126,8 @@ In contexts where the Dropdown needs to be _inline_, to inherit the alignment fr
 
 You can explicitly control the height or width of a list. Any acceptable value (px, rem, em) can be declared:
 
+Note: The height property actually sets a max-height which prevents the list from growing past a certain height.
+
 ```handlebars
 <Hds::Dropdown @isInline={{true}} @height="250px" @width="250px" as |dd|>
   <dd.ToggleButton @text="Text Toggle" />

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -129,7 +129,7 @@ You can explicitly control the height or width of a list. Any acceptable value (
 Note: The `@height` argument actually sets a `max-height` which prevents the list from growing past a certain height.
 
 ```handlebars
-<Hds::Dropdown @isInline={{true}} @height="250px" @width="250px" as |dd|>
+<Hds::Dropdown @isInline={{true}} @height="170px" @width="250px" as |dd|>
   <dd.ToggleButton @text="Text Toggle" />
   <dd.Interactive @route="components" @text="Item One" />
   <dd.Interactive @route="components" @text="Item Two" />

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -126,7 +126,7 @@ In contexts where the Dropdown needs to be _inline_, to inherit the alignment fr
 
 You can explicitly control the height or width of a list. Any acceptable value (px, rem, em) can be declared:
 
-Note: The height property actually sets a max-height which prevents the list from growing past a certain height.
+Note: The `@height` argument actually sets a `max-height` which prevents the list from growing past a certain height.
 
 ```handlebars
 <Hds::Dropdown @isInline={{true}} @height="250px" @width="250px" as |dd|>

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -126,7 +126,11 @@ In contexts where the Dropdown needs to be _inline_, to inherit the alignment fr
 
 You can explicitly control the height or width of a list. Any acceptable value (px, rem, em) can be declared:
 
-Note: The `@height` argument actually sets a `max-height` which prevents the list from growing past a certain height.
+!!! Info
+
+The `@height` argument actually sets a `max-height` which prevents the list from growing past a certain height.
+
+!!!
 
 ```handlebars
 <Hds::Dropdown @isInline={{true}} @height="170px" @width="250px" as |dd|>

--- a/website/docs/components/dropdown/partials/guidelines/guidelines.md
+++ b/website/docs/components/dropdown/partials/guidelines/guidelines.md
@@ -154,7 +154,7 @@ If you do not want the width of the List to expand automatically to accommodate 
 
 #### Height
 
-The height of the ListContainer is automatically determined based on the contents, but the height can also be set manually. We recommend setting the height manually if you know the list will be long.  
+The height of the ListContainer is automatically determined based on the contents, but the height can also be set manually. We recommend setting the height manually if you know the list will be long. In code, the height property actually acts as a max-height.
 
 <div class="hds-dropdown__content" style="height: 275px">
   <Doc::ListContainer class="hds-dropdown__list">

--- a/website/docs/components/dropdown/partials/guidelines/guidelines.md
+++ b/website/docs/components/dropdown/partials/guidelines/guidelines.md
@@ -154,7 +154,7 @@ If you do not want the width of the List to expand automatically to accommodate 
 
 #### Height
 
-The height of the ListContainer is automatically determined based on the contents, but the height can also be set manually. We recommend setting the height manually if you know the list will be long. In code, the height property actually acts as a max-height.
+The height of the ListContainer is automatically determined based on the contents, but the height can also be set manually. We recommend setting the height manually if you know the list will be long. In code, the `@height` property actually acts as a `max-height`.
 
 <div class="hds-dropdown__content" style="height: 275px">
   <Doc::ListContainer class="hds-dropdown__list">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will change the `Dropdown` `@height` to use `max-height` instead of setting a fixed height.

- **Web preview:** https://hds-website-git-hds-2513-modify-dropdown-height-hashicorp.vercel.app/components/dropdown

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?
-->

### :camera_flash: Screenshots
Docs updates:
<img width="874" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/b4b74e81-8c39-4199-bd69-d39e4f3b208c">

----

<img width="852" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/30b15849-b9ce-4439-808c-97637fd52e3a">

----

<img width="852" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/b783ff61-cb9f-4676-aa94-878de5fbf6dc">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2513](https://hashicorp.atlassian.net/browse/HDS-2513)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2513]: https://hashicorp.atlassian.net/browse/HDS-2513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ