### PR TITLE
Remove Axe global rules for `color-contrast` and `list`

### DIFF
--- a/website/tests/a11y-helper.js
+++ b/website/tests/a11y-helper.js
@@ -4,10 +4,6 @@
  */
 
 export const globalAxeOptions = {
-  rules: {
-    'color-contrast': { enabled: false },
-    list: { enabled: false },
-  },
   include: [['#ember-testing-container']],
   exclude: [
     // see: https://github.com/algolia/autocomplete/issues/963#issuecomment-1127507049

--- a/website/tests/acceptance/components/dropdown-test.js
+++ b/website/tests/acceptance/components/dropdown-test.js
@@ -9,6 +9,8 @@ import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { globalAxeOptions } from 'website/tests/a11y-helper';
 
+import { merge } from 'lodash';
+
 module('Acceptance | components/dropdown', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -19,8 +21,16 @@ module('Acceptance | components/dropdown', function (hooks) {
   });
 
   test('components/dropdown page passes automated a11y checks', async function (assert) {
+    let axeOptions = merge(globalAxeOptions, {
+      rules: {
+        list: {
+          enabled: false,
+        },
+      },
+    });
+
     await visit('/components/dropdown');
-    await a11yAudit(globalAxeOptions);
+    await a11yAudit(axeOptions);
     assert.ok(true, 'a11y automation audit passed');
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

Per @MelSumner request here: https://github.com/hashicorp/design-system/pull/1823/files#r1406379782

### :hammer_and_wrench: Detailed description

In this PR I have 
- removed Axe global rules for `color-contrast` and `list`
