### PR TITLE
Page content should be in aria landmarks (HDS-1222)

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -19,7 +19,7 @@
 
     {{content-for "head-footer"}}
   </head>
-  <body>
+  <body class="doc-page-wrapper" id="topofpage">
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>

--- a/website/app/templates/application.hbs
+++ b/website/app/templates/application.hbs
@@ -7,22 +7,20 @@
 
 {{page-title "Helios Design System"}}
 
-<div class="doc-page-wrapper" id="topofpage">
-  <Doc::Page::Header
-    @currentTopRoute={{this.currentTopRoute}}
-    @isSidebarVisibleOnSmallViewport={{this.isSidebarVisibleOnSmallViewport}}
-    @onToggleBurgerMenu={{this.onToggleBurgerMenu}}
-    @routeChangeValidator={{this.transitionValidator}}
-  />
-  {{! uncomment this to turn the survey banner back on, but ensure survey link has been updated as well }}
-  {{! <Doc::Page::Banner /> }}
-  <Doc::Page::Sidebar
-    {{! `this.model.toc` comes from `routes/application.js` }}
-    @toc={{this.model.toc}}
-    @currentPath={{this.target.currentPath}}
-    @currentRoute={{this.target.currentRoute}}
-    @currentTopRoute={{this.currentTopRoute}}
-  />
-  {{outlet}}
-  <Doc::Page::Footer />
-</div>
+<Doc::Page::Header
+  @currentTopRoute={{this.currentTopRoute}}
+  @isSidebarVisibleOnSmallViewport={{this.isSidebarVisibleOnSmallViewport}}
+  @onToggleBurgerMenu={{this.onToggleBurgerMenu}}
+  @routeChangeValidator={{this.transitionValidator}}
+/>
+{{! uncomment this to turn the survey banner back on, but ensure survey link has been updated as well }}
+{{! <Doc::Page::Banner /> }}
+<Doc::Page::Sidebar
+  {{! `this.model.toc` comes from `routes/application.js` }}
+  @toc={{this.model.toc}}
+  @currentPath={{this.target.currentPath}}
+  @currentRoute={{this.target.currentRoute}}
+  @currentTopRoute={{this.currentTopRoute}}
+/>
+{{outlet}}
+<Doc::Page::Footer />


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will delete a wrapping div between the body element and the landmark elements, which was triggering an a11y failure.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1222](https://hashicorp.atlassian.net/browse/HDS-1222)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1222]: https://hashicorp.atlassian.net/browse/HDS-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ