### PR TITLE
Fix wrong paths in website documentation

### DIFF
--- a/website/docs/utilities/disclosure-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/disclosure-primitive/partials/code/how-to-use.md
@@ -9,7 +9,7 @@ The `DisclosurePrimitive` component renders an interactive element that triggers
 
 When the content is disclosed, the container can be closed by toggling the button (`click` or `enter/return`).
 
-**Note:** [MenuPrimitive](/components/menu-primitive), another variant of this primitive, includes extra functionality to close the content panel by either clicking outside of the content, or via the `esc` key.
+**Note:** [MenuPrimitive](/utilities/menu-primitive), another variant of this primitive, includes extra functionality to close the content panel by either clicking outside of the content, or via the `esc` key.
 
 
 ```handlebars

--- a/website/docs/utilities/menu-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/menu-primitive/partials/code/how-to-use.md
@@ -9,7 +9,7 @@ The `MenuPrimitive` component renders an interactive element that triggers a cus
 
 When the content is disclosed, the container can be closed in various way; toggling via the button (`click` or `enter/return`), clicking outside of the content, or via the `esc` key.
 
-**Note:** [DisclosurePrimitive](/components/disclosure-primitive), another variant of this primitive, excludes the functionality to close the content panel by either clicking outside of the content, or via the `esc` key.
+**Note:** [DisclosurePrimitive](/utilities/disclosure-primitive), another variant of this primitive, excludes the functionality to close the content panel by either clicking outside of the content, or via the `esc` key.
 
 ```handlebars
 <Hds::MenuPrimitive>


### PR DESCRIPTION
### :pushpin: Summary

Tiny PR to fix a couple of wrong paths.