### PR TITLE
`Accordion` - Add use case for a generic toggle content to showcase

### DIFF
--- a/showcase/app/templates/components/accordion.hbs
+++ b/showcase/app/templates/components/accordion.hbs
@@ -140,6 +140,24 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Text::H4>With generic content</Shw::Text::H4>
+
+  <Shw::Grid {{style gap="2rem"}} @columns={{2}} as |SG|>
+    <SG.Item @label="With generic content in toggle">
+      <Hds::Accordion as |A|>
+        <A.Item>
+          <:toggle>
+            <Shw::Placeholder @text="generic content" @height="24" />
+          </:toggle>
+          <:content>
+            <Shw::Placeholder @text="generic content" @height="40" />
+          </:content>
+        </A.Item>
+      </Hds::Accordion>
+    </SG.Item>
+    <SG.Item />
+  </Shw::Grid>
+
   <Shw::Text::H4>With rich content</Shw::Text::H4>
 
   <Shw::Flex {{style gap="2rem" marginBottom="2rem"}} @direction="column" as |SF|>


### PR DESCRIPTION
### :pushpin: Summary

While replying in [this thread](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1707335271655979) I realized we were missing a use case for the `Accordion` showcase, in which the `toggle` would contain generic content. 

This PR adds this use case.

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
