### PR TITLE
Fix build errors when watching packages

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "rollup --config",
     "prepublishOnly": "rollup --config",
-    "start": "rollup --config --watch",
+    "start": "rollup --config --watch --environment development",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:css": "stylelint \"src/styles/**/*.scss\"",

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -7,83 +7,84 @@ import { Addon } from '@embroider/addon-dev/rollup';
 import { babel } from '@rollup/plugin-babel';
 import copy from 'rollup-plugin-copy';
 import scss from 'rollup-plugin-scss';
+import process from 'process';
 
 const addon = new Addon({
   srcDir: 'src',
   destDir: 'dist',
 });
 
+const plugins = [
+  // These are the modules that users should be able to import from your
+  // addon. Anything not listed here may get optimized away.
+  addon.publicEntrypoints(['**/*.ts', '**/*.js', 'styles/@hashicorp/*.scss']),
+
+  // These are the modules that should get reexported into the traditional
+  // "app" tree. Things in here should also be in publicEntrypoints above, but
+  // not everything in publicEntrypoints necessarily needs to go here.
+  addon.appReexports([
+    'components/**/*.js',
+    'helpers/**/*.js',
+    'modifiers/**/*.js',
+  ]),
+  // This babel config should *not* apply presets or compile away ES modules.
+  // It exists only to provide development niceties for you, like automatic
+  // template colocation.
+  //
+  // By default, this will load the actual babel config from the file
+  // babel.config.json.
+  babel({
+    babelHelpers: 'bundled',
+    extensions: ['.js', '.ts'],
+  }),
+
+  // Follow the V2 Addon rules about dependencies. Your code can import from
+  // `dependencies` and `peerDependencies` as well as standard Ember-provided
+  // package names.
+  addon.dependencies(),
+
+  // Ensure that standalone .hbs files are properly integrated as Javascript.
+  addon.hbs(),
+
+  scss({
+    fileName: 'styles/@hashicorp/design-system-components.css',
+    includePaths: [
+      '../../node_modules/@hashicorp/design-system-tokens/dist/products/css',
+      '../../node_modules/@hashicorp/ember-flight-icons/dist/styles',
+    ],
+  }),
+
+  scss({
+    fileName: 'styles/@hashicorp/design-system-power-select-overrides.css',
+  }),
+
+  // Addons are allowed to contain imports of .css files, which we want rollup
+  // to leave alone and keep in the published output.
+  addon.keepAssets(['**/*.css', '**/*.scss']),
+
+  // Copy readme and license files into published package
+  copy({
+    targets: [
+      { src: 'README.md', dest: 'dist' },
+      { src: 'LICENSE.md', dest: 'dist' },
+    ],
+  }),
+];
+
+if (!process.env.development) {
+  // Remove leftover build artifacts when starting a new build.
+  plugins.push(addon.clean());
+}
+
 export default {
   // This provides defaults that work well alongside `publicEntrypoints` below.
   // You can augment this if you need to.
   output: addon.output(),
-
-  plugins: [
-    // These are the modules that users should be able to import from your
-    // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['**/*.ts', '**/*.js', 'styles/@hashicorp/*.scss']),
-
-    // These are the modules that should get reexported into the traditional
-    // "app" tree. Things in here should also be in publicEntrypoints above, but
-    // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports([
-      'components/**/*.js',
-      'helpers/**/*.js',
-      'modifiers/**/*.js',
-    ]),
-    // This babel config should *not* apply presets or compile away ES modules.
-    // It exists only to provide development niceties for you, like automatic
-    // template colocation.
-    //
-    // By default, this will load the actual babel config from the file
-    // babel.config.json.
-    babel({
-      babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
-    }),
-
-    // Follow the V2 Addon rules about dependencies. Your code can import from
-    // `dependencies` and `peerDependencies` as well as standard Ember-provided
-    // package names.
-    addon.dependencies(),
-
-    // Ensure that standalone .hbs files are properly integrated as Javascript.
-    addon.hbs(),
-
-    scss({
-      fileName: 'styles/@hashicorp/design-system-components.css',
-      includePaths: [
-        '../../node_modules/@hashicorp/design-system-tokens/dist/products/css',
-        '../../node_modules/@hashicorp/ember-flight-icons/dist/styles',
-      ],
-    }),
-
-    scss({
-      fileName: 'styles/@hashicorp/design-system-power-select-overrides.css',
-    }),
-
-    // Addons are allowed to contain imports of .css files, which we want rollup
-    // to leave alone and keep in the published output.
-    addon.keepAssets(['**/*.css', '**/*.scss']),
-
-    // Remove leftover build artifacts when starting a new build.
-    addon.clean(),
-
-    // Copy readme and license files into published package
-    copy({
-      targets: [
-        { src: '../README.md', dest: '.' },
-        { src: '../LICENSE.md', dest: '.' },
-      ],
-    }),
-  ],
+  plugins: plugins,
   external: [
     'dialog-polyfill',
     'dialog-polyfill/dist/dialog-polyfill.css',
     'ember-modifier',
     'prismjs',
   ],
-  watch: {
-    include: 'src/**',
-  },
 };

--- a/packages/ember-flight-icons/package.json
+++ b/packages/ember-flight-icons/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "rollup --config",
     "prepublishOnly": "rollup --config",
-    "start": "rollup --config --watch",
+    "start": "rollup --config --watch --environment development",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint .",

--- a/packages/ember-flight-icons/rollup.config.mjs
+++ b/packages/ember-flight-icons/rollup.config.mjs
@@ -6,62 +6,63 @@
 import { Addon } from '@embroider/addon-dev/rollup';
 import { babel } from '@rollup/plugin-babel';
 import copy from 'rollup-plugin-copy';
+import process from 'process';
 
 const addon = new Addon({
   srcDir: 'src',
   destDir: 'dist',
 });
 
+const plugins = [
+  // These are the modules that users should be able to import from your
+  // addon. Anything not listed here may get optimized away.
+  addon.publicEntrypoints(['**/*.ts', '**/*.js']),
+
+  // These are the modules that should get reexported into the traditional
+  // "app" tree. Things in here should also be in publicEntrypoints above, but
+  // not everything in publicEntrypoints necessarily needs to go here.
+  addon.appReexports(['**/*.ts', '**/*.js']),
+
+  // This babel config should *not* apply presets or compile away ES modules.
+  // It exists only to provide development niceties for you, like automatic
+  // template colocation.
+  //
+  // By default, this will load the actual babel config from the file
+  // babel.config.json.
+  babel({
+    babelHelpers: 'bundled',
+    extensions: ['.js', '.ts'],
+  }),
+
+  // Follow the V2 Addon rules about dependencies. Your code can import from
+  // `dependencies` and `peerDependencies` as well as standard Ember-provided
+  // package names.
+  addon.dependencies(),
+
+  // Ensure that standalone .hbs files are properly integrated as Javascript.
+  addon.hbs(),
+
+  // Addons are allowed to contain imports of .css files, which we want rollup
+  // to leave alone and keep in the published output.
+  addon.keepAssets(['**/*.css']),
+
+  // Copy readme and license files into published package
+  copy({
+    targets: [
+      { src: 'README.md', dest: 'dist' },
+      { src: 'LICENSE.md', dest: 'dist' },
+    ],
+  }),
+];
+
+if (!process.env.development) {
+  // Remove leftover build artifacts when starting a new build.
+  plugins.push(addon.clean());
+}
+
 export default {
   // This provides defaults that work well alongside `publicEntrypoints` below.
   // You can augment this if you need to.
   output: addon.output(),
-
-  plugins: [
-    // These are the modules that users should be able to import from your
-    // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['**/*.ts', '**/*.js']),
-
-    // These are the modules that should get reexported into the traditional
-    // "app" tree. Things in here should also be in publicEntrypoints above, but
-    // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['**/*.ts', '**/*.js']),
-
-    // This babel config should *not* apply presets or compile away ES modules.
-    // It exists only to provide development niceties for you, like automatic
-    // template colocation.
-    //
-    // By default, this will load the actual babel config from the file
-    // babel.config.json.
-    babel({
-      babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
-    }),
-
-    // Follow the V2 Addon rules about dependencies. Your code can import from
-    // `dependencies` and `peerDependencies` as well as standard Ember-provided
-    // package names.
-    addon.dependencies(),
-
-    // Ensure that standalone .hbs files are properly integrated as Javascript.
-    addon.hbs(),
-
-    // Addons are allowed to contain imports of .css files, which we want rollup
-    // to leave alone and keep in the published output.
-    addon.keepAssets(['**/*.css']),
-
-    // Remove leftover build artifacts when starting a new build.
-    addon.clean(),
-
-    // Copy readme and license files into published package
-    copy({
-      targets: [
-        { src: '../README.md', dest: '.' },
-        { src: '../LICENSE.md', dest: '.' },
-      ],
-    }),
-  ],
-  watch: {
-    include: 'src/**',
-  },
+  plugins: plugins,
 };


### PR DESCRIPTION
### :pushpin: Summary

This PR changes the Rollup config to skip the 'deep clean' done by `addon.clean()` when running Rollup build with watch for development purposes. This is to overcome a [known issue](https://discord.com/channels/480462759797063690/1066065904384876626/1066103413638705172) where the build fails when a `js` file is deleted (even for a fraction of a second, as it happens with Rollup). 

This is an alternative to #1939 which improved things, but some builds still failed (more commonly when js files were changed).

#### How to test

```bash
cd packages/components
yarn start
```

then, in a separate window/tab

```bash
cd showcase
ember s
```

changing any file in `packages/components/src` should trigger a Rollup rebuild and a `showcase` rebuild, without throwing any errors.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
