### PR TITLE
Website search - Use Ember router to avoid page reload

### DIFF
--- a/website/app/components/doc/page/header/algolia-search/index.js
+++ b/website/app/components/doc/page/header/algolia-search/index.js
@@ -26,19 +26,20 @@ export default class DocAlgoliaSearchComponent extends Component {
   didInsertSearchContainer(element) {
     // define the function to execute to transition to a search result `itemUrl` value
     const emberRouterTransitionTo = (itemUrl) => {
-      itemUrl = itemUrl.replace(/#.*/, '');
-      const parts = itemUrl.split('?');
-      const model = parts[0].replace(/^\//, '');
-      const queryParams = {};
-      if (parts[1]) {
-        parts[1].split('&').forEach((keyvalue) => {
-          const [key, value] = decodeURIComponent(keyvalue).split('=');
-          if (key && value) {
-            queryParams[key] = value;
-          }
-        });
-      }
-      this.router.transitionTo('show', model, { queryParams });
+      // TODO leaving it here for some time until we test more thoroughly that simply using the URL works in every condition
+      // itemUrl = itemUrl.replace(/#.*/, '');
+      // const parts = itemUrl.split('?');
+      // const model = parts[0].replace(/^\//, '');
+      // const queryParams = {};
+      // if (parts[1]) {
+      //   parts[1].split('&').forEach((keyvalue) => {
+      //     const [key, value] = decodeURIComponent(keyvalue).split('=');
+      //     if (key && value) {
+      //       queryParams[key] = value;
+      //     }
+      //   });
+      // }
+      this.router.transitionTo(itemUrl);
     };
 
     const autocompleteInstance = autocomplete({


### PR DESCRIPTION
### :pushpin: Summary

This is built on top of https://github.com/hashicorp/design-system/pull/1789, and introduces changes to how "click" and "enter" events are handled for the search results items.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the logic to handle search results links using Ember router
  - when the user clicks on a link, using a global event listener we prevent the default event and use a custom function to transition the route in Ember by providing the `route` (always `show`, since all the content indexed is for `show` pages), the model (extracted from the URL-path) and the optional query parameters (the `tab` essentially, also extracted from the URL-path)
      - Notice: in this case we lose the anchor (`#...`) information, but unfortunately this is something that is not possible to achieve with the current Ember router implementation
  - when the user "activates" an item using the up/down arrow keys, we use the `navigate` function to invoke the custom function to transition the route (same as above)

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2878

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
