### PR TITLE
Website - Include the token value as searchable field

### DIFF
--- a/website/docs/foundations/tokens/index.js
+++ b/website/docs/foundations/tokens/index.js
@@ -50,7 +50,9 @@ export default class Index extends Component {
     if (this.searchQuery) {
       Object.keys(this.groupedTokens).forEach((category) => {
         const filteredTokens = this.groupedTokens[category].filter(
-          (t) => t.name.indexOf(this.searchQuery) !== -1
+          (t) =>
+            t.name.indexOf(this.searchQuery) !== -1 ||
+            t.value.indexOf(this.searchQuery) !== -1
         );
         filteredGroupedTokens[category] =
           filteredTokens.length > 0 ? filteredTokens : false;


### PR DESCRIPTION
### :pushpin: Summary

Currently if a consumer uses a token value in the [tokens' library "filter"](https://helios.hashicorp.design/foundations/tokens)  the filter doesn't return any result, because we're only comparing the token `name` value. There may be cases in which a consumer is looking for the token associated with a specific value.

### :hammer_and_wrench: Detailed description

In this PR I have
- updated the filter logic so that the match criteria checks also the token `value`.

### :camera_flash: Screenshots

<img width="1356" alt="screenshot_3302" src="https://github.com/hashicorp/design-system/assets/686239/328dc24b-2c3a-413c-8195-09bc672e9e1a">

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
