### PR TITLE
`IconTile` - Add support for Vault-Radar

### DIFF
--- a/.changeset/chilled-beans-sneeze.md
+++ b/.changeset/chilled-beans-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-tokens": minor
+---
+
+Added color tokens for “Vault Radar” product

--- a/.changeset/cyan-keys-reply.md
+++ b/.changeset/cyan-keys-reply.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`IconTile` - updated component adding support for `vault-radar` product

--- a/packages/components/addon/components/hds/icon-tile/index.js
+++ b/packages/components/addon/components/hds/icon-tile/index.js
@@ -19,6 +19,7 @@ export const PRODUCTS = [
   'vagrant',
   'vault',
   'vault-secrets',
+  'vault-radar',
   'waypoint',
 ];
 export const COLORS = ['neutral', ...PRODUCTS];

--- a/packages/components/app/styles/components/icon-tile.scss
+++ b/packages/components/app/styles/components/icon-tile.scss
@@ -9,7 +9,7 @@
 
 $hds-icon-tile-sizes: ( "small", "medium", "large" );
 $hds-icon-tile-types: ( "object","resource","logo" );
-$hds-icon-tile-colors-products: ( "boundary", "consul", "hcp", "nomad", "packer", "terraform", "vagrant", "vault", "vault-secrets", "waypoint" );
+$hds-icon-tile-colors-products: ( "boundary", "consul", "hcp", "nomad", "packer", "terraform", "vagrant", "vault", "vault-secrets", "vault-radar", "waypoint" );
 $hds-icon-tile-border-width: 1px;
 $hds-icon-tile-box-shadow: 0 1px 1px rgba(#656a76, 0.05);
 

--- a/packages/components/tests/integration/components/hds/icon-tile/index-test.js
+++ b/packages/components/tests/integration/components/hds/icon-tile/index-test.js
@@ -122,7 +122,7 @@ module('Integration | Component | hds/icon-tile/index', function (hooks) {
   });
   test('it should throw an assertion if a wrong @logo value is passed', async function (assert) {
     const errorMessage =
-      '@logo for "Hds::IconTile" must be one of the following: boundary, consul, hcp, nomad, packer, terraform, vagrant, vault, vault-secrets, waypoint; received: test';
+      '@logo for "Hds::IconTile" must be one of the following: boundary, consul, hcp, nomad, packer, terraform, vagrant, vault, vault-secrets, vault-radar, waypoint; received: test';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/packages/tokens/dist/devdot/css/helpers/color.css
+++ b/packages/tokens/dist/devdot/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Apr 2023 20:11:40 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/devdot/css/helpers/elevation.css
+++ b/packages/tokens/dist/devdot/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Apr 2023 20:11:40 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-elevation-inset { box-shadow: var(--token-elevation-inset-box-shadow); }

--- a/packages/tokens/dist/devdot/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/devdot/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Apr 2023 20:11:40 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/devdot/css/helpers/typography.css
+++ b/packages/tokens/dist/devdot/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Apr 2023 20:11:40 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/devdot/css/tokens.css
+++ b/packages/tokens/dist/devdot/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 29 Sep 2023 09:55:35 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 :root {
@@ -144,6 +144,15 @@
   --token-color-vagrant-gradient-primary-stop: #7dadff;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
+  --token-color-vault-radar-brand: #ffd814;
+  --token-color-vault-radar-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work */
+  --token-color-vault-radar-foreground: #9a6f00;
+  --token-color-vault-radar-surface: #fff9cf;
+  --token-color-vault-radar-border: #feec7b;
+  --token-color-vault-radar-gradient-primary-start: #feec7b;
+  --token-color-vault-radar-gradient-primary-stop: #ffe543;
+  --token-color-vault-radar-gradient-faint-start: #fffdf2; /* this is the 'vault-radar-50' value at 25% opacity on white */
+  --token-color-vault-radar-gradient-faint-stop: #fff9cf;
   --token-color-vault-secrets-brand: #ffd814;
   --token-color-vault-secrets-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work */
   --token-color-vault-secrets-foreground: #9a6f00;

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -3028,6 +3028,215 @@
     "type": "color",
     "group": "branding",
     "original": {
+      "value": "{color.palette.vault-radar-brand.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-radar-brand",
+    "attributes": {
+      "category": "color",
+      "type": "vault-radar",
+      "item": "brand"
+    },
+    "path": [
+      "color",
+      "vault-radar",
+      "brand"
+    ]
+  },
+  {
+    "value": "#000000",
+    "type": "color",
+    "group": "branding",
+    "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work",
+    "original": {
+      "value": "#000",
+      "type": "color",
+      "group": "branding",
+      "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work"
+    },
+    "name": "token-color-vault-radar-brand-alt",
+    "attributes": {
+      "category": "color",
+      "type": "vault-radar",
+      "item": "brand-alt"
+    },
+    "path": [
+      "color",
+      "vault-radar",
+      "brand-alt"
+    ]
+  },
+  {
+    "value": "#9a6f00",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-radar-500.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-radar-foreground",
+    "attributes": {
+      "category": "color",
+      "type": "vault-radar",
+      "item": "foreground"
+    },
+    "path": [
+      "color",
+      "vault-radar",
+      "foreground"
+    ]
+  },
+  {
+    "value": "#fff9cf",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-radar-50.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-radar-surface",
+    "attributes": {
+      "category": "color",
+      "type": "vault-radar",
+      "item": "surface"
+    },
+    "path": [
+      "color",
+      "vault-radar",
+      "surface"
+    ]
+  },
+  {
+    "value": "#feec7b",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-radar-100.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-radar-border",
+    "attributes": {
+      "category": "color",
+      "type": "vault-radar",
+      "item": "border"
+    },
+    "path": [
+      "color",
+      "vault-radar",
+      "border"
+    ]
+  },
+  {
+    "value": "#feec7b",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-radar-100.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-radar-gradient-primary-start",
+    "attributes": {
+      "category": "color",
+      "type": "vault-radar",
+      "item": "gradient",
+      "subitem": "primary",
+      "state": "start"
+    },
+    "path": [
+      "color",
+      "vault-radar",
+      "gradient",
+      "primary",
+      "start"
+    ]
+  },
+  {
+    "value": "#ffe543",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-radar-200.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-radar-gradient-primary-stop",
+    "attributes": {
+      "category": "color",
+      "type": "vault-radar",
+      "item": "gradient",
+      "subitem": "primary",
+      "state": "stop"
+    },
+    "path": [
+      "color",
+      "vault-radar",
+      "gradient",
+      "primary",
+      "stop"
+    ]
+  },
+  {
+    "value": "#fffdf2",
+    "type": "color",
+    "group": "branding",
+    "comment": "this is the 'vault-radar-50' value at 25% opacity on white",
+    "original": {
+      "value": "#fffdf2",
+      "type": "color",
+      "group": "branding",
+      "comment": "this is the 'vault-radar-50' value at 25% opacity on white"
+    },
+    "name": "token-color-vault-radar-gradient-faint-start",
+    "attributes": {
+      "category": "color",
+      "type": "vault-radar",
+      "item": "gradient",
+      "subitem": "faint",
+      "state": "start"
+    },
+    "path": [
+      "color",
+      "vault-radar",
+      "gradient",
+      "faint",
+      "start"
+    ]
+  },
+  {
+    "value": "#fff9cf",
+    "type": "color",
+    "group": "branding",
+    "original": {
+      "value": "{color.palette.vault-radar-50.value}",
+      "type": "color",
+      "group": "branding"
+    },
+    "name": "token-color-vault-radar-gradient-faint-stop",
+    "attributes": {
+      "category": "color",
+      "type": "vault-radar",
+      "item": "gradient",
+      "subitem": "faint",
+      "state": "stop"
+    },
+    "path": [
+      "color",
+      "vault-radar",
+      "gradient",
+      "faint",
+      "stop"
+    ]
+  },
+  {
+    "value": "#ffd814",
+    "type": "color",
+    "group": "branding",
+    "original": {
       "value": "{color.palette.vault-secrets-brand.value}",
       "type": "color",
       "group": "branding"

--- a/packages/tokens/dist/marketing/css/helpers/color.css
+++ b/packages/tokens/dist/marketing/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 21 Jul 2023 16:17:00 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/marketing/css/helpers/elevation.css
+++ b/packages/tokens/dist/marketing/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 21 Jul 2023 16:17:00 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-elevation-inset { box-shadow: var(--token-elevation-inset-box-shadow); }

--- a/packages/tokens/dist/marketing/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/marketing/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 21 Jul 2023 16:17:00 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/marketing/css/helpers/typography.css
+++ b/packages/tokens/dist/marketing/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 21 Jul 2023 16:17:00 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/marketing/css/tokens.css
+++ b/packages/tokens/dist/marketing/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 29 Sep 2023 09:55:35 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 :root {
@@ -142,6 +142,15 @@
   --token-color-vagrant-gradient-primary-stop: #7dadff;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
+  --token-color-vault-radar-brand: #ffd814;
+  --token-color-vault-radar-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work */
+  --token-color-vault-radar-foreground: #9a6f00;
+  --token-color-vault-radar-surface: #fff9cf;
+  --token-color-vault-radar-border: #feec7b;
+  --token-color-vault-radar-gradient-primary-start: #feec7b;
+  --token-color-vault-radar-gradient-primary-stop: #ffe543;
+  --token-color-vault-radar-gradient-faint-start: #fffdf2; /* this is the 'vault-radar-50' value at 25% opacity on white */
+  --token-color-vault-radar-gradient-faint-stop: #fff9cf;
   --token-color-vault-secrets-brand: #ffd814;
   --token-color-vault-secrets-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work */
   --token-color-vault-secrets-foreground: #9a6f00;

--- a/packages/tokens/dist/marketing/tokens.json
+++ b/packages/tokens/dist/marketing/tokens.json
@@ -3368,6 +3368,241 @@
         }
       }
     },
+    "vault-radar": {
+      "brand": {
+        "value": "#ffd814",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault-radar.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-radar-brand.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-radar-brand",
+        "attributes": {
+          "category": "color",
+          "type": "vault-radar",
+          "item": "brand"
+        },
+        "path": [
+          "color",
+          "vault-radar",
+          "brand"
+        ]
+      },
+      "brand-alt": {
+        "value": "#000000",
+        "type": "color",
+        "group": "branding",
+        "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work",
+        "filePath": "src/products/shared/color/semantic-product-vault-radar.json",
+        "isSource": true,
+        "original": {
+          "value": "#000",
+          "type": "color",
+          "group": "branding",
+          "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work"
+        },
+        "name": "token-color-vault-radar-brand-alt",
+        "attributes": {
+          "category": "color",
+          "type": "vault-radar",
+          "item": "brand-alt"
+        },
+        "path": [
+          "color",
+          "vault-radar",
+          "brand-alt"
+        ]
+      },
+      "foreground": {
+        "value": "#9a6f00",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault-radar.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-radar-500.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-radar-foreground",
+        "attributes": {
+          "category": "color",
+          "type": "vault-radar",
+          "item": "foreground"
+        },
+        "path": [
+          "color",
+          "vault-radar",
+          "foreground"
+        ]
+      },
+      "surface": {
+        "value": "#fff9cf",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault-radar.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-radar-50.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-radar-surface",
+        "attributes": {
+          "category": "color",
+          "type": "vault-radar",
+          "item": "surface"
+        },
+        "path": [
+          "color",
+          "vault-radar",
+          "surface"
+        ]
+      },
+      "border": {
+        "value": "#feec7b",
+        "type": "color",
+        "group": "branding",
+        "filePath": "src/products/shared/color/semantic-product-vault-radar.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.palette.vault-radar-100.value}",
+          "type": "color",
+          "group": "branding"
+        },
+        "name": "token-color-vault-radar-border",
+        "attributes": {
+          "category": "color",
+          "type": "vault-radar",
+          "item": "border"
+        },
+        "path": [
+          "color",
+          "vault-radar",
+          "border"
+        ]
+      },
+      "gradient": {
+        "primary": {
+          "start": {
+            "value": "#feec7b",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault-radar.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-radar-100.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-radar-gradient-primary-start",
+            "attributes": {
+              "category": "color",
+              "type": "vault-radar",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vault-radar",
+              "gradient",
+              "primary",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#ffe543",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault-radar.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-radar-200.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-radar-gradient-primary-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vault-radar",
+              "item": "gradient",
+              "subitem": "primary",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vault-radar",
+              "gradient",
+              "primary",
+              "stop"
+            ]
+          }
+        },
+        "faint": {
+          "start": {
+            "value": "#fffdf2",
+            "type": "color",
+            "group": "branding",
+            "comment": "this is the 'vault-radar-50' value at 25% opacity on white",
+            "filePath": "src/products/shared/color/semantic-product-vault-radar.json",
+            "isSource": true,
+            "original": {
+              "value": "#fffdf2",
+              "type": "color",
+              "group": "branding",
+              "comment": "this is the 'vault-radar-50' value at 25% opacity on white"
+            },
+            "name": "token-color-vault-radar-gradient-faint-start",
+            "attributes": {
+              "category": "color",
+              "type": "vault-radar",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "start"
+            },
+            "path": [
+              "color",
+              "vault-radar",
+              "gradient",
+              "faint",
+              "start"
+            ]
+          },
+          "stop": {
+            "value": "#fff9cf",
+            "type": "color",
+            "group": "branding",
+            "filePath": "src/products/shared/color/semantic-product-vault-radar.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.palette.vault-radar-50.value}",
+              "type": "color",
+              "group": "branding"
+            },
+            "name": "token-color-vault-radar-gradient-faint-stop",
+            "attributes": {
+              "category": "color",
+              "type": "vault-radar",
+              "item": "gradient",
+              "subitem": "faint",
+              "state": "stop"
+            },
+            "path": [
+              "color",
+              "vault-radar",
+              "gradient",
+              "faint",
+              "stop"
+            ]
+          }
+        }
+      }
+    },
     "vault-secrets": {
       "brand": {
         "value": "#ffd814",

--- a/packages/tokens/dist/products/css/helpers/color.css
+++ b/packages/tokens/dist/products/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Apr 2023 20:11:40 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/products/css/helpers/elevation.css
+++ b/packages/tokens/dist/products/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Apr 2023 20:11:40 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-elevation-inset { box-shadow: var(--token-elevation-inset-box-shadow); }

--- a/packages/tokens/dist/products/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/products/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Apr 2023 20:11:40 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/products/css/helpers/typography.css
+++ b/packages/tokens/dist/products/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Apr 2023 20:11:40 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 29 Sep 2023 09:55:35 GMT
+ * Generated on Wed, 24 Jan 2024 14:44:08 GMT
  */
 
 :root {
@@ -142,6 +142,15 @@
   --token-color-vagrant-gradient-primary-stop: #7dadff;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
+  --token-color-vault-radar-brand: #ffd814;
+  --token-color-vault-radar-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work */
+  --token-color-vault-radar-foreground: #9a6f00;
+  --token-color-vault-radar-surface: #fff9cf;
+  --token-color-vault-radar-border: #feec7b;
+  --token-color-vault-radar-gradient-primary-start: #feec7b;
+  --token-color-vault-radar-gradient-primary-stop: #ffe543;
+  --token-color-vault-radar-gradient-faint-start: #fffdf2; /* this is the 'vault-radar-50' value at 25% opacity on white */
+  --token-color-vault-radar-gradient-faint-stop: #fff9cf;
   --token-color-vault-secrets-brand: #ffd814;
   --token-color-vault-secrets-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work */
   --token-color-vault-secrets-foreground: #9a6f00;

--- a/packages/tokens/scripts/build-parts/generateColorHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateColorHelpers.ts
@@ -32,7 +32,7 @@ export function generateColorHelpers(tokens: TransformedToken[]): Helpers {
                 // notice: we assume a 1px border (if a user needs a different border width, and want to use the helper, they have to apply an override)
                 helpers.push(`.${PREFIX}-${context}-${name} { border: 1px solid var(--${token.name}); }`)
             }
-        } else if (['hashicorp', 'hcp', 'boundary','consul','nomad','packer','terraform','vagrant','vault','vault-secrets','waypoint'].includes(group)) {
+        } else if (['hashicorp', 'hcp', 'boundary','consul','nomad','packer','terraform','vagrant','vault','vault-secrets','vault-radar','waypoint'].includes(group)) {
             // TODO!
             // to be discussed if we want to expose all these colors as helpers
         } else if (group === 'palette') {

--- a/packages/tokens/src/global/color/palette-products.json
+++ b/packages/tokens/src/global/color/palette-products.json
@@ -397,6 +397,54 @@
                 "group": "palette",
                 "private": "true"
             },
+            "vault-radar-brand": {
+                "value": "#ffd814",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-radar-600": {
+                "value": "#8b6400",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-radar-500": {
+                "value": "#9a6f00",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-radar-400": {
+                "value": "#bb8e1a",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-radar-300": {
+                "value": "#f5d712",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-radar-200": {
+                "value": "#ffe543",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-radar-100": {
+                "value": "#feec7b",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
+            "vault-radar-50": {
+                "value": "#fff9cf",
+                "type": "color",
+                "group": "palette",
+                "private": "true"
+            },
             "waypoint-brand": {
                 "value": "#14c6cb",
                 "type": "color",

--- a/packages/tokens/src/products/shared/color/semantic-product-vault-radar.json
+++ b/packages/tokens/src/products/shared/color/semantic-product-vault-radar.json
@@ -1,0 +1,59 @@
+{
+    "color": {
+        "vault-radar": {
+            "brand": {
+                "value": "{color.palette.vault-radar-brand.value}",
+                "type": "color",
+                "group": "branding"
+            },
+            "brand-alt": {
+                "value": "#000",
+                "type": "color",
+                "group": "branding",
+                "comment": "this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work"
+            },
+            "foreground": {
+                "value": "{color.palette.vault-radar-500.value}",
+                "type": "color",
+                "group": "branding"
+            },
+            "surface": {
+                "value": "{color.palette.vault-radar-50.value}",
+                "type": "color",
+                "group": "branding"
+            },
+            "border": {
+                "value": "{color.palette.vault-radar-100.value}",
+                "type": "color",
+                "group": "branding"
+            },
+            "gradient": {
+                "primary": {
+                    "start": {
+                        "value": "{color.palette.vault-radar-100.value}",
+                        "type": "color",
+                        "group": "branding"
+                    },
+                    "stop": {
+                        "value": "{color.palette.vault-radar-200.value}",
+                        "type": "color",
+                        "group": "branding"
+                    }
+                },
+                "faint": {
+                    "start": {
+                        "value": "#fffdf2",
+                        "type": "color",
+                        "group": "branding",
+                        "comment": "this is the 'vault-radar-50' value at 25% opacity on white"
+                    },
+                    "stop": {
+                        "value": "{color.palette.vault-radar-50.value}",
+                        "type": "color",
+                        "group": "branding"
+                    }
+                }
+            }
+       }
+    }
+}

--- a/website/docs/components/icon-tile/partials/code/component-api.md
+++ b/website/docs/components/icon-tile/partials/code/component-api.md
@@ -2,7 +2,7 @@
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
-  <C.Property @name="logo" @type="enum" @values={{array "hcp" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "waypoint" }}>
+  <C.Property @name="logo" @type="enum" @values={{array "hcp" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "vault-radar" "waypoint" }}>
     Use this parameter to show a product logo.
   </C.Property>
   <C.Property @name="icon" @type="string">


### PR DESCRIPTION
### :pushpin: Summary

Add support for `vault-radar` to the `IconTile` component.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the design tokens to support colors for `vault-radar`
- updated the `IconTile` component to support `vault-radar`
- updated the `IconTile` documentation

👉 👉 👉 **Preview**: https://hds-showcase-git-update-icontile-add-vault-radar-hashicorp.vercel.app/components/icon-tile

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2786

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
