### PR TITLE
Added PR template to `body` of `create-pull-request` in github action for new icons

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### :pushpin: Summary
 
-<!-- If merged, this PR.... 
+<!-- If merged, this PR....
 This should be a short TL;DR that includes the purpose of the PR.
 -->
 
@@ -25,6 +25,6 @@ Figma file: [if it applies]
 - [ ] Percy was checked for any visual regression
 - [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
 - [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
-- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed
+- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))
 
 :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -54,7 +54,7 @@ jobs:
             Make sure that you have followed the instructions described here:
             https://github.com/hashicorp/design-system/blob/main/packages/flight-icons/CONTRIBUTING.md#updating-the-icons-in-flight-icons ("Updating the icons in flight-icons" + "Automated process" + "After you have run the scripts")
 
-            Make also that the "changeset" is added to the PR _before_ asking for review (and expecially don't merge to `main` if the changeset is missing).
+            Make sure that the "changeset" is added to the PR _before_ asking for review (and especially don't merge to `main` if the changeset is missing).
 
             ⚠️ Note: The changeset needs to be applied only to the `@hashicorp/flight-icons` version (typically a new icon or a significant change to an existing icon is considered a `minor` change, a breaking change is always considered a `major`, while for a small update to an icon a `patch` is OK). No need to bump also the version of `ember-flight-icons`: changesets takes care of everything from there (see for example this previous export: https://github.com/hashicorp/design-system/pull/1638/files).
 

--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -16,14 +16,14 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
           cache-dependency-path: yarn.lock
-  
+
       - name: Install Dependencies
         run: yarn install --immutable
 
       - name: Sync icons
         env:
           # this is Brian's personal access token
-          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }} 
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
         run: yarn sync
         working-directory: packages/flight-icons
 
@@ -38,5 +38,43 @@ jobs:
           branch-suffix: 'short-commit-hash'
           commit-message: 'sync & build of flight icons'
           title: 'Updated export of icons from Figma'
-          body: ''
+          body: |
+            ### :pushpin: Summary
+
+            This is an automated PR opened by the Hashibot-HDS using the GitHub Action [Sync & Build Icons](https://github.com/hashicorp/design-system/actions/workflows/open-pull-request-for-icon-update.yml).
+
+            ### :hammer_and_wrench: Detailed description
+
+            <!-- (Remove this comment) once done ------------
+
+            Add specific details for this PR here:
+            - which icons has been added?
+            - which icons have been changed, updated or deleted?
+
+            Make sure that you have followed the instructions described here:
+            https://github.com/hashicorp/design-system/blob/main/packages/flight-icons/CONTRIBUTING.md#updating-the-icons-in-flight-icons ("Updating the icons in flight-icons" + "Automated process" + "After you have run the scripts")
+
+            Make also that the "changeset" is added to the PR _before_ asking for review (and expecially don't merge to `main` if the changeset is missing).
+
+            ⚠️ Note: The changeset needs to be applied only to the `@hashicorp/flight-icons` version (typically a new icon or a significant change to an existing icon is considered a `minor` change, a breaking change is always considered a `major`, while for a small update to an icon a `patch` is OK). No need to bump also the version of `ember-flight-icons`: changesets takes care of everything from there (see for example this previous export: https://github.com/hashicorp/design-system/pull/1638/files).
+
+            ------- (end of the comment to remove) -->
+
+            ### :camera_flash: Screenshots
+
+            <!-- Add relevant screenshots if needed -->
+
+            ### :link: External links
+
+            <!-- Add links to relevant Jira issues, Figma files/frames, Slack threads, documents, etc. -->
+
+            Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
+            Figma file: [if it applies]
+
+            ***
+
+            ### 👀 Component checklist
+
+            - [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed ([instructions here](https://github.com/hashicorp/design-system/blob/main/packages/flight-icons/CONTRIBUTING.md#updating-the-icons-in-flight-icons))
+            - [ ] Percy was checked for any visual regression
           token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -75,6 +75,6 @@ jobs:
 
             ### 👀 Component checklist
 
-            - [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed ([instructions here](https://github.com/hashicorp/design-system/blob/main/packages/flight-icons/CONTRIBUTING.md#updating-the-icons-in-flight-icons))
+            - [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed ([instructions here](https://github.com/hashicorp/design-system/blob/main/packages/flight-icons/CONTRIBUTING.md#updating-the-icons-in-flight-icons) / [expected format here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#new-icons))
             - [ ] Percy was checked for any visual regression
           token: ${{ secrets.PAT_TOKEN }}

--- a/packages/components/NEW-COMPONENT-CHECKLIST.md
+++ b/packages/components/NEW-COMPONENT-CHECKLIST.md
@@ -144,4 +144,4 @@ When ready for review:
 
 - [ ] add situationally appropriate reviewers
 - [ ] add instructions for reviewers in your PR, letting them know what kind of review you need
-- [ ] add a changelog update via [Changesets](https://github.com/changesets/changesets) if needed using the command `yarn changeset` (in the project root)
+- [ ] add a changelog update via [Changesets](https://github.com/changesets/changesets) if needed using the command `yarn changeset` (in the project root) using the [predefined format](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))


### PR DESCRIPTION
### :pushpin: Summary

This PR intends to provide a template for the PR description for when the HashiBot automatically generates pull requests as a result of the [Sync & Build Icons](https://github.com/hashicorp/design-system/actions/workflows/open-pull-request-for-icon-update.yml) GitHub Action.

@heatherlarsen @jorytindall @andgen404 I've tried to define a template based on the default one, but open to suggestions.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added PR template to `body` of `create-pull-request` in github action for new icons

👉 👉 👉 **Generated PR**: https://github.com/hashicorp/design-system/pull/1719 (edit the PR description to see the whole text)

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2532

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
