### PR TITLE
Control the selectedTabIndex from the consuming application

### DIFF
--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -37,7 +37,7 @@
         willDestroyNode=this.willDestroyPanel
         tabIds=this.tabIds
         panelIds=this.panelIds
-        selectedTabIndex=(if this.selectionControlled @selectedTabIndex this.selectedTabIndex)
+        selectedTabIndex=this.selectedIndex
       )
     )
   }}

--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -3,7 +3,12 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 {{! template-lint-disable no-invalid-role }}
-<div class="hds-tabs" {{did-insert this.didInsert}} ...attributes>
+<div
+  class="hds-tabs"
+  {{did-insert this.didInsert}}
+  {{did-update this.setTabIndicator this.selectedIndex}}
+  ...attributes
+>
   <div class="hds-tabs__tablist-wrapper">
     <ul class="hds-tabs__tablist" role="tablist">
       {{yield
@@ -14,7 +19,7 @@
             willDestroyNode=this.willDestroyTab
             tabIds=this.tabIds
             panelIds=this.panelIds
-            selectedTabIndex=this.selectedTabIndex
+            selectedTabIndex=this.selectedIndex
             onClick=this.onClick
             onKeyUp=this.onKeyUp
           )
@@ -32,7 +37,7 @@
         willDestroyNode=this.willDestroyPanel
         tabIds=this.tabIds
         panelIds=this.panelIds
-        selectedTabIndex=this.selectedTabIndex
+        selectedTabIndex=(if this.selectionControlled @selectedTabIndex this.selectedTabIndex)
       )
     )
   }}

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -126,10 +126,9 @@ export default class HdsTabsIndexComponent extends Component {
 
   @action
   setTabIndicator() {
-    const tabElem = this.tabNodes[this.selectedIndex];
-    const tabsParentElem = tabElem.closest('.hds-tabs');
-
     next(() => {
+      const tabElem = this.tabNodes[this.selectedIndex];
+      const tabsParentElem = tabElem.closest('.hds-tabs');
       const tabLeftPos = tabElem.parentNode.offsetLeft;
       const tabWidth = tabElem.parentNode.offsetWidth;
 

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -132,7 +132,6 @@ export default class HdsTabsIndexComponent extends Component {
     next(() => {
       const tabLeftPos = tabElem.parentNode.offsetLeft;
       const tabWidth = tabElem.parentNode.offsetWidth;
-      console.log(tabLeftPos, tabWidth);
 
       // Set CSS custom properties for indicator
       tabsParentElem.style.setProperty(

--- a/packages/components/tests/dummy/app/controllers/components/tabs.js
+++ b/packages/components/tests/dummy/app/controllers/components/tabs.js
@@ -8,6 +8,9 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class TabsController extends Controller {
+  queryParams = ['tab'];
+
+  @tracked tab;
   @tracked showHighlight = false;
 
   @action
@@ -19,5 +22,18 @@ export default class TabsController extends Controller {
   logClickedTab(event) {
     const tabId = event.target.id;
     console.log(`Tab with ID "${tabId}" clicked!`);
+  }
+
+  @action
+  updateQueryParam(event) {
+    this.tab = event.target.parentNode.getAttribute('data-tab-key');
+  }
+
+  get selectedTabIndex() {
+    const { tab } = this;
+    const allTabs = [...document.querySelectorAll('[data-tab-key]')];
+    const selectedTab = document.querySelector(`[data-tab-key="${tab}"]`);
+    const index = allTabs.indexOf(selectedTab);
+    return index >= 0 ? index : 0;
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -126,6 +126,21 @@
     <T.Panel><Shw::Placeholder @text="Tab Three - Content" @height="50" @background="#eee" /></T.Panel>
   </Hds::Tabs>
 
+  <Shw::Text::Body>With selected tab condition</Shw::Text::Body>
+  <Hds::Tabs @selectedTabIndex={{this.selectedTabIndex}} @onClickTab={{this.updateQueryParam}} as |T|>
+    <T.Tab data-tab-key="one">One</T.Tab>
+    <T.Tab data-tab-key="two">Two</T.Tab>
+    <T.Tab data-tab-key="three">Three</T.Tab>
+
+    <T.Panel>
+      <Shw::Placeholder @height="50" @background="#eee">
+        <span>Content one with <a href="#">link to test tabbing</a></span>
+      </Shw::Placeholder>
+    </T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content two" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content three" @height="50" @background="#eee" /></T.Panel>
+  </Hds::Tabs>
+
   <Shw::Divider />
 
   <Shw::Text::H2>Base elements</Shw::Text::H2>

--- a/packages/components/tests/integration/components/hds/tabs/index-test.js
+++ b/packages/components/tests/integration/components/hds/tabs/index-test.js
@@ -231,4 +231,34 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
     assert.dom('.hds-tabs__tab-count').exists();
     assert.dom('.hds-tabs__tab-count').hasText('5');
   });
+
+  test('it should allow for external control of selected index', async function (assert) {
+    this.selectedTabIndex = 0;
+    await render(hbs`
+      <Hds::Tabs @selectedTabIndex={{this.selectedTabIndex}} as |T|>
+        <T.Tab>One</T.Tab>
+        <T.Tab>Two</T.Tab>
+        <T.Panel data-test="one panel">Content 1</T.Panel>
+        <T.Panel data-test="two panel">Content 2</T.Panel>
+      </Hds::Tabs>
+    `);
+
+    assert.dom('.hds-tabs__tab--is-selected').hasText('One');
+    assert
+      .dom('.hds-tabs__panel[data-test="one panel"]')
+      .doesNotHaveAttribute('hidden');
+    assert
+      .dom('.hds-tabs__panel[data-test="two panel"]')
+      .hasAttribute('hidden');
+
+    this.set('selectedTabIndex', 1);
+
+    assert.dom('.hds-tabs__tab--is-selected').hasText('Two');
+    assert
+      .dom('.hds-tabs__panel[data-test="one panel"]')
+      .hasAttribute('hidden');
+    assert
+      .dom('.hds-tabs__panel[data-test="two panel"]')
+      .doesNotHaveAttribute('hidden');
+  });
 });

--- a/website/docs/components/tabs/index.js
+++ b/website/docs/components/tabs/index.js
@@ -5,11 +5,31 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class Index extends Component {
+  @service router;
+
+  @tracked
+  selectedTabIndex = 0;
+
   @action
   logClickedTab(event) {
     const tabId = event.target.id;
     console.log(`Tab with ID "${tabId}" clicked!`);
+  }
+
+  @action
+  changeActiveTab() {
+    const allTabs = [
+      ...document.querySelectorAll('.dynamic-index-control .hds-tabs__tab'),
+    ];
+    const currentTab = document.querySelector(
+      '.dynamic-index-control .hds-tabs__tab--is-selected'
+    );
+    const currentIndex = allTabs.indexOf(currentTab);
+    this.selectedTabIndex =
+      currentIndex < allTabs.length - 1 ? currentIndex + 1 : 0;
   }
 }

--- a/website/docs/components/tabs/partials/code/component-api.md
+++ b/website/docs/components/tabs/partials/code/component-api.md
@@ -9,6 +9,9 @@ The Tabs component is composed of different parts, with their own APIs:
 ### Tabs API
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="selectedTabIndex" @type="string">
+    The index of the tab that should be selected. Use of this property will override the `Tabs::Tab` `isSelected` property.
+  </C.Property>
   <C.Property @name="onClickTab" @type="function"/>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/tabs/partials/code/how-to-use.md
+++ b/website/docs/components/tabs/partials/code/how-to-use.md
@@ -57,3 +57,20 @@ Use the `@onClickTab` handler to pass in a custom function. For example, to stor
   <T.Panel>Content three</T.Panel>
 </Hds::Tabs>
 ```
+
+### Control the selected tab dynamically
+
+Use the `@selectedTabIndex` to manage the currently selected tab manually.
+
+```handlebars
+<Hds::Button @text="Change selected tab" {{on "click" this.changeActiveTab}} />
+<Hds::Tabs @selectedTabIndex={{this.selectedTabIndex}} class="dynamic-index-control" as |T|>
+  <T.Tab>One</T.Tab>
+  <T.Tab>Two</T.Tab>
+  <T.Tab>Three</T.Tab>
+
+  <T.Panel>Content one</T.Panel>
+  <T.Panel>Content two</T.Panel>
+  <T.Panel>Content three</T.Panel>
+</Hds::Tabs>
+```


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
This PR will allow for the consuming application to manage the selected tab index state, in turn allowing for selected tab to be set after render by external controls.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->
Currently the tab index is controlled by the `didInsert` method and can be initially set to any of the tabs through use of the `@isSelected` tab arg. Subsequently the tab can only be changed by controls internal to the component, limiting more dynamic use cases like tracking selected tab as a query parameter and navigating with the browser back and forward buttons. This PR introduces the ability to pass in the selectedTabIndex as an arg on the parent component which will override the internal tracking of the selected tab index. This also moves the tab indicator logic to the `did-update` modifier, which is set up to fire when the selected index changes.

Inspiration was taken from https://github.com/concordnow/ember-aria-tabs

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

https://github.com/hashicorp/design-system/assets/2334991/30e31d4c-3d4e-411a-9b10-c7706d6de5d7

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [ ] A11y tests have been run locally
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
