### PR TITLE
`Pagination` - Remove handling of query parameters on page change for the "compact" variant

### DIFF
--- a/.changeset/loud-readers-flash.md
+++ b/.changeset/loud-readers-flash.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Pagination` - Removed handling of query parameters from `onPageSizeChange` function.
+
+_Notice: while technically this is a breaking change, we consider this a fast-follow fix for the previous release._

--- a/packages/components/addon/components/hds/pagination/compact/index.js
+++ b/packages/components/addon/components/hds/pagination/compact/index.js
@@ -7,15 +7,12 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
-import { inject as service } from '@ember/service';
 
 // for context about the decision to use these values, see:
 // https://hashicorp.slack.com/archives/C03A0N1QK8S/p1673546329082759
 export const DEFAULT_PAGE_SIZES = [10, 30, 50];
 
 export default class HdsPaginationCompactIndexComponent extends Component {
-  @service router;
-
   // This private variable is used to differentiate between
   // "uncontrolled" component (where the state is handled internally) and
   // "controlled" component (where the state is handled externally, by the consumer's code).
@@ -109,10 +106,6 @@ export default class HdsPaginationCompactIndexComponent extends Component {
     return pageSizes;
   }
 
-  get routeQueryParams() {
-    return this.router.currentRoute?.queryParams || {};
-  }
-
   buildQueryParamsObject(page, pageSize) {
     if (this.isControlled) {
       return this.args.queryFunction(page, pageSize);
@@ -161,15 +154,6 @@ export default class HdsPaginationCompactIndexComponent extends Component {
   @action
   onPageSizeChange(newPageSize) {
     let { onPageSizeChange } = this.args;
-
-    // we need to manually update the query parameters in the route (it's not a link!)
-    if (this.isControlled) {
-      // we pass `null` as value for the `page` argument, so consumers can handle this condition accordingly (probably will just change the side of the data/array slice)
-      const queryParams = this.buildQueryParamsObject(null, newPageSize);
-      this.router.transitionTo({ queryParams });
-    } else {
-      this.currentPageSize = newPageSize;
-    }
 
     // invoke the callback function
     if (typeof onPageSizeChange === 'function') {

--- a/packages/components/tests/dummy/app/controllers/components/pagination.js
+++ b/packages/components/tests/dummy/app/controllers/components/pagination.js
@@ -337,6 +337,14 @@ export default class PaginationController extends Controller {
     return this.model.records.slice(start, end);
   }
 
+  @action
+  onPageSizeChange_demo4(pageSize) {
+    // notice: here we don't add specific logic for this, but because of how the cursor-base pagination works
+    // there should be a better handling of how the "paginated" data list is computed and shown to the user to avoid some UX issues
+    // for details see this thread: https://github.com/hashicorp/design-system/pull/1724#issuecomment-1768167782
+    this.currentPageSize_demo4 = pageSize;
+  }
+
   // =============================
   // GENERIC HANDLERS
   // =============================

--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -449,7 +449,7 @@
       @isDisabledPrev={{this.isDisabledPrev_demo4}}
       @isDisabledNext={{this.isDisabledNext_demo4}}
       @onPageChange={{this.genericHandlePageChange}}
-      @onPageSizeChange={{this.genericHandlePageSizeChange}}
+      @onPageSizeChange={{this.onPageSizeChange_demo4}}
     />
   </div>
 


### PR DESCRIPTION
### :pushpin: Summary

@andrew-hashicorp has raised an issue with the adoption of the fix done in #1724:

<img width="926" alt="screenshot_3169" src="https://github.com/hashicorp/design-system/assets/686239/f73fd15d-9829-454e-94b2-c9ed73fd6919">

Upon further investigation, I think he’s right. We (I) ported the implementation from the “Numbered” variant, but actually also that one is flawed: the `onPageSizeChange` should only change the values when is not controlled; when is controlled it should delegate the responsibility to the consumers (they just need to update the value of the query parameter without needing to call a `router.transitionTo`, see `onPageSizeChange_demo4` on this PR).

Demonstration of this is the fact that once you remove the query params update on the `onPageSizeChange` action, you can also get rid of the `routeQueryParams` getter, which leads to removing entirely the need to import the `@service router` in the component (a code smell).

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed route query handling on “page size” change for the “compact” pagination
    - **notice**: in theory we could do the same also for the “numbered” pagination (I tested it, and it works, all the integration/acceptance tests pass) but it would be a breaking change so we need to do it in a [different ticket in the future](https://hashicorp.atlassian.net/browse/HDS-2729)
- updated showcase for “compact” pagination to handle query update on page size change

Re. the changeset version number, technically is a breaking change, but since we released the previous change 12 hours ago I am going to consider this a fast-follow fix, and use a "patch" for it.

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2728

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
