### PR TITLE
Website - Rename doc search to filter

### DIFF
--- a/website/app/components/doc/form/filter.hbs
+++ b/website/app/components/doc/form/filter.hbs
@@ -3,14 +3,14 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<div class="doc-form-search">
+<div class="doc-form-filter">
   {{#let (unique-id) as |searchId|}}
     <Doc::Form::Label @for={{searchId}} @label={{@label}} />
     <input
       type="search"
       name="search"
       id={{searchId}}
-      class="doc-form-search__control"
+      class="doc-form-filter__control"
       placeholder={{@placeholder}}
       value={{@searchQuery}}
       {{on "input" (perform @onInput value="target.value")}}

--- a/website/app/components/doc/icons-list/index.hbs
+++ b/website/app/components/doc/icons-list/index.hbs
@@ -8,7 +8,7 @@
     <Doc::Form::Select @label="Size" @onSelect={{@onSelect}} @selectedValue={{@selectedIconSize}} />
   </div>
   <div class="doc-icons-list-filter__search">
-    <Doc::Form::Search
+    <Doc::Form::Filter
       @label="Filter"
       @placeholder="Type a name or keyword (e.g. arrow)"
       @searchQuery={{@searchQuery}}

--- a/website/app/components/doc/tokens-list/index.hbs
+++ b/website/app/components/doc/tokens-list/index.hbs
@@ -4,7 +4,7 @@
 }}
 
 <div class="doc-tokens-list-filter">
-  <Doc::Form::Search
+  <Doc::Form::Filter
     @label="Filter"
     @placeholder="Type a name or keyword (e.g. red)"
     @searchQuery={{@searchQuery}}

--- a/website/app/styles/doc-components/form/filter.scss
+++ b/website/app/styles/doc-components/form/filter.scss
@@ -8,14 +8,14 @@
 @use "../../typography/mixins" as *;
 
 
-.doc-form-search__control {
+.doc-form-filter__control {
   @include doc-font-style-body();
   width: 100%;
   height: 44px;
   padding-left: 48px;
   color: var(--doc-color-gray-200);
   background-color: var(--doc-color-white);
-  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='%23727374'%3e%3cpath d='M7.25 2a5.25 5.25 0 103.144 9.455l2.326 2.325a.75.75 0 101.06-1.06l-2.325-2.326A5.25 5.25 0 007.25 2zM3.5 7.25a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z' fill-rule='evenodd' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e"); // notice: the icon color is hardcoded here!
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cg fill='%23727374'%3E%3Cpath d='M1 3.75A.75.75 0 011.75 3h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 3.75zM3.5 7.75A.75.75 0 014.25 7h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM6.75 11a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5z'/%3E%3C/g%3E%3C/svg%3E"); // notice: the icon color is hardcoded here!
   background-repeat: no-repeat;
   background-position: left 16px top 11px; // we have to take into account the border
   background-size: 20px 20px;

--- a/website/app/styles/doc-components/form/index.scss
+++ b/website/app/styles/doc-components/form/index.scss
@@ -6,6 +6,6 @@
 // FORM
 
 @import "./label";
-@import "./search";
+@import "./filter";
 @import "./select";
 


### PR DESCRIPTION
## ✅ **Ready to be merged** once https://github.com/hashicorp/design-system/pull/1789 + https://github.com/hashicorp/design-system/pull/1818 have been merged too.

### :pushpin: Summary

Following https://github.com/hashicorp/design-system/pull/1818 I have decided to rename the `Doc::Form::Search` component, used for the filtering of [tokens](https://helios.hashicorp.design/foundations/tokens) and [icons](https://helios.hashicorp.design/icons/library), to `Doc::Form::Filter` (more correct, now that we will have soon a proper "search" feature, to avoid confusion).

Once the work that @Dhaulagiri is doing in https://github.com/hashicorp/design-system/pull/1821 is merged, I'll open a second PR to change the query parameters from `searchQuery` to `filterQuery` (in case in the future we want to persist the full-text search query in the URL).

### :hammer_and_wrench: Detailed description

In this PR I have:
- replaced “search” with “filter” in component used in the filtering of tokens and icons

Preview: 
- tokens: https://hds-website-git-website-search-rename-doc-sear-7cf5a9-hashicorp.vercel.app/foundations/tokens
- icons: https://hds-website-git-website-search-rename-doc-sear-7cf5a9-hashicorp.vercel.app/icons/library

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
