### PR TITLE
`Tooltip` - Fix text alignment

### DIFF
--- a/.changeset/five-buses-burn.md
+++ b/.changeset/five-buses-burn.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Tooltip` - Fixed issue with text alignment, which was inherited from the parent container (now it's always left aligned).

--- a/packages/components/app/styles/components/tooltip.scss
+++ b/packages/components/app/styles/components/tooltip.scss
@@ -79,6 +79,8 @@
     // prevent this container from potentially inheriting other values
     // such as `white-space: nowrap` that would cause content overflow
     white-space: normal;
+    // we want to have the text always aligned to the left (by design
+    text-align: left;
   }
 
   // works with Tippy's custom SVG arrow variation:

--- a/packages/components/tests/dummy/app/styles/showcase-pages/tooltip.scss
+++ b/packages/components/tests/dummy/app/styles/showcase-pages/tooltip.scss
@@ -6,6 +6,10 @@
 // TOOLTIP
 
 body.components-tooltip {
+  .shw-component-tooltip-text-alignment {
+    padding-bottom: 50px;
+  }
+
   .shw-component-tooltip-placement-grid {
     grid-gap: 10px;
     grid-template-rows: repeat(5, 40px) !important;

--- a/packages/components/tests/dummy/app/templates/components/tooltip.hbs
+++ b/packages/components/tests/dummy/app/templates/components/tooltip.hbs
@@ -61,29 +61,6 @@
     adipisicing elit. Doloremque blanditiis sapiente iste beatae voluptates voluptatum.
   </p>
 
-  <Shw::Text::H4>Used within a parent with explicit text alignment</Shw::Text::H4>
-
-  <Shw::Grid @columns={{3}} as |SG|>
-    <SG.Item @label="text-align = left" {{style text-align="left"}}>
-      <Hds::TooltipButton @text="Here is more information" aria-label="Information">
-        <p class="hds-typography-body-300">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-          tempor</p>
-      </Hds::TooltipButton>
-    </SG.Item>
-    <SG.Item @label="text-align = center" {{style text-align="center"}}>
-      <Hds::TooltipButton @text="Here is more information" aria-label="Information">
-        <p class="hds-typography-body-300">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-          tempor</p>
-      </Hds::TooltipButton>
-    </SG.Item>
-    <SG.Item @label="text-align = right" {{style text-align="right"}}>
-      <Hds::TooltipButton @text="Here is more information" aria-label="Information">
-        <p class="hds-typography-body-300">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-          tempor</p>
-      </Hds::TooltipButton>
-    </SG.Item>
-  </Shw::Grid>
-
   <Shw::Text::H4>Used within various non-interactive components</Shw::Text::H4>
 
   <Shw::Flex @direction="column" as |SF|>
@@ -254,6 +231,50 @@
       </div>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Text::Body>Used within a parent with explicit text alignment</Shw::Text::Body>
+
+  <Shw::Grid class="shw-component-tooltip-text-alignment" @columns={{3}} as |SG|>
+    <SG.Item @label="text-align = left" {{style text-align="left"}}>
+      <Shw::Outliner>
+        <Hds::TooltipButton
+          @text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+          @placement="bottom"
+          @extraTippyOptions={{hash showOnCreate=true}}
+          aria-label="Information"
+        >
+          <p class="hds-typography-body-300">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+            tempor</p>
+        </Hds::TooltipButton>
+      </Shw::Outliner>
+    </SG.Item>
+    <SG.Item @label="text-align = center" {{style text-align="center"}}>
+      <Shw::Outliner>
+        <Hds::TooltipButton
+          @text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+          @placement="bottom"
+          @extraTippyOptions={{hash showOnCreate=true}}
+          aria-label="Information"
+        >
+          <p class="hds-typography-body-300">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+            tempor</p>
+        </Hds::TooltipButton>
+      </Shw::Outliner>
+    </SG.Item>
+    <SG.Item @label="text-align = right" {{style text-align="right"}}>
+      <Shw::Outliner>
+        <Hds::TooltipButton
+          @text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+          @placement="bottom"
+          @extraTippyOptions={{hash showOnCreate=true}}
+          aria-label="Information"
+        >
+          <p class="hds-typography-body-300">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+            tempor</p>
+        </Hds::TooltipButton>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
 
   <Shw::Divider @level={{2}} />
 


### PR DESCRIPTION
### :pushpin: Summary

While working on the implementation of tooltips in `Table` (https://github.com/hashicorp/design-system/pull/1860) I've realized that the text in the tooltip "bubble" was inheriting its alignment from the table cell:

![image](https://github.com/hashicorp/design-system/assets/686239/942c3f85-d2d4-42fa-965d-6419cad743d0)

We didn't notice previously because the example/test in the showcase has a too short text, which was not spanning on multiple lines, so the alignment was not visible.

### :hammer_and_wrench: Detailed description

In this PR I have:
- forced left alignment of text in tooltip “bubble”
- updated the alignment example in the showcase

👉 👉 👉 **Preview**: https://hds-showcase-git-tooltip-fix-text-alignment-hashicorp.vercel.app/components/tooltip

### :camera_flash: Screenshots

**Before:**
<img width="1033" alt="screenshot_3357" src="https://github.com/hashicorp/design-system/assets/686239/a6c40e9d-1ed8-426a-b00e-638ad473e445">

**After:**
<img width="1036" alt="screenshot_3358" src="https://github.com/hashicorp/design-system/assets/686239/0bffb040-b01e-443f-8160-cdaca8674614">

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
