### PR TITLE
Fix `ember-flight-icons`'s dependency on `ember-get-config`

### DIFF
--- a/.changeset/healthy-pots-deliver.md
+++ b/.changeset/healthy-pots-deliver.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/ember-flight-icons": patch
+---
+
+Added missing dependency on `ember-get-config`

--- a/packages/ember-flight-icons/package.json
+++ b/packages/ember-flight-icons/package.json
@@ -37,7 +37,8 @@
     "@hashicorp/flight-icons": "^2.20.0",
     "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-htmlbars": "^6.2.0"
+    "ember-cli-htmlbars": "^6.2.0",
+    "ember-get-config": "^2.1.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3613,6 +3613,7 @@ __metadata:
     ember-cli-sri: ^2.1.1
     ember-cli-terser: ^4.0.2
     ember-disable-prototype-extensions: ^1.1.3
+    ember-get-config: ^2.1.1
     ember-load-initializers: ^2.1.2
     ember-page-title: ^7.0.0
     ember-qunit: ^6.2.0


### PR DESCRIPTION
### :pushpin: Summary

Fix `ember-flight-icons`'s dependency on `ember-get-config`

### :hammer_and_wrench: Detailed description

Used in [`load-sprite.js`](https://github.com/hashicorp/design-system/blob/main/packages/ember-flight-icons/addon/instance-initializers/load-sprite.js#L7) this dependency was likely pulled in by other dependencies by chance, but it needs to be explicitly defined as it currently [causes issues to our consumers](https://hashicorp.slack.com/archives/C7KTUHNUS/p1698231526885689).

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2746](https://hashicorp.atlassian.net/browse/HDS-2746)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2746]: https://hashicorp.atlassian.net/browse/HDS-2746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ