### PR TITLE
remove unused function in ember-flight-icons

### DIFF
--- a/.changeset/odd-years-build.md
+++ b/.changeset/odd-years-build.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/ember-flight-icons": patch
+---
+
+remove unused `contextRootURL` function

--- a/packages/ember-flight-icons/addon/components/flight-icon.js
+++ b/packages/ember-flight-icons/addon/components/flight-icon.js
@@ -5,7 +5,6 @@
 
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
-import { getOwner } from '@ember/application';
 import { assert } from '@ember/debug';
 
 import { iconNames } from '@hashicorp/flight-icons/svg';
@@ -20,11 +19,6 @@ export default class FlightIconComponent extends Component {
         `The icon @name "${this.args.name}" provided to <FlightIcon> is not correct. Please verify it exists on https://helios.hashicorp.design/icons/library`
       );
     }
-  }
-
-  get contextRootURL() {
-    const config = getOwner(this).resolveRegistration('config:environment');
-    return config.rootURL || '/';
   }
 
   /**


### PR DESCRIPTION
### :pushpin: Summary

I couldn't find it referenced anywhere in the project. It looks like it was removed from the template way back in https://github.com/hashicorp/flight/pull/245 and never got removed.