### PR TITLE
`CodeBlock`: update to support dynamic content

### DIFF
--- a/.changeset/purple-carrots-burn.md
+++ b/.changeset/purple-carrots-burn.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`CodeBlock` - Fixed issues with dynamic content, compile warning, and line number alignment

--- a/packages/components/addon/components/hds/code-block/index.hbs
+++ b/packages/components/addon/components/hds/code-block/index.hbs
@@ -9,19 +9,16 @@
     {{~yield (hash Description=(component "hds/code-block/description"))~}}
   </div>
   <div class="hds-code-block__body">
+    {{! content within pre tag is whitespace-sensitive; do not add new lines! }}
     <pre
       class="hds-code-block__code"
       {{style maxHeight=@maxHeight}}
       data-line={{@highlightLines}}
       id={{this.preCodeId}}
       tabindex="0"
-    >
-      {{~! ~}}
-      <code {{did-insert this.setPrismCode}} {{did-update this.setPrismCode this.code @language}}>
+    ><code {{did-insert this.setPrismCode}} {{did-update this.setPrismCode this.code @language}}>
         {{~this.prismCode~}}
-      </code>
-      {{~! ~}}
-    </pre>
+      </code></pre>
 
     {{#if @hasCopyButton}}
       <Hds::CodeBlock::CopyButton @targetToCopy="#{{this.preCodeId}}" aria-describedby={{this.preCodeId}} />

--- a/packages/components/addon/components/hds/code-block/index.js
+++ b/packages/components/addon/components/hds/code-block/index.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
-import { next } from '@ember/runloop';
+import { next, schedule } from '@ember/runloop';
 import { htmlSafe } from '@ember/template';
 import { guidFor } from '@ember/object/internals';
 
@@ -121,16 +121,16 @@ export default class HdsCodeBlockIndexComponent extends Component {
           code,
           element,
         });
-      });
 
-      // Force prism-line-highlight plugin initialization
-      // Context: https://github.com/hashicorp/design-system/pull/1749#discussion_r1374288785
-      if (this.args.highlightLines) {
-        setTimeout(() => {
-          // we piggy-back on the plugin's `resize` event listener to trigger a new call of the `highlightLines` function: https://github.com/PrismJS/prism/blob/master/plugins/line-highlight/prism-line-highlight.js#L337
-          if (window) window.dispatchEvent(new Event('resize'));
-        }, 100);
-      }
+        // Force prism-line-highlight plugin initialization
+        // Context: https://github.com/hashicorp/design-system/pull/1749#discussion_r1374288785
+        if (this.args.highlightLines) {
+          schedule('afterRender', () => {
+            // we piggy-back on the plugin's `resize` event listener to trigger a new call of the `highlightLines` function: https://github.com/PrismJS/prism/blob/master/plugins/line-highlight/prism-line-highlight.js#L337
+            if (window) window.dispatchEvent(new Event('resize'));
+          });
+        }
+      });
     }
   }
 

--- a/packages/components/addon/components/hds/code-block/index.js
+++ b/packages/components/addon/components/hds/code-block/index.js
@@ -125,6 +125,7 @@ export default class HdsCodeBlockIndexComponent extends Component {
         // Force prism-line-highlight plugin initialization
         // Context: https://github.com/hashicorp/design-system/pull/1749#discussion_r1374288785
         if (this.args.highlightLines) {
+          // we need to delay re-evaluating the context for prism-line-highlight for as much as possible, and `afterRender` is the 'latest' we can use in the component lifecycle
           schedule('afterRender', () => {
             // we piggy-back on the plugin's `resize` event listener to trigger a new call of the `highlightLines` function: https://github.com/PrismJS/prism/blob/master/plugins/line-highlight/prism-line-highlight.js#L337
             if (window) window.dispatchEvent(new Event('resize'));

--- a/packages/components/addon/components/hds/code-block/index.js
+++ b/packages/components/addon/components/hds/code-block/index.js
@@ -107,18 +107,20 @@ export default class HdsCodeBlockIndexComponent extends Component {
     const grammar = Prism.languages[language];
 
     if (code) {
-      if (language && grammar) {
-        this.prismCode = htmlSafe(Prism.highlight(code, grammar, language));
-      } else {
-        this.prismCode = htmlSafe(Prism.util.encode(code));
-      }
+      setTimeout(() => {
+        if (language && grammar) {
+          this.prismCode = htmlSafe(Prism.highlight(code, grammar, language));
+        } else {
+          this.prismCode = htmlSafe(Prism.util.encode(code));
+        }
 
-      // Force prism-line-numbers plugin initialization, required for Prism.highlight usage
-      // See https://github.com/PrismJS/prism/issues/1234
-      Prism.hooks.run('complete', {
-        code,
-        element,
-      });
+        // Force prism-line-numbers plugin initialization, required for Prism.highlight usage
+        // See https://github.com/PrismJS/prism/issues/1234
+        Prism.hooks.run('complete', {
+          code,
+          element,
+        });
+      }, 100);
 
       // Force prism-line-highlight plugin initialization
       // Context: https://github.com/hashicorp/design-system/pull/1749#discussion_r1374288785

--- a/packages/components/addon/components/hds/code-block/index.js
+++ b/packages/components/addon/components/hds/code-block/index.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
+import { next } from '@ember/runloop';
 import { htmlSafe } from '@ember/template';
 import { guidFor } from '@ember/object/internals';
 
@@ -107,7 +108,7 @@ export default class HdsCodeBlockIndexComponent extends Component {
     const grammar = Prism.languages[language];
 
     if (code) {
-      setTimeout(() => {
+      next(() => {
         if (language && grammar) {
           this.prismCode = htmlSafe(Prism.highlight(code, grammar, language));
         } else {
@@ -120,7 +121,23 @@ export default class HdsCodeBlockIndexComponent extends Component {
           code,
           element,
         });
-      }, 100);
+      });
+
+      // NOTE: Testing replacing with "next" above
+      // setTimeout(() => {
+      //   if (language && grammar) {
+      //     this.prismCode = htmlSafe(Prism.highlight(code, grammar, language));
+      //   } else {
+      //     this.prismCode = htmlSafe(Prism.util.encode(code));
+      //   }
+
+      //   // Force prism-line-numbers plugin initialization, required for Prism.highlight usage
+      //   // See https://github.com/PrismJS/prism/issues/1234
+      //   Prism.hooks.run('complete', {
+      //     code,
+      //     element,
+      //   });
+      // }, 100);
 
       // Force prism-line-highlight plugin initialization
       // Context: https://github.com/hashicorp/design-system/pull/1749#discussion_r1374288785

--- a/packages/components/addon/components/hds/code-block/index.js
+++ b/packages/components/addon/components/hds/code-block/index.js
@@ -123,22 +123,6 @@ export default class HdsCodeBlockIndexComponent extends Component {
         });
       });
 
-      // NOTE: Testing replacing with "next" above
-      // setTimeout(() => {
-      //   if (language && grammar) {
-      //     this.prismCode = htmlSafe(Prism.highlight(code, grammar, language));
-      //   } else {
-      //     this.prismCode = htmlSafe(Prism.util.encode(code));
-      //   }
-
-      //   // Force prism-line-numbers plugin initialization, required for Prism.highlight usage
-      //   // See https://github.com/PrismJS/prism/issues/1234
-      //   Prism.hooks.run('complete', {
-      //     code,
-      //     element,
-      //   });
-      // }, 100);
-
       // Force prism-line-highlight plugin initialization
       // Context: https://github.com/hashicorp/design-system/pull/1749#discussion_r1374288785
       if (this.args.highlightLines) {

--- a/packages/components/app/styles/components/code-block/index.scss
+++ b/packages/components/app/styles/components/code-block/index.scss
@@ -131,7 +131,7 @@ $code-block-code-padding: 16px;
   padding: $code-block-code-padding;
   overflow: auto;
   font-size: 0.8125rem;
-  font-family: var(--hds-typography-code-200);
+  font-family: var(--token-typography-code-200-font-family);
   border-radius: inherit;
 
   ::selection {

--- a/packages/components/tests/dummy/app/controllers/components/code-block.js
+++ b/packages/components/tests/dummy/app/controllers/components/code-block.js
@@ -29,6 +29,8 @@ function replaceMockCopyStatus() {
 export default class CodeBlockController extends Controller {
   @service router;
   @tracked isModalActive = false;
+  @tracked declaration = 'let';
+  @tracked input = '';
 
   constructor() {
     super(...arguments);
@@ -43,6 +45,25 @@ export default class CodeBlockController extends Controller {
 
   get textWithNewline() {
     return "let codeLang='JavaScript';\nconsole.log(`I am ${codeLang} code`);";
+  }
+
+  get codeValue() {
+    let value = `${this.declaration} codeLang='JavaScript';`;
+    if (this.input !== '') {
+      value += `\n\nvar ${this.input} = "the input is: ${this.input}"`;
+    }
+    return value;
+  }
+
+  @action
+  updateCodeValue() {
+    this.declaration = ['var', 'const', 'let'][Math.floor(Math.random() * 3)];
+    this.input = ['rand1', 'rand2', 'rand3', ''][Math.floor(Math.random() * 4)];
+  }
+
+  @action
+  updateInput(event) {
+    this.input = event.target.value;
   }
 
   @action

--- a/packages/components/tests/dummy/app/templates/components/code-block.hbs
+++ b/packages/components/tests/dummy/app/templates/components/code-block.hbs
@@ -553,10 +553,12 @@ console.log(`I am ${codeLang} code`);"
           <Hds::CodeBlock
             @language="go"
             @highlightLines="2, 4"
+            @hasLineWrapping={{true}}
             @value="package main
 import 'fmt'
 func main() {
-  fmt.Println('hello world')
+  res = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam'
+  fmt.Println(res)
 }"
           />
         </T.Panel>

--- a/packages/components/tests/dummy/app/templates/components/code-block.hbs
+++ b/packages/components/tests/dummy/app/templates/components/code-block.hbs
@@ -8,38 +8,7 @@
 <Shw::Text::H1>CodeBlock</Shw::Text::H1>
 
 <section data-test-percy>
-  <Shw::Text::H2>TEST: Dynamic content update</Shw::Text::H2>
-
-  <p>
-    <button type="button" {{on "click" this.updateCodeValue}}>
-      Update value
-    </button>
-  </p>
-
-  <p>
-    <label for="input">Change input value</label>
-    <input id="input" type="text" value={{this.input}} {{on "input" this.updateInput}} />
-  </p>
-
-  <Hds::CodeBlock
-    @value={{this.codeValue}}
-    @language="javascript"
-    @hasCopyButton={{true}}
-    @hasLineNumbers={{false}}
-    id="code-block-with-dynamic-content"
-    as |CB|
-  >
-    <CB.Title>
-      Dynamic content
-    </CB.Title>
-  </Hds::CodeBlock>
-
-  <pre>this.input = {{this.input}}</pre>
-  <pre>this.codeValue = {{this.codeValue}}</pre>
-
-  <Shw::Divider />
-
-  {{!-- <Shw::Text::H2>Content</Shw::Text::H2>
+  <Shw::Text::H2>Content</Shw::Text::H2>
 
   <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="one line">
@@ -107,6 +76,39 @@ console.log(`I am ${codeLang} code`);"
       </Hds::CodeBlock>
     </SG.Item>
   </Shw::Grid>
+
+  <Shw::Divider @level="2" />
+
+  <Shw::Text::H2>with dynamic content</Shw::Text::H2>
+
+  <Shw::Text::Body>
+    <button type="button" {{on "click" this.updateCodeValue}}>
+      Update value
+    </button>
+  </Shw::Text::Body>
+
+  <Shw::Text::Body>
+    <label for="input">Change input value:</label>
+    <input id="input" type="text" value={{this.input}} {{on "input" this.updateInput}} />
+  </Shw::Text::Body>
+
+  <Hds::CodeBlock
+    @value={{this.codeValue}}
+    @language="javascript"
+    @hasCopyButton={{true}}
+    @hasLineNumbers={{false}}
+    id="code-block-with-dynamic-content"
+    as |CB|
+  >
+    <CB.Title>
+      Dynamic content
+    </CB.Title>
+  </Hds::CodeBlock>
+
+  <p>
+    <pre>this.input = {{this.input}}</pre>
+    <pre>this.codeValue = {{this.codeValue}}</pre>
+  </p>
 
   <Shw::Divider />
 
@@ -613,6 +615,5 @@ func main() {
         </Hds::Modal>
       {{/if}}
     </SF.Item>
-  </Shw::Flex> --}}
-
+  </Shw::Flex>
 </section>

--- a/packages/components/tests/dummy/app/templates/components/code-block.hbs
+++ b/packages/components/tests/dummy/app/templates/components/code-block.hbs
@@ -8,7 +8,38 @@
 <Shw::Text::H1>CodeBlock</Shw::Text::H1>
 
 <section data-test-percy>
-  <Shw::Text::H2>Content</Shw::Text::H2>
+  <Shw::Text::H2>TEST: Dynamic content update</Shw::Text::H2>
+
+  <p>
+    <button type="button" {{on "click" this.updateCodeValue}}>
+      Update value
+    </button>
+  </p>
+
+  <p>
+    <label for="input">Change input value</label>
+    <input id="input" type="text" value={{this.input}} {{on "input" this.updateInput}} />
+  </p>
+
+  <Hds::CodeBlock
+    @value={{this.codeValue}}
+    @language="javascript"
+    @hasCopyButton={{true}}
+    @hasLineNumbers={{false}}
+    id="code-block-with-dynamic-content"
+    as |CB|
+  >
+    <CB.Title>
+      Dynamic content
+    </CB.Title>
+  </Hds::CodeBlock>
+
+  <pre>this.input = {{this.input}}</pre>
+  <pre>this.codeValue = {{this.codeValue}}</pre>
+
+  <Shw::Divider />
+
+  {{!-- <Shw::Text::H2>Content</Shw::Text::H2>
 
   <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="one line">
@@ -582,6 +613,6 @@ func main() {
         </Hds::Modal>
       {{/if}}
     </SF.Item>
-  </Shw::Flex>
+  </Shw::Flex> --}}
 
 </section>

--- a/packages/components/tests/dummy/app/templates/components/code-block.hbs
+++ b/packages/components/tests/dummy/app/templates/components/code-block.hbs
@@ -47,6 +47,8 @@ console.log(`I am ${codeLang} code`);"
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Divider @level="2" />
+
   <Shw::Text::H3>Title and description</Shw::Text::H3>
 
   <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
@@ -79,7 +81,7 @@ console.log(`I am ${codeLang} code`);"
 
   <Shw::Divider @level="2" />
 
-  <Shw::Text::H2>with dynamic content</Shw::Text::H2>
+  <Shw::Text::H3>Dynamic content</Shw::Text::H3>
 
   <Shw::Text::Body>
     <button type="button" {{on "click" this.updateCodeValue}}>
@@ -104,11 +106,6 @@ console.log(`I am ${codeLang} code`);"
       Dynamic content
     </CB.Title>
   </Hds::CodeBlock>
-
-  <p>
-    <pre>this.input = {{this.input}}</pre>
-    <pre>this.codeValue = {{this.codeValue}}</pre>
-  </p>
 
   <Shw::Divider />
 

--- a/packages/components/tests/integration/components/hds/code-block/index-test.js
+++ b/packages/components/tests/integration/components/hds/code-block/index-test.js
@@ -5,7 +5,12 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
+import {
+  render,
+  settled,
+  resetOnerror,
+  setupOnerror,
+} from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | hds/code-block/index', function (hooks) {
@@ -31,6 +36,23 @@ module('Integration | Component | hds/code-block/index', function (hooks) {
     assert
       .dom('#test-code-block pre code')
       .containsText("console.log('Hello world');");
+  });
+
+  // DYNAMIC CONTENT
+
+  test('it renders the passed in dynamic content', async function (assert) {
+    this.set('value', "console.log('Hello world');");
+    await render(hbs`
+      <Hds::CodeBlock @value={{this.value}} id="test-code-block" />
+    `);
+    assert
+      .dom('#test-code-block pre code')
+      .hasText("console.log('Hello world');");
+    this.set('value', "console.log('Lorem ipsum');");
+    await settled();
+    assert
+      .dom('#test-code-block pre code')
+      .hasText("console.log('Lorem ipsum');");
   });
 
   // CONTEXTUAL COMPONENTS

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -16,7 +16,7 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
     Used to control whether a copy button for copying the code/text content will be displayed.
   </C.Property>
   <C.Property @name="hasLineNumbers" @type="boolean" @default="true">
-    Used to control display of line numbers.
+    Used to control display of line numbers. Note that due to technical limitations, if the `@value` changes dynamically the line numbers will fail to update.
   </C.Property>
   <C.Property @name="hasLineWrapping" @type="boolean" @default="false">
     Used to control line wrapping for lines of code. If `true`, lines of code will wrap to fit the available space. Otherwise, horizontal scrolling is enabled if lines overflow the available space.

--- a/website/docs/components/code-block/partials/code/how-to-use.md
+++ b/website/docs/components/code-block/partials/code/how-to-use.md
@@ -2,7 +2,11 @@
 
 The basic invocation requires a `@value` argument. The component encodes this argument before displaying it.
 
-_Notice: if the `\n` escape sequence is used in the `@value` string in Handlebars, it will **not** be automatically converted to a newline, as it can have unexpected side effects._
+!!! Info
+
+If the `\n` escape sequence is used in the `@value` string in Handlebars, it will not be automatically converted to a newline, as it can have unexpected side effects.
+
+!!!
 
 ```handlebars
 <Hds::CodeBlock
@@ -68,6 +72,12 @@ Line numbers are displayed by default. Set `hasLineNumbers` to `false` to hide t
 console.log(`I am ${codeLang} code`);"
 />
 ```
+
+!!! Info
+
+Due to technical limitations, if the `@value` changes dynamically the line numbers will fail to update.
+
+!!!
 
 ### Line wrapping
 


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR:
 - updates the `CodeBlock` component to enable it to render updated dynamic content
 - addresses an issue where line numbers are misaligned due to [an issue with font declaration](https://github.com/hashicorp/design-system/pull/1853/commits/cc377c8076e6fca1ebbd24435e956a2514518809)
 - suppresses [a build warning](https://hashicorp.atlassian.net/browse/HDS-2860) caused by parsing Ember comments in the component template.

Limitations:
 - dynamic content does not work with `@hasLineNumbers={{true}}`; this comes from a limitation with the [line-numbers Prism plugin](https://prismjs.com/plugins/line-numbers/) where it can only be instantiated/called once.
 - `@hasLineNumbers={{true}}` does not work as expected when used in a `Tabs` tab that is not visible at render time.

**Showcase:** https://hds-showcase-git-test-codeblock-with-dynamic-content-hashicorp.vercel.app/components/code-block

### :camera_flash: Screenshots

Misalignment issue in HCP. The more line there are the more you can see the issue.
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="718" alt="01-hcp-line-before" src="https://github.com/hashicorp/design-system/assets/788096/53b1dcc6-8fe6-4bcb-9d6f-8609878ea871">


</td><td>

<img width="720" alt="02-hcp-line-after" src="https://github.com/hashicorp/design-system/assets/788096/c89b9aeb-8c14-4df3-a377-2d6540a59734">


</td></tr>
</table>


### :link: External links

- Related Jira ticket: [HDS-2827](https://hashicorp.atlassian.net/browse/HDS-2827)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [x] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2827]: https://hashicorp.atlassian.net/browse/HDS-2827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ