### PR TITLE
`Pagination` - Remove handling of query parameters on page change for the "numbered" variant

### DIFF
--- a/.changeset/sour-tigers-pull.md
+++ b/.changeset/sour-tigers-pull.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+`Pagination` - Removed handling of query parameters from `onPageSizeChange` function for `Pagination::Numbered`.
+
+_Unfortunately, it's not possible to cover this breaking change with a codemod. Consumers should review their usage of the `onPageSizeChange` callback and, if necessary, implement the persistence of the "page number" and "page size" values via query parameters themselves._

--- a/packages/components/src/components/hds/pagination/numbered/index.js
+++ b/packages/components/src/components/hds/pagination/numbered/index.js
@@ -7,7 +7,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
-import { inject as service } from '@ember/service';
 
 // for context about the decision to use these values, see:
 // https://hashicorp.slack.com/archives/C03A0N1QK8S/p1673546329082759
@@ -73,8 +72,6 @@ export const elliptize = ({ pages, current, limit = 7 }) => {
 };
 
 export default class HdsPaginationNumberedIndexComponent extends Component {
-  @service router;
-
   // These two private variables are used to differentiate between
   // "uncontrolled" component (where the state is handled internally) and
   // "controlled" component (where the state is handled externally, by the consumer's code).
@@ -238,10 +235,6 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
     return Math.max(Math.ceil(this.args.totalItems / this.currentPageSize), 1);
   }
 
-  get routeQueryParams() {
-    return this.router.currentRoute?.queryParams || {};
-  }
-
   buildQueryParamsObject(page, pageSize) {
     if (this.isControlled) {
       return this.args.queryFunction(page, pageSize);
@@ -323,12 +316,8 @@ export default class HdsPaginationNumberedIndexComponent extends Component {
   onPageSizeChange(newPageSize) {
     let { onPageSizeChange } = this.args;
 
-    // we need to manually update the query parameters in the route (it's not a link!)
-    if (this.isControlled) {
+    if (!this.isControlled) {
       // notice: we agreed to reset the pagination to the first element (any alternative would result in an unpredictable UX)
-      const queryParams = this.buildQueryParamsObject(1, newPageSize);
-      this.router.transitionTo({ queryParams });
-    } else {
       this.currentPage = 1;
       this.currentPageSize = newPageSize;
     }

--- a/showcase/app/controllers/components/pagination.js
+++ b/showcase/app/controllers/components/pagination.js
@@ -201,6 +201,13 @@ export default class PaginationController extends Controller {
     return this.model.records.slice(start, end);
   }
 
+  @action
+  onPageSizeChange_demo2(pageSize) {
+    // the sensible thing to do here is to reset the pagination to the first element (any alternative would result in an unpredictable UX)
+    this.currentPage_demo2 = 1;
+    this.currentPageSize_demo2 = pageSize;
+  }
+
   // DEMO #3
 
   get newPrevNextCursors_demo3() {

--- a/showcase/app/templates/components/pagination.hbs
+++ b/showcase/app/templates/components/pagination.hbs
@@ -371,7 +371,7 @@
       @route={{this.demoRouteName}}
       @queryFunction={{this.consumerQueryFunction_demo2}}
       @onPageChange={{this.genericHandlePageChange}}
-      @onPageSizeChange={{this.genericHandlePageSizeChange}}
+      @onPageSizeChange={{this.onPageSizeChange_demo2}}
     />
   </div>
 

--- a/website/docs/components/pagination/index.js
+++ b/website/docs/components/pagination/index.js
@@ -355,6 +355,19 @@ export default class Index extends Component {
     };
   }
 
+  @action
+  async handlePageSizeChangeNumbered(pageSize) {
+    const routeQueryParams = this?.router?.currentRoute?.queryParams ?? {};
+    let queryParams = Object.assign({}, routeQueryParams);
+    // the sensible thing to do here is to reset the pagination to the first element (any alternative would result in an unpredictable UX)
+    queryParams.demoCurrentPage = 1;
+    queryParams.demoCurrentPageSize = pageSize;
+    // see: https://github.com/DockYard/ember-router-scroll#preservescrollposition-with-queryparams
+    queryParams.preserveScrollPosition = true;
+    // navigate to the new URL (notice: the anchor/fragment `#...` is not preserved unfortunately)
+    await this.router.transitionTo({ queryParams });
+  }
+
   get demoNewPrevNextCursors() {
     let { newPrevCursor, newNextCursor } = getNewPrevNextCursors(
       this.demoCurrentCursor,

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -115,6 +115,8 @@ If you want the Pagination to change the URL of the page directly (eg. updating 
   @currentPageSize={{this.demoCurrentPageSize}}
   @route={{this.demoRouteName}}
   @queryFunction={{this.demoQueryFunctionNumbered}}
+  @onPageChange={{this.handlePageChange}}
+  @onPageSizeChange={{this.handlePageSizeChangeNumbered}}
 />
 ```
 
@@ -173,6 +175,8 @@ Below you can find an example of an integration between the sortable [`Table`](/
     @currentPageSize={{this.demoCurrentPageSize}}
     @route={{this.demoRouteName}}
     @queryFunction={{this.demoQueryFunctionNumbered}}
+    @onPageChange={{this.handlePageChange}}
+    @onPageSizeChange={{this.handlePageSizeChangeNumbered}}
   />
 </div>
 ```


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of https://github.com/hashicorp/design-system/pull/1736 where we make the same changes, only for the "numbered" pagination this time (we use the opportunity of the upcoming release of breaking changes to sneak in also this one, that has been in the backlog for months now).

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed route query handling on “page size” change for the “numbered” pagination
    - reason for this is that consumers should be responsible for this, not the HDS component 
- updated showcase for “numbered” pagination to handle query update on page size change
- updated “how to use” demos for the numbered pagination in the documentation

👉 👉 👉 **Previews:**
- showcase:
- website: 

⚠️ Notice: this is a breaking change, but unfortunately it's not possible to cover it with a codemod. Consumers should review their usage of the `onPageSizeChange` callback and if necessary implement the persistence of the "page number" and "page size" values via query parameters themselves.

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-2729

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
