### PR TITLE
fix icon library link

### DIFF
--- a/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
+++ b/website/docs/icons/usage-guidelines/partials/code/how-to-use.md
@@ -85,7 +85,7 @@ import { IconArrowRight24 } from '@hashicorp/flight-icons/svg-react/arrow-right-
 
 ## How to use icons
 
-The most basic invocation requires only the `@name` property to be passed with a value matching an existing name in [the Icon library](icons/library).
+The most basic invocation requires only the `@name` property to be passed with a value matching an existing name in [the Icon library](/icons/library).
 
 ```markup
 <FlightIcon @name="alert-circle" />


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes a link to the Icon Library that was relative, which resulted in the URL being incorrect. 

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
