### PR TITLE
Fix `pre-build` script invocation + Update release notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "release": "yarn changeset publish",
-    "version": "yarn changeset version && yarn install --mode update-lockfile"
+    "version": "yarn changeset version && yarn install --mode update-lockfile && yarn workspace website generate-changelog-markdown-files"
   },
   "packageManager": "yarn@3.6.1",
   "resolutions": {

--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -12,6 +12,14 @@
   </a>
 </p>
 
+## 3.0.1
+
+**Patch changes**
+
+**🔄 Updated dependencies:**
+
+- @hashicorp/ember-flight-icons@4.0.1
+
 ## 3.0.0
 
 **Major changes**
@@ -335,44 +343,6 @@ Refactored the layout of the `Dropdown` checkbox and radio inputs to make the ga
 
 - @hashicorp/design-system-tokens@1.8.0
 - @hashicorp/ember-flight-icons@3.1.2
-
-## 2.11.0
-
-**Minor changes**
-
-`Hds::Text` - Added new `Text` component
-
-<small>[#1490](https://github.com/hashicorp/design-system/pull/1490)</small>
-
----
-
-`Hds::Form::MaskedInput` - Add `hasCopyButton` argument
-
-<small>[#1587](https://github.com/hashicorp/design-system/pull/1587)</small>
-
-**Patch changes**
-
-`Form::Indicator` - Remove aria-hidden from the "optional" `<span>`
-
-<small>[#1577](https://github.com/hashicorp/design-system/pull/1577) - Thanks [@DingoEatingFuzz](https://github.com/DingoEatingFuzz) for the contribution! 🙏</small>
-
----
-
-Removed `ember-named-blocks-polyfill` as all consumers of HDS are on Ember 3.25 or later now. This can be installed locally if it is still needed.
-
-<small>[#1606](https://github.com/hashicorp/design-system/pull/1606)</small>
-
----
-
-`Alert`, `Toast`: Fixed an issue with anchor tag color styles within Description that had been overriding `Hds::Link` color; changed the default color for HTML links within Description to "neutral" to better align with existing guidance for links in the actions and improve accessible contrast.
-
-<small>[#1576](https://github.com/hashicorp/design-system/pull/1576)</small>
-
----
-
-**🔄 Updated dependencies:**
-
-- @hashicorp/ember-flight-icons@3.1.1
 
 
 ---

--- a/website/docs/whats-new/release-notes/partials/ember-flight-icons.md
+++ b/website/docs/whats-new/release-notes/partials/ember-flight-icons.md
@@ -12,6 +12,16 @@
   </a>
 </p>
 
+## 4.0.1
+
+**Patch changes**
+
+Added missing dependency on `ember-get-config`
+
+<small>[#1747](https://github.com/hashicorp/design-system/pull/1747)</small>
+
+---
+
 ## 4.0.0
 
 **Major changes**
@@ -101,14 +111,6 @@ Shifted our supported version of Node.js from `12.* || 14.* || >= 16` to `14.* |
 - @hashicorp/flight-icons@2.14.0
 
 <small>[#1395](https://github.com/hashicorp/design-system/pull/1395)</small>
-
-## 3.0.5
-
-**Patch changes**
-
-**🔄 Updated dependencies:**
-
-- @hashicorp/flight-icons@2.13.1
 
 
 ---

--- a/website/package.json
+++ b/website/package.json
@@ -15,8 +15,8 @@
     "test": "tests"
   },
   "scripts": {
-    "prebuild": "node lib/changelog/generate-changelog-markdown-files.mjs",
-    "build": "ember build --environment=production",
+    "generate-changelog-markdown-files": "node lib/changelog/generate-changelog-markdown-files.mjs",
+    "build": "yarn generate-changelog-markdown-files && ember build --environment=production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
### :pushpin: Summary

Context: 
<img width="966" alt="screenshot_3204" src="https://github.com/hashicorp/design-system/assets/686239/6d8fb6e3-b780-4f66-b7ea-24115133bdc7">

Upon investigation, we have found that `yarn` does not execute the `pre/post` scripts automatically:

<img width="530" alt="screenshot_3203" src="https://github.com/hashicorp/design-system/assets/686239/663fdfaf-2a21-4b61-bdf1-43100b2fbff6">

See: https://github.com/yarnpkg/yarn/pull/800

From [the Yarn documentation](https://yarnpkg.com/advanced/lifecycle-scripts):

> In particular, we intentionally don’t support arbitrary pre and post hooks for user-defined scripts

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the node scripts
- re-run the scripts to update the “release notes” files

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
