### PR TITLE
Add IDE setup info

### DIFF
--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -140,3 +140,11 @@ Our styles, components and icons are supported by the following browsers:
 | Safari         | last 2 versions |
 | Firefox        | last 2 versions |
 | Microsoft Edge | last 2 versions |
+
+## Developer environment setup
+
+### VSCode
+
+We recommend installing the [Ember Language Server extension](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) that provides autocomplete, goto definition, and diagnostics for Ember applications and addons, including Helios components.
+
+If you use TypeScript in your Ember application we also recommend installing the [Glint extension](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode) that provides improved autocomplete and quick info for components  (including arguments), as well as symbol renaming and finding references. We are in the process of converting our components to TypeScript so currently only some of them benefit from these features.

--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -141,10 +141,10 @@ Our styles, components and icons are supported by the following browsers:
 | Firefox        | last 2 versions |
 | Microsoft Edge | last 2 versions |
 
-## Developer environment setup
+## Code editor setup
 
 ### VSCode
 
 We recommend installing the [Ember Language Server extension](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) that provides autocomplete, goto definition, and diagnostics for Ember applications and addons, including Helios components.
 
-If you use TypeScript in your Ember application we also recommend installing the [Glint extension](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode) that provides improved autocomplete and quick info for components  (including arguments), as well as symbol renaming and finding references. We are in the process of converting our components to TypeScript so currently only some of them benefit from these features.
+If you use TypeScript in your Ember application, we also recommend installing the [Glint extension](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode) that provides improved autocomplete and quick info for components (including arguments), as well as symbol renaming and finding references. We are in the process of converting our components to TypeScript so currently only some of them benefit from these features.


### PR DESCRIPTION
### :pushpin: Summary

Add IDE setup info to Getting started for engineers.

### :hammer_and_wrench: Detailed description

We add information for a minimal VSCode setup to improve new joiners' efficiency when working with our packages.
Open to suggestions if you use other extensions that may be worth mentioning here.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2514](https://hashicorp.atlassian.net/browse/HDS-2514)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2514]: https://hashicorp.atlassian.net/browse/HDS-2514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ