### PR TITLE
Add demo app

### DIFF
--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -80,4 +80,7 @@ Router.map(function () {
   this.route('overrides', function () {
     this.route('power-select');
   });
+  this.route('demo-app', function () {
+    this.route('sub-page');
+  });
 });

--- a/packages/components/tests/dummy/app/styles/app.scss
+++ b/packages/components/tests/dummy/app/styles/app.scss
@@ -61,3 +61,8 @@
 @import "./showcase-pages/tooltip";
 @import "./showcase-pages/typography";
 // END COMPONENT PAGES IMPORTS
+
+
+// demo app
+
+@import "./demo-app";

--- a/packages/components/tests/dummy/app/styles/demo-app/index.scss
+++ b/packages/components/tests/dummy/app/styles/demo-app/index.scss
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// DEMO APP
+
+body.demo-app {
+  // we remove the grid layout
+  display: initial;
+
+  // we hide the "show" frame elements
+  .shw-page-header,
+  .shw-page-aside {
+    display: none;
+  }
+
+  .shw-page-main {
+    display: contents;
+    padding: 0 !important;
+  }
+
+  // we outline the "frame" elements
+  .hds-app-frame {
+    outline: 1px dotted #d3d3d3;
+  }
+
+  .hds-app-frame__header {
+    border-bottom: 1px dotted #d3d3d3;
+  }
+
+  .hds-app-frame__sidebar {
+    border-right: 1px dotted #d3d3d3;
+  }
+
+  .hds-app-frame__footer {
+    border-top: 1px dotted #d3d3d3;
+  }
+
+  // FAKE ELEMENTS
+
+  .demo-app-fake-banner-footer {
+    margin-bottom: 12px;
+    padding: 16px;
+    color: var(--token-color-foreground-faint);
+    font-size: var(--token-typography-body-100-font-size);
+    font-family: var(--token-typography-body-100-font-family);
+    line-height: var(--token-typography-body-100-line-height);
+  }
+
+  .demo-app-fake-org-switcher {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 36px;
+    padding: 0 12px;
+    color: var(--token-color-palette-neutral-300);
+    font-weight: 400;
+    font-size: var(--token-typography-body-200-font-size);
+    font-family: var(--token-typography-body-200-font-family);
+    line-height: var(--token-typography-body-200-line-height);
+    text-align: left;
+    background-color: var(--token-color-palette-neutral-700);
+    border: 1px solid var(--token-color-palette-neutral-500);
+    border-radius: 5px;
+    box-shadow: none;
+
+    .flight-icon {
+      flex: none;
+    }
+
+    span {
+      flex: 1 1 auto;
+      margin-right: auto;
+      margin-left: 6px;
+    }
+  }
+
+  .demo-app-fake-terraform-welcome-message {
+    padding: 32px 12px;
+
+    h2 {
+      color: var(--token-color-palette-neutral-0);
+    }
+
+    h3 {
+      margin: 8px 0 0;
+      color: var(--token-color-palette-neutral-100);
+    }
+
+    p {
+      margin: 8px 0 0;
+      color: var(--token-color-palette-neutral-200);
+    }
+
+    ul {
+      margin: 8px 0 0;
+      padding: 0;
+    }
+
+    li {
+      margin: 0;
+      padding-left: 8px;
+      color: var(--token-color-palette-neutral-300);
+
+      & + & {
+        margin-top: 4px;
+      }
+    }
+  }
+}

--- a/packages/components/tests/dummy/app/styles/demo-app/index.scss
+++ b/packages/components/tests/dummy/app/styles/demo-app/index.scss
@@ -9,17 +9,6 @@ body.demo-app {
   // we remove the grid layout
   display: initial;
 
-  // we hide the "show" frame elements
-  .shw-page-header,
-  .shw-page-aside {
-    display: none;
-  }
-
-  .shw-page-main {
-    display: contents;
-    padding: 0 !important;
-  }
-
   // we outline the "frame" elements
   .hds-app-frame {
     outline: 1px dotted #d3d3d3;

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -5,18 +5,24 @@
 
 {{page-title "HDS Design System"}}
 
-<header class="shw-page-header">
-  <LinkTo @route="index" class="shw-page-header__logo" aria-label="home page">
-    <Shw::Logo::DesignSystem />
-  </LinkTo>
-  <div class="shw-page-header__title">Components showcase</div>
-</header>
-
-<aside class="shw-page-aside">
-  <LinkTo class="shw-back-to-components-list" @route="index"><FlightIcon @name="arrow-left" @isInlineBlock={{false}} />
-    Component list</LinkTo>
-</aside>
-
-<main id="main" class="shw-page-main">
+{{#if (or (eq this.target.currentURL "/demo-app") (eq this.target.currentURL "/demo-app/sub-page"))}}
   {{outlet}}
-</main>
+{{else}}
+  <header class="shw-page-header">
+    <LinkTo @route="index" class="shw-page-header__logo" aria-label="home page">
+      <Shw::Logo::DesignSystem />
+    </LinkTo>
+    <div class="shw-page-header__title">Components showcase</div>
+  </header>
+
+  <aside class="shw-page-aside">
+    <LinkTo class="shw-back-to-components-list" @route="index">
+      <FlightIcon @name="arrow-left" @isInlineBlock={{false}} />
+      Component list
+    </LinkTo>
+  </aside>
+
+  <main id="main" class="shw-page-main">
+    {{outlet}}
+  </main>
+{{/if}}

--- a/packages/components/tests/dummy/app/templates/demo-app/index.hbs
+++ b/packages/components/tests/dummy/app/templates/demo-app/index.hbs
@@ -4,7 +4,13 @@
 }}
 <Hds::AppFrame as |Frame|>
   <Frame.Sidebar>
-    <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{true}} @a11yRefocusSkipTo="my-content-id">
+    <Hds::SideNav
+      @isResponsive={{true}}
+      @isCollapsible={{true}}
+      @isMinimized={{false}}
+      @hasA11yRefocus={{true}}
+      @a11yRefocusSkipTo="my-content-id"
+    >
       <:header as |Header|>
         <Hds::SideNav::Header>
           <:logo>

--- a/packages/components/tests/dummy/app/templates/demo-app/index.hbs
+++ b/packages/components/tests/dummy/app/templates/demo-app/index.hbs
@@ -1,0 +1,84 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+<Hds::AppFrame as |Frame|>
+  <Frame.Sidebar>
+    <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{true}} @a11yRefocusSkipTo="my-content-id">
+      <:header as |Header|>
+        <Hds::SideNav::Header>
+          <:logo>
+            <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @route="demo-app" />
+          </:logo>
+          <:actions>
+            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+              <dd.ToggleIcon @icon="help" @text="settings menu" />
+              <dd.Title @text="Signed In" />
+              <dd.Description @text="email@domain.com" />
+              <dd.Separator />
+              <dd.Interactive @href="#" @text="Settings and Preferences" />
+            </Hds::Dropdown>
+            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+              <dd.ToggleIcon @icon="user" @text="user menu" />
+              <dd.Title @text="Signed In" />
+              <dd.Description @text="email@domain.com" />
+              <dd.Interactive @href="#" @text="Account Settings" />
+            </Hds::Dropdown>
+          </:actions>
+        </Hds::SideNav::Header>
+        {{#unless Header.isMinimized}}
+          <pre>TEST POST HEADER</pre>
+        {{/unless}}
+      </:header>
+      <:body as |Body|>
+        {{! <pre>PRE BODY FIXED CONTENT</pre> }}
+        {{#unless Body.isMinimized}}
+          <pre>TEST PRE BODY</pre>
+        {{/unless}}
+        <Hds::SideNav::Portal::Target />
+        {{#unless Body.isMinimized}}
+          <pre>TEST POST BODY</pre>
+        {{/unless}}
+      </:body>
+      <:footer>
+        <Hds::Card::Container @level="base" class="demo-app-fake-banner-footer hds-side-nav-hide-when-minimized">
+          Subscription expires in 5 days
+        </Hds::Card::Container>
+        <div class="demo-app-fake-org-switcher hds-side-nav-hide-when-minimized">
+          <FlightIcon @name="org" />
+          <span>fake-org-switcher</span>
+          <FlightIcon @name="caret" />
+        </div>
+        <pre class="hds-side-nav-hide-when-minimized">App version 1.2.3</pre>
+      </:footer>
+    </Hds::SideNav>
+  </Frame.Sidebar>
+  <Frame.Main id="my-content-id">
+    {{outlet}}
+  </Frame.Main>
+  <Frame.Footer>This is the footer!</Frame.Footer>
+  <Frame.Modals id="my-modals-id" data-test-modals-container />
+</Hds::AppFrame>
+
+<Hds::SideNav::Portal as |Nav|>
+  <Nav.extraBefore><pre>Extra before (portal)</pre></Nav.extraBefore>
+  <Nav.Link @route="demo-app" @icon="dashboard" @text="Dashboard" />
+  <Nav.Title>Services</Nav.Title>
+  <Nav.Link @href="#" @icon="boundary" @text="Boundary" />
+  <Nav.Link @href="#" @icon="consul" @text="Consul" />
+  <Nav.Link @href="#" @icon="packer" @text="Packer" @hasSubItems={{true}} />
+  <Nav.Link @href="#" @icon="vault" @text="Vault" />
+  <Nav.Link @href="#" @icon="terraform" @text="Terraform" @hasSubItems={{true}} />
+  <Nav.Link @href="#" @icon="vagrant" @text="Vagrant" />
+  <Nav.Link @route="demo-app.sub-page" @icon="waypoint" @text="Waipoint" @badge="Beta" />
+  <Nav.Title>Something</Nav.Title>
+  <Nav.Item>
+    <div class="demo-app-fake-org-switcher">
+      <span>Partition-1</span>
+      <FlightIcon @name="caret" />
+    </div>
+  </Nav.Item>
+  <Nav.Title>Something else</Nav.Title>
+  <Nav.Link @href="#" @icon="hexagon" @text="Hello" />
+  <Nav.Link @href="#" @icon="hexagon" @text="World" />
+</Hds::SideNav::Portal>

--- a/packages/components/tests/dummy/app/templates/demo-app/sub-page.hbs
+++ b/packages/components/tests/dummy/app/templates/demo-app/sub-page.hbs
@@ -4,7 +4,13 @@
 }}
 <Hds::AppFrame as |Frame|>
   <Frame.Sidebar>
-    <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{true}} @a11yRefocusSkipTo="my-content-id">
+    <Hds::SideNav
+      @isResponsive={{true}}
+      @isCollapsible={{true}}
+      @isMinimized={{false}}
+      @hasA11yRefocus={{true}}
+      @a11yRefocusSkipTo="my-content-id"
+    >
       <:header as |Header|>
         <Hds::SideNav::Header>
           <:logo>

--- a/packages/components/tests/dummy/app/templates/demo-app/sub-page.hbs
+++ b/packages/components/tests/dummy/app/templates/demo-app/sub-page.hbs
@@ -1,0 +1,84 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+<Hds::AppFrame as |Frame|>
+  <Frame.Sidebar>
+    <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{true}} @a11yRefocusSkipTo="my-content-id">
+      <:header as |Header|>
+        <Hds::SideNav::Header>
+          <:logo>
+            <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @route="demo-app" />
+          </:logo>
+          <:actions>
+            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+              <dd.ToggleIcon @icon="help" @text="settings menu" />
+              <dd.Title @text="Signed In" />
+              <dd.Description @text="email@domain.com" />
+              <dd.Separator />
+              <dd.Interactive @href="#" @text="Settings and Preferences" />
+            </Hds::Dropdown>
+            <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="left" as |dd|>
+              <dd.ToggleIcon @icon="user" @text="user menu" />
+              <dd.Title @text="Signed In" />
+              <dd.Description @text="email@domain.com" />
+              <dd.Interactive @href="#" @text="Account Settings" />
+            </Hds::Dropdown>
+          </:actions>
+        </Hds::SideNav::Header>
+        {{#unless Header.isMinimized}}
+          <pre>TEST POST HEADER</pre>
+        {{/unless}}
+      </:header>
+      <:body as |Body|>
+        {{! <pre>PRE BODY FIXED CONTENT</pre> }}
+        {{#unless Body.isMinimized}}
+          <pre>TEST PRE BODY</pre>
+        {{/unless}}
+        <Hds::SideNav::Portal::Target />
+        {{#unless Body.isMinimized}}
+          <pre>TEST POST BODY</pre>
+        {{/unless}}
+      </:body>
+      <:footer>
+        <Hds::Card::Container @level="base" class="demo-app-fake-banner-footer hds-side-nav-hide-when-minimized">
+          Subscription expires in 5 days
+        </Hds::Card::Container>
+        <div class="demo-app-fake-org-switcher hds-side-nav-hide-when-minimized">
+          <FlightIcon @name="org" />
+          <span>fake-org-switcher</span>
+          <FlightIcon @name="caret" />
+        </div>
+        <pre class="hds-side-nav-hide-when-minimized">App version 1.2.3</pre>
+      </:footer>
+    </Hds::SideNav>
+  </Frame.Sidebar>
+  <Frame.Main id="my-content-id">
+    {{outlet}}
+  </Frame.Main>
+  <Frame.Footer>This is the footer!</Frame.Footer>
+  <Frame.Modals id="my-modals-id" data-test-modals-container />
+</Hds::AppFrame>
+
+<Hds::SideNav::Portal as |Nav|>
+  <Nav.extraBefore><pre>Extra before (portal)</pre></Nav.extraBefore>
+  <Nav.Link @route="demo-app" @icon="dashboard" @text="Dashboard" />
+  <Nav.Title>Services</Nav.Title>
+  <Nav.Link @href="#" @icon="boundary" @text="Boundary" />
+  <Nav.Link @href="#" @icon="consul" @text="Consul" />
+  <Nav.Link @href="#" @icon="packer" @text="Packer" @hasSubItems={{true}} />
+  <Nav.Link @href="#" @icon="vault" @text="Vault" />
+  <Nav.Link @href="#" @icon="terraform" @text="Terraform" @hasSubItems={{true}} />
+  <Nav.Link @href="#" @icon="vagrant" @text="Vagrant" />
+  <Nav.Link @route="demo-app.sub-page" @icon="waypoint" @text="Waipoint" @badge="Beta" />
+  <Nav.Title>Something</Nav.Title>
+  <Nav.Item>
+    <div class="demo-app-fake-org-switcher">
+      <span>Partition-1</span>
+      <FlightIcon @name="caret" />
+    </div>
+  </Nav.Item>
+  <Nav.Title>Something else</Nav.Title>
+  <Nav.Link @href="#" @icon="hexagon" @text="Hello" />
+  <Nav.Link @href="#" @icon="hexagon" @text="World" />
+</Hds::SideNav::Portal>


### PR DESCRIPTION
### :pushpin: Summary

This PR exposes a new route called `/demo-app` that contains an empty template with `<Hds::AppFrame>` and `<Hds::SideNav>` components instantiated for testing these as they would appear in a product page.

Preview: https://hds-showcase-git-alex-ju-local-demo-app-hashicorp.vercel.app/demo-app

### :hammer_and_wrench: Detailed description

It was previously drafted by @didoo and used for reviews in a few PRs related to `SideNav` changes, including #1630.

Raising this in a draft state to have [a temporary deployment](https://hds-showcase-git-alex-ju-local-demo-app-hashicorp.vercel.app/demo-app) and discuss the tradeoffs of this approach.

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
