### PR TITLE
satisfy `@ember/string` peerDep

### DIFF
--- a/.changeset/rich-gifts-matter.md
+++ b/.changeset/rich-gifts-matter.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Added `@ember/string` as a direct dependency

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^2.0.5",
+    "@ember/string": "^3.1.1",
     "@ember/test-waiters": "^3.1.0",
     "@hashicorp/design-system-tokens": "^1.9.0",
     "@hashicorp/ember-flight-icons": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4666,6 +4666,7 @@ __metadata:
     "@babel/plugin-proposal-decorators": "npm:^7.23.2"
     "@ember/optional-features": "npm:^2.0.0"
     "@ember/render-modifiers": "npm:^2.0.5"
+    "@ember/string": "npm:^3.1.1"
     "@ember/test-helpers": "npm:^3.2.0"
     "@ember/test-waiters": "npm:^3.1.0"
     "@embroider/test-setup": "npm:^3.0.2"


### PR DESCRIPTION
### :pushpin: Summary

Resolves issue seen when running `yarn`:

```bash
➤ YN0002: │ @hashicorp/design-system-components@workspace:packages/components doesn't provide @ember/string (p00ce8), requested by ember-style-modifier.
```
