### PR TITLE
Remove `ember-cli-typescript`

### DIFF
--- a/packages/components/index.js
+++ b/packages/components/index.js
@@ -25,5 +25,8 @@ module.exports = {
         'dialog-polyfill-css': 'dialog-polyfill/dist/dialog-polyfill.css',
       },
     },
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
   },
 };

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,9 +37,7 @@
     "test:ember-compatibility": "ember try:each",
     "test:ember:percy": "percy exec ember test",
     "test:a11y": "ENABLE_A11Y_AUDIT=true ember test --server",
-    "test:a11y-report": "ENABLE_A11Y_MIDDLEWARE_REPORTER=true ember test",
-    "prepack": "ember ts:precompile",
-    "postpack": "ember ts:clean"
+    "test:a11y-report": "ENABLE_A11Y_MIDDLEWARE_REPORTER=true ember test"
   },
   "dependencies": {
     "@ember/render-modifiers": "^2.0.5",
@@ -53,7 +51,6 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",
     "ember-cli-sass": "^10.0.1",
-    "ember-cli-typescript": "^5.2.1",
     "ember-composable-helpers": "^4.5.0",
     "ember-focus-trap": "^1.0.2",
     "ember-keyboard": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3532,7 +3532,6 @@ __metadata:
     ember-cli-sri: ^2.1.1
     ember-cli-string-helpers: ^6.1.0
     ember-cli-terser: ^4.0.2
-    ember-cli-typescript: ^5.2.1
     ember-composable-helpers: ^4.5.0
     ember-concurrency: ^2.3.7
     ember-focus-trap: ^1.0.2
@@ -11712,7 +11711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-cli-typescript@npm:^5.0.0, ember-cli-typescript@npm:^5.1.1, ember-cli-typescript@npm:^5.2.1":
+"ember-cli-typescript@npm:^5.0.0, ember-cli-typescript@npm:^5.1.1":
   version: 5.2.1
   resolution: "ember-cli-typescript@npm:5.2.1"
   dependencies:


### PR DESCRIPTION
### :pushpin: Summary

This PR is a follow-up on #1580. It removes `ember-cli-typescript` in favor of using `ember-cli-babel` directly for transpilation.

### :hammer_and_wrench: Detailed description

We're doing this change to avoid introducing a dependency on `ember-cli-typescript` (a package that [entered maintenance mode](https://github.com/hashicorp/design-system/pull/1634#pullrequestreview-1684374666)).

This change was tested in [`cloud-ui`](https://github.com/hashicorp/cloud-ui/tree/alex-ju/test-hds-v3) (as a TypeScript consumer) and in [`atlas`](https://github.com/hashicorp/atlas/tree/alex-ju/test-hds-v3) (as a non-TypeScript consumer) both performing well and without any issues. In `cloud-ui` we've also tested type imports and glint to make sure we improve the developer experience.

### :camera_flash: Screenshots

`Hds::Button` component name and arguments autocomplete in `cloud-ui`

<img width="759" alt="typescript-autocomplete-cloud-ui" src="https://github.com/hashicorp/design-system/assets/788096/bedd9878-6717-471c-ab10-78b78e48b2e7">

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
