### PR TITLE
`Table` - Add example for alignment of `Button` in `Table` cell to showcase

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -931,7 +931,25 @@
             <B.Td @align="right"><Hds::Badge @text="Badge" /></B.Td>
           </B.Tr>
           <B.Tr>
-            <B.Th>Dropdown (with inline container)</B.Th>
+            <B.Th>Button (with inline container)</B.Th>
+            <B.Td @align="left">
+              <div {{style display="inline-block"}}>
+                <Hds::Button @size="small" @icon="plus" @text="Lorem ipsum" @color="secondary" />
+              </div>
+            </B.Td>
+            <B.Td @align="center">
+              <div {{style display="inline-block"}}>
+                <Hds::Button @size="small" @icon="plus" @text="Lorem ipsum" @color="secondary" />
+              </div>
+            </B.Td>
+            <B.Td @align="right">
+              <div {{style display="inline-block"}}>
+                <Hds::Button @size="small" @icon="plus" @text="Lorem ipsum" @color="secondary" />
+              </div>
+            </B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Th>Dropdown (with <code>@isInline</code>)</B.Th>
             <B.Td @align="left">
               <Hds::Dropdown @isInline={{true}} @listPosition="right" as |dd|>
                 <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />


### PR DESCRIPTION
### :pushpin: Summary

Context: https://hashicorp.slack.com/archives/C7KTUHNUS/p1697724775883859

### :hammer_and_wrench: Detailed description

In this PR I have:
- added example for alignment of `button` in `table` cell to showcase

Preview: https://hds-showcase-git-table-add-example-for-alignme-7c1ec1-hashicorp.vercel.app/components/table

### 📸 Screenshots

<img width="1079" alt="screenshot_3167" src="https://github.com/hashicorp/design-system/assets/686239/214246a9-8ee5-4f92-bb39-e887b7809ea1">

### :link: External links

Context: https://hashicorp.slack.com/archives/C7KTUHNUS/p1697724775883859

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
