### PR TITLE
`IconTile` - Add "Vault Secrets" product

### DIFF
--- a/.changeset/nervous-lizards-wave.md
+++ b/.changeset/nervous-lizards-wave.md
@@ -1,0 +1,8 @@
+---
+"@hashicorp/design-system-components": minor
+"@hashicorp/design-system-tokens": minor
+---
+
+`Design tokens` - Added color tokens for “Vault Secrets” product
+
+`IconTile` - updated component to include `vault-secrets` product option

--- a/packages/components/addon/components/hds/icon-tile/index.js
+++ b/packages/components/addon/components/hds/icon-tile/index.js
@@ -18,6 +18,7 @@ export const PRODUCTS = [
   'terraform',
   'vagrant',
   'vault',
+  'vault-secrets',
   'waypoint',
 ];
 export const COLORS = ['neutral', ...PRODUCTS];

--- a/packages/components/app/styles/components/icon-tile.scss
+++ b/packages/components/app/styles/components/icon-tile.scss
@@ -9,7 +9,7 @@
 
 $hds-icon-tile-sizes: ( "small", "medium", "large" );
 $hds-icon-tile-types: ( "object","resource","logo" );
-$hds-icon-tile-colors-products: ( "boundary", "consul", "hcp", "nomad", "packer", "terraform", "vagrant", "vault", "waypoint" );
+$hds-icon-tile-colors-products: ( "boundary", "consul", "hcp", "nomad", "packer", "terraform", "vagrant", "vault", "vault-secrets", "waypoint" );
 $hds-icon-tile-border-width: 1px;
 $hds-icon-tile-box-shadow: 0 1px 1px rgba(#656a76, 0.05);
 

--- a/packages/components/tests/dummy/app/templates/components/icon-tile.hbs
+++ b/packages/components/tests/dummy/app/templates/components/icon-tile.hbs
@@ -54,7 +54,7 @@
 
   <Shw::Grid @columns={{5}} as |SG|>
     {{#each @model.PRODUCTS as |product|}}
-      <SG.Item @label={{capitalize product}}>
+      <SG.Item @label={{product}}>
         <Shw::Flex as |SF2|>
           {{#each @model.SIZES as |size|}}
             <SF2.Item>
@@ -72,7 +72,7 @@
     {{#each @model.COLORS as |color|}}
       {{! As agreed with designers, we prefer to hide the option of icon with "hcp" color }}
       {{#if (not-eq color "hcp")}}
-        <SG.Item @label={{capitalize color}}>
+        <SG.Item @label={{color}}>
           <Shw::Flex as |SF|>
             {{#each @model.SIZES as |size|}}
               <SF.Item>

--- a/packages/components/tests/integration/components/hds/icon-tile/index-test.js
+++ b/packages/components/tests/integration/components/hds/icon-tile/index-test.js
@@ -122,7 +122,7 @@ module('Integration | Component | hds/icon-tile/index', function (hooks) {
   });
   test('it should throw an assertion if a wrong @logo value is passed', async function (assert) {
     const errorMessage =
-      '@logo for "Hds::IconTile" must be one of the following: boundary, consul, hcp, nomad, packer, terraform, vagrant, vault, waypoint; received: test';
+      '@logo for "Hds::IconTile" must be one of the following: boundary, consul, hcp, nomad, packer, terraform, vagrant, vault, vault-secrets, waypoint; received: test';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/packages/tokens/dist/devdot/css/tokens.css
+++ b/packages/tokens/dist/devdot/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 28 Jun 2023 07:32:09 GMT
+ * Generated on Fri, 15 Sep 2023 06:10:51 GMT
  */
 
 :root {
@@ -144,6 +144,15 @@
   --token-color-vagrant-gradient-primary-stop: #7dadff;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
+  --token-color-vault-secrets-brand: #ffd814;
+  --token-color-vault-secrets-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work */
+  --token-color-vault-secrets-foreground: #9a6f00;
+  --token-color-vault-secrets-surface: #fff9cf;
+  --token-color-vault-secrets-border: #feec7b;
+  --token-color-vault-secrets-gradient-primary-start: #feec7b;
+  --token-color-vault-secrets-gradient-primary-stop: #ffe543;
+  --token-color-vault-secrets-gradient-faint-start: #fffdf2; /* this is the 'vault-secrets-50' value at 25% opacity on white */
+  --token-color-vault-secrets-gradient-faint-stop: #fff9cf;
   --token-color-vault-brand: #ffd814;
   --token-color-vault-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work */
   --token-color-vault-foreground: #9a6f00;

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -3028,6 +3028,215 @@
     "type": "color",
     "group": "branding",
     "original": {
+      "value": "{color.palette.vault-secrets-brand.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-secrets-brand",
+    "attributes": {
+      "category": "color",
+      "type": "vault-secrets",
+      "item": "brand"
+    },
+    "path": [
+      "color",
+      "vault-secrets",
+      "brand"
+    ]
+  },
+  {
+    "value": "#000000",
+    "type": "color",
+    "group": "branding",
+    "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work",
+    "original": {
+      "value": "#000",
+      "type": "color",
+      "group": "branding",
+      "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work"
+    },
+    "name": "token-color-vault-secrets-brand-alt",
+    "attributes": {
+      "category": "color",
+      "type": "vault-secrets",
+      "item": "brand-alt"
+    },
+    "path": [
+      "color",
+      "vault-secrets",
+      "brand-alt"
+    ]
+  },
+  {
+    "value": "#9a6f00",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-secrets-500.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-secrets-foreground",
+    "attributes": {
+      "category": "color",
+      "type": "vault-secrets",
+      "item": "foreground"
+    },
+    "path": [
+      "color",
+      "vault-secrets",
+      "foreground"
+    ]
+  },
+  {
+    "value": "#fff9cf",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-secrets-50.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-secrets-surface",
+    "attributes": {
+      "category": "color",
+      "type": "vault-secrets",
+      "item": "surface"
+    },
+    "path": [
+      "color",
+      "vault-secrets",
+      "surface"
+    ]
+  },
+  {
+    "value": "#feec7b",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-secrets-100.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-secrets-border",
+    "attributes": {
+      "category": "color",
+      "type": "vault-secrets",
+      "item": "border"
+    },
+    "path": [
+      "color",
+      "vault-secrets",
+      "border"
+    ]
+  },
+  {
+    "value": "#feec7b",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-secrets-100.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-secrets-gradient-primary-start",
+    "attributes": {
+      "category": "color",
+      "type": "vault-secrets",
+      "item": "gradient",
+      "subitem": "primary",
+      "state": "start"
+    },
+    "path": [
+      "color",
+      "vault-secrets",
+      "gradient",
+      "primary",
+      "start"
+    ]
+  },
+  {
+    "value": "#ffe543",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-secrets-200.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-secrets-gradient-primary-stop",
+    "attributes": {
+      "category": "color",
+      "type": "vault-secrets",
+      "item": "gradient",
+      "subitem": "primary",
+      "state": "stop"
+    },
+    "path": [
+      "color",
+      "vault-secrets",
+      "gradient",
+      "primary",
+      "stop"
+    ]
+  },
+  {
+    "value": "#fffdf2",
+    "type": "color",
+    "group": "branding",
+    "comment": "this is the 'vault-secrets-50' value at 25% opacity on white",
+    "original": {
+      "value": "#fffdf2",
+      "type": "color",
+      "group": "branding",
+      "comment": "this is the 'vault-secrets-50' value at 25% opacity on white"
+    },
+    "name": "token-color-vault-secrets-gradient-faint-start",
+    "attributes": {
+      "category": "color",
+      "type": "vault-secrets",
+      "item": "gradient",
+      "subitem": "faint",
+      "state": "start"
+    },
+    "path": [
+      "color",
+      "vault-secrets",
+      "gradient",
+      "faint",
+      "start"
+    ]
+  },
+  {
+    "value": "#fff9cf",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-secrets-50.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-secrets-gradient-faint-stop",
+    "attributes": {
+      "category": "color",
+      "type": "vault-secrets",
+      "item": "gradient",
+      "subitem": "faint",
+      "state": "stop"
+    },
+    "path": [
+      "color",
+      "vault-secrets",
+      "gradient",
+      "faint",
+      "stop"
+    ]
+  },
+  {
+    "value": "#ffd814",
+    "type": "color",
+    "group": "branding",
+    "original": {
       "value": "{color.palette.vault-brand.value}",
       "type": "color",
       "group": "branding"

--- a/packages/tokens/dist/marketing/css/tokens.css
+++ b/packages/tokens/dist/marketing/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 21 Jul 2023 16:17:00 GMT
+ * Generated on Fri, 15 Sep 2023 06:10:51 GMT
  */
 
 :root {
@@ -142,6 +142,15 @@
   --token-color-vagrant-gradient-primary-stop: #7dadff;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
+  --token-color-vault-secrets-brand: #ffd814;
+  --token-color-vault-secrets-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work */
+  --token-color-vault-secrets-foreground: #9a6f00;
+  --token-color-vault-secrets-surface: #fff9cf;
+  --token-color-vault-secrets-border: #feec7b;
+  --token-color-vault-secrets-gradient-primary-start: #feec7b;
+  --token-color-vault-secrets-gradient-primary-stop: #ffe543;
+  --token-color-vault-secrets-gradient-faint-start: #fffdf2; /* this is the 'vault-secrets-50' value at 25% opacity on white */
+  --token-color-vault-secrets-gradient-faint-stop: #fff9cf;
   --token-color-vault-brand: #ffd814;
   --token-color-vault-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work */
   --token-color-vault-foreground: #9a6f00;

--- a/packages/tokens/dist/marketing/tokens.json
+++ b/packages/tokens/dist/marketing/tokens.json
@@ -3368,6 +3368,241 @@
         }
       }
     },
+    "vault-secrets": {
+      "brand": {
+        "value": "#ffd814",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault-secrets.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-secrets-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-secrets-brand",
+        "attributes": {
+          "category": "color",
+          "type": "vault-secrets",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "vault-secrets",
+          "brand"
+        ]
+      },
+      "brand-alt": {
+        "value": "#000000",
+        "type": "color",
+        "group": "branding",
+        "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work",
+        "filePath": "src/products/shared/color/semantic-product-vault-secrets.json",
+        "isSource": true,
+        "original": {
+          "value": "#000",
+          "type": "color",
+          "group": "branding",
+          "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work"
+        },
+        "name": "token-color-vault-secrets-brand-alt",
+        "attributes": {
+          "category": "color",
+          "type": "vault-secrets",
+          "item": "brand-alt"
+        },
+        "path": [
+          "color",
+          "vault-secrets",
+          "brand-alt"
+        ]
+      },
+      "foreground": {
+        "value": "#9a6f00",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault-secrets.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-secrets-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-secrets-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "vault-secrets",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "vault-secrets",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#fff9cf",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault-secrets.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-secrets-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-secrets-surface",
+        "attributes": {
+          "category": "color",
+          "type": "vault-secrets",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "vault-secrets",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#feec7b",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault-secrets.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-secrets-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-secrets-border",
+        "attributes": {
+          "category": "color",
+          "type": "vault-secrets",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "vault-secrets",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#feec7b",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault-secrets.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-secrets-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-secrets-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "vault-secrets",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vault-secrets",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#ffe543",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault-secrets.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-secrets-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-secrets-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vault-secrets",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vault-secrets",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#fffdf2",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'vault-secrets-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-vault-secrets.json",
+            "isSource": true,
+            "original": {
+              "value": "#fffdf2",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'vault-secrets-50' value at 25% opacity on white"
+            },
+            "name": "token-color-vault-secrets-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "vault-secrets",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vault-secrets",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#fff9cf",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault-secrets.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-secrets-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-secrets-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vault-secrets",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vault-secrets",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
     "vault": {
       "brand": {
         "value": "#ffd814",

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 28 Jun 2023 07:32:09 GMT
+ * Generated on Fri, 15 Sep 2023 06:10:51 GMT
  */
 
 :root {
@@ -142,6 +142,15 @@
   --token-color-vagrant-gradient-primary-stop: #7dadff;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
+  --token-color-vault-secrets-brand: #ffd814;
+  --token-color-vault-secrets-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work */
+  --token-color-vault-secrets-foreground: #9a6f00;
+  --token-color-vault-secrets-surface: #fff9cf;
+  --token-color-vault-secrets-border: #feec7b;
+  --token-color-vault-secrets-gradient-primary-start: #feec7b;
+  --token-color-vault-secrets-gradient-primary-stop: #ffe543;
+  --token-color-vault-secrets-gradient-faint-start: #fffdf2; /* this is the 'vault-secrets-50' value at 25% opacity on white */
+  --token-color-vault-secrets-gradient-faint-stop: #fff9cf;
   --token-color-vault-brand: #ffd814;
   --token-color-vault-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work */
   --token-color-vault-foreground: #9a6f00;

--- a/packages/tokens/scripts/build-parts/generateColorHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateColorHelpers.ts
@@ -32,7 +32,7 @@ export function generateColorHelpers(tokens: TransformedToken[]): Helpers {
                 // notice: we assume a 1px border (if a user needs a different border width, and want to use the helper, they have to apply an override)
                 helpers.push(`.${PREFIX}-${context}-${name} { border: 1px solid var(--${token.name}); }`)
             }
-        } else if (['hashicorp', 'hcp', 'boundary','consul','nomad','packer','terraform','vagrant','vault','waypoint'].includes(group)) {
+        } else if (['hashicorp', 'hcp', 'boundary','consul','nomad','packer','terraform','vagrant','vault','vault-secrets','waypoint'].includes(group)) {
             // TODO!
             // to be discussed if we want to expose all these colors as helpers
         } else if (group === 'palette') {

--- a/packages/tokens/src/global/color/palette-products.json
+++ b/packages/tokens/src/global/color/palette-products.json
@@ -349,6 +349,54 @@
                 "group": "palette",
                 "private": "true"
             },
+            "vault-secrets-brand": {
+                "value": "#ffd814",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-secrets-600": {
+                "value": "#8b6400",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-secrets-500": {
+                "value": "#9a6f00",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-secrets-400": {
+                "value": "#bb8e1a",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-secrets-300": {
+                "value": "#f5d712",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-secrets-200": {
+                "value": "#ffe543",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-secrets-100": {
+                "value": "#feec7b",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-secrets-50": {
+                "value": "#fff9cf",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
             "waypoint-brand": {
                 "value": "#14c6cb",
                 "type": "color",

--- a/packages/tokens/src/products/shared/color/semantic-product-vault-secrets.json
+++ b/packages/tokens/src/products/shared/color/semantic-product-vault-secrets.json
@@ -1,0 +1,59 @@
+{
+    "color": {
+        "vault-secrets": {
+            "brand": {
+                "value": "{color.palette.vault-secrets-brand.value}",
+                "type": "color",
+                "group": "branding"
+            },
+            "brand-alt": {
+                "value": "#000",
+                "type": "color",
+                "group": "branding",
+                "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work"
+            },
+            "foreground": {
+                "value": "{color.palette.vault-secrets-500.value}",
+                "type": "color",
+                "group": "branding"
+            },
+            "surface": {
+                "value": "{color.palette.vault-secrets-50.value}",
+                "type": "color",
+                "group": "branding"
+            },
+            "border": {
+                "value": "{color.palette.vault-secrets-100.value}",
+                "type": "color",
+                "group": "branding"
+            },
+            "gradient": {
+                "primary": {
+                    "start": {
+                        "value": "{color.palette.vault-secrets-100.value}",
+                        "type": "color",
+                        "group": "branding"
+                    },
+                    "stop": {
+                        "value": "{color.palette.vault-secrets-200.value}",
+                        "type": "color",
+                        "group": "branding"
+                    }
+                },
+                "faint": {
+                    "start": {
+                        "value": "#fffdf2",
+                        "type": "color",
+                        "group": "branding",
+                        "comment": "this is the 'vault-secrets-50' value at 25% opacity on white"
+                    },
+                    "stop": {
+                        "value": "{color.palette.vault-secrets-50.value}",
+                        "type": "color",
+                        "group": "branding"
+                    }
+                }
+            }
+       }
+    }
+}

--- a/website/cspell-config/project-words.txt
+++ b/website/cspell-config/project-words.txt
@@ -46,6 +46,7 @@ dismissibility
 terraform
 packer
 vault
+vault-secrets
 boundary
 consul
 nomad

--- a/website/docs/components/icon-tile/partials/code/component-api.md
+++ b/website/docs/components/icon-tile/partials/code/component-api.md
@@ -2,7 +2,7 @@
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
-  <C.Property @name="logo" @type="enum" @values={{array "hcp" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "waypoint" }}>
+  <C.Property @name="logo" @type="enum" @values={{array "hcp" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "waypoint" }}>
     Use this parameter to show a product logo.
   </C.Property>
   <C.Property @name="icon" @type="string">
@@ -11,7 +11,7 @@
   <C.Property @name="iconSecondary" @type="string">
     Use this parameter to show an extra “badge” with icon on top of the tile. Any [icon](/icons/library) name is acceptable. The color of the secondary icon is predefined and can’t be changed.
   </C.Property>
-  <C.Property @name="color" @type="enum" @values={{array "neutral" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "waypoint" }} @default="neutral">
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "waypoint" }} @default="neutral">
     The `@color` parameter is overwritten if a `@logo` parameter is passed, in which case the product “brand“ color is used.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/icon-tile/partials/guidelines/guidelines.md
+++ b/website/docs/components/icon-tile/partials/guidelines/guidelines.md
@@ -32,6 +32,7 @@ Use a **product-specific color** for objects or pages directly related to a prod
   <Hds::IconTile @color="terraform" @icon="grid" />
   <Hds::IconTile @color="vagrant" @icon="box" />
   <Hds::IconTile @color="vault" @icon="key" />
+  <Hds::IconTile @color="vault-secrets" @icon="fingerprint" />
   <Hds::IconTile @color="waypoint" @icon="cloud-upload" />
 </Doc::Layout>
 

--- a/website/docs/testing/components/layout/index.md
+++ b/website/docs/testing/components/layout/index.md
@@ -26,6 +26,7 @@ Hds::IconTile components are used in the examples below but you could use Doc::L
   <Hds::IconTile @color="terraform" @icon="grid" />
   <Hds::IconTile @color="vagrant" @icon="box" />
   <Hds::IconTile @color="vault" @icon="key" />
+  <Hds::IconTile @color="vault-secrets" @icon="fingerprint" />
   <Hds::IconTile @color="waypoint" @icon="cloud-upload" />
 </Doc::Layout>
 ```


### PR DESCRIPTION
### :pushpin: Summary

This is the counterpart of the work done in design to add the "Vault Secrets" product option to the `IconTile` component.

### :hammer_and_wrench: Detailed description

In this PR I have:

**design tokens**
- added color design tokens for “Vault Secrets” product
- added “vault-secrets” to CSS color helpers generator
- regenerated design tokens in output

**components**
- updated `IconTile` code to include `vault-secrets`
- did a little tweak to the `IconTile` showcase
- updated integration test for `IconTile`

👉 👉 👉 **Preview**: https://hds-showcase-git-add-vault-secrets-to-icon-tile-hashicorp.vercel.app/components/icon-tile

### :camera_flash: Screenshots

<img width="1036" alt="modified" src="https://github.com/hashicorp/design-system/assets/686239/55120d1e-04af-4be1-a9e8-751493085c4c">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2517

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
