### PR TITLE
`SideNav::List::Title`: wrap text of long strings (HDS-3047)

### DIFF
--- a/packages/components/addon/components/hds/side-nav/list/title.hbs
+++ b/packages/components/addon/components/hds/side-nav/list/title.hbs
@@ -4,5 +4,7 @@
 }}
 
 <Hds::SideNav::List::Item>
-  <div class="hds-side-nav__list-title hds-typography-body-100 hds-font-weight-semibold" ...attributes>{{~yield~}}</div>
+  <div class="hds-side-nav__list-title" ...attributes>
+    <span class="hds-side-nav__list-title-content hds-typography-body-100 hds-font-weight-semibold">{{~yield~}}</span>
+  </div>
 </Hds::SideNav::List::Item>

--- a/packages/components/app/styles/components/side-nav/content.scss
+++ b/packages/components/app/styles/components/side-nav/content.scss
@@ -53,6 +53,12 @@
   }
 }
 
+.hds-side-nav__list-title-content {
+  display: block;
+  max-width: 100%;
+  overflow-wrap: break-word;
+}
+
 
 // LIST (root elements)
 
@@ -147,8 +153,10 @@
 // LIST ITEM > INNER ELEMENTS
 
 .hds-side-nav__list-item-text {
+  max-width: 100%;
   color: var(--token-side-nav-color-foreground-primary);
   text-align: left;
+  overflow-wrap: break-word;
 }
 
 .hds-side-nav__list-item-icon-leading {

--- a/packages/components/tests/dummy/app/templates/components/side-nav.hbs
+++ b/packages/components/tests/dummy/app/templates/components/side-nav.hbs
@@ -513,6 +513,14 @@
         </Hds::SideNav::List::Item>
       </ul>
     </SF.Item>
+    <SF.Item @label="With very long text and no spaces">
+      <ul class="shw-component-sim-side-nav-body">
+        <Hds::SideNav::List::Title>ThisIsLongTextThatShouldWrapToTwoLinesAndNotOverflow</Hds::SideNav::List::Title>
+        <Hds::SideNav::List::Item>
+          <Shw::Placeholder @height="108px" @text="following content" />
+        </Hds::SideNav::List::Item>
+      </ul>
+    </SF.Item>
   </Shw::Flex>
 
   <Shw::Divider @level={{2}} />
@@ -721,6 +729,11 @@
     <SF.Item @label="With very long text">
       <ul class="shw-component-sim-side-nav-body">
         <Hds::SideNav::List::BackLink @text="This is a long text that should go on two lines" @href="#" />
+      </ul>
+    </SF.Item>
+    <SF.Item @label="With very long text and no spaces">
+      <ul class="shw-component-sim-side-nav-body">
+        <Hds::SideNav::List::BackLink @text="ThisIsLongTextThatShouldWrapToTwoLinesAndNotOverflow" @href="#" />
       </ul>
     </SF.Item>
   </Shw::Flex>


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR restructures the SidNav ListTitle DOM and updates styles so long unbroken text strings will wrap. It also updates css for `SideNav::List::BackLink` so long text strings will wrap.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?
-->

### :camera_flash: Screenshots
<img width="889" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/b6b10559-0484-4b50-b02d-72a8325a52dd">
<img width="880" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/c93283b7-1f25-4ad6-8dd6-3aae49ece8db">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3047](https://hashicorp.atlassian.net/browse/HDS-3047)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] ~~A11y tests have been run locally (`yarn test:a11y --filter="COMPONENT-NAME"`)~~
- [ ] ~~If documenting a new component, an acceptance test that includes the `a11yAudit` has been added~~
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
