### PR TITLE
Rename namespaced contextual components

### DIFF
--- a/.changeset/smart-glasses-turn.md
+++ b/.changeset/smart-glasses-turn.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-codemods": patch
+---
+
+Add codemods for `design-system-components` v4

--- a/.changeset/two-gorillas-tease.md
+++ b/.changeset/two-gorillas-tease.md
@@ -1,0 +1,12 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+Renamed namespaced contextual components as follows:
+
+ - `Alert::Link::Standalone` to `Alert::LinkStandalone`
+ - `ApplicationState::Footer::Link::Standalone` to `ApplicationState::Footer::LinkStandalone`
+ - `Form::Checkbox::Group::Checkbox::Field` to `Checkbox::Group::CheckboxField`
+ - `Form::Radio::Group::Radio::Field` to `Form::Radio::Group::RadioField`
+ - `Form::Toggle::Group::Toggle::Field` to `Form::Toggle::Group::ToggleField`
+ - `Toast::Link::Standalone` to `Toast::LinkStandalone`

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -21,6 +21,7 @@ node ./packages/codemods/bin/cli.js v3/dropdown path/to/some/glob/**/*.hbs
 ## Transforms
 
 ### v3
+
 * [v3/dropdown](transforms/v3/dropdown/README.md)
 * [v3/masked-input](transforms/v3/masked-input/README.md)
 * [v3/radio-card](transforms/v3/radio-card/README.md)
@@ -28,8 +29,8 @@ node ./packages/codemods/bin/cli.js v3/dropdown path/to/some/glob/**/*.hbs
 
 ### v4
 <!--TRANSFORMS_START-->
-* [v3](transforms/v3/README.md)
-* [v4](transforms/v4/README.md)
+* [v4/contextual-components](transforms/v4/contextual-components/README.md)
+* [v4/table](transforms/v4/table/README.md)
 <!--TRANSFORMS_END-->
 
 ## Contributing

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -28,7 +28,8 @@ node ./packages/codemods/bin/cli.js v3/dropdown path/to/some/glob/**/*.hbs
 
 ### v4
 <!--TRANSFORMS_START-->
-* [v4/table](transforms/v4/table/README.md)
+* [v3](transforms/v3/README.md)
+* [v4](transforms/v4/README.md)
 <!--TRANSFORMS_END-->
 
 ## Contributing

--- a/packages/codemods/transforms/v4/contextual-components/README.md
+++ b/packages/codemods/transforms/v4/contextual-components/README.md
@@ -1,0 +1,45 @@
+# v4/contextual-components
+
+## Usage
+
+To run this codemod in your project using `npx`, you would run the following:
+
+```bash
+npx @hashicorp/design-system-codemods v4/contextual-components path/to/some/glob/**/*.hbs
+```
+
+## Local usage
+
+To run this codemod in this repository (even before publishing it), you would run the following from the root directory of this repository:
+
+```bash
+node ./packages/codemods/bin/cli.js v4/contextual-components path/to/some/glob/**/*.hbs
+```
+
+## Input
+
+```hbs
+<Hds::Alert as |A|>
+  <A.Link::Standalone />
+</Hds::Alert>
+
+<Hds::Form::Toggle::Group as |G|>
+  <G.Toggle::Field as |F|>
+    <F.Label>Label</F.Label>
+  </G.Toggle::Field>
+</Hds::Form::Toggle::Group>
+```
+
+## Output
+
+```hbs
+<Hds::Alert as |A|>
+  <A.LinkStandalone />
+</Hds::Alert>
+
+<Hds::Form::Toggle::Group as |G|>
+  <G.ToggleField as |F|>
+    <F.Label>Label</F.Label>
+  </G.ToggleField>
+</Hds::Form::Toggle::Group>
+```

--- a/packages/codemods/transforms/v4/contextual-components/__testfixtures__/form-field.input.hbs
+++ b/packages/codemods/transforms/v4/contextual-components/__testfixtures__/form-field.input.hbs
@@ -1,0 +1,37 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Form::Checkbox::Group @name="control-vertical-01" as |G|>
+  <G.Legend>Legend of the group</G.Legend>
+  <G.Checkbox::Field as |F|>
+    <F.Label>Label of control #1</F.Label>
+  </G.Checkbox::Field>
+  <G.Checkbox::Field checked="checked" as |F|>
+    <F.Label>Label of control #2</F.Label>
+  </G.Checkbox::Field>
+  <G.Checkbox::Field indeterminate={{true}} as |F|>
+    <F.Label>Label of control #3</F.Label>
+  </G.Checkbox::Field>
+</Hds::Form::Checkbox::Group>
+
+<Hds::Form::Radio::Group @name="control-vertical-02" as |G|>
+  <G.Legend>Legend of the group</G.Legend>
+  <G.Radio::Field as |F|>
+    <F.Label>Label of control #1</F.Label>
+  </G.Radio::Field>
+  <G.Radio::Field checked="checked" as |F|>
+    <F.Label>Label of control #2</F.Label>
+  </G.Radio::Field>
+  <G.Radio::Field as |F|>
+    <F.Label>Label of control #3</F.Label>
+  </G.Radio::Field>
+</Hds::Form::Radio::Group>
+
+<Hds::Form::Toggle::Group as |G|>
+  <G.Legend>Legend of the group</G.Legend>
+  <G.Toggle::Field checked="checked" as |F|>
+    <F.Label>This is the label</F.Label>
+  </G.Toggle::Field>
+</Hds::Form::Toggle::Group>

--- a/packages/codemods/transforms/v4/contextual-components/__testfixtures__/form-field.output.hbs
+++ b/packages/codemods/transforms/v4/contextual-components/__testfixtures__/form-field.output.hbs
@@ -1,0 +1,37 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Form::Checkbox::Group @name="control-vertical-01" as |G|>
+  <G.Legend>Legend of the group</G.Legend>
+  <G.CheckboxField as |F|>
+    <F.Label>Label of control #1</F.Label>
+  </G.CheckboxField>
+  <G.CheckboxField checked="checked" as |F|>
+    <F.Label>Label of control #2</F.Label>
+  </G.CheckboxField>
+  <G.CheckboxField indeterminate={{true}} as |F|>
+    <F.Label>Label of control #3</F.Label>
+  </G.CheckboxField>
+</Hds::Form::Checkbox::Group>
+
+<Hds::Form::Radio::Group @name="control-vertical-02" as |G|>
+  <G.Legend>Legend of the group</G.Legend>
+  <G.RadioField as |F|>
+    <F.Label>Label of control #1</F.Label>
+  </G.RadioField>
+  <G.RadioField checked="checked" as |F|>
+    <F.Label>Label of control #2</F.Label>
+  </G.RadioField>
+  <G.RadioField as |F|>
+    <F.Label>Label of control #3</F.Label>
+  </G.RadioField>
+</Hds::Form::Radio::Group>
+
+<Hds::Form::Toggle::Group as |G|>
+  <G.Legend>Legend of the group</G.Legend>
+  <G.ToggleField checked="checked" as |F|>
+    <F.Label>This is the label</F.Label>
+  </G.ToggleField>
+</Hds::Form::Toggle::Group>

--- a/packages/codemods/transforms/v4/contextual-components/__testfixtures__/link-standalone.input.hbs
+++ b/packages/codemods/transforms/v4/contextual-components/__testfixtures__/link-standalone.input.hbs
@@ -1,0 +1,19 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Alert @type="inline" @color="warning" as |A|>
+  <A.Link::Standalone @icon="plus" @text="Standalone" @href="#" @color="secondary" />
+</Hds::Alert>
+
+<Hds::ApplicationState as |A|>
+  <A.Footer @hasDivider={{true}} as |F|>
+    <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
+    <F.Link::Standalone @icon="help" @text="Need Help" @href="/components/alert" @iconPosition="trailing" />
+  </A.Footer>
+</Hds::ApplicationState>
+
+<Hds::Toast @color="warning" @onDismiss={{this.noop}} as |T|>
+  <T.Link::Standalone @icon="plus" @text="Standalone" @href="#" @color="secondary" />
+</Hds::Toast>

--- a/packages/codemods/transforms/v4/contextual-components/__testfixtures__/link-standalone.output.hbs
+++ b/packages/codemods/transforms/v4/contextual-components/__testfixtures__/link-standalone.output.hbs
@@ -1,0 +1,19 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Alert @type="inline" @color="warning" as |A|>
+  <A.LinkStandalone @icon="plus" @text="Standalone" @href="#" @color="secondary" />
+</Hds::Alert>
+
+<Hds::ApplicationState as |A|>
+  <A.Footer @hasDivider={{true}} as |F|>
+    <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
+    <F.LinkStandalone @icon="help" @text="Need Help" @href="/components/alert" @iconPosition="trailing" />
+  </A.Footer>
+</Hds::ApplicationState>
+
+<Hds::Toast @color="warning" @onDismiss={{this.noop}} as |T|>
+  <T.LinkStandalone @icon="plus" @text="Standalone" @href="#" @color="secondary" />
+</Hds::Toast>

--- a/packages/codemods/transforms/v4/contextual-components/index.js
+++ b/packages/codemods/transforms/v4/contextual-components/index.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+module.exports = function ({ source /*, path*/ }, { parse, visit }) {
+  const ast = parse(source);
+
+  return visit(ast, () => {
+    const updateTagName = (node, searchValue, replaceValue) => {
+      let isUpdated = false;
+      if (node.tag) {
+        node.tag = node.tag.replace(searchValue, replaceValue);
+        isUpdated = true;
+      }
+      return isUpdated;
+    };
+
+    // find recursively a child node with tag `*.Link::Standalone` and update it
+    const updateLinkStandaloneSubcomponents = (children) => {
+      let hasUpdatedChildren = false;
+      children.forEach((node) => {
+        if (node.tag && node.tag.includes('.Link::Standalone')) {
+          const isUpdated = updateTagName(node, '.Link::Standalone', '.LinkStandalone');
+          hasUpdatedChildren = hasUpdatedChildren && isUpdated;
+        } else if (node.children) {
+          const hasUpdatedSubChildren = updateLinkStandaloneSubcomponents(node.children);
+          hasUpdatedChildren = hasUpdatedChildren && hasUpdatedSubChildren;
+        }
+      });
+      return hasUpdatedChildren;
+    };
+
+    // find recursively a child node with tag `*.[Checkbox|Radio|Toggle]::Field` and update it
+    const updateFormFieldSubcomponents = (children) => {
+      let hasUpdatedChildren = false;
+      children.forEach((node) => {
+        if (node.tag && node.tag.includes('.Checkbox::Field')) {
+          const isUpdated = updateTagName(node, '.Checkbox::Field', '.CheckboxField');
+          hasUpdatedChildren = hasUpdatedChildren && isUpdated;
+        } else if (node.tag && node.tag.includes('.Radio::Field')) {
+          const isUpdated = updateTagName(node, '.Radio::Field', '.RadioField');
+          hasUpdatedChildren = hasUpdatedChildren && isUpdated;
+        } else if (node.tag && node.tag.includes('.Toggle::Field')) {
+          const isUpdated = updateTagName(node, '.Toggle::Field', '.ToggleField');
+          hasUpdatedChildren = hasUpdatedChildren && isUpdated;
+        } else if (node.children) {
+          const hasUpdatedSubChildren = updateFormFieldSubcomponents(node.children);
+          hasUpdatedChildren = hasUpdatedChildren && hasUpdatedSubChildren;
+        }
+      });
+      return hasUpdatedChildren;
+    };
+
+    return {
+      ElementNode(node) {
+        let isUpdated = false;
+        // Link::Standalone
+        let componentsWithLinkStandalone = ['Hds::Alert', 'Hds::ApplicationState', 'Hds::Toast'];
+        if (componentsWithLinkStandalone.includes(node.tag)) {
+          isUpdated = updateLinkStandaloneSubcomponents(node.children);
+        }
+        // Form::Field
+        let componentsWithFormField = [
+          'Hds::Form::Checkbox::Group',
+          'Hds::Form::Radio::Group',
+          'Hds::Form::Toggle::Group',
+        ];
+        if (componentsWithFormField.includes(node.tag)) {
+          isUpdated = updateFormFieldSubcomponents(node.children);
+        }
+        if (isUpdated) {
+          return [node];
+        }
+      },
+    };
+  });
+};
+
+module.exports.type = 'hbs';

--- a/packages/codemods/transforms/v4/contextual-components/test.js
+++ b/packages/codemods/transforms/v4/contextual-components/test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+'use strict';
+
+const { runTransformTest } = require('codemod-cli');
+
+runTransformTest({
+  name: 'v4/contextual-components',
+});

--- a/packages/codemods/transforms/v4/table/README.md
+++ b/packages/codemods/transforms/v4/table/README.md
@@ -1,4 +1,4 @@
-# v3/masked-input
+# v4/table
 
 ## Usage
 

--- a/packages/components/addon/components/hds/alert/index.hbs
+++ b/packages/components/addon/components/hds/alert/index.hbs
@@ -25,7 +25,7 @@
     <div class="hds-alert__actions">
       {{yield
         (hash
-          Button=(component "hds/button" size="small") Link::Standalone=(component "hds/link/standalone" size="small")
+          Button=(component "hds/button" size="small") LinkStandalone=(component "hds/link/standalone" size="small")
         )
       }}
     </div>

--- a/packages/components/addon/components/hds/application-state/footer.hbs
+++ b/packages/components/addon/components/hds/application-state/footer.hbs
@@ -3,5 +3,5 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 <div class={{this.classNames}} ...attributes>
-  {{yield (hash Link::Standalone=(component "hds/link/standalone"))}}
+  {{yield (hash LinkStandalone=(component "hds/link/standalone"))}}
 </div>

--- a/packages/components/addon/components/hds/form/checkbox/group.hbs
+++ b/packages/components/addon/components/hds/form/checkbox/group.hbs
@@ -16,7 +16,7 @@
   <F.Control>
     {{yield
       (hash
-        Checkbox::Field=(component
+        CheckboxField=(component
           "hds/form/checkbox/field"
           contextualClass="hds-form-group__control-field"
           isRequired=@isRequired

--- a/packages/components/addon/components/hds/form/radio/group.hbs
+++ b/packages/components/addon/components/hds/form/radio/group.hbs
@@ -16,7 +16,7 @@
   <F.Control>
     {{yield
       (hash
-        Radio::Field=(component
+        RadioField=(component
           "hds/form/radio/field"
           contextualClass="hds-form-group__control-field"
           isRequired=@isRequired

--- a/packages/components/addon/components/hds/form/toggle/group.hbs
+++ b/packages/components/addon/components/hds/form/toggle/group.hbs
@@ -9,7 +9,7 @@
   <F.Control>
     {{yield
       (hash
-        Toggle::Field=(component
+        ToggleField=(component
           "hds/form/toggle/field"
           contextualClass="hds-form-group__control-field"
           isRequired=@isRequired

--- a/packages/components/addon/components/hds/toast/index.hbs
+++ b/packages/components/addon/components/hds/toast/index.hbs
@@ -12,6 +12,6 @@
   as |A|
 >
   {{yield
-    (hash Title=A.Title Description=A.Description Button=A.Button Link::Standalone=A.Link::Standalone Generic=A.Generic)
+    (hash Title=A.Title Description=A.Description Button=A.Button LinkStandalone=A.LinkStandalone Generic=A.Generic)
   }}
 </Hds::Alert>

--- a/packages/components/tests/dummy/app/templates/components/alert.hbs
+++ b/packages/components/tests/dummy/app/templates/components/alert.hbs
@@ -192,7 +192,7 @@
         <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
         <A.Button @text="Secondary" @color="secondary" />
         <A.Button @icon="plus" @text="Tertiary" @color="tertiary" />
-        <A.Link::Standalone @icon="plus" @text="Standalone" @href="#" @color="secondary" />
+        <A.LinkStandalone @icon="plus" @text="Standalone" @href="#" @color="secondary" />
       </Hds::Alert>
     </SG.Item>
     <SG.Item>
@@ -201,7 +201,7 @@
         <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
           labore et dolore magna aliqua.</A.Description>
         <A.Button @text="Action" @color="secondary" />
-        <A.Link::Standalone @icon="plus" @text="Action" @href="#" @color="secondary" />
+        <A.LinkStandalone @icon="plus" @text="Action" @href="#" @color="secondary" />
         <A.Generic>
           <div class="shw-component-alert-sample-custom-content-after-actions">This for example could be extra text,
             specific for a special use case.</div>

--- a/packages/components/tests/dummy/app/templates/components/application-state.hbs
+++ b/packages/components/tests/dummy/app/templates/components/application-state.hbs
@@ -16,8 +16,8 @@
           @text="Sorry, an unexpected error has occurred. Please try again later or contact support for assistance."
         />
         <A.Footer @hasDivider={{true}} as |F|>
-          <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
-          <F.Link::Standalone @icon="help" @text="Need Help" @href="/components/alert" @iconPosition="trailing" />
+          <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
+          <F.LinkStandalone @icon="help" @text="Need Help" @href="/components/alert" @iconPosition="trailing" />
         </A.Footer>
       </Hds::ApplicationState>
     </SF.Item>
@@ -28,8 +28,8 @@
           @text="Sorry, an unexpected error has occurred. Please try again later or contact support for assistance."
         />
         <A.Footer @hasDivider={{true}} as |F|>
-          <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
-          <F.Link::Standalone @icon="help" @text="Need Help" @href="/components/alert" @iconPosition="trailing" />
+          <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
+          <F.LinkStandalone @icon="help" @text="Need Help" @href="/components/alert" @iconPosition="trailing" />
         </A.Footer>
       </Hds::ApplicationState>
     </SF.Item>
@@ -40,8 +40,8 @@
           @text="Sorry, an unexpected error has occurred. Please try again later or contact support for assistance."
         />
         <A.Footer @hasDivider={{true}} as |F|>
-          <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
-          <F.Link::Standalone @icon="help" @text="Need Help" @href="/components/alert" @iconPosition="trailing" />
+          <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
+          <F.LinkStandalone @icon="help" @text="Need Help" @href="/components/alert" @iconPosition="trailing" />
         </A.Footer>
       </Hds::ApplicationState>
     </SF.Item>
@@ -52,8 +52,8 @@
           <Shw::Placeholder @text="block yield" @height="150px" @background="#e1f5fe" />
         </A.Body>
         <A.Footer @hasDivider={{true}} as |F|>
-          <F.Link::Standalone @icon="arrow-left" @text="Go to previous page" @href="/" />
-          <F.Link::Standalone
+          <F.LinkStandalone @icon="arrow-left" @text="Go to previous page" @href="/" />
+          <F.LinkStandalone
             @icon="help"
             @text="Need Help contact us"
             @href="/components/alert"
@@ -69,8 +69,8 @@
           @text="Sorry, an unexpected error has occurred. Please try again later or contact support for assistance."
         />
         <A.Footer as |F|>
-          <F.Link::Standalone @icon="arrow-left" @text="Go to previous page" @href="/" />
-          <F.Link::Standalone @icon="help" @text="Need Help" @href="/components/alert" @iconPosition="trailing" />
+          <F.LinkStandalone @icon="arrow-left" @text="Go to previous page" @href="/" />
+          <F.LinkStandalone @icon="help" @text="Need Help" @href="/components/alert" @iconPosition="trailing" />
         </A.Footer>
       </Hds::ApplicationState>
     </SF.Item>
@@ -81,7 +81,7 @@
           @text="Sorry, we couldn't find any results matching your search criteria. Please try again with different search terms or refine your filters."
         />
         <A.Footer as |F|>
-          <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
+          <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
         </A.Footer>
       </Hds::ApplicationState>
     </SF.Item>
@@ -92,7 +92,7 @@
           @text="Sorry, we couldn't find any results matching your search criteria. Please try again with different search terms or refine your filters."
         />
         <A.Footer @hasDivider={{true}} as |F|>
-          <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
+          <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
         </A.Footer>
       </Hds::ApplicationState>
     </SF.Item>
@@ -111,7 +111,7 @@
           <Shw::Placeholder @text="components and other things" @height="150px" @background="#e1f5fe" />
         </A.Body>
         <A.Footer as |F|>
-          <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
+          <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
         </A.Footer>
       </Hds::ApplicationState>
     </SF.Item>
@@ -122,7 +122,7 @@
           <Shw::Placeholder @text="components and other things" @height="150px" @background="#e1f5fe" />
         </A.Body>
         <A.Footer as |F|>
-          <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
+          <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
         </A.Footer>
       </Hds::ApplicationState>
     </SF.Item>

--- a/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/checkbox.hbs
@@ -133,90 +133,90 @@
     <SG.Item @label="With legend">
       <Hds::Form::Checkbox::Group @name="control-vertical-01" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SG.Item>
     <SG.Item @label="With legend / With helper text">
       <Hds::Form::Checkbox::Group @name="control-vertical-02" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
           <F.HelperText>Helper text for control #1</F.HelperText>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
           <F.HelperText>Helper text for control #2</F.HelperText>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
           <F.HelperText>Helper text for control #3</F.HelperText>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SG.Item>
     <SG.Item @label="Without legend">
       <Hds::Form::Checkbox::Group @name="control-vertical-03" as |G|>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SG.Item>
     <SG.Item @label="Without legend / With helper text">
       <Hds::Form::Checkbox::Group @name="control-vertical-04" as |G|>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
           <F.HelperText>Helper text for control #1</F.HelperText>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
           <F.HelperText>Helper text for control #2</F.HelperText>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
           <F.HelperText>Helper text for control #3</F.HelperText>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SG.Item>
     <SG.Item @label="With helper text at group level">
       <Hds::Form::Checkbox::Group @name="control-vertical-05" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.HelperText>Helper text for the entire group</G.HelperText>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SG.Item>
     <SG.Item @label="With error at group level">
       <Hds::Form::Checkbox::Group @name="control-vertical-06" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
         <G.Error>Error for the entire group</G.Error>
       </Hds::Form::Checkbox::Group>
     </SG.Item>
@@ -228,81 +228,81 @@
     <SF.Item @label="With legend">
       <Hds::Form::Checkbox::Group @layout="horizontal" @name="control-horizontal-01" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SF.Item>
     <SF.Item @label="Without legend">
       <Hds::Form::Checkbox::Group @layout="horizontal" @name="control-horizontal-02" as |G|>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SF.Item>
     <SF.Item @label="With helper text at group level">
       <Hds::Form::Checkbox::Group @layout="horizontal" @name="control-horizontal-03" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.HelperText>Helper text for the entire group</G.HelperText>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SF.Item>
     <SF.Item @label="With error at group level">
       <Hds::Form::Checkbox::Group @layout="horizontal" @name="control-horizontal-04" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
         <G.Error>Error for the entire group</G.Error>
       </Hds::Form::Checkbox::Group>
     </SF.Item>
     <SF.Item @label="With controls on multiple lines" {{style width="450px"}}>
       <Hds::Form::Checkbox::Group @layout="horizontal" @name="control-horizontal-05" as |G|>
         <G.Legend>Lorem ipsum dolor</G.Legend>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Sit amet</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Consectetur adipiscing</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField as |F|>
           <F.Label>Elit</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField as |F|>
           <F.Label>Pellentesque erat</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField as |F|>
           <F.Label>Lacinia</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>At magna</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SF.Item>
   </Shw::Flex>
@@ -313,29 +313,29 @@
     <SF.Item @label="With legend + Required">
       <Hds::Form::Checkbox::Group @isRequired={{true}} @name="control-required" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SF.Item>
     <SF.Item @label="With legend + Optional">
       <Hds::Form::Checkbox::Group @isOptional={{true}} @name="control-optional" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Checkbox::Field as |F|>
+        <G.CheckboxField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field checked="checked" as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Checkbox::Field>
-        <G.Checkbox::Field indeterminate={{true}} as |F|>
+        </G.CheckboxField>
+        <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Checkbox::Field>
+        </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/dummy/app/templates/components/form/radio.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/radio.hbs
@@ -120,90 +120,90 @@
     <SG.Item @label="With legend">
       <Hds::Form::Radio::Group @name="control-vertical-01" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SG.Item>
     <SG.Item @label="With legend / With helper text">
       <Hds::Form::Radio::Group @name="control-vertical-03" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Label of control #1</F.Label>
           <F.HelperText>Helper text for control #1</F.HelperText>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
           <F.HelperText>Helper text for control #2</F.HelperText>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Label of control #3</F.Label>
           <F.HelperText>Helper text for control #3</F.HelperText>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SG.Item>
     <SG.Item @label="Without legend">
       <Hds::Form::Radio::Group @name="control-vertical-02" as |G|>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SG.Item>
     <SG.Item @label="Without legend / With helper text">
       <Hds::Form::Radio::Group @name="control-vertical-04" as |G|>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Label of control #1</F.Label>
           <F.HelperText>Helper text for control #1</F.HelperText>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
           <F.HelperText>Helper text for control #2</F.HelperText>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Label of control #3</F.Label>
           <F.HelperText>Helper text for control #3</F.HelperText>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SG.Item>
     <SG.Item @label="With helper text at group level">
       <Hds::Form::Radio::Group @name="control-vertical-05" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.HelperText>Helper text for the entire group</G.HelperText>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SG.Item>
     <SG.Item @label="With error at group level">
       <Hds::Form::Radio::Group @name="control-vertical-06" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field name="control-vertical-06" as |F|>
+        <G.RadioField name="control-vertical-06" as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-06" checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField name="control-vertical-06" checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field name="control-vertical-06" as |F|>
+        </G.RadioField>
+        <G.RadioField name="control-vertical-06" as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
         <G.Error>Error for the entire group</G.Error>
       </Hds::Form::Radio::Group>
     </SG.Item>
@@ -215,81 +215,81 @@
     <SF.Item @label="With legend">
       <Hds::Form::Radio::Group @layout="horizontal" @name="control-horizontal-01" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SF.Item>
     <SF.Item @label="Without legend">
       <Hds::Form::Radio::Group @layout="horizontal" @name="control-horizontal-02" as |G|>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SF.Item>
     <SF.Item @label="With helper text at group level">
       <Hds::Form::Radio::Group @layout="horizontal" @name="control-horizontal-03" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.HelperText>Helper text for the entire group</G.HelperText>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SF.Item>
     <SF.Item @label="With error at group level">
       <Hds::Form::Radio::Group @layout="horizontal" @name="control-horizontal-04" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field name="control-horizontal-04" as |F|>
+        <G.RadioField name="control-horizontal-04" as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field name="control-horizontal-04" checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField name="control-horizontal-04" checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field name="control-horizontal-04" as |F|>
+        </G.RadioField>
+        <G.RadioField name="control-horizontal-04" as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
         <G.Error>Error for the entire group</G.Error>
       </Hds::Form::Radio::Group>
     </SF.Item>
     <SF.Item @label="With controls on multiple lines" {{style width="450px"}}>
       <Hds::Form::Radio::Group @layout="horizontal" @name="control-horizontal-05" as |G|>
         <G.Legend>Lorem ipsum dolor</G.Legend>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Sit amet</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Consectetur adipiscing</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Elit</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Pellentesque erat</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Lacinia</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>At magna</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SF.Item>
   </Shw::Flex>
@@ -300,29 +300,29 @@
     <SF.Item @label="With legend + Required">
       <Hds::Form::Radio::Group @isRequired={{true}} @name="control-required" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SF.Item>
     <SF.Item @label="With legend + Optional">
       <Hds::Form::Radio::Group @isOptional={{true}} @name="control-optional" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Radio::Field as |F|>
+        <G.RadioField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field checked="checked" as |F|>
+        </G.RadioField>
+        <G.RadioField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Radio::Field>
-        <G.Radio::Field as |F|>
+        </G.RadioField>
+        <G.RadioField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Radio::Field>
+        </G.RadioField>
       </Hds::Form::Radio::Group>
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
+++ b/packages/components/tests/dummy/app/templates/components/form/toggle.hbs
@@ -116,35 +116,35 @@
     <SG.Item @label="With legend">
       <Hds::Form::Toggle::Group as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Toggle::Field checked="checked" as |F|>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>This is the label</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SG.Item>
     <SG.Item @label="With legend / With helper text">
       <Hds::Form::Toggle::Group as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Toggle::Field checked="checked" as |F|>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>This is the label</F.Label>
           <F.HelperText>This is the helper text</F.HelperText>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SG.Item>
     <SG.Item @label="Without legend">
       <Hds::Form::Toggle::Group as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.HelperText>Helper text for the entire group</G.HelperText>
-        <G.Toggle::Field checked="checked" as |F|>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>This is the label</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SG.Item>
     <SG.Item @label="Without legend / With helper text">
       <Hds::Form::Toggle::Group as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Toggle::Field checked="checked" as |F|>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>This is the label</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
         <G.Error>Error for the entire group</G.Error>
       </Hds::Form::Toggle::Group>
     </SG.Item>
@@ -156,90 +156,90 @@
     <SG.Item @label="With legend">
       <Hds::Form::Toggle::Group as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SG.Item>
     <SG.Item @label="With legend / With helper text">
       <Hds::Form::Toggle::Group as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
           <F.HelperText>Helper text for control #1</F.HelperText>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
           <F.HelperText>Helper text for control #2</F.HelperText>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
           <F.HelperText>Helper text for control #3</F.HelperText>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SG.Item>
     <SG.Item @label="Without legend">
       <Hds::Form::Toggle::Group as |G|>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SG.Item>
     <SG.Item @label="Without legend / With helper text">
       <Hds::Form::Toggle::Group as |G|>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
           <F.HelperText>Helper text for control #1</F.HelperText>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
           <F.HelperText>Helper text for control #2</F.HelperText>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
           <F.HelperText>Helper text for control #3</F.HelperText>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SG.Item>
     <SG.Item @label="With helper text at group level">
       <Hds::Form::Toggle::Group as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.HelperText>Helper text for the entire group</G.HelperText>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SG.Item>
     <SG.Item @label="With error at group level">
       <Hds::Form::Toggle::Group as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
         <G.Error>Error for the entire group</G.Error>
       </Hds::Form::Toggle::Group>
     </SG.Item>
@@ -251,81 +251,81 @@
     <SF.Item @label="With legend">
       <Hds::Form::Toggle::Group @layout="horizontal" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SF.Item>
     <SF.Item @label="Without legend">
       <Hds::Form::Toggle::Group @layout="horizontal" as |G|>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SF.Item>
     <SF.Item @label="With helper text at group level">
       <Hds::Form::Toggle::Group @layout="horizontal" as |G|>
         <G.Legend>Legend of the group</G.Legend>
         <G.HelperText>Helper text for the entire group</G.HelperText>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SF.Item>
     <SF.Item @label="With error at group level">
       <Hds::Form::Toggle::Group @layout="horizontal" as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
         <G.Error>Error for the entire group</G.Error>
       </Hds::Form::Toggle::Group>
     </SF.Item>
     <SF.Item @label="With controls on multiple lines" {{style width="450px"}}>
       <Hds::Form::Toggle::Group @layout="horizontal" as |G|>
         <G.Legend>Lorem ipsum dolor</G.Legend>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Sit amet</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Consectetur adipiscing</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Elit</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Pellentesque erat</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Lacinia</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>At magna</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SF.Item>
   </Shw::Flex>
@@ -336,29 +336,29 @@
     <SF.Item @label="With legend + Required">
       <Hds::Form::Toggle::Group @isRequired={{true}} as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SF.Item>
     <SF.Item @label="With legend + Optional">
       <Hds::Form::Toggle::Group @isOptional={{true}} as |G|>
         <G.Legend>Legend of the group</G.Legend>
-        <G.Toggle::Field as |F|>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #1</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field checked="checked" as |F|>
+        </G.ToggleField>
+        <G.ToggleField checked="checked" as |F|>
           <F.Label>Label of control #2</F.Label>
-        </G.Toggle::Field>
-        <G.Toggle::Field as |F|>
+        </G.ToggleField>
+        <G.ToggleField as |F|>
           <F.Label>Label of control #3</F.Label>
-        </G.Toggle::Field>
+        </G.ToggleField>
       </Hds::Form::Toggle::Group>
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/dummy/app/templates/components/toast.hbs
+++ b/packages/components/tests/dummy/app/templates/components/toast.hbs
@@ -154,7 +154,7 @@
         <T.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</T.Description>
         <T.Button @text="Secondary" @color="secondary" />
         <T.Button @icon="plus" @text="Tertiary" @color="tertiary" />
-        <T.Link::Standalone @icon="plus" @text="Standalone" @href="#" @color="secondary" />
+        <T.LinkStandalone @icon="plus" @text="Standalone" @href="#" @color="secondary" />
       </Hds::Toast>
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/integration/components/hds/alert/index-test.js
+++ b/packages/components/tests/integration/components/hds/alert/index-test.js
@@ -97,7 +97,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   });
   test('it should render an Hds::Link::Standalone component yielded to the "actions" container', async function (assert) {
     await render(
-      hbs`<Hds::Alert @type="inline" aria-labelledby="test-alert-link" id="test-alert" as |A|><A.Link::Standalone @icon="plus" @text="I am a link" @href="#" @size="small" @color="secondary" id="test-alert-link" /></Hds::Alert>`
+      hbs`<Hds::Alert @type="inline" aria-labelledby="test-alert-link" id="test-alert" as |A|><A.LinkStandalone @icon="plus" @text="I am a link" @href="#" @size="small" @color="secondary" id="test-alert-link" /></Hds::Alert>`
     );
     assert
       .dom('#test-alert .hds-alert__actions a')

--- a/packages/components/tests/integration/components/hds/application-state/footer-test.js
+++ b/packages/components/tests/integration/components/hds/application-state/footer-test.js
@@ -31,5 +31,20 @@ module(
 
       assert.dom('.hds-application-state__footer--has-divider').exists();
     });
+
+    // CONTEXTUAL COMPONENTS
+
+    test('it should render an Hds::Link::Standalone component', async function (assert) {
+      await render(hbs`
+        <Hds::ApplicationState::Footer id="test-application-state-footer" as |F|>
+          <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/"/>
+        </Hds::ApplicationState::Footer>
+      `);
+      assert
+        .dom('#test-application-state-footer a')
+        .exists()
+        .hasClass('hds-link-standalone')
+        .hasText('Go back');
+    });
   }
 );

--- a/packages/components/tests/integration/components/hds/form/checkbox/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/checkbox/group-test.js
@@ -27,11 +27,11 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
       hbs`<Hds::Form::Checkbox::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.Checkbox::Field checked="checked" @value="abc123" as |F|>
+            <G.CheckboxField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
               <F.HelperText>This is the control helper text</F.HelperText>
               <F.Error>This is the control error</F.Error>
-            </G.Checkbox::Field>
+            </G.CheckboxField>
             <G.Error>This is the group error</G.Error>
           </Hds::Form::Checkbox::Group>`
     );
@@ -73,11 +73,11 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
       hbs`<Hds::Form::Checkbox::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.Checkbox::Field checked="checked" @value="abc123" as |F|>
+            <G.CheckboxField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
               <F.HelperText>This is the control helper text</F.HelperText>
               <F.Error>This is the control error</F.Error>
-            </G.Checkbox::Field>
+            </G.CheckboxField>
             <G.Error>This is the group error</G.Error>
           </Hds::Form::Checkbox::Group>`
     );
@@ -108,12 +108,12 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
     await render(
       hbs`<Hds::Form::Checkbox::Group @name="datacenter-demo" as |G|>
             <G.Legend>Choose datacenter</G.Legend>
-            <G.Checkbox::Field data-test="first-control" as |F|>
+            <G.CheckboxField data-test="first-control" as |F|>
               <F.Label>NYC1</F.Label>
-            </G.Checkbox::Field>
-            <G.Checkbox::Field data-test="second-control" as |F|>
+            </G.CheckboxField>
+            <G.CheckboxField data-test="second-control" as |F|>
               <F.Label>DC1</F.Label>
-            </G.Checkbox::Field>
+            </G.CheckboxField>
           </Hds::Form::Checkbox::Group>`
     );
     assert
@@ -130,9 +130,9 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
     await render(
       hbs`<Hds::Form::Checkbox::Group @isRequired={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
-            <G.Checkbox::Field checked="checked" @value="abc123" as |F|>
+            <G.CheckboxField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
-            </G.Checkbox::Field>
+            </G.CheckboxField>
           </Hds::Form::Checkbox::Group>`
     );
     assert.dom('legend .hds-form-indicator').exists();
@@ -143,9 +143,9 @@ module('Integration | Component | hds/form/checkbox/group', function (hooks) {
     await render(
       hbs`<Hds::Form::Checkbox::Group @isOptional={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
-            <G.Checkbox::Field checked="checked" @value="abc123" as |F|>
+            <G.CheckboxField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
-            </G.Checkbox::Field>
+            </G.CheckboxField>
           </Hds::Form::Checkbox::Group>`
     );
     assert.dom('legend .hds-form-indicator').exists();

--- a/packages/components/tests/integration/components/hds/form/radio/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/radio/group-test.js
@@ -27,11 +27,11 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
       hbs`<Hds::Form::Radio::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.Radio::Field checked="checked" @value="abc123" as |F|>
+            <G.RadioField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
               <F.HelperText>This is the control helper text</F.HelperText>
               <F.Error>This is the control error</F.Error>
-            </G.Radio::Field>
+            </G.RadioField>
             <G.Error>This is the group error</G.Error>
           </Hds::Form::Radio::Group>`
     );
@@ -73,11 +73,11 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
       hbs`<Hds::Form::Radio::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.Radio::Field checked="checked" @value="abc123" as |F|>
+            <G.RadioField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
               <F.HelperText>This is the control helper text</F.HelperText>
               <F.Error>This is the control error</F.Error>
-            </G.Radio::Field>
+            </G.RadioField>
             <G.Error>This is the group error</G.Error>
           </Hds::Form::Radio::Group>`
     );
@@ -108,12 +108,12 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
     await render(
       hbs`<Hds::Form::Radio::Group @name="datacenter-demo" as |G|>
             <G.Legend>Choose datacenter</G.Legend>
-            <G.Radio::Field data-test="first-control" as |F|>
+            <G.RadioField data-test="first-control" as |F|>
               <F.Label>NYC1</F.Label>
-            </G.Radio::Field>
-            <G.Radio::Field data-test="second-control" as |F|>
+            </G.RadioField>
+            <G.RadioField data-test="second-control" as |F|>
               <F.Label>DC1</F.Label>
-            </G.Radio::Field>
+            </G.RadioField>
           </Hds::Form::Radio::Group>`
     );
     assert
@@ -130,9 +130,9 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
     await render(
       hbs`<Hds::Form::Radio::Group @isRequired={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
-            <G.Radio::Field checked="checked" @value="abc123" as |F|>
+            <G.RadioField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
-            </G.Radio::Field>
+            </G.RadioField>
         </Hds::Form::Radio::Group>`
     );
     assert.dom('legend .hds-form-indicator').exists();
@@ -143,9 +143,9 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
     await render(
       hbs`<Hds::Form::Radio::Group @isOptional={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
-            <G.Radio::Field checked="checked" @value="abc123" as |F|>
+            <G.RadioField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
-            </G.Radio::Field>
+            </G.RadioField>
           </Hds::Form::Radio::Group>`
     );
     assert.dom('legend .hds-form-indicator').exists();

--- a/packages/components/tests/integration/components/hds/form/toggle/group-test.js
+++ b/packages/components/tests/integration/components/hds/form/toggle/group-test.js
@@ -27,11 +27,11 @@ module('Integration | Component | hds/form/toggle/group', function (hooks) {
       hbs`<Hds::Form::Toggle::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.Toggle::Field checked="checked" @value="abc123" as |F|>
+            <G.ToggleField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
               <F.HelperText>This is the control helper text</F.HelperText>
               <F.Error>This is the control error</F.Error>
-            </G.Toggle::Field>
+            </G.ToggleField>
             <G.Error>This is the group error</G.Error>
         </Hds::Form::Toggle::Group>`
     );
@@ -73,11 +73,11 @@ module('Integration | Component | hds/form/toggle/group', function (hooks) {
       hbs`<Hds::Form::Toggle::Group as |G|>
             <G.Legend>This is the legend</G.Legend>
             <G.HelperText>This is the group helper text</G.HelperText>
-            <G.Toggle::Field checked="checked" @value="abc123" as |F|>
+            <G.ToggleField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
               <F.HelperText>This is the control helper text</F.HelperText>
               <F.Error>This is the control error</F.Error>
-            </G.Toggle::Field>
+            </G.ToggleField>
             <G.Error>This is the group error</G.Error>
         </Hds::Form::Toggle::Group>`
     );
@@ -108,9 +108,9 @@ module('Integration | Component | hds/form/toggle/group', function (hooks) {
     await render(
       hbs`<Hds::Form::Toggle::Group @isRequired={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
-            <G.Toggle::Field checked="checked" @value="abc123" as |F|>
+            <G.ToggleField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
-            </G.Toggle::Field>
+            </G.ToggleField>
           </Hds::Form::Toggle::Group>`
     );
     assert.dom('legend .hds-form-indicator').exists();
@@ -121,9 +121,9 @@ module('Integration | Component | hds/form/toggle/group', function (hooks) {
     await render(
       hbs`<Hds::Form::Toggle::Group @isOptional={{true}} as |G|>
             <G.Legend>This is the legend</G.Legend>
-            <G.Toggle::Field checked="checked" @value="abc123" as |F|>
+            <G.ToggleField checked="checked" @value="abc123" as |F|>
               <F.Label>This is the control label</F.Label>
-            </G.Toggle::Field>
+            </G.ToggleField>
           </Hds::Form::Toggle::Group>`
     );
     assert.dom('legend .hds-form-indicator').exists();

--- a/website/docs/components/alert/partials/code/component-api.md
+++ b/website/docs/components/alert/partials/code/component-api.md
@@ -20,7 +20,7 @@
 
 ### Contextual components
 
-Title, description, actions, and generic content are passed into the alert as yielded components, using the `Title`, `Description`, `Button`, `Link::Standalone`, `Generic` keys.
+Title, description, actions, and generic content are passed into the alert as yielded components, using the `Title`, `Description`, `Button`, `LinkStandalone`, `Generic` keys.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="<[A].Title>" @type="yielded component">
@@ -30,10 +30,10 @@ Title, description, actions, and generic content are passed into the alert as yi
     A container that yields its content inside the `"description"` block. Content inherits its style.<br/><br/>Accepts complex content, such as logic/conditionals, HTML elements, other Ember components, etc. Styling is applied for simple HTML elements, such as `strong`, `em`, `a`, `code/pre`. Application teams will need to style the rest of the content.<br/><br/>This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
   <C.Property @name="<[A].Button>" @type="yielded component">
-    A yielded `HDS::Button` component. It exposes the same API of the [`Button` component](/components/button), apart from the `@size` argument, which is pre-defined to be `small`, and the `@color` argument that accepts only `secondary` or `tertiary`.
+    A yielded `Hds::Button` component. It exposes the same API of the [`Button` component](/components/button), apart from the `@size` argument, which is pre-defined to be `small`, and the `@color` argument that accepts only `secondary` or `tertiary`.
   </C.Property>
-  <C.Property @name="<[A].Link::Standalone>" @type="yielded component">
-    A yielded `HDS::Link::Standalone` component. It exposes the same API of the [`Link::Standalone` component](/components/link/standalone), apart from the `@size` argument, which is pre-defined to be `small`.
+  <C.Property @name="<[A].LinkStandalone>" @type="yielded component">
+    A yielded `Hds::Link::Standalone` component. It exposes the same API of the [`Link::Standalone` component](/components/link/standalone), apart from the `@size` argument, which is pre-defined to be `small`.
   </C.Property>
   <C.Property @name="<[A].Generic>" @type="yielded component">
     A component that yields its content.

--- a/website/docs/components/alert/partials/code/how-to-use.md
+++ b/website/docs/components/alert/partials/code/how-to-use.md
@@ -89,14 +89,14 @@ Given the variety of use cases and contexts in which alerts are used across prod
 
 ### Actions
 
-Actions can be passed to the component using one of the suggested `Button` or `Link::Standalone` contextual components.
+Actions can be passed to the component using one of the suggested `Button` or `LinkStandalone` contextual components.
 
 ```handlebars
 <Hds::Alert @type="inline" as |A|>
   <A.Title>Title here</A.Title>
   <A.Description>Description here</A.Description>
   <A.Button @text="Your action" @color="secondary" {{on "click" this.yourOnClickFunction}} />
-  <A.Link::Standalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Another action" @href="#" />
+  <A.LinkStandalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Another action" @href="#" />
 </Hds::Alert>
 ```
 

--- a/website/docs/components/alert/partials/content/content.md
+++ b/website/docs/components/alert/partials/content/content.md
@@ -42,7 +42,7 @@ When linking to internal and external resources in the Alert, default to using a
 <Hds::Alert @type="inline" @color="highlight" as |A|>
   <A.Title>Links in alerts</A.Title>
   <A.Description>Lorem ipsum dolar sit amet.</A.Description>
-  <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @color="secondary" @text="Standalone link" @href="#" />
+  <A.LinkStandalone @icon="arrow-right" @iconPosition="trailing" @color="secondary" @text="Standalone link" @href="#" />
 </Hds::Alert>
 
 Within the Alert description, use the `secondary` [Inline Link](/components/link/inline) as the default link color. A common use case for this is when linking to multiple resources.
@@ -139,7 +139,7 @@ The title or description should contain the alert type, e.g., “Warning,” if 
   <A.Title>Alert with actions</A.Title>
   <A.Description>Lorem ipsum dolar sit amet.</A.Description>
   <A.Button @text="Your action" @color="secondary" @onClick={{this.noop}} />
-  <A.Link::Standalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Learn more" @href="#" />
+  <A.LinkStandalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Learn more" @href="#" />
 </Hds::Alert>
 
 ### With generic content

--- a/website/docs/components/alert/partials/guidelines/guidelines.md
+++ b/website/docs/components/alert/partials/guidelines/guidelines.md
@@ -72,7 +72,7 @@ Use the Alert for more intrusive message communication about errors or critical 
     <A.Title>You have exceeded 50 applies this month</A.Title>
     <A.Description>You may only invoke applies that destroy managed resources. Upgrade now and access additional product features, unlimited applies, and increased concurrency.</A.Description>
     <A.Button @text="Upgrade" @color="secondary" @onClick={{this.noop}} />
-    <A.Link::Standalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="View usage" @href="#" />
+    <A.LinkStandalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="View usage" @href="#" />
   </Hds::Alert>
 !!!
 
@@ -120,7 +120,7 @@ Icons within the `neutral` and `highlight` alerts can be replaced with other ico
 <Hds::Alert @type="inline" @color="highlight" @onDismiss={{this.noop}} @icon="gift" as |A|>
   <A.Title>New features available</A.Title>
   <A.Description>Starting with Terraform 0.15, you can now upgrade to a new version and your workflows will continue to be operational, just as they were in prior versions.</A.Description>
-  <A.Link::Standalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Release notes" @href="#" />
+  <A.LinkStandalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Release notes" @href="#" />
 </Hds::Alert>
 
 ## Dismissal

--- a/website/docs/components/application-state/partials/code/component-api.md
+++ b/website/docs/components/application-state/partials/code/component-api.md
@@ -32,10 +32,11 @@ Supports block invocation for custom content (see [Block Content](https://guides
   
 #### [A].Footer
 
-Yields the [Link::Standalone](../components/link/standalone) component as `Link::Standalone`.
-
 <Doc::ComponentApi as |C|>
   <C.Property @name="hasDivider" @type="boolean" @default="false" @values={{array "true" "false"}}>
     Indicates if there should be a visible divider above the footer.
+  </C.Property>
+  <C.Property @name="<[F].LinkStandalone>" @type="yielded component">
+    A yielded `Hds::Link::Standalone` component. It exposes the same API of the [`Link::Standalone` component](/components/link/standalone).
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/application-state/partials/code/how-to-use.md
+++ b/website/docs/components/application-state/partials/code/how-to-use.md
@@ -27,7 +27,7 @@ This component intends to replace a few different simple error and empty/zero st
   <A.Header @title="Empty state title text" />
   <A.Body @text="The item you were looking for was not found." />
   <A.Footer as |F|>
-    <F.Link::Standalone @icon="help" @text="Need Help" @href="/components/alert"
+    <F.LinkStandalone @icon="help" @text="Need Help" @href="/components/alert"
     @iconPosition="trailing" />
   </A.Footer>
 </Hds::ApplicationState>
@@ -40,7 +40,7 @@ This component intends to replace a few different simple error and empty/zero st
   <A.Header @title="Empty state title text" />
   <A.Body @text="The item you were looking for was not found." />
   <A.Footer @hasDivider={{true}} as |F|>
-    <F.Link::Standalone @icon="help" @text="Need Help" @href="/components/alert"
+    <F.LinkStandalone @icon="help" @text="Need Help" @href="/components/alert"
     @iconPosition="trailing" />
   </A.Footer>
 </Hds::ApplicationState>
@@ -55,7 +55,7 @@ This component intends to replace a few different simple error and empty/zero st
     <Doc::Placeholder @text="block yield" @height="100" @background="#eee" />
   </A.Body>
   <A.Footer as |F|>
-    <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
+    <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
   </A.Footer>
 </Hds::ApplicationState>
 ```
@@ -67,7 +67,7 @@ This component intends to replace a few different simple error and empty/zero st
   <A.Header @title="Empty state title text" />
   <A.Body @text="Some sentence that conveys a good message to the user" />
   <A.Footer as |F|>
-    <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
+    <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
   </A.Footer>
 </Hds::ApplicationState>
 ```
@@ -84,8 +84,8 @@ To indicate that the message is an error state, add `@errorCode` to the `[A].Hea
     Please try again later or contact support for assistance."
   />
   <A.Footer as |F|>
-    <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
-    <F.Link::Standalone @icon="help" @text="Need Help" @href="/components/alert" 
+    <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
+    <F.LinkStandalone @icon="help" @text="Need Help" @href="/components/alert" 
       @iconPosition="trailing" />
   </A.Footer>
 </Hds::ApplicationState>
@@ -101,8 +101,8 @@ To indicate that the message is an error state, add `@errorCode` to the `[A].Hea
     Please try again later or contact support for assistance."
   />
   <A.Footer as |F|>
-    <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
-    <F.Link::Standalone @icon="help" @text="Need Help" @href="/components/alert" 
+    <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
+    <F.LinkStandalone @icon="help" @text="Need Help" @href="/components/alert" 
       @iconPosition="trailing" />
   </A.Footer>
 </Hds::ApplicationState>
@@ -117,8 +117,8 @@ To indicate that the message is an error state, add `@errorCode` to the `[A].Hea
     <Doc::Placeholder @text="block yield" @height="100" @background="#eee" />
   </A.Body>
   <A.Footer as |F|>
-    <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
-    <F.Link::Standalone @icon="help" @text="Need Help" 
+    <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
+    <F.LinkStandalone @icon="help" @text="Need Help" 
       @href="/components/alert" @iconPosition="trailing" />
   </A.Footer>
 </Hds::ApplicationState>
@@ -134,8 +134,8 @@ To indicate that the message is an error state, add `@errorCode` to the `[A].Hea
     Please try again later or contact support for assistance."
   />
   <A.Footer @hasDivider={{true}} as |F|>
-    <F.Link::Standalone @icon="arrow-left" @text="Go back" @href="/" />
-    <F.Link::Standalone @icon="help" @text="Need Help" @href="/components/alert" 
+    <F.LinkStandalone @icon="arrow-left" @text="Go back" @href="/" />
+    <F.LinkStandalone @icon="help" @text="Need Help" @href="/components/alert" 
       @iconPosition="trailing" />
   </A.Footer>
 </Hds::ApplicationState>

--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -130,7 +130,7 @@ For links that require more prominence and CTAs (calls-to-action).
     This page displays all users in the organization who have permissions in this project. A user must be invited to the org first before you can change the user’s role at the project level.
   </A.Description>
   <A.Button @text="Go to HCP Design Sandbox" @color="secondary" @href="#" />
-  <A.Link::Standalone @text="View documentation" @color="primary" @icon="docs-link" @iconPosition="trailing" @href="#" />
+  <A.LinkStandalone @text="View documentation" @color="primary" @icon="docs-link" @iconPosition="trailing" @href="#" />
 </Hds::Alert>
 
 For links that are part of an [inverse button group](/patterns/button-organization#grouping).

--- a/website/docs/components/form/checkbox/partials/code/component-api.md
+++ b/website/docs/components/form/checkbox/partials/code/component-api.md
@@ -36,7 +36,7 @@ The Checkbox component has three different variants with their own APIs:
     <br/><br/>
     The `id` attribute of the element is automatically generated.
   </C.Property>
-  <C.Property @name="<[G].Checkbox::Field>" @type="yielded component">
+  <C.Property @name="<[G].CheckboxField>" @type="yielded component">
     Used to yield one or more fields inside the group. For details about its API, check the `Form::Checkbox::Field` API details.
   </C.Property>
   <C.Property @name="<[G].Error>" @type="yielded component">

--- a/website/docs/components/form/checkbox/partials/code/how-to-use.md
+++ b/website/docs/components/form/checkbox/partials/code/how-to-use.md
@@ -30,18 +30,18 @@ The `@name` argument offers an easy way to provide the same name for all the Che
 ```handlebars
 <Hds::Form::Checkbox::Group @name="datacenter" as |G|>
   <G.Legend>Valid datacenters</G.Legend>
-  <G.Checkbox::Field as |F|>
+  <G.CheckboxField as |F|>
     <F.Label>NYC1</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>DC1</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>NYC2</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>SF1</F.Label>
-  </G.Checkbox::Field>
+  </G.CheckboxField>
 </Hds::Form::Checkbox::Group>
 ```
 
@@ -52,36 +52,36 @@ To better fit your spacing requirements, choose between two different layout ori
 ```handlebars
 <Hds::Form::Checkbox::Group as |G|>
   <G.Legend>Valid datacenters</G.Legend>
-  <G.Checkbox::Field as |F|>
+  <G.CheckboxField as |F|>
     <F.Label>NYC1</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>DC1</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>NYC2</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>SF1</F.Label>
-  </G.Checkbox::Field>
+  </G.CheckboxField>
 </Hds::Form::Checkbox::Group>
 ```
 
 ```handlebars
 <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
   <G.Legend>Valid datacenters</G.Legend>
-  <G.Checkbox::Field as |F|>
+  <G.CheckboxField as |F|>
     <F.Label>NYC1</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>DC1</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>NYC2</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>SF1</F.Label>
-  </G.Checkbox::Field>
+  </G.CheckboxField>
 </Hds::Form::Checkbox::Group>
 ```
 
@@ -100,15 +100,15 @@ When helper text is added, the component automatically adds an `aria-describedby
 <Hds::Form::Checkbox::Group @name="methods-demo2" as |G|>
   <G.Legend>Methods <Hds::Badge @size="small" @text="Beta" @color="highlight" /></G.Legend>
   <G.HelperText>All methods are applied by default unless specified. See <Hds::Link::Inline @href="#">HTTP protocol</Hds::Link::Inline> for more details.</G.HelperText>
-  <G.Checkbox::Field checked as |F|>
+  <G.CheckboxField checked as |F|>
     <F.Label>POST</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field checked as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField checked as |F|>
     <F.Label>GET</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field checked as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField checked as |F|>
     <F.Label>PUT</F.Label>
-  </G.Checkbox::Field>
+  </G.CheckboxField>
 </Hds::Form::Checkbox::Group>
 ```
 
@@ -120,9 +120,9 @@ Use the `@isRequired` and `@isOptional` arguments to add a visual indication tha
 <Hds::Form::Checkbox::Group @isRequired={{true}} @layout="horizontal" @name="methods-demo3" as |G|>
   <G.Legend>Methods</G.Legend>
   <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
-  <G.Checkbox::Field checked as |F|><F.Label>POST</F.Label></G.Checkbox::Field>
-  <G.Checkbox::Field checked as |F|><F.Label>GET</F.Label></G.Checkbox::Field>
-  <G.Checkbox::Field checked as |F|><F.Label>PUT</F.Label></G.Checkbox::Field>
+  <G.CheckboxField checked as |F|><F.Label>POST</F.Label></G.CheckboxField>
+  <G.CheckboxField checked as |F|><F.Label>GET</F.Label></G.CheckboxField>
+  <G.CheckboxField checked as |F|><F.Label>PUT</F.Label></G.CheckboxField>
 </Hds::Form::Checkbox::Group>
 ```
 
@@ -130,9 +130,9 @@ Use the `@isRequired` and `@isOptional` arguments to add a visual indication tha
 <Hds::Form::Checkbox::Group @isOptional={{true}} @layout="horizontal" @name="methods-demo4" as |G|>
   <G.Legend>Methods</G.Legend>
   <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
-  <G.Checkbox::Field checked as |F|><F.Label>POST</F.Label></G.Checkbox::Field>
-  <G.Checkbox::Field checked as |F|><F.Label>GET</F.Label></G.Checkbox::Field>
-  <G.Checkbox::Field checked as |F|><F.Label>PUT</F.Label></G.Checkbox::Field>
+  <G.CheckboxField checked as |F|><F.Label>POST</F.Label></G.CheckboxField>
+  <G.CheckboxField checked as |F|><F.Label>GET</F.Label></G.CheckboxField>
+  <G.CheckboxField checked as |F|><F.Label>PUT</F.Label></G.CheckboxField>
 </Hds::Form::Checkbox::Group>
 ```
 
@@ -143,18 +143,18 @@ To indicate a field is invalid, provide an error message using the `Error` conte
 ```handlebars
 <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
   <G.Legend>Valid datacenters</G.Legend>
-  <G.Checkbox::Field as |F|>
+  <G.CheckboxField as |F|>
     <F.Label>NYC1</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>DC1</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>NYC2</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>SF1</F.Label>
-  </G.Checkbox::Field>
+  </G.CheckboxField>
   <G.Error>Error: you need to choose at least one datacenter.</G.Error>
 </Hds::Form::Checkbox::Group>
 ```
@@ -166,22 +166,22 @@ A group of Checkboxes is made of one or more `Form::Checkbox::Field` components.
 ```handlebars
 <Hds::Form::Checkbox::Group @layout="vertical" as |G|>
   <G.Legend>Valid datacenters</G.Legend>
-  <G.Checkbox::Field name="datacenter1" @id="datacenter-NYC1" @value="NYC1" {{on "change" this.yourOnChangeFunction}} as |F|>
+  <G.CheckboxField name="datacenter1" @id="datacenter-NYC1" @value="NYC1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>NYC1</F.Label>
     <F.HelperText>CoreSite- 32 Avenue of the Americas</F.HelperText>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field name="datacenter2" @id="datacenter-DC1" checked @value="DC1" {{on "change" this.yourOnChangeFunction}} as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField name="datacenter2" @id="datacenter-DC1" checked @value="DC1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>DC1</F.Label>
     <F.HelperText>CoreSite- K Street</F.HelperText>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field name="datacenter3" @id="datacenter-NYC2" checked @value="NYC2" {{on "change" this.yourOnChangeFunction}} as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField name="datacenter3" @id="datacenter-NYC2" checked @value="NYC2" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>NYC2</F.Label>
     <F.HelperText>H5 Data Center - 325 Hudson Street</F.HelperText>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field name="datacenter4" @id="datacenter-SF1" @value="SF1" {{on "change" this.yourOnChangeFunction}} as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField name="datacenter4" @id="datacenter-SF1" @value="SF1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>SF1</F.Label>
     <F.HelperText>INAP - 650 Townsend Street</F.HelperText>
-  </G.Checkbox::Field>
+  </G.CheckboxField>
 </Hds::Form::Checkbox::Group>
 ```
 
@@ -192,10 +192,10 @@ There may be use cases in which you need to create a Checkbox group that contain
 ```handlebars
 <Hds::Form::Checkbox::Group as |G|>
   <G.Legend>Visibility</G.Legend>
-  <G.Checkbox::Field name="private" @id="visibility-private" as |F|>
+  <G.CheckboxField name="private" @id="visibility-private" as |F|>
     <F.Label>Private</F.Label>
     <F.HelperText>Making a box private prevents users from accessing it unless given permission.</F.HelperText>
-  </G.Checkbox::Field>
+  </G.CheckboxField>
 </Hds::Form::Checkbox::Group>
 ```
 

--- a/website/docs/components/form/checkbox/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/checkbox/partials/guidelines/guidelines.md
@@ -17,27 +17,27 @@ We recommend using vertical Checkbox groups, especially with short option lists.
 <Doc::Layout @spacing="48px">
   <Hds::Form::Checkbox::Group @layout="vertical" as |G|>
     <G.Legend>Vertical group</G.Legend>
-    <G.Checkbox::Field as |F|>
+    <G.CheckboxField as |F|>
       <F.Label>Label</F.Label>
-    </G.Checkbox::Field>
-    <G.Checkbox::Field as |F|>
+    </G.CheckboxField>
+    <G.CheckboxField as |F|>
       <F.Label>Label</F.Label>
-    </G.Checkbox::Field>
-    <G.Checkbox::Field as |F|>
+    </G.CheckboxField>
+    <G.CheckboxField as |F|>
       <F.Label>Label</F.Label>
-    </G.Checkbox::Field>
+    </G.CheckboxField>
   </Hds::Form::Checkbox::Group>
   <Hds::Form::Checkbox::Group @layout="horizontal" as |G|>
     <G.Legend>Horizontal group</G.Legend>
-    <G.Checkbox::Field as |F|>
+    <G.CheckboxField as |F|>
       <F.Label>Label</F.Label>
-    </G.Checkbox::Field>
-    <G.Checkbox::Field as |F|>
+    </G.CheckboxField>
+    <G.CheckboxField as |F|>
       <F.Label>Label</F.Label>
-    </G.Checkbox::Field>
-    <G.Checkbox::Field as |F|>
+    </G.CheckboxField>
+    <G.CheckboxField as |F|>
       <F.Label>Label</F.Label>
-    </G.Checkbox::Field>
+    </G.CheckboxField>
   </Hds::Form::Checkbox::Group>
 </Doc::Layout>
 
@@ -61,24 +61,24 @@ For complex forms, indicate **required** fields. This is the most explicit and t
 
 <Hds::Form::Checkbox::Group @layout="vertical" @isRequired={{true}} as |G|>
   <G.Legend>Group label</G.Legend>
-  <G.Checkbox::Field as |F|>
+  <G.CheckboxField as |F|>
     <F.Label>Label</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>Label</F.Label>
-  </G.Checkbox::Field>
+  </G.CheckboxField>
 </Hds::Form::Checkbox::Group>
 
 For shorter, simpler forms (e.g., login/signup and feedback requests), indicate **optional** fields instead.
 
 <Hds::Form::Checkbox::Group @layout="vertical" @isOptional={{true}} as |G|>
   <G.Legend>Group label</G.Legend>
-  <G.Checkbox::Field as |F|>
+  <G.CheckboxField as |F|>
     <F.Label>Label</F.Label>
-  </G.Checkbox::Field>
-  <G.Checkbox::Field as |F|>
+  </G.CheckboxField>
+  <G.CheckboxField as |F|>
     <F.Label>Label</F.Label>
-  </G.Checkbox::Field>
+  </G.CheckboxField>
 </Hds::Form::Checkbox::Group>
 
 ## Error validation

--- a/website/docs/components/form/radio/partials/code/component-api.md
+++ b/website/docs/components/form/radio/partials/code/component-api.md
@@ -41,7 +41,7 @@ Since `radio` controls are always used in a list of options, itâ€™s likely youâ€
     <br/><br/>
     The `id` attribute of the element is automatically generated.
   </C.Property>
-  <C.Property @name="<[G].Radio::Field>" @type="yielded component">
+  <C.Property @name="<[G].RadioField>" @type="yielded component">
     Used to yield one or more fields inside the group. For details about its API, check the `Form::Radio::Field` API details.
   </C.Property>
   <C.Property @name="<[G].Error>" @type="yielded component">

--- a/website/docs/components/form/radio/partials/code/how-to-use.md
+++ b/website/docs/components/form/radio/partials/code/how-to-use.md
@@ -28,18 +28,18 @@ The `@name` argument offers an easy way to provide the same name for all the Rad
 ```handlebars
 <Hds::Form::Radio::Group @name="datacenter" as |G|>
   <G.Legend>Choose datacenter</G.Legend>
-  <G.Radio::Field as |F|>
+  <G.RadioField as |F|>
     <F.Label>NYC1</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>DC1</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>NYC2</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>SF1</F.Label>
-  </G.Radio::Field>
+  </G.RadioField>
 </Hds::Form::Radio::Group>
 ```
 
@@ -50,36 +50,36 @@ To better fit your spacing requirements, choose between two different layout ori
 ```handlebars
 <Hds::Form::Radio::Group @name="datacenter-demo2" as |G|>
   <G.Legend>Choose datacenter</G.Legend>
-  <G.Radio::Field as |F|>
+  <G.RadioField as |F|>
     <F.Label>NYC1</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>DC1</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>NYC2</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>SF1</F.Label>
-  </G.Radio::Field>
+  </G.RadioField>
 </Hds::Form::Radio::Group>
 ```
 
 ```handlebars
 <Hds::Form::Radio::Group @layout="horizontal" @name="datacenter-demo2" as |G|>
   <G.Legend>Choose datacenter</G.Legend>
-  <G.Radio::Field as |F|>
+  <G.RadioField as |F|>
     <F.Label>NYC1</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>DC1</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>NYC2</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>SF1</F.Label>
-  </G.Radio::Field>
+  </G.RadioField>
 </Hds::Form::Radio::Group>
 ```
 
@@ -98,15 +98,15 @@ When helper text is added, the component automatically adds an `aria-describedby
 <Hds::Form::Radio::Group @layout="horizontal" @name="method-demo1" as |G|>
   <G.Legend>Method <Hds::Badge @size="small" @text="Beta" @color="highlight" /></G.Legend>
   <G.HelperText>Choose which HTTP method to use for the communication channel. See <Hds::Link::Inline @href="#">HTTP protocol</Hds::Link::Inline> for more details.</G.HelperText>
-  <G.Radio::Field as |F|>
+  <G.RadioField as |F|>
     <F.Label>POST</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>GET</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>PUT</F.Label>
-  </G.Radio::Field>
+  </G.RadioField>
 </Hds::Form::Radio::Group>
 ```
 
@@ -118,17 +118,17 @@ Use the `@isRequired` and `@isOptional` arguments to add a visual indication tha
 <Hds::Form::Radio::Group @isRequired={{true}} @layout="horizontal" @name="method-demo2" as |G|>
   <G.Legend>Method</G.Legend>
   <G.HelperText>Choose which HTTP method to use for the communication channel.</G.HelperText>
-  <G.Radio::Field as |F|><F.Label>POST</F.Label></G.Radio::Field>
-  <G.Radio::Field as |F|><F.Label>GET</F.Label></G.Radio::Field>
-  <G.Radio::Field as |F|><F.Label>PUT</F.Label></G.Radio::Field>
+  <G.RadioField as |F|><F.Label>POST</F.Label></G.RadioField>
+  <G.RadioField as |F|><F.Label>GET</F.Label></G.RadioField>
+  <G.RadioField as |F|><F.Label>PUT</F.Label></G.RadioField>
 </Hds::Form::Radio::Group>
 <br />
 <Hds::Form::Radio::Group @isOptional={{true}} @layout="horizontal" @name="method-demo3" as |G|>
   <G.Legend>Method</G.Legend>
   <G.HelperText>Choose which HTTP method to use for the communication channel.</G.HelperText>
-  <G.Radio::Field as |F|><F.Label>POST</F.Label></G.Radio::Field>
-  <G.Radio::Field as |F|><F.Label>GET</F.Label></G.Radio::Field>
-  <G.Radio::Field as |F|><F.Label>PUT</F.Label></G.Radio::Field>
+  <G.RadioField as |F|><F.Label>POST</F.Label></G.RadioField>
+  <G.RadioField as |F|><F.Label>GET</F.Label></G.RadioField>
+  <G.RadioField as |F|><F.Label>PUT</F.Label></G.RadioField>
 </Hds::Form::Radio::Group>
 ```
 
@@ -139,18 +139,18 @@ To indicate a field is invalid, provide an error message using the `Error` conte
 ```handlebars
 <Hds::Form::Radio::Group @layout="horizontal" @name="datacenter-demo4" as |G|>
   <G.Legend>Choose datacenter</G.Legend>
-  <G.Radio::Field as |F|>
+  <G.RadioField as |F|>
     <F.Label>NYC1</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>DC1</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>NYC2</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>SF1</F.Label>
-  </G.Radio::Field>
+  </G.RadioField>
   <G.Error>Error: you need to choose one datacenter.</G.Error>
 </Hds::Form::Radio::Group>
 ```
@@ -162,22 +162,22 @@ A group of Radios is made of one or more `Form::Radio::Field` components. All th
 ```handlebars
 <Hds::Form::Radio::Group @layout="vertical" @name="datacenter-demo5" as |G|>
   <G.Legend>Choose datacenter</G.Legend>
-  <G.Radio::Field @id="datacenter-NYC1" checked @value="NYC1" {{on "change" this.yourOnChangeFunction}} as |F|>
+  <G.RadioField @id="datacenter-NYC1" checked @value="NYC1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>NYC1</F.Label>
     <F.HelperText>CoreSite- 32 Avenue of the Americas</F.HelperText>
-  </G.Radio::Field>
-  <G.Radio::Field @id="datacenter-DC1" @value="DC1" {{on "change" this.yourOnChangeFunction}} as |F|>
+  </G.RadioField>
+  <G.RadioField @id="datacenter-DC1" @value="DC1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>DC1</F.Label>
     <F.HelperText>CoreSite- K Street</F.HelperText>
-  </G.Radio::Field>
-  <G.Radio::Field @id="datacenter-NYC2" @value="NYC2" {{on "change" this.yourOnChangeFunction}} as |F|>
+  </G.RadioField>
+  <G.RadioField @id="datacenter-NYC2" @value="NYC2" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>NYC1</F.Label>
     <F.HelperText>H5 Data Center - 325 Hudson Street</F.HelperText>
-  </G.Radio::Field>
-  <G.Radio::Field @id="datacenter-SF1" @value="SF1" {{on "change" this.yourOnChangeFunction}} as |F|>
+  </G.RadioField>
+  <G.RadioField @id="datacenter-SF1" @value="SF1" {{on "change" this.yourOnChangeFunction}} as |F|>
     <F.Label>SF1</F.Label>
     <F.HelperText>INAP - 650 Townsend Street</F.HelperText>
-  </G.Radio::Field>
+  </G.RadioField>
 </Hds::Form::Radio::Group>
 ```
 

--- a/website/docs/components/form/radio/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/radio/partials/guidelines/guidelines.md
@@ -17,27 +17,27 @@ We recommend using vertical Radio groups, especially with short option lists.
 <Doc::Layout @spacing="48px">
   <Hds::Form::Radio::Group @layout="vertical" @name="group" as |G|>
     <G.Legend>Vertical group</G.Legend>
-    <G.Radio::Field as |F|>
+    <G.RadioField as |F|>
       <F.Label>Label</F.Label>
-    </G.Radio::Field>
-    <G.Radio::Field as |F|>
+    </G.RadioField>
+    <G.RadioField as |F|>
       <F.Label>Label</F.Label>
-    </G.Radio::Field>
-    <G.Radio::Field as |F|>
+    </G.RadioField>
+    <G.RadioField as |F|>
       <F.Label>Label</F.Label>
-    </G.Radio::Field>
+    </G.RadioField>
   </Hds::Form::Radio::Group>
   <Hds::Form::Radio::Group @layout="horizontal" @name="group" as |G|>
     <G.Legend>Horizontal group</G.Legend>
-    <G.Radio::Field as |F|>
+    <G.RadioField as |F|>
       <F.Label>Label</F.Label>
-    </G.Radio::Field>
-    <G.Radio::Field as |F|>
+    </G.RadioField>
+    <G.RadioField as |F|>
       <F.Label>Label</F.Label>
-    </G.Radio::Field>
-    <G.Radio::Field as |F|>
+    </G.RadioField>
+    <G.RadioField as |F|>
       <F.Label>Label</F.Label>
-    </G.Radio::Field>
+    </G.RadioField>
   </Hds::Form::Radio::Group>
 </Doc::Layout>
 
@@ -49,24 +49,24 @@ For complex forms, indicate **required** fields. This is the most explicit and t
 
 <Hds::Form::Radio::Group @isRequired={{true}} @layout="vertical" @name="group" as |G|>
   <G.Legend>Group label</G.Legend>
-  <G.Radio::Field as |F|>
+  <G.RadioField as |F|>
     <F.Label>Label</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>Label</F.Label>
-  </G.Radio::Field>
+  </G.RadioField>
 </Hds::Form::Radio::Group>
 
 For shorter, simpler forms (e.g., login/signup and feedback requests), indicate **optional** fields instead.
 
 <Hds::Form::Radio::Group @isOptional={{true}} @layout="vertical" @name="group" as |G|>
   <G.Legend>Group label</G.Legend>
-  <G.Radio::Field as |F|>
+  <G.RadioField as |F|>
     <F.Label>Label</F.Label>
-  </G.Radio::Field>
-  <G.Radio::Field as |F|>
+  </G.RadioField>
+  <G.RadioField as |F|>
     <F.Label>Label</F.Label>
-  </G.Radio::Field>
+  </G.RadioField>
 </Hds::Form::Radio::Group>
 
 ## Error validation

--- a/website/docs/components/form/toggle/partials/code/component-api.md
+++ b/website/docs/components/form/toggle/partials/code/component-api.md
@@ -33,7 +33,7 @@ The Toggle component has two different variants with their own APIs:
     <br/><br/>
     The `id` attribute of the element is automatically generated.
   </C.Property>
-  <C.Property @name="<[G].Toggle::Field>" @type="yielded component">
+  <C.Property @name="<[G].ToggleField>" @type="yielded component">
     Used to yield one or more fields inside the group. For details about its API, check the `Toggle::Field` component above.
   </C.Property>
   <C.Property @name="<[G].Error>" @type="yielded component">

--- a/website/docs/components/form/toggle/partials/code/how-to-use.md
+++ b/website/docs/components/form/toggle/partials/code/how-to-use.md
@@ -27,10 +27,10 @@ There may be use cases in which you need to create a Toggle group that contains 
 ```handlebars
 <Hds::Form::Toggle::Group as |G|>
   <G.Legend>Visibility</G.Legend>
-  <G.Toggle::Field name="private" @id="visibility-private" as |F|>
+  <G.ToggleField name="private" @id="visibility-private" as |F|>
     <F.Label>Private</F.Label>
     <F.HelperText>Making a box private prevents users from accessing it unless given permission.</F.HelperText>
-  </G.Toggle::Field>
+  </G.ToggleField>
 </Hds::Form::Toggle::Group>
 ```
 

--- a/website/docs/components/toast/partials/code/how-to-use.md
+++ b/website/docs/components/toast/partials/code/how-to-use.md
@@ -61,14 +61,14 @@ If you need to hide the icon, pass `false` to the `icon` argument.
 
 ### Actions
 
-Actions can be passed to the component using one of the suggested `Button` or `Link::Standalone` contextual components.
+Actions can be passed to the component using one of the suggested `Button` or `LinkStandalone` contextual components.
 
 ```handlebars
 <Hds::Toast @color="critical" @onDismiss={{this.yourOnDismissFunction}} as |T|>
   <T.Title>Title here</T.Title>
   <T.Description>Description here</T.Description>
   <T.Button @text="Your action" @color="secondary" {{on "click" this.yourOnClickFunction}} />
-  <T.Link::Standalone @color="secondary" @icon="plus" @text="Another action" @route="components" @color="secondary" />
+  <T.LinkStandalone @color="secondary" @icon="plus" @text="Another action" @route="components" @color="secondary" />
 </Hds::Toast>
 ```
 

--- a/website/docs/components/toast/partials/content/content.md
+++ b/website/docs/components/toast/partials/content/content.md
@@ -42,7 +42,7 @@ When linking to internal and external resources in the Toast, default to using a
   <T.Title>Links in Toasts</T.Title>
   <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
   <T.Button @text="Button" @color="secondary" />
-  <T.Link::Standalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Standalone link" @href="#" />
+  <T.LinkStandalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Standalone link" @href="#" />
 </Hds::Toast>
 
 Within the Toast description, use the `secondary` [Inline Link](/components/link/inline) as the default link color. A common use case for this is when linking to multiple resources.
@@ -103,7 +103,7 @@ The title or description should contain the Toast color type, e.g., â€œWarning,â
   <T.Title>Toast with actions</T.Title>
   <T.Description>Lorem ipsum dolar sit amet, consectetur adi.</T.Description>
   <T.Button @text="Button" @color="secondary" />
-  <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+  <T.LinkStandalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
 </Hds::Toast>
 
 ### With generic content

--- a/website/docs/components/toast/partials/guidelines/guidelines.md
+++ b/website/docs/components/toast/partials/guidelines/guidelines.md
@@ -17,31 +17,31 @@
     <T.Title>Neutral toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.LinkStandalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="highlight" @onDismiss={{this.noop}} as |T|>
     <T.Title>Highlight toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.LinkStandalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="success" @onDismiss={{this.noop}} as |T|>
     <T.Title>Success toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.LinkStandalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="warning" @onDismiss={{this.noop}} as |T|>
     <T.Title>Warning toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.LinkStandalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="critical" @onDismiss={{this.noop}} as |T|>
     <T.Title>Critical toast title</T.Title>
     <T.Description>Lorem ipsum dolar sit amet, consecteu adipiscig elit null dignissim felis.</T.Description>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.LinkStandalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
 </Doc::Layout>
 
@@ -111,12 +111,12 @@ Icons within `neutral` and `highlight` Toasts can be replaced with other icons. 
   <Hds::Toast @color="neutral" @icon="running" @onDismiss={{this.noop}} as |T|>
     <T.Title>Plan running</T.Title>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.LinkStandalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
   <Hds::Toast @color="success" @icon="check-circle" @onDismiss={{this.noop}} as |T|>
     <T.Title>Plan finished</T.Title>
     <T.Button @text="Button" @color="secondary" />
-    <T.Link::Standalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
+    <T.LinkStandalone @color="secondary" @icon="plus" @iconPosition="leading" @text="Link text" @href="#" />
   </Hds::Toast>
 </Doc::Layout>
 


### PR DESCRIPTION
### :pushpin: Summary

Rename namespaced contextual components as follows:

 - `Alert::Link::Standalone` to `Alert::LinkStandalone`
 - `ApplicationState::Footer::Link::Standalone` to `ApplicationState::Footer::LinkStandalone`
 - `Form::Checkbox::Group::Checkbox::Field` to `Checkbox::Group::CheckboxField`
 - `Form::Radio::Group::Radio::Field` to `Form::Radio::Group::RadioField`
 - `Form::Toggle::Group::Toggle::Field` to `Form::Toggle::Group::ToggleField`
 - `Toast::Link::Standalone` to `Toast::LinkStandalone`

The new names are more idiomatic, will align these instances with other subcomponents, and provide a smooth path when imported to `gts`.

Note: As this is a major change, we'll try to add codemods in this PR to help with migrating to the new format.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2972](https://hashicorp.atlassian.net/browse/HDS-2972)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [x] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2972]: https://hashicorp.atlassian.net/browse/HDS-2972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ