### PR TITLE
Fixing incorrect Figma links

### DIFF
--- a/website/docs/components/accordion/index.md
+++ b/website/docs/components/accordion/index.md
@@ -3,7 +3,7 @@ title: Accordion
 description: An accordion is a vertically stacked list of container-like toggles that reveal or hide associated sections of content.
 caption: A list of toggles that reveal or hide associated content.
 links:
-  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/branch/nGGr1ZOkVEPvzmq4HkASFn/HDS-Product---Components?type=design&node-id=36870-71031&t=JByoqnVP07zC5rEL-0
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=36870-71032&mode=design&t=72WLExKItFWAX1jX-4
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/accordion
 related: ['components/reveal','components/flyout','components/modal','components/tabs']
 previewImage: assets/illustrations/components/accordion.jpg

--- a/website/docs/components/form/file-input/index.md
+++ b/website/docs/components/form/file-input/index.md
@@ -3,7 +3,7 @@ title: File Input
 description: A form input that enables users to select one or more files from their local device for upload.
 caption: A form input that enables users to upload files.
 links:
-  figma: https://www.figma.com/file/kgEVRu2hmB60aZ4qb75ndt/File-input?type=design&node-id=41223-5657&mode=design
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=41671-85932&mode=design&t=72WLExKItFWAX1jX-4
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/file-input
 previewImage: assets/illustrations/components/form/file-input.jpg
 navigation:

--- a/website/docs/components/segmented-group/index.md
+++ b/website/docs/components/segmented-group/index.md
@@ -3,7 +3,7 @@ title: Segmented Group
 description: Combines one or more input fields and actions to handle complex filtering and data collection.
 caption: Combines one or more input fields and actions to handle complex filtering and data collection.
 links:
-  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=30150%3A45701&t=akpWrhSdwygOH6md-1
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=34323-69877&mode=design&t=72WLExKItFWAX1jX-4
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/segmented-group
 related: ['components/dropdown', 'components/button-set', 'patterns/filter-patterns']
 previewImage: assets/illustrations/components/form/segmented-group.jpg

--- a/website/docs/components/separator/index.md
+++ b/website/docs/components/separator/index.md
@@ -3,7 +3,7 @@ title: Separator
 description: Creates visual breaks between different sections of content
 caption: Creates visual breaks between different sections of content
 links:
-  figma: https://www.figma.com/file/9QeyvUQ8kuyIity6knrznO/Separator-Component?node-id=36433-70314&t=PXCxiaccZSis4g9x-4
+  figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=36433-70314&mode=design&t=72WLExKItFWAX1jX-4
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/separator
 previewImage: assets/illustrations/components/separator.jpg
 navigation:


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes a few incorrect Figma links.

#### Previews
Accordion: https://hds-website-git-hl-fix-figma-links-hashicorp.vercel.app/components/accordion
FileInput: https://hds-website-git-hl-fix-figma-links-hashicorp.vercel.app/components/form/file-input
SegmentedGroup: https://hds-website-git-hl-fix-figma-links-hashicorp.vercel.app/components/segmented-group
Separator: https://hds-website-git-hl-fix-figma-links-hashicorp.vercel.app/components/separator

### :hammer_and_wrench: Detailed description

There are a couple of incorrect Figma links (pointing to archived branches, incorrect pages, or an empty view) on the following components:
- Accordion
- FileInput
- SegmentedGroup
- Separator

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
