### PR TITLE
`Copy::Snippet` - Fix background color for different states

### DIFF
--- a/.changeset/clean-yaks-cross.md
+++ b/.changeset/clean-yaks-cross.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Copy::Snippet` - fixed background colors for different states according to Figma specs (main change is the default/base background is now transparent, not white)

--- a/packages/components/app/styles/components/copy/snippet.scss
+++ b/packages/components/app/styles/components/copy/snippet.scss
@@ -24,11 +24,12 @@
 
 .hds-copy-snippet--color-primary {
   color: var(--token-color-foreground-action);
-  background-color: var(--token-color-surface-interactive);
+  background-color: transparent;
 
   &:hover,
   &.mock-hover {
     color: var(--token-color-foreground-action-hover);
+    background-color: var(--token-color-surface-interactive);
     border-color: var(--token-color-border-strong);
   }
 
@@ -38,14 +39,19 @@
     background-color: var(--token-color-surface-interactive-active);
     border-color: var(--token-color-border-strong);
   }
+
+  &:focus {
+    background-color: transparent;
+  }
 }
 
 .hds-copy-snippet--color-secondary {
   color: var(--token-color-foreground-primary);
-  background-color: var(--token-color-surface-interactive);
+  background-color: transparent;
 
   &:hover,
   &.mock-hover {
+    background-color: var(--token-color-surface-interactive);
     border-color: var(--token-color-border-strong);
   }
 
@@ -73,12 +79,16 @@
 }
 
 .hds-copy-snippet--status-success {
+  background-color: var(--token-color-surface-interactive);
+
   .hds-copy-snippet__icon {
     color: var(--token-color-foreground-success);
   }
 }
 
 .hds-copy-snippet--status-error {
+  background-color: var(--token-color-surface-interactive);
+
   .hds-copy-snippet__icon {
     color: var(--token-color-foreground-critical);
   }

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -34,6 +34,7 @@
 @import "./showcase-pages/button";
 @import "./showcase-pages/card";
 @import "./showcase-pages/copy/button";
+@import "./showcase-pages/copy/snippet";
 @import "./showcase-pages/disclosure-primitive";
 @import "./showcase-pages/dismiss-button";
 @import "./showcase-pages/dropdown";

--- a/packages/components/tests/dummy/app/styles/showcase-pages/copy/snippet.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/copy/snippet.scss
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// COPY > SNIPPET
+
+body.components-copy-snippet {
+  .shw-component-copy-snippet-state-container-chequered-background {
+    background-image: url('data:image/svg+xml,<svg width="6" height="6" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill="%23000" fill-opacity="0.1" d="M0 0h3v3H0zM3 3h3v3H3z"/></svg>');
+    background-size: 12px 12px;
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/copy/snippet.hbs
+++ b/packages/components/tests/dummy/app/templates/components/copy/snippet.hbs
@@ -78,7 +78,18 @@
     {{#each @model.COLORS as |color|}}
       {{#each @model.STATES as |state|}}
         <SG.Item @label={{if (eq color "primary") (capitalize state)}}>
-          <Hds::Copy::Snippet @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r" @color={{color}} mock-state-value={{state}} />
+          <div
+            class={{if
+              (or (eq state "default") (eq state "focus"))
+              "shw-component-copy-snippet-state-container-chequered-background"
+            }}
+          >
+            <Hds::Copy::Snippet
+              @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r"
+              @color={{color}}
+              mock-state-value={{state}}
+            />
+          </div>
         </SG.Item>
       {{/each}}
       {{#let (array "success" "error") as |statuses|}}


### PR DESCRIPTION
### :pushpin: Summary

For details see Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2515

### :hammer_and_wrench: Detailed description

In this PR I have:
- fixed the `background` colors for `Copy::Snippet` according to Figma specs (see screenshot below)
- updated showcase of “Statuses” section for `Copy::Snippet`

 👉👉 👉 **Preview**: https://hds-showcase-git-copy-snippet-remove-white-background-hashicorp.vercel.app/components/copy/snippet

### :camera_flash: Screenshots

Background colors as they are in Figma:

<img width="749" alt="screenshot_3086" src="https://github.com/hashicorp/design-system/assets/686239/7c4e5fbe-5c94-43c3-a272-a42eb2bb153e">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2515

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [ ] A11y tests have been run locally
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
