### PR TITLE
Add `ember-cli-update` config to `showcase`

### DIFF
--- a/showcase/config/ember-cli-update.json
+++ b/showcase/config/ember-cli-update.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "1.0.0",
+  "packages": [
+    {
+      "name": "ember-cli",
+      "version": "5.3.0",
+      "blueprints": [
+        {
+          "name": "app",
+          "outputRepo": "https://github.com/ember-cli/ember-new-output",
+          "codemodsSource": "ember-app-codemods-manifest@1",
+          "isBaseBlueprint": true,
+          "options": [
+            "--ci-provider=github"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### :pushpin: Summary

Adding `ember-cli-update.json` to `showcase` (similar to [the one we have for `website`](https://github.com/hashicorp/design-system/blob/main/website/config/ember-cli-update.json)) to ease future Ember.js migrations of the showcase app. This allows us to run the `ember-cli-update` command within `showcase` then choose the version we want to migrate to.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
