### PR TITLE
Fixed discrepancy in docs

### DIFF
--- a/website/docs/components/dropdown/partials/guidelines/guidelines.md
+++ b/website/docs/components/dropdown/partials/guidelines/guidelines.md
@@ -208,8 +208,8 @@ A Footer provides a fixed space at the bottom of the List. Typically, Footers ho
     <Hds::Dropdown::ListItem::Checkbox @value="Fetched">Fetched</Hds::Dropdown::ListItem::Checkbox>
     <Hds::Dropdown::Footer @hasDivider={{true}}>
       <Hds::ButtonSet>
-        <Hds::Button @text="Apply filters" type="submit" />
-        <Hds::Button @text="Cancel" @color="secondary" />
+        <Hds::Button @text="Apply" type="submit" @size="small" @isFullWidth={{true}} />
+        <Hds::Button @text="Cancel" @color="secondary" @size="small" @isFullWidth={{true}} />
       </Hds::ButtonSet>
     </Hds::Dropdown::Footer>
   </Doc::ListContainer>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes a discrepancy @alex-ju found in the Dropdown docs where the button size in the dropdown footer was using the medium variant but should be using the small variant.

**Preview:** https://hds-website-git-hl-dropdown-doc-fix-hashicorp.vercel.app/components/dropdown#footer

### :camera_flash: Screenshots

**Before:**
<img width="828" alt="Screenshot 2024-01-31 at 2 02 56 PM" src="https://github.com/hashicorp/design-system/assets/8553306/0258c774-92b9-4d49-9841-f86492a90182">

**After:**
<img width="834" alt="Screenshot 2024-01-31 at 2 03 04 PM" src="https://github.com/hashicorp/design-system/assets/8553306/da874067-220c-40b0-9596-33a59185ae51">



***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
