### PR TITLE
Remove white space control syntax from copyright heading

### DIFF
--- a/packages/codemods/transforms/v3/dropdown/__testfixtures__/basic.input.hbs
+++ b/packages/codemods/transforms/v3/dropdown/__testfixtures__/basic.input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <Hds::Dropdown @listPosition="left" as |dd|>
   <dd.ToggleButton @text="Menu left" />

--- a/packages/codemods/transforms/v3/dropdown/__testfixtures__/basic.output.hbs
+++ b/packages/codemods/transforms/v3/dropdown/__testfixtures__/basic.output.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <Hds::Dropdown @listPosition="bottom-left" as |dd|>
   <dd.ToggleButton @text="Menu left" />

--- a/packages/codemods/transforms/v3/masked-input/__testfixtures__/basic.input.hbs
+++ b/packages/codemods/transforms/v3/masked-input/__testfixtures__/basic.input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <Hds::Form::MaskedInput::Base @value="Lorem ipsum dolor" @isMasked={{true}} />
 <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" @isMasked={{true}} as |F|>

--- a/packages/codemods/transforms/v3/masked-input/__testfixtures__/basic.output.hbs
+++ b/packages/codemods/transforms/v3/masked-input/__testfixtures__/basic.output.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <Hds::Form::MaskedInput::Base @value="Lorem ipsum dolor" @isContentMasked={{true}} />
 <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" @isContentMasked={{true}} as |F|>

--- a/packages/codemods/transforms/v3/radio-card/__testfixtures__/basic.input.hbs
+++ b/packages/codemods/transforms/v3/radio-card/__testfixtures__/basic.input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <Hds::Form::RadioCard @name="radio-card" @value="value" @layout="fixed" />
 <Hds::Form::RadioCard @name="radio-card" @value="value" @layout="fixed" as |R|>

--- a/packages/codemods/transforms/v3/radio-card/__testfixtures__/basic.output.hbs
+++ b/packages/codemods/transforms/v3/radio-card/__testfixtures__/basic.output.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <Hds::Form::RadioCard @name="radio-card" @value="value" />
 <Hds::Form::RadioCard @name="radio-card" @value="value" as |R|>

--- a/packages/codemods/transforms/v3/side-nav/__testfixtures__/basic.input.hbs
+++ b/packages/codemods/transforms/v3/side-nav/__testfixtures__/basic.input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <Hds::Test::OpenNode @foo="bar">Test</Hds::Test::OpenNode>
 <Hds::Test::SelfClosingNode @foo="bar" />

--- a/packages/codemods/transforms/v3/side-nav/__testfixtures__/basic.output.hbs
+++ b/packages/codemods/transforms/v3/side-nav/__testfixtures__/basic.output.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <Hds::Test::OpenNode @foo="bar">Test</Hds::Test::OpenNode>
 <Hds::Test::SelfClosingNode @foo="bar" />

--- a/website/app/components/doc/related-components/index.hbs
+++ b/website/app/components/doc/related-components/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-~}}
+}}
 
 <hr class="doc-markdown-hr" />
 


### PR DESCRIPTION
### :pushpin: Summary

The whitespace control syntax makes console noise at build time (for the website).
We remove it from these instances to align them with the rest of the code.

A change was introduced in https://github.com/hashicorp/copywrite to prevent this (unfortunately problematic) syntax from making its way into our codebase in future.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
