### PR TITLE
Explicitly define the entry point for the CSS compilation

### DIFF
--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -17,7 +17,11 @@ const addon = new Addon({
 const plugins = [
   // These are the modules that users should be able to import from your
   // addon. Anything not listed here may get optimized away.
-  addon.publicEntrypoints(['**/*.ts', '**/*.js', 'styles/@hashicorp/*.scss']),
+  addon.publicEntrypoints([
+    '**/*.ts',
+    '**/*.js',
+    'styles/@hashicorp/design-system-components.scss',
+  ]),
 
   // These are the modules that should get reexported into the traditional
   // "app" tree. Things in here should also be in publicEntrypoints above, but


### PR DESCRIPTION
### :pushpin: Summary

Explicitly define the `styles/@hashicorp/design-system-components.scss` as the entry point for the CSS compilation done by `rollup-plugin-scss`. Tested 100 (automated) consecutive runs of `yarn build` and `yarn start` without any fail and with the `packages/components/dist/styles/@hashicorp/design-system-components.css` correctly built.

Thanks @meirish for the suggestion!

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
