### PR TITLE
`Button`- Update padding/sizing for "icon-only" variant

### DIFF
--- a/.changeset/itchy-doors-protect.md
+++ b/.changeset/itchy-doors-protect.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Button` - updated horizontal padding of icon-only variant
+`Dropdown::ToggleIcon` - updated sizing of the "small" variant to match the height of the "small" variant `Button`

--- a/packages/components/addon/components/hds/button/index.js
+++ b/packages/components/addon/components/hds/button/index.js
@@ -158,6 +158,11 @@ export default class HdsButtonIndexComponent extends Component {
       classes.push('hds-button--width-full');
     }
 
+    // add a class if it's icon-only
+    if (this.isIconOnly) {
+      classes.push('hds-button--is-icon-only');
+    }
+
     return classes.join(' ');
   }
 }

--- a/packages/components/app/styles/components/dropdown.scss
+++ b/packages/components/app/styles/components/dropdown.scss
@@ -75,14 +75,14 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 
 .hds-dropdown-toggle-icon--size-small {
   .hds-dropdown-toggle-icon__wrapper {
-    width: 20px;
-    height: 20px;
+    width: 24px; // same as the `button[small]` minus 2*2px becaus there are a 1px padding and 1px border to take into account
+    height: 24px;
   }
 }
 
 .hds-dropdown-toggle-icon--size-medium {
   .hds-dropdown-toggle-icon__wrapper {
-    width: 32px;
+    width: 32px; // same as the `button[medium]` minus 2*2px becaus there are a 1px padding and 1px border to take into account
     height: 32px;
   }
 }

--- a/packages/components/app/styles/mixins/_button.scss
+++ b/packages/components/app/styles/mixins/_button.scss
@@ -14,21 +14,24 @@ $size-props: (
     "font-size": 0.8125rem, // 13px;
     "line-height": 0.875rem, // 14px - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)
     "min-height": 1.75rem,  // 28px
-    "padding": 0.375rem 0.6875rem, // 6px 11px - here we're taking into account the 1px border
+    "padding-vertical": 0.375rem, // 6px - here we're taking into account the 1px border
+    "padding-horizontal": 0.6875rem, // 11px - here we're taking into account the 1px border
     "icon-size": 0.75rem, // 12px
   ),
   "medium": (
     "font-size": 0.875rem, // 14px
     "line-height": 1rem,// 16px
     "min-height": 2.25rem, // 36px
-    "padding": 0.5625rem 0.9375rem, // 9px 15px - here we're taking into account the 1px border
+    "padding-vertical": 0.5625rem, // 9px - here we're taking into account the 1px border
+    "padding-horizontal": 0.9375rem, // 15px - here we're taking into account the 1px border
     "icon-size": 1rem, // 16px
   ),
   "large": (
     "font-size": 1rem, // 16px
     "line-height": 1.5rem, // 24px
     "min-height": 3rem, // 48px
-    "padding": 0.6875rem 1.1875rem, // 11px 19px - here we're taking into account the 1px border
+    "padding-vertical": 0.6875rem, // 11px - here we're taking into account the 1px border
+    "padding-horizontal": 1.1875rem, // 19px - here we're taking into account the 1px border
     "icon-size": 1.5rem, // 24px
   )
 );
@@ -271,7 +274,7 @@ $size-props: (
   @each $size in $hds-button-sizes {
     .#{$blockName}--size-#{$size} {
       min-height: map-get($size-props, $size, "min-height");
-      padding: map-get($size-props, $size, "padding");
+      padding: map-get($size-props, $size, "padding-vertical") map-get($size-props, $size, "padding-horizontal");
 
       .#{$blockName}__icon {
         width: map-get($size-props, $size, "icon-size");
@@ -281,6 +284,13 @@ $size-props: (
       .#{$blockName}__text {
         font-size: map-get($size-props, $size, "font-size");
         line-height: map-get($size-props, $size, "line-height");
+      }
+
+      &.#{$blockName}--is-icon-only {
+        // overrides to have the icon-only button squared
+        min-width: map-get($size-props, $size, "min-height");
+        padding-right: map-get($size-props, $size, "padding-vertical");
+        padding-left: map-get($size-props, $size, "padding-vertical");
       }
     }
   }

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -59,6 +59,8 @@
     {{#each @model.SIZES as |size|}}
       <SF.Item @label={{capitalize size}}>
         <Hds::Button @icon="plus" @text="Lorem ipsum" @size={{size}} />
+        <br />
+        <Hds::Button @icon="plus" @text="Lorem ipsum" @isIconOnly={{true}} @size={{size}} />
       </SF.Item>
     {{/each}}
     <SF.Item @label="Full width">


### PR DESCRIPTION
### :pushpin: Summary

This PR intends to update the sizing (specifically, the padding) of the "icon-only" variant of the `Button` component so that it appears square (see thread in the linked Jira ticket for details about this decision).

### :hammer_and_wrench: Detailed description

In this PR I have: 
- `Button`:
    - updated horizontal padding of icon-only variant
    - updated showcase to show differen sizes of the icon-only button
- `Dropdown::ToggleIcon`: 
    - updated sizing of the "small" variant to match the height of the "small" variant of `Button`

👉 👉 👉 **Preview:** 
- `Button` showcase: https://hds-showcase-git-button-icon-only-padding-hashicorp.vercel.app/components/button
    - see "Sizes" + "Tests for Heather" (bottom of the page)
- `Dropdown` showcase: https://hds-showcase-git-button-icon-only-padding-hashicorp.vercel.app/components/dropdown
    - see "Icon"

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2604

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
