### PR TITLE
button acceptance test with a11y audit

### DIFF
--- a/packages/components/tests/acceptance/components/hds/button-test.js
+++ b/packages/components/tests/acceptance/components/hds/button-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | Component | hds/button', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('Components/button passes a11y automated checks', async function (assert) {
+    await visit('/components/button');
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/packages/components/tests/acceptance/components/hds/button-test.js
+++ b/packages/components/tests/acceptance/components/hds/button-test.js
@@ -7,8 +7,16 @@ module('Acceptance | Component | hds/button', function (hooks) {
   setupApplicationTest(hooks);
 
   test('Components/button passes a11y automated checks', async function (assert) {
+    // if making any changes to this component, enable the rule and run it to check that changes are still compliant
+    let axeOptions = {
+      rules: {
+        'color-contrast': {
+          enabled: false,
+        },
+      },
+    };
     await visit('/components/button');
-    await a11yAudit();
+    await a11yAudit(axeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/packages/components/tests/acceptance/components/hds/button-test.js
+++ b/packages/components/tests/acceptance/components/hds/button-test.js
@@ -7,16 +7,8 @@ module('Acceptance | Component | hds/button', function (hooks) {
   setupApplicationTest(hooks);
 
   test('Components/button passes a11y automated checks', async function (assert) {
-    // if making any changes to this component, enable the rule and run it to check that changes are still compliant
-    let axeOptions = {
-      rules: {
-        'color-contrast': {
-          enabled: false,
-        },
-      },
-    };
     await visit('/components/button');
-    await a11yAudit(axeOptions);
+    await a11yAudit();
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -86,14 +86,42 @@
       {{#each @model.SIZES as |size|}}
         {{#each @model.STATES as |state|}}
           <SG.Item @label="{{capitalize size}} / {{capitalize state}}">
-            <Hds::Button @icon="plus" @text="Lorem" @size={{size}} @color={{color}} mock-state-value={{state}} />
+            {{#if (eq state "disabled")}}
+              <Hds::Button
+                @icon="plus"
+                @text="Lorem"
+                @size={{size}}
+                @color={{color}}
+                mock-state-value={{state}}
+                disabled
+              />
+            {{else}}
+              <Hds::Button @icon="plus" @text="Lorem" @size={{size}} @color={{color}} mock-state-value={{state}} />
+            {{/if}}
           </SG.Item>
         {{/each}}
       {{/each}}
       {{#if (not-eq color "tertiary")}}
         {{#each @model.STATES as |state|}}
           <SG.Item @label="Full width / {{capitalize state}}">
-            <Hds::Button @icon="plus" @text="Lorem" @color={{color}} @isFullWidth={{true}} mock-state-value={{state}} />
+            {{#if (eq state "disabled")}}
+              <Hds::Button
+                @icon="plus"
+                @text="Lorem"
+                @color={{color}}
+                @isFullWidth={{true}}
+                mock-state-value={{state}}
+                disabled
+              />
+            {{else}}
+              <Hds::Button
+                @icon="plus"
+                @text="Lorem"
+                @color={{color}}
+                @isFullWidth={{true}}
+                mock-state-value={{state}}
+              />
+            {{/if}}
           </SG.Item>
         {{/each}}
       {{/if}}

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -85,14 +85,7 @@
         {{#each @model.STATES as |state|}}
           <SG.Item @label="{{capitalize size}} / {{capitalize state}}">
             {{#if (eq state "disabled")}}
-              <Hds::Button
-                @icon="plus"
-                @text="Lorem"
-                @size={{size}}
-                @color={{color}}
-                mock-state-value={{state}}
-                disabled
-              />
+              <Hds::Button @icon="plus" @text="Lorem" @size={{size}} @color={{color}} disabled />
             {{else}}
               <Hds::Button @icon="plus" @text="Lorem" @size={{size}} @color={{color}} mock-state-value={{state}} />
             {{/if}}
@@ -103,14 +96,7 @@
         {{#each @model.STATES as |state|}}
           <SG.Item @label="Full width / {{capitalize state}}">
             {{#if (eq state "disabled")}}
-              <Hds::Button
-                @icon="plus"
-                @text="Lorem"
-                @color={{color}}
-                @isFullWidth={{true}}
-                mock-state-value={{state}}
-                disabled
-              />
+              <Hds::Button @icon="plus" @text="Lorem" @color={{color}} @isFullWidth={{true}} disabled />
             {{else}}
               <Hds::Button
                 @icon="plus"

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -20,7 +20,7 @@
     <SF.Item class="shw-component-button-generated">
       <Shw::Label>With <code>@href</code> ⇒ <code>&lt;a&gt;</code></Shw::Label>
       <Hds::Button @icon="plus" @text="Lorem ipsum" @color="primary" @href="#" />
-      <Hds::Button @icon="plus" @text="Lorem ipsum" @color="primary" @href="#" disabled />
+      <Hds::Button @icon="plus" @text="Invalid HTML" @color="primary" @href="#" disabled />
     </SF.Item>
     <SF.Item class="shw-component-button-generated">
       <Shw::Label>With<code>@route</code>
@@ -29,7 +29,7 @@
         ⇒
         <code>&lt;a&gt;</code></Shw::Label>
       <Hds::Button @icon="plus" @text="Lorem ipsum" @color="primary" @route="index" />
-      <Hds::Button @icon="plus" @text="Lorem ipsum" @color="primary" @route="index" disabled />
+      <Hds::Button @icon="plus" @text="Invalid HTML" @color="primary" @route="index" disabled />
     </SF.Item>
   </Shw::Flex>
 

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -20,7 +20,6 @@
     <SF.Item class="shw-component-button-generated">
       <Shw::Label>With <code>@href</code> ⇒ <code>&lt;a&gt;</code></Shw::Label>
       <Hds::Button @icon="plus" @text="Lorem ipsum" @color="primary" @href="#" />
-      <Hds::Button @icon="plus" @text="Invalid HTML" @color="primary" @href="#" disabled />
     </SF.Item>
     <SF.Item class="shw-component-button-generated">
       <Shw::Label>With<code>@route</code>
@@ -29,7 +28,6 @@
         ⇒
         <code>&lt;a&gt;</code></Shw::Label>
       <Hds::Button @icon="plus" @text="Lorem ipsum" @color="primary" @route="index" />
-      <Hds::Button @icon="plus" @text="Invalid HTML" @color="primary" @route="index" disabled />
     </SF.Item>
   </Shw::Flex>
 


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR would add a button acceptance test for an a11y audit

### :hammer_and_wrench: Detailed description

- added acceptance test for button component
- removed instances where links were being rendered with the disabled attribute (invalid HTML, invalid WCAG)
- removed mock state for buttons with the `disabled` attribute

### :camera_flash: Screenshots

So I know how we talked about the fact that it's bad practice to disable an interactive element, but I don't think I realized that according to HTML spec, `disabled` is not a valid attribute for a `<a>` element: 
![CleanShot 2023-10-17 at 09 16 15](https://github.com/hashicorp/design-system/assets/4587451/f4e52247-54dc-48ea-bc88-00f87d547831)

Because of this, our links styled as buttons would be required to pass color contrast checks even if the links are not enabled. cc @hashicorp/hds-design 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2555](https://hashicorp.atlassian.net/browse/HDS-2555)
Figma file: [if it applies]

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2555]: https://hashicorp.atlassian.net/browse/HDS-2555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ