### PR TITLE
Fix visible scrollbar in SideNav when collapsed

### DIFF
--- a/.changeset/shy-impalas-float.md
+++ b/.changeset/shy-impalas-float.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav` - Fixed visible scrollbar in collapsed SideNav when scroll bar is set to be always visible

--- a/packages/components/app/styles/components/side-nav/content.scss
+++ b/packages/components/app/styles/components/side-nav/content.scss
@@ -17,6 +17,9 @@
   // to have the panels width match the sidebar extended width (it's used in the animated sliding of the panels)
   margin: 0 calc(var(--token-side-nav-wrapper-padding-horizontal) * -1);
 
+  // we hide the content when the SideNav is collapsed to prevent the vertical scrollbar from being visible
+  // when the scrollbar is set to be always visible or a mouse or trackpad force it to be always visible.
+  // ideally we would use `display: none` but doing so would disable the fade-in transition when expanding
   .hds-side-nav--is-minimized & {
     height: 0;
     overflow: hidden;

--- a/packages/components/app/styles/components/side-nav/content.scss
+++ b/packages/components/app/styles/components/side-nav/content.scss
@@ -16,6 +16,11 @@
   // we use this trick (increasing the container size here, and reducing it at single panel level)
   // to have the panels width match the sidebar extended width (it's used in the animated sliding of the panels)
   margin: 0 calc(var(--token-side-nav-wrapper-padding-horizontal) * -1);
+
+  .hds-side-nav--is-minimized & {
+    height: 0;
+    overflow: hidden;
+  }
 }
 
 .hds-side-nav__content-panels {


### PR DESCRIPTION
### :pushpin: Summary

Fix visible scrollbar in `SideNav` when collapsed and the scroll bar is set to be always visible.

### :hammer_and_wrench: Detailed description

When set to be always visible at the OS level or an external mouse or trackpad is used, the scroll bars are always displayed. This is aesthetically unpleasant so we prevent this scroll from being visible by hiding the `hds-side-nav__content` when the SideBar is minimized. This change was tested locally in `cloud-ui` and `atlas`.

Note: the demo app commit was added to ease the review, the commit will be removed before merging.

### :camera_flash: Screenshots

In demo app, with scrollbar set to always be visible

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="201" alt="Screenshot 2023-11-08 at 16 50 07" src="https://github.com/hashicorp/design-system/assets/788096/dca36a30-cfea-488d-9c07-1f9fc87b3610">


</td><td>

<img width="170" alt="Screenshot 2023-11-08 at 16 49 28" src="https://github.com/hashicorp/design-system/assets/788096/7d62a74a-6379-4946-b9b4-48a82a6c9f3a">


</td></tr>
</table>

In `cloud-ui` with slowed down animation and scrollbar set to always be visible

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>


https://github.com/hashicorp/design-system/assets/788096/6d6dd6ea-44bd-43bf-9f1e-8d154a0a50cf



</td><td>


https://github.com/hashicorp/design-system/assets/788096/fba71961-692f-46ec-a2d4-cbbb6a1d4ad7



</td></tr>
</table>


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2853](https://hashicorp.atlassian.net/browse/HDS-2853)
[Slack thread](https://hashicorp.slack.com/archives/C03JP1TCGQM/p1699028609496249?thread_ts=1698859779.592529&cid=C03JP1TCGQM)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [x] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2853]: https://hashicorp.atlassian.net/browse/HDS-2853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ