### PR TITLE
Fix dependencies watch

### DIFF
--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -78,4 +78,7 @@ export default {
     'ember-modifier',
     'prismjs',
   ],
+  watch: {
+    include: 'src/**',
+  },
 };

--- a/packages/ember-flight-icons/rollup.config.mjs
+++ b/packages/ember-flight-icons/rollup.config.mjs
@@ -56,4 +56,7 @@ export default {
       ],
     }),
   ],
+  watch: {
+    include: 'src/**',
+  },
 };


### PR DESCRIPTION
### :pushpin: Summary

Fix dependencies watch by adjusting the rollup config.

Currently when building a package with a watcher (via `yarn start`) and starting `showcase` or `website` (via `ember s`) we often see build fails (TemplateCompiler, SassCompiler, or BroccoliMergeTrees) complaining certain updated files don't exist anymore. With this change we're being more specific about what changes should trigger a rebuild, avoiding such errors.

#### How to test

```bash
cd packages/components
yarn start
```
then, in a separate window/tab
```
cd showcase
ember s
```

change any file in `packages/components/src` or `packages/ember-flight-icons/src` and see the result in `showcase`

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
