### PR TITLE
Remove url test from component acceptance test blueprint

### DIFF
--- a/packages/components/blueprints/hds-component-test/files/tests/acceptance/components/hds/__name__.js
+++ b/packages/components/blueprints/hds-component-test/files/tests/acceptance/components/hds/__name__.js
@@ -4,18 +4,12 @@
  */
 
 import { module, test } from 'qunit';
-import { visit, currentURL } from '@ember/test-helpers';
+import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | components/<%= dasherizedModuleName %>', function (hooks) {
   setupApplicationTest(hooks);
-
-  test('visiting /components/<%= dasherizedModuleName %>', async function (assert) {
-    await visit('/components/<%= dasherizedModuleName %>');
-
-    assert.strictEqual(currentURL(), '/components/<%= dasherizedModuleName %>');
-  });
 
   test('Components/<%= dasherizedModuleName %> page passes automated a11y checks', async function (assert) {
     await visit('/components/<%= dasherizedModuleName %>');


### PR DESCRIPTION
### :pushpin: Summary

Discussed with @alex-ju @MelSumner yesterday and there was agreement to take these out of the tests being added in #1669 and therefore also here in the blueprint for these tests.