### PR TITLE
Demo: adding an appframe demo page to the showcase 

### DIFF
--- a/packages/components/tests/dummy/app/components/shw/aside.hbs
+++ b/packages/components/tests/dummy/app/components/shw/aside.hbs
@@ -1,0 +1,4 @@
+<aside class="shw-page-aside">
+  <LinkTo class="shw-back-to-components-list" @route="index"><FlightIcon @name="arrow-left" @isInlineBlock={{false}} />
+    Component list</LinkTo>
+</aside>

--- a/packages/components/tests/dummy/app/components/shw/header.hbs
+++ b/packages/components/tests/dummy/app/components/shw/header.hbs
@@ -1,0 +1,6 @@
+<header class="shw-page-header">
+  <LinkTo @route="index" class="shw-page-header__logo" aria-label="home page">
+    <Shw::Logo::DesignSystem />
+  </LinkTo>
+  <div class="shw-page-header__title">Components showcase</div>
+</header>

--- a/packages/components/tests/dummy/app/components/shw/main.hbs
+++ b/packages/components/tests/dummy/app/components/shw/main.hbs
@@ -1,0 +1,3 @@
+<main id="main" class="shw-page-main">
+  {{yield}}
+</main>

--- a/packages/components/tests/dummy/app/index.html
+++ b/packages/components/tests/dummy/app/index.html
@@ -22,7 +22,7 @@
 
     {{content-for "head-footer"}}
   </head>
-  <body class="showcase-app">
+  <body>
     {{content-for "body"}}
 
     {{content-for "body-footer"}}

--- a/packages/components/tests/dummy/app/router.js
+++ b/packages/components/tests/dummy/app/router.js
@@ -82,4 +82,8 @@ Router.map(function () {
   this.route('overrides', function () {
     this.route('power-select');
   });
+
+  this.route('demo', function() {
+    this.route('appframe');
+  });
 });

--- a/packages/components/tests/dummy/app/routes/demo/appframe.js
+++ b/packages/components/tests/dummy/app/routes/demo/appframe.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class DemoAppframeRoute extends Route {}

--- a/packages/components/tests/dummy/app/templates/application.hbs
+++ b/packages/components/tests/dummy/app/templates/application.hbs
@@ -5,18 +5,4 @@
 
 {{page-title "HDS Design System"}}
 
-<header class="shw-page-header">
-  <LinkTo @route="index" class="shw-page-header__logo" aria-label="home page">
-    <Shw::Logo::DesignSystem />
-  </LinkTo>
-  <div class="shw-page-header__title">Components showcase</div>
-</header>
-
-<aside class="shw-page-aside">
-  <LinkTo class="shw-back-to-components-list" @route="index"><FlightIcon @name="arrow-left" @isInlineBlock={{false}} />
-    Component list</LinkTo>
-</aside>
-
-<main id="main" class="shw-page-main">
-  {{outlet}}
-</main>
+{{outlet}}

--- a/packages/components/tests/dummy/app/templates/components.hbs
+++ b/packages/components/tests/dummy/app/templates/components.hbs
@@ -1,0 +1,9 @@
+<div class="showcase-app">
+  <Shw::Header />
+
+  <Shw::Aside />
+
+  <Shw::Main>
+    {{outlet}}
+  </Shw::Main>
+</div>

--- a/packages/components/tests/dummy/app/templates/demo/appframe.hbs
+++ b/packages/components/tests/dummy/app/templates/demo/appframe.hbs
@@ -2,20 +2,23 @@
 
 <Hds::AppFrame as |Frame|>
   <Frame.Header>
-    {{! your "header" content goes here, this is just a mock placeholder }}
-    {{!-- <Shw::Placeholder @height="60px" @text="header" @background="#e5ffd2" /> --}}
+    <Shw::Placeholder @height="60px" @text="header" @background="#e5ffd2" />
     {{!-- <Shw::Header /> --}}
   </Frame.Header>
   <Frame.Sidebar>
-    <Hds::SideNav @isResponsive="true" @isCollapsible="true">
+    <Hds::SideNav @isCollapsible="true">
       <:header>
-        <Shw::Placeholder @text="&lt;:header /&gt;" />
+        {{! template-lint-disable no-log }}
+        {{log "@isMinimized" @isMinimized}}
+
+        {{log "this.isMinimized" this.isMinimized}}
+        <p>Some aside::header content</p>
       </:header>
       <:body>
-        <Shw::Placeholder @text="&lt;:body /&gt;" />
+        <p>Some aside::body content wait why isn't this responsive too??</p>
       </:body>
       <:footer>
-        <Shw::Placeholder @text="&lt;:footer /&gt;" />
+        <p>Some aside::footer content</p>
       </:footer>
     </Hds::SideNav>
   </Frame.Sidebar>

--- a/packages/components/tests/dummy/app/templates/demo/appframe.hbs
+++ b/packages/components/tests/dummy/app/templates/demo/appframe.hbs
@@ -1,0 +1,30 @@
+{{page-title "Appframe"}}
+
+<Hds::AppFrame as |Frame|>
+  <Frame.Header>
+    {{! your "header" content goes here, this is just a mock placeholder }}
+    {{!-- <Shw::Placeholder @height="60px" @text="header" @background="#e5ffd2" /> --}}
+    {{!-- <Shw::Header /> --}}
+  </Frame.Header>
+  <Frame.Sidebar>
+    <Hds::SideNav @isResponsive="true" @isCollapsible="true">
+      <:header>
+        <Shw::Placeholder @text="&lt;:header /&gt;" />
+      </:header>
+      <:body>
+        <Shw::Placeholder @text="&lt;:body /&gt;" />
+      </:body>
+      <:footer>
+        <Shw::Placeholder @text="&lt;:footer /&gt;" />
+      </:footer>
+    </Hds::SideNav>
+  </Frame.Sidebar>
+  <Frame.Main>
+    {{! your "main" content goes here, this is just a mock placeholder }}
+    <Shw::Placeholder @height="100%" @text="main" @background="#d2f4ff" />
+  </Frame.Main>
+  <Frame.Footer>
+    {{! your "footer" content goes here, this is just a mock placeholder }}
+    <Shw::Placeholder @height="60px" @text="footer" @background="#fff8d2" />
+  </Frame.Footer>
+</Hds::AppFrame>

--- a/packages/components/tests/dummy/app/templates/foundations.hbs
+++ b/packages/components/tests/dummy/app/templates/foundations.hbs
@@ -1,0 +1,9 @@
+<div class="showcase-app">
+  <Shw::Header />
+
+  <Shw::Aside />
+
+  <Shw::Main>
+    {{outlet}}
+  </Shw::Main>
+</div>

--- a/packages/components/tests/dummy/app/templates/index.hbs
+++ b/packages/components/tests/dummy/app/templates/index.hbs
@@ -2,296 +2,310 @@
 Copyright (c) HashiCorp, Inc.
 SPDX-License-Identifier: MPL-2.0
 }}
-<div class="shw-landing-lists">
-  <div>
-    <Shw::Text::H2>Foundations</Shw::Text::H2>
-    <ol class="shw-text-body">
-      <li>
-        <LinkTo @route="foundations.typography">
-          Typography
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="foundations.icon">
-          Icon
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="foundations.elevation">
-          Elevation
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="foundations.focus-ring">
-          Focus ring
-        </LinkTo>
-      </li>
-    </ol>
-  </div>
-  <div>
-    <Shw::Text::H2>Components</Shw::Text::H2>
-    <ol class="shw-text-body">
-      <li>
-        <LinkTo @route="components.accordion">
-          Accordion
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.alert">
-          Alert
-        </LinkTo>
-      </li>
-      <!--li>
+<div class="showcase-app">
+  <Shw::Header />
+
+  <Shw::Aside />
+
+  <Shw::Main>
+    <div class="shw-landing-lists">
+      <div>
+        <Shw::Text::H2>Foundations</Shw::Text::H2>
+        <ol class="shw-text-body">
+          <li>
+            <LinkTo @route="foundations.typography">
+              Typography
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="foundations.icon">
+              Icon
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="foundations.elevation">
+              Elevation
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="foundations.focus-ring">
+              Focus ring
+            </LinkTo>
+          </li>
+        </ol>
+      </div>
+      <div>
+        <Shw::Text::H2>Components</Shw::Text::H2>
+        <ol class="shw-text-body">
+          <li>
+            <LinkTo @route="components.accordion">
+              Accordion
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.alert">
+              Alert
+            </LinkTo>
+          </li>
+          <!--li>
         <LinkTo @route="components.avatar">
           Avatar
         </LinkTo>
       </li-->
-      <li>
-        <LinkTo @route="components.app-footer">
-          AppFooter
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.application-state">
-          Application State
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.badge">
-          Badge
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.badge-count">
-          BadgeCount
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.breadcrumb">
-          Breadcrumb
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.button">
-          Button
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.button-set">
-          ButtonSet
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.card">
-          Card
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.code-block">
-          CodeBlock
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.copy.button">
-          Copy::Button
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.copy.snippet">
-          Copy::Snippet
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.dropdown">
-          Dropdown
-        </LinkTo>
-      </li>
-      <!--li>
+          <li>
+            <LinkTo @route="components.app-footer">
+              AppFooter
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.application-state">
+              Application State
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.badge">
+              Badge
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.badge-count">
+              BadgeCount
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.breadcrumb">
+              Breadcrumb
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.button">
+              Button
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.button-set">
+              ButtonSet
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.card">
+              Card
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.code-block">
+              CodeBlock
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.copy.button">
+              Copy::Button
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.copy.snippet">
+              Copy::Snippet
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.dropdown">
+              Dropdown
+            </LinkTo>
+          </li>
+          <!--li>
         <LinkTo @route="components.empty-state">
           EmptyState
         </LinkTo>
       </li-->
-      <li>
-        <LinkTo @route="components.flyout">
-          Flyout
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.form.base-elements">
-          Form / Base elements
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.form.checkbox">
-          Form::Checkbox
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.form.file-input">
-          Form::FileInput
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.form.masked-input">
-          Form::MaskedInput
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.form.radio">
-          Form::Radio
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.form.radio-card">
-          Form::RadioCard
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.form.select">
-          Form::Select
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.form.text-input">
-          Form::TextInput
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.form.textarea">
-          Form::Textarea
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.form.toggle">
-          Form::Toggle
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.icon-tile">
-          IconTile
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.link.inline">
-          Link::Inline
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.link.standalone">
-          Link::Standalone
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.modal">
-          Modal
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.page-header">
-          PageHeader
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.pagination">
-          Pagination
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.reveal">
-          Reveal
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.segmented-group">
-          SegmentedGroup
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.separator">
-          Separator
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.side-nav">
-          SideNav
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.stepper">
-          Stepper
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.table">
-          Table
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.tabs">
-          Tabs
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.tag">
-          Tag
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.text">
-          Text
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.toast">
-          Toast
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="components.tooltip">
-          Tooltip
-        </LinkTo>
-      </li>
-    </ol>
-  </div>
-  <div>
-    <Shw::Text::H2>Layouts</Shw::Text::H2>
-    <ol class="shw-text-body">
-      <li>
-        <LinkTo @route="layouts.app-frame">
-          AppFrame
-        </LinkTo>
-      </li>
-    </ol>
-    <Shw::Text::H2>Utilities</Shw::Text::H2>
-    <ol class="shw-text-body">
-      <li>
-        <LinkTo @route="utilities.disclosure-primitive">
-          DisclosurePrimitive
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="utilities.dismiss-button">
-          DismissButton
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="utilities.interactive">
-          Interactive
-        </LinkTo>
-      </li>
-      <li>
-        <LinkTo @route="utilities.menu-primitive">
-          MenuPrimitive
-        </LinkTo>
-      </li>
-    </ol>
-    <Shw::Text::H2>Overrides</Shw::Text::H2>
-    <ol class="shw-text-body">
-      <li>
-        <LinkTo @route="overrides.power-select">
-          PowerSelect
-        </LinkTo>
-      </li>
-    </ol>
-  </div>
+          <li>
+            <LinkTo @route="components.flyout">
+              Flyout
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.form.base-elements">
+              Form / Base elements
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.form.checkbox">
+              Form::Checkbox
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.form.file-input">
+              Form::FileInput
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.form.masked-input">
+              Form::MaskedInput
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.form.radio">
+              Form::Radio
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.form.radio-card">
+              Form::RadioCard
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.form.select">
+              Form::Select
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.form.text-input">
+              Form::TextInput
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.form.textarea">
+              Form::Textarea
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.form.toggle">
+              Form::Toggle
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.icon-tile">
+              IconTile
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.link.inline">
+              Link::Inline
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.link.standalone">
+              Link::Standalone
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.modal">
+              Modal
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.page-header">
+              PageHeader
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.pagination">
+              Pagination
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.reveal">
+              Reveal
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.segmented-group">
+              SegmentedGroup
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.separator">
+              Separator
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.side-nav">
+              SideNav
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.stepper">
+              Stepper
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.table">
+              Table
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.tabs">
+              Tabs
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.tag">
+              Tag
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.text">
+              Text
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.toast">
+              Toast
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="components.tooltip">
+              Tooltip
+            </LinkTo>
+          </li>
+        </ol>
+      </div>
+      <div>
+        <Shw::Text::H2>Layouts</Shw::Text::H2>
+        <ol class="shw-text-body">
+          <li>
+            <LinkTo @route="layouts.app-frame">
+              AppFrame
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="demo.appframe">
+              AppFrame Demo
+            </LinkTo>
+          </li>
+        </ol>
+        <Shw::Text::H2>Utilities</Shw::Text::H2>
+        <ol class="shw-text-body">
+          <li>
+            <LinkTo @route="utilities.disclosure-primitive">
+              DisclosurePrimitive
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="utilities.dismiss-button">
+              DismissButton
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="utilities.interactive">
+              Interactive
+            </LinkTo>
+          </li>
+          <li>
+            <LinkTo @route="utilities.menu-primitive">
+              MenuPrimitive
+            </LinkTo>
+          </li>
+        </ol>
+        <Shw::Text::H2>Overrides</Shw::Text::H2>
+        <ol class="shw-text-body">
+          <li>
+            <LinkTo @route="overrides.power-select">
+              PowerSelect
+            </LinkTo>
+          </li>
+        </ol>
+      </div>
+    </div>
+
+  </Shw::Main>
 </div>

--- a/packages/components/tests/dummy/app/templates/layouts.hbs
+++ b/packages/components/tests/dummy/app/templates/layouts.hbs
@@ -1,0 +1,9 @@
+<div class="showcase-app">
+  <Shw::Header />
+
+  <Shw::Aside />
+
+  <Shw::Main>
+    {{outlet}}
+  </Shw::Main>
+</div>

--- a/packages/components/tests/dummy/app/templates/overrides.hbs
+++ b/packages/components/tests/dummy/app/templates/overrides.hbs
@@ -1,0 +1,9 @@
+<div class="showcase-app">
+  <Shw::Header />
+
+  <Shw::Aside />
+
+  <Shw::Main>
+    {{outlet}}
+  </Shw::Main>
+</div>

--- a/packages/components/tests/dummy/app/templates/utilities.hbs
+++ b/packages/components/tests/dummy/app/templates/utilities.hbs
@@ -1,0 +1,9 @@
+<div class="showcase-app">
+  <Shw::Header />
+
+  <Shw::Aside />
+
+  <Shw::Main>
+    {{outlet}}
+  </Shw::Main>
+</div>


### PR DESCRIPTION
### :pushpin: Summary

Don't merge this, it's just for a demo to share

### :hammer_and_wrench: Detailed description

When working to answer a question in Slack, I realized we didn't have a working full page of the app frame with a side nav component in it, so I re-worked the dummy app a bit so it did that, mostly so we could have a frame of reference (pun intended) to mutually discuss. 

This PR should never leave draft status nor be merged. 

visiting the preview, you should see a new link under Layouts: Appframe Demo. (/demo/appframe). That should be a full-page preview of the appframe with a responsive, collapsible side-nav element. 