### PR TITLE
`AppFooter::StatusLink`: Fix predefined statuses—replace "critical" with "outage" (HDS-2854)

### DIFF
--- a/.changeset/old-forks-scream.md
+++ b/.changeset/old-forks-scream.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AppFooter` – Fixed predefined statuses by replacing `critical` with `outage` and prevented `statusIconColor` from being overridden by `status`

--- a/packages/components/addon/components/hds/app-footer/status-link.js
+++ b/packages/components/addon/components/hds/app-footer/status-link.js
@@ -20,8 +20,8 @@ export const STATUSES = {
     text: 'System maintenance',
     iconName: 'alert-triangle',
   },
-  critical: {
-    text: 'System critical',
+  outage: {
+    text: 'System outage',
     iconName: 'x-circle',
   },
 };
@@ -65,18 +65,6 @@ export default class HdsAppFooterStatusLinkComponent extends Component {
       return STATUSES[this.status].iconName;
     }
     return this.args.statusIcon;
-  }
-
-  /**
-   * @param statusIconColor
-   * @type {string}
-   * @description The color for the StatusLink icon
-   */
-  get statusIconColor() {
-    if (this.status && !this.args.statusIconColor) {
-      return STATUSES[this.status].iconColor;
-    }
-    return this.args.statusIconColor;
   }
 
   /**
@@ -124,7 +112,7 @@ export default class HdsAppFooterStatusLinkComponent extends Component {
     let classes = ['hds-app-footer__status-link'];
 
     // add a class based on the @status argument
-    if (this.args.status) {
+    if (this.status && !this.args.statusIconColor) {
       classes.push(`hds-app-footer__status-link--${this.status}`);
     }
 

--- a/packages/components/addon/components/hds/app-footer/status-link.js
+++ b/packages/components/addon/components/hds/app-footer/status-link.js
@@ -111,7 +111,7 @@ export default class HdsAppFooterStatusLinkComponent extends Component {
   get classNames() {
     let classes = ['hds-app-footer__status-link'];
 
-    // add a class based on the @status argument
+    // add a class based on status if no statusIconColor is explicitly specified
     if (this.status && !this.args.statusIconColor) {
       classes.push(`hds-app-footer__status-link--${this.status}`);
     }

--- a/packages/components/app/styles/components/app-footer.scss
+++ b/packages/components/app/styles/components/app-footer.scss
@@ -62,8 +62,8 @@ $app-footer-icon-text-gap: 6px;
   .flight-icon { fill: var(--app-footer-status-link-icon-maintenance-color); }
 }
 
-.hds-app-footer__status-link--critical {
-  .flight-icon { fill: var(--app-footer-status-link-icon-critical-color); }
+.hds-app-footer__status-link--outage {
+  .flight-icon { fill: var(--app-footer-status-link-icon-outage-color); }
 }
 
 
@@ -127,7 +127,7 @@ $app-footer-icon-text-gap: 6px;
   --app-footer-status-link-icon-operational-color: var(--token-color-foreground-success);
   --app-footer-status-link-icon-degraded-color: var(--token-color-foreground-warning);
   --app-footer-status-link-icon-maintenance-color: var(--token-color-foreground-warning);
-  --app-footer-status-link-icon-critical-color: var(--token-color-foreground-critical);
+  --app-footer-status-link-icon-outage-color: var(--token-color-foreground-critical);
 }
 
 // Dark
@@ -150,5 +150,5 @@ $app-footer-icon-text-gap: 6px;
   --app-footer-status-link-icon-operational-color: #009241;
   --app-footer-status-link-icon-degraded-color: #e88c03;
   --app-footer-status-link-icon-maintenance-color: #e88c03;
-  --app-footer-status-link-icon-critical-color: #ef3016;
+  --app-footer-status-link-icon-outage-color: #ef3016;
 }

--- a/packages/components/tests/integration/components/hds/app-footer/status-link-test.js
+++ b/packages/components/tests/integration/components/hds/app-footer/status-link-test.js
@@ -29,7 +29,7 @@ module(
         <Hds::AppFooter::StatusLink id="test-operational" @status="operational" />
         <Hds::AppFooter::StatusLink id="test-degraded" @status="degraded" />
         <Hds::AppFooter::StatusLink id="test-maintenance" @status="maintenance" />
-        <Hds::AppFooter::StatusLink id="test-critical" @status="critical" />
+        <Hds::AppFooter::StatusLink id="test-outage" @status="outage" />
       </ul>`);
       // operational
       assert
@@ -55,12 +55,12 @@ module(
       assert.dom('#test-maintenance .flight-icon-alert-triangle').hasStyle({
         fill: 'rgb(187, 90, 0)',
       });
-      // critical
+      // outage
       assert
-        .dom('#test-critical')
-        .hasText('System critical')
-        .hasClass('hds-app-footer__status-link--critical');
-      assert.dom('#test-critical .flight-icon-x-circle').hasStyle({
+        .dom('#test-outage')
+        .hasText('System outage')
+        .hasClass('hds-app-footer__status-link--outage');
+      assert.dom('#test-outage .flight-icon-x-circle').hasStyle({
         fill: 'rgb(229, 34, 40)',
       });
     });
@@ -108,7 +108,7 @@ module(
 
     test('it should throw an assertion if an incorrect value for @status is provided', async function (assert) {
       const errorMessage =
-        '@status for "Hds::AppFooter" must be one of the following: operational, degraded, maintenance, critical received: foo';
+        '@status for "Hds::AppFooter" must be one of the following: operational, degraded, maintenance, outage received: foo';
       assert.expect(2);
       setupOnerror(function (error) {
         assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/website/docs/components/app-footer/partials/code/component-api.md
+++ b/website/docs/components/app-footer/partials/code/component-api.md
@@ -40,7 +40,7 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
 ### AppFooter::StatusLink
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="status" @type="string" @values={{array "operational" "degraded" "maintenance" "critical" }}>
+  <C.Property @name="status" @type="string" @values={{array "operational" "degraded" "maintenance" "outage" }}>
     Passing one of the defined values sets the associated `text`, `statusIcon`, and `statusIconColor`. Either `status` or `text` must be passed or an error will be thrown.
   </C.Property>
   <C.Property @name="statusIcon" @type="string">


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will:
- Fix status name to align with Cloud-ui—replace "critical" with "outage"
- Fix issue with custom icon color being overridden by pre-set status colors
- Cleanup old unused code related to icon color

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
- Jira ticket: [HDS-2854](https://hashicorp.atlassian.net/browse/HDS-2854)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [x] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2854]: https://hashicorp.atlassian.net/browse/HDS-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ