### PR TITLE
Acceptance test with a11y audit for Hds::Tabs component

### DIFF
--- a/packages/components/tests/acceptance/components/hds/tabs-test.js
+++ b/packages/components/tests/acceptance/components/hds/tabs-test.js
@@ -17,6 +17,9 @@ module('Acceptance | Component | hds/tabs', function (hooks) {
         listitem: {
           enabled: false,
         },
+        'landmark-unique': {
+          enabled: false,
+        },
       },
     };
     await visit('/components/tabs');

--- a/packages/components/tests/acceptance/components/hds/tabs-test.js
+++ b/packages/components/tests/acceptance/components/hds/tabs-test.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | Component | hds/tabs', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('Components/tabs page passes a11y automated checks', async function (assert) {
+    let axeOptions = {
+      rules: {
+        listitem: {
+          enabled: false,
+        },
+      },
+    };
+    await visit('/components/tabs');
+
+    await a11yAudit(axeOptions);
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds an acceptance test with an a11y audit for the tabs component.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2628](https://hashicorp.atlassian.net/browse/HDS-2628)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2628]: https://hashicorp.atlassian.net/browse/HDS-2628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ