### PR TITLE
trigger ci when github actions change

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files.sh "packages/components" "packages/ember-flight-icons" "packages/flight-icons/catalog.json"
+        run: ./.github/scripts/filter_changed_files.sh "packages/components" "packages/ember-flight-icons" "packages/flight-icons/catalog.json" ".github/workflows/ci-components.yml"
 
   test:
     name: "Tests"

--- a/.github/workflows/ci-ember-flight-icons.yml
+++ b/.github/workflows/ci-ember-flight-icons.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files.sh "packages/ember-flight-icons"
+        run: ./.github/scripts/filter_changed_files.sh "packages/ember-flight-icons" ".github/workflows/ci-ember-flight-icons.yml"
 
   lint:
     needs: [conditional-skip]

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files.sh "website" "packages/flight-icons/catalog.json"
+        run: ./.github/scripts/filter_changed_files.sh "website" "packages/flight-icons/catalog.json" ".github/workflows/ci-website.yml"
         
   lint:
     name: 'Lint'


### PR DESCRIPTION
### :pushpin: Summary

I realized that with the forthcoming automated tsccr updates we'll need to ensure that tests are run in those PRs to validate the actions still work. This PR adds each ci workflow to the files checked to see if each respective set of tests should run or not.