### PR TITLE
`CodeBlock`: Fix line wrapping so overflowing strings wrap

### DIFF
--- a/.changeset/wicked-items-guess.md
+++ b/.changeset/wicked-items-guess.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`CodeBlock`: Fixed lineWrapping to make long strings wrap when they overflow the container

--- a/packages/components/app/styles/components/code-block/index.scss
+++ b/packages/components/app/styles/components/code-block/index.scss
@@ -53,6 +53,7 @@ $code-block-code-padding: 16px;
   .hds-code-block__code,
   .hds-code-block__code code {
     white-space: pre-wrap;
+    overflow-wrap: break-word;
   }
 }
 

--- a/packages/components/tests/dummy/app/templates/components/code-block.hbs
+++ b/packages/components/tests/dummy/app/templates/components/code-block.hbs
@@ -124,6 +124,12 @@ console.log(codeLand);"
         @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';"
       />
     </SG.Item>
+    <SG.Item @label="hasLineWrapping=true with long string" @forceMinWidth={{true}}>
+      <Hds::CodeBlock
+        @hasLineWrapping={{true}}
+        @value="hcp-domain-verification=6ea52e476fc6232d974c31453dcd884a68df6cf374892a50a897c87d11125b67"
+      />
+    </SG.Item>
   </Shw::Grid>
 
   <Shw::Divider @level="2" />


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will add a style so that overflowing strings will be forced to wrap when `@hasLineWrapping` is true.

**Showcase:** https://hds-showcase-git-code-block-make-overflow-wrap-hashicorp.vercel.app/components/code-block

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
Issues, RFC, etc.
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies] -->

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
