### PR TITLE
`Tabs` - remove `@cached` decorator

### DIFF
--- a/.changeset/purple-feet-shop.md
+++ b/.changeset/purple-feet-shop.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Tabs` - removed `@cached` decorator and the associated `ember-cached-decorator-polyfill`

--- a/packages/components/addon/components/hds/tabs/panel.js
+++ b/packages/components/addon/components/hds/tabs/panel.js
@@ -4,7 +4,6 @@
  */
 
 import Component from '@glimmer/component';
-import { cached } from '@glimmer/tracking';
 import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
 
@@ -15,7 +14,6 @@ export default class HdsTabsPanelComponent extends Component {
    */
   panelId = 'panel-' + guidFor(this);
 
-  @cached
   get nodeIndex() {
     return this.args.panelIds
       ? this.args.panelIds.indexOf(this.panelId)

--- a/packages/components/addon/components/hds/tabs/tab.js
+++ b/packages/components/addon/components/hds/tabs/tab.js
@@ -4,7 +4,6 @@
  */
 
 import Component from '@glimmer/component';
-import { cached } from '@glimmer/tracking';
 import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
 
@@ -15,7 +14,6 @@ export default class HdsTabsTabComponent extends Component {
    */
   tabId = 'tab-' + guidFor(this);
 
-  @cached
   get nodeIndex() {
     return this.args.tabIds ? this.args.tabIds.indexOf(this.tabId) : undefined;
   }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,6 @@
     "dialog-polyfill": "^0.5.6",
     "ember-a11y-refocus": "^3.0.2",
     "ember-auto-import": "^2.6.3",
-    "ember-cached-decorator-polyfill": "^1.0.2",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-sass": "^11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,7 +2730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@embroider/macros@npm:^0.50.0 || ^1.0.0, @embroider/macros@npm:^1.0.0, @embroider/macros@npm:^1.10.0, @embroider/macros@npm:^1.12.0, @embroider/macros@npm:^1.13.0, @embroider/macros@npm:^1.13.1, @embroider/macros@npm:^1.2.0, @embroider/macros@npm:^1.8.1, @embroider/macros@npm:^1.8.3":
+"@embroider/macros@npm:^0.50.0 || ^1.0.0, @embroider/macros@npm:^1.0.0, @embroider/macros@npm:^1.10.0, @embroider/macros@npm:^1.12.0, @embroider/macros@npm:^1.13.0, @embroider/macros@npm:^1.13.1, @embroider/macros@npm:^1.2.0, @embroider/macros@npm:^1.8.1":
   version: 1.13.2
   resolution: "@embroider/macros@npm:1.13.2"
   dependencies:
@@ -3483,7 +3483,6 @@ __metadata:
     ember-a11y-testing: "npm:^6.1.1"
     ember-auto-import: "npm:^2.6.3"
     ember-body-class: "npm:^3.0.0"
-    ember-cached-decorator-polyfill: "npm:^1.0.2"
     ember-cli: "npm:~5.3.0"
     ember-cli-babel: "npm:^8.2.0"
     ember-cli-clean-css: "npm:^3.0.0"
@@ -6774,7 +6773,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-import-util@npm:^1.1.0, babel-import-util@npm:^1.2.2, babel-import-util@npm:^1.3.0":
+"babel-import-util@npm:^1.1.0, babel-import-util@npm:^1.3.0":
   version: 1.4.1
   resolution: "babel-import-util@npm:1.4.1"
   checksum: becfbc6a60c8e6d026d648abec94af1a6bcc952d015dc1a802722b36abfffb5c9e0e803345d344738a1dcdab8c63eb33766316fd66b32f78b9dce9a93391a80d
@@ -11083,34 +11082,6 @@ __metadata:
     ember-cli-babel: "npm:^7.26.10"
     ember-get-config: "npm:^0.5.0"
   checksum: ae409e6e20160a64451b950e5e24dc7270a5c7c618700f9993c82f4df03ee98a873d87670e7cadbcafd2cbfcd6ab83f7d06425f779a7042895dca85990af7f5a
-  languageName: node
-  linkType: hard
-
-"ember-cache-primitive-polyfill@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "ember-cache-primitive-polyfill@npm:1.0.1"
-  dependencies:
-    ember-cli-babel: "npm:^7.22.1"
-    ember-cli-version-checker: "npm:^5.1.1"
-    ember-compatibility-helpers: "npm:^1.2.1"
-    silent-error: "npm:^1.1.1"
-  checksum: 6a9b85bb67d17b4d1a2a7556e3ae851ef1e63c7395a19f534421707a4ee19212b0682fa2435c3efaefcc7e9c4c63e7348cbdfde2a31a8e73f5d725344de34db1
-  languageName: node
-  linkType: hard
-
-"ember-cached-decorator-polyfill@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "ember-cached-decorator-polyfill@npm:1.0.2"
-  dependencies:
-    "@embroider/macros": "npm:^1.8.3"
-    "@glimmer/tracking": "npm:^1.1.2"
-    babel-import-util: "npm:^1.2.2"
-    ember-cache-primitive-polyfill: "npm:^1.0.1"
-    ember-cli-babel: "npm:^7.26.11"
-    ember-cli-babel-plugin-helpers: "npm:^1.1.1"
-  peerDependencies:
-    ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
-  checksum: e83d4e3064c9787fa3e1b8f8b7e809360ab06c04f098f95a9aa2f95049634bda614270fedce2859373ca448b013c289658c8f290f5abd4af8ab2eecb2483f2d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: Summary

Removed `@cached` decorator in `Tabs` and the associated `ember-cached-decorator-polyfill`.

### :hammer_and_wrench: Detailed description

We don't see major benefits in using the decorator and it creates issues in our efforts to move the components addon to v2 format.

### :link: External links

<!-- Issues, RFC, etc. -->
[Eng sync notes](https://docs.google.com/document/d/1twnk39hZ7p8oZYrld_FYsdiuUb6yn_weA46KnhF4nu4/edit#bookmark=id.cx2j9tqao36l)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
