### PR TITLE
Retroactive changeset for icon addtions

### DIFF
--- a/.changeset/kind-crabs-warn.md
+++ b/.changeset/kind-crabs-warn.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/flight-icons": minor
+---
+
+Add static loading and running icons, and icons for Google services included docs, forms, slides, sheets, and drive.


### PR DESCRIPTION
### :pushpin: Summary

This PR adds a retroactive changeset to account for the addition of icons:
- `loading-static`
- `running-static`
- `google-docs`
- `google-forms`
- `google-slides`
- `google-sheets`
- `google-drive`

[Added for this previously merged PR](https://github.com/hashicorp/design-system/pull/1649)
