### PR TITLE
`PageHeader` - Force Dropdown positioning to left when used in Actions

### DIFF
--- a/packages/components/app/styles/components/page-header.scss
+++ b/packages/components/app/styles/components/page-header.scss
@@ -44,6 +44,15 @@
     justify-content: space-between;
     min-width: 0; // this is important or it will blow beyond the parent flexbox width with long non-breaking names
   }
+
+  // Dropdowns with @listPosition="bottom-right" need an override to prevent them from spilling outside the page
+  @container (max-width: 767px) {
+    .hds-page-header__actions {
+      .hds-dropdown__content {
+        left: 0;
+      }  
+    }
+  }
 }
 
 .hds-page-header__content {


### PR DESCRIPTION
### :pushpin: Summary

Force Dropdown positioning to left when used in `PageHeader::Actions`

### :hammer_and_wrench: Detailed description

A potential solution to force Dropdown list positioning to the left when used in `PageHeader::Actions`. I don't _like_ this override as it breaks the encapsulation principle but paired with the existing guidance where we expect to only have Buttons and Dropdowns as PageHeader actions it may be worth considering.

### :link: External links

<!-- Issues, RFC, etc. -->
[Slack thread](https://hashicorp.slack.com/archives/C7KTUHNUS/p1706299619555619?thread_ts=1705943470.509759&cid=C7KTUHNUS)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
