### PR TITLE
Truncation documentation fix

### DIFF
--- a/website/docs/components/breadcrumb/partials/code/component-api.md
+++ b/website/docs/components/breadcrumb/partials/code/component-api.md
@@ -56,3 +56,21 @@ The Breadcrumb component is composed of three different parts, each with their o
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>
+
+#### Width-based truncation
+
+!!! Warning
+
+The text will automatically truncate and be replaced with an ellipsis to fit within the container. Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
+!!!
+
+```handlebars
+<Hds::Breadcrumb @itemsCanWrap={{false}}>
+  <Hds::Breadcrumb::Item @text="Level one with a very long string" @icon="org" />
+  <Hds::Breadcrumb::Item @text="Level two with a very long string" @icon="folder" />
+  <Hds::Breadcrumb::Item @text="Level three with a very long string" />
+  <Hds::Breadcrumb::Item @text="Level four with a very long string" />
+  <Hds::Breadcrumb::Item @text="Level five with a very long string" />
+  <Hds::Breadcrumb::Item @text="Current with a very long string" @current={{true}} />
+</Hds::Breadcrumb>
+```

--- a/website/docs/components/breadcrumb/partials/code/how-to-use.md
+++ b/website/docs/components/breadcrumb/partials/code/how-to-use.md
@@ -39,11 +39,6 @@ Add the correct `@route/@models/@model/@query` parameter to each Breadcrumb Item
 
 By default, the Breadcrumb allows items to wrap on multiple lines if the container is too small. Pass `false` to the `@itemsCanWrap` parameter to avoid wrapping.
 
-!!! Warning
-
-The text will automatically truncate and be replaced with an ellipsis to fit within the container. However, this may result in the text being unavailable to keyboard-only users and, thus, is not WCAG-conformant.
-!!!
-
 ```handlebars
 <Hds::Breadcrumb @itemsCanWrap={{false}}>
   <Hds::Breadcrumb::Item @text="My org" @icon="org" />
@@ -53,14 +48,11 @@ The text will automatically truncate and be replaced with an ellipsis to fit wit
 </Hds::Breadcrumb>
 ```
 
-### With truncation
+### Truncation
+
+#### With dropdown 
 
 It’s possible to hide part of the Breadcrumb tree under a "truncated" item that shows the elements on "toggle".
-
-!!! Warning
-
-The text will automatically truncate and be replaced with an ellipsis to fit within the container. However, this may result in the text being unavailable to keyboard-only users and, thus, is not WCAG conformant.
-!!!
 
 ```handlebars
 <Hds::Breadcrumb>
@@ -71,5 +63,19 @@ The text will automatically truncate and be replaced with an ellipsis to fit wit
     <Hds::Breadcrumb::Item @text="Cluster details" @route="components" />
   </Hds::Breadcrumb::Truncation>
   <Hds::Breadcrumb::Item @text="Cluster sub-details" @current={{true}} />
+</Hds::Breadcrumb>
+```
+#### Width-based truncation
+
+By setting `@itemsCanWrap` to `false`, it is possible to constrain the text to one-line and truncate it if it does not fit the available space. Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
+
+```handlebars
+<Hds::Breadcrumb @itemsCanWrap={{false}}>
+  <Hds::Breadcrumb::Item @text="Level one with a very long string" @icon="org" />
+  <Hds::Breadcrumb::Item @text="Level two with a very long string" @icon="folder" />
+  <Hds::Breadcrumb::Item @text="Level three with a very long string" />
+  <Hds::Breadcrumb::Item @text="Level four with a very long string" />
+  <Hds::Breadcrumb::Item @text="Level five with a very long string" />
+  <Hds::Breadcrumb::Item @text="Current with a very long string" @current={{true}} />
 </Hds::Breadcrumb>
 ```

--- a/website/docs/components/breadcrumb/partials/guidelines/guidelines.md
+++ b/website/docs/components/breadcrumb/partials/guidelines/guidelines.md
@@ -116,7 +116,9 @@ Icons shouldn’t be placed randomly within the list. If the preceding item does
 
 We offer various options for truncation due to depth or lack of space.
 
-### Truncate middle
+### With dropdown
+
+#### Truncate middle
 
 “Truncate middle” houses any number of Breadcrumb Items under a menu in the middle of the Breadcrumb. The number of items displayed before and after truncation depends on the use case and space available within the application.  We recommend this method if needing to truncate the Breadcrumb.
 
@@ -130,7 +132,7 @@ We offer various options for truncation due to depth or lack of space.
   <Hds::Breadcrumb::Item @text="Current" @current={{true}} />
 </Hds::Breadcrumb>
 
-### Truncate squeeze
+#### Truncate squeeze
 
 “Truncate squeeze” reduces the persistent Breadcrumb Items to the first and last/current items and hides the other items under a menu. We recommend only using this method when space is limited, such as on mobile viewports.
 
@@ -144,7 +146,7 @@ We offer various options for truncation due to depth or lack of space.
 
 ### Width-based
 
-Each text-based item can truncate using a pixel-based max-width. We recommend this option for items with long text strings.
+Each text-based item can truncate using a pixel-based max-width. We recommend this option for items with long text strings. Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
 
 <Hds::Breadcrumb @itemsCanWrap={{false}} aria-label="breadcrumb width based">
   <Hds::Breadcrumb::Item @text="Level one" />

--- a/website/docs/components/copy/snippet/partials/code/component-api.md
+++ b/website/docs/components/copy/snippet/partials/code/component-api.md
@@ -16,7 +16,7 @@ This component uses [ember-cli-clipboard](https://github.com/jkusa/ember-cli-cli
   <C.Property @name="isTruncated" @type="boolean" @default="false">
     Constrains text to one line and truncates it based on available width. Text will only be truncated if it does not fit within the available space.
     <br><br>
-    There are accessibility concerns if using this feature. See the [Accessibility section](/components/copy/snippet?tab=accessibility) for more information.
+    Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/copy/snippet/partials/code/how-to-use.md
+++ b/website/docs/components/copy/snippet/partials/code/how-to-use.md
@@ -27,7 +27,7 @@ This indicates that the component should take up the full-width of the parent co
 
 When set to `true`, this constrains text to one-line and truncates it if it does not fit the available space.
 
-Care should be taken in choosing to use this feature as there are [accessibility concerns](/components/copy/snippet?tab=accessibility).
+Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
 
 ```handlebars
 <div class="doc-copy-snippet-demo-constrain-width">

--- a/website/docs/components/copy/snippet/partials/guidelines/guidelines.md
+++ b/website/docs/components/copy/snippet/partials/guidelines/guidelines.md
@@ -44,6 +44,8 @@ When there are many secondary links on a page, like in a stepper form, it’s im
 
 ## Truncation
 
+Truncation should be avoided as there is no current known way to make truncated content available to keyboard-only users. This is a current, known limitation of web technology.
+
 Truncation of the Copy Snippet is optional and can be used when space is limited or when showing the full snippet isn’t necessary. When enabled, the visible content is truncated to fit within the parent container. 
 
 !!! Dont

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -175,7 +175,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
   <C.Property @name="isTruncated" @type="boolean" @default="false">
     Constrains text to one line and truncates it based on available width. Text will only be truncated if it does not fit within the available space.
     <br><br>
-    There are accessibility concerns if using this feature. See the [Accessibility section](/components/copy/snippet?tab=accessibility) of the `Copy::Snippet` component for more information.
+    Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
     <br><br>
     _Notice: this argument is forwarded to the [`Copy::Snippet` component](/components/copy/snippet?tab=code#component-api)._
   </C.Property>

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -234,7 +234,7 @@ Pass the argument `@isLoading={{true}}` to the item. This will show a “loading
 
 To enable users to copy a snippet of code (eg. URLs, secrets, code blocks, etc.).
 
-Using the `@isTruncated` argument it is possible to constrain the text to one-line and truncate it if it does not fit the available space. Care should be taken in choosing to use this feature as there are [accessibility concerns](/components/copy/snippet?tab=accessibility).
+Using the `@isTruncated` argument it is possible to constrain the text to one-line and truncate it if it does not fit the available space. Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
 
 ```handlebars
 <Hds::Dropdown as |dd|>


### PR DESCRIPTION
Updated accessibility warning text for truncation 

### :pushpin: Summary

If merged, this PR will update the warning text and wording for truncation in; Breadcrumb, CopySnippet, and Dropdown component

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2525](https://hashicorp.atlassian.net/jira/software/c/projects/HDS/boards/2192/?selectedIssue=HDS-2525)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2525]: https://hashicorp.atlassian.net/browse/HDS-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ