### PR TITLE
Website - Remove leftover “dummy” class names

### DIFF
--- a/packages/components/tests/dummy/app/styles/_globals.scss
+++ b/packages/components/tests/dummy/app/styles/_globals.scss
@@ -168,13 +168,6 @@ body {
   }
 }
 
-.dummy-code {
-  padding: 0 3px;
-  font-family: courier, monospace;
-  background-color: #eee;
-  border-radius: 3px;
-}
-
 // Percy (percySnapshot) doesn't allow to target specific DOM elements, so we have to "blacklist" the elements
 // that we want to exclude from the snapshots using their own "Percy-specific CSS".
 // see: https://docs.percy.io/docs/percy-specific-css#section-hiding-regions-with-percy-specific-css

--- a/website/docs/components/avatar/partials/guidelines/guidelines.md
+++ b/website/docs/components/avatar/partials/guidelines/guidelines.md
@@ -1,14 +1,14 @@
 <section data-section="design-guidelines">
-  
-  <p class="dummy-paragraph">Design guidelines will be available at a future date.</p>
+
+  <p>Design guidelines will be available at a future date.</p>
   {{! UNCOMMENT THIS BLOCK (once the link and/or the image are available) }}
   {{!
-  <div class="dummy-design-guidelines">
-    <p class="dummy-paragraph">
+  <div>
+    <p>
       <a href="[ADD THE LINK TO THE FIGMA FILE/PAGE HERE!]" target="_blank" rel="noopener noreferrer">Figma UI Kit</a>
     </p>
     <br />
-    <img class="dummy-figma-docs" src="/assets/images/avatar-design-usage.png" alt="" role="none" />
+    <img src="/assets/images/avatar-design-usage.png" alt="" role="none" />
   </div>
   }}
 </section>

--- a/website/docs/components/empty-state/partials/specifications/design-guidelines.md
+++ b/website/docs/components/empty-state/partials/specifications/design-guidelines.md
@@ -1,6 +1,6 @@
 <section data-section="design-guidelines">
-  
-  <div class="dummy-design-guidelines">
-    <p class="dummy-paragraph">To be released at a future date.</p>
+
+  <div>
+    <p>To be released at a future date.</p>
   </div>
 </section>

--- a/website/docs/foundations/colors/partials/other/palette.md
+++ b/website/docs/foundations/colors/partials/other/palette.md
@@ -4,78 +4,66 @@
 
 Use for text and icons.
 
-<div class="dummy-colors-list">
-  {{#each this.colors.semantic.foreground as |color|}}
-    <Doc::ColorSwatch @color={{color}} />
-  {{else}}
-    <p class="dummy-paragraph">No tokens found for "semantic/foreground" colors 🤷‍♀️</p>
-  {{/each}}
-</div>
+{{#each this.colors.semantic.foreground as |color|}}
+  <Doc::ColorSwatch @color={{color}} />
+{{else}}
+  <p>No tokens found for "semantic/foreground" colors 🤷‍♀️</p>
+{{/each}}
 
 ### Surface
 
 Use for container and component backgrounds.
 
-<div class="dummy-colors-list">
-  {{#each this.colors.semantic.surface as |color|}}
-    <Doc::ColorSwatch @color={{color}} />
-  {{else}}
-    <p class="dummy-paragraph">No tokens found for "semantic/surface" colors 🤷‍♀️</p>
-  {{/each}}
-</div>
+{{#each this.colors.semantic.surface as |color|}}
+  <Doc::ColorSwatch @color={{color}} />
+{{else}}
+  <p>No tokens found for "semantic/surface" colors 🤷‍♀️</p>
+{{/each}}
 
 ### Border
 
 Use for container and component borders. Neutral values can also be used for horizontal rules.
 
-<div class="dummy-colors-list">
-  {{#each this.colors.semantic.border as |color|}}
-    <Doc::ColorSwatch @color={{color}} />
-  {{else}}
-    <p class="dummy-paragraph">No tokens found for “semantic/border” colors.</p>
-  {{/each}}
-</div>
+{{#each this.colors.semantic.border as |color|}}
+  <Doc::ColorSwatch @color={{color}} />
+{{else}}
+  <p>No tokens found for “semantic/border” colors.</p>
+{{/each}}
 
 ### Focus
 
-Use to indicate an element is in a focused state. Use critical values for critical actions only and action values for everything else. 
+Use to indicate an element is in a focused state. Use critical values for critical actions only and action values for everything else.
 
 !!! Info
 
 These are primarily used internally by the Design Systems Team to define focus states.
 !!!
 
-<div class="dummy-colors-list">
-  {{#each this.colors.semantic.focus as |color|}}
-    <Doc::ColorSwatch @color={{color}} />
-  {{else}}
-    <p class="dummy-paragraph">No tokens found for “semantic/focus” colors.</p>
-  {{/each}}
-</div>
+{{#each this.colors.semantic.focus as |color|}}
+  <Doc::ColorSwatch @color={{color}} />
+{{else}}
+  <p>No tokens found for “semantic/focus” colors.</p>
+{{/each}}
 
 ### Page
 
 Use for page backgrounds.
 
-<div class="dummy-colors-list">
-  {{#each this.colors.semantic.page as |color|}}
-    <Doc::ColorSwatch @color={{color}} />
-  {{else}}
-    <p class="dummy-paragraph">No tokens found for “semantic/page” colors.</p>
-  {{/each}}
-</div>
+{{#each this.colors.semantic.page as |color|}}
+  <Doc::ColorSwatch @color={{color}} />
+{{else}}
+  <p>No tokens found for “semantic/page” colors.</p>
+{{/each}}
 
 ## Brand colors
 
 {{#each-in this.colors.branding as |brand colorsList|}}
-    <h3>{{capitalize brand}}</h3>
-    <div class="dummy-colors-list">
-      {{#each colorsList as |color|}}
-        <Doc::ColorSwatch @color={{color}} />
-      {{/each}}
-    </div>
+  <h3>{{capitalize brand}}</h3>
+  {{#each colorsList as |color|}}
+    <Doc::ColorSwatch @color={{color}} />
+  {{/each}}
 {{else}}
-    <p class="dummy-paragraph">No tokens found for “branding” colors.</p>
+  <p>No tokens found for “branding” colors.</p>
 {{/each-in}}
 
 ## Core palette
@@ -83,12 +71,10 @@ Use for page backgrounds.
 Core palette colors should be used sparingly and only when the correct semantic mapping isn’t available for the use case.
 
 {{#each-in this.colors.palette as |tone colorsList|}}
-    <h3>{{capitalize tone}}</h3>
-    <div class="dummy-colors-list">
-      {{#each colorsList as |color|}}
-        <Doc::ColorSwatch @color={{color}} />
-      {{/each}}
-    </div>
+  <h3>{{capitalize tone}}</h3>
+  {{#each colorsList as |color|}}
+    <Doc::ColorSwatch @color={{color}} />
+  {{/each}}
 {{else}}
-    <p class="dummy-paragraph">No tokens found for “palette” colors.</p>
+  <p>No tokens found for “palette” colors.</p>
 {{/each-in}}


### PR DESCRIPTION
### :pushpin: Summary

While working on the website indexing/search, I noticed there are some legacy `dummy-` class names left in the code (from the previous "scrappy" website).

This small PR cleans up these leftovers.

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
