### PR TITLE
`MaskedInput` - Add multiline text examples to showcase (and update docs)

### DIFF
--- a/packages/components/tests/dummy/app/controllers/components/form/masked-input.js
+++ b/packages/components/tests/dummy/app/controllers/components/form/masked-input.js
@@ -11,6 +11,11 @@ export default class FormMaskedInputController extends Controller {
   @tracked textInputFieldIsInvalid;
   @tracked textareaFieldIsInvalid;
 
+  multilineText1 = 'Lorem\nipsum\ndolor';
+  multilineText2 = `Lorem
+ipsum
+dolor`;
+
   @action onFieldInput(args) {
     if (args.inputControl.localName === 'input') {
       this.textInputFieldIsInvalid = args.currentLength > args.maxLength;

--- a/packages/components/tests/dummy/app/templates/components/form/masked-input.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/masked-input.hbs
@@ -28,6 +28,12 @@
     <SF.Item @label="With value (in clear)">
       <Hds::Form::MaskedInput::Base @isContentMasked={{false}} @value="Lorem ipsum dolor" />
     </SF.Item>
+    <SF.Item @label="With multiline value (inline `\n`)">
+      <Hds::Form::MaskedInput::Base @isContentMasked={{false}} @value={{this.multilineText1}} />
+    </SF.Item>
+    <SF.Item @label="With multiline value (template literal)">
+      <Hds::Form::MaskedInput::Base @isContentMasked={{false}} @value={{this.multilineText2}} />
+    </SF.Item>
   </Shw::Flex>
 
   <Shw::Text::H4>Multiline</Shw::Text::H4>
@@ -44,6 +50,12 @@
     </SF.Item>
     <SF.Item @label="With value (in clear)">
       <Hds::Form::MaskedInput::Base @isMultiline={{true}} @isContentMasked={{false}} @value="Lorem ipsum dolor" />
+    </SF.Item>
+    <SF.Item @label="With multiline value (inline `\n`)">
+      <Hds::Form::MaskedInput::Base @isMultiline={{true}} @isContentMasked={{false}} @value={{this.multilineText1}} />
+    </SF.Item>
+    <SF.Item @label="With multiline value (template literal)">
+      <Hds::Form::MaskedInput::Base @isMultiline={{true}} @isContentMasked={{false}} @value={{this.multilineText2}} />
     </SF.Item>
   </Shw::Flex>
 

--- a/website/docs/components/form/masked-input/partials/code/component-api.md
+++ b/website/docs/components/form/masked-input/partials/code/component-api.md
@@ -10,6 +10,9 @@ The Masked Input component has two different variants with their own APIs:
 <Doc::ComponentApi as |C|>
   <C.Property @name="value" @type="string|number|date">
     Input control’s value.
+    <br/>
+    <br/>
+    _Notice: if the string provided contains newline characters they will be stripped, unless `@isMultiline` is set to `true` (this renders the input as a `<textarea>` element, which supports multi-line text)._
   </C.Property>
   <C.Property @name="isContentMasked" @type="boolean" @default="true">
     Set this argument to `false` to make the input content visible by default or bind it to a variable to control the masking from outside the component.


### PR DESCRIPTION
### :pushpin: Summary

While replying to a consumer request I realized that it may not be obvious that when a multiline text is provided to the non-multiline variant of the `MaskedInput`, the newline characters are stripped from the text.

### :hammer_and_wrench: Detailed description

In this PR I have:
- Added multiline text examples to showcase for `MaskedInput`
- Updated documentation for the `MaskedInput`

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
