### PR TITLE
add external link support to breadcrumb

### DIFF
--- a/.changeset/nervous-boxes-vanish.md
+++ b/.changeset/nervous-boxes-vanish.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Added external link support to Breadcrumb component
+`Breadcrumb` - Added support for external links

--- a/.changeset/nervous-boxes-vanish.md
+++ b/.changeset/nervous-boxes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Added external link support to Breadcrumb component

--- a/packages/components/addon/components/hds/breadcrumb/item.hbs
+++ b/packages/components/addon/components/hds/breadcrumb/item.hbs
@@ -13,18 +13,35 @@
       <span class="hds-breadcrumb__text">{{@text}}</span>
     </div>
   {{else}}
-    <LinkTo
-      class="hds-breadcrumb__link"
-      @models={{hds-link-to-models @model @models}}
-      @query={{hds-link-to-query @query}}
-      @route={{@route}}
-    >
-      {{#if @icon}}
-        <div class="hds-breadcrumb__icon">
-          <FlightIcon @name={{@icon}} @size="16" @stretched={{true}} />
-        </div>
-      {{/if}}
-      <span class="hds-breadcrumb__text">{{@text}}</span>
-    </LinkTo>
+    {{#if @isRouteExternal}}
+      <LinkToExternal
+        @current-when={{@current-when}}
+        @models={{hds-link-to-models @model @models}}
+        @query={{hds-link-to-query @query}}
+        @replace={{@replace}}
+        @route={{@route}}
+      >
+        {{#if @icon}}
+          <div class="hds-breadcrumb__icon">
+            <FlightIcon @name={{@icon}} @size="16" @stretched={{true}} />
+          </div>
+        {{/if}}
+        <span class="hds-breadcrumb__text">{{@text}}</span>
+      </LinkToExternal>
+    {{else}}
+      <LinkTo
+        class="hds-breadcrumb__link"
+        @models={{hds-link-to-models @model @models}}
+        @query={{hds-link-to-query @query}}
+        @route={{@route}}
+      >
+        {{#if @icon}}
+          <div class="hds-breadcrumb__icon">
+            <FlightIcon @name={{@icon}} @size="16" @stretched={{true}} />
+          </div>
+        {{/if}}
+        <span class="hds-breadcrumb__text">{{@text}}</span>
+      </LinkTo>
+    {{/if}}
   {{/if}}
 </li>

--- a/packages/components/addon/components/hds/breadcrumb/item.hbs
+++ b/packages/components/addon/components/hds/breadcrumb/item.hbs
@@ -32,8 +32,10 @@
     {{else}}
       <LinkTo
         class="hds-breadcrumb__link"
+        @current-when={{@current-when}}
         @models={{hds-link-to-models @model @models}}
         @query={{hds-link-to-query @query}}
+        @replace={{@replace}}
         @route={{@route}}
       >
         {{#if @icon}}

--- a/packages/components/addon/components/hds/breadcrumb/item.hbs
+++ b/packages/components/addon/components/hds/breadcrumb/item.hbs
@@ -15,6 +15,7 @@
   {{else}}
     {{#if @isRouteExternal}}
       <LinkToExternal
+        class="hds-breadcrumb__link"
         @current-when={{@current-when}}
         @models={{hds-link-to-models @model @models}}
         @query={{hds-link-to-query @query}}

--- a/website/docs/components/breadcrumb/partials/code/component-api.md
+++ b/website/docs/components/breadcrumb/partials/code/component-api.md
@@ -32,8 +32,11 @@ The Breadcrumb component is composed of three different parts, each with their o
   <C.Property @name="icon" @type="string">
     Use to show an icon. Any [icon](/icons/library) name is acceptable.
   </C.Property>
-  <C.Property @name="route/models/model/query">
-    These parameters are passed down as arguments to the `<LinkTo>` component.
+  <C.Property @name="route/models/model/query/current-when/replace">
+    Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
+  </C.Property>
+  <C.Property @name="isRouteExternal" @type="boolean" @default="false">
+    Controls if the “LinkTo” is external to the Ember engine, in which case it will use a `<LinkToExternal>` for the `@route`.
   </C.Property>
   <C.Property @name="current" @type="boolean" @default="false">
     Determines if an item is the last item in the Breadcrumb, in which case it doesn’t generate a link.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add support for the `LinkToExternal` component to the `Breadcrumb`

### :hammer_and_wrench: Detailed description

- implementation of if/else in breadcrumb based on `@isRouteExternal`
- updated breadcrumb API docs
- added changeset

<!--
### :camera_flash: Screenshots
-->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2650](https://hashicorp.atlassian.net/browse/HDS-2650)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2650]: https://hashicorp.atlassian.net/browse/HDS-2650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ