### PR TITLE
Clarify `isMinimized` docs

### DIFF
--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -25,7 +25,7 @@ This is the full-fledged component (responsive and animated).
     <em>Notice: if `@isResponsive` is set to false, this argument has no effect.</em>
   </C.Property>
   <C.Property @name="isMinimized" @type="boolean" @default="false">
-    Controls if the SideNav is rendered collapsed or expanded when initialized. This allows an application to preserve the collapsed/expanded state across sessions.
+    Controls if the SideNav is rendered collapsed or expanded when initialized. This allows an application to preserve the collapsed/expanded state across sessions. After the initial render this argument is altered based on user interactions (collapse/expand the SideNav or resize the window).
   </C.Property>
   <C.Property @name="hasA11yRefocus" @type="boolean" @default="true">
     Controls whether a "navigator narrator" and a "skip link" are added to the navigation (provided by the [`ember-a11y-refocus` Ember addon](https://github.com/ember-a11y/ember-a11y-refocus)). It can be programmatically turned off by passing `false`. Warning: if it is set to false, then it will fail Bypass Blocks, [Success Criteria 2.4.1](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html). Since this component appears on every page, the application will not be considered conformant.

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -25,7 +25,7 @@ This is the full-fledged component (responsive and animated).
     <em>Notice: if `@isResponsive` is set to false, this argument has no effect.</em>
   </C.Property>
   <C.Property @name="isMinimized" @type="boolean" @default="false">
-    Controls if the SideNav is rendered collapsed or expanded when initialized. This allows an application to preserve the collapsed/expanded state across sessions. After the initial render this argument is altered based on user interactions (collapse/expand the SideNav or resize the window).
+    Controls if the SideNav is rendered collapsed or expanded when initialized. This allows an application to preserve the collapsed/expanded state across sessions. After the initial render, this argument is altered based on user interactions (collapse/expand the SideNav or resize the window) and it is not a suitable way of controlling the SideNav state from outside after render (it’s an internal state).
   </C.Property>
   <C.Property @name="hasA11yRefocus" @type="boolean" @default="true">
     Controls whether a "navigator narrator" and a "skip link" are added to the navigation (provided by the [`ember-a11y-refocus` Ember addon](https://github.com/ember-a11y/ember-a11y-refocus)). It can be programmatically turned off by passing `false`. Warning: if it is set to false, then it will fail Bypass Blocks, [Success Criteria 2.4.1](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html). Since this component appears on every page, the application will not be considered conformant.


### PR DESCRIPTION
### :pushpin: Summary

Expand `isMinimized` docs. Although we state that this argument controls if the SideNav is rendered collapsed or expanded **when initialized**, it might be tempting for the consumer to try and control its state after render. So we're expanding the docs explaining that this argument is altered by the component logic based on user interactions and it is not a suitable way of controlling the SideNav stated from outside after render.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
