### PR TITLE
`Button/ButtonSet` - Documentation for "equal size" and "loading states"

### DIFF
--- a/packages/components/tests/dummy/app/controllers/components/button-set.js
+++ b/packages/components/tests/dummy/app/controllers/components/button-set.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ButtonSetController extends Controller {
+  @tracked isLoading = false;
+  @tracked timer;
+
+  @action
+  toggleIsLoading() {
+    this.isLoading = !this.isLoading;
+
+    clearTimeout(this.timer);
+    // make it go back to the idle state
+    this.timer = setTimeout(() => {
+      this.isLoading = false;
+    }, 4000);
+  }
+}

--- a/packages/components/tests/dummy/app/controllers/components/button.js
+++ b/packages/components/tests/dummy/app/controllers/components/button.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ButtonController extends Controller {
+  @tracked isLoading = false;
+  @tracked timer;
+
+  @action
+  toggleIsLoading() {
+    this.isLoading = !this.isLoading;
+
+    clearTimeout(this.timer);
+    // make it go back to the idle state
+    this.timer = setTimeout(() => {
+      this.isLoading = false;
+    }, 4000);
+  }
+}

--- a/packages/components/tests/dummy/app/templates/components/button-set.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button-set.hbs
@@ -26,6 +26,27 @@
         </Hds::ButtonSet>
       </Shw::Outliner>
     </SF.Item>
+    <SF.Item @label="Parent with max-width and buttons full with">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::ButtonSet>
+          <Hds::Button @text="Save" @isFullWidth={{true}} />
+          <Hds::Button @text="Cancel" @isFullWidth={{true}} @color="secondary" @href="#" />
+        </Hds::ButtonSet>
+      </Shw::Outliner>
+    </SF.Item>
+    <SF.Item {{style width="300px"}} @label="Idle/Loading states (click 'Save' to toggle)">
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::ButtonSet>
+          <Hds::Button
+            @text={{if this.isLoading "Loading" "Save"}}
+            @icon={{if this.isLoading "loading"}}
+            @isFullWidth={{true}}
+            {{on "click" this.toggleIsLoading}}
+          />
+          <Hds::Button @text="Cancel" @isFullWidth={{true}} @color="secondary" @href="#" />
+        </Hds::ButtonSet>
+      </Shw::Outliner>
+    </SF.Item>
   </Shw::Flex>
 
 </section>

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -51,6 +51,14 @@
     <SF.Item {{style width="200px"}} @label="Icon + Long text">
       <Hds::Button @icon="plus" @text="This is a very long text that should go on multiple lines" />
     </SF.Item>
+    <SF.Item {{style width="150px"}} @label="Loading (click to toggle)">
+      <Hds::Button
+        @text={{if this.isLoading "Loading" "Save"}}
+        @icon={{if this.isLoading "loading"}}
+        @isFullWidth={{true}}
+        {{on "click" this.toggleIsLoading}}
+      />
+    </SF.Item>
   </Shw::Flex>
 
   <Shw::Text::H2>Sizes</Shw::Text::H2>

--- a/website/docs/components/button-set/index.js
+++ b/website/docs/components/button-set/index.js
@@ -23,7 +23,7 @@ export default class Index extends Component {
   }
 
   @action
-  alertOnClick() {
-    alert('Hello from Helios!');
+  cancelLoading() {
+    this.isLoading = false;
   }
 }

--- a/website/docs/components/button-set/partials/code/how-to-use.md
+++ b/website/docs/components/button-set/partials/code/how-to-use.md
@@ -1,8 +1,42 @@
 ## How to use this component
 
+The basic invocation requires two or more buttons to be provided as children:
+
 ```handlebars
 <Hds::ButtonSet>
   <Hds::Button @text="Submit" type="submit" />
   <Hds::Button @text="Cancel" @color="secondary" @href="https://hashicorp.com" />
+</Hds::ButtonSet>
+```
+
+### Equal width buttons
+
+If you want to have buttons with equal width, apply a width (via inline style or via CSS class) to the `ButtonSet` container, and the argument `@isFullWidth={{true}}` to the `Button` elements:
+
+```handlebars
+<Hds::ButtonSet {{style width="15rem"}}>
+  <Hds::Button @text="Save" @isFullWidth={{true}} />
+  <Hds::Button @text="Cancel" @color="secondary" @href="https://hashicorp.com" @isFullWidth={{true}} />
+</Hds::ButtonSet>
+```
+
+#### With loading state
+
+This technique is useful if you need to show a loading state, to avoid the resizing and shifting of the buttons:
+
+```handlebars
+<Hds::ButtonSet {{style width="15rem"}}>
+  <Hds::Button
+    @icon={{if this.isLoading "loading"}}
+    @text={{if this.isLoading "Loading" "Save"}}
+    @isFullWidth={{true}}
+    {{on "click" this.toggleIsLoading}}
+  />
+  <Hds::Button
+    @text="Cancel"
+    @color="secondary"
+    @isFullWidth={{true}}
+    {{on "click" this.cancelLoading}}
+  />
 </Hds::ButtonSet>
 ```

--- a/website/docs/components/button-set/partials/code/how-to-use.md
+++ b/website/docs/components/button-set/partials/code/how-to-use.md
@@ -11,7 +11,7 @@ The basic invocation requires two or more buttons to be provided as children:
 
 ### Equal width buttons
 
-If you want to have buttons with equal width, apply a width (via inline style or via CSS class) to the `ButtonSet` container, and the argument `@isFullWidth={{true}}` to the `Button` elements:
+If you want to have buttons with equal width, apply a width (via inline style or CSS class) to the `ButtonSet` container and the argument `@isFullWidth={{true}}` to the `Button` components:
 
 ```handlebars
 <Hds::ButtonSet {{style width="15rem"}}>

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -126,6 +126,25 @@ If the route is external to your current engine, you have to pass `@isRouteExter
 <Hds::Button @text="Back to homepage" @icon="arrow-left" @route="index" />
 ```
 
+### Loading state
+
+If the button needs to toggle between an "idle" and a "loading" state, we suggest to apply a width to it (via inline style or via CSS class) to prevent the button to resize on click (and potentially cause layout shifts):
+
+!!! Info
+
+While applying an explicit with to the button it's possible in general, we suggest to limit the application of this override **only** to this specific use case and let the button resize accordingly to its content.
+
+!!!
+
+```handlebars
+<Hds::Button
+  {{style width="7.5rem"}}
+  @icon={{if this.isLoading "loading"}}
+  @text={{if this.isLoading "Loading" "Save"}}
+  {{on "click" this.toggleIsLoading}}
+/>
+```
+
 ### Disabled Buttons
 
 To disable a Button, manually add the native `disabled` attribute:

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -128,11 +128,11 @@ If the route is external to your current engine, you have to pass `@isRouteExter
 
 ### Loading state
 
-If the button needs to toggle between an "idle" and a "loading" state, we suggest to apply a width to it (via inline style or via CSS class) to prevent the button to resize on click (and potentially cause layout shifts):
+If the button needs to toggle between an "idle" and a "loading" state, we suggest applying a width to it (via inline style or CSS class) to prevent the button from resizing on click (and potentially causing layout shifts):
 
 !!! Info
 
-While applying an explicit with to the button it's possible in general, we suggest to limit the application of this override **only** to this specific use case and let the button resize accordingly to its content.
+While applying an explicit width to the button is possible in general, we suggest limiting the application of this override **only** to this specific use case and letting the button resize accordingly to its content.
 
 !!!
 


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of a discussion we had within the team, to respond to different requests of guidance from our consumers around buttons with loading states and 

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the `Button/ButtonSet` documentation pages to include “equal width” and “loading states”
- added a few use cases to the `Button/ButtonSet` showcases for equal width and loading states

👉 👉 👉 **Previews:**
- website:
    - button: https://hds-website-git-equal-size-for-button-and-load-d1d389-hashicorp.vercel.app/components/button?tab=code#loading-state
    - button-set: https://hds-website-git-equal-size-for-button-and-load-d1d389-hashicorp.vercel.app/components/button-set?tab=code#equal-width-buttons
- showcase:
    - button: https://hds-showcase-git-equal-size-for-button-and-loa-c0f2f9-hashicorp.vercel.app/components/button
    - button-set: https://hds-showcase-git-equal-size-for-button-and-loa-c0f2f9-hashicorp.vercel.app/components/button-set

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2676

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
