### PR TITLE
ButtonSet - Remove coming soon message

### DIFF
--- a/website/docs/components/button-set/partials/guidelines/guidelines.md
+++ b/website/docs/components/button-set/partials/guidelines/guidelines.md
@@ -1,5 +1,3 @@
 ## Usage
 
-Usage documentation for this component is coming soon. In the meantime, help us improve this documentation by letting us know how your team is using it in [#team-design-systems](https://hashicorp.slack.com/archives/C7KTUHNUS) (internal only).
-
 More detailed examples and guidance around button alignment, grouping, and organization can be found in the [button organization](/patterns/button-organization) pattern documentation.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR removes the "coming soon" language from the `ButtonSet` documentation.

**👉🏻 Preview link:** https://hds-website-git-hl-buttonset-docs-hashicorp.vercel.app/components/button-set

### :camera_flash: Screenshots

<img width="938" alt="Screenshot 2023-12-13 at 10 44 19 AM" src="https://github.com/hashicorp/design-system/assets/8553306/84a3f639-e0b4-4054-9393-276cd022179c">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2762](https://hashicorp.atlassian.net/browse/HDS-2762)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2762]: https://hashicorp.atlassian.net/browse/HDS-2762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ