### PR TITLE
Website - A11y testing / Share Axe config

### DIFF
--- a/website/blueprints/hds-component-docs/files/tests/acceptance/components/__name__.js
+++ b/website/blueprints/hds-component-docs/files/tests/acceptance/components/__name__.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/<%= dasherizedModuleName %>', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | components/<%= dasherizedModuleName %>', function (hooks) {
   test('Components/<%= dasherizedModuleName %> page passes automated a11y checks', async function (assert) {
     await visit('/components/<%= dasherizedModuleName %>');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/a11y-helper.js
+++ b/website/tests/a11y-helper.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export const globalAxeOptions = {
+  rules: {
+    'color-contrast': { enabled: false },
+    list: { enabled: false },
+  },
+  include: [['#ember-testing-container']],
+  exclude: [
+    // see: https://github.com/algolia/autocomplete/issues/963#issuecomment-1127507049
+    ['.aa-Autocomplete'],
+  ],
+};

--- a/website/tests/acceptance/about-test.js
+++ b/website/tests/acceptance/about-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | about', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | about', function (hooks) {
   test('about page passes automated a11y checks', async function (assert) {
     await visit('/about');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/about/accessibility-statement-test.js
+++ b/website/tests/acceptance/about/accessibility-statement-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | about/accessibility statement', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | about/accessibility statement', function (hooks) {
   test('about/accessibility-statement page passes automated a11y checks', async function (assert) {
     await visit('/about/accessibility-statement');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/about/contribution-test.js
+++ b/website/tests/acceptance/about/contribution-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | about/contribution', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | about/contribution', function (hooks) {
   test('about/contribution page passes automated a11y checks', async function (assert) {
     await visit('/about/contribution');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/about/overview-test.js
+++ b/website/tests/acceptance/about/overview-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | about/overview', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | about/overview', function (hooks) {
   test('about/overview page passes automated a11y checks', async function (assert) {
     await visit('/about/overview');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/about/principles-test.js
+++ b/website/tests/acceptance/about/principles-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | about/principles', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | about/principles', function (hooks) {
   test('about/principles page passes automated a11y checks', async function (assert) {
     await visit('/about/principles');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/about/support-test.js
+++ b/website/tests/acceptance/about/support-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | about/support', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | about/support', function (hooks) {
   test('about/support page passes automated a11y checks', async function (assert) {
     await visit('/about/support');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components-test.js
+++ b/website/tests/acceptance/components-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components', function (hooks) {
   test('components page passes automated a11y checks', async function (assert) {
     await visit('/components');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/accordion-test.js
+++ b/website/tests/acceptance/components/accordion-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/accordion', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/accordion', function (hooks) {
   test('Components/accordion page passes automated a11y checks', async function (assert) {
     await visit('/components/accordion');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/alert-test.js
+++ b/website/tests/acceptance/components/alert-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/alert', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | components/alert', function (hooks) {
   test('Components/alert page passes automated a11y checks', async function (assert) {
     await visit('/components/alert');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/app-footer-test.js
+++ b/website/tests/acceptance/components/app-footer-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/app-footer', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/app-footer', function (hooks) {
   test('Components/app-footer page passes a11y automated checks', async function (assert) {
     await visit('/components/app-footer');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/application-state-test.js
+++ b/website/tests/acceptance/components/application-state-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/application-state', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/application-state', function (hooks) {
   test('Components/application-state page passes automated a11y checks', async function (assert) {
     await visit('/components/application-state');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/badge-count-test.js
+++ b/website/tests/acceptance/components/badge-count-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/badge count', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | components/badge count', function (hooks) {
   test('Components/badge-count page passes automated a11y checks', async function (assert) {
     await visit('/components/badge-count');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/badge-test.js
+++ b/website/tests/acceptance/components/badge-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/badge', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | components/badge', function (hooks) {
   test('Components/badge page passes automated a11y checks', async function (assert) {
     await visit('/components/badge');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/breadcrumb-test.js
+++ b/website/tests/acceptance/components/breadcrumb-test.js
@@ -7,6 +7,7 @@ import { module, test, skip } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/breadcrumb', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/breadcrumb', function (hooks) {
 
   skip('components/breadcrumb page passes automated a11y checks', async function (assert) {
     await visit('/components/breadcrumb');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/button-set-test.js
+++ b/website/tests/acceptance/components/button-set-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/button set', function (hooks) {
   setupApplicationTest(hooks);
@@ -18,7 +19,7 @@ module('Acceptance | components/button set', function (hooks) {
   });
   test('components/button-set page passes automated a11y checks', async function (assert) {
     await visit('/components/button-set');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/button-test.js
+++ b/website/tests/acceptance/components/button-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/button', function (hooks) {
   setupApplicationTest(hooks);
@@ -18,7 +19,7 @@ module('Acceptance | components/button', function (hooks) {
   });
   test('components/button page passes automated a11y checks', async function (assert) {
     await visit('/components/button');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/card-test.js
+++ b/website/tests/acceptance/components/card-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/card', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/card', function (hooks) {
 
   test('components/card page passes automated a11y checks', async function (assert) {
     await visit('/components/card');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/code-block.js
+++ b/website/tests/acceptance/components/code-block.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/code-block', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | components/code-block', function (hooks) {
   test('Components/code-block page passes automated a11y checks', async function (assert) {
     await visit('/components/code-block');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/copy/button-test.js
+++ b/website/tests/acceptance/components/copy/button-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/copy/button', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/copy/button', function (hooks) {
   test('Components/copy/button page passes automated a11y checks', async function (assert) {
     await visit('/components/copy/button');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/copy/snippet-test.js
+++ b/website/tests/acceptance/components/copy/snippet-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/copy/snippet', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/copy/snippet', function (hooks) {
   test('Components/copy/snippet page passes automated a11y checks', async function (assert) {
     await visit('/components/copy/snippet');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/dropdown-test.js
+++ b/website/tests/acceptance/components/dropdown-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/dropdown', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/dropdown', function (hooks) {
 
   test('components/dropdown page passes automated a11y checks', async function (assert) {
     await visit('/components/dropdown');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/flyout-test.js
+++ b/website/tests/acceptance/components/flyout-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/flyout', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/flyout', function (hooks) {
   test('Components/flyout page passes automated a11y checks', async function (assert) {
     await visit('/components/flyout');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/form/checkbox-test.js
+++ b/website/tests/acceptance/components/form/checkbox-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/form/checkbox', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/form/checkbox', function (hooks) {
 
   test('components/form/checkbox page passes automated a11y checks', async function (assert) {
     await visit('/components/form/checkbox');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/form/primitives-test.js
+++ b/website/tests/acceptance/components/form/primitives-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/form/primitives', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/form/primitives', function (hooks) {
 
   test('components/form/primitives page passes automated a11y checks', async function (assert) {
     await visit('/components/form/primitives');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/form/radio-card-test.js
+++ b/website/tests/acceptance/components/form/radio-card-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/form/radio card', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/form/radio card', function (hooks) {
 
   test('components/form/radio-card page passes automated a11y checks', async function (assert) {
     await visit('/components/form/radio-card');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/form/radio-test.js
+++ b/website/tests/acceptance/components/form/radio-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/form/radio', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/form/radio', function (hooks) {
 
   test('components/form/radio passes a11y automated checks', async function (assert) {
     await visit('/components/form/radio');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/form/select-test.js
+++ b/website/tests/acceptance/components/form/select-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/form/select', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/form/select', function (hooks) {
 
   test('components/form/select passes a11y automated checks', async function (assert) {
     await visit('/components/form/select');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/form/text-input-test.js
+++ b/website/tests/acceptance/components/form/text-input-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/form/text input', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/form/text input', function (hooks) {
 
   test('components/form/text-input passes a11y automated checks', async function (assert) {
     await visit('/components/form/text-input');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/form/textarea-test.js
+++ b/website/tests/acceptance/components/form/textarea-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/form/textarea', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/form/textarea', function (hooks) {
 
   test('components/form/textarea passes a11y automated checks', async function (assert) {
     await visit('/components/form/textarea');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/form/toggle-test.js
+++ b/website/tests/acceptance/components/form/toggle-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/form/toggle', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/form/toggle', function (hooks) {
 
   test('components/form/toggle passes a11y automated checks', async function (assert) {
     await visit('/components/form/toggle');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/icon-tile-test.js
+++ b/website/tests/acceptance/components/icon-tile-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/icon tile', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/icon tile', function (hooks) {
 
   test('components/icon-tile passes a11y automated checks', async function (assert) {
     await visit('/components/icon-tile');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/link/inline-test.js
+++ b/website/tests/acceptance/components/link/inline-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/link/inline', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/link/inline', function (hooks) {
 
   test('components/link/inline passes a11y automated checks', async function (assert) {
     await visit('/components/link/inline');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/link/standalone-test.js
+++ b/website/tests/acceptance/components/link/standalone-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/link/standalone', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/link/standalone', function (hooks) {
 
   test('components/link/standalone passes a11y automated checks', async function (assert) {
     await visit('/components/link/standalone');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/modal-test.js
+++ b/website/tests/acceptance/components/modal-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/modal', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/modal', function (hooks) {
 
   test('components/modal passes a11y automated checks', async function (assert) {
     await visit('/components/modal');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/page-header-test.js
+++ b/website/tests/acceptance/components/page-header-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/page-header', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/page-header', function (hooks) {
   test('Components/page-header page passes automated a11y checks', async function (assert) {
     await visit('/components/page-header');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/pagination-test.js
+++ b/website/tests/acceptance/components/pagination-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/pagination', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/pagination', function (hooks) {
   test('Components/pagination page passes automated a11y checks', async function (assert) {
     await visit('/components/pagination');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/reveal-test.js
+++ b/website/tests/acceptance/components/reveal-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/reveal', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/reveal', function (hooks) {
   test('Components/reveal page passes automated a11y checks', async function (assert) {
     await visit('/components/reveal');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/segmented-group-test.js
+++ b/website/tests/acceptance/components/segmented-group-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | index', function (hooks) {
   test('Components/segmented-group page passes automated a11y checks', async function (assert) {
     await visit('/components/segmented-group');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/separator-test.js
+++ b/website/tests/acceptance/components/separator-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/separator', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/separator', function (hooks) {
   test('Components/separator page passes automated a11y checks', async function (assert) {
     await visit('/components/separator');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/side-nav-test.js
+++ b/website/tests/acceptance/components/side-nav-test.js
@@ -7,6 +7,9 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
+
+import { merge } from 'lodash';
 
 module('Acceptance | components/side-nav', function (hooks) {
   setupApplicationTest(hooks);
@@ -17,12 +20,13 @@ module('Acceptance | components/side-nav', function (hooks) {
     assert.strictEqual(currentURL(), '/components/side-nav');
   });
   test('Components/side-nav page passes automated a11y checks', async function (assert) {
-    let axeOptions = {
+    let axeOptions = merge(globalAxeOptions, {
       rules: {
         'duplicate-id-aria': { enabled: false },
         'duplicate-id-active': { enabled: false },
       },
-    };
+    });
+
     await visit('/components/side-nav');
 
     await a11yAudit(axeOptions);

--- a/website/tests/acceptance/components/stepper-test.js
+++ b/website/tests/acceptance/components/stepper-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/stepper', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/stepper', function (hooks) {
 
   test('components/stepper passes a11y automated checks', async function (assert) {
     await visit('/components/stepper');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/table-test.js
+++ b/website/tests/acceptance/components/table-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/table', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/table', function (hooks) {
 
   test('components/table passes a11y automated checks', async function (assert) {
     await visit('/components/table');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/tabs-test.js
+++ b/website/tests/acceptance/components/tabs-test.js
@@ -7,6 +7,7 @@ import { module, test, skip } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/tabs', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/tabs', function (hooks) {
 
   skip('components/tabs passes a11y automated checks', async function (assert) {
     await visit('/components/tabs');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/tag-test.js
+++ b/website/tests/acceptance/components/tag-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/tag', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/tag', function (hooks) {
 
   test('components/tag passes a11y automated checks', async function (assert) {
     await visit('/components/tag');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/text-test.js
+++ b/website/tests/acceptance/components/text-test.js
@@ -7,6 +7,9 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
+
+import { merge } from 'lodash';
 
 module('Acceptance | components/text', function (hooks) {
   setupApplicationTest(hooks);
@@ -17,13 +20,15 @@ module('Acceptance | components/text', function (hooks) {
     assert.strictEqual(currentURL(), '/components/text');
   });
   test('Components/text page passes automated a11y checks', async function (assert) {
-    let axeOptions = {
+    let axeOptions = merge(globalAxeOptions, {
       rules: {
         'heading-order': {
           enabled: false,
         },
       },
-    };
+    });
+
+    console.log(axeOptions);
 
     await visit('/components/text');
 

--- a/website/tests/acceptance/components/toast-test.js
+++ b/website/tests/acceptance/components/toast-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/toast', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/toast', function (hooks) {
 
   test('components/toast passes a11y automated checks', async function (assert) {
     await visit('/components/toast');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/components/tooltip-test.js
+++ b/website/tests/acceptance/components/tooltip-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | components/tooltip', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | components/tooltip', function (hooks) {
   test('Components/tooltip page passes automated a11y checks', async function (assert) {
     await visit('/components/tooltip');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/error-test.js
+++ b/website/tests/acceptance/error-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | error', function (hooks) {
   setupApplicationTest(hooks);
@@ -26,7 +27,7 @@ module('Acceptance | error', function (hooks) {
   test('error page passes automated a11y checks', async function (assert) {
     await visit('/error');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/foundations-test.js
+++ b/website/tests/acceptance/foundations-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | foundations', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | foundations', function (hooks) {
   test('foundations page passes automated a11y checks', async function (assert) {
     await visit('/foundations');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/foundations/accessibility-test.js
+++ b/website/tests/acceptance/foundations/accessibility-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | foundations/accessibility', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | foundations/accessibility', function (hooks) {
   test('foundations/accessibility page passes automated a11y checks', async function (assert) {
     await visit('/foundations/accessibility');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/foundations/border-test.js
+++ b/website/tests/acceptance/foundations/border-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | foundations/border', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | foundations/border', function (hooks) {
   test('foundations/border page passes automated a11y checks', async function (assert) {
     await visit('/foundations/border');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/foundations/colors-test.js
+++ b/website/tests/acceptance/foundations/colors-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | foundations/colors', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | foundations/colors', function (hooks) {
   test('foundations/colors page passes automated a11y checks', async function (assert) {
     await visit('/foundations/colors');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/foundations/elevation-test.js
+++ b/website/tests/acceptance/foundations/elevation-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | foundations/elevation', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | foundations/elevation', function (hooks) {
   test('foundations/elevation page passes automated a11y checks', async function (assert) {
     await visit('/foundations/elevation');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/foundations/focus-ring-test.js
+++ b/website/tests/acceptance/foundations/focus-ring-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | foundations/focus-ring', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | foundations/focus-ring', function (hooks) {
   test('foundations/focus-ring page passes automated a11y checks', async function (assert) {
     await visit('/foundations/focus-ring');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/foundations/tokens-test.js
+++ b/website/tests/acceptance/foundations/tokens-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | foundations/tokens', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | foundations/tokens', function (hooks) {
   test('foundations/accessibility page passes automated a11y checks', async function (assert) {
     await visit('/foundations/tokens');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/foundations/typography-test.js
+++ b/website/tests/acceptance/foundations/typography-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | foundations/typography', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | foundations/typography', function (hooks) {
   test('foundations/typography page passes automated a11y checks', async function (assert) {
     await visit('/foundations/typography');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/getting-started/for-designers-test.js
+++ b/website/tests/acceptance/getting-started/for-designers-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | getting started/for designers', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | getting started/for designers', function (hooks) {
   test('getting-started/for-designers page passes automated a11y checks', async function (assert) {
     await visit('/getting-started/for-designers');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/getting-started/for-engineers-test.js
+++ b/website/tests/acceptance/getting-started/for-engineers-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | getting started/for engineers', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | getting started/for engineers', function (hooks) {
   test('getting-started/for-engineers page passes automated a11y checks', async function (assert) {
     await visit('/getting-started/for-engineers');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/icons/library-test.js
+++ b/website/tests/acceptance/icons/library-test.js
@@ -7,6 +7,7 @@ import { module, test, skip } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | icons/library', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | icons/library', function (hooks) {
   skip('icons/library page passes automated a11y checks', async function (assert) {
     await visit('/icons/library');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/icons/usage-guidelines-test.js
+++ b/website/tests/acceptance/icons/usage-guidelines-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | icons/usage guidelines', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | icons/usage guidelines', function (hooks) {
   test('icons/usage-guidelines page passes automated a11y checks', async function (assert) {
     await visit('/icons/usage-guidelines');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/index-test.js
+++ b/website/tests/acceptance/index-test.js
@@ -7,6 +7,9 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
+
+import { merge } from 'lodash';
 
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
@@ -18,15 +21,16 @@ module('Acceptance | index', function (hooks) {
   });
 
   test('Homepage (index) passes a11y automated checks', async function (assert) {
-    let axeOptions = {
+    let axeOptions = merge(globalAxeOptions, {
       rules: {
         list: {
           enabled: false,
         },
       },
-    };
+    });
 
     await visit('/');
+
     await a11yAudit(axeOptions);
 
     assert.ok(true, 'a11y automation audit passed');

--- a/website/tests/acceptance/overrides/power-select-test.js
+++ b/website/tests/acceptance/overrides/power-select-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | overrides/power select', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | overrides/power select', function (hooks) {
 
   test('overrides/power-select passes a11y automated checks', async function (assert) {
     await visit('/overrides/power-select');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/patterns-test.js
+++ b/website/tests/acceptance/patterns-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | patterns', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | patterns', function (hooks) {
   test('patterns page passes automated a11y checks', async function (assert) {
     await visit('/patterns');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/utilities/dismiss-button-test.js
+++ b/website/tests/acceptance/utilities/dismiss-button-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | utilities/dismiss button', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | utilities/dismiss button', function (hooks) {
 
   test('utilities/dismiss-button passes a11y automated checks', async function (assert) {
     await visit('/utilities/dismiss-button');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/utilities/interactive-test.js
+++ b/website/tests/acceptance/utilities/interactive-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | utilities/interactive', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | utilities/interactive', function (hooks) {
 
   test('utilities/interactive passes a11y automated checks', async function (assert) {
     await visit('/utilities/interactive');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/utilities/menu-primitive-test.js
+++ b/website/tests/acceptance/utilities/menu-primitive-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | utilities/menu-primitive', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,7 +20,7 @@ module('Acceptance | utilities/menu-primitive', function (hooks) {
 
   test('utilities/menu-primitive passes a11y automated checks', async function (assert) {
     await visit('/utilities/menu-primitive');
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });

--- a/website/tests/acceptance/whats-new/release-notes-test.js
+++ b/website/tests/acceptance/whats-new/release-notes-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 module('Acceptance | whats-new/release-notes', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +21,7 @@ module('Acceptance | whats-new/release-notes', function (hooks) {
   test('whats-new/release-notes page passes automated a11y checks', async function (assert) {
     await visit('/whats-new/release-notes');
 
-    await a11yAudit();
+    await a11yAudit(globalAxeOptions);
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/test-helper.js
+++ b/website/tests/test-helper.js
@@ -10,15 +10,11 @@ import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
+import { globalAxeOptions } from 'website/tests/a11y-helper';
 
 setApplication(Application.create(config.APP));
 
-setRunOptions({
-  rules: {
-    'color-contrast': { enabled: false },
-    list: { enabled: false },
-  },
-});
+setRunOptions(globalAxeOptions);
 
 setup(QUnit.assert);
 


### PR DESCRIPTION
### :pushpin: Summary

In https://github.com/hashicorp/design-system/pull/1789 all the acceptance tests for the website pages  were failing because of an invalid/missing aria attribute on the injected (by Algolia Autocomplete) `.aa-Autocomplete` node:

<img width="1791" alt="screenshot_3289" src="https://github.com/hashicorp/design-system/assets/686239/aeb36fef-2c45-4c57-b4cc-f83efff38bc9">

After a discussion with @alex-ju we have come to the decision that the pragmatic solution is to introduce an `exclude` parameter for the website acceptance tests, so we can exclude that particular DOM node from the tests. To do that, we have to pass that extra argument to every `a11yAudit(...)` call in the tests, it's not possible to do it via the `setRunOptions()` method (apparently works only for the rules).

### :hammer_and_wrench: Detailed description

In this PR we have:
- created a shared a global Axe config
- used the shared config in all the `a11yAudit(...)` calls (only for the website)
- updated the blueprint for acceptance test for website pages

***

### 👀 Component checklist

- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
