### PR TITLE
Fix default button type in docs

### DIFF
--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -79,7 +79,7 @@ This indicates that the Button should take up the full-width of the parent conta
 
 ### Type
 
-This is the native HTML button attribute, `type`. There are three possible values: `button`, `submit`, and `reset`. The default `type` for the Button is `submit`. To prevent a Button from submitting a form, set `type` to `button`.
+This is the native HTML button attribute, `type`. There are three possible values: `button`, `submit`, and `reset`. The default `type` for the Button is `button`. To submit form data to the server, set `type` to `submit`.
 
 ```handlebars
 <Hds::Button @text="Submit" type="submit" />


### PR DESCRIPTION
### :pushpin: Summary

The default type for `Hds::Button` has always been `button`, so we're updating the docs accordingly to avoid confusion.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2654](https://hashicorp.atlassian.net/browse/HDS-2654)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2654]: https://hashicorp.atlassian.net/browse/HDS-2654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ