### PR TITLE
updated Hds::Tag component's CSS for WCAG conformance

### DIFF
--- a/.changeset/neat-owls-rush.md
+++ b/.changeset/neat-owls-rush.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Updated padding for tag dismiss button for WCAG conformance

--- a/.changeset/neat-owls-rush.md
+++ b/.changeset/neat-owls-rush.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Updated padding for tag dismiss button for WCAG conformance
+`Tag` - Updated padding for dismiss button for WCAG conformance

--- a/packages/components/app/styles/components/tag.scss
+++ b/packages/components/app/styles/components/tag.scss
@@ -29,7 +29,7 @@ $hds-tag-border-radius: 50px;
 .hds-tag__dismiss {
   flex: 0 0 auto;
   margin: 0; // reset default button margin
-  padding: 6px 2px 6px 8px;
+  padding: 6px 4px 6px 8px;
   border: none; // reset default button border
   border-radius: inherit;
   border-top-right-radius: 0;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves the WCAG conformance issue with the dismiss button on the `Hds::Tag` component, where the size needed to be increased.

### :hammer_and_wrench: Detailed description

- the right padding on the dismiss button of the tag component was changed from 2px to 4px (for a total of 24px interactive area, as per WCAG guidelines) 

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
