### PR TITLE
remove @ember/render-modifiers resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "packageManager": "yarn@3.6.1",
   "resolutions": {
-    "@ember/render-modifiers": "^2.0.0",
     "broccoli-asset-rewrite@^2.0.0": "patch:broccoli-asset-rewrite@npm%3A2.0.0#./.yarn/patches/broccoli-asset-rewrite-npm-2.0.0-c4ce42084a.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3660,16 +3660,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ember/render-modifiers@npm:^2.0.0":
-  version: 2.0.5
-  resolution: "@ember/render-modifiers@npm:2.0.5"
+"@ember/render-modifiers@npm:^2.0.0, @ember/render-modifiers@npm:^2.0.5":
+  version: 2.1.0
+  resolution: "@ember/render-modifiers@npm:2.1.0"
   dependencies:
     "@embroider/macros": ^1.0.0
     ember-cli-babel: ^7.26.11
     ember-modifier-manager-polyfill: ^1.2.0
   peerDependencies:
-    ember-source: ^3.8 || ^4.0.0
-  checksum: ebeb4d573968f46490f8f5618b9d85f2c7ca39cee5b854bb497a3aee7dee3d710ab02b9677df30f1e2a484e712dd89171045118da563d9d9a6c316ccdccc2671
+    "@glint/template": ^1.0.2
+    ember-source: ^3.8 || ^4.0.0 || ^5.0.0
+  peerDependenciesMeta:
+    "@glint/template":
+      optional: true
+  checksum: 6c4d617b67ee52e8e29e9a2b9f42a30e8ea333a7b7a4c5a61fdf5f15623da11f40d82218aeddfbe32bee1f508c569740e842a8233f4a372728d18b66bbc197d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: Summary

removes the `@ember/render-modifiers` resolution we had in place to work around a bug

### :hammer_and_wrench: Detailed description

This was added in https://github.com/hashicorp/design-system/pull/651 to work around a specific issue we were seeing using `field-guide`, but we are no longer using that tool so this resolution is not needed. As an added bonus, this also moves us to the 2.1 release of `@ember/render-modifiers` which [includes support for Ember 5.x](https://github.com/emberjs/ember-render-modifiers/pull/70/files)

### :camera_flash: Screenshots

```bash
~/c/w/design-system (br-render-modifier|✔) $ yarn why @ember/render-modifiers
├─ @hashicorp/design-system-components@workspace:packages/components
│  └─ @ember/render-modifiers@npm:2.1.0 [3aeb9] (via npm:^2.0.5 [3aeb9])
│
├─ ember-basic-dropdown@npm:7.2.2
│  └─ @ember/render-modifiers@npm:2.1.0 [84211] (via npm:^2.0.5 [84211])
│
├─ ember-prism@npm:0.13.0
│  └─ @ember/render-modifiers@npm:2.1.0 [84211] (via npm:^2.0.5 [84211])
│
└─ ember-stargate@npm:0.4.3
   └─ @ember/render-modifiers@npm:2.1.0 [84211] (via npm:^2.0.5 [84211])
```

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
