### PR TITLE
`Form::MaskedInput` - Fix logic for copy button

### DIFF
--- a/.changeset/fresh-oranges-add.md
+++ b/.changeset/fresh-oranges-add.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Form::MaskedInput` - changed copy logic for `CopyButton` used inside the component

--- a/packages/components/addon/components/hds/form/masked-input/base.hbs
+++ b/packages/components/addon/components/hds/form/masked-input/base.hbs
@@ -36,7 +36,7 @@
       class="hds-form-masked-input__copy-button"
       @text={{this.copyButtonText}}
       @isIconOnly={{true}}
-      @textToCopy="{{@value}}"
+      @targetToCopy="#{{this.id}}"
     />
   {{/if}}
 </div>


### PR DESCRIPTION
### :pushpin: Summary

See [Jira ticket](https://hashicorp.atlassian.net/browse/HDS-2519) for details.

### :hammer_and_wrench: Detailed description

In this PR I have:
- changed the copy logic for `CopyButton` used inside `Form::MaskedInput`

 👉 👉  👉 **Preview**: https://hds-showcase-git-fix-masked-input-copy-hashicorp.vercel.app/components/form/masked-input

### :camera_flash: Screenshots

As you can see from the screenshot, the value in the form field an the the value copied are different.

<img width="1068" alt="screenshot_3077" src="https://github.com/hashicorp/design-system/assets/686239/bbbe4d9e-a2b5-4f20-95ae-ee96c9304eeb">

### :link: External links

Jira ticket: [TODO](https://hashicorp.atlassian.net/browse/HDS-2519)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
