### PR TITLE
Fix `Button` docs to include the correct value in example

### DIFF
--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -120,7 +120,7 @@ The `Hds::Button` component uses the generic `Hds::Interactive` component. For m
 
 If you pass an `@href` argument, an `<a>` link will be generated.
 
-`target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied by default. This is the most common case, as internal links are generally handled using a `@route` argument but can be overridden. If the `href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{true}}` and it will not add the `target` and `rel` attributes.
+`target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied by default. This is the most common case, as internal links are generally handled using a `@route` argument but can be overridden. If the `href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` and it will not add the `target` and `rel` attributes.
 
 ```handlebars
 <Hds::Button @text="Visit website" @icon="external-link" @iconPosition="trailing" @href="https://hashicorp.com" />


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR updates the `Button` docs with the correct value to use for `@isHrefExternal` to override the default behavior.

- **Web Preview:** https://hds-website-git-fix-button-docs-typo-hashicorp.vercel.app/components/button?tab=code#links

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links
- Slack convo: https://hashicorp.slack.com/archives/C7KTUHNUS/p1702420285657109

<!-- Issues, RFC, etc.
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]
 -->

***

### 👀 Component checklist

- [ ] ~~Percy was checked for any visual regression~~
- [ ] ~~A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)~~
- [ ] ~~If documenting a new component, an acceptance test that includes the `a11yAudit` has been added~~
- [ ] ~~A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
