### PR TITLE
Remove double entry in the `Wcag` list in the `AppFooter` page

### DIFF
--- a/website/docs/components/app-footer/partials/accessibility/accessibility.md
+++ b/website/docs/components/app-footer/partials/accessibility/accessibility.md
@@ -8,7 +8,7 @@ When used as recommended, there should not be any WCAG conformance issues with t
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "2.1.1" "2.1.2" "2.4.3" "2.4.7" "2.4.7" "3.2.3" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "2.1.1" "2.1.2" "2.4.3" "2.4.7" "3.2.3" "4.1.2" }} />
 
 ---
 


### PR DESCRIPTION
### :pushpin: Summary

Removed double entry in the `Wcag` list in the `AppFooter` page (was causing two records having the same `objectID` in the indexing script)