### PR TITLE
`Shw::Placeholder` - Fix color contrast

### DIFF
--- a/packages/components/tests/dummy/app/styles/showcase-components/placeholder.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-components/placeholder.scss
@@ -18,6 +18,7 @@
   line-height: 1.2;
   text-align: center;
   text-shadow: 0 0 5px #fff;
+  background-color: #eee;
 
   a,
   a > & {

--- a/packages/components/tests/dummy/app/templates/components/accordion.hbs
+++ b/packages/components/tests/dummy/app/templates/components/accordion.hbs
@@ -18,7 +18,7 @@
         <A.Item>
           <:toggle>Item one</:toggle>
           <:content>
-            <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+            <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
       </Hds::Accordion>
@@ -29,21 +29,21 @@
         <A.Item>
           <:toggle>Item one</:toggle>
           <:content>
-            <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+            <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
 
         <A.Item>
           <:toggle>Item two</:toggle>
           <:content>
-            <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+            <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
 
         <A.Item>
           <:toggle>Item Three</:toggle>
           <:content>
-            <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+            <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
       </Hds::Accordion>
@@ -66,7 +66,7 @@
               <Hds::Accordion::Item>
                 <:toggle>Nested item one</:toggle>
                 <:content>
-                  <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+                  <Shw::Placeholder @text="generic content" @height="40" />
                 </:content>
               </Hds::Accordion::Item>
             </Hds::Accordion>
@@ -84,13 +84,13 @@
               <Hds::Accordion::Item>
                 <:toggle>Nested item one</:toggle>
                 <:content>
-                  <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+                  <Shw::Placeholder @text="generic content" @height="40" />
                 </:content>
               </Hds::Accordion::Item>
               <Hds::Accordion::Item>
                 <:toggle>Nested item two</:toggle>
                 <:content>
-                  <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+                  <Shw::Placeholder @text="generic content" @height="40" />
                 </:content>
               </Hds::Accordion::Item>
             </Hds::Accordion>
@@ -112,7 +112,7 @@
               <Hds::Accordion::Item @containsInteractive={{true}}>
                 <:toggle>Nested item with containsInteractive=true</:toggle>
                 <:content>
-                  <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+                  <Shw::Placeholder @text="generic content" @height="40" />
                 </:content>
               </Hds::Accordion::Item>
             </Hds::Accordion>
@@ -130,7 +130,7 @@
               <Hds::Accordion::Item>
                 <:toggle>Nested item with containsInteractive=false (the default)</:toggle>
                 <:content>
-                  <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+                  <Shw::Placeholder @text="generic content" @height="40" />
                 </:content>
               </Hds::Accordion::Item>
             </Hds::Accordion>
@@ -150,7 +150,7 @@
             <h4 class="hds-typography-display-300">Header tag example</h4>
           </:toggle>
           <:content>
-            <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+            <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
       </Hds::Accordion>
@@ -238,7 +238,7 @@
             dolor sit amet?
           </:toggle>
           <:content>
-            <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+            <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
       </Hds::Accordion>
@@ -266,7 +266,7 @@
                 >
                   <:toggle>Item one</:toggle>
                   <:content>
-                    <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+                    <Shw::Placeholder @text="generic content" @height="40" />
                   </:content>
                 </Hds::Accordion::Item>
               </SF.Item>
@@ -276,7 +276,7 @@
               <Hds::Accordion::Item @containsInteractive={{bool}} @isOpen={{true}}>
                 <:toggle>Item one</:toggle>
                 <:content>
-                  <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+                  <Shw::Placeholder @text="generic content" @height="40" />
                 </:content>
               </Hds::Accordion::Item>
             </SF.Item>
@@ -289,7 +289,7 @@
               >
                 <:toggle>Item one</:toggle>
                 <:content>
-                  <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+                  <Shw::Placeholder @text="generic content" @height="40" />
                 </:content>
               </Hds::Accordion::Item>
             </SF.Item>
@@ -308,7 +308,7 @@
       <Hds::Accordion::Item>
         <:toggle>Item one</:toggle>
         <:content>
-          <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+          <Shw::Placeholder @text="generic content" @height="40" />
         </:content>
       </Hds::Accordion::Item>
     </SF.Item>
@@ -318,7 +318,7 @@
         <A.Item @isOpen={{true}}>
           <:toggle>Item one</:toggle>
           <:content>
-            <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+            <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
       </Hds::Accordion>
@@ -333,7 +333,7 @@
         <A.Item>
           <:toggle>Item one</:toggle>
           <:content>
-            <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+            <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
       </Hds::Accordion>
@@ -344,7 +344,7 @@
         <A.Item @containsInteractive={{true}}>
           <:toggle>Item one</:toggle>
           <:content>
-            <Shw::Placeholder @text="generic content" @height="40" @background="#eee" />
+            <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
       </Hds::Accordion>

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -136,7 +136,7 @@
               <code>A.Generic</code>
               contextual component.</A.Description>
             <A.Generic>
-              <Shw::Placeholder @text="some generic content" @height="50" @background="#eee" />
+              <Shw::Placeholder @text="some generic content" @height="50" />
             </A.Generic>
           </Hds::Alert>
         </SF.Item>

--- a/packages/components/tests/dummy/app/templates/components/app-footer.hbs
+++ b/packages/components/tests/dummy/app/templates/components/app-footer.hbs
@@ -20,29 +20,19 @@
       <SF.Item @label="With only generic content">
         <Hds::AppFooter as |AF|>
           <AF.ExtraBefore>
-            <Shw::Placeholder
-              @height="2em"
-              {{style width="fit-content"}}
-              @text="Extra Content Before"
-              @background="#eee"
-            />
+            <Shw::Placeholder @height="2em" {{style width="fit-content"}} @text="Extra Content Before" />
           </AF.ExtraBefore>
           <AF.Item>
-            <Shw::Placeholder @height="2em" @text="Item" @background="#eee" />
+            <Shw::Placeholder @height="2em" @text="Item" />
           </AF.Item>
           <AF.Item>
-            <Shw::Placeholder @height="2em" @text="Item" @background="#eee" />
+            <Shw::Placeholder @height="2em" @text="Item" />
           </AF.Item>
           <AF.Item>
-            <Shw::Placeholder @height="2em" @text="Item" @background="#eee" />
+            <Shw::Placeholder @height="2em" @text="Item" />
           </AF.Item>
           <AF.ExtraAfter>
-            <Shw::Placeholder
-              @height="2em"
-              {{style width="fit-content"}}
-              @text="Extra Content After"
-              @background="#eee"
-            />
+            <Shw::Placeholder @height="2em" {{style width="fit-content"}} @text="Extra Content After" />
           </AF.ExtraAfter>
         </Hds::AppFooter>
       </SF.Item>
@@ -160,7 +150,6 @@
                     @height="2em"
                     {{style width="fit-content"}}
                     @text="Before"
-                    @background="#eee"
                   />
                 </AF.ExtraBefore>
                 <AF.StatusLink @status="operational" />
@@ -180,7 +169,6 @@
                     @height="2em"
                     {{style width="fit-content"}}
                     @text="After"
-                    @background="#eee"
                   />
                 </AF.ExtraAfter>
               </Hds::AppFooter>

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -705,7 +705,7 @@
         <ul class="hds-dropdown__list" role="listbox" aria-label="Custom content">
           {{#each @model.ITEM_STATES as |state|}}
             <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
-              <Shw::Placeholder @text="custom content" @width="128" @height="20" @background="#eee" />
+              <Shw::Placeholder @text="custom content" @width="128" @height="20" />
             </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
@@ -716,7 +716,7 @@
         <ul class="hds-dropdown__list" role="listbox" aria-label="Custom content, selected">
           {{#each @model.ITEM_STATES as |state|}}
             <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
-              <Shw::Placeholder @text="custom content" @width="128" @height="20" @background="#eee" />
+              <Shw::Placeholder @text="custom content" @width="128" @height="20" />
             </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
@@ -868,7 +868,7 @@
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
             <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">
-              <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
             </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
@@ -879,7 +879,7 @@
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
             <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">
-              <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
             </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
@@ -1026,7 +1026,7 @@
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
             <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">
-              <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
             </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
@@ -1037,7 +1037,7 @@
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
             <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">
-              <Shw::Placeholder @text="custom content" @width="122" @height="20" @background="#eee" />
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
             </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>

--- a/packages/components/tests/dummy/app/templates/components/flyout.hbs
+++ b/packages/components/tests/dummy/app/templates/components/flyout.hbs
@@ -100,7 +100,7 @@
       <Hds::Flyout open id="flyout-example-generic-content" as |F|>
         <F.Header @icon="info">Title</F.Header>
         <F.Body>
-          <Shw::Placeholder @text="some generic content" @height="50" @background="#eee" />
+          <Shw::Placeholder @text="some generic content" @height="50" />
         </F.Body>
       </Hds::Flyout>
     </SF.Item>
@@ -164,7 +164,7 @@
           <p class="hds-typography-body-300 hds-foreground-primary">Flyout content</p>
         </F.Body>
         <F.Footer>
-          <Shw::Placeholder @text="some generic content" @height="50" @background="#eee" />
+          <Shw::Placeholder @text="some generic content" @height="50" />
         </F.Footer>
       </Hds::Flyout>
     </SF.Item>

--- a/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/base-elements.hbs
@@ -281,10 +281,10 @@
               <F.HelperText>This is the helper text</F.HelperText>
               <F.Control>
                 {{#if (eq layout "vertical")}}
-                  <Shw::Placeholder @text="control" @width="100%" @height="32" @background="#eee" />
+                  <Shw::Placeholder @text="control" @width="100%" @height="32" />
                 {{/if}}
                 {{#if (eq layout "flag")}}
-                  <Shw::Placeholder @text="✔" @width="16" @height="16" @background="#eee" />
+                  <Shw::Placeholder @text="✔" @width="16" @height="16" />
                 {{/if}}
               </F.Control>
               <F.Error>This is the error</F.Error>
@@ -305,10 +305,10 @@
               <F.Label>This is the label text</F.Label>
               <F.Control>
                 {{#if (eq layout "vertical")}}
-                  <Shw::Placeholder @text="control" @width="100%" @height="32" @background="#eee" />
+                  <Shw::Placeholder @text="control" @width="100%" @height="32" />
                 {{/if}}
                 {{#if (eq layout "flag")}}
-                  <Shw::Placeholder @text="✔" @width="16" @height="16" @background="#eee" />
+                  <Shw::Placeholder @text="✔" @width="16" @height="16" />
                 {{/if}}
               </F.Control>
             </Hds::Form::Field>
@@ -319,10 +319,10 @@
               <F.HelperText>This is the helper text</F.HelperText>
               <F.Control>
                 {{#if (eq layout "vertical")}}
-                  <Shw::Placeholder @text="control" @width="100%" @height="32" @background="#eee" />
+                  <Shw::Placeholder @text="control" @width="100%" @height="32" />
                 {{/if}}
                 {{#if (eq layout "flag")}}
-                  <Shw::Placeholder @text="✔" @width="16" @height="16" @background="#eee" />
+                  <Shw::Placeholder @text="✔" @width="16" @height="16" />
                 {{/if}}
               </F.Control>
             </Hds::Form::Field>
@@ -333,10 +333,10 @@
               <F.HelperText>This is the helper text</F.HelperText>
               <F.Control>
                 {{#if (eq layout "vertical")}}
-                  <Shw::Placeholder @text="control" @width="100%" @height="32" @background="#eee" />
+                  <Shw::Placeholder @text="control" @width="100%" @height="32" />
                 {{/if}}
                 {{#if (eq layout "flag")}}
-                  <Shw::Placeholder @text="✔" @width="16" @height="16" @background="#eee" />
+                  <Shw::Placeholder @text="✔" @width="16" @height="16" />
                 {{/if}}
               </F.Control>
             </Hds::Form::Field>
@@ -351,10 +351,10 @@
               <F.Label>This is the label</F.Label>
               <F.Control>
                 {{#if (eq layout "vertical")}}
-                  <Shw::Placeholder @text="control" @width="100%" @height="32" @background="#eee" />
+                  <Shw::Placeholder @text="control" @width="100%" @height="32" />
                 {{/if}}
                 {{#if (eq layout "flag")}}
-                  <Shw::Placeholder @text="✔" @width="16" @height="16" @background="#eee" />
+                  <Shw::Placeholder @text="✔" @width="16" @height="16" />
                 {{/if}}
               </F.Control>
               <F.Error>This is the error</F.Error>
@@ -366,10 +366,10 @@
               <F.HelperText>This is the helper text</F.HelperText>
               <F.Control>
                 {{#if (eq layout "vertical")}}
-                  <Shw::Placeholder @text="control" @width="100%" @height="32" @background="#eee" />
+                  <Shw::Placeholder @text="control" @width="100%" @height="32" />
                 {{/if}}
                 {{#if (eq layout "flag")}}
-                  <Shw::Placeholder @text="✔" @width="16" @height="16" @background="#eee" />
+                  <Shw::Placeholder @text="✔" @width="16" @height="16" />
                 {{/if}}
               </F.Control>
               <F.Error>This is the error</F.Error>
@@ -381,10 +381,10 @@
               <F.HelperText>This is the helper text</F.HelperText>
               <F.Control>
                 {{#if (eq layout "vertical")}}
-                  <Shw::Placeholder @text="control" @width="100%" @height="32" @background="#eee" />
+                  <Shw::Placeholder @text="control" @width="100%" @height="32" />
                 {{/if}}
                 {{#if (eq layout "flag")}}
-                  <Shw::Placeholder @text="✔" @width="16" @height="16" @background="#eee" />
+                  <Shw::Placeholder @text="✔" @width="16" @height="16" />
                 {{/if}}
               </F.Control>
               <F.Error as |E|>
@@ -412,10 +412,10 @@
                     <F.HelperText>This is the helper text</F.HelperText>
                     <F.Control>
                       {{#if (eq layout "vertical")}}
-                        <Shw::Placeholder @text="control" @width="100%" @height="32" @background="#eee" />
+                        <Shw::Placeholder @text="control" @width="100%" @height="32" />
                       {{/if}}
                       {{#if (eq layout "flag")}}
-                        <Shw::Placeholder @text="✔" @width="16" @height="16" @background="#eee" />
+                        <Shw::Placeholder @text="✔" @width="16" @height="16" />
                       {{/if}}
                     </F.Control>
                     <F.Error>This is the error</F.Error>
@@ -428,10 +428,10 @@
                     <F.HelperText>This is the helper text that should go on multiple lines</F.HelperText>
                     <F.Control>
                       {{#if (eq layout "vertical")}}
-                        <Shw::Placeholder @text="control" @width="100%" @height="32" @background="#eee" />
+                        <Shw::Placeholder @text="control" @width="100%" @height="32" />
                       {{/if}}
                       {{#if (eq layout "flag")}}
-                        <Shw::Placeholder @text="✔" @width="16" @height="16" @background="#eee" />
+                        <Shw::Placeholder @text="✔" @width="16" @height="16" />
                       {{/if}}
                     </F.Control>
                     <F.Error as |E|>
@@ -472,31 +472,13 @@
               <F.Legend>This is the legend</F.Legend>
               <F.HelperText>This is the helper text</F.HelperText>
               <F.Control>
-                <Shw::Placeholder
-                  @text="field"
-                  @width="120"
-                  @height="32"
-                  @background="#eee"
-                  class="hds-form-group__control-field"
-                />
+                <Shw::Placeholder @text="field" @width="120" @height="32" class="hds-form-group__control-field" />
               </F.Control>
               <F.Control>
-                <Shw::Placeholder
-                  @text="field"
-                  @width="120"
-                  @height="32"
-                  @background="#eee"
-                  class="hds-form-group__control-field"
-                />
+                <Shw::Placeholder @text="field" @width="120" @height="32" class="hds-form-group__control-field" />
               </F.Control>
               <F.Control>
-                <Shw::Placeholder
-                  @text="field"
-                  @width="120"
-                  @height="32"
-                  @background="#eee"
-                  class="hds-form-group__control-field"
-                />
+                <Shw::Placeholder @text="field" @width="120" @height="32" class="hds-form-group__control-field" />
               </F.Control>
               <F.Error>This is the error</F.Error>
             </Hds::Form::Fieldset>
@@ -519,22 +501,10 @@
                     <F.Legend>This is the legend</F.Legend>
                     <F.HelperText>This is the helper text</F.HelperText>
                     <F.Control>
-                      <Shw::Placeholder
-                        @text="field"
-                        @width="120"
-                        @height="32"
-                        @background="#eee"
-                        class="hds-form-group__control-field"
-                      />
+                      <Shw::Placeholder @text="field" @width="120" @height="32" class="hds-form-group__control-field" />
                     </F.Control>
                     <F.Control>
-                      <Shw::Placeholder
-                        @text="field"
-                        @width="120"
-                        @height="32"
-                        @background="#eee"
-                        class="hds-form-group__control-field"
-                      />
+                      <Shw::Placeholder @text="field" @width="120" @height="32" class="hds-form-group__control-field" />
                     </F.Control>
                     <F.Error>This is the error</F.Error>
                   </Hds::Form::Fieldset>
@@ -545,22 +515,10 @@
                     <F.Legend>This is the legend text that should go on multiple lines</F.Legend>
                     <F.HelperText>This is the helper text that should go on multiple lines</F.HelperText>
                     <F.Control>
-                      <Shw::Placeholder
-                        @text="field"
-                        @width="120"
-                        @height="32"
-                        @background="#eee"
-                        class="hds-form-group__control-field"
-                      />
+                      <Shw::Placeholder @text="field" @width="120" @height="32" class="hds-form-group__control-field" />
                     </F.Control>
                     <F.Control>
-                      <Shw::Placeholder
-                        @text="field"
-                        @width="120"
-                        @height="32"
-                        @background="#eee"
-                        class="hds-form-group__control-field"
-                      />
+                      <Shw::Placeholder @text="field" @width="120" @height="32" class="hds-form-group__control-field" />
                     </F.Control>
                     <F.Error as |E|>
                       <E.Message>This is the first error text</E.Message>

--- a/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio-card.hbs
@@ -62,7 +62,7 @@
             <R.Icon @name="hexagon" />
             <R.Label>{{item.label}}</R.Label>
             <R.Generic>
-              <Shw::Placeholder @text={{item.generic}} @height="50" @background="#eee" />
+              <Shw::Placeholder @text={{item.generic}} @height="50" />
             </R.Generic>
           </G.RadioCard>
         {{/each}}

--- a/packages/components/tests/dummy/app/templates/components/modal.hbs
+++ b/packages/components/tests/dummy/app/templates/components/modal.hbs
@@ -149,7 +149,7 @@
           Title
         </M.Header>
         <M.Body>
-          <Shw::Placeholder @text="some generic content" @height="50" @background="#eee" />
+          <Shw::Placeholder @text="some generic content" @height="50" />
         </M.Body>
         <M.Footer>
           <Hds::ButtonSet>

--- a/packages/components/tests/dummy/app/templates/components/reveal.hbs
+++ b/packages/components/tests/dummy/app/templates/components/reveal.hbs
@@ -95,7 +95,7 @@
         Lorem ipsum dolor sit amet consectetur
       </p>
       <Hds::Reveal @text="More options">
-        <Shw::Placeholder @text="generic content" @height="40" @width="200" @background="#eee" />
+        <Shw::Placeholder @text="generic content" @height="40" @width="200" />
       </Hds::Reveal>
       <p class="hds-typography-body-300">
         adipisicing elit. Doloremque blanditiis sapiente iste beatae voluptates voluptatum.
@@ -125,13 +125,13 @@
   <Shw::Flex {{style gap="5rem"}} as |SF|>
     <SF.Item @label="Only using required @text">
       <Hds::Reveal @text="Same text label for open and closed">
-        <Shw::Placeholder @text="generic content" @height="40" @width="200" @background="#eee" />
+        <Shw::Placeholder @text="generic content" @height="40" @width="200" />
       </Hds::Reveal>
     </SF.Item>
 
     <SF.Item @label="Using optional @textWhenOpen">
       <Hds::Reveal @text="Open me" @textWhenOpen="Close me">
-        <Shw::Placeholder @text="generic content" @height="40" @width="200" @background="#eee" />
+        <Shw::Placeholder @text="generic content" @height="40" @width="200" />
       </Hds::Reveal>
     </SF.Item>
   </Shw::Flex>
@@ -141,13 +141,13 @@
   <Shw::Flex {{style gap="5rem"}} as |SF|>
     <SF.Item @label="Default, isOpen=false">
       <Hds::Reveal @text="More options">
-        <Shw::Placeholder @text="generic content" @height="40" @width="200" @background="#eee" />
+        <Shw::Placeholder @text="generic content" @height="40" @width="200" />
       </Hds::Reveal>
     </SF.Item>
 
     <SF.Item @label="isOpen=true">
       <Hds::Reveal @text="More options" @isOpen={{true}}>
-        <Shw::Placeholder @text="generic content" @height="40" @width="200" @background="#eee" />
+        <Shw::Placeholder @text="generic content" @height="40" @width="200" />
       </Hds::Reveal>
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -24,12 +24,12 @@
     <T.Tab>Three</T.Tab>
 
     <T.Panel>
-      <Shw::Placeholder @height="50" @background="#eee">
+      <Shw::Placeholder @height="50">
         <span>Content one with <a href="#">link to test tabbing</a></span>
       </Shw::Placeholder>
     </T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content two" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content three" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content two" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content three" @height="50" /></T.Panel>
   </Hds::Tabs>
 
   <Shw::Text::Body>With optional icon and badge count</Shw::Text::Body>
@@ -40,10 +40,10 @@
     <T.Tab>Three</T.Tab>
     <T.Tab @icon="alert-triangle" @count="5">Four</T.Tab>
 
-    <T.Panel><Shw::Placeholder @text="Content one" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content two" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content three" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content four" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content one" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content two" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content three" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content four" @height="50" /></T.Panel>
   </Hds::Tabs>
 
   <Shw::Text::Body>With pre-selected tab</Shw::Text::Body>
@@ -53,10 +53,10 @@
     <T.Tab>Two</T.Tab>
     <T.Tab @isSelected={{true}}>Three (selected on page load)</T.Tab>
 
-    <T.Panel><Shw::Placeholder @text="Content one" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content two" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content one" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content two" @height="50" /></T.Panel>
     <T.Panel>
-      <Shw::Placeholder @text="Content three (displayed on page load)" @height="50" @background="#eee" />
+      <Shw::Placeholder @text="Content three (displayed on page load)" @height="50" />
     </T.Panel>
   </Hds::Tabs>
 
@@ -74,16 +74,16 @@
     <T.Tab>Nine one-thousand</T.Tab>
     <T.Tab>Ten one-thousand</T.Tab>
 
-    <T.Panel><Shw::Placeholder @text="Content one" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content two" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content three" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content four" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content five" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content six" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content seven" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content eight" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content nine" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content ten" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content one" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content two" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content three" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content four" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content five" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content six" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content seven" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content eight" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content nine" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content ten" @height="50" /></T.Panel>
   </Hds::Tabs>
 
   <Shw::Text::Body>Invoking a callback function when a tab is clicked</Shw::Text::Body>
@@ -93,9 +93,9 @@
     <T.Tab>Two</T.Tab>
     <T.Tab>Three</T.Tab>
 
-    <T.Panel><Shw::Placeholder @text="Content one" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content two" @height="50" @background="#eee" /></T.Panel>
-    <T.Panel><Shw::Placeholder @text="Content three" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content one" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content two" @height="50" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Content three" @height="50" /></T.Panel>
   </Hds::Tabs>
 
   <Shw::Text::Body>Nested tabs</Shw::Text::Body>
@@ -110,20 +110,20 @@
         <T.Tab>Tab One - Sub-tab A</T.Tab>
         <T.Tab>Tab One - Sub-tab B</T.Tab>
         <T.Tab>Tab One - Sub-tab C</T.Tab>
-        <T.Panel><Shw::Placeholder @text="Tab One - Content A" @height="50" @background="#eee" /></T.Panel>
-        <T.Panel><Shw::Placeholder @text="Tab One - Content B" @height="50" @background="#eee" /></T.Panel>
-        <T.Panel><Shw::Placeholder @text="Tab One - Content C" @height="50" @background="#eee" /></T.Panel>
+        <T.Panel><Shw::Placeholder @text="Tab One - Content A" @height="50" /></T.Panel>
+        <T.Panel><Shw::Placeholder @text="Tab One - Content B" @height="50" /></T.Panel>
+        <T.Panel><Shw::Placeholder @text="Tab One - Content C" @height="50" /></T.Panel>
       </Hds::Tabs>
     </T.Panel>
     <T.Panel>
       <Hds::Tabs as |T|>
         <T.Tab>Tab Two - Sub-tab A</T.Tab>
         <T.Tab>Tab Two - Sub-tab B</T.Tab>
-        <T.Panel><Shw::Placeholder @text="Tab Two - Content A" @height="50" @background="#eee" /></T.Panel>
-        <T.Panel><Shw::Placeholder @text="Tab Two - Content B" @height="50" @background="#eee" /></T.Panel>
+        <T.Panel><Shw::Placeholder @text="Tab Two - Content A" @height="50" /></T.Panel>
+        <T.Panel><Shw::Placeholder @text="Tab Two - Content B" @height="50" /></T.Panel>
       </Hds::Tabs>
     </T.Panel>
-    <T.Panel><Shw::Placeholder @text="Tab Three - Content" @height="50" @background="#eee" /></T.Panel>
+    <T.Panel><Shw::Placeholder @text="Tab Three - Content" @height="50" /></T.Panel>
   </Hds::Tabs>
 
   <Shw::Divider />
@@ -189,7 +189,7 @@
   <Shw::Text::H3>Tabs::Panel</Shw::Text::H3>
 
   <Hds::Tabs::Panel>
-    <Shw::Placeholder @text="Panel with generic content" @height="50" @background="#eee" />
+    <Shw::Placeholder @text="Panel with generic content" @height="50" />
   </Hds::Tabs::Panel>
 
 </section>

--- a/packages/components/tests/dummy/app/templates/components/toast.hbs
+++ b/packages/components/tests/dummy/app/templates/components/toast.hbs
@@ -130,7 +130,7 @@
               <code>A.Generic</code>
               contextual component.</T.Description>
             <T.Generic>
-              <Shw::Placeholder @text="some generic content" @height="50" @background="#eee" />
+              <Shw::Placeholder @text="some generic content" @height="50" />
             </T.Generic>
           </Hds::Toast>
         </SF.Item>

--- a/packages/components/tests/dummy/app/templates/utilities/disclosure-primitive.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities/disclosure-primitive.hbs
@@ -21,7 +21,7 @@
             </button>
           </:toggle>
           <:content>
-            <Shw::Placeholder @text="some generic content here" @width="200" @height="90" @background="#FAFAFA" />
+            <Shw::Placeholder @text="some generic content here" @width="200" @height="90" @background="#e1f5fe" />
           </:content>
         </Hds::DisclosurePrimitive>
       </div>

--- a/packages/components/tests/dummy/app/templates/utilities/menu-primitive.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities/menu-primitive.hbs
@@ -21,7 +21,7 @@
             </button>
           </:toggle>
           <:content>
-            <Shw::Placeholder @text="some generic content here" @width="200" @height="90" @background="#FAFAFA" />
+            <Shw::Placeholder @text="some generic content here" @width="200" @height="90" @background="#e1f5fe" />
           </:content>
         </Hds::MenuPrimitive>
       </div>


### PR DESCRIPTION
### :pushpin: Summary

Context: https://github.com/hashicorp/design-system/pull/1695/files#r1347806114

### :hammer_and_wrench: Detailed description

In this PR I have:
- added default background color for `Shw::Placeholder`
- removed `@background` argument for `Shw::Placeholder` when the color was the same as the default
- replaced background colors in a couple of `Shw::Placeholder` instances

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
