### PR TITLE
Fix the `isSortable="true”` declarations

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/pagination.hbs
+++ b/packages/components/tests/dummy/app/templates/components/pagination.hbs
@@ -344,8 +344,8 @@
     <Hds::Table
       @model={{this.paginatedData_demo2}}
       @columns={{array
-        (hash key="id" label="ID" isSortable="true")
-        (hash key="name" label="Name" isSortable="true")
+        (hash key="id" label="ID" isSortable=true)
+        (hash key="name" label="Name" isSortable=true)
         (hash key="email" label="Email")
         (hash key="role" label="Role")
       }}

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -191,9 +191,9 @@
   <Hds::Table
     @model={{this.model.music}}
     @columns={{array
-      (hash key="artist" label="Artist" isSortable="true")
-      (hash key="album" label="Album" isSortable="true")
-      (hash key="year" label="Release Year" isSortable="true")
+      (hash key="artist" label="Artist" isSortable=true)
+      (hash key="album" label="Album" isSortable=true)
+      (hash key="year" label="Release Year" isSortable=true)
     }}
   >
     <:body as |B|>
@@ -210,8 +210,8 @@
   <Hds::Table
     @model={{this.model.music}}
     @columns={{array
-      (hash key="artist" label="Artist" isSortable="true")
-      (hash key="album" label="Album" isSortable="true")
+      (hash key="artist" label="Artist" isSortable=true)
+      (hash key="album" label="Album" isSortable=true)
       (hash key="year" label="Release Year")
     }}
   >
@@ -229,9 +229,9 @@
   <Hds::Table
     @model={{this.model.music}}
     @columns={{array
-      (hash key="artist" label="Artist" isSortable="true")
-      (hash key="album" label="Album" isSortable="true")
-      (hash key="year" label="Release Year" isSortable="true" align="right")
+      (hash key="artist" label="Artist" isSortable=true)
+      (hash key="album" label="Album" isSortable=true)
+      (hash key="year" label="Release Year" isSortable=true align="right")
     }}
   >
     <:body as |B|>
@@ -248,8 +248,8 @@
   <Hds::Table
     @model={{this.model.music}}
     @columns={{array
-      (hash key="artist" label="Artist" isSortable="true")
-      (hash key="album" label="Album" isSortable="true")
+      (hash key="artist" label="Artist" isSortable=true)
+      (hash key="album" label="Album" isSortable=true)
       (hash key="year" label="Release Year")
     }}
     @sortBy="artist"
@@ -276,9 +276,9 @@
   <Hds::Table
     @model={{this.clustersWithExtraData_demo1}}
     @columns={{array
-      (hash label="Peer name" isSortable="true" key="peer-name")
+      (hash label="Peer name" isSortable=true key="peer-name")
       (hash label="Cluster partition")
-      (hash label="Status" isSortable="true" key="status-sort-order")
+      (hash label="Status" isSortable=true key="status-sort-order")
       (hash label="Imported services")
       (hash label="Exported services")
       (hash label="Actions" align="right")
@@ -326,9 +326,9 @@
   <Hds::Table
     @model={{this.model.clusters}}
     @columns={{array
-      (hash label="Peer name" isSortable="true" key="peer-name")
+      (hash label="Peer name" isSortable=true key="peer-name")
       (hash label="Cluster partition")
-      (hash label="Status" isSortable="true" key="status" sortingFunction=this.customSortingFunction_demo2)
+      (hash label="Status" isSortable=true key="status" sortingFunction=this.customSortingFunction_demo2)
       (hash label="Imported services")
       (hash label="Exported services")
       (hash label="Actions" align="right")
@@ -498,9 +498,9 @@
   <Hds::Table
     @model={{this.model.music}}
     @columns={{array
-      (hash key="artist" label="Artist" isSortable="true")
-      (hash key="album" label="Album" isSortable="true")
-      (hash key="year" label="Release Year" isSortable="true")
+      (hash key="artist" label="Artist" isSortable=true)
+      (hash key="album" label="Album" isSortable=true)
+      (hash key="year" label="Release Year" isSortable=true)
       (hash key="other" label="Other" width="55px" align="right")
     }}
     @valign="middle"
@@ -529,9 +529,9 @@
   <Hds::Table
     @model={{this.model.music}}
     @columns={{array
-      (hash key="artist" label="Artist" isSortable="true")
-      (hash key="album" label="Album" isSortable="true")
-      (hash key="year" label="Release Year" isSortable="true")
+      (hash key="artist" label="Artist" isSortable=true)
+      (hash key="album" label="Album" isSortable=true)
+      (hash key="year" label="Release Year" isSortable=true)
       (hash key="vinyl-cost" label="Vinyl Cost (USD)" align="right")
     }}
   >
@@ -550,9 +550,9 @@
   <Hds::Table
     @model={{this.model.music}}
     @columns={{array
-      (hash key="artist" label="Artist" isSortable="true")
-      (hash key="album" label="Album" isSortable="true")
-      (hash key="year" label="Release Year" isSortable="true")
+      (hash key="artist" label="Artist" isSortable=true)
+      (hash key="album" label="Album" isSortable=true)
+      (hash key="year" label="Release Year" isSortable=true)
       (hash key="other" label="Additional Actions")
     }}
   >
@@ -655,9 +655,9 @@
   <Hds::Table
     @model={{this.model.manycolumns}}
     @columns={{array
-      (hash key="first_name" label="First Name" isSortable="true" width="200px")
-      (hash key="last_name" label="Last Name" isSortable="true" width="200px")
-      (hash key="age" label="Age" isSortable="true")
+      (hash key="first_name" label="First Name" isSortable=true width="200px")
+      (hash key="last_name" label="Last Name" isSortable=true width="200px")
+      (hash key="age" label="Age" isSortable=true)
       (hash key="email" label="Email")
       (hash key="bio" label="Biography" width="350px")
     }}
@@ -682,9 +682,9 @@
   <Hds::Table
     @model={{this.model.manycolumns}}
     @columns={{array
-      (hash key="first_name" label="First Name" isSortable="true" width="200px")
-      (hash key="last_name" label="Last Name" isSortable="true" width="200px")
-      (hash key="age" label="Age" isSortable="true")
+      (hash key="first_name" label="First Name" isSortable=true width="200px")
+      (hash key="last_name" label="Last Name" isSortable=true width="200px")
+      (hash key="age" label="Age" isSortable=true)
       (hash key="email" label="Email")
       (hash key="bio" label="Biography" width="350px")
     }}
@@ -706,9 +706,9 @@
   <Hds::Table
     @model={{this.model.manycolumns}}
     @columns={{array
-      (hash key="first_name" label="First Name" isSortable="true" width="20%")
-      (hash key="last_name" label="Last Name" isSortable="true" width="20%")
-      (hash key="age" label="Age" isSortable="true")
+      (hash key="first_name" label="First Name" isSortable=true width="20%")
+      (hash key="last_name" label="Last Name" isSortable=true width="20%")
+      (hash key="age" label="Age" isSortable=true)
       (hash key="email" label="Email")
       (hash key="bio" label="Biography" width="35%")
     }}
@@ -729,9 +729,9 @@
   <Hds::Table
     @model={{this.model.manycolumns}}
     @columns={{array
-      (hash key="first_name" label="First Name" isSortable="true" width="20%")
-      (hash key="last_name" label="Last Name" isSortable="true" width="20%")
-      (hash key="age" label="Age" isSortable="true")
+      (hash key="first_name" label="First Name" isSortable=true width="20%")
+      (hash key="last_name" label="Last Name" isSortable=true width="20%")
+      (hash key="age" label="Age" isSortable=true)
       (hash key="email" label="Email")
       (hash key="bio" label="Biography" width="35%")
     }}
@@ -759,14 +759,14 @@
     <Hds::Table
       @model={{this.model.manycolumns}}
       @columns={{array
-        (hash key="first_name" label="First Name" isSortable="true" width="200px")
-        (hash key="last_name" label="Last Name" isSortable="true" width="200px")
-        (hash key="age" label="Age" isSortable="true")
-        (hash key="email" label="Email" isSortable="true")
-        (hash key="phone" label="Phone" isSortable="true")
+        (hash key="first_name" label="First Name" isSortable=true width="200px")
+        (hash key="last_name" label="Last Name" isSortable=true width="200px")
+        (hash key="age" label="Age" isSortable=true)
+        (hash key="email" label="Email" isSortable=true)
+        (hash key="phone" label="Phone" isSortable=true)
         (hash key="bio" label="Biography" width="350px")
-        (hash key="education" label="Education Degree" isSortable="true")
-        (hash key="occupation" label="Occupation" isSortable="true")
+        (hash key="education" label="Education Degree" isSortable=true)
+        (hash key="occupation" label="Occupation" isSortable=true)
       }}
     >
       <:body as |B|>
@@ -793,14 +793,14 @@
       <Hds::Table
         @model={{this.model.manycolumns}}
         @columns={{array
-          (hash key="first_name" label="First Name" isSortable="true" width="200px")
-          (hash key="last_name" label="Last Name" isSortable="true" width="200px")
-          (hash key="age" label="Age" isSortable="true")
-          (hash key="email" label="Email" isSortable="true")
-          (hash key="phone" label="Phone" isSortable="true")
+          (hash key="first_name" label="First Name" isSortable=true width="200px")
+          (hash key="last_name" label="Last Name" isSortable=true width="200px")
+          (hash key="age" label="Age" isSortable=true)
+          (hash key="email" label="Email" isSortable=true)
+          (hash key="phone" label="Phone" isSortable=true)
           (hash key="bio" label="Biography" width="350px")
-          (hash key="education" label="Education Degree" isSortable="true")
-          (hash key="occupation" label="Occupation" isSortable="true")
+          (hash key="education" label="Education Degree" isSortable=true)
+          (hash key="occupation" label="Occupation" isSortable=true)
         }}
       >
         <:body as |B|>

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -147,8 +147,8 @@ Below you can find an example of an integration between the sortable [`Table`](/
   <Hds::Table
     @model={{this.demoPaginatedDataNumbered}}
     @columns={{array
-      (hash key="id" label="ID" isSortable="true")
-      (hash key="name" label="Name" isSortable="true")
+      (hash key="id" label="ID" isSortable=true)
+      (hash key="name" label="Name" isSortable=true)
       (hash key="email" label="Email")
       (hash key="role" label="Role")
     }}

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -477,9 +477,9 @@ The default table layout is `auto` which means the browser will try to optimize 
   <Hds::Table
     @model={{this.modelWithLargeNumberOfColumns}}
     @columns={{array
-      (hash key="first_name" label="First Name" isSortable="true")
-      (hash key="last_name" label="Last Name" isSortable="true")
-      (hash key="age" label="Age" isSortable="true")
+      (hash key="first_name" label="First Name" isSortable=true)
+      (hash key="last_name" label="Last Name" isSortable=true)
+      (hash key="age" label="Age" isSortable=true)
       (hash key="email" label="Email")
       (hash key="phone" label="Phone")
       (hash key="bio" label="Biography" width="350px")
@@ -518,9 +518,9 @@ In this case the table layout is still set to `auto` (default). If instead you w
     <Hds::Table
       @model={{this.modelWithLargeNumberOfColumns}}
       @columns={{array
-        (hash key="first_name" label="First Name" isSortable="true" width="200px")
-        (hash key="last_name" label="Last Name" isSortable="true" width="200px")
-        (hash key="age" label="Age" isSortable="true")
+        (hash key="first_name" label="First Name" isSortable=true width="200px")
+        (hash key="last_name" label="Last Name" isSortable=true width="200px")
+        (hash key="age" label="Age" isSortable=true)
         (hash key="email" label="Email")
         (hash key="phone" label="Phone")
         (hash key="bio" label="Biography" width="350px")


### PR DESCRIPTION
### :pushpin: Summary

Small maintenance ticket to replace all the instances of `isSortable="true”` with `isSortable=true` in the hashed `@columns` argument of tables (technically more correct: `isSortable="false”` is still `true`).

### :hammer_and_wrench: Detailed description

In this PR I have:

- replaced all the hashed ` isSortable="true”` with ` isSortable=true` (both in the documentation snippets as well as in the showcase)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
