### PR TITLE
Upgrade `stylelint-config-standard-scss` to `11.1.0`

### DIFF
--- a/packages/components/.prettierrc.js
+++ b/packages/components/.prettierrc.js
@@ -10,5 +10,11 @@ module.exports = {
         printWidth: 120,
       },
     },
+    {
+      files: '*.scss',
+      options: {
+        singleQuote: false,
+      },
+    },
   ],
 };

--- a/packages/components/.stylelintrc.js
+++ b/packages/components/.stylelintrc.js
@@ -24,14 +24,6 @@ module.exports = {
     // see: https://stylelint.io/user-guide/rules/list/declaration-empty-line-before/
     'declaration-empty-line-before': null,
 
-    // we've decided to never have spaces inside the parentheses of functions (we all prefer this way, for readability)
-    // see: https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside/
-    'function-parentheses-space-inside': 'never',
-
-    // we've agreed that in some cases is useful to add extra visual space between blocks to better separate/group content
-    // see: https://stylelint.io/user-guide/rules/list/max-empty-lines/
-    'max-empty-lines': 2,
-
     // we've agreed to not enforce a limit on the lines lenght (we embed SVGs so very long strings + plus modern browsers can esily soft-wrap code)
     // see: https://stylelint.io/user-guide/rules/list/max-line-length/
     'max-line-length': null,
@@ -43,10 +35,6 @@ module.exports = {
     // we've decided to disable this rule because we want to be able to order our declarations based on different criteria, if/when needed
     // see: https://stylelint.io/user-guide/rules/list/no-duplicate-selectors/
     'no-duplicate-selectors': null,
-
-    // we all had preference on always having leading zeros (for readability)
-    // see: https://stylelint.io/user-guide/rules/list/number-leading-zero/
-    'number-leading-zero': 'always',
 
     // we've decided to enforce the `.hds|.mock|.flight` naming convention (plus, using the default stylelint rule one doesn't work for us, because we're using BEM)
     // see: https://stylelint.io/user-guide/rules/list/selector-class-pattern/

--- a/packages/components/.stylelintrc.js
+++ b/packages/components/.stylelintrc.js
@@ -61,10 +61,6 @@ module.exports = {
     // see: https://stylelint.io/user-guide/rules/list/shorthand-property-no-redundant-values/
     'shorthand-property-no-redundant-values': null,
 
-    // we've decide to use "double" quotes (notice: this is the default rule, but better to declare it explicitly so it's evident is intentional)
-    // see: https://stylelint.io/user-guide/rules/list/string-quotes/
-    'string-quotes': 'double',
-
     // we've decided to have this custom rule because there's an issue with "currentColor" (https://github.com/stylelint/stylelint/issues/5863)
     // see: https://stylelint.io/user-guide/rules/list/value-keyword-case/
     'value-keyword-case': ['lower', { ignoreKeywords: ['currentColor'] }],

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -118,7 +118,7 @@
     "sinon": "^17.0.0",
     "stylelint": "^15.11.0",
     "stylelint-config-rational-order": "^0.1.2",
-    "stylelint-config-standard-scss": "^5.0.0",
+    "stylelint-config-standard-scss": "^11.1.0",
     "typescript": "^5.2.2",
     "webpack": "^5.89.0"
   },

--- a/packages/ember-flight-icons/.prettierrc.js
+++ b/packages/ember-flight-icons/.prettierrc.js
@@ -10,5 +10,11 @@ module.exports = {
         printWidth: 120,
       },
     },
+    {
+      files: '*.scss',
+      options: {
+        singleQuote: false,
+      },
+    },
   ],
 };

--- a/website/.prettierrc.js
+++ b/website/.prettierrc.js
@@ -10,5 +10,11 @@ module.exports = {
         printWidth: 120,
       },
     },
+    {
+      files: '*.scss',
+      options: {
+        singleQuote: false,
+      },
+    },
   ],
 };

--- a/website/app/styles/breakpoints/index.scss
+++ b/website/app/styles/breakpoints/index.scss
@@ -15,11 +15,11 @@ $doc-breakpoint-for-sidebar: 880px;
 
 
 @mixin small {
-  @media (max-width: calc(#{$doc-breakpoint-medium} - 1px)) { @content; }
+  @media (width <= calc(#{$doc-breakpoint-medium} - 1px)) { @content; }
 }
 
 @mixin medium-only {
-  @media (min-width: $doc-breakpoint-medium) and (max-width: calc(#{$doc-breakpoint-large} - 1px)) { @content; }
+  @media (min-width: $doc-breakpoint-medium) and (width <= calc(#{$doc-breakpoint-large} - 1px)) { @content; }
 }
 
 @mixin medium {
@@ -35,7 +35,7 @@ $doc-breakpoint-for-sidebar: 880px;
 }
 
 @mixin with-mobile-sidebar {
-  @media (max-width: calc(#{$doc-breakpoint-for-sidebar} - 1px)) { @content; }
+  @media (width <= calc(#{$doc-breakpoint-for-sidebar} - 1px)) { @content; }
 }
 
 @mixin with-fixed-sidebar {

--- a/website/app/styles/doc-components/color-swatch.scss
+++ b/website/app/styles/doc-components/color-swatch.scss
@@ -18,7 +18,7 @@ $doc-color-swatch-border-radius: 3px;
   border-radius: $doc-color-swatch-border-radius;
 
 
-  @media screen and (min-width: 1280px) {
+  @media screen and (width >= 1280px) {
     grid-template-rows: 1fr;
     grid-template-columns: (minmax(80px, 80px) auto); // just 80px auto didn't work, maybe a bug?
   }
@@ -28,7 +28,7 @@ $doc-color-swatch-border-radius: 3px;
   border-top-left-radius: $doc-color-swatch-border-radius;
   border-top-right-radius: $doc-color-swatch-border-radius;
 
-  @media screen and (min-width: 1280px) {
+  @media screen and (width >= 1280px) {
     grid-area: 1 / 1 / 2 / 2;
     max-width: 80px;
     border-top-right-radius: 0;
@@ -67,7 +67,7 @@ $doc-color-swatch-border-radius: 3px;
     margin-bottom: 0;
   }
 
-  @media screen and (min-width: 768px) {
+  @media screen and (width >= 768px) {
     grid-column-gap: 1rem;
     grid-template-columns: minmax(90px, max-content) 1fr;
   }
@@ -84,7 +84,7 @@ $doc-color-swatch-border-radius: 3px;
     line-height: 1.2;
     letter-spacing: 0.0125em;
 
-    @media screen and (min-width: 768px) {
+    @media screen and (width >= 768px) {
       margin-bottom: 0;
     }
   }

--- a/website/package.json
+++ b/website/package.json
@@ -102,7 +102,7 @@
     "showdown": "^2.1.0",
     "stylelint": "^15.11.0",
     "stylelint-config-rational-order": "^0.1.2",
-    "stylelint-config-standard-scss": "^5.0.0",
+    "stylelint-config-standard-scss": "^11.1.0",
     "webpack": "^5.89.0",
     "yaml-front-matter": "^4.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4684,7 +4684,7 @@ __metadata:
     sinon: "npm:^17.0.0"
     stylelint: "npm:^15.11.0"
     stylelint-config-rational-order: "npm:^0.1.2"
-    stylelint-config-standard-scss: "npm:^5.0.0"
+    stylelint-config-standard-scss: "npm:^11.1.0"
     tippy.js: "npm:^6.3.7"
     typescript: "npm:^5.2.2"
     webpack: "npm:^5.89.0"
@@ -21350,12 +21350,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-scss@npm:^4.0.2":
-  version: 4.0.4
-  resolution: "postcss-scss@npm:4.0.4"
+"postcss-scss@npm:^4.0.9":
+  version: 4.0.9
+  resolution: "postcss-scss@npm:4.0.9"
   peerDependencies:
-    postcss: ^8.3.3
-  checksum: b4f240dd5eeb0c21738b673d9caf9a06b9a6db665a5b1c815ee4ca10c4c74a67c54f11cd5a4970dea98475cbb9e6d846e05dd3e48924189c2ecbf1f50cd44aa4
+    postcss: ^8.4.29
+  checksum: d191c771344357a28995a2f53041ec699070331b8238e076001cedde97215bd3ebf596d0a9882b22c566977c4b72816dafc00028dc09153c6f97f71cd28a70f7
   languageName: node
   linkType: hard
 
@@ -21380,7 +21380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:^6.0.2, postcss-selector-parser@npm:^6.0.4, postcss-selector-parser@npm:^6.0.6":
+"postcss-selector-parser@npm:^6.0.2, postcss-selector-parser@npm:^6.0.4":
   version: 6.0.11
   resolution: "postcss-selector-parser@npm:6.0.11"
   dependencies:
@@ -24270,48 +24270,56 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint-config-recommended-scss@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "stylelint-config-recommended-scss@npm:7.0.0"
+"stylelint-config-recommended-scss@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "stylelint-config-recommended-scss@npm:13.1.0"
   dependencies:
-    postcss-scss: "npm:^4.0.2"
-    stylelint-config-recommended: "npm:^8.0.0"
-    stylelint-scss: "npm:^4.0.0"
+    postcss-scss: "npm:^4.0.9"
+    stylelint-config-recommended: "npm:^13.0.0"
+    stylelint-scss: "npm:^5.3.0"
   peerDependencies:
-    stylelint: ^14.4.0
-  checksum: 978d3298a1b4d7d0fcc258298c688f4748373092f097733a0bcf24d60ced47b46d9b03c79fe73b88f981219efca8ce27756e870e3e7a2abcac838952b088a8df
+    postcss: ^8.3.3
+    stylelint: ^15.10.0
+  peerDependenciesMeta:
+    postcss:
+      optional: true
+  checksum: 249cc4705759f779da2be797b2155b05b6d0ce49542b5144634d46295955c32b22734468529c772ba0a926fdf3bd3b0583088a74a0790cfc5e354d09b1f9a8c7
   languageName: node
   linkType: hard
 
-"stylelint-config-recommended@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "stylelint-config-recommended@npm:8.0.0"
+"stylelint-config-recommended@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "stylelint-config-recommended@npm:13.0.0"
   peerDependencies:
-    stylelint: ^14.8.0
-  checksum: 0c5ca94625e5308a7afb8315bb350a2b48f46fdd8d8922dd9a8c2e37b3407f2294794d930726ad6bf2007abcde1abd34084808cf83adf150efe3a643e0eb5ac4
+    stylelint: ^15.10.0
+  checksum: a56eb6d1a7c7f3a7a172b54bc34218859ba22a5a06816fb4d0964f66cb83cf372062f2c97830e994ad68243548e15fc49abf28887c3261ab1b471b3aa69f8e82
   languageName: node
   linkType: hard
 
-"stylelint-config-standard-scss@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "stylelint-config-standard-scss@npm:5.0.0"
+"stylelint-config-standard-scss@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "stylelint-config-standard-scss@npm:11.1.0"
   dependencies:
-    stylelint-config-recommended-scss: "npm:^7.0.0"
-    stylelint-config-standard: "npm:^26.0.0"
+    stylelint-config-recommended-scss: "npm:^13.1.0"
+    stylelint-config-standard: "npm:^34.0.0"
   peerDependencies:
-    stylelint: ^14.9.0
-  checksum: e444c864b37f38e4540158fe1ff3b19e7fc47582a877e5af9ceb3a0b7c28c922a2a5ddeb13a4545a06700a66517a7c9b616e592b01afea861cde1ce1c06138e0
+    postcss: ^8.3.3
+    stylelint: ^15.10.0
+  peerDependenciesMeta:
+    postcss:
+      optional: true
+  checksum: fdeb533e19230cec6975f18a5ef97252968b4387f385508c7157d8bef42fe75eb9888ff6ce97c8d6fd985fc7d7d28c897732cd3c3285907cb18a9bf8df91a6d2
   languageName: node
   linkType: hard
 
-"stylelint-config-standard@npm:^26.0.0":
-  version: 26.0.0
-  resolution: "stylelint-config-standard@npm:26.0.0"
+"stylelint-config-standard@npm:^34.0.0":
+  version: 34.0.0
+  resolution: "stylelint-config-standard@npm:34.0.0"
   dependencies:
-    stylelint-config-recommended: "npm:^8.0.0"
+    stylelint-config-recommended: "npm:^13.0.0"
   peerDependencies:
-    stylelint: ^14.9.0
-  checksum: 414ebe2293444da48081f6f616e2a77c61d08b5e22840658426dae62806adba4d5ec6f828131d0d794094ab740d26562ed0fdfaa788baba7dfcb307b47341984
+    stylelint: ^15.10.0
+  checksum: 536249800c04b48a9c354067765f042713982e8222be17bb897a27d26546e50adfb87e6f1e4541807d720de3554345da99ab470e13e8d7ab0ab326c73ae3df61
   languageName: node
   linkType: hard
 
@@ -24328,18 +24336,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint-scss@npm:^4.0.0":
-  version: 4.3.0
-  resolution: "stylelint-scss@npm:4.3.0"
+"stylelint-scss@npm:^5.3.0":
+  version: 5.3.1
+  resolution: "stylelint-scss@npm:5.3.1"
   dependencies:
-    lodash: "npm:^4.17.21"
+    known-css-properties: "npm:^0.29.0"
     postcss-media-query-parser: "npm:^0.2.3"
     postcss-resolve-nested-selector: "npm:^0.1.1"
-    postcss-selector-parser: "npm:^6.0.6"
-    postcss-value-parser: "npm:^4.1.0"
+    postcss-selector-parser: "npm:^6.0.13"
+    postcss-value-parser: "npm:^4.2.0"
   peerDependencies:
-    stylelint: ^14.5.1
-  checksum: e223d9a0f23fa0055acf43e204f1ed4c944dbff3e9e8ecc90293efece10bcf4b33c18c3495cc7ccfc118c4a2e89ed2cd9907d578797bc1a4a48e709e5b7f77cf
+    stylelint: ^14.5.1 || ^15.0.0
+  checksum: 480d3ed021a8374d34caca96166941249f39cfaffdc70ed2e711d3426b572bc0c3a4bf3f6950ed622df819fdbcb31378f58736c7950f64fa4c986a16f7258f48
   languageName: node
   linkType: hard
 
@@ -26251,7 +26259,7 @@ __metadata:
     showdown: "npm:^2.1.0"
     stylelint: "npm:^15.11.0"
     stylelint-config-rational-order: "npm:^0.1.2"
-    stylelint-config-standard-scss: "npm:^5.0.0"
+    stylelint-config-standard-scss: "npm:^11.1.0"
     webpack: "npm:^5.89.0"
     yaml-front-matter: "npm:^4.1.1"
   languageName: unknown


### PR DESCRIPTION
### :pushpin: Summary

The standard SCSS via `stylelint` has changed quite a bit lately. Planning to bring these to the next engineering sync if we don't get a consensus through reviews.

### :hammer_and_wrench: Detailed description

#### Deprecated rules
 - [function-parentheses-space-inside](https://stylelint.io/user-guide/rules/function-parentheses-space-inside/)
 - [max-empty-lines](https://stylelint.io/user-guide/rules/max-empty-lines/)
 - [number-leading-zero](https://stylelint.io/user-guide/rules/number-leading-zero/)
 - [string-quotes](https://stylelint.io/user-guide/rules/string-quotes/)

These are [flagged as deprecated in `stylelint`](https://github.com/stylelint/stylelint/blob/main/docs/user-guide/rules.md#deprecated) and will be retired. We'd need to decide whether we'd like to just drop them (or some of them) or try to cover them via `prettier`.

#### New rules
 - [media-feature-range-notation](https://stylelint.io/user-guide/rules/media-feature-range-notation/)

Luckily the new rules only seem to be affecting `website`, so no changes to our consumers. We'll probably need to decide if we want to override this default or we'll stick with it.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2461](https://hashicorp.atlassian.net/browse/HDS-2461)

https://hashicorp.atlassian.net/browse/HDS-2461

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2461]: https://hashicorp.atlassian.net/browse/HDS-2461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ