### PR TITLE
`Dropdown` - Fixed dropdown list missing an accessible name when Checkmark items were passed in

### DIFF
--- a/.changeset/long-meals-appear.md
+++ b/.changeset/long-meals-appear.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Dropdown` - Fixed dropdown list missing an accessible name when Checkmark items were passed in

--- a/packages/components/src/components/hds/dropdown/index.js
+++ b/packages/components/src/components/hds/dropdown/index.js
@@ -36,12 +36,16 @@ export default class HdsDropdownIndexComponent extends Component {
   }
 
   /**
-   * @param listAriaLabel
-   * @type {string}
-   * @description Sets a label for when  checkmark list items are used in the dropdown list
+   * Gets the id of the associated toggle button
+   * @method labelledby
+   * @return {string} The `id` attribute to be provided to `aria-labelledby`
    */
-  get listAriaLabel() {
-    return this.args.listAriaLabel || '';
+  get labelledby() {
+    let dropdownButton = this.listElement
+      .closest('.hds-dropdown')
+      .querySelector('.hds-dropdown-toggle-button');
+    let id = dropdownButton?.getAttribute('id');
+    return id;
   }
 
   /**
@@ -81,10 +85,11 @@ export default class HdsDropdownIndexComponent extends Component {
 
   @action
   didInsertList(element) {
+    this.listElement = element;
     let checkmarkItems = element.querySelectorAll(`[role="option"]`);
     if (checkmarkItems.length) {
       element.setAttribute('role', 'listbox');
-      element.setAttribute('aria-label', this.listAriaLabel);
+      element.setAttribute('aria-labelledby', this.labelledby);
     }
   }
 }

--- a/packages/components/src/components/hds/dropdown/index.js
+++ b/packages/components/src/components/hds/dropdown/index.js
@@ -72,9 +72,9 @@ export default class HdsDropdownIndexComponent extends Component {
 
   @action
   didInsertList(element) {
-    let checkmarkItems = element.querySelectorAll(`[role="option"]`);
+    const checkmarkItems = element.querySelectorAll(`[role="option"]`);
     if (checkmarkItems.length) {
-      let toggleButtonId = element
+      const toggleButtonId = element
         .closest('.hds-dropdown')
         ?.querySelector('.hds-dropdown-toggle-button')
         ?.getAttribute('id');

--- a/packages/components/src/components/hds/dropdown/index.js
+++ b/packages/components/src/components/hds/dropdown/index.js
@@ -36,19 +36,6 @@ export default class HdsDropdownIndexComponent extends Component {
   }
 
   /**
-   * Gets the id of the associated toggle button
-   * @method labelledby
-   * @return {string} The `id` attribute to be provided to `aria-labelledby`
-   */
-  get labelledby() {
-    let dropdownButton = this.listElement
-      .closest('.hds-dropdown')
-      .querySelector('.hds-dropdown-toggle-button');
-    let id = dropdownButton?.getAttribute('id');
-    return id;
-  }
-
-  /**
    * Get the class names to apply to the element
    * @method classNames
    * @return {string} The "class" attribute to apply to the root element
@@ -85,11 +72,14 @@ export default class HdsDropdownIndexComponent extends Component {
 
   @action
   didInsertList(element) {
-    this.listElement = element;
     let checkmarkItems = element.querySelectorAll(`[role="option"]`);
     if (checkmarkItems.length) {
+      let toggleButtonId = element
+        .closest('.hds-dropdown')
+        ?.querySelector('.hds-dropdown-toggle-button')
+        ?.getAttribute('id');
       element.setAttribute('role', 'listbox');
-      element.setAttribute('aria-labelledby', this.labelledby);
+      element.setAttribute('aria-labelledby', toggleButtonId);
     }
   }
 }

--- a/packages/components/src/components/hds/dropdown/index.js
+++ b/packages/components/src/components/hds/dropdown/index.js
@@ -36,6 +36,15 @@ export default class HdsDropdownIndexComponent extends Component {
   }
 
   /**
+   * @param listAriaLabel
+   * @type {string}
+   * @description Sets a label for when  checkmark list items are used in the dropdown list
+   */
+  get listAriaLabel() {
+    return this.args.listAriaLabel || '';
+  }
+
+  /**
    * Get the class names to apply to the element
    * @method classNames
    * @return {string} The "class" attribute to apply to the root element
@@ -75,6 +84,7 @@ export default class HdsDropdownIndexComponent extends Component {
     let checkmarkItems = element.querySelectorAll(`[role="option"]`);
     if (checkmarkItems.length) {
       element.setAttribute('role', 'listbox');
+      element.setAttribute('aria-label', this.listAriaLabel);
     }
   }
 }

--- a/packages/components/src/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/src/components/hds/dropdown/toggle/button.hbs
@@ -4,6 +4,7 @@
 }}
 <button
   class={{this.classNames}}
+  id={{this.toggleButtonId}}
   ...attributes
   type="button"
   aria-expanded={{if @isOpen "true" "false"}}

--- a/packages/components/src/components/hds/dropdown/toggle/button.js
+++ b/packages/components/src/components/hds/dropdown/toggle/button.js
@@ -5,6 +5,7 @@
 
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import { guidFor } from '@ember/object/internals';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_COLOR = 'primary';
@@ -14,6 +15,13 @@ export const COLORS = ['primary', 'secondary'];
 const NOOP = () => {};
 
 export default class HdsDropdownToggleButtonComponent extends Component {
+  /**
+   * Generates a unique ID for the button
+   *
+   * @param toggleButtonId
+   */
+  toggleButtonId = 'toggle-button-' + guidFor(this);
+
   /**
    * @param text
    * @type {string}

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -818,7 +818,7 @@
   </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
-      <Hds::Dropdown @listPosition="bottom-left" @listAriaLabel="Virtual machine" as |dd|>
+      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
         <dd.ToggleButton @text="Checkmark" @color="secondary" />
         <dd.Checkmark @count="11">virtualbox</dd.Checkmark>
         <dd.Checkmark @count="1" @selected={{true}}>vmware</dd.Checkmark>

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -818,7 +818,7 @@
   </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
-      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+      <Hds::Dropdown @listPosition="bottom-left" @listAriaLabel="Virtual machine" as |dd|>
         <dd.ToggleButton @text="Checkmark" @color="secondary" />
         <dd.Checkmark @count="11">virtualbox</dd.Checkmark>
         <dd.Checkmark @count="1" @selected={{true}}>vmware</dd.Checkmark>

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -176,8 +176,8 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
         <dd.Checkmark>Checkmark</dd.Checkmark>
       </Hds::Dropdown>
     `);
-    let button = this.element.querySelector('.hds-dropdown-toggle-button');
-    let buttonId = button.id;
+    const button = this.element.querySelector('.hds-dropdown-toggle-button');
+    const buttonId = button.id;
     await click('button.hds-dropdown-toggle-button');
     assert.dom('#test-dropdown ul').hasAttribute('role', 'listbox');
     assert.dom('#test-dropdown ul').hasAttribute('aria-labelledby', buttonId);

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -156,7 +156,7 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     await click('button#test-toggle-button');
     assert.dom('#test-dropdown ul').doesNotHaveAttribute('role');
   });
-  test('it should render a list of items with a `listbox` role if selectable items are passed in', async function (assert) {
+  test('it should render a list of items with a `listbox` role, refering an existing `id` via `aria-labelledby` if selectable items are passed in', async function (assert) {
     await render(hbs`
       <Hds::Dropdown id="test-dropdown" as |dd|>
         <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
@@ -165,5 +165,21 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     `);
     await click('button#test-toggle-button');
     assert.dom('#test-dropdown ul').hasAttribute('role', 'listbox');
+    assert
+      .dom('#test-dropdown ul')
+      .hasAttribute('aria-labelledby', 'test-toggle-button');
+  });
+  test('it should render a list of items with a `listbox` role, refering an generated `id` via `aria-labelledby` if selectable items are passed in', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" as |dd|>
+        <dd.ToggleButton @text="toggle button" />
+        <dd.Checkmark>Checkmark</dd.Checkmark>
+      </Hds::Dropdown>
+    `);
+    let button = this.element.querySelector('.hds-dropdown-toggle-button');
+    let buttonId = button.id;
+    await click('button.hds-dropdown-toggle-button');
+    assert.dom('#test-dropdown ul').hasAttribute('role', 'listbox');
+    assert.dom('#test-dropdown ul').hasAttribute('aria-labelledby', buttonId);
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

Elements with `listbox` role require an accessible name (be that via `aria-label`, `aria-labelledby` or `title`).

~~One approach (illustrated in this PR) would be to allow consumers to set an `aria-label` for those instances of `Hds::Dropdown` that contain `ListItem::Checkmark`. This would need to be accompanied by guidance.~~

An alternative approach would be to use the `Dropdown::Toggle::Button` as a label (using `aria-labelledby`), but currently we don't have a direct way to access that element or its properties.

Opened this up to discuss approaches and tradeoffs.

Update: based on feedback, we decided to take the alternative approach, using `aria-labelledby`.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3067](https://hashicorp.atlassian.net/browse/HDS-3067)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3067]: https://hashicorp.atlassian.net/browse/HDS-3067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ