### PR TITLE
update AppFooter's default accessibility URL

### DIFF
--- a/.changeset/purple-buttons-divide.md
+++ b/.changeset/purple-buttons-divide.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AppFooter` - update default accessibility URL to https://hashicorp.com/accessibility

--- a/packages/components/addon/components/hds/app-footer/legal-links.js
+++ b/packages/components/addon/components/hds/app-footer/legal-links.js
@@ -60,7 +60,8 @@ export default class HdsAppFooterLegalLinksComponent extends Component {
    */
   get hrefForAccessibility() {
     return (
-      this.args.hrefForAccessibility ?? 'mailto:accessibility@hashicorp.com'
+      this.args.hrefForAccessibility ??
+      'https://www.hashicorp.com/accessibility'
     );
   }
 }

--- a/packages/components/tests/integration/components/hds/app-footer/legal-links-test.js
+++ b/packages/components/tests/integration/components/hds/app-footer/legal-links-test.js
@@ -45,7 +45,7 @@ module(
       assert
         .dom('#test-legal-links li:nth-child(5) a')
         .hasText('Accessibility')
-        .hasAttribute('href', 'mailto:accessibility@hashicorp.com');
+        .hasAttribute('href', 'https://www.hashicorp.com/accessibility');
     });
 
     // OPTIONS

--- a/website/docs/components/app-footer/partials/code/component-api.md
+++ b/website/docs/components/app-footer/partials/code/component-api.md
@@ -87,7 +87,7 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
   <C.Property @name="hrefForSecurity" @type="string" @default="&quot;https://www.hashicorp.com/security&quot;">
     Override the default href value with a custom url value.
   </C.Property>
-  <C.Property @name="Accessibility" @type="string" @default="&quot;mailto:accessibility@hashicorp.com&quot;">
+  <C.Property @name="Accessibility" @type="string" @default="&quot;https://www.hashicorp.com/accessibility&quot;">
     Override the default href value with a custom url value.
   </C.Property>
   <C.Property @name="ariaLabel" @type="string" @default="&quot;Legal links&quot;">


### PR DESCRIPTION
### :pushpin: Summary

Updates our AppFooter's default accessibility URL

### :hammer_and_wrench: Detailed description

- [x] Ensure marketing has introduced the redirect from `/accessibility` to `/trust/accessibility`

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2893](https://hashicorp.atlassian.net/browse/HDS-2893)

***

### 👀 Component checklist

- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2893]: https://hashicorp.atlassian.net/browse/HDS-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ