### PR TITLE
Upgrade major `dependencies`

### DIFF
--- a/.changeset/modern-monkeys-fold.md
+++ b/.changeset/modern-monkeys-fold.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/ember-flight-icons": patch
+---
+
+Upgraded the following dependencies:
+ - `ember-cli-babel` from `7.26.11` to `8.2.0`

--- a/.changeset/popular-hornets-promise.md
+++ b/.changeset/popular-hornets-promise.md
@@ -1,0 +1,9 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Upgraded the following dependencies:
+ - `ember-cached-decorator-polyfill` from `0.1.4` to `1.0.2`
+ - `ember-cli-babel` from `7.26.11` to `8.2.0`
+ - `ember-cli-sass` from `10.0.1` to `11.0.1`
+ - `ember-composable-helpers` from `4.5.0` to `5.0.0`

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,7 @@
     "ember-a11y-refocus": "^3.0.2",
     "ember-auto-import": "^2.6.3",
     "ember-cached-decorator-polyfill": "^1.0.2",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-sass": "^10.0.1",
     "ember-composable-helpers": "^4.5.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,7 +47,7 @@
     "dialog-polyfill": "^0.5.6",
     "ember-a11y-refocus": "^3.0.2",
     "ember-auto-import": "^2.6.3",
-    "ember-cached-decorator-polyfill": "^0.1.4",
+    "ember-cached-decorator-polyfill": "^1.0.2",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-sass": "^10.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
     "ember-cached-decorator-polyfill": "^1.0.2",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
-    "ember-cli-sass": "^10.0.1",
+    "ember-cli-sass": "^11.0.1",
     "ember-composable-helpers": "^4.5.0",
     "ember-element-helper": "^0.8.5",
     "ember-focus-trap": "^1.1.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -51,7 +51,7 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-sass": "^11.0.1",
-    "ember-composable-helpers": "^4.5.0",
+    "ember-composable-helpers": "^5.0.0",
     "ember-element-helper": "^0.8.5",
     "ember-focus-trap": "^1.1.0",
     "ember-keyboard": "^8.2.1",

--- a/packages/ember-flight-icons/package.json
+++ b/packages/ember-flight-icons/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@hashicorp/flight-icons": "^2.20.0",
     "ember-auto-import": "^2.6.3",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-get-config": "^2.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4680,7 +4680,7 @@ __metadata:
     ember-body-class: ^3.0.0
     ember-cached-decorator-polyfill: ^1.0.2
     ember-cli: ~5.3.0
-    ember-cli-babel: ^7.26.11
+    ember-cli-babel: ^8.2.0
     ember-cli-clean-css: ^3.0.0
     ember-cli-dependency-checker: ^3.3.2
     ember-cli-deprecation-workflow: ^2.1.0
@@ -4777,7 +4777,7 @@ __metadata:
     broccoli-asset-rev: ^3.0.0
     ember-auto-import: ^2.6.3
     ember-cli: ~5.3.0
-    ember-cli-babel: ^7.26.11
+    ember-cli-babel: ^8.2.0
     ember-cli-clean-css: ^3.0.0
     ember-cli-dependency-checker: ^3.3.2
     ember-cli-htmlbars: ^6.3.0
@@ -12455,6 +12455,43 @@ __metadata:
     rimraf: ^3.0.1
     semver: ^5.5.0
   checksum: 72b2819018d4d29b5250284cab5fa992a7fd6b0cf958a1fc4abed4a4f6394c0aca4ee32d4c8981d8643fef7280763fadf70ebd807f262967899f4898679bcb90
+  languageName: node
+  linkType: hard
+
+"ember-cli-babel@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "ember-cli-babel@npm:8.2.0"
+  dependencies:
+    "@babel/helper-compilation-targets": ^7.20.7
+    "@babel/plugin-proposal-class-properties": ^7.16.5
+    "@babel/plugin-proposal-decorators": ^7.20.13
+    "@babel/plugin-proposal-private-methods": ^7.16.5
+    "@babel/plugin-proposal-private-property-in-object": ^7.20.5
+    "@babel/plugin-transform-class-static-block": ^7.22.11
+    "@babel/plugin-transform-modules-amd": ^7.20.11
+    "@babel/plugin-transform-runtime": ^7.13.9
+    "@babel/plugin-transform-typescript": ^7.20.13
+    "@babel/preset-env": ^7.20.2
+    "@babel/runtime": 7.12.18
+    amd-name-resolver: ^1.3.1
+    babel-plugin-debug-macros: ^0.3.4
+    babel-plugin-ember-data-packages-polyfill: ^0.1.2
+    babel-plugin-ember-modules-api-polyfill: ^3.5.0
+    babel-plugin-module-resolver: ^5.0.0
+    broccoli-babel-transpiler: ^8.0.0
+    broccoli-debug: ^0.6.4
+    broccoli-funnel: ^3.0.8
+    broccoli-source: ^3.0.1
+    calculate-cache-key-for-tree: ^2.0.0
+    clone: ^2.1.2
+    ember-cli-babel-plugin-helpers: ^1.1.1
+    ember-cli-version-checker: ^5.1.2
+    ensure-posix-path: ^1.0.2
+    resolve-package-path: ^4.0.3
+    semver: ^7.3.8
+  peerDependencies:
+    "@babel/core": ^7.12.0
+  checksum: 26a5abd3107ddfc76221894141b68cab79fb9cdf79ea0fa9646efe47c42f18bda49b854878118f8b57b3ebf5014828cf0ad640e77ffc209e3565f7eb792d1ef5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4690,7 +4690,7 @@ __metadata:
     ember-cli-sri: ^2.1.1
     ember-cli-string-helpers: ^6.1.0
     ember-cli-terser: ^4.0.2
-    ember-composable-helpers: ^4.5.0
+    ember-composable-helpers: ^5.0.0
     ember-concurrency: ^3.1.1
     ember-element-helper: ^0.8.5
     ember-focus-trap: ^1.1.0
@@ -13090,15 +13090,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-composable-helpers@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "ember-composable-helpers@npm:4.5.0"
+"ember-composable-helpers@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "ember-composable-helpers@npm:5.0.0"
   dependencies:
     "@babel/core": ^7.0.0
     broccoli-funnel: 2.0.1
     ember-cli-babel: ^7.26.3
     resolve: ^1.10.0
-  checksum: 39bc86701eee2c8afde0cd912b757fd7f26b06c25df182fc6bc833722bea86a2c4cc4e51659c489dfdcea5630ed87794010584e68b4c52e6049aee8a8c87808b
+  checksum: 8fdceade42f025cb75cb3718de4a6f3836b1a74eca8d30ca7a8c0313fccdce6663ce6fa5e5bd14fd905ecac2a330d55c169f21f559f092a5900d08ddc290fff6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,7 +3813,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@embroider/macros@npm:^1.12.0, @embroider/macros@npm:^1.13.0, @embroider/macros@npm:^1.13.1":
+"@embroider/macros@npm:^1.12.0, @embroider/macros@npm:^1.13.0, @embroider/macros@npm:^1.13.1, @embroider/macros@npm:^1.8.3":
   version: 1.13.2
   resolution: "@embroider/macros@npm:1.13.2"
   dependencies:
@@ -4678,7 +4678,7 @@ __metadata:
     ember-a11y-testing: ^6.1.1
     ember-auto-import: ^2.6.3
     ember-body-class: ^3.0.0
-    ember-cached-decorator-polyfill: ^0.1.4
+    ember-cached-decorator-polyfill: ^1.0.2
     ember-cli: ~5.3.0
     ember-cli-babel: ^7.26.11
     ember-cli-clean-css: ^3.0.0
@@ -7981,6 +7981,13 @@ __metadata:
   version: 1.3.0
   resolution: "babel-import-util@npm:1.3.0"
   checksum: 41c6b4276ceefd2263f59be97a99bf8d948899c76587b273d115e91fa9067b0d9cc80ba727a795732052e078c30a3665649c725aed966826bf7c0a258a5fcf03
+  languageName: node
+  linkType: hard
+
+"babel-import-util@npm:^1.2.2":
+  version: 1.4.1
+  resolution: "babel-import-util@npm:1.4.1"
+  checksum: a7f43a10141f62f05c0b4b3c80ee31f5f362d5f7a7d614fcef836f3eca2ec3ae0a732f8550674542d1821e87c3fd3d986fea94ed12e2a283a1571b6d1249380a
   languageName: node
   linkType: hard
 
@@ -12357,15 +12364,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-cached-decorator-polyfill@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "ember-cached-decorator-polyfill@npm:0.1.4"
+"ember-cached-decorator-polyfill@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "ember-cached-decorator-polyfill@npm:1.0.2"
   dependencies:
-    "@glimmer/tracking": ^1.0.4
+    "@embroider/macros": ^1.8.3
+    "@glimmer/tracking": ^1.1.2
+    babel-import-util: ^1.2.2
     ember-cache-primitive-polyfill: ^1.0.1
-    ember-cli-babel: ^7.21.0
+    ember-cli-babel: ^7.26.11
     ember-cli-babel-plugin-helpers: ^1.1.1
-  checksum: 8f8228e8fe578a78045c00cfd9ffc124dd287e45908e912dba9823ba48a14c1cb7e15fce64f4a034b68edcf6987c51c0500fbab7825e982ea4708672b019780a
+  peerDependencies:
+    ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
+  checksum: bbfaeafdf89a7ab834d85502829d604e3eb439cb154652b21683492e3e59a918bbaf49d39703f1a896016521d7cf03dc05e89cf5cf06de88fd1489b8e00ef8bb
   languageName: node
   linkType: hard
 
@@ -12409,7 +12420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-cli-babel@npm:^7.10.0, ember-cli-babel@npm:^7.13.0, ember-cli-babel@npm:^7.19.0, ember-cli-babel@npm:^7.21.0, ember-cli-babel@npm:^7.22.1, ember-cli-babel@npm:^7.23.0, ember-cli-babel@npm:^7.23.1, ember-cli-babel@npm:^7.26.0, ember-cli-babel@npm:^7.26.10, ember-cli-babel@npm:^7.26.11, ember-cli-babel@npm:^7.26.3, ember-cli-babel@npm:^7.26.4, ember-cli-babel@npm:^7.26.6, ember-cli-babel@npm:^7.7.3":
+"ember-cli-babel@npm:^7.10.0, ember-cli-babel@npm:^7.13.0, ember-cli-babel@npm:^7.19.0, ember-cli-babel@npm:^7.22.1, ember-cli-babel@npm:^7.23.0, ember-cli-babel@npm:^7.23.1, ember-cli-babel@npm:^7.26.0, ember-cli-babel@npm:^7.26.10, ember-cli-babel@npm:^7.26.11, ember-cli-babel@npm:^7.26.3, ember-cli-babel@npm:^7.26.4, ember-cli-babel@npm:^7.26.6, ember-cli-babel@npm:^7.7.3":
   version: 7.26.11
   resolution: "ember-cli-babel@npm:7.26.11"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4417,7 +4417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@glimmer/tracking@npm:^1.0.0, @glimmer/tracking@npm:^1.0.4, @glimmer/tracking@npm:^1.1.2":
+"@glimmer/tracking@npm:^1.0.0, @glimmer/tracking@npm:^1.1.2":
   version: 1.1.2
   resolution: "@glimmer/tracking@npm:1.1.2"
   dependencies:
@@ -12455,43 +12455,6 @@ __metadata:
     rimraf: ^3.0.1
     semver: ^5.5.0
   checksum: 72b2819018d4d29b5250284cab5fa992a7fd6b0cf958a1fc4abed4a4f6394c0aca4ee32d4c8981d8643fef7280763fadf70ebd807f262967899f4898679bcb90
-  languageName: node
-  linkType: hard
-
-"ember-cli-babel@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "ember-cli-babel@npm:8.2.0"
-  dependencies:
-    "@babel/helper-compilation-targets": ^7.20.7
-    "@babel/plugin-proposal-class-properties": ^7.16.5
-    "@babel/plugin-proposal-decorators": ^7.20.13
-    "@babel/plugin-proposal-private-methods": ^7.16.5
-    "@babel/plugin-proposal-private-property-in-object": ^7.20.5
-    "@babel/plugin-transform-class-static-block": ^7.22.11
-    "@babel/plugin-transform-modules-amd": ^7.20.11
-    "@babel/plugin-transform-runtime": ^7.13.9
-    "@babel/plugin-transform-typescript": ^7.20.13
-    "@babel/preset-env": ^7.20.2
-    "@babel/runtime": 7.12.18
-    amd-name-resolver: ^1.3.1
-    babel-plugin-debug-macros: ^0.3.4
-    babel-plugin-ember-data-packages-polyfill: ^0.1.2
-    babel-plugin-ember-modules-api-polyfill: ^3.5.0
-    babel-plugin-module-resolver: ^5.0.0
-    broccoli-babel-transpiler: ^8.0.0
-    broccoli-debug: ^0.6.4
-    broccoli-funnel: ^3.0.8
-    broccoli-source: ^3.0.1
-    calculate-cache-key-for-tree: ^2.0.0
-    clone: ^2.1.2
-    ember-cli-babel-plugin-helpers: ^1.1.1
-    ember-cli-version-checker: ^5.1.2
-    ensure-posix-path: ^1.0.2
-    resolve-package-path: ^4.0.3
-    semver: ^7.3.8
-  peerDependencies:
-    "@babel/core": ^7.12.0
-  checksum: 26a5abd3107ddfc76221894141b68cab79fb9cdf79ea0fa9646efe47c42f18bda49b854878118f8b57b3ebf5014828cf0ad640e77ffc209e3565f7eb792d1ef5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4686,7 +4686,7 @@ __metadata:
     ember-cli-deprecation-workflow: ^2.1.0
     ember-cli-htmlbars: ^6.3.0
     ember-cli-inject-live-reload: ^2.1.0
-    ember-cli-sass: ^10.0.1
+    ember-cli-sass: ^11.0.1
     ember-cli-sri: ^2.1.1
     ember-cli-string-helpers: ^6.1.0
     ember-cli-terser: ^4.0.2
@@ -12793,18 +12793,6 @@ __metadata:
     broccoli-funnel: ^3.0.8
     debug: ^4.3.2
   checksum: 41b2d0b45a7e9423381965a43bc5c3f0d693d0d78aeeb8a9ebcbbe567f37fff21c56fb3ad9f7a941cdf3fa8a82f20b2c1a13fe9be6f10b33eb40d9553555acab
-  languageName: node
-  linkType: hard
-
-"ember-cli-sass@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "ember-cli-sass@npm:10.0.1"
-  dependencies:
-    broccoli-funnel: ^2.0.1
-    broccoli-merge-trees: ^3.0.1
-    broccoli-sass-source-maps: ^4.0.0
-    ember-cli-version-checker: ^2.1.0
-  checksum: 99eb9045b19c82851a90435df14b4ab4108ee0fd57a9e78d085c225a9d3dfb72bae8118707cf2f1a2d4d37abc2c40ad0dd95c0079f43d051ec90526448189ac3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: Summary

Upgrade most (exceptions detailed below) `dependencies` (majors) across the monorepo.

### :hammer_and_wrench: Detailed description

These are upgrades that will be passed on to our consumers and require releases for our packages.

This branch is based on #1704 to avoid having too many conflicts, with the intent to repoint it and merge it to `main` after #1704 gets in.

Exceptions:
 - `ember-stargate` and `ember-truth-helpers` were updated to v2 add-ons and we're not yet ready to consume them and/or impose them to our consumers.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2619](https://hashicorp.atlassian.net/browse/HDS-2619)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2619]: https://hashicorp.atlassian.net/browse/HDS-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ