### PR TITLE
`Modal`, `Flyout` - Allow custom elements to be interposed with contextual components

### DIFF
--- a/.changeset/new-toes-brake.md
+++ b/.changeset/new-toes-brake.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Modal` - Allowed custom elements to be interposed with contextual components
+`Flyout` - Allowed custom elements to be interposed with contextual components

--- a/packages/components/addon/components/hds/flyout/index.hbs
+++ b/packages/components/addon/components/hds/flyout/index.hbs
@@ -9,10 +9,14 @@
   {{did-insert this.didInsert}}
   {{focus-trap isActive=this.isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=true)}}
 >
-  {{yield (hash Header=(component "hds/flyout/header" id=this.id onDismiss=this.onDismiss))}}
-  {{yield (hash Description=(component "hds/flyout/description"))}}
-  {{yield (hash Body=(component "hds/flyout/body"))}}
-  {{yield (hash Footer=(component "hds/flyout/footer" onDismiss=this.onDismiss))}}
+  {{yield
+    (hash
+      Header=(component "hds/flyout/header" id=this.id onDismiss=this.onDismiss)
+      Description=(component "hds/flyout/description")
+      Body=(component "hds/flyout/body")
+      Footer=(component "hds/flyout/footer" onDismiss=this.onDismiss)
+    )
+  }}
 </dialog>
 {{#if this.isOpen}}
   <div class="hds-flyout__overlay"></div>

--- a/packages/components/addon/components/hds/modal/index.hbs
+++ b/packages/components/addon/components/hds/modal/index.hbs
@@ -9,9 +9,13 @@
   {{did-insert this.didInsert}}
   {{focus-trap isActive=this.isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=true)}}
 >
-  {{yield (hash Header=(component "hds/modal/header" id=this.id onDismiss=this.onDismiss))}}
-  {{yield (hash Body=(component "hds/modal/body"))}}
-  {{yield (hash Footer=(component "hds/modal/footer" onDismiss=this.onDismiss))}}
+  {{yield
+    (hash
+      Header=(component "hds/modal/header" id=this.id onDismiss=this.onDismiss)
+      Body=(component "hds/modal/body")
+      Footer=(component "hds/modal/footer" onDismiss=this.onDismiss)
+    )
+  }}
 </dialog>
 {{#if this.isOpen}}
   <div class="hds-modal__overlay"></div>

--- a/packages/components/tests/dummy/app/templates/components/modal.hbs
+++ b/packages/components/tests/dummy/app/templates/components/modal.hbs
@@ -244,11 +244,11 @@
   {{! template-lint-disable no-autofocus-attribute }}
   {{#if this.formModalActive}}
     <Hds::Modal id="form-modal" @onClose={{fn this.deactivateModal "formModalActive"}} as |M|>
-      <M.Header>
-        Why do you want to leave the beta?
-      </M.Header>
-      <M.Body>
-        <form name="leaving-beta-form">
+      <form name="leaving-beta-form">
+        <M.Header>
+          Why do you want to leave the beta?
+        </M.Header>
+        <M.Body>
           <Hds::Form::Select::Field autofocus @width="100%" as |F|>
             <F.Label>Select the primary reason</F.Label>
             <F.Options>
@@ -258,14 +258,14 @@
           <Hds::Form::Textarea::Field @isOptional={{true}} as |F|>
             <F.Label>Your feedback</F.Label>
           </Hds::Form::Textarea::Field>
-        </form>
-      </M.Body>
-      <M.Footer as |F|>
-        <Hds::ButtonSet>
-          <Hds::Button type="submit" @text="Leave Beta" {{on "click" (fn this.deactivateModal "formModalActive")}} />
-          <Hds::Button type="button" @text="Cancel" @color="secondary" {{on "click" F.close}} />
-        </Hds::ButtonSet>
-      </M.Footer>
+        </M.Body>
+        <M.Footer as |F|>
+          <Hds::ButtonSet>
+            <Hds::Button type="submit" @text="Leave Beta" {{on "click" (fn this.deactivateModal "formModalActive")}} />
+            <Hds::Button type="button" @text="Cancel" @color="secondary" {{on "click" F.close}} />
+          </Hds::ButtonSet>
+        </M.Footer>
+      </form>
     </Hds::Modal>
   {{/if}}
 

--- a/packages/components/tests/integration/components/hds/flyout/index-test.js
+++ b/packages/components/tests/integration/components/hds/flyout/index-test.js
@@ -72,6 +72,26 @@ module('Integration | Component | hds/flyout/index', function (hooks) {
     assert.dom('.hds-flyout__footer').hasText('Footer');
   });
 
+  test('it renders elements interposed with contextual components', async function (assert) {
+    await render(
+      hbs`<Hds::Flyout id="test-flyout" as |F|>
+            <form id="modal-form">
+              <F.Header>Title</F.Header>
+              <F.Body>Body</F.Body>
+              <F.Footer>Footer</F.Footer>
+            </form>
+          </Hds::Flyout>`
+    );
+    assert.dom('.hds-flyout').exists({ count: 1 });
+    assert.dom('#modal-form').exists({ count: 1 });
+    assert.dom('#modal-form .hds-flyout__header').exists({ count: 1 });
+    assert.dom('#modal-form .hds-flyout__header').hasText('Title');
+    assert.dom('#modal-form .hds-flyout__body').exists({ count: 1 });
+    assert.dom('#modal-form .hds-flyout__body').hasText('Body');
+    assert.dom('#modal-form .hds-flyout__footer').exists({ count: 1 });
+    assert.dom('#modal-form .hds-flyout__footer').hasText('Footer');
+  });
+
   // TITLE (ICON, TAGLINE & DESCRIPTION)
 
   test('it renders the title without icon, tagline, and description', async function (assert) {

--- a/packages/components/tests/integration/components/hds/modal/index-test.js
+++ b/packages/components/tests/integration/components/hds/modal/index-test.js
@@ -74,6 +74,26 @@ module('Integration | Component | hds/modal/index', function (hooks) {
     assert.dom('.hds-modal__footer').hasText('Footer');
   });
 
+  test('it renders elements interposed with contextual components', async function (assert) {
+    await render(
+      hbs`<Hds::Modal id="test-modal" as |M|>
+            <form id="modal-form">
+              <M.Header>Title</M.Header>
+              <M.Body>Body</M.Body>
+              <M.Footer>Footer</M.Footer>
+            </form>
+          </Hds::Modal>`
+    );
+    assert.dom('.hds-modal').exists({ count: 1 });
+    assert.dom('#modal-form').exists({ count: 1 });
+    assert.dom('#modal-form .hds-modal__header').exists({ count: 1 });
+    assert.dom('#modal-form .hds-modal__header').hasText('Title');
+    assert.dom('#modal-form .hds-modal__body').exists({ count: 1 });
+    assert.dom('#modal-form .hds-modal__body').hasText('Body');
+    assert.dom('#modal-form .hds-modal__footer').exists({ count: 1 });
+    assert.dom('#modal-form .hds-modal__footer').hasText('Footer');
+  });
+
   // TITLE (ICON & TAGLINE)
 
   test('it renders the title without icon and tagline if not provided', async function (assert) {

--- a/website/app/styles/pages/components/modal.scss
+++ b/website/app/styles/pages/components/modal.scss
@@ -17,4 +17,10 @@
       pointer-events: none;
     }
   }
+
+  #form-modal {
+    .hds-form-field--layout-vertical:first-child {
+      margin-bottom: 20px;
+    }
+  }
 }

--- a/website/docs/components/modal/partials/code/how-to-use.md
+++ b/website/docs/components/modal/partials/code/how-to-use.md
@@ -59,32 +59,32 @@ When the Modal dialog contains information that might be lost on close, use a co
     @onClose={{fn this.deactivateModal "formModalActive"}}
     as |M|
   >
-    <M.Header>
-      Why do you want to leave the beta?
-    </M.Header>
-    <M.Body>
-      <form name="leaving-beta-form">
-        <Hds::Form::Select::Field autofocus @width="100%" as |F|>
-          <F.Label>Select the primary reason</F.Label>
-          <F.Options>
-            <option></option>
-          </F.Options>
-        </Hds::Form::Select::Field>
-        <Hds::Form::Textarea::Field @isOptional={{true}} as |F|>
-          <F.Label>Your feedback</F.Label>
-        </Hds::Form::Textarea::Field>
-      </form>
-    </M.Body>
-    <M.Footer as |F|>
-      <Hds::ButtonSet>
-        <Hds::Button type="submit" @text="Leave Beta"
-          {{on "click" (fn this.deactivateModal "formModalActive")}}
-        />
-        <Hds::Button type="button" @text="Cancel" @color="secondary"
-          {{on "click" F.close}}
-        />
-      </Hds::ButtonSet>
-    </M.Footer>
+    <form name="leaving-beta-form">
+      <M.Header>
+        Why do you want to leave the beta?
+      </M.Header>
+      <M.Body>
+          <Hds::Form::Select::Field autofocus @width="100%" as |F|>
+            <F.Label>Select the primary reason</F.Label>
+            <F.Options>
+              <option></option>
+            </F.Options>
+          </Hds::Form::Select::Field>
+          <Hds::Form::Textarea::Field @isOptional={{true}} as |F|>
+            <F.Label>Your feedback</F.Label>
+          </Hds::Form::Textarea::Field>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::ButtonSet>
+          <Hds::Button type="submit" @text="Leave Beta"
+            {{on "click" (fn this.deactivateModal "formModalActive")}}
+          />
+          <Hds::Button type="button" @text="Cancel" @color="secondary"
+            {{on "click" F.close}}
+          />
+        </Hds::ButtonSet>
+      </M.Footer>
+    </form>
   </Hds::Modal>
 {{/if}}
 ```


### PR DESCRIPTION
### :pushpin: Summary

Allow custom elements to be interposed with contextual components in `Modal` in `Flyout`

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2869](https://hashicorp.atlassian.net/browse/HDS-2869)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2869]: https://hashicorp.atlassian.net/browse/HDS-2869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ