### PR TITLE
`Pagination` - Fix missing `@currentPageSize` argument in the "Compact" variant with `SizeSelector`

### DIFF
--- a/.changeset/light-clouds-explain.md
+++ b/.changeset/light-clouds-explain.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Pagination` - updated the logic for “Compact” variant to expose `@currentPageSize` and handle controlled/uncontrolled changes

--- a/packages/components/addon/components/hds/pagination/compact/index.js
+++ b/packages/components/addon/components/hds/pagination/compact/index.js
@@ -4,6 +4,7 @@
  */
 
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import { inject as service } from '@ember/service';
@@ -15,6 +16,15 @@ export const DEFAULT_PAGE_SIZES = [10, 30, 50];
 export default class HdsPaginationCompactIndexComponent extends Component {
   @service router;
 
+  // This private variable is used to differentiate between
+  // "uncontrolled" component (where the state is handled internally) and
+  // "controlled" component (where the state is handled externally, by the consumer's code).
+  // In the first case, the variable stores the internal state of the component at any moment,
+  // and its value is updated internally according to the user's interaction with the component.
+  // In the second case, the variable stores *only* the initial state of the component (coming from the arguments)
+  // at rendering time, but from that moment on it's not updated anymore, no matter what interaction the user
+  // has with the component (the state is controlled externally, eg. via query parameters)
+  @tracked _currentPageSize = this.args.currentPageSize ?? this.pageSizes[0];
   showSizeSelector = this.args.showSizeSelector ?? false; // if the "size selector" block is visible
 
   constructor() {
@@ -62,6 +72,35 @@ export default class HdsPaginationCompactIndexComponent extends Component {
     return this.args.ariaLabel ?? 'Pagination';
   }
 
+  // This very specific `get/set` pattern is used to handle the two different use cases of the component
+  // being "controlled" (when it has routing, meaning it needs to support links as controls)
+  // vs being "uncontrolled" (see comments above for details).
+  //
+  // If it has routing (and so it's "controlled"), than the value ("state") of the `currentPageSize` variable
+  // is *always* determined by the controller via arguments (most of the times, connected to query parameters in the URL).
+  // For this reason the "get" method always returns the value from the `args`,
+  // while the "set" method never updates the private internal state (_variable).
+  //
+  // If instead it doesn't have routing (and so it's "uncontrolled") than the value ("state") of the `currentPageSize` variables
+  // is *always* determined by the component's internal logic (and updated according to the user interaction with it).
+  // For this reason the "get" and "set" methods always read from or write to the private internal state (_variable).
+
+  get currentPageSize() {
+    if (this.hasRouting) {
+      return this.args.currentPageSize;
+    } else {
+      return this._currentPageSize;
+    }
+  }
+
+  set currentPageSize(value) {
+    if (this.hasRouting) {
+      // noop
+    } else {
+      this._currentPageSize = value;
+    }
+  }
+
   /**
    * @param pageSizes
    * @type {array of numbers}
@@ -83,9 +122,9 @@ export default class HdsPaginationCompactIndexComponent extends Component {
     return this.router.currentRoute?.queryParams || {};
   }
 
-  buildQueryParamsObject(page) {
+  buildQueryParamsObject(page, pageSize) {
     if (this.hasRouting) {
-      return this.args.queryFunction(page, this.currentPage);
+      return this.args.queryFunction(page, pageSize);
     } else {
       return {};
     }
@@ -101,8 +140,14 @@ export default class HdsPaginationCompactIndexComponent extends Component {
 
     // the "query" is dynamic and needs to be calculated
     if (this.hasRouting) {
-      routing.queryPrev = this.buildQueryParamsObject('prev');
-      routing.queryNext = this.buildQueryParamsObject('next');
+      routing.queryPrev = this.buildQueryParamsObject(
+        'prev',
+        this.currentPageSize
+      );
+      routing.queryNext = this.buildQueryParamsObject(
+        'next',
+        this.currentPageSize
+      );
     } else {
       routing.queryPrev = undefined;
       routing.queryNext = undefined;
@@ -119,6 +164,25 @@ export default class HdsPaginationCompactIndexComponent extends Component {
 
     if (typeof onPageChange === 'function') {
       onPageChange(newPage);
+    }
+  }
+
+  @action
+  onPageSizeChange(newPageSize) {
+    let { onPageSizeChange } = this.args;
+
+    // we need to manually update the query parameters in the route (it's not a link!)
+    if (this.hasRouting) {
+      // we pass `null` as value for the `page` argument, so consumers can handle this condition accordingly (probably will just change the side of the data/array slice)
+      const queryParams = this.buildQueryParamsObject(null, newPageSize);
+      this.router.transitionTo({ queryParams });
+    } else {
+      this.currentPageSize = newPageSize;
+    }
+
+    // invoke the callback function
+    if (typeof onPageSizeChange === 'function') {
+      onPageSizeChange(newPageSize);
     }
   }
 }

--- a/packages/components/addon/components/hds/pagination/compact/index.js
+++ b/packages/components/addon/components/hds/pagination/compact/index.js
@@ -25,6 +25,8 @@ export default class HdsPaginationCompactIndexComponent extends Component {
   // at rendering time, but from that moment on it's not updated anymore, no matter what interaction the user
   // has with the component (the state is controlled externally, eg. via query parameters)
   @tracked _currentPageSize = this.args.currentPageSize ?? this.pageSizes[0];
+
+  showLabels = this.args.showLabels ?? true; // if the labels for the "prev/next" controls are visible
   showSizeSelector = this.args.showSizeSelector ?? false; // if the "size selector" block is visible
 
   constructor() {
@@ -49,18 +51,6 @@ export default class HdsPaginationCompactIndexComponent extends Component {
       );
       this.hasRouting = true;
     }
-  }
-
-  /**
-   * @param showLabels
-   * @type {boolean}
-   * @default true
-   * @description Show the labels for the "prev/next" controls
-   */
-  get showLabels() {
-    let { showLabels = true } = this.args;
-
-    return showLabels;
   }
 
   /**

--- a/packages/components/addon/components/hds/pagination/compact/index.js
+++ b/packages/components/addon/components/hds/pagination/compact/index.js
@@ -25,6 +25,7 @@ export default class HdsPaginationCompactIndexComponent extends Component {
   // at rendering time, but from that moment on it's not updated anymore, no matter what interaction the user
   // has with the component (the state is controlled externally, eg. via query parameters)
   @tracked _currentPageSize = this.args.currentPageSize ?? this.pageSizes[0];
+  @tracked isControlled;
 
   showLabels = this.args.showLabels ?? true; // if the labels for the "prev/next" controls are visible
   showSizeSelector = this.args.showSizeSelector ?? false; // if the "size selector" block is visible
@@ -43,13 +44,13 @@ export default class HdsPaginationCompactIndexComponent extends Component {
     // initialized and updated using the arguments passed to it.
 
     if (queryFunction === undefined) {
-      this.hasRouting = false;
+      this.isControlled = false;
     } else {
       assert(
         '@queryFunction for "Hds::Pagination::Numbered" must be a function',
         typeof queryFunction === 'function'
       );
-      this.hasRouting = true;
+      this.isControlled = true;
     }
   }
 
@@ -63,7 +64,7 @@ export default class HdsPaginationCompactIndexComponent extends Component {
   }
 
   // This very specific `get/set` pattern is used to handle the two different use cases of the component
-  // being "controlled" (when it has routing, meaning it needs to support links as controls)
+  // being "controlled" (when it has routing, meaning it needs to support pagination controls as links/`LinkTo`)
   // vs being "uncontrolled" (see comments above for details).
   //
   // If it has routing (and so it's "controlled"), than the value ("state") of the `currentPageSize` variable
@@ -76,7 +77,7 @@ export default class HdsPaginationCompactIndexComponent extends Component {
   // For this reason the "get" and "set" methods always read from or write to the private internal state (_variable).
 
   get currentPageSize() {
-    if (this.hasRouting) {
+    if (this.isControlled) {
       return this.args.currentPageSize;
     } else {
       return this._currentPageSize;
@@ -84,7 +85,7 @@ export default class HdsPaginationCompactIndexComponent extends Component {
   }
 
   set currentPageSize(value) {
-    if (this.hasRouting) {
+    if (this.isControlled) {
       // noop
     } else {
       this._currentPageSize = value;
@@ -113,7 +114,7 @@ export default class HdsPaginationCompactIndexComponent extends Component {
   }
 
   buildQueryParamsObject(page, pageSize) {
-    if (this.hasRouting) {
+    if (this.isControlled) {
       return this.args.queryFunction(page, pageSize);
     } else {
       return {};
@@ -129,7 +130,7 @@ export default class HdsPaginationCompactIndexComponent extends Component {
     };
 
     // the "query" is dynamic and needs to be calculated
-    if (this.hasRouting) {
+    if (this.isControlled) {
       routing.queryPrev = this.buildQueryParamsObject(
         'prev',
         this.currentPageSize
@@ -162,7 +163,7 @@ export default class HdsPaginationCompactIndexComponent extends Component {
     let { onPageSizeChange } = this.args;
 
     // we need to manually update the query parameters in the route (it's not a link!)
-    if (this.hasRouting) {
+    if (this.isControlled) {
       // we pass `null` as value for the `page` argument, so consumers can handle this condition accordingly (probably will just change the side of the data/array slice)
       const queryParams = this.buildQueryParamsObject(null, newPageSize);
       this.router.transitionTo({ queryParams });

--- a/packages/components/addon/components/hds/pagination/numbered/index.js
+++ b/packages/components/addon/components/hds/pagination/numbered/index.js
@@ -85,6 +85,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   // has with the component (the state is controlled externally, eg. via query parameters)
   @tracked _currentPage = this.args.currentPage ?? 1;
   @tracked _currentPageSize = this.args.currentPageSize ?? this.pageSizes[0];
+  @tracked isControlled;
 
   showInfo = this.args.showInfo ?? true; // if the "info" block is visible
   showLabels = this.args.showLabels ?? false; // if the labels for the "prev/next" controls are visible
@@ -107,7 +108,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
     // initialized and updated using the arguments passed to it.
 
     if (queryFunction === undefined) {
-      this.hasRouting = false;
+      this.isControlled = false;
     } else {
       assert(
         '@queryFunction for "Hds::Pagination::Numbered" must be a function',
@@ -118,7 +119,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
         typeof this.args.currentPageSize === 'number' &&
           typeof this.args.currentPage === 'number'
       );
-      this.hasRouting = true;
+      this.isControlled = true;
     }
 
     assert(
@@ -137,7 +138,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   }
 
   // This very specific `get/set` pattern is used to handle the two different use cases of the component
-  // being "controlled" (when it has routing, meaning it needs to support links as controls)
+  // being "controlled" (when it has routing, meaning it needs to support pagination controls as links/`LinkTo`)
   // vs being "uncontrolled" (see comments above for details).
   //
   // If it has routing (and so it's "controlled"), than the value ("state") of the `currentPage/currentPageSize` variables
@@ -150,7 +151,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   // For this reason the "get" and "set" methods always read from or write to the private internal state (_variable).
 
   get currentPage() {
-    if (this.hasRouting) {
+    if (this.isControlled) {
       return this.args.currentPage;
     } else {
       return this._currentPage;
@@ -158,7 +159,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   }
 
   set currentPage(value) {
-    if (this.hasRouting) {
+    if (this.isControlled) {
       // noop
     } else {
       this._currentPage = value;
@@ -166,7 +167,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   }
 
   get currentPageSize() {
-    if (this.hasRouting) {
+    if (this.isControlled) {
       return this.args.currentPageSize;
     } else {
       return this._currentPageSize;
@@ -174,7 +175,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   }
 
   set currentPageSize(value) {
-    if (this.hasRouting) {
+    if (this.isControlled) {
       // noop
     } else {
       this._currentPageSize = value;
@@ -242,7 +243,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   }
 
   buildQueryParamsObject(page, pageSize) {
-    if (this.hasRouting) {
+    if (this.isControlled) {
       return this.args.queryFunction(page, pageSize);
     } else {
       return {};
@@ -258,7 +259,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
     };
 
     // the "query" is dynamic and needs to be calculated
-    if (this.hasRouting) {
+    if (this.isControlled) {
       routing.queryPrev = this.buildQueryParamsObject(
         this.currentPage - 1,
         this.currentPageSize
@@ -323,8 +324,8 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
     let { onPageSizeChange } = this.args;
 
     // we need to manually update the query parameters in the route (it's not a link!)
-    // notice: we agreed to reset the pagination to the first element (any alternative would result in an unpredictable UX)
-    if (this.hasRouting) {
+    if (this.isControlled) {
+      // notice: we agreed to reset the pagination to the first element (any alternative would result in an unpredictable UX)
       const queryParams = this.buildQueryParamsObject(1, newPageSize);
       this.router.transitionTo({ queryParams });
     } else {

--- a/packages/components/addon/components/hds/pagination/numbered/index.js
+++ b/packages/components/addon/components/hds/pagination/numbered/index.js
@@ -325,8 +325,7 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
     // we need to manually update the query parameters in the route (it's not a link!)
     // notice: we agreed to reset the pagination to the first element (any alternative would result in an unpredictable UX)
     if (this.hasRouting) {
-      let queryParams = Object.assign({}, this.routeQueryParams);
-      queryParams = this.buildQueryParamsObject(1, newPageSize);
+      const queryParams = this.buildQueryParamsObject(1, newPageSize);
       this.router.transitionTo({ queryParams });
     } else {
       this.currentPage = 1;

--- a/packages/components/tests/acceptance/components/hds/pagination-test.js
+++ b/packages/components/tests/acceptance/components/hds/pagination-test.js
@@ -72,27 +72,126 @@ module('Acceptance | Component | hds/pagination', function (hooks) {
     await visit('/components/pagination');
 
     assert.strictEqual(currentURL(), '/components/pagination');
-
     assert
       .dom(
         '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr'
       )
       .exists({ count: 5 });
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr .hds-table__td'
+      )
+      .hasText('1');
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr:nth-child(5) .hds-table__td'
+      )
+      .hasText('5');
+
+    // CLICK "NEXT"
+    // ------------
 
     await click(
       '#demo4-compact-with-routing .hds-pagination .hds-pagination-nav__arrow--direction-next'
     );
+
     assert.strictEqual(
       currentURL(),
       '/components/pagination?demoExtraParam=hello&nextCursor_demo4=bmV4dF9fNg%3D%3D'
     );
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr'
+      )
+      .exists({ count: 5 });
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr .hds-table__td'
+      )
+      .hasText('6');
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr:nth-child(5) .hds-table__td'
+      )
+      .hasText('10');
+
+    // CHANGE PAGE SIZE
+    // ----------------
+
+    await select(
+      '#demo4-compact-with-routing .hds-pagination .hds-pagination-size-selector select',
+      '10'
+    );
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr'
+      )
+      .exists({ count: 10 });
+    assert.strictEqual(
+      currentURL(),
+      '/components/pagination?currentPageSize_demo4=10&demoExtraParam=hello&nextCursor_demo4=bmV4dF9fNg%3D%3D'
+    );
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr .hds-table__td'
+      )
+      .hasText('6');
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr:nth-child(10) .hds-table__td'
+      )
+      .hasText('15');
+
+    // CLICK "NEXT" + "PREV"
+    // ------------
+
+    await click(
+      '#demo4-compact-with-routing .hds-pagination .hds-pagination-nav__arrow--direction-next'
+    );
+    await click(
+      '#demo4-compact-with-routing .hds-pagination .hds-pagination-nav__arrow--direction-prev'
+    );
+    assert.strictEqual(
+      currentURL(),
+      '/components/pagination?currentPageSize_demo4=10&demoExtraParam=hello&prevCursor_demo4=cHJldl9fMTY%3D'
+    );
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr .hds-table__td'
+      )
+      .hasText('6');
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr:nth-child(10) .hds-table__td'
+      )
+      .hasText('15');
+
+    // CLICK "PREV"
+    // ------------
+    // this is a special test to make sure that when the prev cursor is less than the page size the demo code still works (there was a bug before)
 
     await click(
       '#demo4-compact-with-routing .hds-pagination .hds-pagination-nav__arrow--direction-prev'
     );
     assert.strictEqual(
       currentURL(),
-      '/components/pagination?demoExtraParam=hello&prevCursor_demo4=cHJldl9fNg%3D%3D'
+      '/components/pagination?currentPageSize_demo4=10&demoExtraParam=hello&prevCursor_demo4=cHJldl9fNg%3D%3D'
     );
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr'
+      )
+      // notice: even if the "page size" is 10, we see only 5 records because we are counting "10 records before record #6" and so only 5 records exist
+      .exists({ count: 5 });
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr .hds-table__td'
+      )
+      .hasText('1');
+    assert
+      .dom(
+        '#demo4-compact-with-routing .hds-table .hds-table__tbody .hds-table__tr:nth-child(5) .hds-table__td'
+      )
+      .hasText('5');
   });
 });

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -43,7 +43,7 @@
     <SF.Item as |SFI|>
       <SFI.Label>With
         <code>@currentPageSize=&lcub;&lcub;30&rcub;&rcub;</code>
-        and
+        +
         <code>@currentPage=&lcub;&lcub;2&rcub;&rcub;</code></SFI.Label>
       <Hds::Pagination::Numbered
         @totalItems={{40}}
@@ -99,6 +99,13 @@
     <SF.Item as |SFI|>
       <SFI.Label>With <code>@showSizeSelector=&lcub;&lcub;true&rcub;&rcub;</code></SFI.Label>
       <Hds::Pagination::Compact @showSizeSelector={{true}} />
+    </SF.Item>
+    <SF.Item as |SFI|>
+      <SFI.Label>With
+        <code>@showSizeSelector=&lcub;&lcub;true&rcub;&rcub;</code>
+        +
+        <code>@currentPageSize=&lcub;&lcub;30&rcub;&rcub;</code></SFI.Label>
+      <Hds::Pagination::Compact @showSizeSelector={{true}} @pageSizes={{array 10 30 50}} @currentPageSize={{30}} />
     </SF.Item>
   </Shw::Flex>
 
@@ -434,11 +441,15 @@
       </:body>
     </Hds::Table>
     <Hds::Pagination::Compact
+      @showSizeSelector={{true}}
       @route={{this.demoRouteName}}
+      @currentPageSize={{this.currentPageSize_demo4}}
+      @pageSizes={{array 5 10 30}}
       @queryFunction={{this.consumerQueryFunction_demo4}}
       @isDisabledPrev={{this.isDisabledPrev_demo4}}
       @isDisabledNext={{this.isDisabledNext_demo4}}
       @onPageChange={{this.genericHandlePageChange}}
+      @onPageSizeChange={{this.genericHandlePageSizeChange}}
     />
   </div>
 

--- a/packages/components/tests/integration/components/hds/pagination/compact-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/compact-test.js
@@ -73,7 +73,7 @@ module('Integration | Component | hds/pagination/compact', function (hooks) {
       .hasText('50');
   });
 
-  test('it renders custom options for passed in pageSizes', async function (assert) {
+  test('it renders custom options for passed in pageSizes and sets currentPageSize to the first PageSizes item', async function (assert) {
     await render(hbs`
       <Hds::Pagination::Compact @showSizeSelector={{true}} @pageSizes={{array 20 40 60}} />
     `);
@@ -86,6 +86,15 @@ module('Integration | Component | hds/pagination/compact', function (hooks) {
     assert
       .dom('.hds-pagination .hds-pagination-size-selector option[value="60"]')
       .hasText('60');
+  });
+
+  test('it renders the passed in currentPageSize value', async function (assert) {
+    await render(hbs`
+      <Hds::Pagination::Compact @showSizeSelector={{true}} @currentPageSize={{40}} @pageSizes={{array 20 40 60}} />
+    `);
+    assert
+      .dom('.hds-pagination .hds-pagination-size-selector select')
+      .hasValue('40');
   });
 
   test('it displays the passed in custom text for the SizeSelector label text', async function (assert) {

--- a/packages/components/tests/integration/components/hds/pagination/numbered-test.js
+++ b/packages/components/tests/integration/components/hds/pagination/numbered-test.js
@@ -61,6 +61,9 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
     `);
     assert.dom('.hds-pagination .hds-pagination-info').hasText('1–20 of 100');
     assert
+      .dom('.hds-pagination .hds-pagination-size-selector select')
+      .hasValue('20');
+    assert
       .dom('.hds-pagination .hds-pagination-size-selector option[value="20"]')
       .hasText('20');
     assert
@@ -76,6 +79,9 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
       <Hds::Pagination::Numbered @totalItems={{100}} @currentPageSize={{40}} @pageSizes={{array 20 40 60}} />
     `);
     assert.dom('.hds-pagination .hds-pagination-info').hasText('1–40 of 100');
+    assert
+      .dom('.hds-pagination .hds-pagination-size-selector select')
+      .hasValue('40');
   });
 
   test('it renders the "nav" content', async function (assert) {

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -28,26 +28,26 @@ These Pagination sub-elements may be used directly if you need to cover a very s
 <C.Property @name="totalItems" @required="true" @type="number">
 Pass the total number of items to be paginated. If no value is defined an error will be thrown.
 </C.Property>
-<C.Property @name="currentPage" @type="integer" @values={{array 1 "integer" }} @default={{1}}>
-Set a custom initial selected page.
-</C.Property>
-<C.Property @name="currentPageSize" @type="number">
-Pass the maximum number of items to display on each page. If no value is defined, the first page size in `pageSizes` will be used. Default is `10` if custom `pageSizes` are not defined.
-</C.Property>
 <C.Property @name="showLabels" @type="boolean" @default="false">
 Used to control the visibility of the "prev/next" text labels.
 </C.Property>
 <C.Property @name="isTruncated" @type="boolean" @default="true">
 Used to to limit the number of page numbers displayed (to save space, it will display an ellipsis for some numbers).
 </C.Property>
+<C.Property @name="currentPage" @type="integer" @values={{array 1 "integer" }} @default={{1}}>
+Set a custom initial selected page.
+</C.Property>
 <C.Property @name="showSizeSelector" @type="boolean" @default="true">
 Used to control the visibility of the "size selector".
+</C.Property>
+<C.Property @name="sizeSelectorLabel" @type="string" @default="Items per page">
+  Add a custom string for the label text overriding the default value.
 </C.Property>
 <C.Property @name="pageSizes" @type="array" @values={{array "[10, 30, 50]" "array of integers" }} @default="[10, 30, 50]">
 Set the page sizes users can select from. Example: `@pageSizes=\{{array 5 20 30}}`.
 </C.Property>
-<C.Property @name="sizeSelectorLabel" @type="string" @default="Items per page">
-  Add a custom string for the label text overriding the default value.
+<C.Property @name="currentPageSize" @type="number">
+Pass the maximum number of items to display on each page. If no value is defined, the first page size in `pageSizes` will be used. Default is `10` if custom `pageSizes` are not defined.
 </C.Property>
 <C.Property @name="route/model/models/replace">
 These are the parameters that are passed down as arguments to the `Hds::Pagination::Arrow`/`Hds::Pagination::Number` child components, and from them to the `Hds::Interactive` component (used internally). For more details about how this low-level component works please refer to [its documentation page](/utilities/interactive/).
@@ -81,20 +81,28 @@ Used to disable the "prev" or "next" controls. Notice: when the control is disab
 <C.Property @name="showSizeSelector" @type="boolean" @default="false">
 Used to control the visibility of the "size selector".
 </C.Property>
+<C.Property @name="sizeSelectorLabel" @type="string" @default="Items per page">
+  Add a custom string for the label text overriding the default value.
+</C.Property>
 <C.Property @name="pageSizes" @type="array" @values={{array "[10, 30, 50]" "array of integers" }} @default="[10, 30, 50]">
 Set the page sizes users can select from. Example: `@pageSizes=\{{array 5 20 30}}`.
 </C.Property>
-<C.Property @name="sizeSelectorLabel" @type="string" @default="Items per page">
-  Add a custom string for the label text overriding the default value.
+<C.Property @name="currentPageSize" @type="number">
+Pass the maximum number of items to display on each page. If no value is defined, the first page size in `pageSizes` will be used. Default is `10` if custom `pageSizes` are not defined.
 </C.Property>
 <C.Property @name="route/model/models/replace">
 These are the parameters that are passed down as arguments to the `Hds::Pagination::Arrow` child components, and from them to the `Hds::Interactive` component (used internally). For more details about how this low-level component works, please refer to [its documentation page](/utilities/interactive/).
 </C.Property>
 <C.Property @name="queryFunction" @type="function">
-A function that returns an object that can be provided as `query` argument for the routing, and that is passed down to the to the child components together with the other routing parameters. The function receives as argument one of two possible values: `prev` / `next`.
+A function that returns an object that can be provided as `query` argument for the routing, and that is passed down to the to the child components together with the other routing parameters. The function receives as arguments one of two possible cursor directions (`prev` / `next`) and the value of the "page size" (integer number).
+<br/>
+**Notice**: on page size change, the function returns `null` as cursor direction, to allow the consumers to handle the pagination logic accordingly.
 </C.Property>
 <C.Property @name="onPageChange" @type="function">
 Callback function invoked (if provided) when a "prev" or "next" control is clicked. The function receives as argument one of two possible values: `prev` / `next`
+</C.Property>
+<C.Property @name="onPageSizeChange" @type="function">
+Callback function invoked (if provided) when the page size selector is changed, and a "page size" change is triggered. The function receives the value of the "page size" as argument (an integer number).
 </C.Property>
 <C.Property @name="...attributes">
 This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -205,6 +205,16 @@ It is also possible to show the SizeSelector (hidden by default):
 <Hds::Pagination::Compact @showSizeSelector={{true}} />
 ```
 
+!!! Warning
+
+**Warning**
+
+When the "page size" is used in the context of a cursor-based pagination, it can lead to increased complexity and potential UX/usability issues (eg. when the cursor is `prev` and the page size is changed, the behaviour may different from what is expected by the user).
+
+**Be mindful of this limitations and implement your code accordingly.**
+
+!!!
+
 ### Event handling
 
 The component exposes a callback function that can be used to respond to page changes:


### PR DESCRIPTION
### :pushpin: Summary

While working on https://github.com/hashicorp/design-system/pull/1700  I completely forgot that the status of the `SizeSelector` for the `Pagination::Compact` needs to be handled too, depending if the component is "controlled" or not (same as for the `Numbered` variant).

Context: https://github.com/hashicorp/design-system/pull/1700/files#r1357503235

### :hammer_and_wrench: Detailed description

In this PR I have: 
- updated the logic for “Compact” variant of `Pagination` to expose `@currentPageSize` and handle controlled/uncontrolled changes
- done some small tweaks
    - converted `showLabels` getter to simple tracked variable (for consistency with the “Numbered” implementation
    - removed useless/leftover variant assignment in “Numbered” variant of `Pagination`
    - renamed `hasRouting` to `isControlled` for consistency with the `Tabs` component ([HDS-2648](https://hashicorp.atlassian.net/browse/HDS-2648))
- added to the `Pagination` showcase relevant use case and demo for the `Compact` variant with `SizeSelector`
- updated integration + acceptance tests
- updated “Component API” and "How to use" documentation for `Pagination`

👉 👉 👉 **Previews**: 
- showcase: https://hds-showcase-git-pagination-compact-expose-cur-e0c119-hashicorp.vercel.app/components/pagination
- website: https://hds-website-git-pagination-compact-expose-curr-600967-hashicorp.vercel.app/components/pagination

### :link: External links

Jira tickets: 
- https://hashicorp.atlassian.net/browse/HDS-2669
- https://hashicorp.atlassian.net/browse/HDS-2648

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2648]: https://hashicorp.atlassian.net/browse/HDS-2648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ