### PR TITLE
Website: update language about using the `disabled` attribute on links.

### DIFF
--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -132,7 +132,7 @@ To disable a Button, manually add the native `disabled` attribute:
 
 !!! Info
 
-If using an `@href` or `@route` and needing to disable the component, you’ll need to intercept the events since links can’t be disabled.
+Links cannot use the `disabled` attribute (per HTML specification); even if you were to intercept the event, they are still subject to color-contrast conformance requirements.
 !!!
 
 ```handlebars


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR clarifies the color-contrast requirements on button components that render as links. 

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2675](https://hashicorp.atlassian.net/browse/HDS-2675)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
