### PR TITLE
`Table` - Add `baseline` option to vertical alignment of cells

### DIFF
--- a/.changeset/ten-monkeys-eat.md
+++ b/.changeset/ten-monkeys-eat.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Table` - Added support for `baseline` vertical alignment

--- a/packages/components/addon/components/hds/table/index.js
+++ b/packages/components/addon/components/hds/table/index.js
@@ -10,7 +10,7 @@ import { assert } from '@ember/debug';
 
 const DENSITIES = ['short', 'medium', 'tall'];
 const DEFAULT_DENSITY = 'medium';
-const VALIGNMENTS = ['top', 'middle'];
+const VALIGNMENTS = ['top', 'middle', 'baseline'];
 const DEFAULT_VALIGN = 'top';
 
 export default class HdsTableIndexComponent extends Component {
@@ -116,7 +116,7 @@ export default class HdsTableIndexComponent extends Component {
    * @param valign
    * @type {string}
    * @default 'top'
-   * @description Determines the vertical alignment of the table cells; options are: "top", "middle". If no valign is defined, "top" is used.
+   * @description Determines the vertical alignment of the table cells; options are: "top", "middle", "baseline". If no valign is defined, "top" is used.
    */
   get valign() {
     let { valign = DEFAULT_VALIGN } = this.args;

--- a/packages/components/app/styles/components/table.scss
+++ b/packages/components/app/styles/components/table.scss
@@ -150,6 +150,10 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
   .hds-table--valign-middle & {
     vertical-align: middle;
   }
+
+  .hds-table--valign-baseline & {
+    vertical-align: baseline;
+  }
 }
 
 // TABLE CELL TEXT ALIGNMENT (LEFT IS DEFAULT)

--- a/packages/components/tests/dummy/app/templates/components/table.hbs
+++ b/packages/components/tests/dummy/app/templates/components/table.hbs
@@ -1154,5 +1154,47 @@
         </:body>
       </Hds::Table>
     </SF.Item>
+    <SF.Item @grow={{true}}>
+      <Hds::Table @valign="baseline">
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Spacer</H.Th>
+            <H.Th>Text</H.Th>
+            <H.Th>Icon</H.Th>
+            <H.Th>Icon + Text</H.Th>
+            <H.Th>Icon + Text (with flex container)</H.Th>
+            <H.Th>Badge</H.Th>
+            <H.Th>Dropdown</H.Th>
+            <H.Th>Tooltip(Button)</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
+          <B.Tr>
+            <B.Th><Shw::Placeholder @height="25" />Baseline<Shw::Placeholder @height="25" /></B.Th>
+            <B.Td>Text is middle aligned</B.Td>
+            <B.Td><FlightIcon @name="film" /></B.Td>
+            <B.Td><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td>
+              <div {{style display="flex" gap="8px" align-items="center"}}>
+                <FlightIcon @name="film" />
+                <span>Text in a <code>&lt;span&gt;</code></span>
+              </div>
+            </B.Td>
+            <B.Td><Hds::Badge @text="Badge" /></B.Td>
+            <B.Td>
+              <Hds::Dropdown as |dd|>
+                <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
+                <dd.Interactive @route="components.table" @text="Dropdown" />
+              </Hds::Dropdown>
+            </B.Td>
+            <B.Td>
+              <Hds::TooltipButton @text="Hello!">
+                December 15, 2022,<br />16:40:09 PM
+              </Hds::TooltipButton>
+            </B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
+    </SF.Item>
   </Shw::Flex>
 </section>

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -76,7 +76,7 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="density" @type="enum" @values={{array "short" "medium" "tall" }} @default="medium">
     If set, determines the density (height) of the table body’s rows.
   </C.Property>
-  <C.Property @name="valign" @type="enum" @values={{array "top" "middle" }} @default="top">
+  <C.Property @name="valign" @type="enum" @values={{array "top" "middle" "baseline" }} @default="top">
     Determines the vertical alignment for content in a table. Does not apply to table headers (`th`). See [MDN reference on vertical-align](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) for more details.
   </C.Property>
   <C.Property @name="caption" @type="string">


### PR DESCRIPTION
### :pushpin: Summary

Context: https://hashicorp.slack.com/archives/C7KTUHNUS/p1701983139108269

### :hammer_and_wrench: Detailed description

In this PR I have:
- added support for `baseline` as vertical alignment for tables
- added example of `baseline` vertical alignment in showcase for table
- updated the website documentation

### :camera_flash: Screenshots

<img width="1042" alt="screenshot_3337" src="https://github.com/hashicorp/design-system/assets/686239/ad2634f4-747d-410f-9352-1a3442c68cd3">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2957

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
