### PR TITLE
Website - Add `VERCEL_DEV` environment variable to the `ember-cli-build.js` file to conditionally fingerprint the "illustrations" assets

### DIFF
--- a/website/ember-cli-build.js
+++ b/website/ember-cli-build.js
@@ -7,6 +7,8 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
+const isVercelProduction = process.env.VERCEL_ENV === 'production';
+
 const appConfig = {
   // Add options here
   sassOptions: {

--- a/website/ember-cli-build.js
+++ b/website/ember-cli-build.js
@@ -27,6 +27,8 @@ const appConfig = {
   fingerprint: {
     // override defaults to also include json files which our markdown is compiled to. without this images don't render properly.
     replaceExtensions: ['html', 'css', 'js', 'json'],
+    // in the algolia index we want to store the fingerprinted illustrations' paths only in "production"
+    exclude: isVercelProduction ? [] : ['assets/illustrations/**'],
   },
   'ember-prism': {
     components: [

--- a/website/ember-cli-build.js
+++ b/website/ember-cli-build.js
@@ -7,43 +7,45 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
+const appConfig = {
+  // Add options here
+  sassOptions: {
+    precision: 4,
+    includePaths: [
+      '../node_modules/@hashicorp/design-system-tokens/dist/products/css',
+    ],
+  },
+  // we need to add this or Ember Sass compilation will mess up the generated CSS
+  minifyCSS: {
+    options: {
+      advanced: false,
+    },
+  },
+  // https://cli.emberjs.com/release/advanced-use/asset-compilation/#fingerprintingandcdnurls
+  fingerprint: {
+    // override defaults to also include json files which our markdown is compiled to. without this images don't render properly.
+    replaceExtensions: ['html', 'css', 'js', 'json'],
+  },
+  'ember-prism': {
+    components: [
+      'bash',
+      'css',
+      'handlebars',
+      'javascript',
+      'markup-templating',
+      'scss',
+    ],
+    theme: 'dracula',
+    plugins: ['line-numbers', 'normalize-whitespace'],
+  },
+  // https://github.com/shipshapecode/prember-sitemap-generator#usage
+  prember: {
+    baseRoot: 'https://helios.hashicorp.design/',
+  },
+};
+
 module.exports = function (defaults) {
-  let app = new EmberApp(defaults, {
-    // Add options here
-    sassOptions: {
-      precision: 4,
-      includePaths: [
-        '../node_modules/@hashicorp/design-system-tokens/dist/products/css',
-      ],
-    },
-    // we need to add this or Ember Sass compilation will mess up the generated CSS
-    minifyCSS: {
-      options: {
-        advanced: false,
-      },
-    },
-    // https://cli.emberjs.com/release/advanced-use/asset-compilation/#fingerprintingandcdnurls
-    fingerprint: {
-      // override defaults to also include json files which our markdown is compiled to. without this images don't render properly.
-      replaceExtensions: ['html', 'css', 'js', 'json'],
-    },
-    'ember-prism': {
-      components: [
-        'bash',
-        'css',
-        'handlebars',
-        'javascript',
-        'markup-templating',
-        'scss',
-      ],
-      theme: 'dracula',
-      plugins: ['line-numbers', 'normalize-whitespace'],
-    },
-    // https://github.com/shipshapecode/prember-sitemap-generator#usage
-    prember: {
-      baseRoot: 'https://helios.hashicorp.design/',
-    },
-  });
+  let app = new EmberApp(defaults, appConfig);
 
   // Use `app.import` to add additional libraries to the generated
   // output files.


### PR DESCRIPTION
### :pushpin: Summary

I have extracted this logic from https://github.com/hashicorp/design-system/pull/1789 so 1) it can be reviewed independently and 2) I was able to make sure the `VERCEL_DEV` environment variable is correctly read in the build process (with the previous implementation, it wasn't).

### :hammer_and_wrench: Detailed description

In this PR I have:
- extracted the `new EmberApp` config object in a standalone variable
- introduced a `isVercelProduction` variable (based on `process.env.VERCEL_ENV` [Vercel environment variable](https://vercel.com/docs/projects/environment-variables/system-environment-variables))
- used the `isVercelProduction` to conditionally skip the fingerprinting of the “illustrations” assets

### :link: External links

Jira ticket: part of the epic https://hashicorp.atlassian.net/browse/HDS-2862

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
