### PR TITLE
Updating content around Badge icon usage

### DIFF
--- a/website/docs/components/badge/partials/accessibility/accessibility.md
+++ b/website/docs/components/badge/partials/accessibility/accessibility.md
@@ -8,7 +8,7 @@ When used as recommended, there should not be any accessibility issues with this
 
 When using icon-only Badges, include annotations of the non-visual experience in your handoff notes. For example:
 
-![Example of an annotation of a badge to provide more context](/assets/components/badge/badge-annotations.png =511x\*)
+![Example of an annotation of a badge to provide more context](/assets/components/badge/badge-annotations.png =511x*)
 
 ---
 

--- a/website/docs/components/badge/partials/accessibility/accessibility.md
+++ b/website/docs/components/badge/partials/accessibility/accessibility.md
@@ -4,21 +4,11 @@
 
 When used as recommended, there should not be any accessibility issues with this component.
 
-## Icon usage
-
-Status Badges (Success, Warning, Critical) require an icon to avoid relying on color alone as a means to indicate status to the user.
-
-<Hds::Badge @color="success" @type="filled" @icon="check" @text="Applied" />
-<Hds::Badge @color="warning" @type="filled" @icon="alert-triangle" @text="Policy override" />
-<Hds::Badge @color="critical" @type="filled" @icon="x" @text="Errored" />
-
 ## Annotations in design
 
 When using icon-only Badges, include annotations of the non-visual experience in your handoff notes. For example:
 
-![Example of an annotation of a badge to provide more context](/assets/components/badge/badge-annotations.png =511x*)
-
-<!-- TODO: add relevant WCAG Success Criteria -->
+![Example of an annotation of a badge to provide more context](/assets/components/badge/badge-annotations.png =511x\*)
 
 ---
 

--- a/website/docs/components/badge/partials/guidelines/guidelines.md
+++ b/website/docs/components/badge/partials/guidelines/guidelines.md
@@ -36,7 +36,7 @@ Use color logically.
 
 ### Alternative color usage
 
-Badges can also indicate different account levels: 
+Badges can also indicate different account levels:
 
 <Hds::Badge @color="critical" @type="filled" @icon="award" @text="Bronze" />
 <Hds::Badge @color="neutral" @type="filled" @icon="award" @text="Silver" />
@@ -81,7 +81,7 @@ For example:
 
 !!! Dont
 
-![example of overuse of inverted badges in a table](/assets/components/badge/badge-inverted-dont.png =584x*)
+![example of overuse of inverted badges in a table](/assets/components/badge/badge-inverted-dont.png =584x\*)
 !!!
 
 ### Outlined
@@ -123,6 +123,14 @@ Badges come in a few icon and text combinations; text only, icon only, and icon 
 <Hds::Badge @color="neutral" @type="filled" @text="Text only" />
 <Hds::Badge @color="neutral" @type="filled" @icon="corner-down-left" @isIconOnly={{true}} @text="Icon only" />
 <Hds::Badge @color="neutral" @type="filled" @icon="hexagon" @text="Text + Icon" />
+
+### Usage in status Badges
+
+To avoid relying on color alone, we recommend including an icon in Badges that communicate status (Success, Warning, Critical).
+
+<Hds::Badge @color="success" @type="filled" @icon="check" @text="Applied" />
+<Hds::Badge @color="warning" @type="filled" @icon="alert-triangle" @text="Policy override" />
+<Hds::Badge @color="critical" @type="filled" @icon="x" @text="Errored" />
 
 ## Content
 

--- a/website/docs/components/badge/partials/guidelines/guidelines.md
+++ b/website/docs/components/badge/partials/guidelines/guidelines.md
@@ -81,7 +81,7 @@ For example:
 
 !!! Dont
 
-![example of overuse of inverted badges in a table](/assets/components/badge/badge-inverted-dont.png =584x\*)
+![example of overuse of inverted badges in a table](/assets/components/badge/badge-inverted-dont.png =584x*)
 !!!
 
 ### Outlined

--- a/website/docs/components/badge/partials/guidelines/guidelines.md
+++ b/website/docs/components/badge/partials/guidelines/guidelines.md
@@ -128,7 +128,7 @@ Badges come in a few icon and text combinations; text only, icon only, and icon 
 
 Badges are commonly used to communicate status of items and objects. To avoid relying solely on color as a means to communicate status, we recommend:
 
-- Including an icon that aligns with the intended severity or importance of the status. Some common examples of this are `check` for success/positive, `alert` for warning/caution, and `x` for error/critical.
+- Including an icon that aligns with the intended severity or importance of the status. Some common examples of this are `check` for success, `alert` for warning, and `x` for critical.
 - Using explicit, straightforward language when communicating status, e.g., for items that are in a positive state, use "Successful" or "Active".
 
 <Hds::Badge @color="success" @type="filled" @icon="check" @text="Successful" />

--- a/website/docs/components/badge/partials/guidelines/guidelines.md
+++ b/website/docs/components/badge/partials/guidelines/guidelines.md
@@ -124,13 +124,16 @@ Badges come in a few icon and text combinations; text only, icon only, and icon 
 <Hds::Badge @color="neutral" @type="filled" @icon="corner-down-left" @isIconOnly={{true}} @text="Icon only" />
 <Hds::Badge @color="neutral" @type="filled" @icon="hexagon" @text="Text + Icon" />
 
-### Usage in status Badges
+## Using Badges for status
 
-To avoid relying on color alone, we recommend including an icon in Badges that communicate status (Success, Warning, Critical).
+Badges are commonly used to communicate status of items and objects. To avoid relying solely on color as a means to communicate status, we recommend:
 
-<Hds::Badge @color="success" @type="filled" @icon="check" @text="Applied" />
-<Hds::Badge @color="warning" @type="filled" @icon="alert-triangle" @text="Policy override" />
-<Hds::Badge @color="critical" @type="filled" @icon="x" @text="Errored" />
+- Including an icon that aligns with the intended severity or importance of the status. Some common examples of this are `check` for success/positive, `alert` for warning/caution, and `x` for error/critical.
+- Using explicit, straightforward language when communicating status, e.g., for items that are in a positive state, use "Successful" or "Active".
+
+<Hds::Badge @color="success" @type="filled" @icon="check" @text="Successful" />
+<Hds::Badge @color="warning" @type="filled" @icon="alert-triangle" @text="Degraded" />
+<Hds::Badge @color="critical" @type="filled" @icon="x" @text="Error" />
 
 ## Content
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will update the guidance around icon usage within the Badge component to match both the changes that were made in the Figma component (making the icon a boolean property across all variants), and the flexibility of the Ember component. 

Since this recommendation has changed from a restriction (in the Figma component at least), to guidance, I've moved the content to the Guidelines tab under the Icon section (where it was previously in the Accessibility tab). Open to feedback on this, let me know!

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2394](https://hashicorp.atlassian.net/browse/HDS-2394)
Figma file: [Badge component](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=2337%3A20761&mode=design&t=38lctI0gUuYNftl0-1)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2394]: https://hashicorp.atlassian.net/browse/HDS-2394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ