### PR TITLE
`Tabs` - replace `assert` with `warn` in `setIndicator`

### DIFF
--- a/.changeset/olive-carpets-clean.md
+++ b/.changeset/olive-carpets-clean.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Tabs` - replace `assert` with `warn` in `setIndicator` function

--- a/packages/components/addon/components/hds/tabs/index.js
+++ b/packages/components/addon/components/hds/tabs/index.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { assert } from '@ember/debug';
+import { assert, warn } from '@ember/debug';
 import { next, schedule } from '@ember/runloop';
 
 export default class HdsTabsIndexComponent extends Component {
@@ -188,13 +188,23 @@ export default class HdsTabsIndexComponent extends Component {
           );
         }
       } else {
-        assert(
-          `"Hds::Tabs" has tried to set the indicator for an element that doesn't exist (the value ${
+        let message;
+        message +=
+          '"Hds::Tabs" has tried to set the indicator for an element that doesn\'t exist';
+        if (this.tabNodes.length === 0) {
+          message +=
+            ' (the array `this.tabNodes` is empty, there are no tabs, probably already destroyed)';
+        } else {
+          message += ` (the value ${
             this.selectedTabIndex
-          } of \`this.selectedTabIndex\` is out of bound for the array \`this.tabNodes\`, whose index range is [0-${
+          } of \`this.selectedTabIndex\` is out of bound for the array \`this.tabNodes\`, whose index range is [0 - ${
             this.tabNodes.length - 1
-          }])`
-        );
+          }])`;
+        }
+        // https://api.emberjs.com/ember/5.3/classes/@ember%2Fdebug/methods/warn?anchor=warn
+        warn(message, true, {
+          id: 'hds-debug.tabs.setTabIndicator-tabElem-not-available',
+        });
       }
     });
   }

--- a/packages/components/tests/integration/components/hds/tabs/index-test.js
+++ b/packages/components/tests/integration/components/hds/tabs/index-test.js
@@ -370,19 +370,6 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
     });
   });
 
-  test('it should throw an assertion @selecteTabIndex if out of bound for the array of tabs', async function (assert) {
-    const errorMessage =
-      '"Hds::Tabs" has tried to set the indicator for an element that doesn\'t exist (the value 99 of `this.selectedTabIndex` is out of bound for the array `this.tabNodes`, whose index range is [0-1])';
-    assert.expect(2);
-    setupOnerror(function (error) {
-      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
-    });
-    await this.createTabs({ selectedTabIndex: 99 });
-    assert.throws(function () {
-      throw new Error(errorMessage);
-    });
-  });
-
   // ===============================================================
 
   // TAB OPTIONS


### PR DESCRIPTION
### :pushpin: Summary

Following this [report of a failing test in TFC](https://hashicorp.slack.com/archives/C03JP1TCGQM/p1697131130239269?thread_ts=1695236557.036929&cid=C03JP1TCGQM) after upgrading to `@hashicorp/design-system-components@2.14.1` (which contains the changes done in https://github.com/hashicorp/design-system/pull/1709) we have discussed the way in which we're throwing an assertion within the `setIndicator` function, and came the conclusion that we were being too strict: since we have decoupled the rendering of the tabs from the `setIndicator` execution (using `next() {}`) there may be cases in which the tabs are rendered and immediately after destroyed, leaving the `setIndicator` trying to apply to a set of tabs that don't exist anymore (this is the case in the tests, where the tabs were used in a loop of different conditions, each one rendering tabs and then destroying them at the end of the loop iteration). So we have decided that instead of an `assertion` (which blocks the JS execution) is better to just use a `warn` (that displays a message in the console, but without blocking the JS execution).

### :hammer_and_wrench: Detailed description

In this PR I have:
- replaced `assert` with `warn` in the `setIndicator function (and updated the warning message to handle two different possible cases)

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2662

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
