### PR TITLE
Remove `.aa-Autocomplete` from the Axe global “exclude” configuration

### DIFF
--- a/website/tests/a11y-helper.js
+++ b/website/tests/a11y-helper.js
@@ -5,8 +5,6 @@
 
 export const globalAxeOptions = {
   include: [['#ember-testing-container']],
-  exclude: [
-    // see: https://github.com/algolia/autocomplete/issues/963#issuecomment-1127507049
-    ['.aa-Autocomplete'],
-  ],
+  // add global exclude rules here, if needed
+  // exclude: [['.your-selector-here']],
 };


### PR DESCRIPTION
### :pushpin: Summary

Context: https://github.com/hashicorp/design-system/pull/1789#discussion_r1410697806

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed `.aa-Autocomplete` from the Axe global “exclude” configuration

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
