### PR TITLE
Align component names in `website`

### DIFF
--- a/website/docs/components/app-footer/index.md
+++ b/website/docs/components/app-footer/index.md
@@ -1,5 +1,5 @@
 ---
-title: AppFooter
+title: App Footer
 description: A footer that appears on every screen to display supplementary information and links.
 caption: Displays supplementary information and links for the application.
 links:

--- a/website/docs/components/app-footer/partials/guidelines/guidelines.md
+++ b/website/docs/components/app-footer/partials/guidelines/guidelines.md
@@ -14,7 +14,7 @@ While the Ember component allows flexibility in the ordering of links and conten
 - Plain text items (or metadata, such as version numbers)
 - Copyright
 
-![Example of the recommended order of content within the AppFooter](/assets/components/app-footer/app-footer-order-priority.png)
+![Example of the recommended order of content within the App Footer](/assets/components/app-footer/app-footer-order-priority.png)
 
 ## Status link
 
@@ -26,45 +26,45 @@ The StatusLink is used to communicate the application status via a third-party s
 
 A set of standard legal links are provided by default. These are recommended for customer-facing products, but can be turned on/off within the component as needed. 
 
-![Example of the AppFooter with legal links only](/assets/components/app-footer/app-footer-legal-links.png)
+![Example of the App Footer with legal links only](/assets/components/app-footer/app-footer-legal-links.png)
 
 ## Additional links
 
 Additional links can be added as necessary. Common examples may include linking to a changelog, GitHub, etc.
 
-![Example of the AppFooter with additional links](/assets/components/app-footer/app-footer-additional-links.png)
+![Example of the App Footer with additional links](/assets/components/app-footer/app-footer-additional-links.png)
 
 ## Plain text items
 
 Plain text content can be added after the links. This is often used for displaying the version number or other metadata related to the product. 
 
-![Example of the AppFooter with plain text list items](/assets/components/app-footer/app-footer-items.png)
+![Example of the App Footer with plain text list items](/assets/components/app-footer/app-footer-items.png)
 
 ## Extra content blocks
 
 Extra content blocks are available before the list of links and before the copyright.
 
-![Example of where additional content can go in the AppFooter](/assets/components/app-footer/app-footer-extra-content.png)
+![Example of where additional content can go in the App Footer](/assets/components/app-footer/app-footer-extra-content.png)
 
 !!! Do
 
 The extra content block can be used to add quick interactions that change the whole application, e.g., a theme switcher.
 
-![Example of what additional content can go in the AppFooter](/assets/components/app-footer/app-footer-extra-content-do.png)
+![Example of what additional content can go in the App Footer](/assets/components/app-footer/app-footer-extra-content-do.png)
 !!!
 
 !!! Dont
 
-Avoid adding information that's critical to the user's journey in the AppFooter. 
+Avoid adding information that's critical to the user's journey in the App Footer. 
 
-![Example of what additional content should not go in the AppFooter](/assets/components/app-footer/app-footer-extra-content-dont.png)
+![Example of what additional content should not go in the App Footer](/assets/components/app-footer/app-footer-extra-content-dont.png)
 !!!
 
 ## Themes
 
-The AppFooter supports both `Light` and `Dark` theme options. The dark theme can be used when there is a need for a footer on a dark background, e.g., a loading screen, but it should be used sparingly. 
+The App Footer supports both `Light` and `Dark` theme options. The dark theme can be used when there is a need for a footer on a dark background, e.g., a loading screen, but it should be used sparingly. 
 
-![Example of the AppFooter in a dark theme](/assets/components/app-footer/app-footer-dark.png)
+![Example of the App Footer in a dark theme](/assets/components/app-footer/app-footer-dark.png)
 
 ## Responsiveness
 
@@ -81,8 +81,8 @@ The `Large` size accounts for most larger viewport sizes and, depending on the n
 
 _Please note, this screenshot is reduced in size to fit within the content container of the website._
 
-![Example of the AppFooter at a large screen size](/assets/components/app-footer/app-footer-large.png)
+![Example of the App Footer at a large screen size](/assets/components/app-footer/app-footer-large.png)
 
 ### Small
 
-![Example of the AppFooter at a small screen size](/assets/components/app-footer/app-footer-small.png)
+![Example of the App Footer at a small screen size](/assets/components/app-footer/app-footer-small.png)

--- a/website/docs/components/app-footer/partials/guidelines/overview.md
+++ b/website/docs/components/app-footer/partials/guidelines/overview.md
@@ -1,1 +1,1 @@
-The AppFooter is a universal component designed to provide essential links and content at the bottom of the application. 
+The App Footer is a universal component designed to provide essential links and content at the bottom of the application.

--- a/website/docs/components/button-set/partials/guidelines/overview.md
+++ b/website/docs/components/button-set/partials/guidelines/overview.md
@@ -1,1 +1,1 @@
-Use a button set to ensure a consistent layout when using multiple buttons in a single row.
+Use a Button Set to ensure a consistent layout when using multiple [Buttons](/components/button) in a single row.

--- a/website/docs/components/code-block/index.md
+++ b/website/docs/components/code-block/index.md
@@ -1,5 +1,5 @@
 ---
-title: CodeBlock
+title: Code Block
 description: A container for displaying formatted chunks of code with syntax highlighting and related features.
 caption: A container for formatting chunks of code with syntax highlighting.
 links:

--- a/website/docs/components/code-block/partials/guidelines/guidelines.md
+++ b/website/docs/components/code-block/partials/guidelines/guidelines.md
@@ -9,11 +9,11 @@
 - As a full-blown code editor.
 - As an embedded terminal or terminal emulator.
 
-### When to use a CodeBlock vs a Copy Snippet
+### When to use a Code Block vs. a Copy Snippet
 
-There is some overlap in the copying functionality of the [Copy Snippet](/components/copy/snippet) and the CodeBlock. Which to use generally comes down to the complexity of the code/value displayed within the component, and whether the user benefits from seeing the larger context of the code example.
+There is some overlap in the copying functionality of the [Copy Snippet](/components/copy/snippet) and the Code Block. Which to use generally comes down to the complexity of the code/value displayed within the component, and whether the user benefits from seeing the larger context of the code example.
 
-**Use a CodeBlock:**
+**Use a Code Block:**
 
 - If viewing or displaying code is the primary purpose, and copying the code is secondary.
 - If the example consists of a command, e.g., a `curl` and `bash` script. These are oftentimes on a single line, but consist of multiple commands and functions.
@@ -26,43 +26,43 @@ There is some overlap in the copying functionality of the [Copy Snippet](/compon
 
 ## Standalone
 
-The `isStandalone` property increases the portability of the CodeBlock to ensure that it can be used in different contexts. For example, a common use case of the CodeBlock is in a "standalone" context, which can be part of a form, multi-step process, and is generally a part of the normal layout flow.
+The `isStandalone` property increases the portability of the Code Block to ensure that it can be used in different contexts. For example, a common use case of the Code Block is in a "standalone" context, which can be part of a form, multi-step process, and is generally a part of the normal layout flow.
 
-![CodeBlock with rounded corners in a standalone context](/assets/components/code-block/code-block-rounded-standalone.png)
+![Code Block with rounded corners in a standalone context](/assets/components/code-block/code-block-rounded-standalone.png)
 
-Sometimes it may be necessary to use the CodeBlock in a more dense layout or nested within another component. In this circumstance, setting `isStandalone` to false ensures that the CodeBlock fits alongside other elements, in a split view, or as part of a larger layout mechanism.
+Sometimes it may be necessary to use the Code Block in a more dense layout or nested within another component. In this circumstance, setting `isStandalone` to false ensures that the Code Block fits alongside other elements, in a split view, or as part of a larger layout mechanism.
 
-![CodeBlock in a block context](/assets/components/code-block/code-block-block-level.png)
+![Code Block in a block context](/assets/components/code-block/code-block-block-level.png)
 
 ## Header
 
-Use a `title` and/or `description` in the header to provide additional information, instructions, or to label a CodeBlock. Both of these properties are optional, but including them can help to provide additional context about a specific block of code.
+Use a `title` and/or `description` in the header to provide additional information, instructions, or to label a Code Block. Both of these properties are optional, but including them can help to provide additional context about a specific block of code.
 
-![Example metadata in the CodeBlock](/assets/components/code-block/code-block-metadata.png)
+![Example metadata in the Code Block](/assets/components/code-block/code-block-metadata.png)
 
 ### When not to use a header
 
-There can be an overlap between content that you may choose to include in the header as a `title` or `description`, and content that is part of the normal layout flow in a headline or paragraph. If it is necessary to elevate this content in the hierarchy of the page, we recommend including it in the normal layout flow, rather than as a `title` or `description` within the CodeBlock.
+There can be an overlap between content that you may choose to include in the header as a `title` or `description`, and content that is part of the normal layout flow in a headline or paragraph. If it is necessary to elevate this content in the hierarchy of the page, we recommend including it in the normal layout flow, rather than as a `title` or `description` within the Code Block.
 
-![An example showcasing the CodeBlock paired with content in the nautral flow](/assets/components/code-block/code-block-dont-use-metadata.png)
+![An example showcasing the Code Block paired with content in the nautral flow](/assets/components/code-block/code-block-dont-use-metadata.png)
 
 ## CopyButton
 
-Use a CopyButton within the CodeBlock to make copying the snippet a single action. More details can be found in the [CopyButton guidelines](/components/copy/button).
+Use a CopyButton within the Code Block to make copying the snippet a single action. More details can be found in the [CopyButton guidelines](/components/copy/button).
 
-![An example of the Copy Button within the CodeBlock](/assets/components/code-block/code-block-copy-button.png)
+![An example of the Copy Button within the Code Block](/assets/components/code-block/code-block-copy-button.png)
 
 ### Line selection
 
-If a user needs to copy only a portion of the CodeBlock, the relevant portion can be selected with a cursor and copied via the keyboard or mouse.
+If a user needs to copy only a portion of the Code Block, the relevant portion can be selected with a cursor and copied via the keyboard or mouse.
 
-![Selecting a single line in the CodeBlock](/assets/components/code-block/code-block-line-selection.png)
+![Selecting a single line in the Code Block](/assets/components/code-block/code-block-line-selection.png)
 
 ## Line numbers
 
 Line numbers are displayed by default and can make longer blocks of code and snippets easier to parse. This is especially true in the case of logs and long configuration files that may have a higher degree of complexity.
 
-![Example of line numbers within the CodeBlock](/assets/components/code-block/code-block-line-numbers.png)
+![Example of line numbers within the Code Block](/assets/components/code-block/code-block-line-numbers.png)
 
 !!! Info
 
@@ -73,7 +73,7 @@ In the Figma component, the code examples have the appropriate number of lines b
 
 Use line highlighting to target and call attention to specific lines or multiple lines within a block of code.
 
-![Example of line highlighting in the CodeBlock](/assets/components/code-block/code-block-line-highlighting.png)
+![Example of line highlighting in the Code Block](/assets/components/code-block/code-block-line-highlighting.png)
 
 !!! Info
 
@@ -88,10 +88,10 @@ Language determines how syntax highlighting is applied and formatted within the 
 
 The **Ember** component uses [Prism.js](https://prismjs.com/index.html) to handle syntax highlighting and comes with a pre-defined set of languages.
 
-In **Figma** we provide a handful of example languages that are intended to be _representative_ of the end result in production. Syntax highlighting in Figma is a non-trivial process and requires the manual application of color styles to each "type" of code. Despite this, creating a custom code snippet with the CodeBlock is supported by typing/pasting into the text layer, but syntax highlighting will not be automatically applied.
+In **Figma** we provide a handful of example languages that are intended to be _representative_ of the end result in production. Syntax highlighting in Figma is a non-trivial process and requires the manual application of color styles to each "type" of code. Despite this, creating a custom code snippet with the Code Block is supported by typing/pasting into the text layer, but syntax highlighting will not be automatically applied.
 
 ### Applying syntax highlighting
 
-If you wish to create custom examples using the CodeBlock, we publish all of the relevant syntax highlighting styles in the HDS [Foundations](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?type=design&node-id=2130%3A2&mode=design&t=Pfj7CheLS6cR0hKa-1) library. However, due to the number of languages supported by the component, the color styles use a generic naming schema (e.g., cyan, red, purple) to remain as agnostic as possible when being applied to different languages.
+If you wish to create custom examples using the Code Block, we publish all of the relevant syntax highlighting styles in the HDS [Foundations](https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?type=design&node-id=2130%3A2&mode=design&t=Pfj7CheLS6cR0hKa-1) library. However, due to the number of languages supported by the component, the color styles use a generic naming schema (e.g., cyan, red, purple) to remain as agnostic as possible when being applied to different languages.
 
 For more details around syntax visit the [specifications](?tab=specifications).

--- a/website/docs/components/code-block/partials/guidelines/overview.md
+++ b/website/docs/components/code-block/partials/guidelines/overview.md
@@ -1,1 +1,1 @@
-The CodeBlock is used to display, format, and highlight the syntax of code snippets.
+The Code Block is used to display, format, and highlight the syntax of code snippets.

--- a/website/docs/components/code-block/partials/specifications/anatomy.md
+++ b/website/docs/components/code-block/partials/specifications/anatomy.md
@@ -1,6 +1,6 @@
 ## Anatomy
 
-![Anatomy of codeBlock](/assets/components/code-block/code-block-anatomy.png)
+![Anatomy of Code Block](/assets/components/code-block/code-block-anatomy.png)
 
 | Element          | Usage    |
 |------------------|----------|

--- a/website/docs/components/code-block/partials/specifications/states.md
+++ b/website/docs/components/code-block/partials/specifications/states.md
@@ -2,8 +2,8 @@
 
 ### Focus with header content
 
-![Focus state of the CodeBlock with the header](/assets/components/code-block/code-block-focus-header.png)
+![Focus state of the Code Block with the header](/assets/components/code-block/code-block-focus-header.png)
 
 ### Focus without header content
 
-![Focus state of the CodeBlock without the header](/assets/components/code-block/code-block-focus-no-header.png)
+![Focus state of the Code Block without the header](/assets/components/code-block/code-block-focus-no-header.png)

--- a/website/docs/components/link/standalone/partials/guidelines/guidelines.md
+++ b/website/docs/components/link/standalone/partials/guidelines/guidelines.md
@@ -81,10 +81,9 @@ Always use the leading position for product or service icons (e.g., GitHub).
 
 !!!
 
-
 ### Trailing
 
-Consider trailing icons when there’s no other meaningful icon or when guiding the user forward through the product. 
+Consider trailing icons when there’s no other meaningful icon or when guiding the user forward through the product.
 
 - Use `arrow-right` for internal links.
 - Use `learn-link` for links to tutorials.
@@ -141,7 +140,7 @@ We recommend at least 16px between Standalone Links when placed in a horizontal 
 
 ## Common patterns
 
-### Within button sets
+### Within Button Sets
 
 Standalone Links often appear in [Button Sets](/components/button-set).
 

--- a/website/docs/whats-new/release-notes/partials/figma-library-foundations.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-foundations.md
@@ -18,11 +18,11 @@
 
 ### October 31st, 2023
 
-`Components / Code Block / Code / 200` - Added component-specific text style for the CodeBlock.
+`Components / Code Block / Code / 200` - Added component-specific text style for the Code Block.
 
 ### October 20th, 2023
 
-`Components / Code Block / Syntax` - Added syntax highlighting styles used by the CodeBlock component.
+`Components / Code Block / Syntax` - Added syntax highlighting styles used by the Code Block component.
 
 
 ---


### PR DESCRIPTION
### :pushpin: Summary

When it comes to letter casing we seem to be using capitals for each word (also referred to as 'Start Case') when we refer to our components in general (inherently comprising the Figma version and the Ember version).

We use `PascalCase` (and mark it as code, using a fixed-width style) when we refer to Ember components and subcomponents.

In this PR we align AppFooter and CodeBlock to the existing naming convention and split them apart, resulting in App Footer and Code Block. We also correct two instances where the button set does not have capitals.

In terms of impact, for the URLs in `website` we convert both 'Start Case' and 'PascalCase' to 'kebab-case', so operating these changes will not impact the URLs for these components.

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="1512" alt="component-name-before" src="https://github.com/hashicorp/design-system/assets/788096/4d2f1bbe-2bed-42b1-9d4f-3f7b83f63044">


</td><td>

<img width="1512" alt="component-name-after" src="https://github.com/hashicorp/design-system/assets/788096/93ae227a-5cba-46e7-a854-3a34bd8bdc0c">


</td></tr>
</table>


***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
