### PR TITLE
Fix acceptance tests failing on `foundations/tokens`

### DIFF
--- a/website/testem.js
+++ b/website/testem.js
@@ -10,6 +10,7 @@ module.exports = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
+  browser_disconnect_timeout: 20,
   browser_start_timeout: 120,
   browser_args: {
     Chrome: {


### PR DESCRIPTION
### :pushpin: Summary

Fix acceptance tests [failing on `foundations/tokens`](https://github.com/hashicorp/design-system/actions/runs/7874856195/job/21485458245?pr=1942#step:7:151) by increasing `browser_disconnect_timeout` from 10s to 20s.

We've seen this flake way too many times to ignore it.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
