### PR TITLE
Remove remnant v1 format exports

### DIFF
--- a/packages/components/app/components/hds/table/th-button-sort.js
+++ b/packages/components/app/components/hds/table/th-button-sort.js
@@ -1,6 +1,0 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
-export { default } from '@hashicorp/design-system-components/components/hds/table/th-button-sort';

--- a/packages/components/app/components/hds/table/th-button-tooltip.js
+++ b/packages/components/app/components/hds/table/th-button-tooltip.js
@@ -1,6 +1,0 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
-export { default } from '@hashicorp/design-system-components/components/hds/table/th-button-tooltip';

--- a/packages/components/app/components/hds/table/th-selectable.js
+++ b/packages/components/app/components/hds/table/th-selectable.js
@@ -1,6 +1,0 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
-export { default } from '@hashicorp/design-system-components/components/hds/table/th-selectable';


### PR DESCRIPTION
### :pushpin: Summary

After rebasing the v2 addon branch, we ended up with a few remnant exports in v1 format (from the table work).

In the v2 format the `app` folder doesn't exist anymore and exports are done via `app-js` definitions in `package.json`

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
