### PR TITLE
`Table` - Add example with `rowspan/colspan` to showcase

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -819,6 +819,57 @@
     </div>
   </div>
 
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Table with <code>colspan/rowspan</code> attributes</Shw::Text::H3>
+
+  <Hds::Table>
+    <:head as |H|>
+      <H.Tr>
+        <H.Th>Lorem</H.Th>
+        <H.Th>Ipsum</H.Th>
+        <H.Th>Dolor</H.Th>
+        <H.Th>Sit amet</H.Th>
+      </H.Tr>
+    </:head>
+    <:body as |B|>
+      <B.Tr>
+        <B.Th rowspan="3">Scope Row with rowspan="3"</B.Th>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+      </B.Tr>
+      <B.Tr>
+        <B.Td colspan="2">Cell Content with colspan="2"</B.Td>
+        <B.Td>Cell Content</B.Td>
+      </B.Tr>
+      <B.Tr>
+        <B.Td colspan="3">Cell Content with colspan="3"</B.Td>
+      </B.Tr>
+      <B.Tr>
+        <B.Th rowspan="2">Scope Row with rowspan="2"</B.Th>
+        <B.Td>Cell Content</B.Td>
+        <B.Td rowspan="3">Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+      </B.Tr>
+      <B.Tr>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+      </B.Tr>
+      <B.Tr>
+        <B.Th>Scope Row</B.Th>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+      </B.Tr>
+      <B.Tr>
+        <B.Th>Scope Row</B.Th>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+        <B.Td>Cell Content</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+
   <Shw::Divider />
 
   <Shw::Text::H2>Base elements</Shw::Text::H2>


### PR DESCRIPTION
### :pushpin: Summary

Context: https://hashicorp.slack.com/archives/C7KTUHNUS/p1700162017441919

### :hammer_and_wrench: Detailed description

In this PR I have:
- added to the showcase an example of an `Hds::Table` with `rowspan/colspan`attributes 

### :camera_flash: Screenshots

<img width="1058" alt="screenshot_3270" src="https://github.com/hashicorp/design-system/assets/686239/63374ff7-1d45-4479-af3b-16b9cf89436b">

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
