### PR TITLE
`Text` component - Fix issue with whitespace

### DIFF
--- a/.changeset/wise-peas-deliver.md
+++ b/.changeset/wise-peas-deliver.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Text` - Fixed issue with whitespace adding extra underline when used in links (eg. inside a `Link::Inline`)

--- a/packages/components/addon/components/hds/text/body.hbs
+++ b/packages/components/addon/components/hds/text/body.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Hds::Text
   @group="body"
   @size={{this.size}}

--- a/packages/components/addon/components/hds/text/code.hbs
+++ b/packages/components/addon/components/hds/text/code.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Hds::Text
   @group="code"
   @size={{this.size}}

--- a/packages/components/addon/components/hds/text/display.hbs
+++ b/packages/components/addon/components/hds/text/display.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Hds::Text
   @group="display"
   @size={{this.size}}

--- a/packages/components/addon/components/hds/text/index.hbs
+++ b/packages/components/addon/components/hds/text/index.hbs
@@ -2,7 +2,9 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
-{{#let (element this.componentTag) as |Tag|}}
-  <Tag class={{this.classNames}} {{style color=this.customColor}} ...attributes>{{yield}}</Tag>
-{{/let}}
+{{! IMPORTANT: we removed any extra newlines before/after the `let` to reduce the issues with unexpected whitespaces (see https://github.com/hashicorp/design-system/pull/1652) }}
+{{#let (element this.componentTag) as |Tag|}}<Tag
+    class={{this.classNames}}
+    {{style color=this.customColor}}
+    ...attributes
+  >{{yield}}</Tag>{{/let}}

--- a/packages/components/tests/dummy/app/templates/components/link/inline.hbs
+++ b/packages/components/tests/dummy/app/templates/components/link/inline.hbs
@@ -34,25 +34,81 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider />
+
   <Shw::Text::H2>Content</Shw::Text::H2>
 
-  <Shw::Flex as |SF|>
-    <SF.Item @label="Only text">
+  <Shw::Grid
+    @columns={{3}}
+    {{style width="fit-content" grid-template-columns="repeat(3, auto)" gap="1rem 2rem"}}
+    as |SG|
+  >
+    <SG.Item @label="Only text">
       <div class="hds-typography-body-300">
-        <Hds::Link::Inline @color="primary" @href="#">Lorem ipsum</Hds::Link::Inline>
+        <Hds::Link::Inline @color="primary" @href="#">Lorem ipsum dolor</Hds::Link::Inline>
       </div>
-    </SF.Item>
-    <SF.Item @label="Text + leading icon">
+    </SG.Item>
+    <SG.Item @label="Text + leading icon">
       <div class="hds-typography-body-300">
-        <Hds::Link::Inline @color="primary" @icon="globe" @iconPosition="leading" @href="#">Lorem ipsum</Hds::Link::Inline>
+        <Hds::Link::Inline @color="primary" @icon="globe" @iconPosition="leading" @href="#">Lorem ipsum dolor</Hds::Link::Inline>
       </div>
-    </SF.Item>
-    <SF.Item @label="Text + trailing icon">
+    </SG.Item>
+    <SG.Item @label="Text + trailing icon">
       <div class="hds-typography-body-300">
-        <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#">Lorem ipsum</Hds::Link::Inline>
+        <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#">Lorem ipsum
+          dolor</Hds::Link::Inline>
       </div>
-    </SF.Item>
-  </Shw::Flex>
+    </SG.Item>
+    <SG.Item @label="HDS::Text::Body">
+      <Hds::Link::Inline @color="primary" @href="#"><Hds::Text::Body @size="300" @tag="span">Lorem ipsum dolor</Hds::Text::Body></Hds::Link::Inline>
+    </SG.Item>
+    <SG.Item @label="HDS::Text::Body + leading icon">
+      <Hds::Link::Inline @color="primary" @icon="globe" @iconPosition="leading" @href="#"><Hds::Text::Body
+          @size="300"
+          @tag="span"
+        >Lorem ipsum dolor</Hds::Text::Body></Hds::Link::Inline>
+    </SG.Item>
+    <SG.Item @label="HDS::Text::Body + trailing icon">
+      <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#"><Hds::Text::Body
+          @size="300"
+          @tag="span"
+        >Lorem ipsum dolor</Hds::Text::Body></Hds::Link::Inline>
+    </SG.Item>
+    <SG.Item @label="HDS::Text::Display">
+      <Hds::Link::Inline @color="primary" @href="#"><Hds::Text::Display @size="200" @tag="span">Lorem ipsum dolor</Hds::Text::Display></Hds::Link::Inline>
+    </SG.Item>
+    <SG.Item @label="HDS::Text::Display + leading icon">
+      <Hds::Link::Inline @color="primary" @icon="globe" @iconPosition="leading" @href="#"><Hds::Text::Display
+          @size="200"
+          @tag="span"
+        >Lorem ipsum dolor</Hds::Text::Display></Hds::Link::Inline>
+    </SG.Item>
+    <SG.Item @label="HDS::Text::Display + trailing icon">
+      <Hds::Link::Inline
+        @color="primary"
+        @icon="arrow-right-circle"
+        @iconPosition="trailing"
+        @href="#"
+      ><Hds::Text::Display @size="200" @tag="span">Lorem ipsum dolor</Hds::Text::Display></Hds::Link::Inline>
+    </SG.Item>
+    <SG.Item @label="HDS::Text::Code">
+      <Hds::Link::Inline @color="primary" @href="#"><Hds::Text::Code @size="200" @tag="code">Lorem ipsum dolor</Hds::Text::Code></Hds::Link::Inline>
+    </SG.Item>
+    <SG.Item @label="HDS::Text::Code + leading icon">
+      <Hds::Link::Inline @color="primary" @icon="globe" @iconPosition="leading" @href="#"><Hds::Text::Code
+          @size="200"
+          @tag="code"
+        >Lorem ipsum dolor</Hds::Text::Code></Hds::Link::Inline>
+    </SG.Item>
+    <SG.Item @label="HDS::Text::Code + trailing icon">
+      <Hds::Link::Inline @color="primary" @icon="arrow-right-circle" @iconPosition="trailing" @href="#"><Hds::Text::Code
+          @size="200"
+          @tag="code"
+        >Lorem ipsum dolor</Hds::Text::Code></Hds::Link::Inline>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Flex as |SF|>
     <SF.Item @label="With different text sizes">
@@ -83,6 +139,8 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Grid @columns={{3}} as |SG|>
     <SG.Item @label="Within text block">
       <div class="hds-typography-body-300">
@@ -105,6 +163,8 @@
       </div>
     </SG.Item>
   </Shw::Grid>
+
+  <Shw::Divider />
 
   <Shw::Text::H2>States</Shw::Text::H2>
 


### PR DESCRIPTION
### :pushpin: Summary

While reviewing #1623 and doing some tests with the `Hds::Link::Inline` in combination with the `Hds::Text` component, I noticed a classic effect of whitespace in Ember components: an extra underline in the links.

This PR intends to address this issue.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the showcase for the `Link::Inline` to add use some cases where the text is rendered using the `<Hds::Text>` component (for all the styles: `Body`, `Display`, `Code`)
- then fixed the issue of whitespace in `Text` component by removing extra newlines in a few files

👉 👉 👉 **Preview**: https://hds-showcase-git-fix-whitespace-in-text-component-hashicorp.vercel.app/components/link/inline

Notice: I am considering this a patch, but if you have different opinions happy to increase the semver

### :camera_flash: Screenshots

**Before:**
<img width="608" alt="modified" src="https://github.com/hashicorp/design-system/assets/686239/fea20ae2-640a-4cae-ab38-62637fedcc73">

**After:**
<img width="624" alt="screenshot_3099" src="https://github.com/hashicorp/design-system/assets/686239/d5099d9a-dac1-41a5-9b6d-c45e6045bf5b">

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
