### PR TITLE
Emphasize `@ariaLabel` on `SideNav::Portal` must be unique

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/side-nav.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav.hbs
@@ -82,7 +82,7 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Hds::SideNav::Portal @targetName="sidenav-portal-demo-1" as |Nav|>
+  <Hds::SideNav::Portal @targetName="sidenav-portal-demo-1" @ariaLabel="Primary on portal demo 1" as |Nav|>
     <Nav.extraBefore><Shw::Placeholder @height="72px" @text="extraBefore" @background="#f3d9c5" /></Nav.extraBefore>
     <Nav.Item><Shw::Placeholder @height="200px" @text="portaled content" @background="#e4e4e4" /></Nav.Item>
     <Nav.extraAfter><Shw::Placeholder @height="72px" @text="extraAfter" @background="#f3d9c5" /></Nav.extraAfter>
@@ -139,7 +139,7 @@
           </div>
         </SF.Item>
       </Shw::Flex>
-      <Hds::SideNav::Portal @targetName="sidenav-portal-demo-2" as |Nav|>
+      <Hds::SideNav::Portal @targetName="sidenav-portal-demo-2" @ariaLabel="Primary on portal demo 2" as |Nav|>
         <Nav.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
         <Nav.Title>Services</Nav.Title>
         <Nav.Link @text="Boundary" @icon="boundary" @href="#" />
@@ -195,11 +195,11 @@
               </:header>
 
               <:body>
-                <Hds::SideNav::List as |SNL|>
+                <Hds::SideNav::List aria-label="Dashboard" as |SNL|>
                   <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
                 </Hds::SideNav::List>
 
-                <Hds::SideNav::List as |SNL|>
+                <Hds::SideNav::List aria-label="Services" as |SNL|>
                   <SNL.Title>Services</SNL.Title>
                   <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
                   <SNL.Link @text="Consul" @icon="consul" @href="#" />
@@ -211,7 +211,7 @@
                   <SNL.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} />
                 </Hds::SideNav::List>
 
-                <Hds::SideNav::List as |SNL|>
+                <Hds::SideNav::List aria-label="Organization" as |SNL|>
                   <SNL.Title>Default Org</SNL.Title>
                   <SNL.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />
                   <SNL.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
@@ -426,7 +426,7 @@
   <Shw::Flex as |SF|>
     <SF.Item @label="Title with multiple items">
       <div class="shw-component-sim-side-nav-body">
-        <Hds::SideNav::List as |SNL|>
+        <Hds::SideNav::List aria-label="Multiple items" as |SNL|>
           <SNL.Title>Services</SNL.Title>
 
           <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
@@ -450,10 +450,10 @@
 
     <SF.Item @label="Multiple groups">
       <div class="shw-component-sim-side-nav-body">
-        <Hds::SideNav::List as |SNL|>
+        <Hds::SideNav::List aria-label="Dashboard (multiple groups)" as |SNL|>
           <SNL.Link @text="Dashboard" @icon="dashboard" @href="#" />
         </Hds::SideNav::List>
-        <Hds::SideNav::List as |SNL|>
+        <Hds::SideNav::List aria-label="Services (multiple groups)" as |SNL|>
           <SNL.Title>Services</SNL.Title>
 
           <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
@@ -465,7 +465,7 @@
           <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
           <SNL.Link @text="Waypoint" @icon="waypoint" @badge="Alpha" @hasSubItems={{true}} @href="#" />
         </Hds::SideNav::List>
-        <Hds::SideNav::List as |SNL|>
+        <Hds::SideNav::List aria-label="Organization (multiple groups)" as |SNL|>
           <SNL.Title>Default Org</SNL.Title>
 
           <SNL.Link @text="HashiCorp Virtual Networks" @icon="network" @href="#" />

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -174,7 +174,7 @@ The content yielded in the component is injected inside a `Hds::SideNav::List` e
     The unique name used by [`ember-stargate`](https://github.com/simonihmig/ember-stargate#usage) to identify the target portal. If provided, the same name must be used in the `SideNav::PortalTarget` to identify it.
   </C.Property>
   <C.Property @name="ariaLabel" @type="string">
-    The value of the `aria-label` that is applied to the `<nav>` element in the `Hds::SideNav::List` component.
+    The value of the `aria-label` that is applied to the `<nav>` element in the `Hds::SideNav::List` component. This value must be unique on the page, so they can be distinguished from one another.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -317,7 +317,7 @@ will be injected automatically in the "target" portal declared above;
 if multiple portals are declared, multiple "panels" will be rendered
 based on the nesting of the page route within the application’s global routing
 --}}
-<Hds::SideNav::Portal as |Nav|>
+<Hds::SideNav::Portal @ariaLabel="Primary" as |Nav|>
   <Nav.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
   <Nav.Title>Services</Nav.Title>
   <Nav.Link @text="Boundary" @icon="boundary" @href="#" />


### PR DESCRIPTION
### :hammer_and_wrench: Detailed description

`Hds::SideNav::Portal` is the `SideNav` subcomponent that renders the `<nav>` element.

In this PR we update the SideNav API docs to emphasize `@ariaLabel` on `SideNav::Portal` must be unique and we update the `SideNav::Portal` example under 'How to use' to explicitly define an `@ariaLabel` for the `<nav>` element.

Since we're tackling this item, we also update the showcase to fix the errors flagged by the automated accessibility tests.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2215](https://hashicorp.atlassian.net/browse/HDS-2215)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2215]: https://hashicorp.atlassian.net/browse/HDS-2215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ