### PR TITLE
Design tokens for email

### DIFF
--- a/.changeset/chilled-ducks-march.md
+++ b/.changeset/chilled-ducks-march.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-tokens": minor
+---
+
+Added new pipeline to Style Dictionary for `cloud-email` - `email/sass-variables` to be used in email templating

--- a/packages/tokens/dist/cloud-email/helpers/color.css
+++ b/packages/tokens/dist/cloud-email/helpers/color.css
@@ -1,47 +1,47 @@
 /**
  * Do not edit directly
- * Generated on Thu, 29 Feb 2024 14:07:07 GMT
+ * Generated on Tue, 05 Mar 2024 09:58:47 GMT
  */
 
-.hds-border-primary { border: 1px solid var(--token-color-border-primary); }
-.hds-border-faint { border: 1px solid var(--token-color-border-faint); }
-.hds-border-strong { border: 1px solid var(--token-color-border-strong); }
-.hds-border-action { border: 1px solid var(--token-color-border-action); }
-.hds-border-highlight { border: 1px solid var(--token-color-border-highlight); }
-.hds-border-success { border: 1px solid var(--token-color-border-success); }
-.hds-border-warning { border: 1px solid var(--token-color-border-warning); }
-.hds-border-critical { border: 1px solid var(--token-color-border-critical); }
-.hds-foreground-strong { color: var(--token-color-foreground-strong); }
-.hds-foreground-primary { color: var(--token-color-foreground-primary); }
-.hds-foreground-faint { color: var(--token-color-foreground-faint); }
-.hds-foreground-high-contrast { color: var(--token-color-foreground-high-contrast); }
-.hds-foreground-disabled { color: var(--token-color-foreground-disabled); }
-.hds-foreground-action { color: var(--token-color-foreground-action); }
-.hds-foreground-action-hover { color: var(--token-color-foreground-action-hover); }
-.hds-foreground-action-active { color: var(--token-color-foreground-action-active); }
-.hds-foreground-highlight { color: var(--token-color-foreground-highlight); }
-.hds-foreground-highlight-on-surface { color: var(--token-color-foreground-highlight-on-surface); }
-.hds-foreground-highlight-high-contrast { color: var(--token-color-foreground-highlight-high-contrast); }
-.hds-foreground-success { color: var(--token-color-foreground-success); }
-.hds-foreground-success-on-surface { color: var(--token-color-foreground-success-on-surface); }
-.hds-foreground-success-high-contrast { color: var(--token-color-foreground-success-high-contrast); }
-.hds-foreground-warning { color: var(--token-color-foreground-warning); }
-.hds-foreground-warning-on-surface { color: var(--token-color-foreground-warning-on-surface); }
-.hds-foreground-warning-high-contrast { color: var(--token-color-foreground-warning-high-contrast); }
-.hds-foreground-critical { color: var(--token-color-foreground-critical); }
-.hds-foreground-critical-on-surface { color: var(--token-color-foreground-critical-on-surface); }
-.hds-foreground-critical-high-contrast { color: var(--token-color-foreground-critical-high-contrast); }
-.hds-page-primary { background-color: var(--token-color-page-primary); }
-.hds-page-faint { background-color: var(--token-color-page-faint); }
-.hds-surface-primary { background-color: var(--token-color-surface-primary); }
-.hds-surface-faint { background-color: var(--token-color-surface-faint); }
-.hds-surface-strong { background-color: var(--token-color-surface-strong); }
-.hds-surface-interactive { background-color: var(--token-color-surface-interactive); }
-.hds-surface-interactive-hover { background-color: var(--token-color-surface-interactive-hover); }
-.hds-surface-interactive-active { background-color: var(--token-color-surface-interactive-active); }
-.hds-surface-interactive-disabled { background-color: var(--token-color-surface-interactive-disabled); }
-.hds-surface-action { background-color: var(--token-color-surface-action); }
-.hds-surface-highlight { background-color: var(--token-color-surface-highlight); }
-.hds-surface-success { background-color: var(--token-color-surface-success); }
-.hds-surface-warning { background-color: var(--token-color-surface-warning); }
-.hds-surface-critical { background-color: var(--token-color-surface-critical); }
+.hds-border-primary { border: 1px solid #656a7633; }
+.hds-border-faint { border: 1px solid #656a761a; }
+.hds-border-strong { border: 1px solid #3b3d4566; }
+.hds-border-action { border: 1px solid #cce3fe; }
+.hds-border-highlight { border: 1px solid #ead2fe; }
+.hds-border-success { border: 1px solid #cceeda; }
+.hds-border-warning { border: 1px solid #fbeabf; }
+.hds-border-critical { border: 1px solid #fbd4d4; }
+.hds-foreground-strong { color: #0c0c0e; }
+.hds-foreground-primary { color: #3b3d45; }
+.hds-foreground-faint { color: #656a76; }
+.hds-foreground-high-contrast { color: #ffffff; }
+.hds-foreground-disabled { color: #8c909c; }
+.hds-foreground-action { color: #1060ff; }
+.hds-foreground-action-hover { color: #0c56e9; }
+.hds-foreground-action-active { color: #0046d1; }
+.hds-foreground-highlight { color: #a737ff; }
+.hds-foreground-highlight-on-surface { color: #911ced; }
+.hds-foreground-highlight-high-contrast { color: #42215b; }
+.hds-foreground-success { color: #008a22; }
+.hds-foreground-success-on-surface { color: #00781e; }
+.hds-foreground-success-high-contrast { color: #054220; }
+.hds-foreground-warning { color: #bb5a00; }
+.hds-foreground-warning-on-surface { color: #9e4b00; }
+.hds-foreground-warning-high-contrast { color: #542800; }
+.hds-foreground-critical { color: #e52228; }
+.hds-foreground-critical-on-surface { color: #c00005; }
+.hds-foreground-critical-high-contrast { color: #51130a; }
+.hds-page-primary { background-color: #ffffff; }
+.hds-page-faint { background-color: #fafafa; }
+.hds-surface-primary { background-color: #ffffff; }
+.hds-surface-faint { background-color: #fafafa; }
+.hds-surface-strong { background-color: #f1f2f3; }
+.hds-surface-interactive { background-color: #ffffff; }
+.hds-surface-interactive-hover { background-color: #f1f2f3; }
+.hds-surface-interactive-active { background-color: #dedfe3; }
+.hds-surface-interactive-disabled { background-color: #fafafa; }
+.hds-surface-action { background-color: #f2f8ff; }
+.hds-surface-highlight { background-color: #f9f2ff; }
+.hds-surface-success { background-color: #f2fbf6; }
+.hds-surface-warning { background-color: #fff9e8; }
+.hds-surface-critical { background-color: #fff5f5; }

--- a/packages/tokens/dist/cloud-email/helpers/color.css
+++ b/packages/tokens/dist/cloud-email/helpers/color.css
@@ -1,0 +1,47 @@
+/**
+ * Do not edit directly
+ * Generated on Thu, 29 Feb 2024 14:07:07 GMT
+ */
+
+.hds-border-primary { border: 1px solid var(--token-color-border-primary); }
+.hds-border-faint { border: 1px solid var(--token-color-border-faint); }
+.hds-border-strong { border: 1px solid var(--token-color-border-strong); }
+.hds-border-action { border: 1px solid var(--token-color-border-action); }
+.hds-border-highlight { border: 1px solid var(--token-color-border-highlight); }
+.hds-border-success { border: 1px solid var(--token-color-border-success); }
+.hds-border-warning { border: 1px solid var(--token-color-border-warning); }
+.hds-border-critical { border: 1px solid var(--token-color-border-critical); }
+.hds-foreground-strong { color: var(--token-color-foreground-strong); }
+.hds-foreground-primary { color: var(--token-color-foreground-primary); }
+.hds-foreground-faint { color: var(--token-color-foreground-faint); }
+.hds-foreground-high-contrast { color: var(--token-color-foreground-high-contrast); }
+.hds-foreground-disabled { color: var(--token-color-foreground-disabled); }
+.hds-foreground-action { color: var(--token-color-foreground-action); }
+.hds-foreground-action-hover { color: var(--token-color-foreground-action-hover); }
+.hds-foreground-action-active { color: var(--token-color-foreground-action-active); }
+.hds-foreground-highlight { color: var(--token-color-foreground-highlight); }
+.hds-foreground-highlight-on-surface { color: var(--token-color-foreground-highlight-on-surface); }
+.hds-foreground-highlight-high-contrast { color: var(--token-color-foreground-highlight-high-contrast); }
+.hds-foreground-success { color: var(--token-color-foreground-success); }
+.hds-foreground-success-on-surface { color: var(--token-color-foreground-success-on-surface); }
+.hds-foreground-success-high-contrast { color: var(--token-color-foreground-success-high-contrast); }
+.hds-foreground-warning { color: var(--token-color-foreground-warning); }
+.hds-foreground-warning-on-surface { color: var(--token-color-foreground-warning-on-surface); }
+.hds-foreground-warning-high-contrast { color: var(--token-color-foreground-warning-high-contrast); }
+.hds-foreground-critical { color: var(--token-color-foreground-critical); }
+.hds-foreground-critical-on-surface { color: var(--token-color-foreground-critical-on-surface); }
+.hds-foreground-critical-high-contrast { color: var(--token-color-foreground-critical-high-contrast); }
+.hds-page-primary { background-color: var(--token-color-page-primary); }
+.hds-page-faint { background-color: var(--token-color-page-faint); }
+.hds-surface-primary { background-color: var(--token-color-surface-primary); }
+.hds-surface-faint { background-color: var(--token-color-surface-faint); }
+.hds-surface-strong { background-color: var(--token-color-surface-strong); }
+.hds-surface-interactive { background-color: var(--token-color-surface-interactive); }
+.hds-surface-interactive-hover { background-color: var(--token-color-surface-interactive-hover); }
+.hds-surface-interactive-active { background-color: var(--token-color-surface-interactive-active); }
+.hds-surface-interactive-disabled { background-color: var(--token-color-surface-interactive-disabled); }
+.hds-surface-action { background-color: var(--token-color-surface-action); }
+.hds-surface-highlight { background-color: var(--token-color-surface-highlight); }
+.hds-surface-success { background-color: var(--token-color-surface-success); }
+.hds-surface-warning { background-color: var(--token-color-surface-warning); }
+.hds-surface-critical { background-color: var(--token-color-surface-critical); }

--- a/packages/tokens/dist/cloud-email/helpers/elevation.css
+++ b/packages/tokens/dist/cloud-email/helpers/elevation.css
@@ -1,18 +1,18 @@
 /**
  * Do not edit directly
- * Generated on Tue, 05 Mar 2024 08:51:10 GMT
+ * Generated on Tue, 05 Mar 2024 09:58:47 GMT
  */
 
-.hds-elevation-high { box-shadow: var(--token-elevation-high-box-shadow); }
-.hds-elevation-higher { box-shadow: var(--token-elevation-higher-box-shadow); }
-.hds-elevation-inset { box-shadow: var(--token-elevation-inset-box-shadow); }
-.hds-elevation-low { box-shadow: var(--token-elevation-low-box-shadow); }
-.hds-elevation-mid { box-shadow: var(--token-elevation-mid-box-shadow); }
-.hds-elevation-overlay { box-shadow: var(--token-elevation-overlay-box-shadow); }
-.hds-surface-inset { box-shadow: var(--token-surface-inset-box-shadow); }
-.hds-surface-base { box-shadow: var(--token-surface-base-box-shadow); }
-.hds-surface-low { box-shadow: var(--token-surface-low-box-shadow); }
-.hds-surface-mid { box-shadow: var(--token-surface-mid-box-shadow); }
-.hds-surface-high { box-shadow: var(--token-surface-high-box-shadow); }
-.hds-surface-higher { box-shadow: var(--token-surface-higher-box-shadow); }
-.hds-surface-overlay { box-shadow: var(--token-surface-overlay-box-shadow); }
+.hds-elevation-high { box-shadow: 0px 2px 3px 0px #656a7626, 0px 16px 16px -10px #656a7633); }
+.hds-elevation-higher { box-shadow: 0px 2px 3px 0px #656a761a, 0px 12px 28px 0px #656a7640); }
+.hds-elevation-inset { box-shadow: inset 0px 1px 2px 1px #656a761a); }
+.hds-elevation-low { box-shadow: 0px 1px 1px 0px #656a760d, 0px 2px 2px 0px #656a760d); }
+.hds-elevation-mid { box-shadow: 0px 2px 3px 0px #656a761a, 0px 8px 16px -10px #656a7633); }
+.hds-elevation-overlay { box-shadow: 0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559); }
+.hds-surface-inset { box-shadow: inset 0 0 0 1px #656a764d, inset 0px 1px 2px 1px #656a761a; }
+.hds-surface-base { box-shadow: 0 0 0 1px #656a7633; }
+.hds-surface-low { box-shadow: 0 0 0 1px #656a7626, 0px 1px 1px 0px #656a760d, 0px 2px 2px 0px #656a760d; }
+.hds-surface-mid { box-shadow: 0 0 0 1px #656a7626, 0px 2px 3px 0px #656a761a, 0px 8px 16px -10px #656a7633; }
+.hds-surface-high { box-shadow: 0 0 0 1px #656a7640, 0px 2px 3px 0px #656a7626, 0px 16px 16px -10px #656a7633; }
+.hds-surface-higher { box-shadow: 0 0 0 1px #656a7633, 0px 2px 3px 0px #656a761a, 0px 12px 28px 0px #656a7640; }
+.hds-surface-overlay { box-shadow: 0 0 0 1px #3b3d4540, 0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559; }

--- a/packages/tokens/dist/cloud-email/helpers/elevation.css
+++ b/packages/tokens/dist/cloud-email/helpers/elevation.css
@@ -1,0 +1,18 @@
+/**
+ * Do not edit directly
+ * Generated on Tue, 05 Mar 2024 08:51:10 GMT
+ */
+
+.hds-elevation-high { box-shadow: var(--token-elevation-high-box-shadow); }
+.hds-elevation-higher { box-shadow: var(--token-elevation-higher-box-shadow); }
+.hds-elevation-inset { box-shadow: var(--token-elevation-inset-box-shadow); }
+.hds-elevation-low { box-shadow: var(--token-elevation-low-box-shadow); }
+.hds-elevation-mid { box-shadow: var(--token-elevation-mid-box-shadow); }
+.hds-elevation-overlay { box-shadow: var(--token-elevation-overlay-box-shadow); }
+.hds-surface-inset { box-shadow: var(--token-surface-inset-box-shadow); }
+.hds-surface-base { box-shadow: var(--token-surface-base-box-shadow); }
+.hds-surface-low { box-shadow: var(--token-surface-low-box-shadow); }
+.hds-surface-mid { box-shadow: var(--token-surface-mid-box-shadow); }
+.hds-surface-high { box-shadow: var(--token-surface-high-box-shadow); }
+.hds-surface-higher { box-shadow: var(--token-surface-higher-box-shadow); }
+.hds-surface-overlay { box-shadow: var(--token-surface-overlay-box-shadow); }

--- a/packages/tokens/dist/cloud-email/helpers/focus-ring.css
+++ b/packages/tokens/dist/cloud-email/helpers/focus-ring.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly
- * Generated on Tue, 05 Mar 2024 08:51:10 GMT
+ * Generated on Tue, 05 Mar 2024 09:58:47 GMT
  */
 
-.hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }
-.hds-focus-ring-critical-box-shadow { box-shadow: var(--token-focus-ring-critical-box-shadow); }
+.hds-focus-ring-action-box-shadow { box-shadow: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff; }
+.hds-focus-ring-critical-box-shadow { box-shadow: inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578; }

--- a/packages/tokens/dist/cloud-email/helpers/focus-ring.css
+++ b/packages/tokens/dist/cloud-email/helpers/focus-ring.css
@@ -1,0 +1,7 @@
+/**
+ * Do not edit directly
+ * Generated on Tue, 05 Mar 2024 08:51:10 GMT
+ */
+
+.hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }
+.hds-focus-ring-critical-box-shadow { box-shadow: var(--token-focus-ring-critical-box-shadow); }

--- a/packages/tokens/dist/cloud-email/helpers/typography.css
+++ b/packages/tokens/dist/cloud-email/helpers/typography.css
@@ -1,0 +1,23 @@
+/**
+ * Do not edit directly
+ * Generated on Thu, 29 Feb 2024 14:07:07 GMT
+ */
+
+.hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }
+.hds-font-family-sans-text { font-family: var(--token-typography-font-stack-text); }
+.hds-font-family-mono-code { font-family: var(--token-typography-font-stack-code); }
+.hds-font-weight-regular { font-weight: 400; }
+.hds-font-weight-medium { font-weight: 500; }
+.hds-font-weight-semibold { font-weight: 600; }
+.hds-font-weight-bold { font-weight: 700; }
+.hds-typography-display-500 { font-family: var(--token-typography-display-500-font-family); font-size: var(--token-typography-display-500-font-size); line-height: var(--token-typography-display-500-line-height); margin: 0; padding: 0; }
+.hds-typography-display-400 { font-family: var(--token-typography-display-400-font-family); font-size: var(--token-typography-display-400-font-size); line-height: var(--token-typography-display-400-line-height); margin: 0; padding: 0; }
+.hds-typography-display-300 { font-family: var(--token-typography-display-300-font-family); font-size: var(--token-typography-display-300-font-size); line-height: var(--token-typography-display-300-line-height); margin: 0; padding: 0; }
+.hds-typography-display-200 { font-family: var(--token-typography-display-200-font-family); font-size: var(--token-typography-display-200-font-size); line-height: var(--token-typography-display-200-line-height); margin: 0; padding: 0; }
+.hds-typography-display-100 { font-family: var(--token-typography-display-100-font-family); font-size: var(--token-typography-display-100-font-size); line-height: var(--token-typography-display-100-line-height); margin: 0; padding: 0; }
+.hds-typography-body-300 { font-family: var(--token-typography-body-300-font-family); font-size: var(--token-typography-body-300-font-size); line-height: var(--token-typography-body-300-line-height); margin: 0; padding: 0; }
+.hds-typography-body-200 { font-family: var(--token-typography-body-200-font-family); font-size: var(--token-typography-body-200-font-size); line-height: var(--token-typography-body-200-line-height); margin: 0; padding: 0; }
+.hds-typography-body-100 { font-family: var(--token-typography-body-100-font-family); font-size: var(--token-typography-body-100-font-size); line-height: var(--token-typography-body-100-line-height); margin: 0; padding: 0; }
+.hds-typography-code-100 { font-family: var(--token-typography-code-100-font-family); font-size: var(--token-typography-code-100-font-size); line-height: var(--token-typography-code-100-line-height); margin: 0; padding: 0; }
+.hds-typography-code-200 { font-family: var(--token-typography-code-200-font-family); font-size: var(--token-typography-code-200-font-size); line-height: var(--token-typography-code-200-line-height); margin: 0; padding: 0; }
+.hds-typography-code-300 { font-family: var(--token-typography-code-300-font-family); font-size: var(--token-typography-code-300-font-size); line-height: var(--token-typography-code-300-line-height); margin: 0; padding: 0; }

--- a/packages/tokens/dist/cloud-email/helpers/typography.css
+++ b/packages/tokens/dist/cloud-email/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 05 Mar 2024 09:58:47 GMT
+ * Generated on Tue, 05 Mar 2024 10:10:42 GMT
  */
 
 .hds-font-family-sans-display { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; }
@@ -10,14 +10,14 @@
 .hds-font-weight-medium { font-weight: 500; }
 .hds-font-weight-semibold { font-weight: 600; }
 .hds-font-weight-bold { font-weight: 700; }
-.hds-typography-display-500 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 1.875rem; line-height: 1.2666; margin: 0; padding: 0; }
-.hds-typography-display-400 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 1.5rem; line-height: 1.3333; margin: 0; padding: 0; }
-.hds-typography-display-300 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 1.125rem; line-height: 1.3333; margin: 0; padding: 0; }
-.hds-typography-display-200 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 1rem; line-height: 1.5; margin: 0; padding: 0; }
-.hds-typography-display-100 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 0.8125rem; line-height: 1.3846; margin: 0; padding: 0; }
-.hds-typography-body-300 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 1rem; line-height: 1.5; margin: 0; padding: 0; }
-.hds-typography-body-200 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 0.875rem; line-height: 1.4286; margin: 0; padding: 0; }
-.hds-typography-body-100 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 0.8125rem; line-height: 1.3846; margin: 0; padding: 0; }
-.hds-typography-code-100 { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 0.8125rem; line-height: 1.23; margin: 0; padding: 0; }
-.hds-typography-code-200 { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 0.875rem; line-height: 1.125; margin: 0; padding: 0; }
-.hds-typography-code-300 { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 1rem; line-height: 1.25; margin: 0; padding: 0; }
+.hds-typography-display-500 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 30px; line-height: 1.2666; margin: 0; padding: 0; }
+.hds-typography-display-400 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 24px; line-height: 1.3333; margin: 0; padding: 0; }
+.hds-typography-display-300 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 18px; line-height: 1.3333; margin: 0; padding: 0; }
+.hds-typography-display-200 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 16px; line-height: 1.5; margin: 0; padding: 0; }
+.hds-typography-display-100 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 13px; line-height: 1.3846; margin: 0; padding: 0; }
+.hds-typography-body-300 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 16px; line-height: 1.5; margin: 0; padding: 0; }
+.hds-typography-body-200 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 14px; line-height: 1.4286; margin: 0; padding: 0; }
+.hds-typography-body-100 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 13px; line-height: 1.3846; margin: 0; padding: 0; }
+.hds-typography-code-100 { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 13px; line-height: 1.23; margin: 0; padding: 0; }
+.hds-typography-code-200 { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 14px; line-height: 1.125; margin: 0; padding: 0; }
+.hds-typography-code-300 { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 16px; line-height: 1.25; margin: 0; padding: 0; }

--- a/packages/tokens/dist/cloud-email/helpers/typography.css
+++ b/packages/tokens/dist/cloud-email/helpers/typography.css
@@ -1,23 +1,23 @@
 /**
  * Do not edit directly
- * Generated on Thu, 29 Feb 2024 14:07:07 GMT
+ * Generated on Tue, 05 Mar 2024 09:58:47 GMT
  */
 
-.hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }
-.hds-font-family-sans-text { font-family: var(--token-typography-font-stack-text); }
-.hds-font-family-mono-code { font-family: var(--token-typography-font-stack-code); }
+.hds-font-family-sans-display { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; }
+.hds-font-family-sans-text { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; }
+.hds-font-family-mono-code { font-family: ui-monospace, Menlo, Consolas, monospace; }
 .hds-font-weight-regular { font-weight: 400; }
 .hds-font-weight-medium { font-weight: 500; }
 .hds-font-weight-semibold { font-weight: 600; }
 .hds-font-weight-bold { font-weight: 700; }
-.hds-typography-display-500 { font-family: var(--token-typography-display-500-font-family); font-size: var(--token-typography-display-500-font-size); line-height: var(--token-typography-display-500-line-height); margin: 0; padding: 0; }
-.hds-typography-display-400 { font-family: var(--token-typography-display-400-font-family); font-size: var(--token-typography-display-400-font-size); line-height: var(--token-typography-display-400-line-height); margin: 0; padding: 0; }
-.hds-typography-display-300 { font-family: var(--token-typography-display-300-font-family); font-size: var(--token-typography-display-300-font-size); line-height: var(--token-typography-display-300-line-height); margin: 0; padding: 0; }
-.hds-typography-display-200 { font-family: var(--token-typography-display-200-font-family); font-size: var(--token-typography-display-200-font-size); line-height: var(--token-typography-display-200-line-height); margin: 0; padding: 0; }
-.hds-typography-display-100 { font-family: var(--token-typography-display-100-font-family); font-size: var(--token-typography-display-100-font-size); line-height: var(--token-typography-display-100-line-height); margin: 0; padding: 0; }
-.hds-typography-body-300 { font-family: var(--token-typography-body-300-font-family); font-size: var(--token-typography-body-300-font-size); line-height: var(--token-typography-body-300-line-height); margin: 0; padding: 0; }
-.hds-typography-body-200 { font-family: var(--token-typography-body-200-font-family); font-size: var(--token-typography-body-200-font-size); line-height: var(--token-typography-body-200-line-height); margin: 0; padding: 0; }
-.hds-typography-body-100 { font-family: var(--token-typography-body-100-font-family); font-size: var(--token-typography-body-100-font-size); line-height: var(--token-typography-body-100-line-height); margin: 0; padding: 0; }
-.hds-typography-code-100 { font-family: var(--token-typography-code-100-font-family); font-size: var(--token-typography-code-100-font-size); line-height: var(--token-typography-code-100-line-height); margin: 0; padding: 0; }
-.hds-typography-code-200 { font-family: var(--token-typography-code-200-font-family); font-size: var(--token-typography-code-200-font-size); line-height: var(--token-typography-code-200-line-height); margin: 0; padding: 0; }
-.hds-typography-code-300 { font-family: var(--token-typography-code-300-font-family); font-size: var(--token-typography-code-300-font-size); line-height: var(--token-typography-code-300-line-height); margin: 0; padding: 0; }
+.hds-typography-display-500 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 1.875rem; line-height: 1.2666; margin: 0; padding: 0; }
+.hds-typography-display-400 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 1.5rem; line-height: 1.3333; margin: 0; padding: 0; }
+.hds-typography-display-300 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 1.125rem; line-height: 1.3333; margin: 0; padding: 0; }
+.hds-typography-display-200 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 1rem; line-height: 1.5; margin: 0; padding: 0; }
+.hds-typography-display-100 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 0.8125rem; line-height: 1.3846; margin: 0; padding: 0; }
+.hds-typography-body-300 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 1rem; line-height: 1.5; margin: 0; padding: 0; }
+.hds-typography-body-200 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 0.875rem; line-height: 1.4286; margin: 0; padding: 0; }
+.hds-typography-body-100 { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 0.8125rem; line-height: 1.3846; margin: 0; padding: 0; }
+.hds-typography-code-100 { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 0.8125rem; line-height: 1.23; margin: 0; padding: 0; }
+.hds-typography-code-200 { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 0.875rem; line-height: 1.125; margin: 0; padding: 0; }
+.hds-typography-code-300 { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 1rem; line-height: 1.25; margin: 0; padding: 0; }

--- a/packages/tokens/dist/cloud-email/tokens.scss
+++ b/packages/tokens/dist/cloud-email/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 29 Feb 2024 10:44:03 GMT
+// Generated on Tue, 05 Mar 2024 08:51:10 GMT
 
 $token-color-palette-blue-500: #1c345f;
 $token-color-palette-blue-400: #0046d1;
@@ -176,6 +176,21 @@ $token-color-waypoint-gradient-primary-start: #cbf1f3;
 $token-color-waypoint-gradient-primary-stop: #62d4dc;
 $token-color-waypoint-gradient-faint-start: #f6feff; // this is the 'waypoint-50' value at 25% opacity on white
 $token-color-waypoint-gradient-faint-stop: #e0fcff;
+$token-elevation-high-box-shadow: 0px 2px 3px 0px #656a7626, 0px 16px 16px -10px #656a7633;
+$token-elevation-higher-box-shadow: 0px 2px 3px 0px #656a761a, 0px 12px 28px 0px #656a7640;
+$token-elevation-inset-box-shadow: inset 0px 1px 2px 1px #656a761a;
+$token-elevation-low-box-shadow: 0px 1px 1px 0px #656a760d, 0px 2px 2px 0px #656a760d;
+$token-elevation-mid-box-shadow: 0px 2px 3px 0px #656a761a, 0px 8px 16px -10px #656a7633;
+$token-elevation-overlay-box-shadow: 0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559;
+$token-surface-inset-box-shadow: inset 0 0 0 1px #656a764d, inset 0px 1px 2px 1px #656a761a;
+$token-surface-base-box-shadow: 0 0 0 1px #656a7633;
+$token-surface-low-box-shadow: 0 0 0 1px #656a7626, 0px 1px 1px 0px #656a760d, 0px 2px 2px 0px #656a760d;
+$token-surface-mid-box-shadow: 0 0 0 1px #656a7626, 0px 2px 3px 0px #656a761a, 0px 8px 16px -10px #656a7633;
+$token-surface-high-box-shadow: 0 0 0 1px #656a7640, 0px 2px 3px 0px #656a7626, 0px 16px 16px -10px #656a7633;
+$token-surface-higher-box-shadow: 0 0 0 1px #656a7633, 0px 2px 3px 0px #656a761a, 0px 12px 28px 0px #656a7640;
+$token-surface-overlay-box-shadow: 0 0 0 1px #3b3d4540, 0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559;
+$token-focus-ring-action-box-shadow: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff;
+$token-focus-ring-critical-box-shadow: inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578;
 $token-typography-font-stack-display: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
 $token-typography-font-stack-text: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
 $token-typography-font-stack-code: ui-monospace, Menlo, Consolas, monospace;

--- a/packages/tokens/dist/cloud-email/tokens.scss
+++ b/packages/tokens/dist/cloud-email/tokens.scss
@@ -1,0 +1,220 @@
+
+// Do not edit directly
+// Generated on Thu, 29 Feb 2024 10:44:03 GMT
+
+$token-color-palette-blue-500: #1c345f;
+$token-color-palette-blue-400: #0046d1;
+$token-color-palette-blue-300: #0c56e9;
+$token-color-palette-blue-200: #1060ff;
+$token-color-palette-blue-100: #cce3fe;
+$token-color-palette-blue-50: #f2f8ff;
+$token-color-palette-purple-500: #42215b;
+$token-color-palette-purple-400: #7b00db;
+$token-color-palette-purple-300: #911ced;
+$token-color-palette-purple-200: #a737ff;
+$token-color-palette-purple-100: #ead2fe;
+$token-color-palette-purple-50: #f9f2ff;
+$token-color-palette-green-500: #054220;
+$token-color-palette-green-400: #006619;
+$token-color-palette-green-300: #00781e;
+$token-color-palette-green-200: #008a22;
+$token-color-palette-green-100: #cceeda;
+$token-color-palette-green-50: #f2fbf6;
+$token-color-palette-amber-500: #542800;
+$token-color-palette-amber-400: #803d00;
+$token-color-palette-amber-300: #9e4b00;
+$token-color-palette-amber-200: #bb5a00;
+$token-color-palette-amber-100: #fbeabf;
+$token-color-palette-amber-50: #fff9e8;
+$token-color-palette-red-500: #51130a;
+$token-color-palette-red-400: #940004;
+$token-color-palette-red-300: #c00005;
+$token-color-palette-red-200: #e52228;
+$token-color-palette-red-100: #fbd4d4;
+$token-color-palette-red-50: #fff5f5;
+$token-color-palette-neutral-700: #0c0c0e;
+$token-color-palette-neutral-600: #3b3d45;
+$token-color-palette-neutral-500: #656a76;
+$token-color-palette-neutral-400: #8c909c;
+$token-color-palette-neutral-300: #c2c5cb;
+$token-color-palette-neutral-200: #dedfe3;
+$token-color-palette-neutral-100: #f1f2f3;
+$token-color-palette-neutral-50: #fafafa;
+$token-color-palette-neutral-0: #ffffff;
+$token-color-palette-alpha-300: #3b3d4566;
+$token-color-palette-alpha-200: #656a7633;
+$token-color-palette-alpha-100: #656a761a;
+$token-color-border-primary: #656a7633;
+$token-color-border-faint: #656a761a;
+$token-color-border-strong: #3b3d4566;
+$token-color-border-action: #cce3fe;
+$token-color-border-highlight: #ead2fe;
+$token-color-border-success: #cceeda;
+$token-color-border-warning: #fbeabf;
+$token-color-border-critical: #fbd4d4;
+$token-color-focus-action-internal: #0c56e9;
+$token-color-focus-action-external: #5990ff; // this is a special color used only for the focus style, to pass color contrast for a11y purpose
+$token-color-focus-critical-internal: #c00005;
+$token-color-focus-critical-external: #dd7578; // this is a special color used only for the focus style, to pass color contrast for a11y purpose
+$token-color-foreground-strong: #0c0c0e;
+$token-color-foreground-primary: #3b3d45;
+$token-color-foreground-faint: #656a76;
+$token-color-foreground-high-contrast: #ffffff;
+$token-color-foreground-disabled: #8c909c;
+$token-color-foreground-action: #1060ff;
+$token-color-foreground-action-hover: #0c56e9;
+$token-color-foreground-action-active: #0046d1;
+$token-color-foreground-highlight: #a737ff;
+$token-color-foreground-highlight-on-surface: #911ced;
+$token-color-foreground-highlight-high-contrast: #42215b;
+$token-color-foreground-success: #008a22;
+$token-color-foreground-success-on-surface: #00781e;
+$token-color-foreground-success-high-contrast: #054220;
+$token-color-foreground-warning: #bb5a00;
+$token-color-foreground-warning-on-surface: #9e4b00;
+$token-color-foreground-warning-high-contrast: #542800;
+$token-color-foreground-critical: #e52228;
+$token-color-foreground-critical-on-surface: #c00005;
+$token-color-foreground-critical-high-contrast: #51130a;
+$token-color-page-primary: #ffffff;
+$token-color-page-faint: #fafafa;
+$token-color-surface-primary: #ffffff;
+$token-color-surface-faint: #fafafa;
+$token-color-surface-strong: #f1f2f3;
+$token-color-surface-interactive: #ffffff;
+$token-color-surface-interactive-hover: #f1f2f3;
+$token-color-surface-interactive-active: #dedfe3;
+$token-color-surface-interactive-disabled: #fafafa;
+$token-color-surface-action: #f2f8ff;
+$token-color-surface-highlight: #f9f2ff;
+$token-color-surface-success: #f2fbf6;
+$token-color-surface-warning: #fff9e8;
+$token-color-surface-critical: #fff5f5;
+$token-color-hashicorp-brand: #000000;
+$token-color-boundary-brand: #f24c53;
+$token-color-boundary-foreground: #cf2d32;
+$token-color-boundary-surface: #ffecec;
+$token-color-boundary-border: #fbd7d8;
+$token-color-boundary-gradient-primary-start: #f97076;
+$token-color-boundary-gradient-primary-stop: #db363b;
+$token-color-boundary-gradient-faint-start: #fffafa; // this is the 'boundary-50' value at 25% opacity on white
+$token-color-boundary-gradient-faint-stop: #ffecec;
+$token-color-consul-brand: #e03875;
+$token-color-consul-foreground: #d01c5b;
+$token-color-consul-surface: #ffe9f1;
+$token-color-consul-border: #ffcede;
+$token-color-consul-gradient-primary-start: #ff99be;
+$token-color-consul-gradient-primary-stop: #da306e;
+$token-color-consul-gradient-faint-start: #fff9fb; // this is the 'consul-50' value at 25% opacity on white
+$token-color-consul-gradient-faint-stop: #ffe9f1;
+$token-color-hcp-brand: #000000;
+$token-color-nomad-brand: #06d092;
+$token-color-nomad-foreground: #008661;
+$token-color-nomad-surface: #d3fdeb;
+$token-color-nomad-border: #bff3dd;
+$token-color-nomad-gradient-primary-start: #bff3dd;
+$token-color-nomad-gradient-primary-stop: #60dea9;
+$token-color-nomad-gradient-faint-start: #f3fff9; // this is the 'nomad-50' value at 25% opacity on white
+$token-color-nomad-gradient-faint-stop: #d3fdeb;
+$token-color-packer-brand: #02a8ef;
+$token-color-packer-foreground: #007eb4;
+$token-color-packer-surface: #d4f2ff;
+$token-color-packer-border: #b4e4ff;
+$token-color-packer-gradient-primary-start: #b4e4ff;
+$token-color-packer-gradient-primary-stop: #63d0ff;
+$token-color-packer-gradient-faint-start: #f3fcff; // this is the 'packer-50' value at 25% opacity on white
+$token-color-packer-gradient-faint-stop: #d4f2ff;
+$token-color-terraform-brand: #7b42bc;
+$token-color-terraform-brand-on-dark: #a067da; // this is an alternative brand color meant to be used on dark backgrounds
+$token-color-terraform-foreground: #773cb4;
+$token-color-terraform-surface: #f4ecff;
+$token-color-terraform-border: #ebdbfc;
+$token-color-terraform-gradient-primary-start: #bb8deb;
+$token-color-terraform-gradient-primary-stop: #844fba;
+$token-color-terraform-gradient-faint-start: #fcfaff; // this is the 'terraform-50' value at 25% opacity on white
+$token-color-terraform-gradient-faint-stop: #f4ecff;
+$token-color-vagrant-brand: #1868f2;
+$token-color-vagrant-foreground: #1c61d8;
+$token-color-vagrant-surface: #d6ebff;
+$token-color-vagrant-border: #c7dbfc;
+$token-color-vagrant-gradient-primary-start: #c7dbfc;
+$token-color-vagrant-gradient-primary-stop: #7dadff;
+$token-color-vagrant-gradient-faint-start: #f4faff; // this is the 'vagrant-50' value at 25% opacity on white
+$token-color-vagrant-gradient-faint-stop: #d6ebff;
+$token-color-vault-radar-brand: #ffcf25;
+$token-color-vault-radar-brand-alt: #000000; // this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault radar would not work
+$token-color-vault-radar-foreground: #9a6f00;
+$token-color-vault-radar-surface: #fff9cf;
+$token-color-vault-radar-border: #feec7b;
+$token-color-vault-radar-gradient-primary-start: #feec7b;
+$token-color-vault-radar-gradient-primary-stop: #ffe543;
+$token-color-vault-radar-gradient-faint-start: #fffdf2; // this is the 'vault-radar-50' value at 25% opacity on white
+$token-color-vault-radar-gradient-faint-stop: #fff9cf;
+$token-color-vault-secrets-brand: #ffcf25;
+$token-color-vault-secrets-brand-alt: #000000; // this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault Secrets would not work
+$token-color-vault-secrets-foreground: #9a6f00;
+$token-color-vault-secrets-surface: #fff9cf;
+$token-color-vault-secrets-border: #feec7b;
+$token-color-vault-secrets-gradient-primary-start: #feec7b;
+$token-color-vault-secrets-gradient-primary-stop: #ffe543;
+$token-color-vault-secrets-gradient-faint-start: #fffdf2; // this is the 'vault-secrets-50' value at 25% opacity on white
+$token-color-vault-secrets-gradient-faint-stop: #fff9cf;
+$token-color-vault-brand: #ffcf25;
+$token-color-vault-brand-alt: #000000; // this is a special “alternative” color, used as an exception in some contexts where the normal “brand” color for Vault would not work
+$token-color-vault-foreground: #9a6f00;
+$token-color-vault-surface: #fff9cf;
+$token-color-vault-border: #feec7b;
+$token-color-vault-gradient-primary-start: #feec7b;
+$token-color-vault-gradient-primary-stop: #ffe543;
+$token-color-vault-gradient-faint-start: #fffdf2; // this is the 'vault-50' value at 25% opacity on white
+$token-color-vault-gradient-faint-stop: #fff9cf;
+$token-color-waypoint-brand: #14c6cb;
+$token-color-waypoint-foreground: #008196;
+$token-color-waypoint-surface: #e0fcff;
+$token-color-waypoint-border: #cbf1f3;
+$token-color-waypoint-gradient-primary-start: #cbf1f3;
+$token-color-waypoint-gradient-primary-stop: #62d4dc;
+$token-color-waypoint-gradient-faint-start: #f6feff; // this is the 'waypoint-50' value at 25% opacity on white
+$token-color-waypoint-gradient-faint-stop: #e0fcff;
+$token-typography-font-stack-display: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$token-typography-font-stack-text: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$token-typography-font-stack-code: ui-monospace, Menlo, Consolas, monospace;
+$token-typography-font-weight-regular: 400;
+$token-typography-font-weight-medium: 500;
+$token-typography-font-weight-semibold: 600;
+$token-typography-font-weight-bold: 700;
+$token-typography-display-500-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$token-typography-display-500-font-size: 1.875rem; // 30px/1.875rem
+$token-typography-display-500-line-height: 1.2666; // 38px
+$token-typography-display-400-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$token-typography-display-400-font-size: 1.5rem; // 24px/1.5rem
+$token-typography-display-400-line-height: 1.3333; // 32px
+$token-typography-display-300-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$token-typography-display-300-font-size: 1.125rem; // 18px/1.125rem
+$token-typography-display-300-line-height: 1.3333; // 24px
+$token-typography-display-300-letter-spacing: -0.5px; // this is `tracking`
+$token-typography-display-200-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$token-typography-display-200-font-size: 1rem; // 16px/1rem
+$token-typography-display-200-line-height: 1.5; // 24px
+$token-typography-display-200-letter-spacing: -0.5px; // this is `tracking`
+$token-typography-display-100-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$token-typography-display-100-font-size: 0.8125rem; // 13px/0.8125rem
+$token-typography-display-100-line-height: 1.3846; // 18px
+$token-typography-body-300-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$token-typography-body-300-font-size: 1rem; // 16px/1rem
+$token-typography-body-300-line-height: 1.5; // 24px
+$token-typography-body-200-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$token-typography-body-200-font-size: 0.875rem; // 14px/0.875rem
+$token-typography-body-200-line-height: 1.4286; // 20px
+$token-typography-body-100-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$token-typography-body-100-font-size: 0.8125rem; // 13px/0.8125rem
+$token-typography-body-100-line-height: 1.3846; // 18px
+$token-typography-code-100-font-family: ui-monospace, Menlo, Consolas, monospace;
+$token-typography-code-100-font-size: 0.8125rem; // 13px/0.8125rem
+$token-typography-code-100-line-height: 1.23; // 16px
+$token-typography-code-200-font-family: ui-monospace, Menlo, Consolas, monospace;
+$token-typography-code-200-font-size: 0.875rem; // 14px/0.875rem
+$token-typography-code-200-line-height: 1.125; // 18px
+$token-typography-code-300-font-family: ui-monospace, Menlo, Consolas, monospace;
+$token-typography-code-300-font-size: 1rem; // 16px/1rem
+$token-typography-code-300-line-height: 1.25; // 20px

--- a/packages/tokens/dist/cloud-email/tokens.scss
+++ b/packages/tokens/dist/cloud-email/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 05 Mar 2024 08:51:10 GMT
+// Generated on Tue, 05 Mar 2024 10:10:42 GMT
 
 $token-color-palette-blue-500: #1c345f;
 $token-color-palette-blue-400: #0046d1;
@@ -199,37 +199,37 @@ $token-typography-font-weight-medium: 500;
 $token-typography-font-weight-semibold: 600;
 $token-typography-font-weight-bold: 700;
 $token-typography-display-500-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-$token-typography-display-500-font-size: 1.875rem; // 30px/1.875rem
+$token-typography-display-500-font-size: 30px; // 30px/1.875rem
 $token-typography-display-500-line-height: 1.2666; // 38px
 $token-typography-display-400-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-$token-typography-display-400-font-size: 1.5rem; // 24px/1.5rem
+$token-typography-display-400-font-size: 24px; // 24px/1.5rem
 $token-typography-display-400-line-height: 1.3333; // 32px
 $token-typography-display-300-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-$token-typography-display-300-font-size: 1.125rem; // 18px/1.125rem
+$token-typography-display-300-font-size: 18px; // 18px/1.125rem
 $token-typography-display-300-line-height: 1.3333; // 24px
 $token-typography-display-300-letter-spacing: -0.5px; // this is `tracking`
 $token-typography-display-200-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-$token-typography-display-200-font-size: 1rem; // 16px/1rem
+$token-typography-display-200-font-size: 16px; // 16px/1rem
 $token-typography-display-200-line-height: 1.5; // 24px
 $token-typography-display-200-letter-spacing: -0.5px; // this is `tracking`
 $token-typography-display-100-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-$token-typography-display-100-font-size: 0.8125rem; // 13px/0.8125rem
+$token-typography-display-100-font-size: 13px; // 13px/0.8125rem
 $token-typography-display-100-line-height: 1.3846; // 18px
 $token-typography-body-300-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-$token-typography-body-300-font-size: 1rem; // 16px/1rem
+$token-typography-body-300-font-size: 16px; // 16px/1rem
 $token-typography-body-300-line-height: 1.5; // 24px
 $token-typography-body-200-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-$token-typography-body-200-font-size: 0.875rem; // 14px/0.875rem
+$token-typography-body-200-font-size: 14px; // 14px/0.875rem
 $token-typography-body-200-line-height: 1.4286; // 20px
 $token-typography-body-100-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-$token-typography-body-100-font-size: 0.8125rem; // 13px/0.8125rem
+$token-typography-body-100-font-size: 13px; // 13px/0.8125rem
 $token-typography-body-100-line-height: 1.3846; // 18px
 $token-typography-code-100-font-family: ui-monospace, Menlo, Consolas, monospace;
-$token-typography-code-100-font-size: 0.8125rem; // 13px/0.8125rem
+$token-typography-code-100-font-size: 13px; // 13px/0.8125rem
 $token-typography-code-100-line-height: 1.23; // 16px
 $token-typography-code-200-font-family: ui-monospace, Menlo, Consolas, monospace;
-$token-typography-code-200-font-size: 0.875rem; // 14px/0.875rem
+$token-typography-code-200-font-size: 14px; // 14px/0.875rem
 $token-typography-code-200-line-height: 1.125; // 18px
 $token-typography-code-300-font-family: ui-monospace, Menlo, Consolas, monospace;
-$token-typography-code-300-font-size: 1rem; // 16px/1rem
+$token-typography-code-300-font-size: 16px; // 16px/1rem
 $token-typography-code-300-line-height: 1.25; // 20px

--- a/packages/tokens/scripts/build-parts/generateColorHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateColorHelpers.ts
@@ -9,7 +9,7 @@ import { PREFIX } from './generateCssHelpers';
 
 type Helpers = string[];
 
-export function generateColorHelpers(tokens: TransformedToken[]): Helpers {
+export function generateColorHelpers(tokens: TransformedToken[], outputCssVars: boolean): Helpers {
 
     const helpers: Helpers = [];
 
@@ -18,19 +18,20 @@ export function generateColorHelpers(tokens: TransformedToken[]): Helpers {
         if (!(token.attributes?.category === 'color')) return;
 
         const group = token.attributes.type || '';
+        const value = outputCssVars ? `var(--${token.name})` : token.value;
 
         if (['foreground', 'page', 'surface', 'border'].includes(group)) {
             const context = token.path[1];
             const name = token.path[2];
             if (context === 'foreground') {
-                helpers.push(`.${PREFIX}-${context}-${name} { color: var(--${token.name}); }`)
+                helpers.push(`.${PREFIX}-${context}-${name} { color: ${value}; }`)
             }
             if (context === 'page' || context === 'surface') {
-                helpers.push(`.${PREFIX}-${context}-${name} { background-color: var(--${token.name}); }`)
+                helpers.push(`.${PREFIX}-${context}-${name} { background-color: ${value}; }`)
             }
             if (context === 'border') {
                 // notice: we assume a 1px border (if a user needs a different border width, and want to use the helper, they have to apply an override)
-                helpers.push(`.${PREFIX}-${context}-${name} { border: 1px solid var(--${token.name}); }`)
+                helpers.push(`.${PREFIX}-${context}-${name} { border: 1px solid ${value}; }`)
             }
         } else if (['hashicorp', 'hcp', 'boundary','consul','nomad','packer','terraform','vagrant','vault','vault-secrets','vault-radar','waypoint'].includes(group)) {
             // TODO!
@@ -40,8 +41,6 @@ export function generateColorHelpers(tokens: TransformedToken[]): Helpers {
             // do we want people to use palette colors directly as CSS helpers?
         } else if (group === 'focus') {
             // we don't want to expose them as helpers (they're related to a11y, so we don't want users to mess up with them)
-        } else if (['neutral', 'action', 'highlight', 'success', 'warning', 'critical'].includes(group)) {
-            // THESE ARE THE OLD COLOR GROUPS, WE SKIP THEM
         } else {
             // show an error in case in the future we add new colors with a new grouping
             console.log(`ATTENTION: you need to add the color group "${group}" to the list of helpers`);

--- a/packages/tokens/scripts/build-parts/generateCssHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateCssHelpers.ts
@@ -21,28 +21,33 @@ export async function generateCssHelpers(dictionary: Dictionary, config: Platfor
     // tried to use style-dictionary/lib/common/formatHelpers/fileHeader.js but didn't work
     const header = `/**\n * Do not edit directly\n * Generated on ${new Date().toUTCString()}\n */\n`;
 
+    // unfortunately there's no way to pass arguments/parameters to the actions
+    // so we need to use the `config` to detect which transformGroup is running
+    // and depending on it output CSS variables or not (they're not supported in emails)
+    const outputCssVars = config.transformGroup !== 'products/email';
+
     if (dictionary.tokens.color) {
         // notice: the "color" tokens have different structure depending on the type
         // so it's simpler to process all the tokens (flat structure) and filter them
-        const helpers = generateColorHelpers(dictionary.allTokens);
+        const helpers = generateColorHelpers(dictionary.allTokens, outputCssVars);
         const content = `${header}\n${helpers.join('\n')}\n`;
         await fs.writeFile(`${config.buildPath}/helpers/color.css`, content);
     }
 
     if (dictionary.tokens.typography) {
-        const helpers = generateTypographyHelpers(dictionary.tokens.typography);
+        const helpers = generateTypographyHelpers(dictionary.tokens.typography, outputCssVars);
         const content = `${header}\n${helpers.join('\n')}\n`;
         await fs.writeFile(`${config.buildPath}/helpers/typography.css`, content);
     }
 
     if (dictionary.tokens.elevation) {
-        const helpers = generateElevationHelpers(dictionary.tokens.elevation, dictionary.tokens.surface);
+        const helpers = generateElevationHelpers(dictionary.tokens.elevation, dictionary.tokens.surface, outputCssVars);
         const content = `${header}\n${helpers.join('\n')}\n`;
         await fs.writeFile(`${config.buildPath}/helpers/elevation.css`, content);
     }
 
     if (dictionary.tokens['focus-ring']) {
-        const helpers = generateFocusRingHelpers(dictionary.tokens['focus-ring']);
+        const helpers = generateFocusRingHelpers(dictionary.tokens['focus-ring'], outputCssVars);
         const content = `${header}\n${helpers.join('\n')}\n`;
         await fs.writeFile(`${config.buildPath}/helpers/focus-ring.css`, content);
     }

--- a/packages/tokens/scripts/build-parts/generateElevationHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateElevationHelpers.ts
@@ -9,7 +9,7 @@ import { PREFIX } from './generateCssHelpers';
 
 type Helpers = string[];
 
-export function generateElevationHelpers(tokensElevation: TransformedTokens, tokensSurface: TransformedTokens): Helpers {
+export function generateElevationHelpers(tokensElevation: TransformedTokens, tokensSurface: TransformedTokens, outputCssVars: boolean): Helpers {
 
     const helpersElevation: Helpers = [];
     const helpersSurface: Helpers = [];
@@ -24,7 +24,8 @@ export function generateElevationHelpers(tokensElevation: TransformedTokens, tok
 
         if (levelValues.hasOwnProperty('box-shadow')) {
             const selector = `.${PREFIX}-elevation-${levelName}`;
-            helpersElevation.push(`${selector} { box-shadow: var(--token-elevation-${levelName}-box-shadow); }`);
+            const value = outputCssVars ? `var(--token-elevation-${levelName}-box-shadow` : levelValues['box-shadow'].value;
+            helpersElevation.push(`${selector} { box-shadow: ${value}); }`);
         }
     });
 
@@ -35,7 +36,8 @@ export function generateElevationHelpers(tokensElevation: TransformedTokens, tok
 
         if (levelValues.hasOwnProperty('box-shadow')) {
             const selector = `.${PREFIX}-surface-${levelName}`;
-            helpersSurface.push(`${selector} { box-shadow: var(--token-surface-${levelName}-box-shadow); }`);
+            const value = outputCssVars ? `var(--token-surface-${levelName}-box-shadow)` : levelValues['box-shadow'].value;
+            helpersSurface.push(`${selector} { box-shadow: ${value}; }`);
         }
     });
 

--- a/packages/tokens/scripts/build-parts/generateFocusRingHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateFocusRingHelpers.ts
@@ -9,7 +9,7 @@ import { PREFIX } from './generateCssHelpers';
 
 type Helpers = string[];
 
-export function generateFocusRingHelpers(tokens: TransformedTokens): Helpers {
+export function generateFocusRingHelpers(tokens: TransformedTokens, outputCssVars: boolean): Helpers {
 
     const helpersFocusRing: Helpers = [];
 
@@ -17,7 +17,8 @@ export function generateFocusRingHelpers(tokens: TransformedTokens): Helpers {
         const color = key;
         if (tokens[color].hasOwnProperty('box-shadow')) {
             const selector = `.${PREFIX}-focus-ring-${color}-box-shadow`;
-            helpersFocusRing.push(`${selector} { box-shadow: var(--token-focus-ring-${color}-box-shadow); }`);
+            const value = outputCssVars ? `var(--token-focus-ring-${color}-box-shadow)` : tokens[color]['box-shadow'].value;
+            helpersFocusRing.push(`${selector} { box-shadow: ${value}; }`);
         }
     });
 

--- a/packages/tokens/scripts/build-parts/generateTypographyHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateTypographyHelpers.ts
@@ -9,7 +9,7 @@ import { PREFIX } from './generateCssHelpers';
 
 type Helpers = string[];
 
-export function generateTypographyHelpers(tokens: TransformedTokens): Helpers {
+export function generateTypographyHelpers(tokens: TransformedTokens, outputCssVars: boolean): Helpers {
 
     const helpers: Helpers = [];
 
@@ -23,13 +23,16 @@ export function generateTypographyHelpers(tokens: TransformedTokens): Helpers {
 
             const selector = `.${PREFIX}-font`;
             if (fontStackTokens?.sans?.display) {
-                helpers.push(`${selector}-family-sans-display { font-family: var(--token-typography-font-stack-display); }`);
+                const valueFontStackDisplay = outputCssVars ? 'var(--token-typography-font-stack-display)' : fontStackTokens.display.value;
+                helpers.push(`${selector}-family-sans-display { font-family: ${valueFontStackDisplay}; }`);
             }
             if (fontStackTokens?.sans?.text) {
-                helpers.push(`${selector}-family-sans-text { font-family: var(--token-typography-font-stack-text); }`);
+                const valueFontStackText = outputCssVars ? 'var(--token-typography-font-stack-text)' : fontStackTokens.text.value;
+                helpers.push(`${selector}-family-sans-text { font-family: ${valueFontStackText}; }`);
             }
             if (fontStackTokens?.monospace?.code) {
-                helpers.push(`${selector}-family-mono-code { font-family: var(--token-typography-font-stack-code); }`);
+                const valueFontStackCode = outputCssVars ? 'var(--token-typography-font-stack-code)' : fontStackTokens.code.value;
+                helpers.push(`${selector}-family-mono-code { font-family: ${valueFontStackCode}; }`);
             }
 
         } else if (key === 'font-weight') {
@@ -46,9 +49,12 @@ export function generateTypographyHelpers(tokens: TransformedTokens): Helpers {
             let stylename = key;
 
             // basic font styles
-            declarations.push(`font-family: var(--token-typography-${stylename}-font-family);`);
-            declarations.push(`font-size: var(--token-typography-${stylename}-font-size);`);
-            declarations.push(`line-height: var(--token-typography-${stylename}-line-height);`);
+            const valueFontFamily = outputCssVars ? `var(--token-typography-${stylename}-font-family)` : tokens[stylename]['font-family'].value;
+            const valueFontSize = outputCssVars ? `var(--token-typography-${stylename}-font-size)` : tokens[stylename]['font-size'].value;
+            const valueLineHeight = outputCssVars ? `var(--token-typography-${stylename}-line-height)` : tokens[stylename]['line-height'].value;
+            declarations.push(`font-family: ${valueFontFamily};`);
+            declarations.push(`font-size: ${valueFontSize};`);
+            declarations.push(`line-height: ${valueLineHeight};`);
 
             // we reset margin/padding for all the text elements
             declarations.push('margin: 0;');

--- a/packages/tokens/scripts/build.ts
+++ b/packages/tokens/scripts/build.ts
@@ -154,7 +154,7 @@ const targets: ConfigTargets = {
     'cloud-email': {
         // we need only foundational tokens (colors, typography, etc)
         'source': [
-            `src/global/color/*.json`,
+            `src/global/**/*.json`,
             `src/products/shared/color/**/*.json`,
             `src/products/shared/typography.json`,
         ],

--- a/packages/tokens/scripts/build.ts
+++ b/packages/tokens/scripts/build.ts
@@ -86,6 +86,12 @@ StyleDictionaryPackage.registerTransformGroup({
 });
 
 StyleDictionaryPackage.registerTransformGroup({
+    name: 'products/email',
+    // TODO! update this according to the needs we have for the email templates
+    transforms: ['attribute/cti', 'name/cti/kebab', 'font-size/rem', 'size/px', 'color/css', 'color/with-alpha', 'time/seconds']
+});
+
+StyleDictionaryPackage.registerTransformGroup({
     name: 'marketing/web',
     transforms: ['attribute/cti', 'name/cti/kebab', 'font-size/rem', 'size/px', 'color/css', 'color/with-alpha', 'time/seconds']
 });
@@ -143,6 +149,17 @@ const targets: ConfigTargets = {
         ],
         'transformGroup': 'marketing/web',
         'platforms': ['web/css-variables', 'json']
+    },
+    // these tokens will be consumed by the email templating system in https://github.com/hashicorp/cloud-email
+    'cloud-email': {
+        // we need only foundational tokens (colors, typography, etc)
+        'source': [
+            `src/global/color/*.json`,
+            `src/products/shared/color/**/*.json`,
+            `src/products/shared/typography.json`,
+        ],
+        'transformGroup': 'products/email',
+        'platforms': ['email/sass-variables']
     }
 };
 
@@ -200,6 +217,24 @@ function getStyleDictionaryConfig({ target }: { target: string }): Config {
                 {
                     "destination": "tokens.json",
                     "format": "json",
+                    "filter": function(token: DesignToken) {
+                        return !token.private;
+                    },
+                }
+            ]
+        }
+    }
+
+    if (platforms.includes("email/sass-variables")) {
+        config.platforms["email/sass-variables"] = {
+            transformGroup,
+            "buildPath": `dist/${target}/`,
+            "prefix": "token",
+            "basePxFontSize": 16,
+            "files": [
+                {
+                    "destination": "tokens.scss",
+                    "format": "scss/variables",
                     "filter": function(token: DesignToken) {
                         return !token.private;
                     },

--- a/packages/tokens/scripts/build.ts
+++ b/packages/tokens/scripts/build.ts
@@ -239,7 +239,8 @@ function getStyleDictionaryConfig({ target }: { target: string }): Config {
                         return !token.private;
                     },
                 }
-            ]
+            ],
+            'actions': ['generate-css-helpers'],
         }
     }
 

--- a/packages/tokens/scripts/build.ts
+++ b/packages/tokens/scripts/build.ts
@@ -49,6 +49,19 @@ StyleDictionaryPackage.registerTransform({
     transformer: transformPxToRem
 });
 
+StyleDictionaryPackage.registerTransform({
+    name: 'font-size/px',
+    type: 'value',
+    matcher: function(token) {
+        return token?.attributes?.category === 'typography' && token.type === 'font-size';
+    },
+    transformer: function (token) {
+        const val = parseFloat(token.value);
+        if (isNaN(val)) throw `Invalid Number: '${token.name}: ${token.value}' is not a valid number, cannot transform to 'px'.\n`;
+        return `${token.value}px`;
+    }
+});
+
 // NOTICE: in case in the future we need more complex transformations, we can use this approach (see the "modify" attribute):
 // https://github.com/amzn/style-dictionary/blob/main/examples/advanced/transitive-transforms/
 //
@@ -87,8 +100,8 @@ StyleDictionaryPackage.registerTransformGroup({
 
 StyleDictionaryPackage.registerTransformGroup({
     name: 'products/email',
-    // TODO! update this according to the needs we have for the email templates
-    transforms: ['attribute/cti', 'name/cti/kebab', 'font-size/rem', 'size/px', 'color/css', 'color/with-alpha', 'time/seconds']
+    // notice: for emails we need the font-size in `px` (not `rem`)
+    transforms: ['attribute/cti', 'name/cti/kebab', 'font-size/px', 'size/px', 'color/css', 'color/with-alpha', 'time/seconds']
 });
 
 StyleDictionaryPackage.registerTransformGroup({
@@ -230,7 +243,6 @@ function getStyleDictionaryConfig({ target }: { target: string }): Config {
             transformGroup,
             "buildPath": `dist/${target}/`,
             "prefix": "token",
-            "basePxFontSize": 16,
             "files": [
                 {
                     "destination": "tokens.scss",


### PR DESCRIPTION
### :pushpin: Summary

This PR adds a new "target" for the design tokens pipeline, specifically to support the work that @venusang is doing in the context of the "adoption" of the HDS visual language in the email templating system.

Since the email templates don't support CSS variables, it was necessary to export the design tokens as Sass variables, so they can then be consumed by the Foundation Email framework as "overrides" of their defaults.

We also export CSS helper classes, in case they have to be used in the email templating system, or by the consumers of the templating system itself.

_Notice: for this initial release, we will focus only on foundations; later we may want to include design tokens for the `Button` component too, but will be discussed and decided in a second phase (could also be a fast-follow, it depends on the explorations @venusang is doing on her side of the code)._

### :hammer_and_wrench: Detailed description

In this PR I have:
- added new pipeline to style dictionary for `cloud-email` - `email/sass-variables` to be used in email templating
- generated new design tokens (as Sass variables) for email templating

### :link: External links

Main HDS epic: https://hashicorp.atlassian.net/browse/HDS-2158
Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3158

Other relevant links:
- [PLAT-713: HDS Adoption/Migration for Identity Flows](https://hashicorp.atlassian.net/browse/PLAT-713)
- [HCPIE-742: Q1 HDS Adoption (Identity Emails)](https://hashicorp.atlassian.net/browse/HCPIE-742)
- [[HCP-010] HDS Adoption Strategy for cloud-email](https://docs.google.com/document/d/1pkIzEW9VFWsmfz5VPP4BWSvSQo7cTwIGvd2-LZuCG0o/edit)


***

### 👀 Component checklist

- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
