### PR TITLE
[Test] Font weight for Tabs

### DIFF
--- a/packages/components/addon/components/hds/tabs/tab.hbs
+++ b/packages/components/addon/components/hds/tabs/tab.hbs
@@ -5,7 +5,7 @@
 {{! template-lint-disable require-context-role no-invalid-role }}
 <li class={{this.classNames}} ...attributes role="presentation">
   <button
-    class="hds-tabs__tab-button hds-typography-body-200 hds-font-weight-medium"
+    class="hds-tabs__tab-button hds-typography-body-300 hds-font-weight-medium"
     role="tab"
     type="button"
     id={{this.tabId}}

--- a/packages/components/addon/components/hds/tabs/tab.hbs
+++ b/packages/components/addon/components/hds/tabs/tab.hbs
@@ -5,7 +5,7 @@
 {{! template-lint-disable require-context-role no-invalid-role }}
 <li class={{this.classNames}} ...attributes role="presentation">
   <button
-    class="hds-tabs__tab-button hds-typography-body-300 hds-font-weight-medium"
+    class="hds-tabs__tab-button hds-typography-body-300 hds-font-weight-semibold"
     role="tab"
     type="button"
     id={{this.tabId}}

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -17,10 +17,14 @@
   &::before {
     position: absolute;
     right: 0;
-    bottom: calc((var(--token-tabs-indicator-height) - var(--token-tabs-divider-height)) / 2);
+    bottom: calc(
+      (var(--token-tabs-indicator-height) - var(--token-tabs-divider-height)) /
+        2
+    );
     left: 0;
     display: block;
-    border-top: var(--token-tabs-divider-height) solid var(--token-color-border-primary);
+    border-top: var(--token-tabs-divider-height) solid
+      var(--token-color-border-primary);
     content: "";
   }
 }
@@ -40,7 +44,9 @@
   align-items: center;
   height: var(--token-tabs-tab-height);
   margin: 0;
-  padding: var(--token-tabs-tab-padding-vertical) var(--token-tabs-tab-padding-horizontal);
+  // padding: var(--token-tabs-tab-padding-vertical) var(--token-tabs-tab-padding-horizontal);
+  padding-left: 20px;
+  padding-right: 10;
   color: var(--token-color-foreground-primary);
   white-space: nowrap;
   text-decoration: none;
@@ -69,7 +75,7 @@
     $top: var(--token-tabs-tab-focus-inset),
     $right: var(--token-tabs-tab-focus-inset),
     $bottom: var(--token-tabs-tab-focus-inset),
-    $left: var(--token-tabs-tab-focus-inset),
+    $left: var(--token-tabs-tab-focus-inset)
   );
   position: static;
   display: flex;

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -45,8 +45,7 @@
   height: var(--token-tabs-tab-height);
   margin: 0;
   // padding: var(--token-tabs-tab-padding-vertical) var(--token-tabs-tab-padding-horizontal);
-  padding-left: 20px;
-  padding-right: 10px;
+  padding: 10px 20px;
   color: var(--token-color-foreground-primary);
   white-space: nowrap;
   text-decoration: none;

--- a/packages/components/app/styles/components/tabs.scss
+++ b/packages/components/app/styles/components/tabs.scss
@@ -46,7 +46,7 @@
   margin: 0;
   // padding: var(--token-tabs-tab-padding-vertical) var(--token-tabs-tab-padding-horizontal);
   padding-left: 20px;
-  padding-right: 10;
+  padding-right: 10px;
   color: var(--token-color-foreground-primary);
   white-space: nowrap;
   text-decoration: none;


### PR DESCRIPTION
### :pushpin: Summary
This is a visual test to see what the new padding and font weight would look like in a browser. I will also add some screenshots from the Figma file to compare visually. 

Showcase ----> https://hds-showcase-git-tabs-spacing-testing-hashicorp.vercel.app/components/tabs

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

<img width="991" alt="Screenshot 2024-01-25 at 1 20 12 PM" src="https://github.com/hashicorp/design-system/assets/124841193/4881954d-2237-42af-a55f-e37911bd0653">
<img width="918" alt="Screenshot 2024-01-25 at 1 20 24 PM" src="https://github.com/hashicorp/design-system/assets/124841193/758fd06d-33c8-473c-91a0-49b1f744ff3b">
<img width="912" alt="Screenshot 2024-01-25 at 1 20 30 PM" src="https://github.com/hashicorp/design-system/assets/124841193/1991a7e6-0b72-4078-a894-094fb3353801">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [Tabs File](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/branch/j9s6CQgHkpf3UAtdTEHOhn/HDS-Product---Components?type=design&node-id=52939%3A101680&mode=design&t=nGRS9CmjbdzSv4BF-1)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
