### PR TITLE
Fix labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,24 @@
 docs-website:
-  - website/docs/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - website/docs/**/*
 packages/components:
-  - packages/components/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - packages/components/**/*
 packages/ember-flight-icons:
-  - packages/ember-flight-icons/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - packages/ember-flight-icons/**/*
 packages/flight-icons:
-  - packages/flight-icons/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - packages/flight-icons/**/*
 packages/tokens:
-  - packages/tokens/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - packages/tokens/**/*
 showcase:
-  - showcase/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - showcase/**/*


### PR DESCRIPTION
### :pushpin: Summary

Updates our labeler setup to use the updated format that comes with v5 which we updated to in #1931 . We were not alone in being surprised by this change https://github.com/actions/labeler/issues/712

Note: I've included a commit for testing in this PR that I will drop after things work correctly