### PR TITLE
[bugfix] adds aria-label to the copy snippet button

### DIFF
--- a/packages/components/src/components/hds/copy/snippet/index.hbs
+++ b/packages/components/src/components/hds/copy/snippet/index.hbs
@@ -6,6 +6,7 @@
   type="button"
   class={{this.classNames}}
   {{hds-clipboard text=@textToCopy onSuccess=this.onSuccess onError=this.onError}}
+  aria-label={{concat 'copy ' @textToCopy}}
   ...attributes
 >
   <Hds::Text::Code class="hds-copy-snippet__text" @tag="span" @size="100">

--- a/showcase/tests/integration/components/hds/copy/snippet/index-test.js
+++ b/showcase/tests/integration/components/hds/copy/snippet/index-test.js
@@ -39,6 +39,13 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet');
   });
 
+  test('it should render the component with an aria-label that includes the correct copy text', async function (assert) {
+    await render(
+      hbs`<Hds::Copy::Snippet id="test-copy-snippet" @textToCopy="this aria label" />`
+    );
+    assert.dom('#test-copy-snippet').hasAria('label', 'copy this aria label');
+  });
+
   // VARIANTS
 
   test('it should render the correct default component variation: primary color, idle status', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves the issue where there wasn't an appropriate `aria-label` on the copy snippet button. 
It also adds a test to ensure that it's there in the future.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3146](https://hashicorp.atlassian.net/browse/HDS-3146)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
