### PR TITLE
`SideNav` - Reduce the width of `SideNav::ToggleButton`

### DIFF
--- a/.changeset/khaki-penguins-remain.md
+++ b/.changeset/khaki-penguins-remain.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav` - Reduced the width of `SideNav::ToggleButton`

--- a/packages/components/app/styles/components/side-nav/toggle-button.scss
+++ b/packages/components/app/styles/components/side-nav/toggle-button.scss
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
-  width: 24px;
+  width: var(--hds-app-sidenav-toggle-button-width);
   height: 36px;
   padding: 0 4px;
   color: var(--token-color-foreground-high-contrast);

--- a/packages/components/app/styles/components/side-nav/toggle-button.scss
+++ b/packages/components/app/styles/components/side-nav/toggle-button.scss
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
-  width: 26px;
+  width: 24px;
   height: 36px;
   padding: 0 4px;
   color: var(--token-color-foreground-high-contrast);

--- a/packages/components/app/styles/components/side-nav/vars.scss
+++ b/packages/components/app/styles/components/side-nav/vars.scss
@@ -23,6 +23,8 @@
   --hds-app-sidenav-animation-duration: 200ms;
   --hds-app-sidenav-animation-delay: var(--hds-app-sidenav-animation-duration);
   --hds-app-sidenav-animation-easing: cubic-bezier(0.65, 0, 0.35, 1);
+  // toggle-button
+  --hds-app-sidenav-toggle-button-width: 24px;
 }
 
 // reduced motion


### PR DESCRIPTION
### :pushpin: Summary

Reduce the width of `SideNav::ToggleButton` from `26px` to `24px`.

### :hammer_and_wrench: Detailed description

To prevent the button from overlapping other elements in pages where main content padding is narrow.

### :link: External links

As discussed with design manager and agreed with senior product designer

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
