### PR TITLE
`Tabs` - Avoid VRT failures because of dynamic content

### DIFF
--- a/packages/components/tests/dummy/app/controllers/components/tabs.js
+++ b/packages/components/tests/dummy/app/controllers/components/tabs.js
@@ -25,10 +25,10 @@ export default class TabsController extends Controller {
   @tracked currentTab_demo2;
   @tracked currentTab_demo2_subtab1;
   @tracked currentTab_demo2_subtab2;
-  // ---
-  @tracked badge1_demo3 = getRandomInteger();
-  @tracked badge2_demo3 = getRandomInteger();
-  @tracked badge3_demo3 = getRandomInteger();
+  // --- we initialize to non-random values to avoid visual regression tests to fail
+  @tracked badge1_demo3 = undefined;
+  @tracked badge2_demo3 = 2;
+  @tracked badge3_demo3 = 3;
   // ---
   @tracked atSelected_demo4 = 'two';
 


### PR DESCRIPTION
### :pushpin: Summary

Context: https://github.com/hashicorp/design-system/pull/1709#pullrequestreview-1674250853

### :hammer_and_wrench: Detailed description

In this PR I have:
- initialized the dynamic badges values in `Tabs` showcase to static values 

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
