### PR TITLE
Fix `HdsInteractiveSignature` type import

### DIFF
--- a/.changeset/shy-lamps-drive.md
+++ b/.changeset/shy-lamps-drive.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Button` - Fixed `HdsInteractiveSignature` type import

--- a/packages/components/addon/components/hds/button/index.ts
+++ b/packages/components/addon/components/hds/button/index.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import { HdsInteractiveSignature } from '../interactive';
+import { type HdsInteractiveSignature } from '../interactive';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_COLOR = 'primary';


### PR DESCRIPTION
### :pushpin: Summary

Fix `HdsInteractiveSignature` type import.

### :hammer_and_wrench: Detailed description

This notation is only enforced in the latest version of `tsconfig`, so it's currently not affecting our consumers, but it will and it's a requirement for us migrating to that version.

Extracted from https://github.com/hashicorp/design-system/pull/1755#discussion_r1380090467

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
