### PR TITLE
Remove unnecessary trailing slash from canonical url

### DIFF
--- a/website/app/services/head-data.js
+++ b/website/app/services/head-data.js
@@ -36,7 +36,7 @@ export default class CustomHeadDataService extends HeadDataService {
     const url =
       this.router.currentURL === '/'
         ? config['ember-meta'].url
-        : `${config['ember-meta'].url}/${this.router.currentURL}`;
+        : `${config['ember-meta'].url}${this.router.currentURL}`;
     return url;
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

In looking for some of the metadata that is rendered along with various pieces of content for the search project, I found a small bug in the getter for the canonical URL in which an extra trailing slash is added to the root domain. This probably doesn't impact anything in reality, but I figured it was a quick fix?

Otherwise, disregard and 🗑️ this!

### :camera_flash: Screenshots

Before:
<img width="560" alt="Screenshot 2023-10-31 at 9 50 48 AM" src="https://github.com/hashicorp/design-system/assets/2200899/bddf2dc8-cb40-4263-a111-97052d4095c6">

After:
<img width="696" alt="Screenshot 2023-10-31 at 9 51 06 AM" src="https://github.com/hashicorp/design-system/assets/2200899/802ab012-1b4b-459f-8f65-bba4f2fbeccf">

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
