### PR TITLE
Update `shell-session` default color

### DIFF
--- a/.changeset/rich-hairs-change.md
+++ b/.changeset/rich-hairs-change.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`CodeBlock` - Fixed the default token color in the syntax highlighting theme.

--- a/packages/components/app/styles/components/code-block/theme.scss
+++ b/packages/components/app/styles/components/code-block/theme.scss
@@ -161,4 +161,8 @@
     .token.entity.named-entity { color: var(--hds-code-block-color-lang-markup-entity-named); }
     .token.entity:not(.named-entity) { color: var(--hds-code-block-color-lang-markup-entity-not-named); }
   }
+
+  .language-shell-session {
+    .token { color: var(--hds-code-block-color-foreground-primary)}
+  }
 }

--- a/packages/components/app/styles/components/code-block/theme.scss
+++ b/packages/components/app/styles/components/code-block/theme.scss
@@ -50,7 +50,7 @@
 
   // Syntax highlighting tokens:
   // general ----
-  --hds-code-block-color-token: var(--hds-code-block-color-green);
+  --hds-code-block-color-token: var(--hds-code-block-color-foreground-primary);
   // specific ----
   --hds-code-block-color-atrule: var(--hds-code-block-color-blue);
   --hds-code-block-color-code-block-attr-name: var(--hds-code-block-color-blue);
@@ -160,9 +160,5 @@
     .token.attr-value { color: var(--hds-code-block-color-lang-markup-attr-value); }
     .token.entity.named-entity { color: var(--hds-code-block-color-lang-markup-entity-named); }
     .token.entity:not(.named-entity) { color: var(--hds-code-block-color-lang-markup-entity-not-named); }
-  }
-
-  .language-shell-session {
-    .token { color: var(--hds-code-block-color-foreground-primary)}
   }
 }

--- a/packages/components/tests/dummy/app/templates/components/code-block.hbs
+++ b/packages/components/tests/dummy/app/templates/components/code-block.hbs
@@ -10,24 +10,29 @@ SPDX-License-Identifier: MPL-2.0
 <section data-test-percy>
   <Shw::Text::H2>Content</Shw::Text::H2>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="one line">
-      <Hds::CodeBlock @language="javascript"
-        @value="console.log('I am JavaScript code');" />
+      <Hds::CodeBlock @language="javascript" @value="console.log('I am JavaScript code');" />
     </SG.Item>
     <SG.Item @label="multi-line">
-      <Hds::CodeBlock @language="javascript" @value="let codeLang='JavaScript';
-console.log(`I am ${codeLang} code`);" />
+      <Hds::CodeBlock
+        @language="javascript"
+        @value="let codeLang='JavaScript';
+console.log(`I am ${codeLang} code`);"
+      />
     </SG.Item>
   </Shw::Grid>
 
   <Shw::Text::Body>New lines handling</Shw::Text::Body>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @forceMinWidth={{true}} as |SGI|>
       <SGI.Label>new lines in Handlebars</SGI.Label>
-      <Hds::CodeBlock @language="javascript" @value="let codeLang='JavaScript';
-console.log(`I am ${codeLang} code`);" />
+      <Hds::CodeBlock
+        @language="javascript"
+        @value="let codeLang='JavaScript';
+console.log(`I am ${codeLang} code`);"
+      />
     </SG.Item>
     <SG.Item @forceMinWidth={{true}} as |SGI|>
       <SGI.Label>new lines with
@@ -40,8 +45,10 @@ console.log(`I am ${codeLang} code`);" />
       <SGI.Label><code>\n</code>
         in Handlebars (not interpreted as newline)
       </SGI.Label>
-      <Hds::CodeBlock @language="javascript"
-        @value="let codeLang='JavaScript';\nconsole.log(`I am ${codeLang} code`);" />
+      <Hds::CodeBlock
+        @language="javascript"
+        @value="let codeLang='JavaScript';\nconsole.log(`I am ${codeLang} code`);"
+      />
     </SG.Item>
   </Shw::Grid>
 
@@ -49,25 +56,21 @@ console.log(`I am ${codeLang} code`);" />
 
   <Shw::Text::H3>Title and description</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="title">
-      <Hds::CodeBlock @value="console.log('I am JavaScript code');"
-        @language="javascript" as |CB|>
+      <Hds::CodeBlock @value="console.log('I am JavaScript code');" @language="javascript" as |CB|>
         <CB.Title>Title</CB.Title>
       </Hds::CodeBlock>
     </SG.Item>
 
     <SG.Item @label="description">
-      <Hds::CodeBlock @value="console.log('I am JavaScript code');"
-        @language="javascript" as |CB|>
+      <Hds::CodeBlock @value="console.log('I am JavaScript code');" @language="javascript" as |CB|>
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
     </SG.Item>
     <SG.Item @label="title and description">
-      <Hds::CodeBlock @value="console.log('I am JavaScript code');"
-        @language="javascript" as |CB|>
-        <CB.Title>Title that may wrap on multiple lines if the parent container
-          is limiting its width</CB.Title>
+      <Hds::CodeBlock @value="console.log('I am JavaScript code');" @language="javascript" as |CB|>
+        <CB.Title>Title that may wrap on multiple lines if the parent container is limiting its width</CB.Title>
         <CB.Description>
           Description that could contain
           <a href="#">a link</a>
@@ -93,13 +96,17 @@ console.log(`I am ${codeLang} code`);" />
 
   <Shw::Text::Body>
     <label for="input">Change input value:</label>
-    <input id="input" type="text" value={{this.input}} {{on "input"
-      this.updateInput}} />
+    <input id="input" type="text" value={{this.input}} {{on "input" this.updateInput}} />
   </Shw::Text::Body>
 
-  <Hds::CodeBlock @value={{this.codeValue}} @language="javascript"
-    @hasCopyButton={{true}} @hasLineNumbers={{false}}
-    id="code-block-with-dynamic-content" as |CB|>
+  <Hds::CodeBlock
+    @value={{this.codeValue}}
+    @language="javascript"
+    @hasCopyButton={{true}}
+    @hasLineNumbers={{false}}
+    id="code-block-with-dynamic-content"
+    as |CB|
+  >
     <CB.Title>
       Dynamic content
     </CB.Title>
@@ -111,14 +118,22 @@ console.log(`I am ${codeLang} code`);" />
 
   <Shw::Text::H3>Standalone</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="isStandalone=false">
-      <Hds::CodeBlock @isStandalone={{false}} @language="javascript" @value="let codeLang='JavaScript';
-console.log(`I am ${codeLang} code`);" />
+      <Hds::CodeBlock
+        @isStandalone={{false}}
+        @language="javascript"
+        @value="let codeLang='JavaScript';
+console.log(`I am ${codeLang} code`);"
+      />
     </SG.Item>
     <SG.Item @label="isStandalone=false, title and description">
-      <Hds::CodeBlock @value="console.log('I am JavaScript code');"
-        @language="javascript" @isStandalone={{false}} as |CB|>
+      <Hds::CodeBlock
+        @value="console.log('I am JavaScript code');"
+        @language="javascript"
+        @isStandalone={{false}}
+        as |CB|
+      >
         <CB.Title>Title</CB.Title>
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
@@ -129,19 +144,26 @@ console.log(`I am ${codeLang} code`);" />
 
   <Shw::Text::H3>Line wrapping</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="hasLineWrapping=false (default)" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="javascript" @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';
-console.log(codeLand);" />
+      <Hds::CodeBlock
+        @language="javascript"
+        @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';
+console.log(codeLand);"
+      />
     </SG.Item>
     <SG.Item @label="hasLineWrapping=true" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="javascript" @hasLineWrapping={{true}}
-        @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';" />
+      <Hds::CodeBlock
+        @language="javascript"
+        @hasLineWrapping={{true}}
+        @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';"
+      />
     </SG.Item>
-    <SG.Item @label="hasLineWrapping=true with long string"
-      @forceMinWidth={{true}}>
-      <Hds::CodeBlock @hasLineWrapping={{true}}
-        @value="hcp-domain-verification=6ea52e476fc6232d974c31453dcd884a68df6cf374892a50a897c87d11125b67" />
+    <SG.Item @label="hasLineWrapping=true with long string" @forceMinWidth={{true}}>
+      <Hds::CodeBlock
+        @hasLineWrapping={{true}}
+        @value="hcp-domain-verification=6ea52e476fc6232d974c31453dcd884a68df6cf374892a50a897c87d11125b67"
+      />
     </SG.Item>
   </Shw::Grid>
 
@@ -149,14 +171,23 @@ console.log(codeLand);" />
 
   <Shw::Text::H3>Line numbers</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="hasLineNumbers=false">
-      <Hds::CodeBlock @language="javascript" @hasLineNumbers={{false}} @value="let codeLang='JavaScript';
-    console.log(`I am ${codeLang} code`);" />
+      <Hds::CodeBlock
+        @language="javascript"
+        @hasLineNumbers={{false}}
+        @value="let codeLang='JavaScript';
+    console.log(`I am ${codeLang} code`);"
+      />
     </SG.Item>
     <SG.Item @label="hasLineNumbers=false, title and description">
-      <Hds::CodeBlock @language="javascript" @hasLineNumbers={{false}} @value="let codeLang='JavaScript';
-console.log(`I am ${codeLang} code`);" as |CB|>
+      <Hds::CodeBlock
+        @language="javascript"
+        @hasLineNumbers={{false}}
+        @value="let codeLang='JavaScript';
+console.log(`I am ${codeLang} code`);"
+        as |CB|
+      >
         <CB.Title>Title</CB.Title>
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
@@ -167,10 +198,13 @@ console.log(`I am ${codeLang} code`);" as |CB|>
 
   <Shw::Text::H3>Height limit</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="maxHeight='105px'" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock @language="javascript" @maxHeight="105px" @value="function convertObjectToArray (obj) {
+      <Hds::CodeBlock
+        @language="javascript"
+        @maxHeight="105px"
+        @value="function convertObjectToArray (obj) {
   let arr = Object
     .keys(obj) // return object's keys as an array
     .map(key => {return [key, obj[key] ]}) // map a function on each array item
@@ -188,14 +222,17 @@ function assertObjectsEqual (actual, expected, testName) {
   } else {
     console.log(`FAILED [${testName}] Expected ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);
   }
-}" />
+}"
+      />
       {{! template-lint-enable no-whitespace-for-layout }}
     </SG.Item>
 
-    <SG.Item @label="maxHeight='105px', title and description"
-      @forceMinWidth={{true}}>
+    <SG.Item @label="maxHeight='105px', title and description" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock @language="javascript" @maxHeight="105px" @value="function convertObjectToArray (obj) {
+      <Hds::CodeBlock
+        @language="javascript"
+        @maxHeight="105px"
+        @value="function convertObjectToArray (obj) {
   let arr = Object
     .keys(obj) // return object's keys as an array
     .map(key => {return [key, obj[key] ]}) // map a function on each array item
@@ -213,7 +250,9 @@ function assertObjectsEqual (actual, expected, testName) {
   } else {
     console.log(`FAILED [${testName}] Expected ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);
   }
-}" as |CB|>
+}"
+        as |CB|
+      >
         <CB.Title>Title</CB.Title>
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
@@ -225,17 +264,18 @@ function assertObjectsEqual (actual, expected, testName) {
 
   <Shw::Text::H3>Copy button</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="hasCopyButton=true" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="shell-session" @hasCopyButton={{true}}
-        @value="$ brew tap hashicorp/tap" />
+      <Hds::CodeBlock @language="shell-session" @hasCopyButton={{true}} @value="$ brew tap hashicorp/tap" />
     </SG.Item>
-    <SG.Item
-      @label="hasCopyButton=true, maxHeight='105px', title and description"
-      @forceMinWidth={{true}}>
+    <SG.Item @label="hasCopyButton=true, maxHeight='105px', title and description" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock id="clipboardTarget2" @hasCopyButton={{true}}
-        @language="javascript" @maxHeight="105px" @value="function convertObjectToArray (obj) {
+      <Hds::CodeBlock
+        id="clipboardTarget2"
+        @hasCopyButton={{true}}
+        @language="javascript"
+        @maxHeight="105px"
+        @value="function convertObjectToArray (obj) {
   let arr = Object
     .keys(obj) // return object's keys as an array
     .map(key => {return [key, obj[key] ]}) // map a function on each array item
@@ -253,7 +293,9 @@ function assertObjectsEqual (actual, expected, testName) {
   } else {
     console.log(`FAILED [${testName}] Expected ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);
   }
-}" as |CB|>
+}"
+        as |CB|
+      >
         <CB.Title>Title</CB.Title>
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
@@ -265,9 +307,12 @@ function assertObjectsEqual (actual, expected, testName) {
 
   <Shw::Text::H3>Highlight lines</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="Highlight lines 2 & 4" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="javascript" @highlightLines="2, 4" @value="import Application from '@ember/application';
+      <Hds::CodeBlock
+        @language="javascript"
+        @highlightLines="2, 4"
+        @value="import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'dummy/config/environment';
@@ -278,11 +323,15 @@ export default class App extends Application {
   Resolver = Resolver;
 }
 
-loadInitializers(App, config.modulePrefix);" />
+loadInitializers(App, config.modulePrefix);"
+      />
     </SG.Item>
 
     <SG.Item @label="Highlight lines 6-10" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="javascript" @highlightLines="6-10" @value="import Application from '@ember/application';
+      <Hds::CodeBlock
+        @language="javascript"
+        @highlightLines="6-10"
+        @value="import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'dummy/config/environment';
@@ -293,7 +342,8 @@ export default class App extends Application {
   Resolver = Resolver;
 }
 
-loadInitializers(App, config.modulePrefix);" />
+loadInitializers(App, config.modulePrefix);"
+      />
     </SG.Item>
   </Shw::Grid>
 
@@ -301,42 +351,51 @@ loadInitializers(App, config.modulePrefix);" />
 
   <Shw::Text::H3>Language</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
     <SG.Item @label="no language (default)" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @value="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU
+      <Hds::CodeBlock
+        @value="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU
 GPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3
 Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA
 t3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En
 mZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx
-NrRFi9wrf+M7Q==" />
+NrRFi9wrf+M7Q=="
+      />
     </SG.Item>
 
     <SG.Item @label="bash" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="bash"
-        @value="aws ec2 --region us-west-1 accept-vpc-peering-connection" />
+      <Hds::CodeBlock @language="bash" @value="aws ec2 --region us-west-1 accept-vpc-peering-connection" />
     </SG.Item>
 
     <SG.Item @label="Go" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="go" @value="package main
+      <Hds::CodeBlock
+        @language="go"
+        @value="package main
 import 'fmt'
 func main() {
   fmt.Println('hello world')
-}" />
+}"
+      />
     </SG.Item>
 
     <SG.Item @label="HashiCorp Configuration Language" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock @language="hcl" @value='variable "hvn_id" {
+      <Hds::CodeBlock
+        @language="hcl"
+        @value='variable "hvn_id" {
   description = "The ID of the HCP HVN."
   type        = string
   default     = "learn-hcp-vault-hvn"
-}' />
+}'
+      />
       {{! template-lint-enable no-whitespace-for-layout }}
     </SG.Item>
 
     <SG.Item @label="JSON" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock @language="json" @value='{
+      <Hds::CodeBlock
+        @language="json"
+        @value='{
   "result": [
     {
       "expressions": [
@@ -351,13 +410,15 @@ func main() {
       ]
     }
   ]
- }' />
+ }'
+      />
       {{! template-lint-enable no-whitespace-for-layout }}
     </SG.Item>
 
     <SG.Item @label="log" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock @language="log"
+      <Hds::CodeBlock
+        @language="log"
         @value='web_1            | USE_L10N =3D True
 web_1            | USE_THOUSAND_SEPARATOR =3D False
 web_1            | USE_TZ =3D True
@@ -393,17 +454,19 @@ web_1            |     } for x in query.model.Context.sources]
 web_1            |   File "/code/context/scooters/views.py", line 26, in <listcomp>
 web_1            |     } for x in query.model.Context.sources]
 web_1            | TypeError: source() takes 1 positional argument but 2 were given
-web_1            | [13/Jun/2019 02:54:33] "GET /api/v1/rides/ HTTP/1.1" 500 90495' />
+web_1            | [13/Jun/2019 02:54:33] "GET /api/v1/rides/ HTTP/1.1" 500 90495'
+      />
       {{! template-lint-enable no-whitespace-for-layout }}
     </SG.Item>
 
     <SG.Item @label="Shell" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="shell-session"
-        @value="$ brew tap hashicorp/tap" />
+      <Hds::CodeBlock @language="shell-session" @value="$ brew tap hashicorp/tap" />
     </SG.Item>
 
     <SG.Item @label="YAML" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="yaml" @value="---
+      <Hds::CodeBlock
+        @language="yaml"
+        @value="---
 result:
 - expressions:
   - value: true
@@ -411,22 +474,29 @@ result:
     location:
       row: 1
       col: 1
-" />
+"
+      />
     </SG.Item>
 
     <SG.Item @label="Ruby" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="ruby" @value='Vagrant.configure("2") do |config|
+      <Hds::CodeBlock
+        @language="ruby"
+        @value='Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/noble64"
-end' />
+end'
+      />
     </SG.Item>
 
     <SG.Item @label="Invalid language (foo)" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock @language="foo" @value='variable "hvn_id" {
+      <Hds::CodeBlock
+        @language="foo"
+        @value='variable "hvn_id" {
   description = "The ID of the HCP HVN."
   type        = string
   default     = "learn-hcp-vault-hvn"
-}' />
+}'
+      />
       {{! template-lint-enable no-whitespace-for-layout }}
     </SG.Item>
   </Shw::Grid>
@@ -439,20 +509,25 @@ end' />
 
   <Shw::Grid @columns={{6}} as |SG|>
     {{#each @model.STATES as |state|}}
-    <SG.Item @label={{(capitalize state)}}
-      class="shw-component-code-block-copy-button">
-      <Hds::CodeBlock::CopyButton mock-state-value={{state}}
-        @textToCopy="copy me" class="hds-code-block--theme-dark" />
-    </SG.Item>
+      <SG.Item @label={{(capitalize state)}} class="shw-component-code-block-copy-button">
+        <Hds::CodeBlock::CopyButton
+          mock-state-value={{state}}
+          @textToCopy="copy me"
+          class="hds-code-block--theme-dark"
+        />
+      </SG.Item>
     {{/each}}
     {{#let (array "success" "error") as |statuses|}}
-    {{#each statuses as |status|}}
-    <SG.Item @label={{(capitalize status)}}
-      class="shw-component-code-block-copy-button">
-      <Hds::CodeBlock::CopyButton @status={{status}} mock-copy-status={{status}}
-        @textToCopy="copy me" class="hds-code-block--theme-dark" />
-    </SG.Item>
-    {{/each}}
+      {{#each statuses as |status|}}
+        <SG.Item @label={{(capitalize status)}} class="shw-component-code-block-copy-button">
+          <Hds::CodeBlock::CopyButton
+            @status={{status}}
+            mock-copy-status={{status}}
+            @textToCopy="copy me"
+            class="hds-code-block--theme-dark"
+          />
+        </SG.Item>
+      {{/each}}
     {{/let}}
   </Shw::Grid>
 
@@ -460,30 +535,37 @@ end' />
 
   <Shw::Text::H2>Demo</Shw::Text::H2>
 
-  <Shw::Flex {{style gap="2rem" }} @direction="column" as |SF|>
+  <Shw::Flex {{style gap="2rem"}} @direction="column" as |SF|>
     <SF.Item>
       <Shw::Label>Within Tabs</Shw::Label>
-      <Hds::Tabs {{style width="400px" }} as |T|>
+      <Hds::Tabs {{style width="400px"}} as |T|>
         <T.Tab>JavaScript</T.Tab>
         <T.Tab>Go</T.Tab>
         <T.Tab>Lorem</T.Tab>
 
         <T.Panel>
-          <Hds::CodeBlock @language="javascript" @highlightLines="2" @value="let codeLang='JavaScript';
-console.log(`I am ${codeLang} code`);" />
+          <Hds::CodeBlock
+            @language="javascript"
+            @highlightLines="2"
+            @value="let codeLang='JavaScript';
+console.log(`I am ${codeLang} code`);"
+          />
         </T.Panel>
         <T.Panel>
-          <Hds::CodeBlock @language="go" @highlightLines="2, 4"
-            @hasLineWrapping={{true}} @value="package main
+          <Hds::CodeBlock
+            @language="go"
+            @highlightLines="2, 4"
+            @hasLineWrapping={{true}}
+            @value="package main
 import 'fmt'
 func main() {
   res = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam'
   fmt.Println(res)
-}" />
+}"
+          />
         </T.Panel>
         <T.Panel>
-          <Hds::CodeBlock @language="shell-session"
-            @value="$ brew tap hashicorp/tap" />
+          <Hds::CodeBlock @language="shell-session" @value="$ brew tap hashicorp/tap" />
         </T.Panel>
       </Hds::Tabs>
 
@@ -493,44 +575,48 @@ func main() {
       <Hds::Dropdown @listPosition="bottom-left" as |dd|>
         <dd.ToggleButton @text="Open menu" />
         <dd.Generic>
-          <Hds::CodeBlock @hasCopyButton={{true}} @language="go"
-            @highlightLines="2, 4" @value="package main
+          <Hds::CodeBlock
+            @hasCopyButton={{true}}
+            @language="go"
+            @highlightLines="2, 4"
+            @value="package main
 import 'fmt'
 func main() {
   fmt.Println('hello world')
-}" />
+}"
+          />
         </dd.Generic>
       </Hds::Dropdown>
     </SF.Item>
     <SF.Item>
       <Shw::Label>Within a Modal</Shw::Label>
-      <Hds::Button @color="secondary" @text="Open modal" {{on "click"
-        this.activateModal}} />
+      <Hds::Button @color="secondary" @text="Open modal" {{on "click" this.activateModal}} />
 
       {{! template-lint-disable no-autofocus-attribute }}
       {{#if this.isModalActive}}
-      <Hds::Modal id="test-copy-button-modal" @onClose={{this.deactivateModal}}
-        as |M|>
-        <M.Header>
-          Lorem ipsum dolor
-        </M.Header>
-        <M.Body>
-          <Hds::CodeBlock @hasCopyButton={{true}} @language="go"
-            @highlightLines="2, 4" @value="package main
+        <Hds::Modal id="test-copy-button-modal" @onClose={{this.deactivateModal}} as |M|>
+          <M.Header>
+            Lorem ipsum dolor
+          </M.Header>
+          <M.Body>
+            <Hds::CodeBlock
+              @hasCopyButton={{true}}
+              @language="go"
+              @highlightLines="2, 4"
+              @value="package main
 import 'fmt'
 func main() {
   fmt.Println('hello world')
-}" />
-        </M.Body>
-        <M.Footer as |F|>
-          <Hds::ButtonSet>
-            <Hds::Button type="submit" @text="OK" {{on "click"
-              this.deactivateModal}} />
-            <Hds::Button type="button" @text="Cancel" @color="secondary"
-              {{on "click" F.close}} />
-          </Hds::ButtonSet>
-        </M.Footer>
-      </Hds::Modal>
+}"
+            />
+          </M.Body>
+          <M.Footer as |F|>
+            <Hds::ButtonSet>
+              <Hds::Button type="submit" @text="OK" {{on "click" this.deactivateModal}} />
+              <Hds::Button type="button" @text="Cancel" @color="secondary" {{on "click" F.close}} />
+            </Hds::ButtonSet>
+          </M.Footer>
+        </Hds::Modal>
       {{/if}}
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/dummy/app/templates/components/code-block.hbs
+++ b/packages/components/tests/dummy/app/templates/components/code-block.hbs
@@ -10,29 +10,24 @@ SPDX-License-Identifier: MPL-2.0
 <section data-test-percy>
   <Shw::Text::H2>Content</Shw::Text::H2>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
     <SG.Item @label="one line">
-      <Hds::CodeBlock @language="javascript" @value="console.log('I am JavaScript code');" />
+      <Hds::CodeBlock @language="javascript"
+        @value="console.log('I am JavaScript code');" />
     </SG.Item>
     <SG.Item @label="multi-line">
-      <Hds::CodeBlock
-        @language="javascript"
-        @value="let codeLang='JavaScript';
-console.log(`I am ${codeLang} code`);"
-      />
+      <Hds::CodeBlock @language="javascript" @value="let codeLang='JavaScript';
+console.log(`I am ${codeLang} code`);" />
     </SG.Item>
   </Shw::Grid>
 
   <Shw::Text::Body>New lines handling</Shw::Text::Body>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
     <SG.Item @forceMinWidth={{true}} as |SGI|>
       <SGI.Label>new lines in Handlebars</SGI.Label>
-      <Hds::CodeBlock
-        @language="javascript"
-        @value="let codeLang='JavaScript';
-console.log(`I am ${codeLang} code`);"
-      />
+      <Hds::CodeBlock @language="javascript" @value="let codeLang='JavaScript';
+console.log(`I am ${codeLang} code`);" />
     </SG.Item>
     <SG.Item @forceMinWidth={{true}} as |SGI|>
       <SGI.Label>new lines with
@@ -45,10 +40,8 @@ console.log(`I am ${codeLang} code`);"
       <SGI.Label><code>\n</code>
         in Handlebars (not interpreted as newline)
       </SGI.Label>
-      <Hds::CodeBlock
-        @language="javascript"
-        @value="let codeLang='JavaScript';\nconsole.log(`I am ${codeLang} code`);"
-      />
+      <Hds::CodeBlock @language="javascript"
+        @value="let codeLang='JavaScript';\nconsole.log(`I am ${codeLang} code`);" />
     </SG.Item>
   </Shw::Grid>
 
@@ -56,21 +49,25 @@ console.log(`I am ${codeLang} code`);"
 
   <Shw::Text::H3>Title and description</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
     <SG.Item @label="title">
-      <Hds::CodeBlock @value="console.log('I am JavaScript code');" @language="javascript" as |CB|>
+      <Hds::CodeBlock @value="console.log('I am JavaScript code');"
+        @language="javascript" as |CB|>
         <CB.Title>Title</CB.Title>
       </Hds::CodeBlock>
     </SG.Item>
 
     <SG.Item @label="description">
-      <Hds::CodeBlock @value="console.log('I am JavaScript code');" @language="javascript" as |CB|>
+      <Hds::CodeBlock @value="console.log('I am JavaScript code');"
+        @language="javascript" as |CB|>
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
     </SG.Item>
     <SG.Item @label="title and description">
-      <Hds::CodeBlock @value="console.log('I am JavaScript code');" @language="javascript" as |CB|>
-        <CB.Title>Title that may wrap on multiple lines if the parent container is limiting its width</CB.Title>
+      <Hds::CodeBlock @value="console.log('I am JavaScript code');"
+        @language="javascript" as |CB|>
+        <CB.Title>Title that may wrap on multiple lines if the parent container
+          is limiting its width</CB.Title>
         <CB.Description>
           Description that could contain
           <a href="#">a link</a>
@@ -96,17 +93,13 @@ console.log(`I am ${codeLang} code`);"
 
   <Shw::Text::Body>
     <label for="input">Change input value:</label>
-    <input id="input" type="text" value={{this.input}} {{on "input" this.updateInput}} />
+    <input id="input" type="text" value={{this.input}} {{on "input"
+      this.updateInput}} />
   </Shw::Text::Body>
 
-  <Hds::CodeBlock
-    @value={{this.codeValue}}
-    @language="javascript"
-    @hasCopyButton={{true}}
-    @hasLineNumbers={{false}}
-    id="code-block-with-dynamic-content"
-    as |CB|
-  >
+  <Hds::CodeBlock @value={{this.codeValue}} @language="javascript"
+    @hasCopyButton={{true}} @hasLineNumbers={{false}}
+    id="code-block-with-dynamic-content" as |CB|>
     <CB.Title>
       Dynamic content
     </CB.Title>
@@ -118,22 +111,14 @@ console.log(`I am ${codeLang} code`);"
 
   <Shw::Text::H3>Standalone</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
     <SG.Item @label="isStandalone=false">
-      <Hds::CodeBlock
-        @isStandalone={{false}}
-        @language="javascript"
-        @value="let codeLang='JavaScript';
-console.log(`I am ${codeLang} code`);"
-      />
+      <Hds::CodeBlock @isStandalone={{false}} @language="javascript" @value="let codeLang='JavaScript';
+console.log(`I am ${codeLang} code`);" />
     </SG.Item>
     <SG.Item @label="isStandalone=false, title and description">
-      <Hds::CodeBlock
-        @value="console.log('I am JavaScript code');"
-        @language="javascript"
-        @isStandalone={{false}}
-        as |CB|
-      >
+      <Hds::CodeBlock @value="console.log('I am JavaScript code');"
+        @language="javascript" @isStandalone={{false}} as |CB|>
         <CB.Title>Title</CB.Title>
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
@@ -144,26 +129,19 @@ console.log(`I am ${codeLang} code`);"
 
   <Shw::Text::H3>Line wrapping</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
     <SG.Item @label="hasLineWrapping=false (default)" @forceMinWidth={{true}}>
-      <Hds::CodeBlock
-        @language="javascript"
-        @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';
-console.log(codeLand);"
-      />
+      <Hds::CodeBlock @language="javascript" @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';
+console.log(codeLand);" />
     </SG.Item>
     <SG.Item @label="hasLineWrapping=true" @forceMinWidth={{true}}>
-      <Hds::CodeBlock
-        @language="javascript"
-        @hasLineWrapping={{true}}
-        @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';"
-      />
+      <Hds::CodeBlock @language="javascript" @hasLineWrapping={{true}}
+        @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';" />
     </SG.Item>
-    <SG.Item @label="hasLineWrapping=true with long string" @forceMinWidth={{true}}>
-      <Hds::CodeBlock
-        @hasLineWrapping={{true}}
-        @value="hcp-domain-verification=6ea52e476fc6232d974c31453dcd884a68df6cf374892a50a897c87d11125b67"
-      />
+    <SG.Item @label="hasLineWrapping=true with long string"
+      @forceMinWidth={{true}}>
+      <Hds::CodeBlock @hasLineWrapping={{true}}
+        @value="hcp-domain-verification=6ea52e476fc6232d974c31453dcd884a68df6cf374892a50a897c87d11125b67" />
     </SG.Item>
   </Shw::Grid>
 
@@ -171,23 +149,14 @@ console.log(codeLand);"
 
   <Shw::Text::H3>Line numbers</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
     <SG.Item @label="hasLineNumbers=false">
-      <Hds::CodeBlock
-        @language="javascript"
-        @hasLineNumbers={{false}}
-        @value="let codeLang='JavaScript';
-    console.log(`I am ${codeLang} code`);"
-      />
+      <Hds::CodeBlock @language="javascript" @hasLineNumbers={{false}} @value="let codeLang='JavaScript';
+    console.log(`I am ${codeLang} code`);" />
     </SG.Item>
     <SG.Item @label="hasLineNumbers=false, title and description">
-      <Hds::CodeBlock
-        @language="javascript"
-        @hasLineNumbers={{false}}
-        @value="let codeLang='JavaScript';
-console.log(`I am ${codeLang} code`);"
-        as |CB|
-      >
+      <Hds::CodeBlock @language="javascript" @hasLineNumbers={{false}} @value="let codeLang='JavaScript';
+console.log(`I am ${codeLang} code`);" as |CB|>
         <CB.Title>Title</CB.Title>
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
@@ -198,13 +167,10 @@ console.log(`I am ${codeLang} code`);"
 
   <Shw::Text::H3>Height limit</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
     <SG.Item @label="maxHeight='105px'" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock
-        @language="javascript"
-        @maxHeight="105px"
-        @value="function convertObjectToArray (obj) {
+      <Hds::CodeBlock @language="javascript" @maxHeight="105px" @value="function convertObjectToArray (obj) {
   let arr = Object
     .keys(obj) // return object's keys as an array
     .map(key => {return [key, obj[key] ]}) // map a function on each array item
@@ -222,17 +188,14 @@ function assertObjectsEqual (actual, expected, testName) {
   } else {
     console.log(`FAILED [${testName}] Expected ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);
   }
-}"
-      />
+}" />
       {{! template-lint-enable no-whitespace-for-layout }}
     </SG.Item>
 
-    <SG.Item @label="maxHeight='105px', title and description" @forceMinWidth={{true}}>
+    <SG.Item @label="maxHeight='105px', title and description"
+      @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock
-        @language="javascript"
-        @maxHeight="105px"
-        @value="function convertObjectToArray (obj) {
+      <Hds::CodeBlock @language="javascript" @maxHeight="105px" @value="function convertObjectToArray (obj) {
   let arr = Object
     .keys(obj) // return object's keys as an array
     .map(key => {return [key, obj[key] ]}) // map a function on each array item
@@ -250,9 +213,7 @@ function assertObjectsEqual (actual, expected, testName) {
   } else {
     console.log(`FAILED [${testName}] Expected ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);
   }
-}"
-        as |CB|
-      >
+}" as |CB|>
         <CB.Title>Title</CB.Title>
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
@@ -264,18 +225,17 @@ function assertObjectsEqual (actual, expected, testName) {
 
   <Shw::Text::H3>Copy button</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
     <SG.Item @label="hasCopyButton=true" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="shell-session" @hasCopyButton={{true}} @value="$ brew tap hashicorp/tap" />
+      <Hds::CodeBlock @language="shell-session" @hasCopyButton={{true}}
+        @value="$ brew tap hashicorp/tap" />
     </SG.Item>
-    <SG.Item @label="hasCopyButton=true, maxHeight='105px', title and description" @forceMinWidth={{true}}>
+    <SG.Item
+      @label="hasCopyButton=true, maxHeight='105px', title and description"
+      @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock
-        id="clipboardTarget2"
-        @hasCopyButton={{true}}
-        @language="javascript"
-        @maxHeight="105px"
-        @value="function convertObjectToArray (obj) {
+      <Hds::CodeBlock id="clipboardTarget2" @hasCopyButton={{true}}
+        @language="javascript" @maxHeight="105px" @value="function convertObjectToArray (obj) {
   let arr = Object
     .keys(obj) // return object's keys as an array
     .map(key => {return [key, obj[key] ]}) // map a function on each array item
@@ -293,9 +253,7 @@ function assertObjectsEqual (actual, expected, testName) {
   } else {
     console.log(`FAILED [${testName}] Expected ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);
   }
-}"
-        as |CB|
-      >
+}" as |CB|>
         <CB.Title>Title</CB.Title>
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
@@ -307,12 +265,9 @@ function assertObjectsEqual (actual, expected, testName) {
 
   <Shw::Text::H3>Highlight lines</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
     <SG.Item @label="Highlight lines 2 & 4" @forceMinWidth={{true}}>
-      <Hds::CodeBlock
-        @language="javascript"
-        @highlightLines="2, 4"
-        @value="import Application from '@ember/application';
+      <Hds::CodeBlock @language="javascript" @highlightLines="2, 4" @value="import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'dummy/config/environment';
@@ -323,15 +278,11 @@ export default class App extends Application {
   Resolver = Resolver;
 }
 
-loadInitializers(App, config.modulePrefix);"
-      />
+loadInitializers(App, config.modulePrefix);" />
     </SG.Item>
 
     <SG.Item @label="Highlight lines 6-10" @forceMinWidth={{true}}>
-      <Hds::CodeBlock
-        @language="javascript"
-        @highlightLines="6-10"
-        @value="import Application from '@ember/application';
+      <Hds::CodeBlock @language="javascript" @highlightLines="6-10" @value="import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'dummy/config/environment';
@@ -342,8 +293,7 @@ export default class App extends Application {
   Resolver = Resolver;
 }
 
-loadInitializers(App, config.modulePrefix);"
-      />
+loadInitializers(App, config.modulePrefix);" />
     </SG.Item>
   </Shw::Grid>
 
@@ -351,51 +301,42 @@ loadInitializers(App, config.modulePrefix);"
 
   <Shw::Text::H3>Language</Shw::Text::H3>
 
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+  <Shw::Grid @columns={{2}} {{style gap="2rem" }} as |SG|>
     <SG.Item @label="no language (default)" @forceMinWidth={{true}}>
-      <Hds::CodeBlock
-        @value="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU
+      <Hds::CodeBlock @value="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU
 GPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3
 Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA
 t3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En
 mZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx
-NrRFi9wrf+M7Q=="
-      />
+NrRFi9wrf+M7Q==" />
     </SG.Item>
 
     <SG.Item @label="bash" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="bash" @value="aws ec2 --region us-west-1 accept-vpc-peering-connection" />
+      <Hds::CodeBlock @language="bash"
+        @value="aws ec2 --region us-west-1 accept-vpc-peering-connection" />
     </SG.Item>
 
     <SG.Item @label="Go" @forceMinWidth={{true}}>
-      <Hds::CodeBlock
-        @language="go"
-        @value="package main
+      <Hds::CodeBlock @language="go" @value="package main
 import 'fmt'
 func main() {
   fmt.Println('hello world')
-}"
-      />
+}" />
     </SG.Item>
 
     <SG.Item @label="HashiCorp Configuration Language" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock
-        @language="hcl"
-        @value='variable "hvn_id" {
+      <Hds::CodeBlock @language="hcl" @value='variable "hvn_id" {
   description = "The ID of the HCP HVN."
   type        = string
   default     = "learn-hcp-vault-hvn"
-}'
-      />
+}' />
       {{! template-lint-enable no-whitespace-for-layout }}
     </SG.Item>
 
     <SG.Item @label="JSON" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock
-        @language="json"
-        @value='{
+      <Hds::CodeBlock @language="json" @value='{
   "result": [
     {
       "expressions": [
@@ -410,15 +351,13 @@ func main() {
       ]
     }
   ]
- }'
-      />
+ }' />
       {{! template-lint-enable no-whitespace-for-layout }}
     </SG.Item>
 
     <SG.Item @label="log" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock
-        @language="log"
+      <Hds::CodeBlock @language="log"
         @value='web_1            | USE_L10N =3D True
 web_1            | USE_THOUSAND_SEPARATOR =3D False
 web_1            | USE_TZ =3D True
@@ -454,19 +393,17 @@ web_1            |     } for x in query.model.Context.sources]
 web_1            |   File "/code/context/scooters/views.py", line 26, in <listcomp>
 web_1            |     } for x in query.model.Context.sources]
 web_1            | TypeError: source() takes 1 positional argument but 2 were given
-web_1            | [13/Jun/2019 02:54:33] "GET /api/v1/rides/ HTTP/1.1" 500 90495'
-      />
+web_1            | [13/Jun/2019 02:54:33] "GET /api/v1/rides/ HTTP/1.1" 500 90495' />
       {{! template-lint-enable no-whitespace-for-layout }}
     </SG.Item>
 
     <SG.Item @label="Shell" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="shell-session" @value="$ brew tap hashicorp/tap" />
+      <Hds::CodeBlock @language="shell-session"
+        @value="$ brew tap hashicorp/tap" />
     </SG.Item>
 
     <SG.Item @label="YAML" @forceMinWidth={{true}}>
-      <Hds::CodeBlock
-        @language="yaml"
-        @value="---
+      <Hds::CodeBlock @language="yaml" @value="---
 result:
 - expressions:
   - value: true
@@ -474,119 +411,23 @@ result:
     location:
       row: 1
       col: 1
-"
-      />
+" />
     </SG.Item>
 
     <SG.Item @label="Ruby" @forceMinWidth={{true}}>
-      <Hds::CodeBlock
-        @language="ruby"
-        @value='Vagrant.configure("2") do |config|
+      <Hds::CodeBlock @language="ruby" @value='Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/noble64"
-end'
-      />
+end' />
     </SG.Item>
 
     <SG.Item @label="Invalid language (foo)" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
-      <Hds::CodeBlock
-        @language="foo"
-        @value='variable "hvn_id" {
+      <Hds::CodeBlock @language="foo" @value='variable "hvn_id" {
   description = "The ID of the HCP HVN."
   type        = string
   default     = "learn-hcp-vault-hvn"
-}'
-      />
+}' />
       {{! template-lint-enable no-whitespace-for-layout }}
-    </SG.Item>
-  </Shw::Grid>
-
-  <Shw::Divider @level="2" />
-
-  <Shw::Text::H3>Shell Session examples</Shw::Text::H3>
-
-  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
-
-    <SG.Item @label="Basic example (@language=shell-session)">
-      <Hds::CodeBlock @language="shell-session" @value="brew tap hashicorp/tap" />
-    </SG.Item>
-
-    <SG.Item @label="Basic example (@language=bash)">
-      <Hds::CodeBlock @language="bash" @value="brew tap hashicorp/tap" />
-    </SG.Item>
-
-    <SG.Item @label="Bash example 01 (@language=shell-session)">
-      <Hds::CodeBlock
-        @language="shell-session"
-        @value="nano hello.sh
-#!/bin/bash
-#Creates a new variable with a value of 'Hello Wolrd'
-learningbash='Hello World'
-echo $learningbash"
-      />
-    </SG.Item>
-
-    <SG.Item @label="Bash example 01 (@language=bash)">
-      <Hds::CodeBlock
-        @language="bash"
-        @value="nano hello.sh
-#!/bin/bash
-#Creates a new variable with a value of 'Hello Wolrd'
-learningbash='Hello World'
-echo $learningbash"
-      />
-    </SG.Item>
-
-    <SG.Item @label="Bash example 02 (@language=shell-session)">
-      <Hds::CodeBlock
-        @language="shell-session"
-        @value="nano loop.sh
-#!/bin/bash
-n=0
-while :
-do
-echo Countdown: $n
-((n++))
-done"
-      />
-    </SG.Item>
-
-    <SG.Item @label="Bash example 02 (@language=bash)">
-      <Hds::CodeBlock
-        @language="bash"
-        @value="nano loop.sh
-#!/bin/bash
-n=0
-while :
-do
-echo Countdown: $n
-((n++))
-done"
-      />
-    </SG.Item>
-
-    <SG.Item @label="Bash example 03 (@language=shell-session)">
-      <Hds::CodeBlock
-        @language="shell-session"
-        @value="#!/bin/bash
-nano function.sh
-hello () {
-   echo 'Hello World!'
-}
-hello"
-      />
-    </SG.Item>
-
-    <SG.Item @label="Bash example 03 (@language=bash)">
-      <Hds::CodeBlock
-        @language="bash"
-        @value="#!/bin/bash
-nano function.sh
-hello () {
-   echo 'Hello World!'
-}
-hello"
-      />
     </SG.Item>
   </Shw::Grid>
 
@@ -598,25 +439,20 @@ hello"
 
   <Shw::Grid @columns={{6}} as |SG|>
     {{#each @model.STATES as |state|}}
-      <SG.Item @label={{(capitalize state)}} class="shw-component-code-block-copy-button">
-        <Hds::CodeBlock::CopyButton
-          mock-state-value={{state}}
-          @textToCopy="copy me"
-          class="hds-code-block--theme-dark"
-        />
-      </SG.Item>
+    <SG.Item @label={{(capitalize state)}}
+      class="shw-component-code-block-copy-button">
+      <Hds::CodeBlock::CopyButton mock-state-value={{state}}
+        @textToCopy="copy me" class="hds-code-block--theme-dark" />
+    </SG.Item>
     {{/each}}
     {{#let (array "success" "error") as |statuses|}}
-      {{#each statuses as |status|}}
-        <SG.Item @label={{(capitalize status)}} class="shw-component-code-block-copy-button">
-          <Hds::CodeBlock::CopyButton
-            @status={{status}}
-            mock-copy-status={{status}}
-            @textToCopy="copy me"
-            class="hds-code-block--theme-dark"
-          />
-        </SG.Item>
-      {{/each}}
+    {{#each statuses as |status|}}
+    <SG.Item @label={{(capitalize status)}}
+      class="shw-component-code-block-copy-button">
+      <Hds::CodeBlock::CopyButton @status={{status}} mock-copy-status={{status}}
+        @textToCopy="copy me" class="hds-code-block--theme-dark" />
+    </SG.Item>
+    {{/each}}
     {{/let}}
   </Shw::Grid>
 
@@ -624,37 +460,30 @@ hello"
 
   <Shw::Text::H2>Demo</Shw::Text::H2>
 
-  <Shw::Flex {{style gap="2rem"}} @direction="column" as |SF|>
+  <Shw::Flex {{style gap="2rem" }} @direction="column" as |SF|>
     <SF.Item>
       <Shw::Label>Within Tabs</Shw::Label>
-      <Hds::Tabs {{style width="400px"}} as |T|>
+      <Hds::Tabs {{style width="400px" }} as |T|>
         <T.Tab>JavaScript</T.Tab>
         <T.Tab>Go</T.Tab>
         <T.Tab>Lorem</T.Tab>
 
         <T.Panel>
-          <Hds::CodeBlock
-            @language="javascript"
-            @highlightLines="2"
-            @value="let codeLang='JavaScript';
-console.log(`I am ${codeLang} code`);"
-          />
+          <Hds::CodeBlock @language="javascript" @highlightLines="2" @value="let codeLang='JavaScript';
+console.log(`I am ${codeLang} code`);" />
         </T.Panel>
         <T.Panel>
-          <Hds::CodeBlock
-            @language="go"
-            @highlightLines="2, 4"
-            @hasLineWrapping={{true}}
-            @value="package main
+          <Hds::CodeBlock @language="go" @highlightLines="2, 4"
+            @hasLineWrapping={{true}} @value="package main
 import 'fmt'
 func main() {
   res = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam'
   fmt.Println(res)
-}"
-          />
+}" />
         </T.Panel>
         <T.Panel>
-          <Hds::CodeBlock @language="shell-session" @value="$ brew tap hashicorp/tap" />
+          <Hds::CodeBlock @language="shell-session"
+            @value="$ brew tap hashicorp/tap" />
         </T.Panel>
       </Hds::Tabs>
 
@@ -664,48 +493,44 @@ func main() {
       <Hds::Dropdown @listPosition="bottom-left" as |dd|>
         <dd.ToggleButton @text="Open menu" />
         <dd.Generic>
-          <Hds::CodeBlock
-            @hasCopyButton={{true}}
-            @language="go"
-            @highlightLines="2, 4"
-            @value="package main
+          <Hds::CodeBlock @hasCopyButton={{true}} @language="go"
+            @highlightLines="2, 4" @value="package main
 import 'fmt'
 func main() {
   fmt.Println('hello world')
-}"
-          />
+}" />
         </dd.Generic>
       </Hds::Dropdown>
     </SF.Item>
     <SF.Item>
       <Shw::Label>Within a Modal</Shw::Label>
-      <Hds::Button @color="secondary" @text="Open modal" {{on "click" this.activateModal}} />
+      <Hds::Button @color="secondary" @text="Open modal" {{on "click"
+        this.activateModal}} />
 
       {{! template-lint-disable no-autofocus-attribute }}
       {{#if this.isModalActive}}
-        <Hds::Modal id="test-copy-button-modal" @onClose={{this.deactivateModal}} as |M|>
-          <M.Header>
-            Lorem ipsum dolor
-          </M.Header>
-          <M.Body>
-            <Hds::CodeBlock
-              @hasCopyButton={{true}}
-              @language="go"
-              @highlightLines="2, 4"
-              @value="package main
+      <Hds::Modal id="test-copy-button-modal" @onClose={{this.deactivateModal}}
+        as |M|>
+        <M.Header>
+          Lorem ipsum dolor
+        </M.Header>
+        <M.Body>
+          <Hds::CodeBlock @hasCopyButton={{true}} @language="go"
+            @highlightLines="2, 4" @value="package main
 import 'fmt'
 func main() {
   fmt.Println('hello world')
-}"
-            />
-          </M.Body>
-          <M.Footer as |F|>
-            <Hds::ButtonSet>
-              <Hds::Button type="submit" @text="OK" {{on "click" this.deactivateModal}} />
-              <Hds::Button type="button" @text="Cancel" @color="secondary" {{on "click" F.close}} />
-            </Hds::ButtonSet>
-          </M.Footer>
-        </Hds::Modal>
+}" />
+        </M.Body>
+        <M.Footer as |F|>
+          <Hds::ButtonSet>
+            <Hds::Button type="submit" @text="OK" {{on "click"
+              this.deactivateModal}} />
+            <Hds::Button type="button" @text="Cancel" @color="secondary"
+              {{on "click" F.close}} />
+          </Hds::ButtonSet>
+        </M.Footer>
+      </Hds::Modal>
       {{/if}}
     </SF.Item>
   </Shw::Flex>

--- a/packages/components/tests/dummy/app/templates/components/code-block.hbs
+++ b/packages/components/tests/dummy/app/templates/components/code-block.hbs
@@ -569,7 +569,7 @@ done"
       <Hds::CodeBlock
         @language="shell-session"
         @value="#!/bin/bash
-nano function.sh      
+nano function.sh
 hello () {
    echo 'Hello World!'
 }
@@ -581,7 +581,7 @@ hello"
       <Hds::CodeBlock
         @language="bash"
         @value="#!/bin/bash
-nano function.sh      
+nano function.sh
 hello () {
    echo 'Hello World!'
 }

--- a/packages/components/tests/dummy/app/templates/components/code-block.hbs
+++ b/packages/components/tests/dummy/app/templates/components/code-block.hbs
@@ -1,6 +1,6 @@
 {{!
-  Copyright (c) HashiCorp, Inc.
-  SPDX-License-Identifier: MPL-2.0
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
 }}
 
 {{page-title "CodeBlock Component"}}
@@ -35,11 +35,16 @@ console.log(`I am ${codeLang} code`);"
       />
     </SG.Item>
     <SG.Item @forceMinWidth={{true}} as |SGI|>
-      <SGI.Label>new lines with <code>\n</code> escape sequence in JavaScript</SGI.Label>
+      <SGI.Label>new lines with
+        <code>\n</code>
+        escape sequence in JavaScript
+      </SGI.Label>
       <Hds::CodeBlock @language="javascript" @value={{this.textWithNewline}} />
     </SG.Item>
     <SG.Item @forceMinWidth={{true}} as |SGI|>
-      <SGI.Label><code>\n</code> in Handlebars (not interpreted as newline)</SGI.Label>
+      <SGI.Label><code>\n</code>
+        in Handlebars (not interpreted as newline)
+      </SGI.Label>
       <Hds::CodeBlock
         @language="javascript"
         @value="let codeLang='JavaScript';\nconsole.log(`I am ${codeLang} code`);"
@@ -493,6 +498,95 @@ end'
 }'
       />
       {{! template-lint-enable no-whitespace-for-layout }}
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level="2" />
+
+  <Shw::Text::H3>Shell Session examples</Shw::Text::H3>
+
+  <Shw::Grid @columns={{2}} {{style gap="2rem"}} as |SG|>
+
+    <SG.Item @label="Basic example (@language=shell-session)">
+      <Hds::CodeBlock @language="shell-session" @value="brew tap hashicorp/tap" />
+    </SG.Item>
+
+    <SG.Item @label="Basic example (@language=bash)">
+      <Hds::CodeBlock @language="bash" @value="brew tap hashicorp/tap" />
+    </SG.Item>
+
+    <SG.Item @label="Bash example 01 (@language=shell-session)">
+      <Hds::CodeBlock
+        @language="shell-session"
+        @value="nano hello.sh
+#!/bin/bash
+#Creates a new variable with a value of 'Hello Wolrd'
+learningbash='Hello World'
+echo $learningbash"
+      />
+    </SG.Item>
+
+    <SG.Item @label="Bash example 01 (@language=bash)">
+      <Hds::CodeBlock
+        @language="bash"
+        @value="nano hello.sh
+#!/bin/bash
+#Creates a new variable with a value of 'Hello Wolrd'
+learningbash='Hello World'
+echo $learningbash"
+      />
+    </SG.Item>
+
+    <SG.Item @label="Bash example 02 (@language=shell-session)">
+      <Hds::CodeBlock
+        @language="shell-session"
+        @value="nano loop.sh
+#!/bin/bash
+n=0
+while :
+do
+echo Countdown: $n
+((n++))
+done"
+      />
+    </SG.Item>
+
+    <SG.Item @label="Bash example 02 (@language=bash)">
+      <Hds::CodeBlock
+        @language="bash"
+        @value="nano loop.sh
+#!/bin/bash
+n=0
+while :
+do
+echo Countdown: $n
+((n++))
+done"
+      />
+    </SG.Item>
+
+    <SG.Item @label="Bash example 03 (@language=shell-session)">
+      <Hds::CodeBlock
+        @language="shell-session"
+        @value="#!/bin/bash
+nano function.sh      
+hello () {
+   echo 'Hello World!'
+}
+hello"
+      />
+    </SG.Item>
+
+    <SG.Item @label="Bash example 03 (@language=bash)">
+      <Hds::CodeBlock
+        @language="bash"
+        @value="#!/bin/bash
+nano function.sh      
+hello () {
+   echo 'Hello World!'
+}
+hello"
+      />
     </SG.Item>
   </Shw::Grid>
 


### PR DESCRIPTION
### :pushpin: Summary

This is a draft PR to capture some of the different examples referenced in [these Figma mockups](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/branch/ORBrWlIRWeSs5SgDlSWBWp/HDS-Product---Components?type=design&node-id=52600%3A5383&mode=design&t=AbnZ8vAjm7hsyF5w-1) around syntax highlighting for shell-session examples and bash examples.

Can be trashed, this is meant to be more representative.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2949](https://hashicorp.atlassian.net/browse/HDS-2949)
Figma file: [CodeBlock Color Updates](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/branch/ORBrWlIRWeSs5SgDlSWBWp/HDS-Product---Components?type=design&node-id=52600%3A5383&mode=design&t=AbnZ8vAjm7hsyF5w-1)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)
- [x] If documenting a new component, an acceptance test that includes the `a11yAudit` has been added
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2949]: https://hashicorp.atlassian.net/browse/HDS-2949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ