### PR TITLE
`Modal`, `Flyout` - Remove `close` event listener on destroy

### DIFF
--- a/.changeset/fast-goats-approve.md
+++ b/.changeset/fast-goats-approve.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Modal - Removed `close` event listener on destroy
+Flyout - Removed `close` event listener on destroy

--- a/packages/components/addon/components/hds/flyout/index.hbs
+++ b/packages/components/addon/components/hds/flyout/index.hbs
@@ -7,6 +7,7 @@
   ...attributes
   aria-labelledby={{this.id}}
   {{did-insert this.didInsert}}
+  {{will-destroy this.willDestroyNode}}
   {{focus-trap isActive=this.isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=true)}}
 >
   {{yield (hash Header=(component "hds/flyout/header" id=this.id onDismiss=this.onDismiss))}}

--- a/packages/components/addon/components/hds/flyout/index.js
+++ b/packages/components/addon/components/hds/flyout/index.js
@@ -67,6 +67,14 @@ export default class HdsFlyoutIndexComponent extends Component {
     return classes.join(' ');
   }
 
+  @action registerOnCloseCallback() {
+    if (this.args.onClose && typeof this.args.onClose === 'function') {
+      this.args.onClose();
+    }
+
+    this.isOpen = false;
+  }
+
   @action
   didInsert(element) {
     // Store references of `<dialog>` and `<body>` elements
@@ -94,17 +102,22 @@ export default class HdsFlyoutIndexComponent extends Component {
     }
 
     // Register "onClose" callback function to be called when a native 'close' event is dispatched
-    this.element.addEventListener('close', () => {
-      if (this.args.onClose && typeof this.args.onClose === 'function') {
-        this.args.onClose();
-      }
-
-      this.isOpen = false;
-    });
+    this.element.addEventListener('close', this.registerOnCloseCallback, true);
 
     // If the flyout dialog is not already open
     if (!this.element.open) {
       this.open();
+    }
+  }
+
+  @action
+  willDestroyNode() {
+    if (this.element) {
+      this.element.removeEventListener(
+        'close',
+        this.registerOnCloseCallback,
+        true
+      );
     }
   }
 

--- a/packages/components/addon/components/hds/modal/index.hbs
+++ b/packages/components/addon/components/hds/modal/index.hbs
@@ -7,6 +7,7 @@
   ...attributes
   aria-labelledby={{this.id}}
   {{did-insert this.didInsert}}
+  {{will-destroy this.willDestroyNode}}
   {{focus-trap isActive=this.isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=true)}}
 >
   {{yield (hash Header=(component "hds/modal/header" id=this.id onDismiss=this.onDismiss))}}


### PR DESCRIPTION
### :pushpin: Summary

Remove `close` event listener on destroy for Modal and Flyout.
This is good practice and helps resolve an issue with a failing test in Boundary desktop.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3005](https://hashicorp.atlassian.net/browse/HDS-3005)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [x] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3005]: https://hashicorp.atlassian.net/browse/HDS-3005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ