### PR TITLE
`Button`: Add isInline argument (HDS-2681)

### DIFF
--- a/.changeset/calm-adults-collect.md
+++ b/.changeset/calm-adults-collect.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Button` - added `@isInline` argument

--- a/packages/components/addon/components/hds/button/index.ts
+++ b/packages/components/addon/components/hds/button/index.ts
@@ -26,6 +26,7 @@ export interface HdsButtonSignature {
     icon?: string;
     iconPosition?: HdsButtonIconPosition;
     isIconOnly?: boolean;
+    isInline?: boolean;
     isFullWidth?: boolean;
   };
   Element: HdsInteractiveSignature['Element'];
@@ -165,9 +166,6 @@ export default class HdsButtonIndexComponent extends Component<HdsButtonSignatur
   get classNames() {
     let classes = ['hds-button'];
 
-    // add a class based on the @size argument
-    classes.push(`hds-button--size-${this.size}`);
-
     // add a class based on the @color argument
     classes.push(`hds-button--color-${this.color}`);
 
@@ -176,10 +174,18 @@ export default class HdsButtonIndexComponent extends Component<HdsButtonSignatur
       classes.push('hds-button--width-full');
     }
 
-    // add a class if it's icon-only
+    // add a class based on isIconOnly argument
     if (this.isIconOnly) {
       classes.push('hds-button--is-icon-only');
     }
+
+    // add a class based on the @isInline argument
+    if (this.args.isInline) {
+      classes.push('hds-button--is-inline');
+    }
+
+    // add a class based on the @size argument
+    classes.push(`hds-button--size-${this.size}`);
 
     return classes.join(' ');
   }

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -73,10 +73,6 @@
   text-align: center;
 }
 
-
-// SIZE
-@include hds-button-size-classes("hds-button");
-
 // COLORS & STATES
 // Note: the order of the pseuo-selectors need to stay the way they are; it doesn't match the Figma file but it's the correct order for browsers to render the styles correctly.
 
@@ -95,6 +91,14 @@
 .hds-button--color-critical {
   @include hds-button-color-critical();
 }
+
+// ISINLINE
+.hds-button--is-inline {
+  display: inline-block;
+}
+
+// SIZE
+@include hds-button-size-classes("hds-button");
 
 
 // SPECIAL

--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -92,13 +92,13 @@
   @include hds-button-color-critical();
 }
 
+// SIZE
+@include hds-button-size-classes("hds-button");
+
 // ISINLINE
 .hds-button--is-inline {
   display: inline-block;
 }
-
-// SIZE
-@include hds-button-size-classes("hds-button");
 
 
 // SPECIAL

--- a/packages/components/tests/dummy/app/styles/showcase-pages/button.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/button.scss
@@ -6,6 +6,13 @@
 // BUTTON
 
 body.components-button {
+  .shw-component-button-display-sample {
+    min-width: 200px;
+    padding: 4px;
+    text-align: right;
+    outline: 1px dashed #d3d3d3;
+  }
+
   .shw-component-button-generated {
     > .hds-button + .hds-button {
       margin-top: 8px;

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -89,14 +89,17 @@
   <Shw::Text::H2>Display</Shw::Text::H2>
 
   <Shw::Flex as |SF|>
-    <SF.Item @label="default, isLine=false">
-      <Hds::Button @text="Lorem ipsum" />
-      <Hds::Button @text="Lorem ipsum" />
+    <SF.Item @label="Block">
+      <div class="shw-component-button-display-sample">
+        <Hds::Button @text="Block" />
+        <Hds::Button @text="Block" />
+      </div>
     </SF.Item>
-
-    <SF.Item @label="isLine=true">
-      <Hds::Button @text="Lorem ipsum" @isInline={{true}} />
-      <Hds::Button @text="Lorem ipsum" @isInline={{true}} />
+    <SF.Item @label="Inline">
+      <div class="shw-component-button-display-sample">
+        <Hds::Button @text="Inline" @isInline={{true}} />
+        <Hds::Button @text="Inline" @isInline={{true}} />
+      </div>
     </SF.Item>
   </Shw::Flex>
 

--- a/packages/components/tests/dummy/app/templates/components/button.hbs
+++ b/packages/components/tests/dummy/app/templates/components/button.hbs
@@ -86,6 +86,20 @@
     {{/each}}
   </Shw::Flex>
 
+  <Shw::Text::H2>Display</Shw::Text::H2>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="default, isLine=false">
+      <Hds::Button @text="Lorem ipsum" />
+      <Hds::Button @text="Lorem ipsum" />
+    </SF.Item>
+
+    <SF.Item @label="isLine=true">
+      <Hds::Button @text="Lorem ipsum" @isInline={{true}} />
+      <Hds::Button @text="Lorem ipsum" @isInline={{true}} />
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Text::H2>States</Shw::Text::H2>
 
   {{#each @model.COLORS as |color|}}

--- a/packages/components/tests/integration/components/hds/button/index-test.js
+++ b/packages/components/tests/integration/components/hds/button/index-test.js
@@ -92,6 +92,15 @@ module('Integration | Component | hds/button/index', function (hooks) {
       .doesNotHaveAria('label', 'copy to clipboard');
   });
 
+  // ISINLINE
+
+  test('it should render the element as `inline` if the value of @isInline is "true"', async function (assert) {
+    await render(hbs`
+      <Hds::Button @text="Lorem ipsum" @isInline={{true}} id="test-button" />
+    `);
+    assert.dom('#test-button').hasClass('hds-button--is-inline');
+  });
+
   // TEXT
 
   test('it renders a button with the defined text', async function (assert) {

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -30,6 +30,7 @@
 @import "pages/foundations/icon";
 @import "pages/components/accordion";
 @import "pages/components/app-footer";
+@import "pages/components/button";
 @import "pages/components/code-block";
 @import "pages/components/copy-snippet";
 @import "pages/components/dropdown";

--- a/website/app/styles/pages/components/button.scss
+++ b/website/app/styles/pages/components/button.scss
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// COMPONENTS > BUTTON
+
+#show-content-components-button {
+  .doc-button-mock-text-align-right {
+    text-align: right;
+  }
+}

--- a/website/docs/components/button/partials/code/component-api.md
+++ b/website/docs/components/button/partials/code/component-api.md
@@ -26,6 +26,9 @@
   <C.Property @name="isHrefExternal" @type="boolean" @default="false">
     Controls if the `<a>` link is external and so for security reasons we need to add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it.
   </C.Property>
+  <C.Property @name="isInline" @type="boolean" @default="false">
+    If an `@isInline` parameter is provided, then the element will be displayed as `inline-block` (useful to achieve specific layouts). Otherwise, it will have a `block` layout.
+  </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo/LinkToExternal>` component.
   </C.Property>

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -81,18 +81,21 @@ This indicates that the Button should take up the full-width of the parent conta
 
 To change the default `block` layout to `inline`, set `@isLine` to `true`.
 
-#### Default block layout
+In contexts where the Button needs to be <em>inline</em>, to inherit the alignment from a parent, you can use the `@isInline` argument
+
+<!-- #### Default block layout
 
 ```handlebars
 <Hds::Button @text="default block layout" />
 <Hds::Button @text="default block layout" />
-```
+``` -->
 
-#### Inline layout
+<!-- #### Inline layout -->
 
 ```handlebars
-<Hds::Button @text="inline layout" @isInline={{true}} />
-<Hds::Button @text="inline layout" @isInline={{true}} />
+<div class="doc-button-mock-text-align-right">
+  <Hds::Button @text="inline layout" @isInline={{true}} />
+</div>
 ```
 
 ### Type

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -77,7 +77,7 @@ This indicates that the Button should take up the full-width of the parent conta
 <Hds::Button @text="Full width button" @isFullWidth={{true}} />
 ```
 
-### Inline layout
+### Layout
 
 To change the default `block` layout to `inline`, set `@isLine` to `true`.
 
@@ -88,7 +88,8 @@ To change the default `block` layout to `inline`, set `@isLine` to `true`.
 <Hds::Button @text="default block layout" />
 ```
 
-### Inline layout
+#### Inline layout
+
 ```handlebars
 <Hds::Button @text="inline layout" @isInline={{true}} />
 <Hds::Button @text="inline layout" @isInline={{true}} />

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -79,9 +79,7 @@ This indicates that the Button should take up the full-width of the parent conta
 
 ### Layout
 
-To change the default `block` layout to `inline`, set `@isLine` to `true`.
-
-In contexts where the Button needs to be <em>inline</em>, to inherit the alignment from a parent, you can use the `@isInline` argument
+To change the default `block` layout to `inline`, set `@isLine` to `true`. This can be useful in contexts where the Button needs to be <em>inline</em>, for example to inherit the alignment from a parent.
 
 ```handlebars
 <div class="doc-button-mock-text-align-right">

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -77,6 +77,23 @@ This indicates that the Button should take up the full-width of the parent conta
 <Hds::Button @text="Full width button" @isFullWidth={{true}} />
 ```
 
+### Inline layout
+
+To change the default `block` layout to `inline`, set `@isLine` to `true`.
+
+#### Default block layout
+
+```handlebars
+<Hds::Button @text="default block layout" />
+<Hds::Button @text="default block layout" />
+```
+
+### Inline layout
+```handlebars
+<Hds::Button @text="inline layout" @isInline={{true}} />
+<Hds::Button @text="inline layout" @isInline={{true}} />
+```
+
 ### Type
 
 This is the native HTML button attribute, `type`. There are three possible values: `button`, `submit`, and `reset`. The default `type` for the Button is `button`. To submit form data to the server, set `type` to `submit`.

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -83,15 +83,6 @@ To change the default `block` layout to `inline`, set `@isLine` to `true`.
 
 In contexts where the Button needs to be <em>inline</em>, to inherit the alignment from a parent, you can use the `@isInline` argument
 
-<!-- #### Default block layout
-
-```handlebars
-<Hds::Button @text="default block layout" />
-<Hds::Button @text="default block layout" />
-``` -->
-
-<!-- #### Inline layout -->
-
 ```handlebars
 <div class="doc-button-mock-text-align-right">
   <Hds::Button @text="inline layout" @isInline={{true}} />

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -25,7 +25,7 @@ The Dropdown component is composed of different child components each with their
     If a `@height` parameter is provided then the list will have a max-height.
   </C.Property>
   <C.Property @name="isInline" @type="boolean" @default="false">
-    If a `@isInline` parameter is provided then the element will be displayed as `inline-block` (useful to achieve specific layouts like in a container with right alignment). Otherwise it will be have a `block` layout.
+    If an `@isInline` parameter is provided, then the element will be displayed as `inline-block` (useful to achieve specific layouts like in a container with right alignment). Otherwise, it will have a `block` layout.
   </C.Property>
   <C.Property @name="close" @type="function">
     Function to programmatically close the Dropdown.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds the `@isInline` argument to the `Button` component.

- [Showcase](https://hds-showcase-git-hds-2681-button-add-isinline-hashicorp.vercel.app/components/button): See "Display" section added
- [Web docs](https://hds-website-git-hds-2681-button-add-isinline-hashicorp.vercel.app/components/button?tab=code#layout)

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

- Jira ticket: [HDS-2681](https://hashicorp.atlassian.net/browse/HDS-2681)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`) _- I ran this and am seeing a bunch of failed tests but they seem unrelated to my changes._
- [ ] ~~If documenting a new component, an acceptance test that includes the `a11yAudit` has been added~~
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2681]: https://hashicorp.atlassian.net/browse/HDS-2681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ