### PR TITLE
skip ember-flight-icons tests if no files changed

### DIFF
--- a/.github/scripts/filter_changed_files_efi.sh
+++ b/.github/scripts/filter_changed_files_efi.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+trigger_ci=false
+
+# If we are on main we want to always run the tests
+if [[ $GITHUB_REF_NAME == "main" ]]; then
+	trigger_ci=true
+	echo "On main, running CI: $trigger_ci"
+	echo "trigger-ci=$trigger_ci" >>"$GITHUB_OUTPUT"
+	exit 0
+fi
+
+# Get the list of changed files
+files_to_check=$(git diff --name-only origin/main)
+
+# Define the directories to check
+included_directories=("packages/ember-flight-icons")
+
+# Loop through the changed files and find directories/files that trigger need for tests
+for file_to_check in $files_to_check; do
+	file_is_included=false
+	for dir in "${included_directories[@]}"; do
+		if [[ $file_to_check == "$dir"* ]]; then
+			file_is_included=true
+			break
+		fi
+	done
+	# if we get a match we can note that and exit without looping over other files
+	if [ "$file_is_included" = "true" ]; then
+		trigger_ci=true
+		echo "Ember Flight Icon package files changed - triggered ci: $trigger_ci"
+		echo "trigger-ci=$trigger_ci" >>"$GITHUB_OUTPUT"
+		exit 0
+	fi
+done
+
+echo "trigger-ci=$trigger_ci" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/ci-ember-flight-icons.yml
+++ b/.github/workflows/ci-ember-flight-icons.yml
@@ -14,10 +14,24 @@ concurrency:
    cancel-in-progress: true
 
 jobs:
+    conditional-skip:
+    runs-on: ubuntu-latest 
+    name: Get files changed and conditionally skip CI
+    outputs:
+      trigger-ci: ${{ steps.read-files.outputs.trigger-ci }}
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          fetch-depth: 0  
+      - name: Get changed files
+        id: read-files
+        run: ./.github/scripts/filter_changed_files_efi.sh
+
   lint:
+    needs: [conditional-skip]
     name: "Lint"
     runs-on: ubuntu-latest
-
+    if: needs.conditional-skip.outputs.trigger-ci == 'true' || 
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Install Node


### PR DESCRIPTION
### :pushpin: Summary

Alternative to https://github.com/hashicorp/design-system/pull/1637 which is more complex for us but has the benefit of allowing the jobs to be skipped and show as "Success" (similar to if it had run and passed) vs "pending". Heavily inspired by how Consul set theirs up.

Starting small with ember-flight-icons as an experiment.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2157](https://hashicorp.atlassian.net/browse/HDS-2157)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2157]: https://hashicorp.atlassian.net/browse/HDS-2157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ