### PR TITLE
`Table` - Add ability to visually hide a table column header

### DIFF
--- a/.changeset/tidy-rivers-sin.md
+++ b/.changeset/tidy-rivers-sin.md
@@ -3,4 +3,4 @@
 ---
 
 - `Hds::Table` - updated `@columns` object to support `isVisuallyHidden` argument
-- `Hds::Table::Th` - updated sub-component to support `isVisuallyHidden` argument
+- `Hds::Table::Th` - updated to support `isVisuallyHidden` argument

--- a/.changeset/tidy-rivers-sin.md
+++ b/.changeset/tidy-rivers-sin.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+- `Hds::Table` - updated `@columns` object to support `isVisuallyHidden` argument
+- `Hds::Table::Th` - updated sub-component to support `isVisuallyHidden` argument

--- a/packages/components/addon/components/hds/table/index.hbs
+++ b/packages/components/addon/components/hds/table/index.hbs
@@ -22,7 +22,11 @@
               {{column.label}}
             </Hds::Table::ThSort>
           {{else}}
-            <Hds::Table::Th @align={{column.align}} @width={{column.width}}>{{column.label}}</Hds::Table::Th>
+            <Hds::Table::Th
+              @align={{column.align}}
+              @width={{column.width}}
+              @isVisuallyHidden={{column.isVisuallyHidden}}
+            >{{column.label}}</Hds::Table::Th>
           {{/if}}
         {{/each}}
       </Hds::Table::Tr>

--- a/packages/components/addon/components/hds/table/th.hbs
+++ b/packages/components/addon/components/hds/table/th.hbs
@@ -3,5 +3,9 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 <th class={{this.classNames}} {{style width=@width minWidth=@width}} ...attributes scope={{(or @scope "col")}}>
-  {{yield}}
+  {{#if @isVisuallyHidden}}
+    <span class="sr-only">{{yield}}</span>
+  {{else}}
+    {{yield}}
+  {{/if}}
 </th>

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -493,7 +493,7 @@
 
   <Shw::Text::H2>Customization</Shw::Text::H2>
 
-  <Shw::Text::H4 @tag="h3">Sortable table, last column not sortable and has custom width.</Shw::Text::H4>
+  <Shw::Text::H4 @tag="h3">Sortable table, last column not sortable, visually hidden and with custom width.</Shw::Text::H4>
 
   <Hds::Table
     @model={{this.model.music}}
@@ -501,7 +501,7 @@
       (hash key="artist" label="Artist" isSortable=true)
       (hash key="album" label="Album" isSortable=true)
       (hash key="year" label="Release Year" isSortable=true)
-      (hash key="other" label="Other" width="55px" align="right")
+      (hash key="other" label="Select an action from the menu" width="55px" isVisuallyHidden=true)
     }}
     @valign="middle"
   >
@@ -920,8 +920,8 @@
 
   <Shw::Text::H3>Th</Shw::Text::H3>
 
-  <Shw::Flex @label="Th with custom width" as |SF|>
-    <SF.Item @grow={{true}}>
+  <Shw::Flex @direction="column" as |SF|>
+    <SF.Item @label="Th with custom width" @grow={{true}}>
       <Hds::Table>
         <:head as |H|>
           <H.Tr>
@@ -937,6 +937,32 @@
             <B.Td>Cell Content</B.Td>
             <B.Td>Cell Content</B.Td>
             <B.Td>100px</B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
+    </SF.Item>
+    <SF.Item @label="Th with visually hidden text" @grow={{true}}>
+      <Hds::Table>
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Lorem</H.Th>
+            <H.Th>Ipsum</H.Th>
+            <H.Th>Dolor</H.Th>
+            <H.Th @isVisuallyHidden={{true}}>Sit amet</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
+          <B.Tr>
+            <B.Th>Scope Row</B.Th>
+            <B.Td>Cell Content</B.Td>
+            <B.Td>Cell Content</B.Td>
+            <B.Td>Cell Content</B.Td>
+          </B.Tr>
+          <B.Tr>
+            <B.Th @isVisuallyHidden={{true}}>Scope Row</B.Th>
+            <B.Td>Cell Content</B.Td>
+            <B.Td>Cell Content</B.Td>
+            <B.Td>Cell Content</B.Td>
           </B.Tr>
         </:body>
       </Hds::Table>

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -53,6 +53,9 @@ The Table component itself is where most of the options will be applied. However
       <D.Property @name="width" @type="string" @valueNote="Any valid CSS">
         If set, determines the column’s width.
       </D.Property>
+      <C.Property @name="isVisuallyHidden" @type="boolean" @default="false">
+        If set to `true`, it visually hides the column’s text content (it will still be available to screen readers for accessibility). <em>Only available for non-sortable columns.</em>
+      </C.Property>
       <D.Property @name="sortingFunction" @type="function">
         Callback function to provide support for custom sorting logic. It should implement a typical bubble-sorting algorithm using two elements and comparing them. For more details, see the example of custom sorting in the How To Use section.
       </D.Property>
@@ -123,6 +126,9 @@ If the `Th` component is passed as the first cell of a table body row, `scope="r
   </C.Property>
   <C.Property @name="width" @type="string" @valueNote="Any valid CSS">
     If set, determines the column’s width.
+  </C.Property>
+  <C.Property @name="isVisuallyHidden" @type="boolean" @default="false">
+    If set to `true`, it visually hides the column’s text content (it will still be available to screen readers for accessibility).
   </C.Property>
   <C.Property @name="yield">
     Elements passed as children of this component are yielded inside the `<th>` element.

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -547,6 +547,46 @@ In this case the table layout is still set to `auto` (default). If instead you w
 
 ### More examples
 
+#### Visually hidden table headers
+
+Labels within the table header are intended to provide contextual information about the column's content to the end user. There may be special cases in which that label is redundant from a visual perspective, because the kind of content can be inferred by looking at it (eg. a contextual dropdown). In this case it's possible to visually hide the label by passing `isVisuallyHidden=true` to the column (only for non-sortable tables).
+
+```handlebars
+<Hds::Table
+  @model={{this.model.myDemoData}}
+  @columns={{array
+    (hash key="artist" label="Artist" isSortable=true)
+    (hash key="album" label="Album" isSortable=true)
+    (hash key="year" label="Year" isSortable=true)
+    (hash key="other" label="Select an action from the menu" isVisuallyHidden=true width="60px")
+  }}
+>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
+      <B.Td>
+          <Hds::Dropdown as |dd|>
+            <dd.ToggleIcon
+              @icon="more-horizontal"
+              @text="Overflow Options"
+              @hasChevron={{false}}
+              @size="small"
+            />
+            <dd.Interactive
+              @href="#"
+              @text="Delete"
+              @color="critical"
+              @icon="trash"
+            />
+          </Hds::Dropdown>
+        </B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>
+```
+
 #### Internationalized column headers, overflow menu dropdown
 
 Here’s a Table implementation that uses an array hash with localized strings for the column headers, indicates which columns should be sortable, and adds an overflow menu.

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -595,10 +595,10 @@ Here’s a Table implementation that uses an array hash with localized strings f
 <Hds::Table
   @model={{this.model.myDemoData}}
   @columns={{array
-      (hash key='artist' label=(t 'components.table.headers.artist') isSortable=true)
-      (hash key='album' label=(t 'components.table.headers.album') isSortable=true)
-      (hash key='year' label=(t 'components.table.headers.year') isSortable=true)
-      (hash key='other' label=(t 'global.titles.other'))
+      (hash key="artist" label=(t "components.table.headers.artist") isSortable=true)
+      (hash key="album" label=(t "components.table.headers.album") isSortable=true)
+      (hash key="year" label=(t "components.table.headers.year") isSortable=true)
+      (hash key="other" label=(t "global.titles.other"))
     }}
 >
   <:body as |B|>
@@ -609,17 +609,17 @@ Here’s a Table implementation that uses an array hash with localized strings f
       <B.Td>
           <Hds::Dropdown as |dd|>
             <dd.ToggleIcon
-              @icon='more-horizontal'
-              @text='Overflow Options'
+              @icon="more-horizontal"
+              @text="Overflow Options"
               @hasChevron={{false}}
-              @size='small'
+              @size="small"
             />
-            <dd.Interactive @route='components.table' @text='Create' />
-            <dd.Interactive @route='components.table' @text='Read' />
-            <dd.Interactive @route='components.table' @text='Update' />
+            <dd.Interactive @href="#" @text="Create" />
+            <dd.Interactive @href="#" @text="Read" />
+            <dd.Interactive @href="#" @text="Update" />
             <dd.Separator />
             <dd.Interactive
-              @route='components.table'
+              @href="#"
               @text='Delete'
               @color='critical'
               @icon='trash'


### PR DESCRIPTION
### :pushpin: Summary

We have received some user requests to expose a way for them to be able to have tables without column headers. Since this is not possible for accessibility reasons, what we can do is to allow them to _visually hide_ the label in the table headers, but keeping the label in the DOM for screen readers.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added `@isVisuallyHidden` argument to `Hds::Table::Th`
- updated `Hds::Table` to support `isVisuallyHidden` argument in the `@columns` object
- updated the showcase for `Table` component to include also examples container visually hidden table headers
- updated the “Component API” documentation
- added an example with visually hidden table headers to the “How to use” section
    - I've also updated second example to avoid complains from the compiler in case it’s rendered

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2355

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
