### PR TITLE
Fix links after migration to v2 format

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -17,8 +17,8 @@ project {
     # SVG icons packed as `tsx` files
     "packages/flight-icons/svg-react/*",
     # Handlebars components sensitive to white-space
-    "packages/components/addon/components/hds/interactive/*.hbs",
-    "packages/components/addon/components/hds/link/*.hbs",
+    "packages/components/src/components/hds/interactive/*.hbs",
+    "packages/components/src/components/hds/link/*.hbs",
     # Reworked from `field-guide` and `broccoli-static-site-json`
     "website/app/components/dynamic-template-error.hbs",
     "website/app/components/dynamic-template-error.js",

--- a/website/docs/components/accordion/index.md
+++ b/website/docs/components/accordion/index.md
@@ -4,7 +4,7 @@ description: An accordion is a vertically stacked list of container-like toggles
 caption: A list of toggles that reveal or hide associated content.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=36870-71032&mode=design&t=72WLExKItFWAX1jX-4
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/accordion
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/accordion
 related: ['components/reveal','components/flyout','components/modal','components/tabs']
 previewImage: assets/illustrations/components/accordion.jpg
 navigation:

--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -4,7 +4,7 @@ description: Displays a brief message without interrupting a user’s task.
 caption: Displays a brief message without interrupting a user’s task.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=1377%3A11987
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/alert
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/alert
 related: ['components/modal', 'components/toast']
 previewImage: assets/illustrations/components/alert.jpg
 navigation:

--- a/website/docs/components/app-footer/index.md
+++ b/website/docs/components/app-footer/index.md
@@ -4,7 +4,7 @@ description: A footer that appears on every screen to display supplementary info
 caption: Displays supplementary information and links for the application.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=46946-2369&mode=design
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/app-footer
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/app-footer
 related: ['layouts/app-frame', 'components/side-nav']
 previewImage: assets/illustrations/components/app-footer.jpg
 navigation:

--- a/website/docs/components/application-state/index.md
+++ b/website/docs/components/application-state/index.md
@@ -4,7 +4,7 @@ description: An informational element that displays the current state of the app
 caption: An informational element that displays the current state of the application.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=31113-50004
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/application-state
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/application-state
 previewImage: assets/illustrations/components/application-state.jpg
 navigation:
   keywords: ['empty state', 'error state', 'message']

--- a/website/docs/components/badge-count/index.md
+++ b/website/docs/components/badge-count/index.md
@@ -4,7 +4,7 @@ description: A numeric label used to display things like version number or colle
 caption: A non-interactive numeric label.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A20946&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/badge-count
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/badge-count
 related: ['components/badge', 'components/tag']
 previewImage: assets/illustrations/components/badge-count.jpg
 navigation:

--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -4,7 +4,7 @@ description: Concise, non-interactive labels that represent metadata.
 caption: Concise, non-interactive labels that represent metadata.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2337%3A20761&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/badge
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/badge
 related: ['components/badge-count','components/tag']
 previewImage: assets/illustrations/components/badge.jpg
 navigation:

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -4,7 +4,7 @@ description: A Breadcrumb is a type of secondary navigation that reveals the use
 caption: A secondary navigation that shows the user’s current location.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=3073%3A11771&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/breadcrumb
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/breadcrumb
 related: ['components/side-nav', 'components/tabs']
 previewImage: assets/illustrations/components/breadcrumb.jpg
 navigation:

--- a/website/docs/components/button-set/index.md
+++ b/website/docs/components/button-set/index.md
@@ -3,7 +3,7 @@ title: Button Set
 description: Provides consistent layout and spacing for a set of buttons.
 caption: A set of buttons.
 links:
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button-set
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/button-set
 related: ['components/button','patterns/button-organization','components/segmented-group']
 previewImage: assets/illustrations/components/button-set.jpg
 navigation:

--- a/website/docs/components/button/index.md
+++ b/website/docs/components/button/index.md
@@ -4,7 +4,7 @@ description: An interactive element that initiates an action or event, such as a
 caption: An interactive element that initiates an action.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2340%3A21001&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/button
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/button
 related: ['components/button-set','patterns/button-organization','components/link/inline','components/link/standalone']
 previewImage: assets/illustrations/components/button.jpg
 navigation:

--- a/website/docs/components/card/index.md
+++ b/website/docs/components/card/index.md
@@ -4,7 +4,7 @@ description: A block container that provides styling for elevation, border, and 
 caption: A block container that provides styling for elevation, border, and background.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2359%3A19245&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/card
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/card
 previewImage: assets/illustrations/components/card.jpg
 navigation:
   keywords: ['tile', 'container', 'box']

--- a/website/docs/components/code-block/index.md
+++ b/website/docs/components/code-block/index.md
@@ -4,7 +4,7 @@ description: A container for displaying formatted chunks of code with syntax hig
 caption: A container for formatting chunks of code with syntax highlighting.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=44796%3A2786&mode=design&t=pZ5PoxE7Q7U0kDaa-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/code-block
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/code-block
 related: ['components/copy/snippet', 'components/copy/button']
 previewImage: assets/illustrations/components/code-block.jpg
 navigation:

--- a/website/docs/components/copy/button/index.md
+++ b/website/docs/components/copy/button/index.md
@@ -4,7 +4,7 @@ description: A button that copies the attached or associated text upon interacti
 caption: A button that copies the attached or associated text upon interaction.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=37400-71082&mode=design
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/copy/button
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/copy/button
 related: ['components/copy/snippet']
 previewImage: assets/illustrations/components/copy-button.jpg
 navigation:

--- a/website/docs/components/copy/snippet/index.md
+++ b/website/docs/components/copy/snippet/index.md
@@ -4,7 +4,7 @@ description: A button that enables users to copy a snippet of code
 caption: A button that copies the text content of the button itself.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=40399-101361&mode=design
-  github:  https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/copy/snippet
+  github:  https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/copy/snippet
 related: ['components/copy/button']
 previewImage: assets/illustrations/components/copy-snippet.jpg
 navigation:

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -4,7 +4,7 @@ description: Displays a list of actions or options revealed by a toggle button. 
 caption: Hide/Show a list of actions or options with a toggle button.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=5633%3A16319&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/dropdown
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/dropdown
 related: ['components/segmented-group','patterns/filter-patterns']
 previewImage: assets/illustrations/components/dropdown.jpg
 navigation:

--- a/website/docs/components/flyout/index.md
+++ b/website/docs/components/flyout/index.md
@@ -4,7 +4,7 @@ description: Displays additional details and information about an item or object
 caption: Displays additional details and information about an item or object, overlaid on the main page content.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=23645%3A53756
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/flyout
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/flyout
 related: ['components/reveal','components/modal','components/accordion']
 previewImage: assets/illustrations/components/flyout.jpg
 navigation:

--- a/website/docs/components/form/checkbox/index.md
+++ b/website/docs/components/form/checkbox/index.md
@@ -4,7 +4,7 @@ description: A form element that allows users to select one or more items from a
 caption: A form element that allows users to select one or more items from a group of items.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=9120%3A23132&t=pDgL7LJUJXZUN7Xq-3
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/checkbox
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/form/checkbox
 related: ['components/form/toggle','components/form/radio','components/form/select']
 previewImage: assets/illustrations/components/form/checkbox.jpg
 navigation:

--- a/website/docs/components/form/file-input/index.md
+++ b/website/docs/components/form/file-input/index.md
@@ -4,7 +4,7 @@ description: A form input that enables users to select one or more files from th
 caption: A form input that enables users to upload files.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=41671-85932&mode=design&t=72WLExKItFWAX1jX-4
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/file-input
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/form/file-input
 previewImage: assets/illustrations/components/form/file-input.jpg
 navigation:
   keywords: ['file', 'upload', 'input', 'form']

--- a/website/docs/components/form/masked-input/index.md
+++ b/website/docs/components/form/masked-input/index.md
@@ -4,7 +4,7 @@ description: A form input that visually obfuscates characters to protect sensiti
 caption: A form input that obfuscates sensitive information.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=39336%3A85955&mode=design&t=Cxb5rUqyu3pTHA9V-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/masked-input
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/form/masked-input
 related: ['components/form/text-input', 'components/form/textarea']
 previewImage: assets/illustrations/components/form/masked-input.jpg
 navigation:

--- a/website/docs/components/form/primitives/index.md
+++ b/website/docs/components/form/primitives/index.md
@@ -3,7 +3,7 @@ title: Primitives
 description: Elements used to compose form fields.
 caption: Elements used to compose form fields.
 links:
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/form
 related: ['patterns/form-patterns']
 previewImage: assets/illustrations/components/form/primitives.jpg
 navigation:

--- a/website/docs/components/form/radio-card/index.md
+++ b/website/docs/components/form/radio-card/index.md
@@ -4,7 +4,7 @@ description: A type of radio input represented as a card.
 caption: A type of radio input represented as a card.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=17482%3A56258&t=pDgL7LJUJXZUN7Xq-3
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/radio-card
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/form/radio-card
 related: ['components/form/radio']
 previewImage: assets/illustrations/components/form/radio-card.jpg
 navigation:

--- a/website/docs/components/form/radio/index.md
+++ b/website/docs/components/form/radio/index.md
@@ -4,7 +4,7 @@ description: A form element that allows users to select a single item from group
 caption: A form element that allows users to select a single item from group of items.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13181%3A36977&t=pDgL7LJUJXZUN7Xq-3
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/radio
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/form/radio
 related: ['components/form/checkbox', 'components/form/toggle', 'components/form/select']
 previewImage: assets/illustrations/components/form/radio.jpg
 navigation:

--- a/website/docs/components/form/select/index.md
+++ b/website/docs/components/form/select/index.md
@@ -4,7 +4,7 @@ description: A form element that allows users to choose one option from a list.
 caption: A form element that allows users to choose one option from a list.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=14283%3A34475&t=pDgL7LJUJXZUN7Xq-3
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/select
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/form/select
 related: ['components/form/text-input','components/form/radio','components/form/checkbox']
 previewImage: assets/illustrations/components/form/select.jpg
 navigation:

--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -4,7 +4,7 @@ description: A form element that provides users with a way to read, input, or ed
 caption: A form element that provides users with a way to read, input, or edit data.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=11530%3A28348&t=pDgL7LJUJXZUN7Xq-3
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/text-input
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/form/text-input
 related: ['components/form/select', 'components/form/textarea', 'components/form/masked-input']
 previewImage: assets/illustrations/components/form/text-input.jpg
 navigation:

--- a/website/docs/components/form/textarea/index.md
+++ b/website/docs/components/form/textarea/index.md
@@ -4,7 +4,7 @@ description: A form input that accepts multi-line text.
 caption: A form input that accepts multi-line text.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13343%3A31585&t=pDgL7LJUJXZUN7Xq-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/textarea
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/form/textarea
 related: ['components/form/text-input','components/form/masked-input']
 previewImage: assets/illustrations/components/form/textarea.jpg
 navigation:

--- a/website/docs/components/form/toggle/index.md
+++ b/website/docs/components/form/toggle/index.md
@@ -4,7 +4,7 @@ description: A form element that allows users to select between two mutually exc
 caption: A form element that allows users to select between two mutually exclusive states.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13181%3A36435&t=pDgL7LJUJXZUN7Xq-3
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/form/toggle
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/form/toggle
 related: ['components/form/checkbox', 'components/form/radio']
 previewImage: assets/illustrations/components/form/toggle.jpg
 navigation:

--- a/website/docs/components/icon-tile/index.md
+++ b/website/docs/components/icon-tile/index.md
@@ -4,7 +4,7 @@ description: Used to display an icon in a tile-like object.
 caption: Used to display an icon in a tile-like object.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2632%3A8072&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/icon-tile
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/icon-tile
 previewImage: assets/illustrations/components/icon-tile.jpg
 navigation:
   keywords: ['symbol', 'logo']

--- a/website/docs/components/link/inline/index.md
+++ b/website/docs/components/link/inline/index.md
@@ -4,7 +4,7 @@ description: A link used within a body of text.
 caption: A link used within a body of text.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2365%3A21590&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/link
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/link
 related: ['components/link/standalone','components/button']
 previewImage: assets/illustrations/components/link/inline.jpg
 navigation:

--- a/website/docs/components/link/standalone/index.md
+++ b/website/docs/components/link/standalone/index.md
@@ -4,7 +4,7 @@ description: A link used in isolation and not as a part of surrounding body text
 caption: A link used in isolation and not as a part of surrounding body text.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=2365%3A21590&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/link
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/link
 related: ['components/link/inline','components/button']
 previewImage: assets/illustrations/components/link/standalone.jpg
 navigation:

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -4,7 +4,7 @@ description: A pop-up window used to request information or feedback from the us
 caption: A pop-up window used to request information, confirm a decision, or provide additional context.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=22928%3A56204&t=pDgL7LJUJXZUN7Xq-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/modal
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/modal
 related: ['components/alert','components/flyout','components/accordion','components/tooltip']
 previewImage: assets/illustrations/components/modal.jpg
 navigation:

--- a/website/docs/components/page-header/index.md
+++ b/website/docs/components/page-header/index.md
@@ -4,7 +4,7 @@ description: An informational element that displays the title of the page, relev
 caption: Displays the title of the page, metadata, and page-level actions.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=34664%3A70976&t=2f1KLqP6H7lnQQSz-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/page-header
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/page-header
 related: ['components/breadcrumb', 'components/button', 'components/dropdown', 'components/icon-tile']
 previewImage: assets/illustrations/components/page-header.jpg
 navigation:

--- a/website/docs/components/pagination/index.md
+++ b/website/docs/components/pagination/index.md
@@ -4,7 +4,7 @@ description: Used to let users navigate through content broken down into pages. 
 caption: Used to let users navigate through content broken down into pages.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=18709%3A42011&t=pIE459t8qucXP9uR-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/pagination
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/pagination
 related: ['components/table','patterns/filter-patterns']
 previewImage: assets/illustrations/components/pagination.jpg
 ---

--- a/website/docs/components/reveal/index.md
+++ b/website/docs/components/reveal/index.md
@@ -4,7 +4,7 @@ description: A toggle that reveals additional information or details about an el
 caption: A toggle that reveals additional content to the user when triggered.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=35103%3A70091&t=PdXIqxQkqpsXUQki-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/reveal
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/reveal
 related: ['components/flyout','components/accordion','components/tooltip']
 previewImage: assets/illustrations/components/reveal.jpg
 navigation:

--- a/website/docs/components/segmented-group/index.md
+++ b/website/docs/components/segmented-group/index.md
@@ -4,7 +4,7 @@ description: Combines one or more input fields and actions to handle complex fil
 caption: Combines one or more input fields and actions to handle complex filtering and data collection.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=34323-69877&mode=design&t=72WLExKItFWAX1jX-4
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/segmented-group
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/segmented-group
 related: ['components/dropdown', 'components/button-set', 'patterns/filter-patterns']
 previewImage: assets/illustrations/components/form/segmented-group.jpg
 navigation:

--- a/website/docs/components/separator/index.md
+++ b/website/docs/components/separator/index.md
@@ -4,7 +4,7 @@ description: Creates visual breaks between different sections of content
 caption: Creates visual breaks between different sections of content
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=36433-70314&mode=design&t=72WLExKItFWAX1jX-4
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/separator
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/separator
 previewImage: assets/illustrations/components/separator.jpg
 navigation:
   keywords: ['horizontal', 'rule', 'line' , 'hr', 'section', 'divider', 'break']

--- a/website/docs/components/side-nav/index.md
+++ b/website/docs/components/side-nav/index.md
@@ -4,7 +4,7 @@ description: Used as the primary navigation of an application.
 caption: A side navigation menu that provides access to the main pages of the product.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=26174%3A58558&t=kVEJBi3HIfTpV8nG-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/side-nav
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/side-nav
 related: ['components/breadcrumb','components/tabs', 'layouts/app-frame']
 previewImage: assets/illustrations/components/side-nav.jpg
 navigation:

--- a/website/docs/components/stepper/index.md
+++ b/website/docs/components/stepper/index.md
@@ -4,7 +4,7 @@ description: Helps the user maintain context and directionality when advancing t
 caption: Helps the user maintain context and directionality when advancing through a multi-step flow or feature.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=15313%3A50538&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/stepper
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/stepper
 previewImage: assets/illustrations/components/stepper.jpg
 navigation:
   keywords: ['progress', 'progress bar', 'steps', 'tracker']

--- a/website/docs/components/table/index.md
+++ b/website/docs/components/table/index.md
@@ -4,7 +4,7 @@ description: Used to display organized, two-dimensional tabular data.
 caption: Used to display organized, two-dimensional tabular data.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=18814%3A54972&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/table
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/table
 related: ['components/pagination','patterns/filter-patterns']
 previewImage: assets/illustrations/components/table.jpg
 navigation:

--- a/website/docs/components/tabs/index.md
+++ b/website/docs/components/tabs/index.md
@@ -4,7 +4,7 @@ description: Allows users to move among different views within the same context 
 caption: Allows users to move among different views within the same context.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=16384%3A46484&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/tabs
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/tabs
 related: ['components/accordion','components/breadcrumb','components/side-nav']
 previewImage: assets/illustrations/components/tabs.jpg
 navigation:

--- a/website/docs/components/tag/index.md
+++ b/website/docs/components/tag/index.md
@@ -4,7 +4,7 @@ description: Used to indicate an object’s categorization.
 caption: Used to indicate an object’s categorization.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=13720%3A34360&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/tag
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/tag
 related: ['components/badge','components/badge-count']
 previewImage: assets/illustrations/components/tag.jpg
 navigation:

--- a/website/docs/components/text/index.md
+++ b/website/docs/components/text/index.md
@@ -4,7 +4,7 @@ description: A component that applies predefined typographic styles to a block o
 caption: A component that applies predefined typographic styles to its content.
 links:
   figma: https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?type=design&node-id=1262-9192
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/text
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/text
 related: ['foundations/typography']
 previewImage: assets/illustrations/components/text.jpg
 navigation:

--- a/website/docs/components/toast/index.md
+++ b/website/docs/components/toast/index.md
@@ -4,7 +4,7 @@ description: Used to display messages that are the result of a user’s actions.
 caption: Used to display messages that are the result of a user’s actions.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=7636%3A30467&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/toast
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/toast
 related: ['components/alert']
 previewImage: assets/illustrations/components/toast.jpg
 navigation:

--- a/website/docs/components/tooltip/index.md
+++ b/website/docs/components/tooltip/index.md
@@ -4,7 +4,7 @@ description: The Tooltip component provides additional information to users in a
 caption: Provides additional information or context for a UI element.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=32036%3A51885&t=hyPMnP9pSH15dgcy-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/tooltip-button
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/tooltip-button
 related: ['components/modal']
 previewImage: assets/illustrations/components/tooltip.jpg
 navigation:

--- a/website/docs/layouts/app-frame/index.md
+++ b/website/docs/layouts/app-frame/index.md
@@ -3,7 +3,7 @@ title: AppFrame
 description: A layout component used as top-level “frame“ for the application.
 caption: A layout component used as top-level “frame“ for the application.
 links:
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/app-frame
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/app-frame
 previewImage: assets/illustrations/layouts/app-frame.jpg
 navigation:
   keywords: ['layout', 'application', 'frame', 'header', 'sidebar', 'sidenav', 'footer', 'modal']


### PR DESCRIPTION
### :pushpin: Summary

The GitHub link for the CodeBlock component was using the old `addon/` path rather than the new `src/` path.