### PR TITLE
Terraform color update - Design tokens

### DIFF
--- a/.changeset/strange-mugs-bathe.md
+++ b/.changeset/strange-mugs-bathe.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-tokens": minor
+---
+
+Added design token for `terraform-brand-on-dark` color

--- a/packages/tokens/dist/devdot/css/tokens.css
+++ b/packages/tokens/dist/devdot/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Wed, 31 Jan 2024 10:30:15 GMT
  */
 
 :root {
@@ -129,6 +129,7 @@
   --token-color-packer-gradient-faint-start: #f3fcff; /* this is the 'packer-50' value at 25% opacity on white */
   --token-color-packer-gradient-faint-stop: #d4f2ff;
   --token-color-terraform-brand: #7b42bc;
+  --token-color-terraform-brand-on-dark: #a067da; /* this is an alternative brand color meant to be used on dark backgrounds */
   --token-color-terraform-foreground: #773cb4;
   --token-color-terraform-surface: #f4ecff;
   --token-color-terraform-border: #ebdbfc;

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -2673,6 +2673,29 @@
     ]
   },
   {
+    "value": "#a067da",
+    "type": "color",
+    "group": "branding",
+    "comment": "this is an alternative brand color meant to be used on dark backgrounds",
+    "original": {
+      "value": "#a067da",
+      "type": "color",
+      "group": "branding",
+      "comment": "this is an alternative brand color meant to be used on dark backgrounds"
+    },
+    "name": "token-color-terraform-brand-on-dark",
+    "attributes": {
+      "category": "color",
+      "type": "terraform",
+      "item": "brand-on-dark"
+    },
+    "path": [
+      "color",
+      "terraform",
+      "brand-on-dark"
+    ]
+  },
+  {
     "value": "#773cb4",
     "type": "color",
     "group": "branding",

--- a/packages/tokens/dist/marketing/css/tokens.css
+++ b/packages/tokens/dist/marketing/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Wed, 31 Jan 2024 10:30:15 GMT
  */
 
 :root {
@@ -127,6 +127,7 @@
   --token-color-packer-gradient-faint-start: #f3fcff; /* this is the 'packer-50' value at 25% opacity on white */
   --token-color-packer-gradient-faint-stop: #d4f2ff;
   --token-color-terraform-brand: #7b42bc;
+  --token-color-terraform-brand-on-dark: #a067da; /* this is an alternative brand color meant to be used on dark backgrounds */
   --token-color-terraform-foreground: #773cb4;
   --token-color-terraform-surface: #f4ecff;
   --token-color-terraform-border: #ebdbfc;

--- a/packages/tokens/dist/marketing/tokens.json
+++ b/packages/tokens/dist/marketing/tokens.json
@@ -2972,6 +2972,31 @@
           "brand"
         ]
       },
+      "brand-on-dark": {
+        "value": "#a067da",
+        "type": "color",
+        "group": "branding",
+        "comment": "this is an alternative brand color meant to be used on dark backgrounds",
+        "filePath": "src/products/shared/color/semantic-product-terraform.json",
+        "isSource": true,
+        "original": {
+          "value": "#a067da",
+          "type": "color",
+          "group": "branding",
+          "comment": "this is an alternative brand color meant to be used on dark backgrounds"
+        },
+        "name": "token-color-terraform-brand-on-dark",
+        "attributes": {
+          "category": "color",
+          "type": "terraform",
+          "item": "brand-on-dark"
+        },
+        "path": [
+          "color",
+          "terraform",
+          "brand-on-dark"
+        ]
+      },
       "foreground": {
         "value": "#773cb4",
         "type": "color",

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jan 2024 14:44:08 GMT
+ * Generated on Wed, 31 Jan 2024 10:30:15 GMT
  */
 
 :root {
@@ -127,6 +127,7 @@
   --token-color-packer-gradient-faint-start: #f3fcff; /* this is the 'packer-50' value at 25% opacity on white */
   --token-color-packer-gradient-faint-stop: #d4f2ff;
   --token-color-terraform-brand: #7b42bc;
+  --token-color-terraform-brand-on-dark: #a067da; /* this is an alternative brand color meant to be used on dark backgrounds */
   --token-color-terraform-foreground: #773cb4;
   --token-color-terraform-surface: #f4ecff;
   --token-color-terraform-border: #ebdbfc;

--- a/packages/tokens/src/products/shared/color/semantic-product-terraform.json
+++ b/packages/tokens/src/products/shared/color/semantic-product-terraform.json
@@ -6,6 +6,12 @@
                 "type": "color",
                 "group": "branding"
             },
+            "brand-on-dark": {
+                "value": "#a067da",
+                "type": "color",
+                "group": "branding",
+                "comment": "this is an alternative brand color meant to be used on dark backgrounds"
+            },
             "foreground": {
                 "value": "{color.palette.terraform-500.value}",
                 "type": "color",


### PR DESCRIPTION
### :hammer_and_wrench: Detailed description

In this PR I have:
- added design token for `terraform-brand-on-dark` color
- regenerated the design tokens

### :link: External links

Jira tickets: https://hashicorp.atlassian.net/browse/HDS-3066

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
