### PR TITLE
Fix missing comma in v2 addon instructions

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,7 +13,7 @@ sassOptions: {
   precision: 4,
   includePaths: [
     './node_modules/@hashicorp/design-system-tokens/dist/products/css',
-    './node_modules/@hashicorp/ember-flight-icons/dist/styles'
+    './node_modules/@hashicorp/ember-flight-icons/dist/styles',
     './node_modules/@hashicorp/design-system-components/dist/styles',
   ],
 },

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -37,7 +37,7 @@ sassOptions: {
   precision: 4,
   includePaths: [
     './node_modules/@hashicorp/design-system-tokens/dist/products/css',
-    './node_modules/@hashicorp/ember-flight-icons/dist/styles'
+    './node_modules/@hashicorp/ember-flight-icons/dist/styles',
     './node_modules/@hashicorp/design-system-components/dist/styles',
   ],
 },

--- a/packages/ember-flight-icons/CHANGELOG.md
+++ b/packages/ember-flight-icons/CHANGELOG.md
@@ -13,7 +13,7 @@ sassOptions: {
   precision: 4,
   includePaths: [
     './node_modules/@hashicorp/design-system-tokens/dist/products/css',
-    './node_modules/@hashicorp/ember-flight-icons/dist/styles'
+    './node_modules/@hashicorp/ember-flight-icons/dist/styles',
     './node_modules/@hashicorp/design-system-components/dist/styles',
   ],
 },

--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -38,7 +38,7 @@ sassOptions: {
   precision: 4,
   includePaths: [
     './node_modules/@hashicorp/design-system-tokens/dist/products/css',
-    './node_modules/@hashicorp/ember-flight-icons/dist/styles'
+    './node_modules/@hashicorp/ember-flight-icons/dist/styles',
     './node_modules/@hashicorp/design-system-components/dist/styles',
   ],
 },

--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -25,7 +25,7 @@ sassOptions: {
   precision: 4,
   includePaths: [
     './node_modules/@hashicorp/design-system-tokens/dist/products/css',
-    './node_modules/@hashicorp/ember-flight-icons/dist/styles'
+    './node_modules/@hashicorp/ember-flight-icons/dist/styles',
     './node_modules/@hashicorp/design-system-components/dist/styles',
   ],
 },

--- a/website/docs/whats-new/release-notes/partials/ember-flight-icons.md
+++ b/website/docs/whats-new/release-notes/partials/ember-flight-icons.md
@@ -25,7 +25,7 @@ sassOptions: {
   precision: 4,
   includePaths: [
     './node_modules/@hashicorp/design-system-tokens/dist/products/css',
-    './node_modules/@hashicorp/ember-flight-icons/dist/styles'
+    './node_modules/@hashicorp/ember-flight-icons/dist/styles',
     './node_modules/@hashicorp/design-system-components/dist/styles',
   ],
 },


### PR DESCRIPTION
### :pushpin: Summary

Oops. Happened when we reordered the path entries.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
