### PR TITLE
`SideNav` - Disable keyboard navigation/focus of hidden elements

### DIFF
--- a/.changeset/strong-balloons-repeat.md
+++ b/.changeset/strong-balloons-repeat.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav` - fixed issue with navigation elements remaining interactive when minimized

--- a/packages/components/src/components/hds/side-nav/base.hbs
+++ b/packages/components/src/components/hds/side-nav/base.hbs
@@ -9,10 +9,10 @@
     <div class="hds-side-nav__wrapper-header">
       {{yield to="header"}}
     </div>
-    <div class="hds-side-nav__wrapper-body">
+    <div class="hds-side-nav__wrapper-body" inert={{@isMinimized}}>
       {{yield to="body"}}
     </div>
-    <div class="hds-side-nav__wrapper-footer">
+    <div class="hds-side-nav__wrapper-footer" inert={{@isMinimized}}>
       {{yield to="footer"}}
     </div>
   </div>

--- a/packages/components/src/components/hds/side-nav/base.hbs
+++ b/packages/components/src/components/hds/side-nav/base.hbs
@@ -9,10 +9,10 @@
     <div class="hds-side-nav__wrapper-header">
       {{yield to="header"}}
     </div>
-    <div class="hds-side-nav__wrapper-body" inert={{@isMinimized}}>
+    <div class="hds-side-nav__wrapper-body">
       {{yield to="body"}}
     </div>
-    <div class="hds-side-nav__wrapper-footer" inert={{@isMinimized}}>
+    <div class="hds-side-nav__wrapper-footer">
       {{yield to="footer"}}
     </div>
   </div>

--- a/packages/components/src/components/hds/side-nav/index.hbs
+++ b/packages/components/src/components/hds/side-nav/index.hbs
@@ -5,6 +5,7 @@
 
 <Hds::SideNav::Base
   class={{this.classNames}}
+  @isMinimized={{this.isMinimized}}
   ...attributes
   {{on "transitionstart" (fn this.setTransition "start")}}
   {{on "transitionend" (fn this.setTransition "end")}}

--- a/packages/components/src/components/hds/side-nav/index.hbs
+++ b/packages/components/src/components/hds/side-nav/index.hbs
@@ -9,6 +9,7 @@
   {{on "transitionstart" (fn this.setTransition "start")}}
   {{on "transitionend" (fn this.setTransition "end")}}
   {{focus-trap isActive=this.shouldTrapFocus}}
+  {{did-insert this.didInsert}}
 >
   <:root>
     {{#if this.hasA11yRefocus}}

--- a/packages/components/src/components/hds/side-nav/index.hbs
+++ b/packages/components/src/components/hds/side-nav/index.hbs
@@ -5,7 +5,6 @@
 
 <Hds::SideNav::Base
   class={{this.classNames}}
-  @isMinimized={{this.isMinimized}}
   ...attributes
   {{on "transitionstart" (fn this.setTransition "start")}}
   {{on "transitionend" (fn this.setTransition "end")}}

--- a/packages/components/src/components/hds/side-nav/index.js
+++ b/packages/components/src/components/hds/side-nav/index.js
@@ -111,11 +111,26 @@ export default class HdsSideNavComponent extends Component {
   toggleMinimizedStatus() {
     this.isMinimized = !this.isMinimized;
 
+    this.containersToHide.forEach((element) => {
+      if (this.isMinimized) {
+        element.setAttribute('inert', '');
+      } else {
+        element.removeAttribute('inert');
+      }
+    });
+
     let { onToggleMinimizedStatus } = this.args;
 
     if (typeof onToggleMinimizedStatus === 'function') {
       onToggleMinimizedStatus(this.isMinimized);
     }
+  }
+
+  @action
+  didInsert(element) {
+    this.containersToHide = element.querySelectorAll(
+      '.hds-side-nav-hide-when-minimized'
+    );
   }
 
   @action

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -217,6 +217,8 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     assert
       .dom('#test-side-nav-footer')
       .doesNotHaveAttribute('data-test-minimized');
+    assert.dom('.hds-side-nav__wrapper-body').doesNotHaveAttribute('inert');
+    assert.dom('.hds-side-nav__wrapper-footer').doesNotHaveAttribute('inert');
 
     await click('.hds-side-nav__toggle-button');
 
@@ -230,6 +232,8 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     assert.dom('#test-side-nav-header').hasAttribute('data-test-minimized');
     assert.dom('#test-side-nav-body').hasAttribute('data-test-minimized');
     assert.dom('#test-side-nav-footer').hasAttribute('data-test-minimized');
+    assert.dom('.hds-side-nav__wrapper-body').hasAttribute('inert');
+    assert.dom('.hds-side-nav__wrapper-footer').hasAttribute('inert');
   });
 
   // CALLBACKS

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -195,6 +195,7 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
         </:header>
         <:body as |B|>
           <span id="test-side-nav-body" data-test-minimized={{B.isMinimized}} />
+          <span class="hds-side-nav-hide-when-minimized" />
         </:body>
         <:footer as |F|>
           <span id="test-side-nav-footer" data-test-minimized={{F.isMinimized}} />
@@ -217,6 +218,9 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     assert
       .dom('#test-side-nav-footer')
       .doesNotHaveAttribute('data-test-minimized');
+    assert
+      .dom('.hds-side-nav-hide-when-minimized')
+      .doesNotHaveAttribute('inert');
 
     await click('.hds-side-nav__toggle-button');
 
@@ -230,6 +234,7 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     assert.dom('#test-side-nav-header').hasAttribute('data-test-minimized');
     assert.dom('#test-side-nav-body').hasAttribute('data-test-minimized');
     assert.dom('#test-side-nav-footer').hasAttribute('data-test-minimized');
+    assert.dom('.hds-side-nav-hide-when-minimized').hasAttribute('inert');
   });
 
   // CALLBACKS

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -217,8 +217,6 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     assert
       .dom('#test-side-nav-footer')
       .doesNotHaveAttribute('data-test-minimized');
-    assert.dom('.hds-side-nav__wrapper-body').doesNotHaveAttribute('inert');
-    assert.dom('.hds-side-nav__wrapper-footer').doesNotHaveAttribute('inert');
 
     await click('.hds-side-nav__toggle-button');
 
@@ -232,8 +230,6 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     assert.dom('#test-side-nav-header').hasAttribute('data-test-minimized');
     assert.dom('#test-side-nav-body').hasAttribute('data-test-minimized');
     assert.dom('#test-side-nav-footer').hasAttribute('data-test-minimized');
-    assert.dom('.hds-side-nav__wrapper-body').hasAttribute('inert');
-    assert.dom('.hds-side-nav__wrapper-footer').hasAttribute('inert');
   });
 
   // CALLBACKS

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -221,6 +221,7 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     assert
       .dom('.hds-side-nav-hide-when-minimized')
       .doesNotHaveAttribute('inert');
+    assert.dom('#test-side-nav-body').doesNotHaveAttribute('inert');
 
     await click('.hds-side-nav__toggle-button');
 
@@ -235,6 +236,7 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     assert.dom('#test-side-nav-body').hasAttribute('data-test-minimized');
     assert.dom('#test-side-nav-footer').hasAttribute('data-test-minimized');
     assert.dom('.hds-side-nav-hide-when-minimized').hasAttribute('inert');
+    assert.dom('#test-side-nav-body').doesNotHaveAttribute('inert');
   });
 
   // CALLBACKS


### PR DESCRIPTION
### :pushpin: Summary

Currently, interactive elements within the SideNav are focusable even when the SideNav is minimized/collapsed. This makes them visible and interactive to screen-reader users even though they are not visible.

The usual and easiest way to fix this issue is to set `display: none` on such elements. However, because of the desired fade effect, we can't use this method and we rely on changing the `visibility` of these containers. To fix this issue while preserving the fade effect, we make inert the containers potentially holding such interactive elements.

To facilitate the review of this feature I resurrected [the demo app](https://hds-showcase-git-alex-ju-local-demo-app-hashicorp.vercel.app/demo-app) previously used for other SideNav improvements.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2936](https://hashicorp.atlassian.net/browse/HDS-2936)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2936]: https://hashicorp.atlassian.net/browse/HDS-2936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ