### PR TITLE
`Link::Standalone` increase target size

### DIFF
--- a/.changeset/small-coats-return.md
+++ b/.changeset/small-coats-return.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Link::Standalone` – increase target size

--- a/packages/components/app/styles/components/link/standalone.scss
+++ b/packages/components/app/styles/components/link/standalone.scss
@@ -21,6 +21,8 @@ $hds-link-standalone-border-width: 1px;
   align-items: center;
   justify-content: center;
   width: fit-content;
+  padding-top: 4px;
+  padding-bottom: 4px;
   font-weight: var(--token-typography-font-weight-regular);
   font-family: var(--token-typography-font-stack-text);
   background-color: transparent; // needs to exist for a11y
@@ -137,7 +139,7 @@ $hds-link-standalone-focus-shift: 4px;
   $shift-extra: $shift + 2px;
 
   // notice: this is used not only for the focus, but also to increase the clickable area
-  @include hds-focus-ring-with-pseudo-element($top: -$shift, $right: -$shift, $bottom: -$shift, $left: -$shift, $radius: $hds-link-standalone-focus-border-radius);
+  @include hds-focus-ring-with-pseudo-element($right: -$shift, $left: -$shift, $radius: $hds-link-standalone-focus-border-radius);
 
   // we need to override a couple of values for better visual alignment
   &.hds-link-standalone--icon-position-leading::before {


### PR DESCRIPTION
### :pushpin: Summary

Increase the target size of `Link::Standalone` component to be at least `24px` in height

### :hammer_and_wrench: Detailed description

We do this by adding top and bottom padding, which requires adjustments in how we construct the pseudoelement used for the focus-ring.

[👉 Preview](https://hds-showcase-git-alex-ju-link-standalone-incre-1aa8c7-hashicorp.vercel.app/components/link/standalone)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2214](https://hashicorp.atlassian.net/browse/HDS-2214)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [x] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2214]: https://hashicorp.atlassian.net/browse/HDS-2214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ