### PR TITLE
add component a11y test blueprints for docs and components

### DIFF
--- a/packages/components/blueprints/hds-component-test/files/tests/acceptance/components/hds/__name__.js
+++ b/packages/components/blueprints/hds-component-test/files/tests/acceptance/components/hds/__name__.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/<%= dasherizedModuleName %>', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/<%= dasherizedModuleName %>', async function (assert) {
+    await visit('/components/<%= dasherizedModuleName %>');
+
+    assert.strictEqual(currentURL(), '/components/<%= dasherizedModuleName %>');
+  });
+
+  test('Components/<%= dasherizedModuleName %> page passes automated a11y checks', async function (assert) {
+    await visit('/components/<%= dasherizedModuleName %>');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/website/blueprints/hds-component-docs/files/tests/acceptance/components/__name__.js
+++ b/website/blueprints/hds-component-docs/files/tests/acceptance/components/__name__.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/<%= dasherizedModuleName %>', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/<%= dasherizedModuleName %>', async function (assert) {
+    await visit('/components/<%= dasherizedModuleName %>');
+
+    assert.strictEqual(currentURL(), '/components/<%= dasherizedModuleName %>');
+  });
+
+  test('Components/<%= dasherizedModuleName %> page passes automated a11y checks', async function (assert) {
+    await visit('/components/<%= dasherizedModuleName %>');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

adds a component a11y test blueprints for the website and the components package that will generate these tests when running existing generators

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2529](https://hashicorp.atlassian.net/browse/HDS-2529)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2529]: https://hashicorp.atlassian.net/browse/HDS-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ