### PR TITLE
Match tab order in Footer to source order.

### DIFF
--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -5,8 +5,8 @@
 
 // FOOTER
 
-@use "../../breakpoints" as breakpoint;
-@use "../../typography/mixins" as *;
+@use '../../breakpoints' as breakpoint;
+@use '../../typography/mixins' as *;
 
 .doc-page-footer {
   // z-index: var(--doc-z-index-footer);
@@ -14,7 +14,9 @@
 
   body.application:not(.index) & {
     @include breakpoint.with-fixed-sidebar() {
-      padding-left: var(--doc-page-sidebar-width); // we need to compensate for the fixed position of the sidebar
+      padding-left: var(
+        --doc-page-sidebar-width
+      ); // we need to compensate for the fixed position of the sidebar
     }
   }
 }
@@ -26,18 +28,13 @@
   padding: 16px 24px;
   color: var(--doc-color-black);
 
-  @include breakpoint.medium () {
+  @include breakpoint.medium() {
     flex-direction: row;
     justify-content: space-between;
   }
 
   body.application.index & {
-    flex-direction: column-reverse;
     color: var(--doc-color-white);
-
-    @include breakpoint.medium () {
-      flex-direction: row-reverse;
-    }
   }
 }
 

--- a/website/app/styles/pages/application/footer.scss
+++ b/website/app/styles/pages/application/footer.scss
@@ -5,8 +5,8 @@
 
 // FOOTER
 
-@use '../../breakpoints' as breakpoint;
-@use '../../typography/mixins' as *;
+@use "../../breakpoints" as breakpoint;
+@use "../../typography/mixins" as *;
 
 .doc-page-footer {
   // z-index: var(--doc-z-index-footer);
@@ -14,9 +14,7 @@
 
   body.application:not(.index) & {
     @include breakpoint.with-fixed-sidebar() {
-      padding-left: var(
-        --doc-page-sidebar-width
-      ); // we need to compensate for the fixed position of the sidebar
+      padding-left: var(--doc-page-sidebar-width); // we need to compensate for the fixed position of the sidebar
     }
   }
 }
@@ -28,7 +26,7 @@
   padding: 16px 24px;
   color: var(--doc-color-black);
 
-  @include breakpoint.medium() {
+  @include breakpoint.medium () {
     flex-direction: row;
     justify-content: space-between;
   }


### PR DESCRIPTION
### :pushpin: Summary

This PR removes the flex properties that manipulate the source order of the footer with CSS to alter the visual layout.

### :hammer_and_wrench: Detailed description

The elements in the website footer receive a tab order that differs from the source/DOM order on the homepage. This is caused by setting the `flex-direction` in the footer to `row-reverse` which creates a disconnect between the visual layout and source order. This does not occur on pages other than the homepage as the direction is set conditionally based on the location in the application.

In an attempt to workaround this I experimented with a few different concepts that didn't actually end up solving the problem:

1. Add a `tabindex` attribute to each link within the footer to force the tab order. This doesn't work (and upon further investigation actually highlights [additional accessibility concerns](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#accessibility_concerns)) as the layout is determined conditionally. Therefore, defining one set order will cause the other instances/pages to have an incorrect tab order.
2. Add an `aria-flowto` property to determine what element should follow in the tab order, but this solution suffers from the same problem as adding a `tabindex`.

This is a known accessibility problem and result of using `reverse` in any flex or grid layout.

### Potential solutions

1. Remove the conditional property to change the source order depending on the location in the application (this PR satisfies this solution). This would result in a small visual change on the homepage (outlined below) but would satisfy [WCAG 1.3.2](https://www.w3.org/WAI/WCAG21/Techniques/css/C27) for matching the DOM order and the visual order.
2. Conditionally apply a `tabindex` based on the location within the application. This would likely require some fancy JavaScript that I did not explore.
3. Do nothing, if we determine that this isn't a change worth making. There is a [proposal](https://developer.chrome.com/blog/reading-order/) to add a CSS property to account for this in the future, though a timeline doesn't exist for the feature yet.

### :camera_flash: Screenshots

**Before:**

<img width="965" alt="Screenshot 2023-09-29 at 2 14 24 PM" src="https://github.com/hashicorp/design-system/assets/2200899/6031d3ca-1a77-4106-a03f-6a390912f22d">

<img width="975" alt="Screenshot 2023-09-29 at 2 15 32 PM" src="https://github.com/hashicorp/design-system/assets/2200899/0e61bf35-5387-4eee-83d9-4fd6a07e3475">

**After:**

<img width="958" alt="Screenshot 2023-09-29 at 2 14 52 PM" src="https://github.com/hashicorp/design-system/assets/2200899/fe9fa98d-ae35-4acb-9f76-85cab02056bc">

<img width="727" alt="Screenshot 2023-09-29 at 2 15 52 PM" src="https://github.com/hashicorp/design-system/assets/2200899/3bc9d723-987a-4c0c-a247-e6fad8e50d1b">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1436](https://hashicorp.atlassian.net/browse/HDS-1436)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1436]: https://hashicorp.atlassian.net/browse/HDS-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ