### PR TITLE
Change inline-block display to inline-flex for layout variant

### DIFF
--- a/packages/components/app/styles/components/button.scss
+++ b/packages/components/app/styles/components/button.scss
@@ -97,7 +97,7 @@
 
 // ISINLINE
 .hds-button--is-inline {
-  display: inline-block;
+  display: inline-flex;
 }
 
 


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR changes the display for the `.hds-button--is-inline` variant from `inline-block` to `inline-flex`.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser

### :link: External links
Issues, RFC, etc. 
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]
-->

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] ~~A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)~~
- [ ] ~~If documenting a new component, an acceptance test that includes the `a11yAudit` has been added~~
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
