### PR TITLE
Improved resilience of SVG sprite loading script

### DIFF
--- a/.changeset/silly-ducks-decide.md
+++ b/.changeset/silly-ducks-decide.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/ember-flight-icons": patch
+---
+
+Improved resilience of SVG sprite loading script

--- a/packages/ember-flight-icons/addon/instance-initializers/load-sprite.js
+++ b/packages/ember-flight-icons/addon/instance-initializers/load-sprite.js
@@ -6,7 +6,7 @@
 import config from 'ember-get-config';
 
 export async function initialize() {
-  if (config.emberFlightIcons?.lazyEmbed) {
+  if (config?.emberFlightIcons?.lazyEmbed) {
     const { default: svgSprite } = await import(
       '@hashicorp/flight-icons/svg-sprite/svg-sprite-module'
     );
@@ -15,10 +15,10 @@ export async function initialize() {
     // to avoid issues with tools like Percy that only consider content inside that element
     if (config.environment === 'test') {
       window.document
-        .getElementById('ember-testing')
-        .insertAdjacentHTML('afterbegin', svgSprite);
+        ?.getElementById('ember-testing')
+        ?.insertAdjacentHTML('afterbegin', svgSprite);
     } else {
-      window.document.body.insertAdjacentHTML('beforeend', svgSprite);
+      window.document?.body?.insertAdjacentHTML('beforeend', svgSprite);
     }
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

When testing the `lazyEmbed` solution in `website` (as part of the v2 addon testing) we discovered that the script assumes `config` and `document` are always present, which is not always the case (in various environments, such as tests and server-side rendering they might not). For example, when building `website` with prember this script fails execution without the few safeguards added in this commit.

This commit is ported from https://github.com/hashicorp/design-system/commit/67d42e0d7e6da585c619d4f88b988de1e92012e3.

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
