### PR TITLE
 `CodeBlock`: Add Ruby language support (HDS-2926)

### DIFF
--- a/.changeset/friendly-hounds-jog.md
+++ b/.changeset/friendly-hounds-jog.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`CodeBlock` - Added language support for Ruby syntax

--- a/packages/components/addon/components/hds/code-block/index.js
+++ b/packages/components/addon/components/hds/code-block/index.js
@@ -20,9 +20,9 @@ import 'prismjs/components/prism-go';
 import 'prismjs/components/prism-hcl';
 import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-log';
+import 'prismjs/components/prism-ruby';
 import 'prismjs/components/prism-shell-session';
 import 'prismjs/components/prism-yaml';
-import 'prismjs/components/prism-ruby';
 
 // These imports are required to overcome a global variable clash in Helios website
 // where language import are overriden by the Prism instance in `CodeBlock`

--- a/packages/components/addon/components/hds/code-block/index.js
+++ b/packages/components/addon/components/hds/code-block/index.js
@@ -22,6 +22,7 @@ import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-log';
 import 'prismjs/components/prism-shell-session';
 import 'prismjs/components/prism-yaml';
+import 'prismjs/components/prism-ruby';
 
 // These imports are required to overcome a global variable clash in Helios website
 // where language import are overriden by the Prism instance in `CodeBlock`

--- a/packages/components/tests/dummy/app/templates/components/code-block.hbs
+++ b/packages/components/tests/dummy/app/templates/components/code-block.hbs
@@ -443,6 +443,15 @@ result:
       />
     </SG.Item>
 
+    <SG.Item @label="Ruby" @forceMinWidth={{true}}>
+      <Hds::CodeBlock
+        @language="ruby"
+        @value='Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/noble64"
+end'
+      />
+    </SG.Item>
+
     <SG.Item @label="Invalid language (foo)" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
       <Hds::CodeBlock

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -6,7 +6,7 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
   <C.Property @name="value" @type="string">
     The text/code content for the `CodeBlock`. The component encodes this argument before displaying it.
   </C.Property>
-  <C.Property @name="language" @type="string" @values={{array "bash" "go" "hcl" "json" "log" "shell-session" "yaml"}}>
+  <C.Property @name="language" @type="string" @values={{array "bash" "go" "hcl" "json" "log" "ruby" "shell-session" "yaml"}}>
     The coding language to use for syntax highlighting. If you need additional languages <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>.
   </C.Property>
   <C.Property @name="isStandalone" @type="boolean" @default="true">

--- a/website/docs/components/code-block/partials/code/how-to-use.md
+++ b/website/docs/components/code-block/partials/code/how-to-use.md
@@ -30,7 +30,7 @@ as |CB|>
 
 ### Language
 
-The `language` argument sets the syntax highlighting used. We only support the following languages: `bash`, `go`, `hcl`, `json`, `log`, `shell-session`, and `yaml`. If you need additional languages <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>
+The `language` argument sets the syntax highlighting used. We only support the following languages: `bash`, `go`, `hcl`, `json`, `log`, `ruby`, `shell-session`, and `yaml`. If you need additional languages <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>
 
 ```handlebars
 <Hds::CodeBlock


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR will add Ruby language support to the `CodeBlock` component.

* Showcase: https://hds-showcase-git-hds-2926-add-codeblock-ruby-support-hashicorp.vercel.app/components/code-block
* Website: https://hds-website-git-hds-2926-add-codeblock-ruby-support-hashicorp.vercel.app/components/code-block?tab=code

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
Jira ticket: [2926](https://hashicorp.atlassian.net/browse/2926)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
