### PR TITLE
Vault brand color update - Design tokens

### DIFF
--- a/.changeset/gorgeous-chicken-wash.md
+++ b/.changeset/gorgeous-chicken-wash.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-tokens": minor
+---
+
+Updated `vault`, `vault-secrets`, and `vault-radar` brand color values

--- a/packages/tokens/dist/devdot/css/helpers/color.css
+++ b/packages/tokens/dist/devdot/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/devdot/css/helpers/elevation.css
+++ b/packages/tokens/dist/devdot/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-elevation-inset { box-shadow: var(--token-elevation-inset-box-shadow); }

--- a/packages/tokens/dist/devdot/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/devdot/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/devdot/css/helpers/typography.css
+++ b/packages/tokens/dist/devdot/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/devdot/css/tokens.css
+++ b/packages/tokens/dist/devdot/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 31 Jan 2024 10:30:15 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 :root {
@@ -145,7 +145,7 @@
   --token-color-vagrant-gradient-primary-stop: #7dadff;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
-  --token-color-vault-radar-brand: #ffd814;
+  --token-color-vault-radar-brand: #ffcf25;
   --token-color-vault-radar-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work */
   --token-color-vault-radar-foreground: #9a6f00;
   --token-color-vault-radar-surface: #fff9cf;
@@ -154,7 +154,7 @@
   --token-color-vault-radar-gradient-primary-stop: #ffe543;
   --token-color-vault-radar-gradient-faint-start: #fffdf2; /* this is the 'vault-radar-50' value at 25% opacity on white */
   --token-color-vault-radar-gradient-faint-stop: #fff9cf;
-  --token-color-vault-secrets-brand: #ffd814;
+  --token-color-vault-secrets-brand: #ffcf25;
   --token-color-vault-secrets-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work */
   --token-color-vault-secrets-foreground: #9a6f00;
   --token-color-vault-secrets-surface: #fff9cf;
@@ -163,7 +163,7 @@
   --token-color-vault-secrets-gradient-primary-stop: #ffe543;
   --token-color-vault-secrets-gradient-faint-start: #fffdf2; /* this is the 'vault-secrets-50' value at 25% opacity on white */
   --token-color-vault-secrets-gradient-faint-stop: #fff9cf;
-  --token-color-vault-brand: #ffd814;
+  --token-color-vault-brand: #ffcf25;
   --token-color-vault-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work */
   --token-color-vault-foreground: #9a6f00;
   --token-color-vault-surface: #fff9cf;

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -3047,7 +3047,7 @@
     ]
   },
   {
-    "value": "#ffd814",
+    "value": "#ffcf25",
     "type": "color",
     "group": "branding",
     "original": {
@@ -3256,7 +3256,7 @@
     ]
   },
   {
-    "value": "#ffd814",
+    "value": "#ffcf25",
     "type": "color",
     "group": "branding",
     "original": {
@@ -3465,7 +3465,7 @@
     ]
   },
   {
-    "value": "#ffd814",
+    "value": "#ffcf25",
     "type": "color",
     "group": "branding",
     "original": {

--- a/packages/tokens/dist/marketing/css/helpers/color.css
+++ b/packages/tokens/dist/marketing/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/marketing/css/helpers/elevation.css
+++ b/packages/tokens/dist/marketing/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-elevation-inset { box-shadow: var(--token-elevation-inset-box-shadow); }

--- a/packages/tokens/dist/marketing/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/marketing/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/marketing/css/helpers/typography.css
+++ b/packages/tokens/dist/marketing/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/marketing/css/tokens.css
+++ b/packages/tokens/dist/marketing/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 31 Jan 2024 10:30:15 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 :root {
@@ -143,7 +143,7 @@
   --token-color-vagrant-gradient-primary-stop: #7dadff;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
-  --token-color-vault-radar-brand: #ffd814;
+  --token-color-vault-radar-brand: #ffcf25;
   --token-color-vault-radar-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work */
   --token-color-vault-radar-foreground: #9a6f00;
   --token-color-vault-radar-surface: #fff9cf;
@@ -152,7 +152,7 @@
   --token-color-vault-radar-gradient-primary-stop: #ffe543;
   --token-color-vault-radar-gradient-faint-start: #fffdf2; /* this is the 'vault-radar-50' value at 25% opacity on white */
   --token-color-vault-radar-gradient-faint-stop: #fff9cf;
-  --token-color-vault-secrets-brand: #ffd814;
+  --token-color-vault-secrets-brand: #ffcf25;
   --token-color-vault-secrets-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work */
   --token-color-vault-secrets-foreground: #9a6f00;
   --token-color-vault-secrets-surface: #fff9cf;
@@ -161,7 +161,7 @@
   --token-color-vault-secrets-gradient-primary-stop: #ffe543;
   --token-color-vault-secrets-gradient-faint-start: #fffdf2; /* this is the 'vault-secrets-50' value at 25% opacity on white */
   --token-color-vault-secrets-gradient-faint-stop: #fff9cf;
-  --token-color-vault-brand: #ffd814;
+  --token-color-vault-brand: #ffcf25;
   --token-color-vault-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work */
   --token-color-vault-foreground: #9a6f00;
   --token-color-vault-surface: #fff9cf;

--- a/packages/tokens/dist/marketing/tokens.json
+++ b/packages/tokens/dist/marketing/tokens.json
@@ -3395,7 +3395,7 @@
     },
     "vault-radar": {
       "brand": {
-        "value": "#ffd814",
+        "value": "#ffcf25",
         "type": "color",
         "group": "branding",
         "filePath": "src/products/shared/color/semantic-product-vault-radar.json",
@@ -3630,7 +3630,7 @@
     },
     "vault-secrets": {
       "brand": {
-        "value": "#ffd814",
+        "value": "#ffcf25",
         "type": "color",
         "group": "branding",
         "filePath": "src/products/shared/color/semantic-product-vault-secrets.json",
@@ -3865,7 +3865,7 @@
     },
     "vault": {
       "brand": {
-        "value": "#ffd814",
+        "value": "#ffcf25",
         "type": "color",
         "group": "branding",
         "filePath": "src/products/shared/color/semantic-product-vault.json",

--- a/packages/tokens/dist/products/css/helpers/color.css
+++ b/packages/tokens/dist/products/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/products/css/helpers/elevation.css
+++ b/packages/tokens/dist/products/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-elevation-inset { box-shadow: var(--token-elevation-inset-box-shadow); }

--- a/packages/tokens/dist/products/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/products/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/products/css/helpers/typography.css
+++ b/packages/tokens/dist/products/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 31 Jan 2024 10:30:15 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:58 GMT
  */
 
 :root {
@@ -143,7 +143,7 @@
   --token-color-vagrant-gradient-primary-stop: #7dadff;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
-  --token-color-vault-radar-brand: #ffd814;
+  --token-color-vault-radar-brand: #ffcf25;
   --token-color-vault-radar-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work */
   --token-color-vault-radar-foreground: #9a6f00;
   --token-color-vault-radar-surface: #fff9cf;
@@ -152,7 +152,7 @@
   --token-color-vault-radar-gradient-primary-stop: #ffe543;
   --token-color-vault-radar-gradient-faint-start: #fffdf2; /* this is the 'vault-radar-50' value at 25% opacity on white */
   --token-color-vault-radar-gradient-faint-stop: #fff9cf;
-  --token-color-vault-secrets-brand: #ffd814;
+  --token-color-vault-secrets-brand: #ffcf25;
   --token-color-vault-secrets-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work */
   --token-color-vault-secrets-foreground: #9a6f00;
   --token-color-vault-secrets-surface: #fff9cf;
@@ -161,7 +161,7 @@
   --token-color-vault-secrets-gradient-primary-stop: #ffe543;
   --token-color-vault-secrets-gradient-faint-start: #fffdf2; /* this is the 'vault-secrets-50' value at 25% opacity on white */
   --token-color-vault-secrets-gradient-faint-stop: #fff9cf;
-  --token-color-vault-brand: #ffd814;
+  --token-color-vault-brand: #ffcf25;
   --token-color-vault-brand-alt: #000000; /* this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work */
   --token-color-vault-foreground: #9a6f00;
   --token-color-vault-surface: #fff9cf;

--- a/packages/tokens/src/global/color/palette-products.json
+++ b/packages/tokens/src/global/color/palette-products.json
@@ -302,7 +302,7 @@
                 "private": "true"
             },
             "vault-brand": {
-                "value": "#ffd814",
+                "value": "#ffcf25",
                 "type": "color",
                 "group": "palette",
                 "private": "true"
@@ -350,7 +350,7 @@
                 "private": "true"
             },
             "vault-secrets-brand": {
-                "value": "#ffd814",
+                "value": "#ffcf25",
                 "type": "color",
                 "group": "palette",
                 "private": "true"
@@ -398,7 +398,7 @@
                 "private": "true"
             },
             "vault-radar-brand": {
-                "value": "#ffd814",
+                "value": "#ffcf25",
                 "type": "color",
                 "group": "palette",
                 "private": "true"


### PR DESCRIPTION
### :hammer_and_wrench: Detailed description

In this PR I have:
- updated brand color value for all the `vault`-related products/services (`vault`, `vault-secrets`, and `vault-radar`)
- regenerated design tokens

### :link: External links

Jira tickets: 
- https://hashicorp.atlassian.net/browse/HDS-3082
- https://hashicorp.atlassian.net/browse/HDS-3083

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
