### PR TITLE
Add extra headings to character count documentation

### DIFF
--- a/website/docs/components/form/masked-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/masked-input/partials/code/how-to-use.md
@@ -159,6 +159,8 @@ When the user input needs to be in a certain range, use both `@minLength` and `@
 </Hds::Form::MaskedInput::Field>
 ```
 
+##### Custom message
+
 For custom messages, you can use the following arguments to build a relevant message: `currentLength` (the current number of characters in the associated form control), `maxLength` (the maximum number of characters allowed in the associated form control), `minLength` (the minimum number of characters required in the associated form control), `remaining` (the difference between `maxLength` and `currentLength`), and `shortfall` (the difference between `currentLength` and `minLength`).
 
 ```handlebars
@@ -169,6 +171,8 @@ For custom messages, you can use the following arguments to build a relevant mes
   </F.CharacterCount>
 </Hds::Form::MaskedInput::Field>
 ```
+
+##### Validation using the `@onInput` callback
 
 You can use the `@onInput` callback function to dynamically raise an error based on the number of characters entered into a field. The function receives as argument an object with the following properties: `inputControl` (a reference to the associated form control node element), `currentLength` (the current number of characters in the associated form control), `maxLength` (the maximum number of characters allowed in the associated form control), `minLength` (the minimum number of characters required in the associated form control), `remaining` (the difference between `maxLength` and `currentLength`), and `shortfall` (the difference between `currentLength` and `minLength`).
 

--- a/website/docs/components/form/primitives/partials/code/how-to-use.md
+++ b/website/docs/components/form/primitives/partials/code/how-to-use.md
@@ -101,6 +101,8 @@ When the user input needs to be in a certain range, use both `@minLength` and `@
 <Hds::Form::CharacterCount @minLength={{3}} @maxLength={{10}} @controlId="input-character-count-min-max"/>
 ```
 
+##### Custom message
+
 For custom messages, you can use the following arguments to build a relevant message: `currentLength` (the current number of characters in the associated form control), `maxLength` (the maximum number of characters allowed in the associated form control), `minLength` (the minimum number of characters required in the associated form control), `remaining` (the difference between `maxLength` and `currentLength`), and `shortfall` (the difference between `currentLength` and `minLength`).
 
 ```handlebars

--- a/website/docs/components/form/text-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/text-input/partials/code/how-to-use.md
@@ -10,7 +10,7 @@ We omit the `name` and `ID` attributes in the examples since processing of the d
 There are two ways to use the Text Input component:
 
 - `Form::TextInput::Base` - the base component: just the `<input>` control.
-- `Form::TextInput::Field` - the field component: the `<input>` control, with label, helper text, and error messaging (in a wrapping container). 
+- `Form::TextInput::Field` - the field component: the `<input>` control, with label, helper text, and error messaging (in a wrapping container).
 
 We recommend using the Field component as it provides built-in accessibility functionality. Use the Base component if needing to achieve custom layouts or for special use cases not covered by the Field component.
 
@@ -131,6 +131,8 @@ When the user input needs to be in a certain range, use both `@minLength` and `@
 </Hds::Form::TextInput::Field>
 ```
 
+##### Custom message
+
 For custom messages, you can use the following arguments to build a relevant message: `currentLength` (the current number of characters in the associated form control), `maxLength` (the maximum number of characters allowed in the associated form control), `minLength` (the minimum number of characters required in the associated form control), `remaining` (the difference between `maxLength` and `currentLength`), and `shortfall` (the difference between `currentLength` and `minLength`).
 
 ```handlebars
@@ -141,6 +143,8 @@ For custom messages, you can use the following arguments to build a relevant mes
   </F.CharacterCount>
 </Hds::Form::TextInput::Field>
 ```
+
+##### Validation using the `@onInput` callback
 
 You can use the `@onInput` callback function to dynamically raise an error based on the number of characters entered into a field. The function receives as argument an object with the following properties: `inputControl` (a reference to the associated form control node element), `currentLength` (the current number of characters in the associated form control), `maxLength` (the maximum number of characters allowed in the associated form control), `minLength` (the minimum number of characters required in the associated form control), `remaining` (the difference between `maxLength` and `currentLength`), and `shortfall` (the difference between `currentLength` and `minLength`).
 
@@ -230,7 +234,7 @@ Because this component supports use of `...attributes`, you can use all the usua
 
 #### Custom width
 
-By default, the input control width is set to fill the parent container, with the exception of "date" and "time" input types. 
+By default, the input control width is set to fill the parent container, with the exception of "date" and "time" input types.
 
 Pass a custom width for the control using the `@width` argument.
 

--- a/website/docs/components/form/textarea/partials/code/how-to-use.md
+++ b/website/docs/components/form/textarea/partials/code/how-to-use.md
@@ -19,7 +19,7 @@ We recommend using the Field component because it provides built-in accessibilit
 
 ### Form::Textarea::Field
 
-The basic invocation requires a `Label`. This creates: 
+The basic invocation requires a `Label`. This creates:
 
 - a `<label>` element with a `for` attribute automatically associated with the textarea `ID` attribute.
 - a `<textarea>` control with an automatically generated `ID` attribute.
@@ -112,6 +112,8 @@ When the user input needs to be in a certain range, use both `@minLength` and `@
 </Hds::Form::Textarea::Field>
 ```
 
+##### Custom message
+
 For custom messages, you can use the following arguments to build a relevant message: `currentLength` (the current number of characters in the associated form control), `maxLength` (the maximum number of characters allowed in the associated form control), `minLength` (the minimum number of characters required in the associated form control), `remaining` (the difference between `maxLength` and `currentLength`), and `shortfall` (the difference between `currentLength` and `minLength`).
 
 ```handlebars
@@ -122,6 +124,8 @@ For custom messages, you can use the following arguments to build a relevant mes
   </F.CharacterCount>
 </Hds::Form::Textarea::Field>
 ```
+
+##### Validation using the `@onInput` callback
 
 You can use the `@onInput` callback function to dynamically raise an error based on the number of characters entered into a field. The function receives as argument an object with the following properties: `inputControl` (a reference to the associated form control node element), `currentLength` (the current number of characters in the associated form control), `maxLength` (the maximum number of characters allowed in the associated form control), `minLength` (the minimum number of characters required in the associated form control), `remaining` (the difference between `maxLength` and `currentLength`), and `shortfall` (the difference between `currentLength` and `minLength`).
 
@@ -212,7 +216,7 @@ Because this component supports use of `...attributes`, you can use all the usua
 
 #### Custom width
 
-By default, the textarea control width is set to fill the parent container. 
+By default, the textarea control width is set to fill the parent container.
 
 Pass a custom width for the control using the `@width` argument.
 


### PR DESCRIPTION
### :pushpin: Summary

While replying to a question related to the character count functionality, I noticed we could improve the documentation by adding a couple of extra headings to the "how to" section related to character count, to simplify linking to specific instructions.

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
