### PR TITLE
`Pagination::Compact` - Expose the `SizeSelector`

### DIFF
--- a/.changeset/cyan-adults-laugh.md
+++ b/.changeset/cyan-adults-laugh.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Pagination::Compact` - Added option to show "SizeSelector" element

--- a/packages/components/addon/components/hds/pagination/compact/index.hbs
+++ b/packages/components/addon/components/hds/pagination/compact/index.hbs
@@ -27,4 +27,13 @@
       @disabled={{@isDisabledNext}}
     />
   </nav>
+
+  {{#if this.showSizeSelector}}
+    <Hds::Pagination::SizeSelector
+      @pageSizes={{this.pageSizes}}
+      @label={{@sizeSelectorLabel}}
+      @selectedSize={{this.currentPageSize}}
+      @onChange={{this.onPageSizeChange}}
+    />
+  {{/if}}
 </div>

--- a/packages/components/addon/components/hds/pagination/compact/index.js
+++ b/packages/components/addon/components/hds/pagination/compact/index.js
@@ -8,8 +8,14 @@ import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import { inject as service } from '@ember/service';
 
+// for context about the decision to use these values, see:
+// https://hashicorp.slack.com/archives/C03A0N1QK8S/p1673546329082759
+export const DEFAULT_PAGE_SIZES = [10, 30, 50];
+
 export default class HdsPaginationCompactIndexComponent extends Component {
   @service router;
+
+  showSizeSelector = this.args.showSizeSelector ?? false; // if the "size selector" block is visible
 
   constructor() {
     super(...arguments);
@@ -54,6 +60,23 @@ export default class HdsPaginationCompactIndexComponent extends Component {
    */
   get ariaLabel() {
     return this.args.ariaLabel ?? 'Pagination';
+  }
+
+  /**
+   * @param pageSizes
+   * @type {array of numbers}
+   * @description Set the page sizes users can select from.
+   * @default [10, 30, 50]
+   */
+  get pageSizes() {
+    let { pageSizes = DEFAULT_PAGE_SIZES } = this.args;
+
+    assert(
+      `pageSizes argument must be an array. Received: ${pageSizes}`,
+      Array.isArray(pageSizes) === true
+    );
+
+    return pageSizes;
   }
 
   get routeQueryParams() {

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -96,6 +96,10 @@
       <SFI.Label>With <code>@showLabels=&lcub;&lcub;false&rcub;&rcub;</code></SFI.Label>
       <Hds::Pagination::Compact @showLabels={{false}} />
     </SF.Item>
+    <SF.Item as |SFI|>
+      <SFI.Label>With <code>@showSizeSelector=&lcub;&lcub;true&rcub;&rcub;</code></SFI.Label>
+      <Hds::Pagination::Compact @showSizeSelector={{true}} />
+    </SF.Item>
   </Shw::Flex>
 
   <Shw::Divider />

--- a/packages/components/tests/integration/components/hds/pagination/compact-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/compact-test.js
@@ -49,6 +49,52 @@ module('Integration | Component | hds/pagination/compact', function (hooks) {
     assert.dom('.hds-pagination-nav__arrow-label').doesNotExist();
   });
 
+  // SIZE SELECTOR
+
+  test('it shows the "size-selector" if @showSizeSelector is true', async function (assert) {
+    await render(hbs`
+      <Hds::Pagination::Compact @showSizeSelector={{true}} />
+    `);
+    assert.dom('.hds-pagination .hds-pagination-size-selector').exists();
+  });
+
+  test('it renders the "size selector" content with default pageSizes values', async function (assert) {
+    await render(hbs`
+      <Hds::Pagination::Compact @showSizeSelector={{true}} />
+    `);
+    assert
+      .dom('.hds-pagination .hds-pagination-size-selector option[value="10"]')
+      .hasText('10');
+    assert
+      .dom('.hds-pagination .hds-pagination-size-selector option[value="30"]')
+      .hasText('30');
+    assert
+      .dom('.hds-pagination .hds-pagination-size-selector option[value="50"]')
+      .hasText('50');
+  });
+
+  test('it renders custom options for passed in pageSizes', async function (assert) {
+    await render(hbs`
+      <Hds::Pagination::Compact @showSizeSelector={{true}} @pageSizes={{array 20 40 60}} />
+    `);
+    assert
+      .dom('.hds-pagination .hds-pagination-size-selector option[value="20"]')
+      .hasText('20');
+    assert
+      .dom('.hds-pagination .hds-pagination-size-selector option[value="40"]')
+      .hasText('40');
+    assert
+      .dom('.hds-pagination .hds-pagination-size-selector option[value="60"]')
+      .hasText('60');
+  });
+
+  test('it displays the passed in custom text for the SizeSelector label text', async function (assert) {
+    await render(hbs`
+      <Hds::Pagination::Compact @showSizeSelector={{true}} @sizeSelectorLabel="Custom text" />
+    `);
+    assert.dom('.hds-pagination-size-selector label').hasText('Custom text');
+  });
+
   // DISABLED
 
   test('it should render disabled buttons when @isDisabledPrev/Next are set to true', async function (assert) {

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -28,23 +28,26 @@ These Pagination sub-elements may be used directly if you need to cover a very s
 <C.Property @name="totalItems" @required="true" @type="number">
 Pass the total number of items to be paginated. If no value is defined an error will be thrown.
 </C.Property>
-<C.Property @name="currentPageSize" @type="number">
-Pass the maximum number of items to display on each page. If no value is defined, the first page size in `pageSizes` will be used. Default is `10` if custom `pageSizes` are not defined.
-</C.Property>
-<C.Property @name="pageSizes" @type="array" @values={{array "[10, 30, 50]" "array of integers" }} @default="[10, 30, 50]">
-Set the page sizes users can select from. Example: `@pageSizes=\{{array 5 20 30}}`.
-</C.Property>
 <C.Property @name="currentPage" @type="integer" @values={{array 1 "integer" }} @default={{1}}>
 Set a custom initial selected page.
 </C.Property>
-<C.Property @name="sizeSelectorLabel" @type="string" @default="Items per page">
-  Add a custom string for the label text overriding the default value.
+<C.Property @name="currentPageSize" @type="number">
+Pass the maximum number of items to display on each page. If no value is defined, the first page size in `pageSizes` will be used. Default is `10` if custom `pageSizes` are not defined.
+</C.Property>
+<C.Property @name="showLabels" @type="boolean" @default="false">
+Used to control the visibility of the "prev/next" text labels.
 </C.Property>
 <C.Property @name="isTruncated" @type="boolean" @default="true">
 Used to to limit the number of page numbers displayed (to save space, it will display an ellipsis for some numbers).
 </C.Property>
-<C.Property @name="showLabels" @type="boolean" @default="false">
-Used to control the visibility of the "prev/next" text labels.
+<C.Property @name="showSizeSelector" @type="boolean" @default="true">
+Used to control the visibility of the "size selector".
+</C.Property>
+<C.Property @name="pageSizes" @type="array" @values={{array "[10, 30, 50]" "array of integers" }} @default="[10, 30, 50]">
+Set the page sizes users can select from. Example: `@pageSizes=\{{array 5 20 30}}`.
+</C.Property>
+<C.Property @name="sizeSelectorLabel" @type="string" @default="Items per page">
+  Add a custom string for the label text overriding the default value.
 </C.Property>
 <C.Property @name="route/model/models/replace">
 These are the parameters that are passed down as arguments to the `Hds::Pagination::Arrow`/`Hds::Pagination::Number` child components, and from them to the `Hds::Interactive` component (used internally). For more details about how this low-level component works please refer to [its documentation page](/utilities/interactive/).
@@ -69,17 +72,26 @@ This component supports use of [`...attributes`](https://guides.emberjs.com/rele
 <C.Property @name="ariaLabel" @type="string" @default="Pagination">
     Accepts a localized string.
 </C.Property>
+<C.Property @name="showLabels" @type="boolean" @default="true">
+Used to control the visibility of the "prev/next" text labels.
+</C.Property>
+<C.Property @name="isDisabledPrev/isDisabledNext" @type="boolean" @default="false">
+Used to disable the "prev" or "next" controls. Notice: when the control is disabled, it’s always rendered as an HTML `<button>` element.
+</C.Property>
+<C.Property @name="showSizeSelector" @type="boolean" @default="true">
+Used to control the visibility of the "size selector".
+</C.Property>
+<C.Property @name="pageSizes" @type="array" @values={{array "[10, 30, 50]" "array of integers" }} @default="[10, 30, 50]">
+Set the page sizes users can select from. Example: `@pageSizes=\{{array 5 20 30}}`.
+</C.Property>
+<C.Property @name="sizeSelectorLabel" @type="string" @default="Items per page">
+  Add a custom string for the label text overriding the default value.
+</C.Property>
 <C.Property @name="route/model/models/replace">
 These are the parameters that are passed down as arguments to the `Hds::Pagination::Arrow` child components, and from them to the `Hds::Interactive` component (used internally). For more details about how this low-level component works, please refer to [its documentation page](/utilities/interactive/).
 </C.Property>
 <C.Property @name="queryFunction" @type="function">
 A function that returns an object that can be provided as `query` argument for the routing, and that is passed down to the to the child components together with the other routing parameters. The function receives as argument one of two possible values: `prev` / `next`.
-</C.Property>
-<C.Property @name="isDisabledPrev/isDisabledNext" @type="boolean" @default="false">
-Used to disable the "prev" or "next" controls. Notice: when the control is disabled, it’s always rendered as an HTML `<button>` element.
-</C.Property>
-<C.Property @name="showLabels" @type="boolean" @default="true">
-Used to control the visibility of the "prev/next" text labels.
 </C.Property>
 <C.Property @name="onPageChange" @type="function">
 Callback function invoked (if provided) when a "prev" or "next" control is clicked. The function receives as argument one of two possible values: `prev` / `next`

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -78,7 +78,7 @@ Used to control the visibility of the "prev/next" text labels.
 <C.Property @name="isDisabledPrev/isDisabledNext" @type="boolean" @default="false">
 Used to disable the "prev" or "next" controls. Notice: when the control is disabled, it’s always rendered as an HTML `<button>` element.
 </C.Property>
-<C.Property @name="showSizeSelector" @type="boolean" @default="true">
+<C.Property @name="showSizeSelector" @type="boolean" @default="false">
 Used to control the visibility of the "size selector".
 </C.Property>
 <C.Property @name="pageSizes" @type="array" @values={{array "[10, 30, 50]" "array of integers" }} @default="[10, 30, 50]">

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -4,14 +4,14 @@ There are two different variants of the `Pagination` component (with different w
 
 This differentiation is necessary to cover both use cases of pagination for a list with a known number of elements (i.e., "numbered") and one in which this information is not available or is [cursor-based](https://jsonapi.org/profiles/ethanresnick/cursor-pagination/) (i.e., "compact").
 
-In the first one, the user is presented with a list of navigation controls ("prev/next" and "page numbers" to go directly to a specific page) and other optional UI elements; in the second, much simpler one, the user is presented with only the "prev/next" controls.
+In the first one, the user is presented with a list of navigation controls ("prev/next" and "page numbers" to go directly to a specific page) and other optional UI elements; in the second, much simpler one, the user is presented with only the "prev/next" controls (by default).
 
 When pagination is invoked directly using one of these two components, it will **automatically**:
 
 - provide the correct responsive layout for the entire Pagination and its sub-parts.
 - manage the "current page" status across the different sub-components it’s made of (based on the arguments provided to it and its children).
 - when one of the "navigation controls" is clicked, a callback function (if provided) is called, and a route (if provided) update is triggered.
-- when the "page size" is changed via the provided selector, it will automatically recalculate the total number of pages to display to the user.
+- when the "page size" is changed via the provided selector, in the "numbered" variant it will automatically recalculate the total number of pages to display to the user.
 
 
 ## Pagination sub-components
@@ -197,6 +197,12 @@ If necessary, it’s possible to hide the control labels:
 
 ```handlebars
 <Hds::Pagination::Compact @showLabels={{false}} />
+```
+
+It is also possible to show the SizeSelector (hidden by default):
+
+```handlebars
+<Hds::Pagination::Compact @showSizeSelector={{true}} />
 ```
 
 ### Event handling


### PR DESCRIPTION
### :pushpin: Summary

In a first assessment I though the “problem” was the documentation, but after speaking with @andrew-hashicorp I have realized that the “problem” is an assumption that we made long time ago when we designed and built the Pagination component: that the Compact variant (cursor-based pagination) could not have not only the totalItems/currentPage but also the pageSize. In reality even with this type of pagination, it’s possible to define a pageSize (imagine it like the number of items retrieved by the backend per query). Demonstration is the fact that in the Consul UI Kit they [have implemented exactly this pattern](https://github.com/hashicorp/consul-ui-toolkit/blob/main/toolkit/src/components/cut/list/pagination.hbs#L5-L37) (as custom), as well as the fact that this is what is needed by @andrew-hashicorp.

So the goal of this ticket is to expose this sub-UI-component in the Compact variant too.

Notice: no need to do anything from the Figma/design side, because this combination is already achievable with the current Figma component (cc @heatherlarsen)

### :hammer_and_wrench: Detailed description

In this PR I have:
- added `Pagination::sizeSelector` to `Pagination::Compact` (hidden by default)
- updated “Pagination” showcase to include use case where `SizeSelector` is visible
- updated integration tests
- updated "How to use" and "Component API" documentation
👉 👉 👉 **Preview**:
- showcase: https://hds-showcase-git-pagination-compact-add-page-s-013ac9-hashicorp.vercel.app/components/pagination
- documentation: https://hds-website-git-pagination-compact-add-page-si-866250-hashicorp.vercel.app/components/pagination?tab=code

#### ⚠️ To discuss

In the current implementation, I have set the default of `@showSizeSelector` to `false` for the `Compact` variant, while for the `Numbered` variant is `true` by default. The reason for this differentiation is that, looking at the component's usage, seems that [in most of the cases it's used without the "size selector"](https://github.com/search?q=%3CHds%3A%3APagination%3A%3ACompact+user%3Ahashicorp&type=code&ref=advsearch). The alternative would be to set it to `true` for consistency, but in that case the change should be released as breaking (with the `3.0` release, likely) and a codemod should be added to handle the change in the consumers' codebases (adding a `@showSizeSelector={{false}}` in all the instances found).
Personally I see pros/cons in both alternatives, so I'm eager to hear the reviewer's opinion too.

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2638

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
