### PR TITLE
Added missing acceptance tests

### DIFF
--- a/website/app/initializers/showdown-extensions.js
+++ b/website/app/initializers/showdown-extensions.js
@@ -91,7 +91,7 @@ export function initialize(/* application */) {
         // escape { and } for the code sample
         highlightedCodeBlock = highlightedCodeBlock.replace(/{/g, '&#123;').replace(/}/g, '&#125;')
 
-        let preBlock = `<pre class="doc-code-block__code-snippet language-${language}"><code ${language ? `class="${language} language-${language}"` : ''}>${highlightedCodeBlock}</code></pre>`;
+        let preBlock = `<pre class="doc-code-block__code-snippet language-${language}" tabindex="0"><code ${language ? `class="${language} language-${language}"` : ''}>${highlightedCodeBlock}</code></pre>`;
 
         let autoExecuteLanguages = ['html', 'handlebars', 'hbs'];
 

--- a/website/tests/acceptance/components/accordion-test.js
+++ b/website/tests/acceptance/components/accordion-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/accordion', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/accordion', async function (assert) {
+    await visit('/components/accordion');
+
+    assert.strictEqual(currentURL(), '/components/accordion');
+  });
+  test('Components/accordion page passes a11y automated checks', async function (assert) {
+    await visit('/components/accordion');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/application-state-test.js
+++ b/website/tests/acceptance/components/application-state-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/application-state', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/application-state', async function (assert) {
+    await visit('/components/application-state');
+
+    assert.strictEqual(currentURL(), '/components/application-state');
+  });
+  test('Components/application-state page passes a11y automated checks', async function (assert) {
+    await visit('/components/application-state');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/copy/button-test.js
+++ b/website/tests/acceptance/components/copy/button-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/copy/button', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/copy/button', async function (assert) {
+    await visit('/components/copy/button');
+
+    assert.strictEqual(currentURL(), '/components/copy/button');
+  });
+  test('Components/copy/button page passes a11y automated checks', async function (assert) {
+    await visit('/components/copy/button');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/copy/snippet-test.js
+++ b/website/tests/acceptance/components/copy/snippet-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/copy/snippet', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/copy/snippet', async function (assert) {
+    await visit('/components/copy/snippet');
+
+    assert.strictEqual(currentURL(), '/components/copy/snippet');
+  });
+  test('Components/copy/snippet page passes a11y automated checks', async function (assert) {
+    await visit('/components/copy/snippet');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/flyout-test.js
+++ b/website/tests/acceptance/components/flyout-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/flyout', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/flyout', async function (assert) {
+    await visit('/components/flyout');
+
+    assert.strictEqual(currentURL(), '/components/flyout');
+  });
+  test('Components/flyout page passes a11y automated checks', async function (assert) {
+    await visit('/components/flyout');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/page-header-test.js
+++ b/website/tests/acceptance/components/page-header-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/page-header', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/page-header', async function (assert) {
+    await visit('/components/page-header');
+
+    assert.strictEqual(currentURL(), '/components/page-header');
+  });
+  test('Components/page-header page passes a11y automated checks', async function (assert) {
+    await visit('/components/page-header');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/pagination-test.js
+++ b/website/tests/acceptance/components/pagination-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/pagination', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/pagination', async function (assert) {
+    await visit('/components/pagination');
+
+    assert.strictEqual(currentURL(), '/components/pagination');
+  });
+  test('Components/pagination page passes a11y automated checks', async function (assert) {
+    await visit('/components/pagination');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/reveal-test.js
+++ b/website/tests/acceptance/components/reveal-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/reveal', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/reveal', async function (assert) {
+    await visit('/components/reveal');
+
+    assert.strictEqual(currentURL(), '/components/reveal');
+  });
+  test('Components/reveal page passes a11y automated checks', async function (assert) {
+    await visit('/components/reveal');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/segmented-group-test.js
+++ b/website/tests/acceptance/components/segmented-group-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | index', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/segmented-group', async function (assert) {
+    await visit('/components/segmented-group');
+
+    assert.strictEqual(currentURL(), '/components/segmented-group');
+  });
+  test('Components/segmented-group page passes a11y automated checks', async function (assert) {
+    await visit('/components/segmented-group');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/separator-test.js
+++ b/website/tests/acceptance/components/separator-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/separator', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/separator', async function (assert) {
+    await visit('/components/separator');
+
+    assert.strictEqual(currentURL(), '/components/separator');
+  });
+  test('Components/separator page passes a11y automated checks', async function (assert) {
+    await visit('/components/separator');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/side-nav-test.js
+++ b/website/tests/acceptance/components/side-nav-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/side-nav', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/side-nav', async function (assert) {
+    await visit('/components/side-nav');
+
+    assert.strictEqual(currentURL(), '/components/side-nav');
+  });
+  test('Components/side-nav page passes a11y automated checks', async function (assert) {
+    let axeOptions = {
+      rules: {
+        'duplicate-id-aria': { enabled: false },
+        'duplicate-id-active': { enabled: false },
+      },
+    };
+    await visit('/components/side-nav');
+
+    await a11yAudit(axeOptions);
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/text-test.js
+++ b/website/tests/acceptance/components/text-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/text', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/text', async function (assert) {
+    await visit('/components/text');
+
+    assert.strictEqual(currentURL(), '/components/text');
+  });
+  test('Components/text page passes a11y automated checks', async function (assert) {
+    let axeOptions = {
+      rules: {
+        'heading-order': {
+          enabled: false,
+        },
+      },
+    };
+
+    await visit('/components/text');
+
+    await a11yAudit(axeOptions);
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/tests/acceptance/components/tooltip-test.js
+++ b/website/tests/acceptance/components/tooltip-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/tooltip', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/tooltip', async function (assert) {
+    await visit('/components/tooltip');
+
+    assert.strictEqual(currentURL(), '/components/tooltip');
+  });
+  test('Components/tooltip page passes a11y automated checks', async function (assert) {
+    await visit('/components/tooltip');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds the missing component page acceptance tests for the website. 

### :hammer_and_wrench: Detailed description

- adds acceptance tests with a11y audits for component pages that did not have them yet
- adds ability to keyboard navigate scrollable regions

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
