### PR TITLE
rename our version command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: changesets/action@f13b1baaa620fde937751f5d2c3572b9da32af23 # v1.4.5
         with:
           version: yarn version-packages
-          publish: yarn release
+          publish: yarn release-packages
         env:
           # Token setup in hashibot-hds' account
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@f13b1baaa620fde937751f5d2c3572b9da32af23 # v1.4.5
         with:
-          version: yarn version
+          version: yarn version-packages
           publish: yarn release
         env:
           # Token setup in hashibot-hds' account

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "release": "yarn changeset publish",
-    "version": "yarn changeset version && yarn install --mode update-lockfile && yarn workspace website generate-changelog-markdown-files"
+    "version-packages": "yarn changeset version && yarn install --mode update-lockfile && yarn workspace website generate-changelog-markdown-files"
   },
   "packageManager": "yarn@4.0.1",
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@changesets/get-github-info": "^0.5.2"
   },
   "scripts": {
-    "release": "yarn changeset publish",
+    "release-packages": "yarn changeset publish",
     "version-packages": "yarn changeset version && yarn install --mode update-lockfile && yarn workspace website generate-changelog-markdown-files"
   },
   "packageManager": "yarn@4.0.1",


### PR DESCRIPTION
### :pushpin: Summary

rename our version command so our release action can work again. (it's [broken](https://github.com/hashicorp/design-system/actions/runs/6747109720/job/18342500797#step:5:21))

### :hammer_and_wrench: Detailed description

`yarn version` is a yarn command, so our attempts to call `yarn version` from the release action are triggering that command, not the one we have specific in our package.json. This wasn't a problem in yarn 3.x as the [`version` command had to be installed as a plugin](https://v3.yarnpkg.com/cli/version). In yarn 4 it is [installed by default](https://yarnpkg.com/cli/version).
