### PR TITLE
Drop Node.js 14 support

### DIFF
--- a/.changeset/long-grapes-call.md
+++ b/.changeset/long-grapes-call.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/ember-flight-icons": major
+"@hashicorp/design-system-components": major
+---
+
+Drop support for Node 14

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -11,7 +11,7 @@ Compatibility
 
 * Ember.js v3.28 or above
 * Ember CLI v3.28 or above
-* Node.js v14 or above
+* Node.js v16 or above
 
 
 Installation

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -140,7 +140,7 @@
     "webpack": "^5.84.1"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "ember": {
     "edition": "octane"

--- a/packages/ember-flight-icons/README.md
+++ b/packages/ember-flight-icons/README.md
@@ -17,7 +17,7 @@ Goals:
 
 * Ember.js v3.28 or above
 * Ember CLI v3.28 or above
-* Node.js v14 or above
+* Node.js v16 or above
 
 ## Installation and Usage
 

--- a/packages/ember-flight-icons/package.json
+++ b/packages/ember-flight-icons/package.json
@@ -77,7 +77,7 @@
     "webpack": "^5.84.1"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION

### :pushpin: Summary

Node.js 14 was end-of-life since April 30, 2023. As we prepare to [update to Ember 5.3](https://github.com/hashicorp/design-system/pull/1704) (which doesn't support 14 anymore) and dropping Node.js support is considered a breaking we take the opportunity of [the upcoming major release](https://github.com/hashicorp/design-system/pull/1634) to flag this change to our consumer

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2621](https://hashicorp.atlassian.net/browse/HDS-2621)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2621]: https://hashicorp.atlassian.net/browse/HDS-2621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ