### PR TITLE
Add image error handling to `Dropdown::Toggle::Icon`

### DIFF
--- a/.changeset/smooth-hairs-nail.md
+++ b/.changeset/smooth-hairs-nail.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Added image error handling to `Dropdown::Toggle::Icon`

--- a/packages/components/src/components/hds/dropdown/toggle/icon.hbs
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.hbs
@@ -8,11 +8,16 @@
   ...attributes
   aria-expanded={{if @isOpen "true" "false"}}
   {{on "click" this.onClick}}
+  {{did-update this.onDidUpdateImageSrc @imageSrc}}
   type="button"
 >
   <div class="hds-dropdown-toggle-icon__wrapper">
     {{#if @imageSrc}}
-      <img src={{@imageSrc}} alt="" role="presentation" height="32" width="32" />
+      {{#if this.hasImage}}
+        <img src={{@imageSrc}} alt="" role="presentation" height="32" width="32" {{on "error" this.onImageLoadError}} />
+      {{else}}
+        <FlightIcon @name="user" @size={{this.iconSize}} />
+      {{/if}}
     {{else if @icon}}
       <FlightIcon @name={{@icon}} @size={{this.iconSize}} />
     {{/if}}

--- a/packages/components/src/components/hds/dropdown/toggle/icon.hbs
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.hbs
@@ -14,7 +14,7 @@
   <div class="hds-dropdown-toggle-icon__wrapper">
     {{#if @imageSrc}}
       {{#if this.hasImage}}
-        <img src={{@imageSrc}} alt="" role="presentation" height="32" width="32" {{on "error" this.onImageLoadError}} />
+        <img src={{@imageSrc}} alt="" role="presentation" {{on "error" this.onImageLoadError}} />
       {{else}}
         <FlightIcon @name="user" @size={{this.iconSize}} />
       {{/if}}

--- a/packages/components/src/components/hds/dropdown/toggle/icon.js
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.js
@@ -4,7 +4,9 @@
  */
 
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 import { assert } from '@ember/debug';
+import { tracked } from '@glimmer/tracking';
 
 export const DEFAULT_SIZE = 'medium';
 export const SIZES = ['small', 'medium'];
@@ -12,6 +14,8 @@ export const SIZES = ['small', 'medium'];
 const NOOP = () => {};
 
 export default class HdsDropdownToggleIconComponent extends Component {
+  @tracked hasImage = false;
+
   constructor() {
     super(...arguments);
     if (!(this.args.icon || this.args.imageSrc)) {
@@ -19,6 +23,16 @@ export default class HdsDropdownToggleIconComponent extends Component {
         '@icon or @imageSrc must be defined for "Hds::Dropdown::Toggle::Icon"'
       );
     }
+  }
+
+  @action
+  onDidUpdateImageSrc() {
+    this.hasImage = true;
+  }
+
+  @action
+  onImageLoadError() {
+    this.hasImage = false;
   }
 
   /**

--- a/packages/components/src/components/hds/dropdown/toggle/icon.js
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.js
@@ -14,7 +14,7 @@ export const SIZES = ['small', 'medium'];
 const NOOP = () => {};
 
 export default class HdsDropdownToggleIconComponent extends Component {
-  @tracked hasImage = false;
+  @tracked hasImage = true;
 
   constructor() {
     super(...arguments);

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -216,6 +216,9 @@
     <SF.Item @label="With image (avatar), medium">
       <Hds::Dropdown::Toggle::Icon @imageSrc="/assets/images/avatar.png" @text="user menu" />
     </SF.Item>
+    <SF.Item @label="With broken image (fallback to icon)">
+      <Hds::Dropdown::Toggle::Icon @imageSrc="/assets/images/avatar-broken.png" @text="user menu" />
+    </SF.Item>
   </Shw::Flex>
 
   <Shw::Flex as |SF|>

--- a/showcase/tests/integration/components/hds/dropdown/toggle/icon-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/toggle/icon-test.js
@@ -35,11 +35,20 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
 
   // IMAGE (AVATAR)
 
-  test('if an @imageSrc is declared the image should render in the component', async function (assert) {
+  test('if an @imageSrc is declared and exists the image should render in the component', async function (assert) {
     await render(
       hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" @imageSrc="/assets/images/avatar.png" id="test-toggle-icon" />`
     );
     assert.dom('img').exists();
+  });
+
+  test('if an @imageSrc is declared but does not exist, the flight icon should render in the component', async function (assert) {
+    await render(
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" @imageSrc="/assets/images/avatar-no-existe.png" id="test-toggle-icon" />`
+    );
+    assert.dom('img').doesNotExist();
+    assert.dom('#test-toggle-icon').hasClass('hds-dropdown-toggle-icon');
+    assert.dom('.flight-icon.flight-icon-user').exists();
   });
 
   // CHEVRON

--- a/showcase/tests/integration/components/hds/dropdown/toggle/icon-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/toggle/icon-test.js
@@ -5,7 +5,12 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
+import {
+  render,
+  resetOnerror,
+  settled,
+  setupOnerror,
+} from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
@@ -43,12 +48,15 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
   });
 
   test('if an @imageSrc is declared but does not exist, the flight icon should render in the component', async function (assert) {
+    this.set('imageSrc', '/assets/images/avatar.png');
     await render(
-      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" @imageSrc="/assets/images/avatar-no-existe.png" id="test-toggle-icon" />`
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" @imageSrc={{this.imageSrc}} id="test-toggle-icon" />`
     );
+    // we load the image dynamically to cover this usecase and also to prevent this test from intermittently failing for no obvious reason
+    this.set('imageSrc', '/assets/images/avatar-broken.png');
+    await settled();
     assert.dom('img').doesNotExist();
-    assert.dom('#test-toggle-icon').hasClass('hds-dropdown-toggle-icon');
-    assert.dom('.flight-icon.flight-icon-user').exists();
+    assert.dom('#test-toggle-icon .flight-icon.flight-icon-user').exists();
   });
 
   // CHEVRON


### PR DESCRIPTION
### :pushpin: Summary

Add error handling to the `Dropdown::Toggle::Icon` component that handles setting `@imageSrc`.
If the image fails to load it falls back to showing the default icon.

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="600" alt="Screenshot 2024-03-05 at 09 32 46" src="https://github.com/hashicorp/design-system/assets/788096/7f27b64d-a195-4046-97fe-dc8175cce5b8">


</td><td>

<img width="600" alt="Screenshot 2024-03-05 at 09 31 52" src="https://github.com/hashicorp/design-system/assets/788096/bcb93cff-14f3-4e53-8f01-d0301fb2814d">


</td></tr>
</table>


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3167](https://hashicorp.atlassian.net/browse/HDS-3167)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3167]: https://hashicorp.atlassian.net/browse/HDS-3167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ