### PR TITLE
`PowerSelect` - fix style overrides when the list is positioned above

### DIFF
--- a/.changeset/curvy-cherries-sin.md
+++ b/.changeset/curvy-cherries-sin.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+PowerSelect - fix style overrides when the list is positioned above

--- a/packages/components/app/styles/@hashicorp/design-system-power-select-overrides.scss
+++ b/packages/components/app/styles/@hashicorp/design-system-power-select-overrides.scss
@@ -71,12 +71,20 @@
 
   .ember-basic-select-dropdown,
   .ember-power-select-dropdown {
+    &.ember-basic-dropdown-content--below,
     &.ember-basic-dropdown-content--in-place {
       margin-top: -3px;
       border: var(--token-form-control-border-width) solid var(--token-form-control-base-border-color-default);
       border-bottom-right-radius: 6px;
       border-bottom-left-radius: 6px;
       box-shadow: var(--token-elevation-high-box-shadow), var(--token-elevation-high-box-shadow);
+    }
+
+    &.ember-basic-dropdown-content--above {
+      margin-top: 3px;
+      border: var(--token-form-control-border-width) solid var(--token-form-control-base-border-color-default);
+      border-radius: 6px 6px 0 0;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/tests/dummy/app/templates/overrides/power-select.hbs
+++ b/packages/components/tests/dummy/app/templates/overrides/power-select.hbs
@@ -95,6 +95,38 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Text::H3>List position</Shw::Text::H3>
+
+  <Shw::Flex {{style max-width="50%"}} @direction="column" as |SF|>
+    <SF.Item @label="Below (default)">
+      <div class="hds-power-select">
+        <PowerSelect
+          @options={{@model.OPTIONS}}
+          @selected={{@model.SELECTED}}
+          @onChange={{this.noop}}
+          @renderInPlace={{true}}
+          as |option|
+        >
+          {{option}}
+        </PowerSelect>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Above">
+      <div class="hds-power-select">
+        <PowerSelect
+          @options={{@model.OPTIONS}}
+          @selected={{@model.SELECTED}}
+          @onChange={{this.noop}}
+          @renderInPlace={{true}}
+          @verticalPosition="above"
+          as |option|
+        >
+          {{option}}
+        </PowerSelect>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Text::H2>Multiple selection</Shw::Text::H2>
 
   <Shw::Text::H3>Interaction</Shw::Text::H3>


### PR DESCRIPTION
### :pushpin: Summary

Fixing styles when the PowerSelect is configured to have the list positioned above (by setting `@verticalPosition="above"`).

### :hammer_and_wrench: Detailed description

The `border-radius` for the list needs to be placed at the other end of the list, `margin`s need adjustments and the `box-shadow can't be applied anymore as it would cast on the field itself, which is undesirable.

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>


<img width="532" alt="Screenshot 2023-09-21 at 15 12 17" src="https://github.com/hashicorp/design-system/assets/788096/ae03633d-c29c-4fcd-a1f2-fc483143d363">

</td><td>

<img width="531" alt="Screenshot 2023-09-21 at 15 11 55" src="https://github.com/hashicorp/design-system/assets/788096/d995501a-4aa8-4f98-a2f8-35425fc50930">


</td></tr>
</table>


### :link: External links

<!-- Issues, RFC, etc. -->
Slack: [HDS-2533](https://hashicorp.atlassian.net/browse/HDS-2533)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2533]: https://hashicorp.atlassian.net/browse/HDS-2533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ