### PR TITLE
Fix legend spacing (HDS-2948)

### DIFF
--- a/.changeset/sharp-phones-agree.md
+++ b/.changeset/sharp-phones-agree.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Form::Legend` & consuming components - changed spacing from 4px to 8px
+`Form::Legend` as consumed by `Checkbox::Group`, `Radio::Group`, and `RadioCard::Group` - changed spacing from 4px to 8px

--- a/.changeset/sharp-phones-agree.md
+++ b/.changeset/sharp-phones-agree.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Form::Legend` as consumed by `Checkbox::Group`, `Radio::Group`, and `RadioCard::Group` - changed spacing from 4px to 8px
+`Form::Fieldset` as consumed by `Form::Checkbox::Group`, `Form::Radio::Group`, `Form::RadioCard::Group`, and `Form::Toggle::Group` - changed spacing from 4px to 8px

--- a/.changeset/sharp-phones-agree.md
+++ b/.changeset/sharp-phones-agree.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Form::Legend` - change spacing from 4px to 8px

--- a/.changeset/sharp-phones-agree.md
+++ b/.changeset/sharp-phones-agree.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Form::Legend` - change spacing from 4px to 8px
+`Form::Legend` & consuming components - changed spacing from 4px to 8px

--- a/.changeset/sharp-phones-agree.md
+++ b/.changeset/sharp-phones-agree.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Form::Fieldset` as consumed by `Form::Checkbox::Group`, `Form::Radio::Group`, `Form::RadioCard::Group`, and `Form::Toggle::Group` - changed spacing from 4px to 8px
+`Form::Fieldset` as consumed by `Form::Checkbox::Group`, `Form::Radio::Group`, `Form::RadioCard::Group`, and `Form::Toggle::Group` - changed spacing between `legend` and content from 4px to 8px

--- a/packages/components/app/styles/components/form/group.scss
+++ b/packages/components/app/styles/components/form/group.scss
@@ -15,7 +15,7 @@
 }
 
 .hds-form-group__legend { // notice: this is a <legend> element
-  margin: 0 0 4px 0;
+  margin: 0 0 8px 0;
   padding: 0;
 }
 


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR changes the form legend spacing from 4px to 8px

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

- Jira ticket: [HDS-2948](https://hashicorp.atlassian.net/browse/HDS-2948)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [ ] ~~A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)~~
- [ ] ~~If documenting a new component, an acceptance test that includes the `a11yAudit` has been added~~
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2948]: https://hashicorp.atlassian.net/browse/HDS-2948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ