### PR TITLE
Add clarity around adding changelog entries for Figma libraries

### DIFF
--- a/wiki/Website-Changelog.md
+++ b/wiki/Website-Changelog.md
@@ -128,7 +128,8 @@ Entries made for the Figma Components and Foundations UI Kits require a few addi
 
 1. Copy and paste the appropriate template into the relevant changelog file in the components package; `packages/components/CHANGELOG-FIGMA-{COMPONENTS or FOUNDATIONS}` depending on what library the change was made in.
 2. If the change in Figma has corresponding changes in code or requires an update to the documentation, the changelog entry can be added in the same PR as the rest of the changes. The release process will automatically add these changes to the changelog on the website.
-3. Otherwise, if the change only pertains to Figma and does not result in a documentation change, open a new PR to add a changelog entry. Since this change does not correspond with a code release, the script used to generate the Figma changelog must be triggered manually from the webiste directory by running `yarn generate-changelog-markdown-files`.
+3. Otherwise, if the change only pertains to Figma and does not result in a documentation change, open a new PR to add a changelog entry. 
+    - Since this change does not correspond with a code release, the script used to generate the Figma changelog must be triggered manually from the webiste directory by running `yarn generate-changelog-markdown-files`.
 4. Replace all elements in brackets with the specific component or style/token name.
 5. For consistency purposes it's recommended to publish the changes in Figma at the same time as the changelog entry is merged and added to the website.
 

--- a/wiki/Website-Changelog.md
+++ b/wiki/Website-Changelog.md
@@ -10,7 +10,6 @@
 - [Templates](#templates)
   - [Templates for npm packages](#templates-for-npm-packages)
   - [Templates for Figma changelog entries](#templates-for-figma-changelog-entries)
-- [Adding Figma changelog entries](#adding-figma-changelog-entries)
 
 ---
 

--- a/wiki/Website-Changelog.md
+++ b/wiki/Website-Changelog.md
@@ -10,6 +10,7 @@
 - [Templates](#templates)
   - [Templates for npm packages](#templates-for-npm-packages)
   - [Templates for Figma changelog entries](#templates-for-figma-changelog-entries)
+- [Adding Figma changelog entries](#adding-figma-changelog-entries)
 
 ---
 
@@ -124,7 +125,11 @@ _{...important details}_
 
 ### Templates for Figma changelog entries
 
-Entries made for the Figma Components and Foundations UI Kits require a few additional steps. Copy and paste this template and adjust as necessary after publishing changes in Figma. _Replace all elements in brackets._
+Entries made for the Figma Components and Foundations UI Kits require a few additional steps.
+
+1. Open a PR to capture the relevant updates to the changelog.
+2. After publishing changes in Figma, copy and paste the appropriate template into the relevant changelog file in the components package; either `packages/components/CHANGELOG-FIGMA-{COMPONENTS or FOUNDATIONS}` depending on what library the change was made in.
+3. Replace all elements in brackets with the specific component or style/token name.
 
 #### Simple entry
 ```
@@ -177,3 +182,8 @@ _{additional details}..._
   - Added a Header and Footer to the List.
   - Added the ability to set a fixed height on the List resulting in the use of a scrollbar for longer lists.
 </details>
+
+
+
+
+

--- a/wiki/Website-Changelog.md
+++ b/wiki/Website-Changelog.md
@@ -182,8 +182,3 @@ _{additional details}..._
   - Added a Header and Footer to the List.
   - Added the ability to set a fixed height on the List resulting in the use of a scrollbar for longer lists.
 </details>
-
-
-
-
-

--- a/wiki/Website-Changelog.md
+++ b/wiki/Website-Changelog.md
@@ -126,8 +126,8 @@ _{...important details}_
 
 Entries made for the Figma Components and Foundations UI Kits require a few additional steps.
 
-1. Open a PR to capture the relevant updates to the changelog.
-2. After publishing changes in Figma, copy and paste the appropriate template into the relevant changelog file in the components package; either `packages/components/CHANGELOG-FIGMA-{COMPONENTS or FOUNDATIONS}` depending on what library the change was made in.
+1. After publishing changes in Figma, copy and pasted the appropriate template into the relevant changelog file in the components package; either `packages/components/CHANGELOG-FIGMA-{COMPONENTS or FOUNDATIONS}` depending on what library the change was made in.
+2. If the change in Figma has corresponding changes in code or requires an update to the documentation, the changelog entry can be added in the same PR as the rest of the changes. Otherwise, if the change only pertains to Figma and does not result in a documentation change, open a new PR to add a changelog entry.
 3. Replace all elements in brackets with the specific component or style/token name.
 
 #### Simple entry

--- a/wiki/Website-Changelog.md
+++ b/wiki/Website-Changelog.md
@@ -127,9 +127,10 @@ _{...important details}_
 Entries made for the Figma Components and Foundations UI Kits require a few additional steps.
 
 1. Copy and paste the appropriate template into the relevant changelog file in the components package; `packages/components/CHANGELOG-FIGMA-{COMPONENTS or FOUNDATIONS}` depending on what library the change was made in.
-2. If the change in Figma has corresponding changes in code or requires an update to the documentation, the changelog entry can be added in the same PR as the rest of the changes. Otherwise, if the change only pertains to Figma and does not result in a documentation change, open a new PR to add a changelog entry.
-3. Replace all elements in brackets with the specific component or style/token name.
-4. For consistency purposes it's recommended to publish the changes in Figma at the same time as the changelog entry is merged and added to the website.
+2. If the change in Figma has corresponding changes in code or requires an update to the documentation, the changelog entry can be added in the same PR as the rest of the changes. The release process will automatically add these changes to the changelog on the website.
+3. Otherwise, if the change only pertains to Figma and does not result in a documentation change, open a new PR to add a changelog entry. Since this change does not correspond with a code release, the script used to generate the Figma changelog must be triggered manually from the webiste directory by running `yarn generate-changelog-markdown-files`.
+4. Replace all elements in brackets with the specific component or style/token name.
+5. For consistency purposes it's recommended to publish the changes in Figma at the same time as the changelog entry is merged and added to the website.
 
 #### Simple entry
 ```

--- a/wiki/Website-Changelog.md
+++ b/wiki/Website-Changelog.md
@@ -126,9 +126,10 @@ _{...important details}_
 
 Entries made for the Figma Components and Foundations UI Kits require a few additional steps.
 
-1. After publishing changes in Figma, copy and pasted the appropriate template into the relevant changelog file in the components package; either `packages/components/CHANGELOG-FIGMA-{COMPONENTS or FOUNDATIONS}` depending on what library the change was made in.
+1. Copy and paste the appropriate template into the relevant changelog file in the components package; `packages/components/CHANGELOG-FIGMA-{COMPONENTS or FOUNDATIONS}` depending on what library the change was made in.
 2. If the change in Figma has corresponding changes in code or requires an update to the documentation, the changelog entry can be added in the same PR as the rest of the changes. Otherwise, if the change only pertains to Figma and does not result in a documentation change, open a new PR to add a changelog entry.
 3. Replace all elements in brackets with the specific component or style/token name.
+4. For consistency purposes it's recommended to publish the changes in Figma at the same time as the changelog entry is merged and added to the website.
 
 #### Simple entry
 ```


### PR DESCRIPTION
### :pushpin: Summary

This PR adds a bit more clarity in the wiki around adding changelog entries for Figma libraries.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
