### PR TITLE
`TextInput` - toggle visibility documentation guidelines 

### DIFF
--- a/website/docs/components/form/text-input/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/text-input/partials/guidelines/guidelines.md
@@ -21,7 +21,9 @@ Text Input accepts [all native HTML types](https://developer.mozilla.org/en-US/d
 
 ### Password
 
-<Hds::Form::TextInput::Field @type="password" placeholder="Password" @value="password" @width="300px" as |F|>
+The `TextInput` component has a visibility toggle feature for password fields. By default, a button appears allowing users to switch easily between visible and obfuscated input.
+
+<Hds::Form::TextInput::Field @type="password" @hasVisibilityToggle={{true}} placeholder="Password" @value="password" @width="300px" as |F|>
   <F.Label>Password</F.Label>
 </Hds::Form::TextInput::Field>
 


### PR DESCRIPTION
### :pushpin: Summary

`TextInput` - Toggle visibility documentation will be added to the component section on the website.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2360](https://hashicorp.atlassian.net/browse/HDS-2360)
Figma file: [Figma File](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/branch/sJHCJxIXKmRf9mlUbV1u0K/HDS-Product---Components?type=design&node-id=11530-26396&mode=design&t=vmY5xn8bMw90FZIs-0)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2360]: https://hashicorp.atlassian.net/browse/HDS-2360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ