### PR TITLE
skip dropdown test to debug instability issues

### DIFF
--- a/packages/components/tests/acceptance/components/hds/dropdown-test.js
+++ b/packages/components/tests/acceptance/components/hds/dropdown-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { module, test, skip } from 'qunit';
+import { module, skip } from 'qunit';
 import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';

--- a/packages/components/tests/acceptance/components/hds/dropdown-test.js
+++ b/packages/components/tests/acceptance/components/hds/dropdown-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -11,7 +11,7 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 module('Acceptance | Component | hds/dropdown', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Components/dropdown passes a11y automated checks', async function (assert) {
+  skip('Components/dropdown passes a11y automated checks', async function (assert) {
     await visit('/components/dropdown');
     await a11yAudit();
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR skips the dropdown acceptance test, the suspected source of the test suite instability as of late.


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2758](https://hashicorp.atlassian.net/browse/HDS-2758)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2758]: https://hashicorp.atlassian.net/browse/HDS-2758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ