### PR TITLE
Website indexing script - Add custom `objectID` to records missing it

### DIFF
--- a/website/docs-scraper/index-website-content.mjs
+++ b/website/docs-scraper/index-website-content.mjs
@@ -21,6 +21,7 @@ import dotenv from 'dotenv';
 import fs from 'fs-extra';
 import path from 'path';
 import chalk from 'chalk';
+import hash from 'object-hash';
 
 // import { pick } from 'lodash'; // not sure why this doesn't work in a `.mjs` module
 import _ from 'lodash';
@@ -204,10 +205,11 @@ async function indexWebsiteContent() {
           record: currBaseRecord,
           content: tabContent,
         });
-        // add the page title to the record's hierarchy
-        records.forEach(
-          (record) => (record.hierarchy.lvl1 = pageMetadata.title)
-        );
+        // add the objectID to the records and the page title to the records' hierarchy
+        records.forEach((record) => {
+          record.objectID = `record__content-${record.type}-${hash(record)}`; // https://www.algolia.com/doc-beta/guides/sending-and-managing-data/send-and-update-your-data#unique-object-identifiers
+          record.hierarchy.lvl1 = pageMetadata.title;
+        });
         // add the records to the algolia list
         algoliaRecords.push(...records);
       });
@@ -221,14 +223,18 @@ async function indexWebsiteContent() {
         record: currBaseRecord,
         content: pageContent,
       });
-      // add the page title to the record's hierarchy
-      records.forEach((record) => (record.hierarchy.lvl1 = pageMetadata.title));
+      // add the objectID to the records and the page title to the records' hierarchy
+      records.forEach((record) => {
+        record.objectID = `record__content-${record.type}-${hash(record)}`; // https://www.algolia.com/doc-beta/guides/sending-and-managing-data/send-and-update-your-data#unique-object-identifiers
+        record.hierarchy.lvl1 = pageMetadata.title;
+      });
       // add the records to the algolia list
       algoliaRecords.push(...records);
     }
 
     // add a custom entry for the top-page
     const topPageRecord = _.merge({}, algoliaBaseRecord, {
+      objectID: `record__page-${hash(pageURL)}`, // https://www.algolia.com/doc-beta/guides/sending-and-managing-data/send-and-update-your-data#unique-object-identifiers
       searchResultURL: `/${pageURL}`,
       pageTab: null,
       level: 0, // we use `level=0` here to put it on top of the other pages

--- a/website/package.json
+++ b/website/package.json
@@ -101,6 +101,7 @@
     "mdast-util-from-markdown": "^2.0.0",
     "mdast-util-to-string": "^4.0.0",
     "npm-run-all": "^4.1.5",
+    "object-hash": "^3.0.0",
     "prember": "^2.0.0",
     "prember-middleware": "^0.1.0",
     "prember-sitemap-generator": "https://github.com/shipshapecode/prember-sitemap-generator.git#commit=c95f47042d86c4fa7b8b631f271da090672e13df",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21346,6 +21346,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-hash@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "object-hash@npm:3.0.0"
+  checksum: f498d456a20512ba7be500cef4cf7b3c183cc72c65372a549c9a0e6dd78ce26f375e9b1315c07592d3fde8f10d5019986eba35970570d477ed9a2a702514432a
+  languageName: node
+  linkType: hard
+
 "object-inspect@npm:^1.12.0, object-inspect@npm:^1.9.0":
   version: 1.12.2
   resolution: "object-inspect@npm:1.12.2"
@@ -27520,6 +27527,7 @@ __metadata:
     mdast-util-from-markdown: "npm:^2.0.0"
     mdast-util-to-string: "npm:^4.0.0"
     npm-run-all: "npm:^4.1.5"
+    object-hash: "npm:^3.0.0"
     prember: "npm:^2.0.0"
     prember-middleware: "npm:^0.1.0"
     prember-sitemap-generator: "https://github.com/shipshapecode/prember-sitemap-generator.git#commit=c95f47042d86c4fa7b8b631f271da090672e13df"


### PR DESCRIPTION
### :pushpin: Summary

This _should_ "fix" the problem or duplicated records added when the script is run on some local machines (Brian/Alex) but not on others (Cristiano) or CI.

Important: it may have downsides, so we need to investigate better what is happening and why, but for now it could be an interim solution (still to be tested).

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
