### PR TITLE
allow for specific icons to be loaded in isolation

### DIFF
--- a/website/app/components/doc/icons-list/item.hbs
+++ b/website/app/components/doc/icons-list/item.hbs
@@ -18,5 +18,16 @@
     <Doc::MetaRow @label="Ember" @valueToCopy={{@meta.iconName}} @copyable={{true}} />
     <Doc::MetaRow @label="React" @valueToCopy={{@meta.name}} @copyable={{true}} />
     <Doc::MetaRow @label="Keywords" @valueToShow={{@meta.description}} />
+    {{#let (concat "icon:" @meta.iconName) as |searchQueryValue|}}
+      <LinkTo
+        class="doc-icons-list-grid-item__permalink"
+        @route="show"
+        @model="icons/library"
+        @query={{hash searchQuery=searchQueryValue selectedIconSize=@meta.size}}
+        aria-label="Permalink for the {{@meta.iconName}} icon"
+      >
+        <FlightIcon class="doc-icons-list-grid-item__permalink-icon" @name="link" />
+      </LinkTo>
+    {{/let}}
   </div>
 </li>

--- a/website/app/styles/doc-components/icons-list/index.scss
+++ b/website/app/styles/doc-components/icons-list/index.scss
@@ -78,6 +78,7 @@
 
   @include breakpoint.medium () {
     flex-direction: row;
+    align-items: flex-start;
   }
 }
 
@@ -85,14 +86,19 @@
   display: flex;
   flex: none;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   width: 100%;
-  height: 120px;
+  height: 60px;
+  padding-left: 16px;
   border-bottom: 1px solid var(--doc-color-gray-500);
 
   @include breakpoint.medium () {
-    width: 120px;
+    align-items: flex-start;
+    justify-content: center;
+    width: 60px;
     height: 100%;
+    padding-top: 24px;
+    padding-left: 0;
     border-right: 1px solid var(--doc-color-gray-500);
     border-bottom: none;
   }
@@ -103,10 +109,39 @@
 }
 
 .doc-icons-list-grid-item__meta {
+  position: relative;
   width: 100%;
-  padding: 16px;
+  min-width: 0;
+  padding: 8px 16px;
 }
 
+.doc-icons-list-grid-item__permalink {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  color: var(--doc-color-gray-300);
+
+  &:hover {
+    color: var(--doc-color-gray-100);
+  }
+
+  &:active {
+    color: var(--doc-color-feedback-information-100);
+  }
+}
+
+.doc-icons-list-grid-item__permalink-icon {
+  visibility: hidden;
+
+  .doc-icons-list-grid-item:hover & {
+    visibility: visible;
+  }
+}
 
 // not found
 

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -34,11 +34,24 @@ export default class Index extends Component {
 
   get filteredIcons() {
     if (this.searchQuery) {
-      return this.allIcons.filter(
-        (i) =>
-          i.size === this.selectedIconSize &&
-          i.searchable.indexOf(this.searchQuery) !== -1
-      );
+      // check if the query is for an exact match (prefixed with `icon:`)
+      if (this.searchQuery.match(/^icon:/)) {
+        const exactIconName = this.searchQuery
+          .replace(/^icon:/, '')
+          .replace(/(-16|-24)$/, '');
+        const icon = this.allIcons.find((i) => {
+          return (
+            i.iconName === exactIconName && i.size === this.selectedIconSize
+          );
+        });
+        return icon ? [icon] : [];
+      } else {
+        return this.allIcons.filter(
+          (i) =>
+            i.size === this.selectedIconSize &&
+            i.searchable.indexOf(this.searchQuery) !== -1
+        );
+      }
     } else {
       return this.allIcons.filter((i) => i.size === this.selectedIconSize);
     }

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -5,7 +5,6 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 
@@ -16,12 +15,6 @@ const DEBOUNCE_MS = 250;
 export default class Index extends Component {
   @service router;
 
-  // query params come from `controllers/show.js` and we access them here because there
-  // is no "controller" for individual component documentation routes
-  @tracked selectedIconSize =
-    this.router.currentRoute.queryParams['selectedIconSize'] || '24';
-  @tracked searchQuery = this.router.currentRoute.queryParams['searchQuery'];
-
   allIcons = catalog.assets.map(({ iconName, fileName, size, description }) => {
     return {
       iconName: `${iconName}`,
@@ -31,6 +24,14 @@ export default class Index extends Component {
       searchable: `${iconName}, ${description}`,
     };
   });
+
+  get searchQuery() {
+    return this.router.currentRoute.queryParams['searchQuery'];
+  }
+
+  get selectedIconSize() {
+    return this.router.currentRoute.queryParams['selectedIconSize'] || '24';
+  }
 
   get filteredIcons() {
     if (this.searchQuery) {
@@ -57,30 +58,24 @@ export default class Index extends Component {
     }
   }
 
-  updateQueryParams() {
-    const newQueryParams = { queryParams: {} };
-    if (this.searchQuery) {
-      newQueryParams.queryParams.searchQuery = this.searchQuery;
-    } else {
-      newQueryParams.queryParams.searchQuery = null;
-    }
-
-    if (this.selectedIconSize) {
-      newQueryParams.queryParams.selectedIconSize = this.selectedIconSize;
-    }
-    this.router.transitionTo(newQueryParams);
-  }
-
   @action
   selectIconSize(event) {
-    this.selectedIconSize = event.target.value;
-    this.updateQueryParams();
+    this.router.transitionTo({
+      queryParams: {
+        searchQuery: this.searchQuery,
+        selectedIconSize: event.target.value,
+      },
+    });
   }
 
   @restartableTask *searchIcons(searchQuery) {
     yield timeout(DEBOUNCE_MS);
 
-    this.searchQuery = searchQuery;
-    this.updateQueryParams();
+    this.router.transitionTo({
+      queryParams: {
+        searchQuery: searchQuery !== '' ? searchQuery : null,
+        selectedIconSize: this.selectedIconSize,
+      },
+    });
   }
 }

--- a/website/tests/acceptance/icon-test.js
+++ b/website/tests/acceptance/icon-test.js
@@ -31,6 +31,23 @@ module('Acceptance | Icon Search', function (hooks) {
     );
 
     assert.dom('.doc-icons-list-grid-item').exists({ count: 1 });
+    assert.dom('.flight-icon-cpu').exists({ count: 1 });
+    assert.dom('.doc-copy-button__visible-value ').hasText('cpu');
+  });
+
+  test('should load a specific icon based on query param', async function (assert) {
+    await visit(
+      '/icons/library?searchQuery=icon%3Ayoutube&selectedIconSize=24'
+    );
+
+    assert.strictEqual(
+      currentURL(),
+      '/icons/library?searchQuery=icon%3Ayoutube&selectedIconSize=24'
+    );
+
+    assert.dom('.doc-icons-list-grid-item').exists({ count: 1 });
+    assert.dom('.flight-icon-youtube').exists({ count: 1 });
+    assert.dom('.doc-copy-button__visible-value ').hasText('youtube');
   });
 
   test('should clear search results if input is cleared', async function (assert) {
@@ -45,6 +62,13 @@ module('Acceptance | Icon Search', function (hooks) {
 
   test('should show message when no results are found', async function (assert) {
     await visit('/icons/library?searchQuery=wubalubadubdub');
+
+    assert.dom('.doc-icons-list-grid__not-found').exists();
+    assert.dom('[data-test-icon="activity"]').doesNotExist();
+  });
+
+  test('should show message when no results are found for a specific icon', async function (assert) {
+    await visit('/icons/library?searchQuery=icon%3awubalubadubdub');
 
     assert.dom('.doc-icons-list-grid__not-found').exists();
     assert.dom('[data-test-icon="activity"]').doesNotExist();


### PR DESCRIPTION
### :pushpin: Summary

Adds the ability for us (and consumers) to link to a specific icon in the icon library. This has a specific use case for our upcoming search feature.

https://hds-website-git-br-select-icon-hashicorp.vercel.app/

### :hammer_and_wrench: Detailed description

- [x] Add anchor link
- [x] Decide if we want to use new param or existing param
- [x] Add tests


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1708](https://hashicorp.atlassian.net/browse/HDS-1708)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1708]: https://hashicorp.atlassian.net/browse/HDS-1708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ