### PR TITLE
`SegmentedGroup`: Fix border radius for lone segments (HDS-2988)

### DIFF
--- a/.changeset/happy-eagles-hug.md
+++ b/.changeset/happy-eagles-hug.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SegmentedGroup` - Fixed issue with border-radius of single child element being overridden

--- a/packages/components/app/styles/components/segmented-group.scss
+++ b/packages/components/app/styles/components/segmented-group.scss
@@ -14,7 +14,7 @@
   > .hds-dropdown,
   > .hds-form-select,
   > .hds-form-text-input {
-    &:first-child {
+    &:first-child:not(:only-child) {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
 
@@ -26,7 +26,7 @@
       }
     }
 
-    &:last-child {
+    &:last-child:not(:only-child) {
       margin-left: -1px;
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
@@ -39,7 +39,7 @@
       }
     }
 
-    &:not(:first-child, :last-child) {
+    &:not(:first-child, :last-child, :only-child) {
       margin-left: -1px;
       border-radius: 0;
 

--- a/packages/components/tests/dummy/app/templates/components/segmented-group.hbs
+++ b/packages/components/tests/dummy/app/templates/components/segmented-group.hbs
@@ -11,6 +11,23 @@
 
   <Shw::Text::H2>Content</Shw::Text::H2>
 
+  <Shw::Text::H3>One segment</Shw::Text::H3>
+
+  <Shw::Grid @columns={{4}} as |SG|>
+    <SG.Item @label="Button only">
+      <Hds::SegmentedGroup as |S|>
+        <S.Button @color="secondary" @text="Button" />
+      </Hds::SegmentedGroup>
+    </SG.Item>
+    <SG.Item @label="Input only">
+      <Hds::SegmentedGroup as |S|>
+        <S.TextInput aria-label="segmented-text-input-lone-item" />
+      </Hds::SegmentedGroup>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Two segments</Shw::Text::H3>
 
   <Shw::Grid @columns={{4}} as |SG|>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will update the SegmentedGroup styling so that lone items won't have their border-radius styles overridden and adds a Showcase example with lone items.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

----

<img width="479" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/4a16b5ba-2c60-45bc-b995-08a811defa8a">

----

### :link: External links

- Jira ticket: [HDS-2988](https://hashicorp.atlassian.net/browse/HDS-2988)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [ ] ~~A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)~~
- [ ] ~~If documenting a new component, an acceptance test that includes the `a11yAudit` has been added~~
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2988]: https://hashicorp.atlassian.net/browse/HDS-2988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ