### PR TITLE
Adjust `TextInput` guidance on `@type`

### DIFF
--- a/website/docs/components/form/text-input/partials/code/component-api.md
+++ b/website/docs/components/form/text-input/partials/code/component-api.md
@@ -9,7 +9,7 @@ The Text Input component has two different variants with their own APIs:
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" "datetime-local" }} @default="text">
-    Sets the native HTML `type` of the `<input>`. See the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) for a full list of covered types.
+    Sets the native HTML `type` of the `<input>`.
   </C.Property>
   <C.Property @name="value" @type="string|number|date">
     Input control’s value.
@@ -36,7 +36,7 @@ The Text Input component has two different variants with their own APIs:
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" "datetime-local" }} @default="text">
-    Sets the native HTML `type` of the `<input>`. See the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) for a full list of covered types.
+    Sets the native HTML `type` of the `<input>`.
   </C.Property>
   <C.Property @name="value" @type="string|number|date">
     Input control’s value.

--- a/website/docs/components/form/text-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/text-input/partials/code/how-to-use.md
@@ -41,7 +41,7 @@ Pass a `@value` argument to pre-populate the input.
 
 #### Type
 
-Pass a `@type` argument to change the type of input. For the list of supported types, see [Component API](#component-api).
+Pass a `@type` argument to change the type of input. `@type="number"` is not supported as it causes accessibility and usability problems. If you are looking for additional validation or to display a numeric keypad on devices with dynamic keypads we recommend using `inputmode="numeric" pattern="[0-9]*"`. For the list of supported types, see [Component API](#component-api).
 
 ```handlebars
 <Hds::Form::TextInput::Field @type="email" @value="janedoe@email.com" as |F|>

--- a/website/docs/components/form/text-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/text-input/partials/code/how-to-use.md
@@ -41,7 +41,13 @@ Pass a `@value` argument to pre-populate the input.
 
 #### Type
 
-Pass a `@type` argument to change the type of input. `@type="number"` is not supported as it causes accessibility and usability problems. If you are looking for additional validation or to display a numeric keypad on devices with dynamic keypads we recommend using `inputmode="numeric" pattern="[0-9]*"`. For the list of supported types, see [Component API](#component-api).
+Pass a `@type` argument to change the type of input.
+
+!!! Info
+
+`@type="number"` is not supported as it causes [accessibility and usability problems](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/). If you are looking for additional validation or to display a numeric keypad on devices with dynamic keypads we recommend using `inputmode="numeric" pattern="[0-9]*"`. For the list of supported types, see [Component API](#component-api).
+
+!!!
 
 ```handlebars
 <Hds::Form::TextInput::Field @type="email" @value="janedoe@email.com" as |F|>


### PR DESCRIPTION
### :pushpin: Summary

Adjust `TextInput` guidance on `@type`

### :hammer_and_wrench: Detailed description

We currently support only a subset of [the standard types for `<input>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) in our `TextInput` component. This is because some of them are covered by other components (`checkbox`, `radio`, `file`), some of them require further work and have not yet been prioritized (`range`) and some of them are discouraged (`image`, `number`). As we received two inquiries regarding `type="number"` we're adding a paragraph to explain why this type was not included and the recommended alternative.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2546](https://hashicorp.atlassian.net/browse/HDS-2546)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2546]: https://hashicorp.atlassian.net/browse/HDS-2546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ