### PR TITLE
`Tabs` - Fix subcomponents' backing-class names

### DIFF
--- a/.changeset/metal-keys-relax.md
+++ b/.changeset/metal-keys-relax.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Tabs` - Fix subcomponents' backing-class names

--- a/packages/components/addon/components/hds/tabs/panel.js
+++ b/packages/components/addon/components/hds/tabs/panel.js
@@ -8,7 +8,7 @@ import { cached } from '@glimmer/tracking';
 import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
 
-export default class HdsTabsIndexComponent extends Component {
+export default class HdsTabsPanelComponent extends Component {
   /**
    * Generate a unique ID for the Panel
    * @return {string}

--- a/packages/components/addon/components/hds/tabs/tab.js
+++ b/packages/components/addon/components/hds/tabs/tab.js
@@ -8,7 +8,7 @@ import { cached } from '@glimmer/tracking';
 import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
 
-export default class HdsTabsIndexComponent extends Component {
+export default class HdsTabsTabComponent extends Component {
   /**
    * Generate a unique ID for the Tab
    * @return {string}


### PR DESCRIPTION
### :pushpin: Summary

Fix the backing-class names for `Tabs` subcomponents (`Panel` and `Tab`).

### :hammer_and_wrench: Detailed description

While these currently do not seem to have much of an impact on consumers (other than them not being able to import or extend these subcomponents) it does create issues in the v2 addon world.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2875](https://hashicorp.atlassian.net/browse/HDS-2875)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [ ] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2875]: https://hashicorp.atlassian.net/browse/HDS-2875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ