### PR TITLE
remove unnused languages from website ember-prism config

### DIFF
--- a/website/ember-cli-build.js
+++ b/website/ember-cli-build.js
@@ -29,15 +29,11 @@ module.exports = function (defaults) {
     },
     'ember-prism': {
       components: [
-        'apacheconf',
         'bash',
         'css',
         'handlebars',
-        'http',
         'javascript',
-        'json',
         'markup-templating',
-        'ruby',
         'scss',
       ],
       theme: 'dracula',


### PR DESCRIPTION
### :pushpin: Summary

remove unnused languages from website ember-prism config

### :hammer_and_wrench: Detailed description

I mainly "tested" this by grepping through all the docs for blocks of _```language_ and left behind all the ones we seemed to be using. If one happens to be missing the code block will still render with the default styles.

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2670](https://hashicorp.atlassian.net/browse/HDS-2670)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2670]: https://hashicorp.atlassian.net/browse/HDS-2670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ