### PR TITLE
Remove extra script call in `build` script for “website”

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "generate-changelog-markdown-files": "node lib/changelog/generate-changelog-markdown-files.mjs",
-    "build": "yarn generate-changelog-markdown-files && ember build --environment=production",
+    "build": "ember build --environment=production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
### :pushpin: Summary

Context: 
- https://github.com/hashicorp/design-system/pull/1750
- https://github.com/hashicorp/design-system/pull/1750#discussion_r1372086174

We have now seen [it's working as expected](https://github.com/hashicorp/design-system/pull/1752/files#diff-8d1e2d7985e686bad4bbab7902306fc95c8fcf425577d6b657ace0547f546675) so we can remove the extra script call.

### :hammer_and_wrench: Detailed description

In this PR I have:
- Removed the extra script call in `build` script for “website”, not needed anymore (the script is run by the `yarn version` command)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
