### PR TITLE
Adds acceptance test for dropdown component to test a11y

### DIFF
--- a/packages/components/tests/acceptance/components/hds/dropdown-test.js
+++ b/packages/components/tests/acceptance/components/hds/dropdown-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | Component | hds/dropdown', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('Components/dropdown passes a11y automated checks', async function (assert) {
+    await visit('/components/dropdown');
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/packages/components/tests/dummy/app/templates/components/dropdown.hbs
+++ b/packages/components/tests/dummy/app/templates/components/dropdown.hbs
@@ -247,7 +247,11 @@
     {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
       {{#each @model.TOGGLE_STATES as |state|}}
         <SG.Item @label="{{capitalize color}}">
-          <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} mock-state-value={{state}} />
+          {{#if (eq state "disabled")}}
+            <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} mock-state-value={{state}} disabled />
+          {{else}}
+            <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} mock-state-value={{state}} />
+          {{/if}}
         </SG.Item>
       {{/each}}
       <SG.Item @label="{{capitalize color}}">
@@ -255,7 +259,17 @@
       </SG.Item>
       {{#each @model.TOGGLE_STATES as |state|}}
         <SG.Item @label="With icon">
-          <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+          {{#if (eq state "disabled")}}
+            <Hds::Dropdown::Toggle::Button
+              @icon="hexagon"
+              @text="Lorem"
+              @color={{color}}
+              mock-state-value={{state}}
+              disabled
+            />
+          {{else}}
+            <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+          {{/if}}
         </SG.Item>
       {{/each}}
       <SG.Item @label="With icon">
@@ -263,7 +277,17 @@
       </SG.Item>
       {{#each @model.TOGGLE_STATES as |state|}}
         <SG.Item @label="With count">
-          <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+          {{#if (eq state "disabled")}}
+            <Hds::Dropdown::Toggle::Button
+              @count="12"
+              @text="Lorem"
+              @color={{color}}
+              mock-state-value={{state}}
+              disabled
+            />
+          {{else}}
+            <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+          {{/if}}
         </SG.Item>
       {{/each}}
       <SG.Item @label="With count">
@@ -271,13 +295,24 @@
       </SG.Item>
       {{#each @model.TOGGLE_STATES as |state|}}
         <SG.Item @label="With badge">
-          <Hds::Dropdown::Toggle::Button
-            @badge="Sit"
-            @badgeIcon="hexagon"
-            @text="Lorem"
-            @color={{color}}
-            mock-state-value={{state}}
-          />
+          {{#if (eq state "disabled")}}
+            <Hds::Dropdown::Toggle::Button
+              @badge="Sit"
+              @badgeIcon="hexagon"
+              @text="Lorem"
+              @color={{color}}
+              mock-state-value={{state}}
+              disabled
+            />
+          {{else}}
+            <Hds::Dropdown::Toggle::Button
+              @badge="Sit"
+              @badgeIcon="hexagon"
+              @text="Lorem"
+              @color={{color}}
+              mock-state-value={{state}}
+            />
+          {{/if}}
         </SG.Item>
       {{/each}}
       <SG.Item @label="With badge">
@@ -1261,6 +1296,7 @@
           <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Interactive for testing" />
           <Hds::Dropdown::ListItem::Generic>
             <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
           </Hds::Dropdown::ListItem::Generic>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds an acceptance test with an a11y audit for the dropdown component preview page.

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
