### PR TITLE
`Tabs` - Handle `@isSelected` within `each` loop

### DIFF
--- a/.changeset/sharp-needles-kick.md
+++ b/.changeset/sharp-needles-kick.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Tabs` - Fixed issue with `@isSelected` dynamically changed within `#each` loops

--- a/packages/components/addon/components/hds/tabs/index.hbs
+++ b/packages/components/addon/components/hds/tabs/index.hbs
@@ -6,7 +6,9 @@
 <div
   class="hds-tabs"
   {{did-insert this.didInsert}}
-  {{did-update this.updateTabIndicator this.selectedTabIndex @isParentVisible}}
+  {{did-update this.didUpdateSelectedTabIndex this.selectedTabIndex}}
+  {{did-update this.didUpdateSelectedTabId this.selectedTabId}}
+  {{did-update this.didUpdateParentVisibility @isParentVisible}}
   ...attributes
 >
   <div class="hds-tabs__tablist-wrapper">

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -62,9 +62,6 @@ export default class HdsTabsIndexComponent extends Component {
     this.tabNodes = [...this.tabNodes, element];
     this.tabIds = [...this.tabIds, element.id];
     if (isSelected) {
-      if (this.selectedTabId) {
-        assert('Only one tab may use isSelected argument');
-      }
       this.selectedTabId = element.id;
     }
   }

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -58,6 +58,32 @@ export default class HdsTabsIndexComponent extends Component {
   }
 
   @action
+  didUpdateSelectedTabIndex() {
+    schedule('afterRender', () => {
+      this.setTabIndicator();
+    });
+  }
+
+  @action
+  didUpdateSelectedTabId() {
+    // if the selected tab is set dynamically (eg. in a `each` loop)
+    // the `Tab` nodes will be re-inserted/rendered, which means the `this.selectedTabId` variable changes
+    // but the parent `Tabs` component has already been rendered/inserted but doesn't re-render
+    // so the value of the `selectedTabIndex` is not updated, unless we trigger a recalculation
+    // using the `did-update` modifier that checks for changes in the `this.selectedTabId` variable
+    if (this.selectedTabId) {
+      this.selectedTabIndex = this.tabIds.indexOf(this.selectedTabId);
+    }
+  }
+
+  @action
+  didUpdateParentVisibility() {
+    schedule('afterRender', () => {
+      this.setTabIndicator();
+    });
+  }
+
+  @action
   didInsertTab(element, isSelected) {
     this.tabNodes = [...this.tabNodes, element];
     this.tabIds = [...this.tabIds, element.id];
@@ -171,10 +197,5 @@ export default class HdsTabsIndexComponent extends Component {
         );
       }
     });
-  }
-
-  @action
-  updateTabIndicator() {
-    this.setTabIndicator();
   }
 }

--- a/packages/components/tests/dummy/app/controllers/components/tabs.js
+++ b/packages/components/tests/dummy/app/controllers/components/tabs.js
@@ -31,6 +31,8 @@ export default class TabsController extends Controller {
   @tracked badge3_demo3 = getRandomInteger();
   // ---
   @tracked atSelected_demo4 = 'two';
+  // ---
+  @tracked selectedTab_demo5 = 'two';
 
   // =============================
   // GENERIC HANDLERS
@@ -113,5 +115,32 @@ export default class TabsController extends Controller {
   @action
   setAtSelectedDemo4(tab) {
     this.atSelected_demo4 = tab;
+  }
+
+  // DEMO #5
+
+  get tabsDemo5() {
+    return [
+      {
+        label: 'One',
+        content: 'Content one',
+        isSelected: this.selectedTab_demo5 === 'one',
+      },
+      {
+        label: 'Two',
+        content: 'Content two',
+        isSelected: this.selectedTab_demo5 === 'two',
+      },
+      {
+        label: 'Three',
+        content: 'Content three',
+        isSelected: this.selectedTab_demo5 === 'three',
+      },
+    ];
+  }
+
+  @action
+  setSelectedTabDemo5(tab) {
+    this.selectedTab_demo5 = tab;
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/tabs.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tabs.hbs
@@ -318,4 +318,20 @@
     <T.Panel><Shw::Placeholder @text="Content three" @height="50" /></T.Panel>
   </Hds::Tabs>
 
+  <div class="shw-component-tabs-example-heading">
+    <Shw::Text::Body>Dynamic <code>@isSelected</code> argument within a loop</Shw::Text::Body>
+    <div class="shw-component-tabs-example-heading-button-set">
+      <span>@isSelected = </span>
+      <button type="button" {{on "click" (fn this.setSelectedTabDemo5 "one")}}>"one"</button>
+      <button type="button" {{on "click" (fn this.setSelectedTabDemo5 "two")}}>"two"</button>
+      <button type="button" {{on "click" (fn this.setSelectedTabDemo5 "three")}}>"three"</button>
+    </div>
+  </div>
+  <Hds::Tabs as |T|>
+    {{#each this.tabsDemo5 as |tab|}}
+      <T.Tab @isSelected={{tab.isSelected}}>{{tab.label}}</T.Tab>
+      <T.Panel><Shw::Placeholder @text={{tab.content}} @height="50" /></T.Panel>
+    {{/each}}
+  </Hds::Tabs>
+
 </section>


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes one use case that was not covered before, where the `@isSelected` is dynamically set within a loop, where the condition of which tab is selected changes after the `Tabs` parent component has already rendered.

The problem was arising by the fact that there was a check in place, to avoid having multiple `Tab` elements with `@isSelected={{true}}` at the same time, but because of the nature of the Ember lifecycle and how this component is implemented under the hood, this is not possible to avoid: there are conditions (see screenshot below) where there are more `tab` in memory than the one actually rendered (the new tabs are _inserted_ but the old tabs are not yet _destroyed_).

<img width="1556" alt="screenshot_3145" src="https://github.com/hashicorp/design-system/assets/686239/47172466-d729-4d98-ab61-1f95b310bce9">

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed check on multiple "selected" tabs
- improved logic that handles the "selected" tab
    - now it handles also dynamic changes of the selected tab after the rendering of the tabs
- added a new example to the tabs showcase to cover also this use case

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2658

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
