### PR TITLE
`Token preview` - Standalone component

### DIFF
--- a/website/app/components/doc/token-preview/index.hbs
+++ b/website/app/components/doc/token-preview/index.hbs
@@ -11,9 +11,9 @@
 {{else if this.fontPreviewStyle}}
   <div class="doc-token-preview doc-token-preview--font" style={{this.fontPreviewStyle}}>Aa</div>
 {{else if this.sizePreviewStyle}}
-  <div class="doc-token-preview doc-token-preview--size" style={{this.sizePreviewStyle}}><span
-      class="doc-token-preview__value"
-    >{{this.token.value}}</span></div>
+  <div class="doc-token-preview doc-token-preview--size" style={{this.sizePreviewStyle}}>
+    <span class="doc-token-preview__value">{{this.token.value}}</span>
+  </div>
 {{else if this.boxShadowPreviewStyle}}
   <div class="doc-token-preview doc-token-preview--boxshadow" style={{this.boxShadowPreviewStyle}}></div>
 {{else}}

--- a/website/app/components/doc/token-preview/index.hbs
+++ b/website/app/components/doc/token-preview/index.hbs
@@ -1,0 +1,22 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{! template-lint-disable no-inline-styles }}
+{{#if this.colorPreviewStyle}}
+  <div class="doc-token-preview doc-token-preview--color" style={{this.colorPreviewStyle}}></div>
+{{else if this.backgroundImagePreviewStyle}}
+  <div class="doc-token-preview doc-token-preview--image" style={{this.backgroundImagePreviewStyle}}></div>
+{{else if this.fontPreviewStyle}}
+  <div class="doc-token-preview doc-token-preview--font" style={{this.fontPreviewStyle}}>Aa</div>
+{{else if this.sizePreviewStyle}}
+  <div class="doc-token-preview doc-token-preview--size" style={{this.sizePreviewStyle}}><span
+      class="doc-token-preview__value"
+    >{{this.token.value}}</span></div>
+{{else if this.boxShadowPreviewStyle}}
+  <div class="doc-token-preview doc-token-preview--boxshadow" style={{this.boxShadowPreviewStyle}}></div>
+{{else}}
+  <div class="doc-token-preview doc-token-preview--unknown"></div>
+{{/if}}
+{{! template-lint-enable no-inline-styles }}

--- a/website/app/components/doc/token-preview/index.js
+++ b/website/app/components/doc/token-preview/index.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { htmlSafe } from '@ember/template';
+
+export default class DocTokenPreviewComponent extends Component {
+  get token() {
+    let { token } = this.args;
+    return {
+      name: token.name,
+      type: token.type,
+      value: token.value,
+    };
+  }
+
+  get colorPreviewStyle() {
+    const isColor =
+      this.token.value.startsWith('#') || this.token.value.startsWith('rgb');
+    return isColor
+      ? htmlSafe(`background-color: ${this.token.value}`)
+      : undefined;
+  }
+
+  get backgroundImagePreviewStyle() {
+    const isBackgroundImage = this.token.value.match(/url\("data:image\//);
+    let backgroundColor;
+    if (this.token.value.match(/fill='%23f{3,6}'/i)) {
+      backgroundColor = 'rgb(0 0 0 / 15%)';
+    } else {
+      backgroundColor = 'transparent';
+    }
+    return isBackgroundImage
+      ? htmlSafe(
+          `background-image: ${this.token.value}; background-color: ${backgroundColor}`
+        )
+      : undefined;
+  }
+
+  get fontPreviewStyle() {
+    if (this.token.type === 'font-size') {
+      let size = '16px';
+      if (this.token.value.match(/rem$/)) {
+        size = `${Math.min(1, this.token.value.replace(/rem$/, ''))}rem`;
+      }
+      return htmlSafe(`font-size: ${size}`);
+    } else if (
+      this.token.name.startsWith('token-typography') &&
+      (this.token.name.includes('font-stack') ||
+        this.token.name.includes('font-family'))
+    ) {
+      return htmlSafe(`font-family: ${this.token.value}`);
+    } else if (this.token.name.startsWith('token-typography-font-weight')) {
+      return htmlSafe(`font-weight: ${this.token.value}`);
+    } else {
+      return undefined;
+    }
+  }
+
+  get sizePreviewStyle() {
+    const isSize =
+      this.token.type === 'size' && this.token.value.endsWith('px');
+    return isSize
+      ? htmlSafe(`--token-value-height: ${this.token.value}`)
+      : undefined;
+  }
+
+  get boxShadowPreviewStyle() {
+    const isBoxShadow = this.token.name.endsWith('box-shadow');
+    return isBoxShadow
+      ? htmlSafe(`--token-value-box-shadow: ${this.token.value}`)
+      : undefined;
+  }
+}

--- a/website/app/components/doc/tokens-list/item.hbs
+++ b/website/app/components/doc/tokens-list/item.hbs
@@ -4,23 +4,8 @@
 }}
 
 <li class="doc-tokens-list__item">
-  <div class="doc-tokens-list__preview {{this.token.previewClass}}">
-    {{! template-lint-disable no-inline-styles }}
-    {{#if this.colorPreviewStyle}}
-      <span class="doc-tokens-list__preview-color" style={{this.colorPreviewStyle}}></span>
-    {{else if this.backgroundImagePreviewStyle}}
-      <span class="doc-tokens-list__preview-image" style={{this.backgroundImagePreviewStyle}}></span>
-    {{else if this.fontPreviewStyle}}
-      <span class="doc-tokens-list__preview-font" style={{this.fontSizePreviewStyle}}>Aa</span>
-    {{else if this.sizePreviewStyle}}
-      <span class="doc-tokens-list__preview-size" style={{this.sizePreviewStyle}}></span>
-    {{else if this.boxShadowPreviewStyle}}
-      <span class="doc-tokens-list__preview-boxshadow" style={{this.boxShadowPreviewStyle}}></span>
-    {{else}}
-      <span class="doc-tokens-list__preview-unknown"></span>
-    {{/if}}
-    {{this.token.previewText}}
-    {{! template-lint-enable no-inline-styles }}
+  <div class="doc-tokens-list__preview">
+    <Doc::TokenPreview @token={{this.token}} />
   </div>
   <div class="doc-tokens-list__content">
     <button

--- a/website/app/components/doc/tokens-list/item.js
+++ b/website/app/components/doc/tokens-list/item.js
@@ -6,9 +6,8 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { htmlSafe } from '@ember/template';
 
-export default class DocTokenCardIndexComponent extends Component {
+export default class DocTokensListComponent extends Component {
   @tracked isExpanded = false;
 
   get token() {
@@ -34,58 +33,6 @@ export default class DocTokenCardIndexComponent extends Component {
 
   get isDeprecated() {
     return this.token.deprecated;
-  }
-
-  get colorPreviewStyle() {
-    const isColor =
-      this.token.value.startsWith('#') || this.token.value.startsWith('rgb');
-    return isColor
-      ? htmlSafe(`background-color: ${this.token.value}`)
-      : undefined;
-  }
-
-  get backgroundImagePreviewStyle() {
-    const isBackgroundImage = this.token.value.match(/url\("data:image\//);
-    let backgroundColor;
-    if (this.token.value.match(/fill='%23f{3,6}'/i)) {
-      backgroundColor = 'rgb(0 0 0 / 15%)';
-    } else {
-      backgroundColor = 'transparent';
-    }
-    return isBackgroundImage
-      ? htmlSafe(
-          `background-image: ${this.token.value}; background-color: ${backgroundColor}`
-        )
-      : undefined;
-  }
-
-  get fontPreviewStyle() {
-    if (this.token.type === 'font-size') {
-      return htmlSafe(`font-size: ${this.token.value}`);
-    } else if (
-      this.token.name.startsWith('token-typography') &&
-      (this.token.name.includes('font-stack') ||
-        this.token.name.includes('font-family'))
-    ) {
-      return htmlSafe(`font-family: ${this.token.value}`);
-    } else if (this.token.name.startsWith('token-typography-font-weight')) {
-      return htmlSafe(`font-weight: ${this.token.value}`);
-    } else {
-      return undefined;
-    }
-  }
-
-  get sizePreviewStyle() {
-    const isSize =
-      this.token.type === 'size' && this.token.value.endsWith('px');
-    return isSize ? htmlSafe(`height: ${this.token.value}`) : undefined;
-  }
-
-  get boxShadowPreviewStyle() {
-    const isBoxShadow = this.token.name.endsWith('box-shadow');
-    return isBoxShadow
-      ? htmlSafe(`box-shadow: ${this.token.value}`)
-      : undefined;
   }
 
   @action

--- a/website/app/styles/doc-components/index.scss
+++ b/website/app/styles/doc-components/index.scss
@@ -20,5 +20,6 @@
 @import "meta-row";
 @import "placeholder";
 @import "table-of-contents";
+@import "token-preview";
 @import "tokens-list";
 @import "vars-list";

--- a/website/app/styles/doc-components/meta-row.scss
+++ b/website/app/styles/doc-components/meta-row.scss
@@ -28,21 +28,17 @@
 
 .doc-meta-row__value-not-copyable {
   @include doc-font-style-code();
-  display: inline-block;
-  padding-top: 2px; // optical alignment with the copyable one
+  display: block;
+  padding-top: 4px; // optical alignment with the copyable one
   padding-left: 8px;
   color: var(--doc-color-black);
   word-break: break-word;
 
   &.doc-meta-row__value-not-copyable--is-clipped {
-    position: relative;
-    display: block;
-    /* stylelint-disable-next-line value-no-vendor-prefix */
-    display: -webkit-box;
     max-width: 100%;
     overflow: hidden;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 }
 

--- a/website/app/styles/doc-components/token-preview.scss
+++ b/website/app/styles/doc-components/token-preview.scss
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// TOKEN PREVIEW
+
+@use "../typography/mixins" as *;
+
+.doc-token-preview {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 2px;
+}
+
+.doc-token-preview--color {
+  box-shadow: inset 0 0 1px 0 rgb(0, 0, 0, 25%);
+}
+
+.doc-token-preview--image {
+  background-repeat: no-repeat;
+  background-position: center center;
+  box-shadow: inset 0 0 1px 0 rgb(0, 0, 0, 25%);
+
+  &::before {
+    position: absolute;
+    z-index: -1;
+    overflow: hidden;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 2'%3E%3Cpath d='M1 2V0h1v1H0v1z' fill-opacity='.05'/%3E%3C/svg%3E");
+    background-size: cover;
+    // use this to fine tune the size of the checkered pattern
+    background-size: 8px 8px;
+    border-radius: inherit;
+    content: "";
+    inset: 0;
+  }
+}
+
+.doc-token-preview--font {
+  color: var(--doc-color-black);
+}
+
+.doc-token-preview--size {
+  --color: #ff9a8b;
+  --height: var(--token-value-height); // this is set via JavaScript
+
+  .doc-token-preview__value {
+    @include doc-font-family("mono");
+    position: absolute;
+    top: calc(50% - 4px);
+    left: 10px;
+    color: var(--color);
+    font-size: 8px;
+    line-height: 8px;
+  }
+
+  &::before {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 7px;
+    height: var(--height);
+    max-height: 24px;
+    border-top: 1px solid var(--color);
+    border-bottom: 1px solid var(--color);
+    transform: translateY(-50%);
+    content: "";
+  }
+
+  &::after {
+    position: absolute;
+    top: 50%;
+    left: 3px;
+    height: var(--height);
+    max-height: 24px;
+    border-left: 1px solid var(--color);
+    transform: translateY(-50%);
+    content: "";
+  }
+}
+
+.doc-token-preview--boxshadow {
+  --box-shadow: var(--token-value-box-shadow); // this is set via JavaScript
+  box-shadow: var(--box-shadow);
+}
+
+.doc-token-preview--unknown {
+  &::after {
+    position: absolute;
+    top: calc(50% - 16px);
+    left: 50%;
+    width: 1px;
+    height: 32px;
+    background-color: #999;
+    transform: rotate(45deg);
+    transform-origin: center center;
+    content: "";
+  }
+}

--- a/website/app/styles/doc-components/tokens-list.scss
+++ b/website/app/styles/doc-components/tokens-list.scss
@@ -35,10 +35,9 @@
 
 .doc-tokens-list__preview {
   display: flex;
-  align-items: center;
-  align-self: stretch;
+  align-items: flex-start;
   justify-content: flex-start;
-  padding: 16px;
+  padding: 36px 16px 16px 16px; // the vertical padding is to optically align to the center the token preview when the panel is collapsed
   border: 1px solid var(--doc-color-gray-500);
   border-radius: 3px 3px 0 0;
 

--- a/website/app/styles/doc-components/tokens-list.scss
+++ b/website/app/styles/doc-components/tokens-list.scss
@@ -5,8 +5,7 @@
 
 // TOKENS LIST
 
-@use "../../typography/mixins" as *;
-@use "../../breakpoints" as breakpoint;
+@use "../breakpoints" as breakpoint;
 
 
 .doc-tokens-list {
@@ -47,79 +46,6 @@
     justify-content: center;
     border-radius: 3px 0 0 3px;
   }
-}
-
-.doc-tokens-list__preview-color {
-  width: 24px;
-  height: 24px;
-  border-radius: 2px;
-  box-shadow: inset 0 0 1px 0 rgb(0, 0, 0, 25%);
-}
-
-.doc-tokens-list__preview-image {
-  position: relative;
-  width: 24px;
-  height: 24px;
-  background-repeat: no-repeat;
-  background-position: center center;
-  border-radius: 2px;
-  box-shadow: inset 0 0 1px 0 rgb(0, 0, 0, 25%);
-
-  &::before {
-    position: absolute;
-    z-index: -1;
-    overflow: hidden;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 2'%3E%3Cpath d='M1 2V0h1v1H0v1z' fill-opacity='.05'/%3E%3C/svg%3E");
-    background-size: cover;
-    // use this to fine tune the size of the checkered pattern
-    background-size: 8px 8px;
-    border-radius: inherit;
-    content: "";
-    inset: 0;
-  }
-}
-
-.doc-tokens-list__preview-font {
-  color: var(--doc-color-black);
-}
-
-.doc-tokens-list__preview-size {
-  --border-color: #ff9a8b;
-  position: relative;
-  display: block;
-  width: 1px;
-  border-left: 1px solid var(--border-color);
-
-  &::before {
-    position: absolute;
-    top: 0;
-    right: -6px;
-    left: -6px;
-    border-top: 1px solid var(--border-color);
-    content: "";
-  }
-
-  &::after {
-    position: absolute;
-    right: -6px;
-    bottom: 0;
-    left: -6px;
-    border-bottom: 1px solid var(--border-color);
-    content: "";
-  }
-}
-
-.doc-tokens-list__preview-boxshadow {
-  width: 24px;
-  height: 24px;
-  border-radius: 2px;
-}
-
-.doc-tokens-list__preview-unknown {
-  position: relative;
-  width: 24px;
-  height: 24px;
-  background: linear-gradient(-45deg, #fff 0%, #fff 48%, #000 50%, #fff 48%, #fff 100%);
 }
 
 // CONTENT


### PR DESCRIPTION
### :pushpin: Summary

These changes have been extracted/cherry-picked from https://github.com/hashicorp/design-system/pull/1789. At the beginning I thought I could reuse the `Doc::TokenPreview` component in the search result, but later I've realized it's not possible for how Algolia Autocomplete works. Since this standalone component may come handy in the future, I've decided to create a PR anyway, so we have it in the codebase anyway.

### :hammer_and_wrench: Detailed description

In this PR I have:
- refactored `Doc::TokensList` component to expose `Doc::TokenPreview` as standalone reusable component

In the process, I have also
- introduced a limit to the dimensions of the preview element, so that it's always `24px` even in case of "size" tokens with larger values
- fixed the jumping of the content when the “Token” panel is open/closed

 👉 👉 👉 **Preview**: https://hds-website-git-token-preview-standalone-component-hashicorp.vercel.app/foundations/tokens

![tokens-preview](https://github.com/hashicorp/design-system/assets/686239/f7878a27-2798-4262-b8aa-3e4a138a7e37)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
