### PR TITLE
Only run integration tests in `ember-try`

### DIFF
--- a/packages/components/config/ember-try.js
+++ b/packages/components/config/ember-try.js
@@ -10,6 +10,7 @@ const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
   return {
+    command: 'ember test --filter="integration" --reporter xunit',
     useYarn: true,
     // override this to avoid ember-try trying to use `--no-lockfile` which
     // doesn't exist in yarn3


### PR DESCRIPTION
### :pushpin: Summary

To skip running the a11y tests in `ember-try`

### :hammer_and_wrench: Detailed description

The default command is `ember test --reporter xunit`, we add a filter to only run integration tests (hence skip the acceptance ones) to save us some time. The acceptance tests only contain the a11y tests, which are already running in the main test suite (outside of `ember-try`)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
