### PR TITLE
Fix `ThSort` `onclick` example

### DIFF
--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -383,12 +383,12 @@
     <:head as |H|>
       <H.Tr>
         <H.ThSort
-          onClick={{fn this.onClickThSort__demo3 "peer-name" H.setSortBy}}
+          @onClick={{fn this.onClickThSort__demo3 "peer-name" H.setSortBy}}
           @sortOrder={{if (eq "peer-name" H.sortBy) H.sortOrder}}
         >Peer name</H.ThSort>
         <H.Th>Cluster partition</H.Th>
         <H.ThSort
-          onClick={{fn this.onClickThSort__demo3 "status" H.setSortBy}}
+          @onClick={{fn this.onClickThSort__demo3 "status" H.setSortBy}}
           @sortOrder={{if (eq "status" H.sortBy) H.sortOrder}}
         >Status</H.ThSort>
         <H.Th>Imported services</H.Th>
@@ -448,7 +448,7 @@
           name</H.ThSort>
         <H.Th>Cluster partition</H.Th>
         <H.ThSort
-          onClick={{fn H.setSortBy "status"}}
+          @onClick={{fn H.setSortBy "status"}}
           @sortOrder={{if (eq "status" H.sortBy) H.sortOrder}}
         >Status</H.ThSort>
         <H.Th>Imported services</H.Th>

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -288,9 +288,9 @@ _The code has been simplified for clarity._
 <Hds::Table>
   <:head as |H|>
     <H.Tr>
-      <H.ThSort onClick={{fn H.setSortBy "peer-name"}} @sortOrder={{if (eq "peer-name" H.sortBy) H.sortOrder}}>Peer Name</H.ThSort>
-      <H.ThSort onClick={{fn H.setSortBy "status"}} @sortOrder={{if (eq "status" H.sortBy) H.sortOrder}}>Status</H.ThSort>
-      <H.ThSort onClick={{fn H.setSortBy "partition"}} @sortOrder={{if (eq "partition" H.sortBy) H.sortOrder}}>Partition</H.ThSort>
+      <H.ThSort @onClick={{fn H.setSortBy "peer-name"}} @sortOrder={{if (eq "peer-name" H.sortBy) H.sortOrder}}>Peer Name</H.ThSort>
+      <H.ThSort @onClick={{fn H.setSortBy "status"}} @sortOrder={{if (eq "status" H.sortBy) H.sortOrder}}>Status</H.ThSort>
+      <H.ThSort @onClick={{fn H.setSortBy "partition"}} @sortOrder={{if (eq "partition" H.sortBy) H.sortOrder}}>Partition</H.ThSort>
       <H.Th>Description</H.Th>
     </H.Tr>
   </:head>


### PR DESCRIPTION
### :pushpin: Summary

Using `@onClick` instead of `onClick` on `ThSort` sample code and in our showcase (apparently `onClick` works fine for these instances, but it makes sense to stick to our guidance).

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2919](https://hashicorp.atlassian.net/browse/HDS-2919)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2919]: https://hashicorp.atlassian.net/browse/HDS-2919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ