### PR TITLE
Document `SideNav`s `onToggleMinimizedStatus`

### DIFF
--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -49,6 +49,9 @@ This is the full-fledged component (responsive and animated).
   <C.Property @name="ariaLabel" @type="string">
     Accepts a localized string; the fallback is set to `Open menu` if the menu is closed, and `Close menu` if the menu is open.
   </C.Property>
+  <C.Property @name="onToggleMinimizedStatus" @type="function">
+    Callback function invoked when the `SideNav` is collapsed or expanded. The function receives a boolean argument stating if the `SideNav` is minimized on not.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>


### PR DESCRIPTION
### :pushpin: Summary

Document `SideNav`s `onToggleMinimizedStatus` callback function.

[Code reference](https://github.com/hashicorp/design-system/blob/main/packages/components/addon/components/hds/side-nav/index.js#L117).

As always, open to suggestions to improve the clarity of our documentation.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2825](https://hashicorp.atlassian.net/browse/HDS-2825)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2825]: https://hashicorp.atlassian.net/browse/HDS-2825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ