### PR TITLE
Icons - Update script to support a "category" field

### DIFF
--- a/.changeset/tall-windows-hug.md
+++ b/.changeset/tall-windows-hug.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/flight-icons": patch
+---
+
+Added "category" to the icons' metadata in the `catalog.json` file.

--- a/packages/flight-icons/catalog.json
+++ b/packages/flight-icons/catalog.json
@@ -1,14 +1,9 @@
 {
-  "lastRunTimeISO": "2024-02-02T00:07:43.006Z",
+  "lastRunTimeISO": "2024-02-29T19:06:39.648Z",
   "lastRunFigma": {
     "id": "TLnoT5AYQfy3tZ0H68BgOr",
     "page": "Export",
-    "frames": [
-      "Core",
-      "Services",
-      "Products",
-      "Animated"
-    ]
+    "excludeFrames": []
   },
   "assets": [
     {
@@ -16,6 +11,7 @@
       "fileName": "loading-24",
       "iconName": "loading",
       "description": "loading, loader, spinner, animated",
+      "category": "Animated",
       "size": "24",
       "width": 24,
       "height": 24
@@ -25,6 +21,7 @@
       "fileName": "loading-16",
       "iconName": "loading",
       "description": "loading, loader, spinner, animated",
+      "category": "Animated",
       "size": "16",
       "width": 16,
       "height": 16
@@ -34,6 +31,7 @@
       "fileName": "loading-static-24",
       "iconName": "loading-static",
       "description": "loading, loader, spinner, static",
+      "category": "Animated",
       "size": "24",
       "width": 24,
       "height": 24
@@ -43,6 +41,7 @@
       "fileName": "loading-static-16",
       "iconName": "loading-static",
       "description": "loading, loader, spinner, static",
+      "category": "Animated",
       "size": "16",
       "width": 16,
       "height": 16
@@ -52,6 +51,7 @@
       "fileName": "running-24",
       "iconName": "running",
       "description": "running, run, animated",
+      "category": "Animated",
       "size": "24",
       "width": 24,
       "height": 24
@@ -61,6 +61,7 @@
       "fileName": "running-16",
       "iconName": "running",
       "description": "running, run, animated",
+      "category": "Animated",
       "size": "16",
       "width": 16,
       "height": 16
@@ -70,6 +71,7 @@
       "fileName": "running-static-24",
       "iconName": "running-static",
       "description": "running, run, syncing, sync, static",
+      "category": "Animated",
       "size": "24",
       "width": 24,
       "height": 24
@@ -79,6 +81,7 @@
       "fileName": "running-static-16",
       "iconName": "running-static",
       "description": "running, run, syncing, sync, static",
+      "category": "Animated",
       "size": "16",
       "width": 16,
       "height": 16
@@ -88,6 +91,7 @@
       "fileName": "apple-24",
       "iconName": "apple",
       "description": "apple, macos, ios",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -97,6 +101,7 @@
       "fileName": "apple-16",
       "iconName": "apple",
       "description": "apple, macos, ios",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -106,6 +111,7 @@
       "fileName": "apple-color-24",
       "iconName": "apple-color",
       "description": "apple, macos, ios",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -115,6 +121,7 @@
       "fileName": "apple-color-16",
       "iconName": "apple-color",
       "description": "apple, macos, ios",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -124,6 +131,7 @@
       "fileName": "alibaba-24",
       "iconName": "alibaba",
       "description": "alibaba, alibaba cloud",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -133,6 +141,7 @@
       "fileName": "alibaba-16",
       "iconName": "alibaba",
       "description": "alibaba, alibaba cloud",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -142,6 +151,7 @@
       "fileName": "alibaba-color-24",
       "iconName": "alibaba-color",
       "description": "alibaba, alibaba cloud",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -151,6 +161,7 @@
       "fileName": "alibaba-color-16",
       "iconName": "alibaba-color",
       "description": "alibaba, alibaba cloud",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -160,6 +171,7 @@
       "fileName": "amazon-ecs-24",
       "iconName": "amazon-ecs",
       "description": "amazon, aws, ecs",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -169,6 +181,7 @@
       "fileName": "amazon-ecs-16",
       "iconName": "amazon-ecs",
       "description": "amazon, aws, ecs",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -178,6 +191,7 @@
       "fileName": "amazon-ecs-color-24",
       "iconName": "amazon-ecs-color",
       "description": "amazon, aws, ecs",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -187,6 +201,7 @@
       "fileName": "amazon-ecs-color-16",
       "iconName": "amazon-ecs-color",
       "description": "amazon, aws, ecs",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -196,6 +211,7 @@
       "fileName": "amazon-eks-24",
       "iconName": "amazon-eks",
       "description": "amazon, aws, eks, kubenetes",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -205,6 +221,7 @@
       "fileName": "amazon-eks-16",
       "iconName": "amazon-eks",
       "description": "amazon, aws, eks, kubenetes",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -214,6 +231,7 @@
       "fileName": "amazon-eks-color-24",
       "iconName": "amazon-eks-color",
       "description": "amazon, aws, eks, kubenetes",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -223,6 +241,7 @@
       "fileName": "amazon-eks-color-16",
       "iconName": "amazon-eks-color",
       "description": "amazon, aws, eks, kubenetes",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -232,6 +251,7 @@
       "fileName": "auth0-24",
       "iconName": "auth0",
       "description": "auth0",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -241,6 +261,7 @@
       "fileName": "auth0-16",
       "iconName": "auth0",
       "description": "auth0",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -250,6 +271,7 @@
       "fileName": "auth0-color-24",
       "iconName": "auth0-color",
       "description": "auth0",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -259,6 +281,7 @@
       "fileName": "auth0-color-16",
       "iconName": "auth0-color",
       "description": "auth0",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -268,6 +291,7 @@
       "fileName": "aws-24",
       "iconName": "aws",
       "description": "amazon, aws, amazon web services",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -277,6 +301,7 @@
       "fileName": "aws-16",
       "iconName": "aws",
       "description": "amazon, aws, amazon web services",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -286,6 +311,7 @@
       "fileName": "aws-color-24",
       "iconName": "aws-color",
       "description": "amazon, aws, amazon web services",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -295,6 +321,7 @@
       "fileName": "aws-color-16",
       "iconName": "aws-color",
       "description": "amazon, aws, amazon web services",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -304,6 +331,7 @@
       "fileName": "aws-cdk-24",
       "iconName": "aws-cdk",
       "description": "amazon, aws, amazon web services,cdk",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -313,6 +341,7 @@
       "fileName": "aws-cdk-16",
       "iconName": "aws-cdk",
       "description": "amazon, aws, amazon web services,cdk",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -322,6 +351,7 @@
       "fileName": "aws-cdk-color-24",
       "iconName": "aws-cdk-color",
       "description": "amazon, aws, amazon web services,cdk",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -331,6 +361,7 @@
       "fileName": "aws-cdk-color-16",
       "iconName": "aws-cdk-color",
       "description": "amazon, aws, amazon web services,cdk",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -340,6 +371,7 @@
       "fileName": "aws-cloudwatch-24",
       "iconName": "aws-cloudwatch",
       "description": "amazon, aws, cloudwatch",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -349,6 +381,7 @@
       "fileName": "aws-cloudwatch-16",
       "iconName": "aws-cloudwatch",
       "description": "amazon, aws, cloudwatch",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -358,6 +391,7 @@
       "fileName": "aws-cloudwatch-color-24",
       "iconName": "aws-cloudwatch-color",
       "description": "amazon, aws, cloudwatch",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -367,6 +401,7 @@
       "fileName": "aws-cloudwatch-color-16",
       "iconName": "aws-cloudwatch-color",
       "description": "amazon, aws, cloudwatch",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -376,6 +411,7 @@
       "fileName": "aws-ec2-24",
       "iconName": "aws-ec2",
       "description": "amazon, aws, ec2",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -385,6 +421,7 @@
       "fileName": "aws-ec2-16",
       "iconName": "aws-ec2",
       "description": "amazon, aws, ec2",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -394,6 +431,7 @@
       "fileName": "aws-ec2-color-24",
       "iconName": "aws-ec2-color",
       "description": "amazon, aws, ec2",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -403,6 +441,7 @@
       "fileName": "aws-ec2-color-16",
       "iconName": "aws-ec2-color",
       "description": "amazon, aws, ec2",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -412,6 +451,7 @@
       "fileName": "aws-lambda-24",
       "iconName": "aws-lambda",
       "description": "amazon, aws, lambda",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -421,6 +461,7 @@
       "fileName": "aws-lambda-16",
       "iconName": "aws-lambda",
       "description": "amazon, aws, lambda",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -430,6 +471,7 @@
       "fileName": "aws-lambda-color-24",
       "iconName": "aws-lambda-color",
       "description": "amazon, aws, lambda",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -439,6 +481,7 @@
       "fileName": "aws-lambda-color-16",
       "iconName": "aws-lambda-color",
       "description": "amazon, aws, lambda",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -448,6 +491,7 @@
       "fileName": "aws-s3-24",
       "iconName": "aws-s3",
       "description": "amazon, aws, s3",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -457,6 +501,7 @@
       "fileName": "aws-s3-16",
       "iconName": "aws-s3",
       "description": "amazon, aws, s3",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -466,6 +511,7 @@
       "fileName": "aws-s3-color-24",
       "iconName": "aws-s3-color",
       "description": "amazon, aws, s3",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -475,6 +521,7 @@
       "fileName": "aws-s3-color-16",
       "iconName": "aws-s3-color",
       "description": "amazon, aws, s3",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -484,6 +531,7 @@
       "fileName": "azure-24",
       "iconName": "azure",
       "description": "azure, microsoft",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -493,6 +541,7 @@
       "fileName": "azure-16",
       "iconName": "azure",
       "description": "azure, microsoft",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -502,6 +551,7 @@
       "fileName": "azure-color-24",
       "iconName": "azure-color",
       "description": "azure, microsoft",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -511,6 +561,7 @@
       "fileName": "azure-color-16",
       "iconName": "azure-color",
       "description": "azure, microsoft",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -520,6 +571,7 @@
       "fileName": "azure-aks-24",
       "iconName": "azure-aks",
       "description": "azure, microsoft, aks",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -529,6 +581,7 @@
       "fileName": "azure-aks-16",
       "iconName": "azure-aks",
       "description": "azure, microsoft, aks",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -538,6 +591,7 @@
       "fileName": "azure-aks-color-24",
       "iconName": "azure-aks-color",
       "description": "azure, microsoft, aks",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -547,6 +601,7 @@
       "fileName": "azure-aks-color-16",
       "iconName": "azure-aks-color",
       "description": "azure, microsoft, aks",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -556,6 +611,7 @@
       "fileName": "azure-blob-storage-24",
       "iconName": "azure-blob-storage",
       "description": "microsoft, azure, blob, storage",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -565,6 +621,7 @@
       "fileName": "azure-blob-storage-16",
       "iconName": "azure-blob-storage",
       "description": "microsoft, azure, blob, storage",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -574,6 +631,7 @@
       "fileName": "azure-blob-storage-color-24",
       "iconName": "azure-blob-storage-color",
       "description": "microsoft, azure, blob, storage",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -583,6 +641,7 @@
       "fileName": "azure-blob-storage-color-16",
       "iconName": "azure-blob-storage-color",
       "description": "microsoft, azure, blob, storage",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -592,6 +651,7 @@
       "fileName": "azure-devops-24",
       "iconName": "azure-devops",
       "description": "azure, microsoft",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -601,6 +661,7 @@
       "fileName": "azure-devops-16",
       "iconName": "azure-devops",
       "description": "azure, microsoft",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -610,6 +671,7 @@
       "fileName": "azure-devops-color-24",
       "iconName": "azure-devops-color",
       "description": "azure, microsoft",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -619,6 +681,7 @@
       "fileName": "azure-devops-color-16",
       "iconName": "azure-devops-color",
       "description": "azure, microsoft",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -628,6 +691,7 @@
       "fileName": "azure-vms-24",
       "iconName": "azure-vms",
       "description": "azure, microsoft, vms",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -637,6 +701,7 @@
       "fileName": "azure-vms-16",
       "iconName": "azure-vms",
       "description": "azure, microsoft, vms",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -646,6 +711,7 @@
       "fileName": "azure-vms-color-24",
       "iconName": "azure-vms-color",
       "description": "azure, microsoft, vms",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -655,6 +721,7 @@
       "fileName": "azure-vms-color-16",
       "iconName": "azure-vms-color",
       "description": "azure, microsoft, vms",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -664,6 +731,7 @@
       "fileName": "bitbucket-24",
       "iconName": "bitbucket",
       "description": "bitbucket, atlassian",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -673,6 +741,7 @@
       "fileName": "bitbucket-16",
       "iconName": "bitbucket",
       "description": "bitbucket, atlassian",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -682,6 +751,7 @@
       "fileName": "bitbucket-color-24",
       "iconName": "bitbucket-color",
       "description": "bitbucket, atlassian",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -691,6 +761,7 @@
       "fileName": "bitbucket-color-16",
       "iconName": "bitbucket-color",
       "description": "bitbucket, atlassian",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -700,6 +771,7 @@
       "fileName": "bridgecrew-24",
       "iconName": "bridgecrew",
       "description": "bridgecrew",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -709,6 +781,7 @@
       "fileName": "bridgecrew-16",
       "iconName": "bridgecrew",
       "description": "bridgecrew",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -718,6 +791,7 @@
       "fileName": "bridgecrew-color-24",
       "iconName": "bridgecrew-color",
       "description": "bridgecrew",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -727,6 +801,7 @@
       "fileName": "bridgecrew-color-16",
       "iconName": "bridgecrew-color",
       "description": "bridgecrew",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -736,6 +811,7 @@
       "fileName": "cisco-24",
       "iconName": "cisco",
       "description": "cisco",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -745,6 +821,7 @@
       "fileName": "cisco-16",
       "iconName": "cisco",
       "description": "cisco",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -754,6 +831,7 @@
       "fileName": "cisco-color-24",
       "iconName": "cisco-color",
       "description": "cisco",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -763,6 +841,7 @@
       "fileName": "cisco-color-16",
       "iconName": "cisco-color",
       "description": "cisco",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -772,6 +851,7 @@
       "fileName": "codepen-24",
       "iconName": "codepen",
       "description": "codepen",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -781,6 +861,7 @@
       "fileName": "codepen-16",
       "iconName": "codepen",
       "description": "codepen",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -790,6 +871,7 @@
       "fileName": "codepen-color-24",
       "iconName": "codepen-color",
       "description": "codepen",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -799,6 +881,7 @@
       "fileName": "codepen-color-16",
       "iconName": "codepen-color",
       "description": "codepen",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -808,6 +891,7 @@
       "fileName": "datadog-24",
       "iconName": "datadog",
       "description": "datadog",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -817,6 +901,7 @@
       "fileName": "datadog-16",
       "iconName": "datadog",
       "description": "datadog",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -826,6 +911,7 @@
       "fileName": "datadog-color-24",
       "iconName": "datadog-color",
       "description": "datadog",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -835,6 +921,7 @@
       "fileName": "datadog-color-16",
       "iconName": "datadog-color",
       "description": "datadog",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -844,6 +931,7 @@
       "fileName": "digital-ocean-24",
       "iconName": "digital-ocean",
       "description": "digital, ocean",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -853,6 +941,7 @@
       "fileName": "digital-ocean-16",
       "iconName": "digital-ocean",
       "description": "digital, ocean",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -862,6 +951,7 @@
       "fileName": "digital-ocean-color-24",
       "iconName": "digital-ocean-color",
       "description": "digital, ocean",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -871,6 +961,7 @@
       "fileName": "digital-ocean-color-16",
       "iconName": "digital-ocean-color",
       "description": "digital, ocean",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -880,6 +971,7 @@
       "fileName": "docker-24",
       "iconName": "docker",
       "description": "docker",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -889,6 +981,7 @@
       "fileName": "docker-16",
       "iconName": "docker",
       "description": "docker",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -898,6 +991,7 @@
       "fileName": "docker-color-24",
       "iconName": "docker-color",
       "description": "docker",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -907,6 +1001,7 @@
       "fileName": "docker-color-16",
       "iconName": "docker-color",
       "description": "docker",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -916,6 +1011,7 @@
       "fileName": "elastic-observability-24",
       "iconName": "elastic-observability",
       "description": "elastic, observability, provider, cloud",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -925,6 +1021,7 @@
       "fileName": "elastic-observability-16",
       "iconName": "elastic-observability",
       "description": "elastic, observability, provider, cloud",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -934,6 +1031,7 @@
       "fileName": "elastic-observability-color-24",
       "iconName": "elastic-observability-color",
       "description": "elastic, observability, provider, cloud",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -943,6 +1041,7 @@
       "fileName": "elastic-observability-color-16",
       "iconName": "elastic-observability-color",
       "description": "elastic, observability, provider, cloud",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -952,6 +1051,7 @@
       "fileName": "f5-24",
       "iconName": "f5",
       "description": "f5",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -961,6 +1061,7 @@
       "fileName": "f5-16",
       "iconName": "f5",
       "description": "f5",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -970,6 +1071,7 @@
       "fileName": "f5-color-24",
       "iconName": "f5-color",
       "description": "f5",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -979,6 +1081,7 @@
       "fileName": "f5-color-16",
       "iconName": "f5-color",
       "description": "f5",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -988,6 +1091,7 @@
       "fileName": "facebook-24",
       "iconName": "facebook",
       "description": "facebook",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -997,6 +1101,7 @@
       "fileName": "facebook-16",
       "iconName": "facebook",
       "description": "facebook",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1006,6 +1111,7 @@
       "fileName": "facebook-color-24",
       "iconName": "facebook-color",
       "description": "facebook",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1015,6 +1121,7 @@
       "fileName": "facebook-color-16",
       "iconName": "facebook-color",
       "description": "facebook",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1024,6 +1131,7 @@
       "fileName": "figma-24",
       "iconName": "figma",
       "description": "figma",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1033,6 +1141,7 @@
       "fileName": "figma-16",
       "iconName": "figma",
       "description": "figma",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1042,6 +1151,7 @@
       "fileName": "figma-color-24",
       "iconName": "figma-color",
       "description": "figma",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1051,6 +1161,7 @@
       "fileName": "figma-color-16",
       "iconName": "figma-color",
       "description": "figma",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1060,6 +1171,7 @@
       "fileName": "gcp-24",
       "iconName": "gcp",
       "description": "google, gcp, google cloud platform",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1069,6 +1181,7 @@
       "fileName": "gcp-16",
       "iconName": "gcp",
       "description": "google, gcp, google cloud platform",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1078,6 +1191,7 @@
       "fileName": "gcp-color-24",
       "iconName": "gcp-color",
       "description": "google, gcp, google cloud platform",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1087,6 +1201,7 @@
       "fileName": "gcp-color-16",
       "iconName": "gcp-color",
       "description": "google, gcp, google cloud platform",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1096,6 +1211,7 @@
       "fileName": "gitlab-24",
       "iconName": "gitlab",
       "description": "gitlab",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1105,6 +1221,7 @@
       "fileName": "gitlab-16",
       "iconName": "gitlab",
       "description": "gitlab",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1114,6 +1231,7 @@
       "fileName": "gitlab-color-24",
       "iconName": "gitlab-color",
       "description": "gitlab",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1123,6 +1241,7 @@
       "fileName": "gitlab-color-16",
       "iconName": "gitlab-color",
       "description": "gitlab",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1132,6 +1251,7 @@
       "fileName": "github-24",
       "iconName": "github",
       "description": "github",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1141,6 +1261,7 @@
       "fileName": "github-16",
       "iconName": "github",
       "description": "github",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1150,6 +1271,7 @@
       "fileName": "github-color-24",
       "iconName": "github-color",
       "description": "github",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1159,6 +1281,7 @@
       "fileName": "github-color-16",
       "iconName": "github-color",
       "description": "github",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1168,6 +1291,7 @@
       "fileName": "google-24",
       "iconName": "google",
       "description": "kubernetes, k8s",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1177,6 +1301,7 @@
       "fileName": "google-16",
       "iconName": "google",
       "description": "kubernetes, k8s",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1186,6 +1311,7 @@
       "fileName": "google-color-24",
       "iconName": "google-color",
       "description": "kubernetes, k8s",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1195,6 +1321,7 @@
       "fileName": "google-color-16",
       "iconName": "google-color",
       "description": "kubernetes, k8s",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1204,6 +1331,7 @@
       "fileName": "google-docs-24",
       "iconName": "google-docs",
       "description": "google, docs",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1213,6 +1341,7 @@
       "fileName": "google-docs-16",
       "iconName": "google-docs",
       "description": "google, docs",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1222,6 +1351,7 @@
       "fileName": "google-docs-color-24",
       "iconName": "google-docs-color",
       "description": "google, docs",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1231,6 +1361,7 @@
       "fileName": "google-docs-color-16",
       "iconName": "google-docs-color",
       "description": "google, docs",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1240,6 +1371,7 @@
       "fileName": "google-drive-24",
       "iconName": "google-drive",
       "description": "google, drive",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1249,6 +1381,7 @@
       "fileName": "google-drive-16",
       "iconName": "google-drive",
       "description": "google, drive",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1258,6 +1391,7 @@
       "fileName": "google-drive-color-24",
       "iconName": "google-drive-color",
       "description": "google, drive",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1267,6 +1401,7 @@
       "fileName": "google-drive-color-16",
       "iconName": "google-drive-color",
       "description": "google, drive",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1276,6 +1411,7 @@
       "fileName": "google-forms-24",
       "iconName": "google-forms",
       "description": "google, forms",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1285,6 +1421,7 @@
       "fileName": "google-forms-16",
       "iconName": "google-forms",
       "description": "google, forms",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1294,6 +1431,7 @@
       "fileName": "google-forms-color-24",
       "iconName": "google-forms-color",
       "description": "google, forms",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1303,6 +1441,7 @@
       "fileName": "google-forms-color-16",
       "iconName": "google-forms-color",
       "description": "google, forms",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1312,6 +1451,7 @@
       "fileName": "google-sheets-24",
       "iconName": "google-sheets",
       "description": "google, sheets",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1321,6 +1461,7 @@
       "fileName": "google-sheets-16",
       "iconName": "google-sheets",
       "description": "google, sheets",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1330,6 +1471,7 @@
       "fileName": "google-sheets-color-24",
       "iconName": "google-sheets-color",
       "description": "google, sheets",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1339,6 +1481,7 @@
       "fileName": "google-sheets-color-16",
       "iconName": "google-sheets-color",
       "description": "google, sheets",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1348,6 +1491,7 @@
       "fileName": "google-slides-24",
       "iconName": "google-slides",
       "description": "google, slides",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1357,6 +1501,7 @@
       "fileName": "google-slides-16",
       "iconName": "google-slides",
       "description": "google, slides",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1366,6 +1511,7 @@
       "fileName": "google-slides-color-24",
       "iconName": "google-slides-color",
       "description": "google, slides",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1375,6 +1521,7 @@
       "fileName": "google-slides-color-16",
       "iconName": "google-slides-color",
       "description": "google, slides",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1384,6 +1531,7 @@
       "fileName": "grafana-24",
       "iconName": "grafana",
       "description": "grafana",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1393,6 +1541,7 @@
       "fileName": "grafana-16",
       "iconName": "grafana",
       "description": "grafana",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1402,6 +1551,7 @@
       "fileName": "grafana-color-24",
       "iconName": "grafana-color",
       "description": "grafana",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1411,6 +1561,7 @@
       "fileName": "grafana-color-16",
       "iconName": "grafana-color",
       "description": "grafana",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1420,6 +1571,7 @@
       "fileName": "helm-24",
       "iconName": "helm",
       "description": "helm",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1429,6 +1581,7 @@
       "fileName": "helm-16",
       "iconName": "helm",
       "description": "helm",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1438,6 +1591,7 @@
       "fileName": "helm-color-24",
       "iconName": "helm-color",
       "description": "helm",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1447,6 +1601,7 @@
       "fileName": "helm-color-16",
       "iconName": "helm-color",
       "description": "helm",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1456,6 +1611,7 @@
       "fileName": "infracost-24",
       "iconName": "infracost",
       "description": "infracost",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1465,6 +1621,7 @@
       "fileName": "infracost-16",
       "iconName": "infracost",
       "description": "infracost",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1474,6 +1631,7 @@
       "fileName": "infracost-color-24",
       "iconName": "infracost-color",
       "description": "infracost",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1483,6 +1641,7 @@
       "fileName": "infracost-color-16",
       "iconName": "infracost-color",
       "description": "infracost",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1492,6 +1651,7 @@
       "fileName": "jfrog-24",
       "iconName": "jfrog",
       "description": "jfrog",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1501,6 +1661,7 @@
       "fileName": "jfrog-16",
       "iconName": "jfrog",
       "description": "jfrog",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1510,6 +1671,7 @@
       "fileName": "jfrog-color-24",
       "iconName": "jfrog-color",
       "description": "jfrog",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1519,6 +1681,7 @@
       "fileName": "jfrog-color-16",
       "iconName": "jfrog-color",
       "description": "jfrog",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1528,6 +1691,7 @@
       "fileName": "jira-24",
       "iconName": "jira",
       "description": "jira, atlassian, tasks, tickets",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1537,6 +1701,7 @@
       "fileName": "jira-16",
       "iconName": "jira",
       "description": "jira, atlassian, tasks, tickets",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1546,6 +1711,7 @@
       "fileName": "jira-color-24",
       "iconName": "jira-color",
       "description": "jira, atlassian, tasks, tickets",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1555,6 +1721,7 @@
       "fileName": "jira-color-16",
       "iconName": "jira-color",
       "description": "jira, atlassian, tasks, tickets",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1564,6 +1731,7 @@
       "fileName": "jwt-24",
       "iconName": "jwt",
       "description": "json web tokens, jwt",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1573,6 +1741,7 @@
       "fileName": "jwt-16",
       "iconName": "jwt",
       "description": "json web tokens, jwt",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1582,6 +1751,7 @@
       "fileName": "jwt-color-24",
       "iconName": "jwt-color",
       "description": "json web tokens, jwt",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1591,6 +1761,7 @@
       "fileName": "jwt-color-16",
       "iconName": "jwt-color",
       "description": "json web tokens, jwt",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1600,6 +1771,7 @@
       "fileName": "kubernetes-24",
       "iconName": "kubernetes",
       "description": "kubernetes, k8s",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1609,6 +1781,7 @@
       "fileName": "kubernetes-16",
       "iconName": "kubernetes",
       "description": "kubernetes, k8s",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1618,6 +1791,7 @@
       "fileName": "kubernetes-color-24",
       "iconName": "kubernetes-color",
       "description": "kubernetes, k8s",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1627,6 +1801,7 @@
       "fileName": "kubernetes-color-16",
       "iconName": "kubernetes-color",
       "description": "kubernetes, k8s",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1636,6 +1811,7 @@
       "fileName": "lightlytics-24",
       "iconName": "lightlytics",
       "description": "lightlytics",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1645,6 +1821,7 @@
       "fileName": "lightlytics-16",
       "iconName": "lightlytics",
       "description": "lightlytics",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1654,6 +1831,7 @@
       "fileName": "lightlytics-color-24",
       "iconName": "lightlytics-color",
       "description": "lightlytics",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1663,6 +1841,7 @@
       "fileName": "lightlytics-color-16",
       "iconName": "lightlytics-color",
       "description": "lightlytics",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1672,6 +1851,7 @@
       "fileName": "linkedin-24",
       "iconName": "linkedin",
       "description": "linkedin, microsoft",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1681,6 +1861,7 @@
       "fileName": "linkedin-16",
       "iconName": "linkedin",
       "description": "linkedin, microsoft",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1690,6 +1871,7 @@
       "fileName": "linkedin-color-24",
       "iconName": "linkedin-color",
       "description": "linkedin, microsoft",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1699,6 +1881,7 @@
       "fileName": "linkedin-color-16",
       "iconName": "linkedin-color",
       "description": "linkedin, microsoft",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1708,6 +1891,7 @@
       "fileName": "linode-24",
       "iconName": "linode",
       "description": "linode",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1717,6 +1901,7 @@
       "fileName": "linode-16",
       "iconName": "linode",
       "description": "linode",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1726,6 +1911,7 @@
       "fileName": "linode-color-24",
       "iconName": "linode-color",
       "description": "linode",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1735,6 +1921,7 @@
       "fileName": "linode-color-16",
       "iconName": "linode-color",
       "description": "linode",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1744,6 +1931,7 @@
       "fileName": "linux-24",
       "iconName": "linux",
       "description": "linux, os",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1753,6 +1941,7 @@
       "fileName": "linux-16",
       "iconName": "linux",
       "description": "linux, os",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1762,6 +1951,7 @@
       "fileName": "linux-color-24",
       "iconName": "linux-color",
       "description": "linux, os",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1771,6 +1961,7 @@
       "fileName": "linux-color-16",
       "iconName": "linux-color",
       "description": "linux, os",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1780,6 +1971,7 @@
       "fileName": "loom-24",
       "iconName": "loom",
       "description": "loom",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1789,6 +1981,7 @@
       "fileName": "loom-16",
       "iconName": "loom",
       "description": "loom",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1798,6 +1991,7 @@
       "fileName": "loom-color-24",
       "iconName": "loom-color",
       "description": "loom",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1807,6 +2001,7 @@
       "fileName": "loom-color-16",
       "iconName": "loom-color",
       "description": "loom",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1816,6 +2011,7 @@
       "fileName": "meetup-24",
       "iconName": "meetup",
       "description": "meetup",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1825,6 +2021,7 @@
       "fileName": "meetup-16",
       "iconName": "meetup",
       "description": "meetup",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1834,6 +2031,7 @@
       "fileName": "meetup-color-24",
       "iconName": "meetup-color",
       "description": "meetup",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1843,6 +2041,7 @@
       "fileName": "meetup-color-16",
       "iconName": "meetup-color",
       "description": "meetup",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1852,6 +2051,7 @@
       "fileName": "microsoft-24",
       "iconName": "microsoft",
       "description": "microsoft, ms, windows",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1861,6 +2061,7 @@
       "fileName": "microsoft-16",
       "iconName": "microsoft",
       "description": "microsoft, ms, windows",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1870,6 +2071,7 @@
       "fileName": "microsoft-color-24",
       "iconName": "microsoft-color",
       "description": "microsoft, ms, windows",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1879,6 +2081,7 @@
       "fileName": "microsoft-color-16",
       "iconName": "microsoft-color",
       "description": "microsoft, ms, windows",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1888,6 +2091,7 @@
       "fileName": "microsoft-teams-24",
       "iconName": "microsoft-teams",
       "description": "microsoft, teams",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1897,6 +2101,7 @@
       "fileName": "microsoft-teams-16",
       "iconName": "microsoft-teams",
       "description": "microsoft, teams",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1906,6 +2111,7 @@
       "fileName": "microsoft-teams-color-24",
       "iconName": "microsoft-teams-color",
       "description": "microsoft, teams",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1915,6 +2121,7 @@
       "fileName": "microsoft-teams-color-16",
       "iconName": "microsoft-teams-color",
       "description": "microsoft, teams",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1924,6 +2131,7 @@
       "fileName": "new-relic-24",
       "iconName": "new-relic",
       "description": "new relic, provider, cloud",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1933,6 +2141,7 @@
       "fileName": "new-relic-16",
       "iconName": "new-relic",
       "description": "new relic, provider, cloud",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1942,6 +2151,7 @@
       "fileName": "new-relic-color-24",
       "iconName": "new-relic-color",
       "description": "new relic, provider, cloud",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1951,6 +2161,7 @@
       "fileName": "new-relic-color-16",
       "iconName": "new-relic-color",
       "description": "new relic, provider, cloud",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1960,6 +2171,7 @@
       "fileName": "okta-24",
       "iconName": "okta",
       "description": "okta",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1969,6 +2181,7 @@
       "fileName": "okta-16",
       "iconName": "okta",
       "description": "okta",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1978,6 +2191,7 @@
       "fileName": "okta-color-24",
       "iconName": "okta-color",
       "description": "okta",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -1987,6 +2201,7 @@
       "fileName": "okta-color-16",
       "iconName": "okta-color",
       "description": "okta",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -1996,6 +2211,7 @@
       "fileName": "oracle-24",
       "iconName": "oracle",
       "description": "oracle, oracle cloud",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2005,6 +2221,7 @@
       "fileName": "oracle-16",
       "iconName": "oracle",
       "description": "oracle, oracle cloud",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2014,6 +2231,7 @@
       "fileName": "oracle-color-24",
       "iconName": "oracle-color",
       "description": "oracle, oracle cloud",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2023,6 +2241,7 @@
       "fileName": "oracle-color-16",
       "iconName": "oracle-color",
       "description": "oracle, oracle cloud",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2032,6 +2251,7 @@
       "fileName": "opa-24",
       "iconName": "opa",
       "description": "opa, open, policy, agent",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2041,6 +2261,7 @@
       "fileName": "opa-16",
       "iconName": "opa",
       "description": "opa, open, policy, agent",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2050,6 +2271,7 @@
       "fileName": "opa-color-24",
       "iconName": "opa-color",
       "description": "opa, open, policy, agent",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2059,6 +2281,7 @@
       "fileName": "opa-color-16",
       "iconName": "opa-color",
       "description": "opa, open, policy, agent",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2068,6 +2291,7 @@
       "fileName": "openid-24",
       "iconName": "openid",
       "description": "OpenID, OIDC",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2077,6 +2301,7 @@
       "fileName": "openid-16",
       "iconName": "openid",
       "description": "OpenID, OIDC",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2086,6 +2311,7 @@
       "fileName": "openid-color-24",
       "iconName": "openid-color",
       "description": "OpenID, OIDC",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2095,6 +2321,7 @@
       "fileName": "openid-color-16",
       "iconName": "openid-color",
       "description": "OpenID, OIDC",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2104,6 +2331,7 @@
       "fileName": "pack-24",
       "iconName": "pack",
       "description": "pack, buildpack, cloud, native",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2113,6 +2341,7 @@
       "fileName": "pack-16",
       "iconName": "pack",
       "description": "pack, buildpack, cloud, native",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2122,6 +2351,7 @@
       "fileName": "pack-color-24",
       "iconName": "pack-color",
       "description": "pack, buildpack, cloud, native",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2131,6 +2361,7 @@
       "fileName": "pack-color-16",
       "iconName": "pack-color",
       "description": "pack, buildpack, cloud, native",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2140,6 +2371,7 @@
       "fileName": "rabbitmq-24",
       "iconName": "rabbitmq",
       "description": "RabbitMQ",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2149,6 +2381,7 @@
       "fileName": "rabbitmq-16",
       "iconName": "rabbitmq",
       "description": "RabbitMQ",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2158,6 +2391,7 @@
       "fileName": "rabbitmq-color-24",
       "iconName": "rabbitmq-color",
       "description": "RabbitMQ",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2167,6 +2401,7 @@
       "fileName": "rabbitmq-color-16",
       "iconName": "rabbitmq-color",
       "description": "RabbitMQ",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2176,6 +2411,7 @@
       "fileName": "saml-24",
       "iconName": "saml",
       "description": "saml",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2185,6 +2421,7 @@
       "fileName": "saml-16",
       "iconName": "saml",
       "description": "saml",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2194,6 +2431,7 @@
       "fileName": "saml-color-24",
       "iconName": "saml-color",
       "description": "saml",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2203,6 +2441,7 @@
       "fileName": "saml-color-16",
       "iconName": "saml-color",
       "description": "saml",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2212,6 +2451,7 @@
       "fileName": "slack-24",
       "iconName": "slack",
       "description": "slack, salesforce",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2221,6 +2461,7 @@
       "fileName": "slack-16",
       "iconName": "slack",
       "description": "slack, salesforce",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2230,6 +2471,7 @@
       "fileName": "slack-color-24",
       "iconName": "slack-color",
       "description": "slack, salesforce",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2239,6 +2481,7 @@
       "fileName": "slack-color-16",
       "iconName": "slack-color",
       "description": "slack, salesforce",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2248,6 +2491,7 @@
       "fileName": "snyk-24",
       "iconName": "snyk",
       "description": "snyk",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2257,6 +2501,7 @@
       "fileName": "snyk-16",
       "iconName": "snyk",
       "description": "snyk",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2266,6 +2511,7 @@
       "fileName": "snyk-color-24",
       "iconName": "snyk-color",
       "description": "snyk",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2275,6 +2521,7 @@
       "fileName": "snyk-color-16",
       "iconName": "snyk-color",
       "description": "snyk",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2284,6 +2531,7 @@
       "fileName": "splunk-24",
       "iconName": "splunk",
       "description": "splunk",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2293,6 +2541,7 @@
       "fileName": "splunk-16",
       "iconName": "splunk",
       "description": "splunk",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2302,6 +2551,7 @@
       "fileName": "splunk-color-24",
       "iconName": "splunk-color",
       "description": "splunk",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2311,6 +2561,7 @@
       "fileName": "splunk-color-16",
       "iconName": "splunk-color",
       "description": "splunk",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2320,6 +2571,7 @@
       "fileName": "twitch-24",
       "iconName": "twitch",
       "description": "twitch",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2329,6 +2581,7 @@
       "fileName": "twitch-16",
       "iconName": "twitch",
       "description": "twitch",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2338,6 +2591,7 @@
       "fileName": "twitch-color-24",
       "iconName": "twitch-color",
       "description": "twitch",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2347,6 +2601,7 @@
       "fileName": "twitch-color-16",
       "iconName": "twitch-color",
       "description": "twitch",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2356,6 +2611,7 @@
       "fileName": "twitter-24",
       "iconName": "twitter",
       "description": "twitter",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2365,6 +2621,7 @@
       "fileName": "twitter-16",
       "iconName": "twitter",
       "description": "twitter",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2374,6 +2631,7 @@
       "fileName": "twitter-color-24",
       "iconName": "twitter-color",
       "description": "twitter",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2383,6 +2641,7 @@
       "fileName": "twitter-color-16",
       "iconName": "twitter-color",
       "description": "twitter",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2392,6 +2651,7 @@
       "fileName": "twitter-x-24",
       "iconName": "twitter-x",
       "description": "twitter, x",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2401,6 +2661,7 @@
       "fileName": "twitter-x-16",
       "iconName": "twitter-x",
       "description": "twitter, x",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2410,6 +2671,7 @@
       "fileName": "twitter-x-color-24",
       "iconName": "twitter-x-color",
       "description": "twitter, x",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2419,6 +2681,7 @@
       "fileName": "twitter-x-color-16",
       "iconName": "twitter-x-color",
       "description": "twitter, x",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2428,6 +2691,7 @@
       "fileName": "vantage-24",
       "iconName": "vantage",
       "description": "vantage",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2437,6 +2701,7 @@
       "fileName": "vantage-16",
       "iconName": "vantage",
       "description": "vantage",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2446,6 +2711,7 @@
       "fileName": "vantage-color-24",
       "iconName": "vantage-color",
       "description": "vantage",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2455,6 +2721,7 @@
       "fileName": "vantage-color-16",
       "iconName": "vantage-color",
       "description": "vantage",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2464,6 +2731,7 @@
       "fileName": "venafi-24",
       "iconName": "venafi",
       "description": "venafi, identity",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2473,6 +2741,7 @@
       "fileName": "venafi-16",
       "iconName": "venafi",
       "description": "venafi, identity",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2482,6 +2751,7 @@
       "fileName": "venafi-color-24",
       "iconName": "venafi-color",
       "description": "venafi, identity",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2491,6 +2761,7 @@
       "fileName": "venafi-color-16",
       "iconName": "venafi-color",
       "description": "venafi, identity",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2500,6 +2771,7 @@
       "fileName": "vercel-24",
       "iconName": "vercel",
       "description": "vercel",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2509,6 +2781,7 @@
       "fileName": "vercel-16",
       "iconName": "vercel",
       "description": "vercel",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2518,6 +2791,7 @@
       "fileName": "vercel-color-24",
       "iconName": "vercel-color",
       "description": "vercel",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2527,6 +2801,7 @@
       "fileName": "vercel-color-16",
       "iconName": "vercel-color",
       "description": "vercel",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2536,6 +2811,7 @@
       "fileName": "vmware-24",
       "iconName": "vmware",
       "description": "vmware, vmware cloud",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2545,6 +2821,7 @@
       "fileName": "vmware-16",
       "iconName": "vmware",
       "description": "vmware, vmware cloud",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2554,6 +2831,7 @@
       "fileName": "vmware-color-24",
       "iconName": "vmware-color",
       "description": "vmware, vmware cloud",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2563,6 +2841,7 @@
       "fileName": "vmware-color-16",
       "iconName": "vmware-color",
       "description": "vmware, vmware cloud",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2572,6 +2851,7 @@
       "fileName": "youtube-24",
       "iconName": "youtube",
       "description": "youtube, google",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2581,6 +2861,7 @@
       "fileName": "youtube-16",
       "iconName": "youtube",
       "description": "youtube, google",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2590,6 +2871,7 @@
       "fileName": "youtube-color-24",
       "iconName": "youtube-color",
       "description": "youtube, google",
+      "category": "Services",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2599,6 +2881,7 @@
       "fileName": "youtube-color-16",
       "iconName": "youtube-color",
       "description": "youtube, google",
+      "category": "Services",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2608,6 +2891,7 @@
       "fileName": "boundary-24",
       "iconName": "boundary",
       "description": "boundary",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2617,6 +2901,7 @@
       "fileName": "boundary-16",
       "iconName": "boundary",
       "description": "boundary",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2626,6 +2911,7 @@
       "fileName": "boundary-color-24",
       "iconName": "boundary-color",
       "description": "boundary",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2635,6 +2921,7 @@
       "fileName": "boundary-color-16",
       "iconName": "boundary-color",
       "description": "boundary",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2644,6 +2931,7 @@
       "fileName": "boundary-fill-24",
       "iconName": "boundary-fill",
       "description": "boundary",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2653,6 +2941,7 @@
       "fileName": "boundary-fill-16",
       "iconName": "boundary-fill",
       "description": "boundary",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2662,6 +2951,7 @@
       "fileName": "boundary-fill-color-24",
       "iconName": "boundary-fill-color",
       "description": "boundary",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2671,6 +2961,7 @@
       "fileName": "boundary-fill-color-16",
       "iconName": "boundary-fill-color",
       "description": "boundary",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2680,6 +2971,7 @@
       "fileName": "boundary-square-24",
       "iconName": "boundary-square",
       "description": "boundary",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2689,6 +2981,7 @@
       "fileName": "boundary-square-16",
       "iconName": "boundary-square",
       "description": "boundary",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2698,6 +2991,7 @@
       "fileName": "boundary-square-color-24",
       "iconName": "boundary-square-color",
       "description": "boundary",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2707,6 +3001,7 @@
       "fileName": "boundary-square-color-16",
       "iconName": "boundary-square-color",
       "description": "boundary",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2716,6 +3011,7 @@
       "fileName": "consul-24",
       "iconName": "consul",
       "description": "consul",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2725,6 +3021,7 @@
       "fileName": "consul-16",
       "iconName": "consul",
       "description": "consul",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2734,6 +3031,7 @@
       "fileName": "consul-color-24",
       "iconName": "consul-color",
       "description": "consul",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2743,6 +3041,7 @@
       "fileName": "consul-color-16",
       "iconName": "consul-color",
       "description": "consul",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2752,6 +3051,7 @@
       "fileName": "consul-fill-24",
       "iconName": "consul-fill",
       "description": "consul",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2761,6 +3061,7 @@
       "fileName": "consul-fill-16",
       "iconName": "consul-fill",
       "description": "consul",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2770,6 +3071,7 @@
       "fileName": "consul-fill-color-24",
       "iconName": "consul-fill-color",
       "description": "consul",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2779,6 +3081,7 @@
       "fileName": "consul-fill-color-16",
       "iconName": "consul-fill-color",
       "description": "consul",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2788,6 +3091,7 @@
       "fileName": "consul-square-24",
       "iconName": "consul-square",
       "description": "consul",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2797,6 +3101,7 @@
       "fileName": "consul-square-16",
       "iconName": "consul-square",
       "description": "consul",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2806,6 +3111,7 @@
       "fileName": "consul-square-color-24",
       "iconName": "consul-square-color",
       "description": "consul",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2815,6 +3121,7 @@
       "fileName": "consul-square-color-16",
       "iconName": "consul-square-color",
       "description": "consul",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2824,6 +3131,7 @@
       "fileName": "nomad-24",
       "iconName": "nomad",
       "description": "nomad",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2833,6 +3141,7 @@
       "fileName": "nomad-16",
       "iconName": "nomad",
       "description": "nomad",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2842,6 +3151,7 @@
       "fileName": "nomad-color-24",
       "iconName": "nomad-color",
       "description": "nomad",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2851,6 +3161,7 @@
       "fileName": "nomad-color-16",
       "iconName": "nomad-color",
       "description": "nomad",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2860,6 +3171,7 @@
       "fileName": "nomad-fill-24",
       "iconName": "nomad-fill",
       "description": "nomad",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2869,6 +3181,7 @@
       "fileName": "nomad-fill-16",
       "iconName": "nomad-fill",
       "description": "nomad",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2878,6 +3191,7 @@
       "fileName": "nomad-fill-color-24",
       "iconName": "nomad-fill-color",
       "description": "nomad",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2887,6 +3201,7 @@
       "fileName": "nomad-fill-color-16",
       "iconName": "nomad-fill-color",
       "description": "nomad",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2896,6 +3211,7 @@
       "fileName": "nomad-square-24",
       "iconName": "nomad-square",
       "description": "nomad",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2905,6 +3221,7 @@
       "fileName": "nomad-square-16",
       "iconName": "nomad-square",
       "description": "nomad",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2914,6 +3231,7 @@
       "fileName": "nomad-square-color-24",
       "iconName": "nomad-square-color",
       "description": "nomad",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2923,6 +3241,7 @@
       "fileName": "nomad-square-color-16",
       "iconName": "nomad-square-color",
       "description": "nomad",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2932,6 +3251,7 @@
       "fileName": "packer-24",
       "iconName": "packer",
       "description": "packer",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2941,6 +3261,7 @@
       "fileName": "packer-16",
       "iconName": "packer",
       "description": "packer",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2950,6 +3271,7 @@
       "fileName": "packer-color-24",
       "iconName": "packer-color",
       "description": "packer",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2959,6 +3281,7 @@
       "fileName": "packer-color-16",
       "iconName": "packer-color",
       "description": "packer",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2968,6 +3291,7 @@
       "fileName": "packer-fill-24",
       "iconName": "packer-fill",
       "description": "packer",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2977,6 +3301,7 @@
       "fileName": "packer-fill-16",
       "iconName": "packer-fill",
       "description": "packer",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -2986,6 +3311,7 @@
       "fileName": "packer-fill-color-24",
       "iconName": "packer-fill-color",
       "description": "packer",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -2995,6 +3321,7 @@
       "fileName": "packer-fill-color-16",
       "iconName": "packer-fill-color",
       "description": "packer",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3004,6 +3331,7 @@
       "fileName": "packer-square-24",
       "iconName": "packer-square",
       "description": "packer",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3013,6 +3341,7 @@
       "fileName": "packer-square-16",
       "iconName": "packer-square",
       "description": "packer",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3022,6 +3351,7 @@
       "fileName": "packer-square-color-24",
       "iconName": "packer-square-color",
       "description": "packer",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3031,6 +3361,7 @@
       "fileName": "packer-square-color-16",
       "iconName": "packer-square-color",
       "description": "packer",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3040,6 +3371,7 @@
       "fileName": "terraform-24",
       "iconName": "terraform",
       "description": "terraform",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3049,6 +3381,7 @@
       "fileName": "terraform-16",
       "iconName": "terraform",
       "description": "terraform",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3058,6 +3391,7 @@
       "fileName": "terraform-color-24",
       "iconName": "terraform-color",
       "description": "terraform",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3067,6 +3401,7 @@
       "fileName": "terraform-color-16",
       "iconName": "terraform-color",
       "description": "terraform",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3076,6 +3411,7 @@
       "fileName": "terraform-fill-24",
       "iconName": "terraform-fill",
       "description": "terraform",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3085,6 +3421,7 @@
       "fileName": "terraform-fill-16",
       "iconName": "terraform-fill",
       "description": "terraform",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3094,6 +3431,7 @@
       "fileName": "terraform-fill-color-24",
       "iconName": "terraform-fill-color",
       "description": "terraform",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3103,6 +3441,7 @@
       "fileName": "terraform-fill-color-16",
       "iconName": "terraform-fill-color",
       "description": "terraform",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3112,6 +3451,7 @@
       "fileName": "terraform-square-24",
       "iconName": "terraform-square",
       "description": "terraform",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3121,6 +3461,7 @@
       "fileName": "terraform-square-16",
       "iconName": "terraform-square",
       "description": "terraform",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3130,6 +3471,7 @@
       "fileName": "terraform-square-color-24",
       "iconName": "terraform-square-color",
       "description": "terraform",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3139,6 +3481,7 @@
       "fileName": "terraform-square-color-16",
       "iconName": "terraform-square-color",
       "description": "terraform",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3148,6 +3491,7 @@
       "fileName": "vagrant-24",
       "iconName": "vagrant",
       "description": "vagrant",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3157,6 +3501,7 @@
       "fileName": "vagrant-16",
       "iconName": "vagrant",
       "description": "vagrant",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3166,6 +3511,7 @@
       "fileName": "vagrant-color-24",
       "iconName": "vagrant-color",
       "description": "vagrant",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3175,6 +3521,7 @@
       "fileName": "vagrant-color-16",
       "iconName": "vagrant-color",
       "description": "vagrant",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3184,6 +3531,7 @@
       "fileName": "vagrant-fill-24",
       "iconName": "vagrant-fill",
       "description": "vagrant",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3193,6 +3541,7 @@
       "fileName": "vagrant-fill-16",
       "iconName": "vagrant-fill",
       "description": "vagrant",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3202,6 +3551,7 @@
       "fileName": "vagrant-fill-color-24",
       "iconName": "vagrant-fill-color",
       "description": "vagrant",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3211,6 +3561,7 @@
       "fileName": "vagrant-fill-color-16",
       "iconName": "vagrant-fill-color",
       "description": "vagrant",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3220,6 +3571,7 @@
       "fileName": "vagrant-square-24",
       "iconName": "vagrant-square",
       "description": "vagrant",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3229,6 +3581,7 @@
       "fileName": "vagrant-square-16",
       "iconName": "vagrant-square",
       "description": "vagrant",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3238,6 +3591,7 @@
       "fileName": "vagrant-square-color-24",
       "iconName": "vagrant-square-color",
       "description": "vagrant",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3247,6 +3601,7 @@
       "fileName": "vagrant-square-color-16",
       "iconName": "vagrant-square-color",
       "description": "vagrant",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3256,6 +3611,7 @@
       "fileName": "vault-24",
       "iconName": "vault",
       "description": "vault",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3265,6 +3621,7 @@
       "fileName": "vault-16",
       "iconName": "vault",
       "description": "vault",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3274,6 +3631,7 @@
       "fileName": "vault-color-24",
       "iconName": "vault-color",
       "description": "vault",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3283,6 +3641,7 @@
       "fileName": "vault-color-16",
       "iconName": "vault-color",
       "description": "vault",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3292,6 +3651,7 @@
       "fileName": "vault-fill-24",
       "iconName": "vault-fill",
       "description": "vault",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3301,6 +3661,7 @@
       "fileName": "vault-fill-16",
       "iconName": "vault-fill",
       "description": "vault",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3310,6 +3671,7 @@
       "fileName": "vault-fill-color-24",
       "iconName": "vault-fill-color",
       "description": "vault",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3319,6 +3681,7 @@
       "fileName": "vault-fill-color-16",
       "iconName": "vault-fill-color",
       "description": "vault",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3328,6 +3691,7 @@
       "fileName": "vault-square-24",
       "iconName": "vault-square",
       "description": "vault",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3337,6 +3701,7 @@
       "fileName": "vault-square-16",
       "iconName": "vault-square",
       "description": "vault",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3346,6 +3711,7 @@
       "fileName": "vault-square-color-24",
       "iconName": "vault-square-color",
       "description": "vault",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3355,6 +3721,7 @@
       "fileName": "vault-square-color-16",
       "iconName": "vault-square-color",
       "description": "vault",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3364,6 +3731,7 @@
       "fileName": "vault-radar-24",
       "iconName": "vault-radar",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3373,6 +3741,7 @@
       "fileName": "vault-radar-16",
       "iconName": "vault-radar",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3382,6 +3751,7 @@
       "fileName": "vault-radar-color-24",
       "iconName": "vault-radar-color",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3391,6 +3761,7 @@
       "fileName": "vault-radar-color-16",
       "iconName": "vault-radar-color",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3400,6 +3771,7 @@
       "fileName": "vault-radar-fill-24",
       "iconName": "vault-radar-fill",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3409,6 +3781,7 @@
       "fileName": "vault-radar-fill-16",
       "iconName": "vault-radar-fill",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3418,6 +3791,7 @@
       "fileName": "vault-radar-fill-color-24",
       "iconName": "vault-radar-fill-color",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3427,6 +3801,7 @@
       "fileName": "vault-radar-fill-color-16",
       "iconName": "vault-radar-fill-color",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3436,6 +3811,7 @@
       "fileName": "vault-radar-square-24",
       "iconName": "vault-radar-square",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3445,6 +3821,7 @@
       "fileName": "vault-radar-square-16",
       "iconName": "vault-radar-square",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3454,6 +3831,7 @@
       "fileName": "vault-radar-square-color-24",
       "iconName": "vault-radar-square-color",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3463,6 +3841,7 @@
       "fileName": "vault-radar-square-color-16",
       "iconName": "vault-radar-square-color",
       "description": "vault, hcp vault, radar",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3472,6 +3851,7 @@
       "fileName": "vault-secrets-24",
       "iconName": "vault-secrets",
       "description": "vault secrets, hcp vault secrets",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3481,6 +3861,7 @@
       "fileName": "vault-secrets-16",
       "iconName": "vault-secrets",
       "description": "vault secrets, hcp vault secrets",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3490,6 +3871,7 @@
       "fileName": "vault-secrets-color-24",
       "iconName": "vault-secrets-color",
       "description": "vault secrets, hcp vault secrets",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3499,6 +3881,7 @@
       "fileName": "vault-secrets-color-16",
       "iconName": "vault-secrets-color",
       "description": "vault secrets, hcp vault secrets",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3508,6 +3891,7 @@
       "fileName": "vault-secrets-fill-24",
       "iconName": "vault-secrets-fill",
       "description": "vault, hcp vault, secrets",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3517,6 +3901,7 @@
       "fileName": "vault-secrets-fill-16",
       "iconName": "vault-secrets-fill",
       "description": "vault, hcp vault, secrets",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3526,6 +3911,7 @@
       "fileName": "vault-secrets-fill-color-24",
       "iconName": "vault-secrets-fill-color",
       "description": "vault, hcp vault, secrets",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3535,6 +3921,7 @@
       "fileName": "vault-secrets-fill-color-16",
       "iconName": "vault-secrets-fill-color",
       "description": "vault, hcp vault, secrets",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3544,6 +3931,7 @@
       "fileName": "vault-secrets-square-24",
       "iconName": "vault-secrets-square",
       "description": "vault, hcp vault, secrets",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3553,6 +3941,7 @@
       "fileName": "vault-secrets-square-16",
       "iconName": "vault-secrets-square",
       "description": "vault, hcp vault, secrets",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3562,6 +3951,7 @@
       "fileName": "vault-secrets-square-color-24",
       "iconName": "vault-secrets-square-color",
       "description": "vault, hcp vault, secrets",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3571,6 +3961,7 @@
       "fileName": "vault-secrets-square-color-16",
       "iconName": "vault-secrets-square-color",
       "description": "vault, hcp vault, secrets",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3580,6 +3971,7 @@
       "fileName": "waypoint-24",
       "iconName": "waypoint",
       "description": "waypoint",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3589,6 +3981,7 @@
       "fileName": "waypoint-16",
       "iconName": "waypoint",
       "description": "waypoint",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3598,6 +3991,7 @@
       "fileName": "waypoint-color-24",
       "iconName": "waypoint-color",
       "description": "waypoint",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3607,6 +4001,7 @@
       "fileName": "waypoint-color-16",
       "iconName": "waypoint-color",
       "description": "waypoint",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3616,6 +4011,7 @@
       "fileName": "waypoint-fill-24",
       "iconName": "waypoint-fill",
       "description": "waypoint",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3625,6 +4021,7 @@
       "fileName": "waypoint-fill-16",
       "iconName": "waypoint-fill",
       "description": "waypoint",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3634,6 +4031,7 @@
       "fileName": "waypoint-fill-color-24",
       "iconName": "waypoint-fill-color",
       "description": "waypoint",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3643,6 +4041,7 @@
       "fileName": "waypoint-fill-color-16",
       "iconName": "waypoint-fill-color",
       "description": "waypoint",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3652,6 +4051,7 @@
       "fileName": "waypoint-square-24",
       "iconName": "waypoint-square",
       "description": "waypoint",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3661,6 +4061,7 @@
       "fileName": "waypoint-square-16",
       "iconName": "waypoint-square",
       "description": "waypoint",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3670,6 +4071,7 @@
       "fileName": "waypoint-square-color-24",
       "iconName": "waypoint-square-color",
       "description": "waypoint",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3679,6 +4081,7 @@
       "fileName": "waypoint-square-color-16",
       "iconName": "waypoint-square-color",
       "description": "waypoint",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3688,6 +4091,7 @@
       "fileName": "hashicorp-24",
       "iconName": "hashicorp",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3697,6 +4101,7 @@
       "fileName": "hashicorp-16",
       "iconName": "hashicorp",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3706,6 +4111,7 @@
       "fileName": "hashicorp-color-24",
       "iconName": "hashicorp-color",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3715,6 +4121,7 @@
       "fileName": "hashicorp-color-16",
       "iconName": "hashicorp-color",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3724,6 +4131,7 @@
       "fileName": "hashicorp-fill-24",
       "iconName": "hashicorp-fill",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3733,6 +4141,7 @@
       "fileName": "hashicorp-fill-16",
       "iconName": "hashicorp-fill",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3742,6 +4151,7 @@
       "fileName": "hashicorp-fill-color-24",
       "iconName": "hashicorp-fill-color",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3751,6 +4161,7 @@
       "fileName": "hashicorp-fill-color-16",
       "iconName": "hashicorp-fill-color",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3760,6 +4171,7 @@
       "fileName": "hashicorp-square-24",
       "iconName": "hashicorp-square",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3769,6 +4181,7 @@
       "fileName": "hashicorp-square-16",
       "iconName": "hashicorp-square",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3778,6 +4191,7 @@
       "fileName": "hashicorp-square-color-24",
       "iconName": "hashicorp-square-color",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3787,6 +4201,7 @@
       "fileName": "hashicorp-square-color-16",
       "iconName": "hashicorp-square-color",
       "description": "hashicorp, logo, brand",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3796,6 +4211,7 @@
       "fileName": "hcp-24",
       "iconName": "hcp",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3805,6 +4221,7 @@
       "fileName": "hcp-16",
       "iconName": "hcp",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3814,6 +4231,7 @@
       "fileName": "hcp-color-24",
       "iconName": "hcp-color",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3823,6 +4241,7 @@
       "fileName": "hcp-color-16",
       "iconName": "hcp-color",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3832,6 +4251,7 @@
       "fileName": "hcp-fill-24",
       "iconName": "hcp-fill",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3841,6 +4261,7 @@
       "fileName": "hcp-fill-16",
       "iconName": "hcp-fill",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3850,6 +4271,7 @@
       "fileName": "hcp-fill-color-24",
       "iconName": "hcp-fill-color",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3859,6 +4281,7 @@
       "fileName": "hcp-fill-color-16",
       "iconName": "hcp-fill-color",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3868,6 +4291,7 @@
       "fileName": "hcp-square-24",
       "iconName": "hcp-square",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3877,6 +4301,7 @@
       "fileName": "hcp-square-16",
       "iconName": "hcp-square",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3886,6 +4311,7 @@
       "fileName": "hcp-square-color-24",
       "iconName": "hcp-square-color",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3895,6 +4321,7 @@
       "fileName": "hcp-square-color-16",
       "iconName": "hcp-square-color",
       "description": "hcp, cloud, portal",
+      "category": "Products",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3904,6 +4331,7 @@
       "fileName": "activity-24",
       "iconName": "activity",
       "description": "activity, pulse, health",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3913,6 +4341,7 @@
       "fileName": "activity-16",
       "iconName": "activity",
       "description": "activity, pulse, health",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3922,6 +4351,7 @@
       "fileName": "accessibility-24",
       "iconName": "accessibility",
       "description": "a11y, inclusive, universal access",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3931,6 +4361,7 @@
       "fileName": "accessibility-16",
       "iconName": "accessibility",
       "description": "a11y, inclusive, universal access",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3940,6 +4371,7 @@
       "fileName": "alert-circle-24",
       "iconName": "alert-circle",
       "description": "alert, circle, error, attention, warning",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3949,6 +4381,7 @@
       "fileName": "alert-circle-16",
       "iconName": "alert-circle",
       "description": "alert, circle, error, attention, warning",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3958,6 +4391,7 @@
       "fileName": "alert-circle-fill-24",
       "iconName": "alert-circle-fill",
       "description": "alert, circle, error, attention, warning",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3967,6 +4401,7 @@
       "fileName": "alert-circle-fill-16",
       "iconName": "alert-circle-fill",
       "description": "alert, circle, error, attention, warning",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3976,6 +4411,7 @@
       "fileName": "alert-diamond-24",
       "iconName": "alert-diamond",
       "description": "alert, diamond, error, attention, warning",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -3985,6 +4421,7 @@
       "fileName": "alert-diamond-16",
       "iconName": "alert-diamond",
       "description": "alert, diamond, error, attention, warning",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -3994,6 +4431,7 @@
       "fileName": "alert-diamond-fill-24",
       "iconName": "alert-diamond-fill",
       "description": "alert, diamond, error, attention, warning",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4003,6 +4441,7 @@
       "fileName": "alert-diamond-fill-16",
       "iconName": "alert-diamond-fill",
       "description": "alert, diamond, error, attention, warning",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4012,6 +4451,7 @@
       "fileName": "alert-triangle-24",
       "iconName": "alert-triangle",
       "description": "alert, triangle, error, attention, warning",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4021,6 +4461,7 @@
       "fileName": "alert-triangle-16",
       "iconName": "alert-triangle",
       "description": "alert, triangle, error, attention, warning",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4030,6 +4471,7 @@
       "fileName": "alert-triangle-fill-24",
       "iconName": "alert-triangle-fill",
       "description": "alert, triangle, error, attention, warning",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4039,6 +4481,7 @@
       "fileName": "alert-triangle-fill-16",
       "iconName": "alert-triangle-fill",
       "description": "alert, triangle, error, attention, warning",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4048,6 +4491,7 @@
       "fileName": "alert-octagon-24",
       "iconName": "alert-octagon",
       "description": "alert, octagon, error, attention, warning",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4057,6 +4501,7 @@
       "fileName": "alert-octagon-16",
       "iconName": "alert-octagon",
       "description": "alert, octagon, error, attention, warning",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4066,6 +4511,7 @@
       "fileName": "alert-octagon-fill-24",
       "iconName": "alert-octagon-fill",
       "description": "alert, octagon, error, attention",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4075,6 +4521,7 @@
       "fileName": "alert-octagon-fill-16",
       "iconName": "alert-octagon-fill",
       "description": "alert, octagon, error, attention",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4084,6 +4531,7 @@
       "fileName": "align-center-24",
       "iconName": "align-center",
       "description": "align, text, center",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4093,6 +4541,7 @@
       "fileName": "align-center-16",
       "iconName": "align-center",
       "description": "align, text, center",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4102,6 +4551,7 @@
       "fileName": "align-justify-24",
       "iconName": "align-justify",
       "description": "align, text, justify",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4111,6 +4561,7 @@
       "fileName": "align-justify-16",
       "iconName": "align-justify",
       "description": "align, text, justify",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4120,6 +4571,7 @@
       "fileName": "align-left-24",
       "iconName": "align-left",
       "description": "align, text, left",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4129,6 +4581,7 @@
       "fileName": "align-left-16",
       "iconName": "align-left",
       "description": "align, text, left",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4138,6 +4591,7 @@
       "fileName": "align-right-24",
       "iconName": "align-right",
       "description": "align, text, right",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4147,6 +4601,7 @@
       "fileName": "align-right-16",
       "iconName": "align-right",
       "description": "align, text, right",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4156,6 +4611,7 @@
       "fileName": "ampersand-24",
       "iconName": "ampersand",
       "description": "and, or, conditional",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4165,6 +4621,7 @@
       "fileName": "ampersand-16",
       "iconName": "ampersand",
       "description": "and, or, conditional",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4174,6 +4631,7 @@
       "fileName": "api-24",
       "iconName": "api",
       "description": "api, data, interface",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4183,6 +4641,7 @@
       "fileName": "api-16",
       "iconName": "api",
       "description": "api, data, interface",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4192,6 +4651,7 @@
       "fileName": "archive-24",
       "iconName": "archive",
       "description": "archive, box, inbox",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4201,6 +4661,7 @@
       "fileName": "archive-16",
       "iconName": "archive",
       "description": "archive, box, inbox",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4210,6 +4671,7 @@
       "fileName": "arrow-down-24",
       "iconName": "arrow-down",
       "description": "arrow, direction, down",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4219,6 +4681,7 @@
       "fileName": "arrow-down-16",
       "iconName": "arrow-down",
       "description": "arrow, direction, down",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4228,6 +4691,7 @@
       "fileName": "arrow-down-circle-24",
       "iconName": "arrow-down-circle",
       "description": "arrow, direction, down, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4237,6 +4701,7 @@
       "fileName": "arrow-down-circle-16",
       "iconName": "arrow-down-circle",
       "description": "arrow, direction, down, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4246,6 +4711,7 @@
       "fileName": "arrow-down-left-24",
       "iconName": "arrow-down-left",
       "description": "arrow, direction, down, left",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4255,6 +4721,7 @@
       "fileName": "arrow-down-left-16",
       "iconName": "arrow-down-left",
       "description": "arrow, direction, down, left",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4264,6 +4731,7 @@
       "fileName": "arrow-down-right-24",
       "iconName": "arrow-down-right",
       "description": "arrow, direction, down, right",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4273,6 +4741,7 @@
       "fileName": "arrow-down-right-16",
       "iconName": "arrow-down-right",
       "description": "arrow, direction, down, right",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4282,6 +4751,7 @@
       "fileName": "arrow-left-24",
       "iconName": "arrow-left",
       "description": "arrow, direction, left",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4291,6 +4761,7 @@
       "fileName": "arrow-left-16",
       "iconName": "arrow-left",
       "description": "arrow, direction, left",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4300,6 +4771,7 @@
       "fileName": "arrow-left-circle-24",
       "iconName": "arrow-left-circle",
       "description": "arrow, direction, left, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4309,6 +4781,7 @@
       "fileName": "arrow-left-circle-16",
       "iconName": "arrow-left-circle",
       "description": "arrow, direction, left, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4318,6 +4791,7 @@
       "fileName": "arrow-right-24",
       "iconName": "arrow-right",
       "description": "arrow, direction, right",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4327,6 +4801,7 @@
       "fileName": "arrow-right-16",
       "iconName": "arrow-right",
       "description": "arrow, direction, right",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4336,6 +4811,7 @@
       "fileName": "arrow-right-circle-24",
       "iconName": "arrow-right-circle",
       "description": "arrow, direction, right, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4345,6 +4821,7 @@
       "fileName": "arrow-right-circle-16",
       "iconName": "arrow-right-circle",
       "description": "arrow, direction, right, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4354,6 +4831,7 @@
       "fileName": "arrow-up-24",
       "iconName": "arrow-up",
       "description": "arrow, direction, up",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4363,6 +4841,7 @@
       "fileName": "arrow-up-16",
       "iconName": "arrow-up",
       "description": "arrow, direction, up",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4372,6 +4851,7 @@
       "fileName": "arrow-up-circle-24",
       "iconName": "arrow-up-circle",
       "description": "arrow, direction, up, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4381,6 +4861,7 @@
       "fileName": "arrow-up-circle-16",
       "iconName": "arrow-up-circle",
       "description": "arrow, direction, up, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4390,6 +4871,7 @@
       "fileName": "arrow-up-left-24",
       "iconName": "arrow-up-left",
       "description": "arrow, direction, up, left",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4399,6 +4881,7 @@
       "fileName": "arrow-up-left-16",
       "iconName": "arrow-up-left",
       "description": "arrow, direction, up, left",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4408,6 +4891,7 @@
       "fileName": "arrow-up-right-24",
       "iconName": "arrow-up-right",
       "description": "arrow, direction, up, right",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4417,6 +4901,7 @@
       "fileName": "arrow-up-right-16",
       "iconName": "arrow-up-right",
       "description": "arrow, direction, up, right",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4426,6 +4911,7 @@
       "fileName": "at-sign-24",
       "iconName": "at-sign",
       "description": "at, @, email, handle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4435,6 +4921,7 @@
       "fileName": "at-sign-16",
       "iconName": "at-sign",
       "description": "at, @, email, handle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4444,6 +4931,7 @@
       "fileName": "award-24",
       "iconName": "award",
       "description": "award, medal, badge, achievement",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4453,6 +4941,7 @@
       "fileName": "award-16",
       "iconName": "award",
       "description": "award, medal, badge, achievement",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4462,6 +4951,7 @@
       "fileName": "auto-apply-24",
       "iconName": "auto-apply",
       "description": "apply, auto",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4471,6 +4961,7 @@
       "fileName": "auto-apply-16",
       "iconName": "auto-apply",
       "description": "apply, auto",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4480,6 +4971,7 @@
       "fileName": "bank-vault-24",
       "iconName": "bank-vault",
       "description": "vault, secure, safe, secret",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4489,6 +4981,7 @@
       "fileName": "bank-vault-16",
       "iconName": "bank-vault",
       "description": "vault, secure, safe, secret",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4498,6 +4991,7 @@
       "fileName": "bar-chart-24",
       "iconName": "bar-chart",
       "description": "chart, graph, usage, signal, bars",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4507,6 +5001,7 @@
       "fileName": "bar-chart-16",
       "iconName": "bar-chart",
       "description": "chart, graph, usage, signal, bars",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4516,6 +5011,7 @@
       "fileName": "bar-chart-alt-24",
       "iconName": "bar-chart-alt",
       "description": "chart, graph, usage, bars",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4525,6 +5021,7 @@
       "fileName": "bar-chart-alt-16",
       "iconName": "bar-chart-alt",
       "description": "chart, graph, usage, bars",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4534,6 +5031,7 @@
       "fileName": "battery-24",
       "iconName": "battery",
       "description": "battery, empty, charge",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4543,6 +5041,7 @@
       "fileName": "battery-16",
       "iconName": "battery",
       "description": "battery, empty, charge",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4552,6 +5051,7 @@
       "fileName": "battery-charging-24",
       "iconName": "battery-charging",
       "description": "battery, charging",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4561,6 +5061,7 @@
       "fileName": "battery-charging-16",
       "iconName": "battery-charging",
       "description": "battery, charging",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4570,6 +5071,7 @@
       "fileName": "beaker-24",
       "iconName": "beaker",
       "description": "beaker, lab, experiment, science, test",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4579,6 +5081,7 @@
       "fileName": "beaker-16",
       "iconName": "beaker",
       "description": "beaker, lab, experiment, science, test",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4588,6 +5091,7 @@
       "fileName": "bell-24",
       "iconName": "bell",
       "description": "bell, notification, notify, ring, alert",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4597,6 +5101,7 @@
       "fileName": "bell-16",
       "iconName": "bell",
       "description": "bell, notification, notify, ring, alert",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4606,6 +5111,7 @@
       "fileName": "bell-active-fill-24",
       "iconName": "bell-active-fill",
       "description": "bell, notification, notify, ring, alert",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4615,6 +5121,7 @@
       "fileName": "bell-active-fill-16",
       "iconName": "bell-active-fill",
       "description": "bell, notification, notify, ring, alert",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4624,6 +5131,7 @@
       "fileName": "bell-active-24",
       "iconName": "bell-active",
       "description": "bell, notification, notify, ring, alert",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4633,6 +5141,7 @@
       "fileName": "bell-active-16",
       "iconName": "bell-active",
       "description": "bell, notification, notify, ring, alert",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4642,6 +5151,7 @@
       "fileName": "bell-off-24",
       "iconName": "bell-off",
       "description": "bell, notification, notify, ring, alert, off, disabled",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4651,6 +5161,7 @@
       "fileName": "bell-off-16",
       "iconName": "bell-off",
       "description": "bell, notification, notify, ring, alert, off, disabled",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4660,6 +5171,7 @@
       "fileName": "bookmark-24",
       "iconName": "bookmark",
       "description": "bookmark, save",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4669,6 +5181,7 @@
       "fileName": "bookmark-16",
       "iconName": "bookmark",
       "description": "bookmark, save",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4678,6 +5191,7 @@
       "fileName": "bookmark-fill-24",
       "iconName": "bookmark-fill",
       "description": "bookmark, bookmarked, saved",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4687,6 +5201,7 @@
       "fileName": "bookmark-fill-16",
       "iconName": "bookmark-fill",
       "description": "bookmark, bookmarked, saved",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4696,6 +5211,7 @@
       "fileName": "bookmark-add-24",
       "iconName": "bookmark-add",
       "description": "bookmark, add, save",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4705,6 +5221,7 @@
       "fileName": "bookmark-add-16",
       "iconName": "bookmark-add",
       "description": "bookmark, add, save",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4714,6 +5231,7 @@
       "fileName": "bookmark-add-fill-24",
       "iconName": "bookmark-add-fill",
       "description": "bookmark, add, save",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4723,6 +5241,7 @@
       "fileName": "bookmark-add-fill-16",
       "iconName": "bookmark-add-fill",
       "description": "bookmark, add, save",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4732,6 +5251,7 @@
       "fileName": "bookmark-remove-24",
       "iconName": "bookmark-remove",
       "description": "bookmark, minus, remove",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4741,6 +5261,7 @@
       "fileName": "bookmark-remove-16",
       "iconName": "bookmark-remove",
       "description": "bookmark, minus, remove",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4750,6 +5271,7 @@
       "fileName": "bookmark-remove-fill-24",
       "iconName": "bookmark-remove-fill",
       "description": "bookmark, minus, remove",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4759,6 +5281,7 @@
       "fileName": "bookmark-remove-fill-16",
       "iconName": "bookmark-remove-fill",
       "description": "bookmark, minus, remove",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4768,6 +5291,7 @@
       "fileName": "bottom-24",
       "iconName": "bottom",
       "description": "bottom, scroll, down",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4777,6 +5301,7 @@
       "fileName": "bottom-16",
       "iconName": "bottom",
       "description": "bottom, scroll, down",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4786,6 +5311,7 @@
       "fileName": "box-24",
       "iconName": "box",
       "description": "box, package, cube, object",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4795,6 +5321,7 @@
       "fileName": "box-16",
       "iconName": "box",
       "description": "box, package, cube, object",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4804,6 +5331,7 @@
       "fileName": "briefcase-24",
       "iconName": "briefcase",
       "description": "briefcase, job, work, office, bag",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4813,6 +5341,7 @@
       "fileName": "briefcase-16",
       "iconName": "briefcase",
       "description": "briefcase, job, work, office, bag",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4822,6 +5351,7 @@
       "fileName": "bug-24",
       "iconName": "bug",
       "description": "bug, issue, security, malware, vulnerability",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4831,6 +5361,7 @@
       "fileName": "bug-16",
       "iconName": "bug",
       "description": "bug, issue, security, malware, vulnerability",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4840,6 +5371,7 @@
       "fileName": "build-24",
       "iconName": "build",
       "description": "build, wrench, tool",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4849,6 +5381,7 @@
       "fileName": "build-16",
       "iconName": "build",
       "description": "build, wrench, tool",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4858,6 +5391,7 @@
       "fileName": "bulb-24",
       "iconName": "bulb",
       "description": "bulb, light, idea, smart, insight, on",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4867,6 +5401,7 @@
       "fileName": "bulb-16",
       "iconName": "bulb",
       "description": "bulb, light, idea, smart, insight, on",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4876,6 +5411,7 @@
       "fileName": "calendar-24",
       "iconName": "calendar",
       "description": "calendar, date, appointment, event, schedule, day, month",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4885,6 +5421,7 @@
       "fileName": "calendar-16",
       "iconName": "calendar",
       "description": "calendar, date, appointment, event, schedule, day, month",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4894,6 +5431,7 @@
       "fileName": "camera-24",
       "iconName": "camera",
       "description": "camera, photo",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4903,6 +5441,7 @@
       "fileName": "camera-16",
       "iconName": "camera",
       "description": "camera, photo",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4912,6 +5451,7 @@
       "fileName": "camera-off-24",
       "iconName": "camera-off",
       "description": "camera, photo, off, disabled",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4921,6 +5461,7 @@
       "fileName": "camera-off-16",
       "iconName": "camera-off",
       "description": "camera, photo, off, disabled",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4930,6 +5471,7 @@
       "fileName": "caret-24",
       "iconName": "caret",
       "description": "caret, open, dropdown, double arrow, chevron",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4939,6 +5481,7 @@
       "fileName": "caret-16",
       "iconName": "caret",
       "description": "caret, open, dropdown, double arrow, chevron",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4948,6 +5491,7 @@
       "fileName": "cast-24",
       "iconName": "cast",
       "description": "cast, stream",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4957,6 +5501,7 @@
       "fileName": "cast-16",
       "iconName": "cast",
       "description": "cast, stream",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4966,6 +5511,7 @@
       "fileName": "certificate-24",
       "iconName": "certificate",
       "description": "certificate, award, achievement, badge",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4975,6 +5521,7 @@
       "fileName": "certificate-16",
       "iconName": "certificate",
       "description": "certificate, award, achievement, badge",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -4984,6 +5531,7 @@
       "fileName": "change-24",
       "iconName": "change",
       "description": "change, modified",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -4993,6 +5541,7 @@
       "fileName": "change-16",
       "iconName": "change",
       "description": "change, modified",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5002,6 +5551,7 @@
       "fileName": "change-circle-24",
       "iconName": "change-circle",
       "description": "change, modified, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5011,6 +5561,7 @@
       "fileName": "change-circle-16",
       "iconName": "change-circle",
       "description": "change, modified, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5020,6 +5571,7 @@
       "fileName": "change-square-24",
       "iconName": "change-square",
       "description": "change, modified, square",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5029,6 +5581,7 @@
       "fileName": "change-square-16",
       "iconName": "change-square",
       "description": "change, modified, square",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5038,6 +5591,7 @@
       "fileName": "channel-24",
       "iconName": "channel",
       "description": "channel, path",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5047,6 +5601,7 @@
       "fileName": "channel-16",
       "iconName": "channel",
       "description": "channel, path",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5056,6 +5611,7 @@
       "fileName": "check-24",
       "iconName": "check",
       "description": "check, tick, success, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5065,6 +5621,7 @@
       "fileName": "check-16",
       "iconName": "check",
       "description": "check, tick, success, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5074,6 +5631,7 @@
       "fileName": "check-circle-24",
       "iconName": "check-circle",
       "description": "check, tick, success, circle, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5083,6 +5641,7 @@
       "fileName": "check-circle-16",
       "iconName": "check-circle",
       "description": "check, tick, success, circle, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5092,6 +5651,7 @@
       "fileName": "check-circle-fill-24",
       "iconName": "check-circle-fill",
       "description": "check, tick, success, circle, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5101,6 +5661,7 @@
       "fileName": "check-circle-fill-16",
       "iconName": "check-circle-fill",
       "description": "check, tick, success, circle, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5110,6 +5671,7 @@
       "fileName": "check-diamond-24",
       "iconName": "check-diamond",
       "description": "check, tick, success, diamond, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5119,6 +5681,7 @@
       "fileName": "check-diamond-16",
       "iconName": "check-diamond",
       "description": "check, tick, success, diamond, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5128,6 +5691,7 @@
       "fileName": "check-diamond-fill-24",
       "iconName": "check-diamond-fill",
       "description": "check, tick, success, diamond, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5137,6 +5701,7 @@
       "fileName": "check-diamond-fill-16",
       "iconName": "check-diamond-fill",
       "description": "check, tick, success, diamond, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5146,6 +5711,7 @@
       "fileName": "check-hexagon-24",
       "iconName": "check-hexagon",
       "description": "check, tick, success, diamond, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5155,6 +5721,7 @@
       "fileName": "check-hexagon-16",
       "iconName": "check-hexagon",
       "description": "check, tick, success, diamond, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5164,6 +5731,7 @@
       "fileName": "check-hexagon-fill-24",
       "iconName": "check-hexagon-fill",
       "description": "check, tick, success, diamond, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5173,6 +5741,7 @@
       "fileName": "check-hexagon-fill-16",
       "iconName": "check-hexagon-fill",
       "description": "check, tick, success, diamond, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5182,6 +5751,7 @@
       "fileName": "check-square-24",
       "iconName": "check-square",
       "description": "check, tick, success, checkbox, square, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5191,6 +5761,7 @@
       "fileName": "check-square-16",
       "iconName": "check-square",
       "description": "check, tick, success, checkbox, square, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5200,6 +5771,7 @@
       "fileName": "check-square-fill-24",
       "iconName": "check-square-fill",
       "description": "check, tick, success, checkbox, square, checked, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5209,6 +5781,7 @@
       "fileName": "check-square-fill-16",
       "iconName": "check-square-fill",
       "description": "check, tick, success, checkbox, square, checked, complete, done, test, accept, approve",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5218,6 +5791,7 @@
       "fileName": "chevron-down-24",
       "iconName": "chevron-down",
       "description": "chevron, down, arrow, direction",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5227,6 +5801,7 @@
       "fileName": "chevron-down-16",
       "iconName": "chevron-down",
       "description": "chevron, down, arrow, direction",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5236,6 +5811,7 @@
       "fileName": "chevron-left-24",
       "iconName": "chevron-left",
       "description": "chevron, left, previous, back, arrow, direction",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5245,6 +5821,7 @@
       "fileName": "chevron-left-16",
       "iconName": "chevron-left",
       "description": "chevron, left, previous, back, arrow, direction",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5254,6 +5831,7 @@
       "fileName": "chevron-right-24",
       "iconName": "chevron-right",
       "description": "chevron, right, next, forward, arrow, direction",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5263,6 +5841,7 @@
       "fileName": "chevron-right-16",
       "iconName": "chevron-right",
       "description": "chevron, right, next, forward, arrow, direction",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5272,6 +5851,7 @@
       "fileName": "chevron-up-24",
       "iconName": "chevron-up",
       "description": "chevron, up, arrow, direction",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5281,6 +5861,7 @@
       "fileName": "chevron-up-16",
       "iconName": "chevron-up",
       "description": "chevron, up, arrow, direction",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5290,6 +5871,7 @@
       "fileName": "chevrons-down-24",
       "iconName": "chevrons-down",
       "description": "chevrons, down, arrow, direction",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5299,6 +5881,7 @@
       "fileName": "chevrons-down-16",
       "iconName": "chevrons-down",
       "description": "chevrons, down, arrow, direction",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5308,6 +5891,7 @@
       "fileName": "chevrons-left-24",
       "iconName": "chevrons-left",
       "description": "chevrons, left, previous, back, arrow, direction",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5317,6 +5901,7 @@
       "fileName": "chevrons-left-16",
       "iconName": "chevrons-left",
       "description": "chevrons, left, previous, back, arrow, direction",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5326,6 +5911,7 @@
       "fileName": "chevrons-right-24",
       "iconName": "chevrons-right",
       "description": "chevrons, right, next, forward, arrow, direction",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5335,6 +5921,7 @@
       "fileName": "chevrons-right-16",
       "iconName": "chevrons-right",
       "description": "chevrons, right, next, forward, arrow, direction",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5344,6 +5931,7 @@
       "fileName": "chevrons-up-24",
       "iconName": "chevrons-up",
       "description": "chevrons, up, arrow, direction",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5353,6 +5941,7 @@
       "fileName": "chevrons-up-16",
       "iconName": "chevrons-up",
       "description": "chevrons, up, arrow, direction",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5362,6 +5951,7 @@
       "fileName": "circle-24",
       "iconName": "circle",
       "description": "circle, ring, arrow, direction, round",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5371,6 +5961,7 @@
       "fileName": "circle-16",
       "iconName": "circle",
       "description": "circle, ring, arrow, direction, round",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5380,6 +5971,7 @@
       "fileName": "circle-dot-24",
       "iconName": "circle-dot",
       "description": "circle, dot, round",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5389,6 +5981,7 @@
       "fileName": "circle-dot-16",
       "iconName": "circle-dot",
       "description": "circle, dot, round",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5398,6 +5991,7 @@
       "fileName": "circle-fill-24",
       "iconName": "circle-fill",
       "description": "circle, dot, round",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5407,6 +6001,7 @@
       "fileName": "circle-fill-16",
       "iconName": "circle-fill",
       "description": "circle, dot, round",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5416,6 +6011,7 @@
       "fileName": "circle-half-24",
       "iconName": "circle-half",
       "description": "circle, dot, half, progress, round",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5425,6 +6021,7 @@
       "fileName": "circle-half-16",
       "iconName": "circle-half",
       "description": "circle, dot, half, progress, round",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5434,6 +6031,7 @@
       "fileName": "clipboard-24",
       "iconName": "clipboard",
       "description": "clipboard, copy, paste, content",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5443,6 +6041,7 @@
       "fileName": "clipboard-16",
       "iconName": "clipboard",
       "description": "clipboard, copy, paste, content",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5452,6 +6051,7 @@
       "fileName": "clipboard-checked-24",
       "iconName": "clipboard-checked",
       "description": "clipboard, copy, copied, success, paste, content",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5461,6 +6061,7 @@
       "fileName": "clipboard-checked-16",
       "iconName": "clipboard-checked",
       "description": "clipboard, copy, copied, success, paste, content",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5470,6 +6071,7 @@
       "fileName": "clipboard-copy-24",
       "iconName": "clipboard-copy",
       "description": "clipboard, copy, snippet, paste, content",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5479,6 +6081,7 @@
       "fileName": "clipboard-copy-16",
       "iconName": "clipboard-copy",
       "description": "clipboard, copy, snippet, paste, content",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5488,6 +6091,7 @@
       "fileName": "clipboard-x-24",
       "iconName": "clipboard-x",
       "description": "clipboard, copy, copied, error, paste, content",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5497,6 +6101,7 @@
       "fileName": "clipboard-x-16",
       "iconName": "clipboard-x",
       "description": "clipboard, copy, copied, error, paste, content",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5506,6 +6111,7 @@
       "fileName": "clock-24",
       "iconName": "clock",
       "description": "clock, time, activity, hour",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5515,6 +6121,7 @@
       "fileName": "clock-16",
       "iconName": "clock",
       "description": "clock, time, activity, hour",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5524,6 +6131,7 @@
       "fileName": "clock-filled-24",
       "iconName": "clock-filled",
       "description": "clock, time, activity, hour",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5533,6 +6141,7 @@
       "fileName": "clock-filled-16",
       "iconName": "clock-filled",
       "description": "clock, time, activity, hour",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5542,6 +6151,7 @@
       "fileName": "cloud-24",
       "iconName": "cloud",
       "description": "cloud, data, storage",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5551,6 +6161,7 @@
       "fileName": "cloud-16",
       "iconName": "cloud",
       "description": "cloud, data, storage",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5560,6 +6171,7 @@
       "fileName": "closed-caption-24",
       "iconName": "closed-caption",
       "description": "cc, closed-caption",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5569,6 +6181,7 @@
       "fileName": "closed-caption-16",
       "iconName": "closed-caption",
       "description": "cc, closed-caption",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5578,6 +6191,7 @@
       "fileName": "cloud-check-24",
       "iconName": "cloud-check",
       "description": "cloud, check, success, data, storage",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5587,6 +6201,7 @@
       "fileName": "cloud-check-16",
       "iconName": "cloud-check",
       "description": "cloud, check, success, data, storage",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5596,6 +6211,7 @@
       "fileName": "cloud-download-24",
       "iconName": "cloud-download",
       "description": "cloud, download, sync, data, storage",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5605,6 +6221,7 @@
       "fileName": "cloud-download-16",
       "iconName": "cloud-download",
       "description": "cloud, download, sync, data, storage",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5614,6 +6231,7 @@
       "fileName": "cloud-lightning-24",
       "iconName": "cloud-lightning",
       "description": "cloud, lightning, data, storage",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5623,6 +6241,7 @@
       "fileName": "cloud-lightning-16",
       "iconName": "cloud-lightning",
       "description": "cloud, lightning, data, storage",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5632,6 +6251,7 @@
       "fileName": "cloud-lock-24",
       "iconName": "cloud-lock",
       "description": "cloud, lock, secure, data, storage, protected",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5641,6 +6261,7 @@
       "fileName": "cloud-lock-16",
       "iconName": "cloud-lock",
       "description": "cloud, lock, secure, data, storage, protected",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5650,6 +6271,7 @@
       "fileName": "cloud-off-24",
       "iconName": "cloud-off",
       "description": "cloud, off, disabled, data, storage",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5659,6 +6281,7 @@
       "fileName": "cloud-off-16",
       "iconName": "cloud-off",
       "description": "cloud, off, disabled, data, storage",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5668,6 +6291,7 @@
       "fileName": "cloud-upload-24",
       "iconName": "cloud-upload",
       "description": "cloud, upload, sync, data, storage",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5677,6 +6301,7 @@
       "fileName": "cloud-upload-16",
       "iconName": "cloud-upload",
       "description": "cloud, upload, sync, data, storage",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5686,6 +6311,7 @@
       "fileName": "cloud-x-24",
       "iconName": "cloud-x",
       "description": "cloud, fail, delete, data, storage",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5695,6 +6321,7 @@
       "fileName": "cloud-x-16",
       "iconName": "cloud-x",
       "description": "cloud, fail, delete, data, storage",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5704,6 +6331,7 @@
       "fileName": "code-24",
       "iconName": "code",
       "description": "code, snippet, software, application, development",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5713,6 +6341,7 @@
       "fileName": "code-16",
       "iconName": "code",
       "description": "code, snippet, software, application, development",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5722,6 +6351,7 @@
       "fileName": "collections-24",
       "iconName": "collections",
       "description": "collections, books, projects, resources",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5731,6 +6361,7 @@
       "fileName": "collections-16",
       "iconName": "collections",
       "description": "collections, books, projects, resources",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5740,6 +6371,7 @@
       "fileName": "command-24",
       "iconName": "command",
       "description": "command, cmd, shortcut",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5749,6 +6381,7 @@
       "fileName": "command-16",
       "iconName": "command",
       "description": "command, cmd, shortcut",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5758,6 +6391,7 @@
       "fileName": "compass-24",
       "iconName": "compass",
       "description": "compass, navigate, browser, map",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5767,6 +6401,7 @@
       "fileName": "compass-16",
       "iconName": "compass",
       "description": "compass, navigate, browser, map",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5776,6 +6411,7 @@
       "fileName": "connection-24",
       "iconName": "connection",
       "description": "git, vcs, commit, link, network",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5785,6 +6421,7 @@
       "fileName": "connection-16",
       "iconName": "connection",
       "description": "git, vcs, commit, link, network",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5794,6 +6431,7 @@
       "fileName": "connection-gateway-24",
       "iconName": "connection-gateway",
       "description": "git, vcs, commit, link, network",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5803,6 +6441,7 @@
       "fileName": "connection-gateway-16",
       "iconName": "connection-gateway",
       "description": "git, vcs, commit, link, network",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5812,6 +6451,7 @@
       "fileName": "corner-down-left-24",
       "iconName": "corner-down-left",
       "description": "corner, arrow, down, left",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5821,6 +6461,7 @@
       "fileName": "corner-down-left-16",
       "iconName": "corner-down-left",
       "description": "corner, arrow, down, left",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5830,6 +6471,7 @@
       "fileName": "corner-down-right-24",
       "iconName": "corner-down-right",
       "description": "corner, arrow, down, right",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5839,6 +6481,7 @@
       "fileName": "corner-down-right-16",
       "iconName": "corner-down-right",
       "description": "corner, arrow, down, right",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5848,6 +6491,7 @@
       "fileName": "corner-left-down-24",
       "iconName": "corner-left-down",
       "description": "corner, arrow, down, left",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5857,6 +6501,7 @@
       "fileName": "corner-left-down-16",
       "iconName": "corner-left-down",
       "description": "corner, arrow, down, left",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5866,6 +6511,7 @@
       "fileName": "corner-left-up-24",
       "iconName": "corner-left-up",
       "description": "corner, arrow, up, left",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5875,6 +6521,7 @@
       "fileName": "corner-left-up-16",
       "iconName": "corner-left-up",
       "description": "corner, arrow, up, left",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5884,6 +6531,7 @@
       "fileName": "corner-right-down-24",
       "iconName": "corner-right-down",
       "description": "corner, arrow, down, right",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5893,6 +6541,7 @@
       "fileName": "corner-right-down-16",
       "iconName": "corner-right-down",
       "description": "corner, arrow, down, right",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5902,6 +6551,7 @@
       "fileName": "corner-right-up-24",
       "iconName": "corner-right-up",
       "description": "corner, arrow, up, right",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5911,6 +6561,7 @@
       "fileName": "corner-right-up-16",
       "iconName": "corner-right-up",
       "description": "corner, arrow, up, right",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5920,6 +6571,7 @@
       "fileName": "corner-up-left-24",
       "iconName": "corner-up-left",
       "description": "corner, arrow, up, left",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5929,6 +6581,7 @@
       "fileName": "corner-up-left-16",
       "iconName": "corner-up-left",
       "description": "corner, arrow, up, left",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5938,6 +6591,7 @@
       "fileName": "corner-up-right-24",
       "iconName": "corner-up-right",
       "description": "corner, arrow, up, right",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5947,6 +6601,7 @@
       "fileName": "corner-up-right-16",
       "iconName": "corner-up-right",
       "description": "corner, arrow, up, right",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5956,6 +6611,7 @@
       "fileName": "cpu-24",
       "iconName": "cpu",
       "description": "cpu, memory, chip, computer",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5965,6 +6621,7 @@
       "fileName": "cpu-16",
       "iconName": "cpu",
       "description": "cpu, memory, chip, computer",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5974,6 +6631,7 @@
       "fileName": "credit-card-24",
       "iconName": "credit-card",
       "description": "credit, card, billing, business, money, payment",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -5983,6 +6641,7 @@
       "fileName": "credit-card-16",
       "iconName": "credit-card",
       "description": "credit, card, billing, business, money, payment",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -5992,6 +6651,7 @@
       "fileName": "crop-24",
       "iconName": "crop",
       "description": "crop, edit",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6001,6 +6661,7 @@
       "fileName": "crop-16",
       "iconName": "crop",
       "description": "crop, edit",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6010,6 +6671,7 @@
       "fileName": "crosshair-24",
       "iconName": "crosshair",
       "description": "crosshair, target",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6019,6 +6681,7 @@
       "fileName": "crosshair-16",
       "iconName": "crosshair",
       "description": "crosshair, target",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6028,6 +6691,7 @@
       "fileName": "dashboard-24",
       "iconName": "dashboard",
       "description": "grid, dashboard, overview, layout",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6037,6 +6701,7 @@
       "fileName": "dashboard-16",
       "iconName": "dashboard",
       "description": "grid, dashboard, overview, layout",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6046,6 +6711,7 @@
       "fileName": "database-24",
       "iconName": "database",
       "description": "database, data,, information, computing",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6055,6 +6721,7 @@
       "fileName": "database-16",
       "iconName": "database",
       "description": "database, data,, information, computing",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6064,6 +6731,7 @@
       "fileName": "delay-24",
       "iconName": "delay",
       "description": "delay, time, clock, queue",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6073,6 +6741,7 @@
       "fileName": "delay-16",
       "iconName": "delay",
       "description": "delay, time, clock, queue",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6082,6 +6751,7 @@
       "fileName": "delete-24",
       "iconName": "delete",
       "description": "delete, backspace",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6091,6 +6761,7 @@
       "fileName": "delete-16",
       "iconName": "delete",
       "description": "delete, backspace",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6100,6 +6771,7 @@
       "fileName": "diamond-24",
       "iconName": "diamond",
       "description": "diamond, test",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6109,6 +6781,7 @@
       "fileName": "diamond-16",
       "iconName": "diamond",
       "description": "diamond, test",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6118,6 +6791,7 @@
       "fileName": "diamond-fill-24",
       "iconName": "diamond-fill",
       "description": "diamond, test",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6127,6 +6801,7 @@
       "fileName": "diamond-fill-16",
       "iconName": "diamond-fill",
       "description": "diamond, test",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6136,6 +6811,7 @@
       "fileName": "disc-24",
       "iconName": "disc",
       "description": "disc, cd",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6145,6 +6821,7 @@
       "fileName": "disc-16",
       "iconName": "disc",
       "description": "disc, cd",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6154,6 +6831,7 @@
       "fileName": "discussion-circle-24",
       "iconName": "discussion-circle",
       "description": "discussion, comment, conversation, bubble, chat, communication",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6163,6 +6841,7 @@
       "fileName": "discussion-circle-16",
       "iconName": "discussion-circle",
       "description": "discussion, comment, conversation, bubble, chat, communication",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6172,6 +6851,7 @@
       "fileName": "discussion-square-24",
       "iconName": "discussion-square",
       "description": "discussion, comment, conversation, bubble, chat, communication",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6181,6 +6861,7 @@
       "fileName": "discussion-square-16",
       "iconName": "discussion-square",
       "description": "discussion, comment, conversation, bubble, chat, communication",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6190,6 +6871,7 @@
       "fileName": "docs-24",
       "iconName": "docs",
       "description": "book, docs, learn",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6199,6 +6881,7 @@
       "fileName": "docs-16",
       "iconName": "docs",
       "description": "book, docs, learn",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6208,6 +6891,7 @@
       "fileName": "docs-download-24",
       "iconName": "docs-download",
       "description": "book, docs, learn, download",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6217,6 +6901,7 @@
       "fileName": "docs-download-16",
       "iconName": "docs-download",
       "description": "book, docs, learn, download",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6226,6 +6911,7 @@
       "fileName": "docs-link-24",
       "iconName": "docs-link",
       "description": "book, docs, learn, link, arrow",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6235,6 +6921,7 @@
       "fileName": "docs-link-16",
       "iconName": "docs-link",
       "description": "book, docs, learn, link, arrow",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6244,6 +6931,7 @@
       "fileName": "dollar-sign-24",
       "iconName": "dollar-sign",
       "description": "dollar, money, variable, payment",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6253,6 +6941,7 @@
       "fileName": "dollar-sign-16",
       "iconName": "dollar-sign",
       "description": "dollar, money, variable, payment",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6262,6 +6951,7 @@
       "fileName": "dot-24",
       "iconName": "dot",
       "description": "circle, dot, bullet",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6271,6 +6961,7 @@
       "fileName": "dot-16",
       "iconName": "dot",
       "description": "circle, dot, bullet",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6280,6 +6971,7 @@
       "fileName": "dot-half-24",
       "iconName": "dot-half",
       "description": "circle, dot, bullet, half, progress",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6289,6 +6981,7 @@
       "fileName": "dot-half-16",
       "iconName": "dot-half",
       "description": "circle, dot, bullet, half, progress",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6298,6 +6991,7 @@
       "fileName": "download-24",
       "iconName": "download",
       "description": "download, file, export, save",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6307,6 +7001,7 @@
       "fileName": "download-16",
       "iconName": "download",
       "description": "download, file, export, save",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6316,6 +7011,7 @@
       "fileName": "droplet-24",
       "iconName": "droplet",
       "description": "drop, water",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6325,6 +7021,7 @@
       "fileName": "droplet-16",
       "iconName": "droplet",
       "description": "drop, water",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6334,6 +7031,7 @@
       "fileName": "duplicate-24",
       "iconName": "duplicate",
       "description": "duplicate, copy, clone, multiply",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6343,6 +7041,7 @@
       "fileName": "duplicate-16",
       "iconName": "duplicate",
       "description": "duplicate, copy, clone, multiply",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6352,6 +7051,7 @@
       "fileName": "edit-24",
       "iconName": "edit",
       "description": "edit, pencil, draw, writing",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6361,6 +7061,7 @@
       "fileName": "edit-16",
       "iconName": "edit",
       "description": "edit, pencil, draw, writing",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6370,6 +7071,7 @@
       "fileName": "enterprise-24",
       "iconName": "enterprise",
       "description": "enterprise, business, company, organization, org, global, world",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6379,6 +7081,7 @@
       "fileName": "enterprise-16",
       "iconName": "enterprise",
       "description": "enterprise, business, company, organization, org, global, world",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6388,6 +7091,7 @@
       "fileName": "entry-point-24",
       "iconName": "entry-point",
       "description": "arrow, circle, enter, entry, service, start",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6397,6 +7101,7 @@
       "fileName": "entry-point-16",
       "iconName": "entry-point",
       "description": "arrow, circle, enter, entry, service, start",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6406,6 +7111,7 @@
       "fileName": "exit-point-24",
       "iconName": "exit-point",
       "description": "arrow, circle, exit, end, service",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6415,6 +7121,7 @@
       "fileName": "exit-point-16",
       "iconName": "exit-point",
       "description": "arrow, circle, exit, end, service",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6424,6 +7131,7 @@
       "fileName": "external-link-24",
       "iconName": "external-link",
       "description": "link, external, go",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6433,6 +7141,7 @@
       "fileName": "external-link-16",
       "iconName": "external-link",
       "description": "link, external, go",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6442,6 +7151,7 @@
       "fileName": "event-24",
       "iconName": "event",
       "description": "event, calendar, date",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6451,6 +7161,7 @@
       "fileName": "event-16",
       "iconName": "event",
       "description": "event, calendar, date",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6460,6 +7171,7 @@
       "fileName": "eye-24",
       "iconName": "eye",
       "description": "eye, view",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6469,6 +7181,7 @@
       "fileName": "eye-16",
       "iconName": "eye",
       "description": "eye, view",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6478,6 +7191,7 @@
       "fileName": "eye-off-24",
       "iconName": "eye-off",
       "description": "eye, view, off, disabled",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6487,6 +7201,7 @@
       "fileName": "eye-off-16",
       "iconName": "eye-off",
       "description": "eye, view, off, disabled",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6496,6 +7211,7 @@
       "fileName": "fast-forward-24",
       "iconName": "fast-forward",
       "description": "fastforward, forward, skip",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6505,6 +7221,7 @@
       "fileName": "fast-forward-16",
       "iconName": "fast-forward",
       "description": "fastforward, forward, skip",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6514,6 +7231,7 @@
       "fileName": "file-24",
       "iconName": "file",
       "description": "file, document, format, paper",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6523,6 +7241,7 @@
       "fileName": "file-16",
       "iconName": "file",
       "description": "file, document, format, paper",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6532,6 +7251,7 @@
       "fileName": "file-check-24",
       "iconName": "file-check",
       "description": "file, document, success, check, format, paper",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6541,6 +7261,7 @@
       "fileName": "file-check-16",
       "iconName": "file-check",
       "description": "file, document, success, check, format, paper",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6550,6 +7271,7 @@
       "fileName": "file-change-24",
       "iconName": "file-change",
       "description": "file, document, change, modified, format, paper",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6559,6 +7281,7 @@
       "fileName": "file-change-16",
       "iconName": "file-change",
       "description": "file, document, change, modified, format, paper",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6568,6 +7291,7 @@
       "fileName": "file-diff-24",
       "iconName": "file-diff",
       "description": "file, document, diff, change, format, paper",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6577,6 +7301,7 @@
       "fileName": "file-diff-16",
       "iconName": "file-diff",
       "description": "file, document, diff, change, format, paper",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6586,6 +7311,7 @@
       "fileName": "file-minus-24",
       "iconName": "file-minus",
       "description": "file, document, remove, minus, format, paper",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6595,6 +7321,7 @@
       "fileName": "file-minus-16",
       "iconName": "file-minus",
       "description": "file, document, remove, minus, format, paper",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6604,6 +7331,7 @@
       "fileName": "file-plus-24",
       "iconName": "file-plus",
       "description": "file, document, create, add, plus, format, paper",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6613,6 +7341,7 @@
       "fileName": "file-plus-16",
       "iconName": "file-plus",
       "description": "file, document, create, add, plus, format, paper",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6622,6 +7351,7 @@
       "fileName": "file-source-24",
       "iconName": "file-source",
       "description": "file, document, source, code, format, paper",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6631,6 +7361,7 @@
       "fileName": "file-source-16",
       "iconName": "file-source",
       "description": "file, document, source, code, format, paper",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6640,6 +7371,7 @@
       "fileName": "file-text-24",
       "iconName": "file-text",
       "description": "file, document, text, format, paper",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6649,6 +7381,7 @@
       "fileName": "file-text-16",
       "iconName": "file-text",
       "description": "file, document, text, format, paper",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6658,6 +7391,7 @@
       "fileName": "file-x-24",
       "iconName": "file-x",
       "description": "file, document, deleted, removed, format, paper",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6667,6 +7401,7 @@
       "fileName": "file-x-16",
       "iconName": "file-x",
       "description": "file, document, deleted, removed, format, paper",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6676,6 +7411,7 @@
       "fileName": "files-24",
       "iconName": "files",
       "description": "files, documents, group, hosts, format, paper",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6685,6 +7421,7 @@
       "fileName": "files-16",
       "iconName": "files",
       "description": "files, documents, group, hosts, format, paper",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6694,6 +7431,7 @@
       "fileName": "film-24",
       "iconName": "film",
       "description": "film, movie, video",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6703,6 +7441,7 @@
       "fileName": "film-16",
       "iconName": "film",
       "description": "film, movie, video",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6712,6 +7451,7 @@
       "fileName": "filter-24",
       "iconName": "filter",
       "description": "filter, options, configuration",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6721,6 +7461,7 @@
       "fileName": "filter-16",
       "iconName": "filter",
       "description": "filter, options, configuration",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6730,6 +7471,7 @@
       "fileName": "filter-circle-24",
       "iconName": "filter-circle",
       "description": "filter, circle, inactive, off, options, configuration",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6739,6 +7481,7 @@
       "fileName": "filter-circle-16",
       "iconName": "filter-circle",
       "description": "filter, circle, inactive, off, options, configuration",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6748,6 +7491,7 @@
       "fileName": "filter-fill-24",
       "iconName": "filter-fill",
       "description": "filter, circle, active, on, options, configuration",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6757,6 +7501,7 @@
       "fileName": "filter-fill-16",
       "iconName": "filter-fill",
       "description": "filter, circle, active, on, options, configuration",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6766,6 +7511,7 @@
       "fileName": "fingerprint-24",
       "iconName": "fingerprint",
       "description": "",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6775,6 +7521,7 @@
       "fileName": "fingerprint-16",
       "iconName": "fingerprint",
       "description": "",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6784,6 +7531,7 @@
       "fileName": "flag-24",
       "iconName": "flag",
       "description": "flag, mark",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6793,6 +7541,7 @@
       "fileName": "flag-16",
       "iconName": "flag",
       "description": "flag, mark",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6802,6 +7551,7 @@
       "fileName": "folder-24",
       "iconName": "folder",
       "description": "folder, directory, project, document, file",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6811,6 +7561,7 @@
       "fileName": "folder-16",
       "iconName": "folder",
       "description": "folder, directory, project, document, file",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6820,6 +7571,7 @@
       "fileName": "folder-fill-24",
       "iconName": "folder-fill",
       "description": "folder, directory, project, document, file",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6829,6 +7581,7 @@
       "fileName": "folder-fill-16",
       "iconName": "folder-fill",
       "description": "folder, directory, project, document, file",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6838,6 +7591,7 @@
       "fileName": "folder-minus-24",
       "iconName": "folder-minus",
       "description": "folder, directory, project, minus, remove, document, file",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6847,6 +7601,7 @@
       "fileName": "folder-minus-16",
       "iconName": "folder-minus",
       "description": "folder, directory, project, minus, remove, document, file",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6856,6 +7611,7 @@
       "fileName": "folder-minus-fill-24",
       "iconName": "folder-minus-fill",
       "description": "folder, directory, project, minus, remove, document, file",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6865,6 +7621,7 @@
       "fileName": "folder-minus-fill-16",
       "iconName": "folder-minus-fill",
       "description": "folder, directory, project, minus, remove, document, file",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6874,6 +7631,7 @@
       "fileName": "folder-plus-24",
       "iconName": "folder-plus",
       "description": "folder, directory, project, plus, add, create, document, file",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6883,6 +7641,7 @@
       "fileName": "folder-plus-16",
       "iconName": "folder-plus",
       "description": "folder, directory, project, plus, add, create, document, file",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6892,6 +7651,7 @@
       "fileName": "folder-plus-fill-24",
       "iconName": "folder-plus-fill",
       "description": "folder, directory, project, plus, add, create, document, file",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6901,6 +7661,7 @@
       "fileName": "folder-plus-fill-16",
       "iconName": "folder-plus-fill",
       "description": "folder, directory, project, plus, add, create, document, file",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6910,6 +7671,7 @@
       "fileName": "folder-star-24",
       "iconName": "folder-star",
       "description": "folder, directory, starred, favorite, pinned, document, file",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6919,6 +7681,7 @@
       "fileName": "folder-star-16",
       "iconName": "folder-star",
       "description": "folder, directory, starred, favorite, pinned, document, file",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6928,6 +7691,7 @@
       "fileName": "folder-users-24",
       "iconName": "folder-users",
       "description": "folder, directory, project, group, users, document, file",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6937,6 +7701,7 @@
       "fileName": "folder-users-16",
       "iconName": "folder-users",
       "description": "folder, directory, project, group, users, document, file",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6946,6 +7711,7 @@
       "fileName": "frown-24",
       "iconName": "frown",
       "description": "emoji, frown, negative, sad, face",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6955,6 +7721,7 @@
       "fileName": "frown-16",
       "iconName": "frown",
       "description": "emoji, frown, negative, sad, face",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6964,6 +7731,7 @@
       "fileName": "gateway-24",
       "iconName": "gateway",
       "description": "gateway, entrance, tunnel",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6973,6 +7741,7 @@
       "fileName": "gateway-16",
       "iconName": "gateway",
       "description": "gateway, entrance, tunnel",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -6982,6 +7751,7 @@
       "fileName": "gift-24",
       "iconName": "gift",
       "description": "gift, present, new",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -6991,6 +7761,7 @@
       "fileName": "gift-16",
       "iconName": "gift",
       "description": "gift, present, new",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7000,6 +7771,7 @@
       "fileName": "git-branch-24",
       "iconName": "git-branch",
       "description": "git, vcs, branch",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7009,6 +7781,7 @@
       "fileName": "git-branch-16",
       "iconName": "git-branch",
       "description": "git, vcs, branch",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7018,6 +7791,7 @@
       "fileName": "git-commit-24",
       "iconName": "git-commit",
       "description": "git, vcs, commit",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7027,6 +7801,7 @@
       "fileName": "git-commit-16",
       "iconName": "git-commit",
       "description": "git, vcs, commit",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7036,6 +7811,7 @@
       "fileName": "git-merge-24",
       "iconName": "git-merge",
       "description": "git, vcs, merge",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7045,6 +7821,7 @@
       "fileName": "git-merge-16",
       "iconName": "git-merge",
       "description": "git, vcs, merge",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7054,6 +7831,7 @@
       "fileName": "git-pull-request-24",
       "iconName": "git-pull-request",
       "description": "git, vcs, pull, request, pr",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7063,6 +7841,7 @@
       "fileName": "git-pull-request-16",
       "iconName": "git-pull-request",
       "description": "git, vcs, pull, request, pr",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7072,6 +7851,7 @@
       "fileName": "git-repo-24",
       "iconName": "git-repo",
       "description": "git, vcs, repository",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7081,6 +7861,7 @@
       "fileName": "git-repo-16",
       "iconName": "git-repo",
       "description": "git, vcs, repository",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7090,6 +7871,7 @@
       "fileName": "globe-24",
       "iconName": "globe",
       "description": "globe, world, global",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7099,6 +7881,7 @@
       "fileName": "globe-16",
       "iconName": "globe",
       "description": "globe, world, global",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7108,6 +7891,7 @@
       "fileName": "globe-private-24",
       "iconName": "globe-private",
       "description": "globe, world, global, private, secure, encrypted, protected",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7117,6 +7901,7 @@
       "fileName": "globe-private-16",
       "iconName": "globe-private",
       "description": "globe, world, global, private, secure, encrypted, protected",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7126,6 +7911,7 @@
       "fileName": "government-24",
       "iconName": "government",
       "description": "government, public, sector, organization, building",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7135,6 +7921,7 @@
       "fileName": "government-16",
       "iconName": "government",
       "description": "government, public, sector, organization, building",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7144,6 +7931,7 @@
       "fileName": "grid-24",
       "iconName": "grid",
       "description": "grid, format, view, group, layout",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7153,6 +7941,7 @@
       "fileName": "grid-16",
       "iconName": "grid",
       "description": "grid, format, view, group, layout",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7162,6 +7951,7 @@
       "fileName": "grid-alt-24",
       "iconName": "grid-alt",
       "description": "grid, format, view, group, layout",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7171,6 +7961,7 @@
       "fileName": "grid-alt-16",
       "iconName": "grid-alt",
       "description": "grid, format, view, group, layout",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7180,6 +7971,7 @@
       "fileName": "guide-24",
       "iconName": "guide",
       "description": "book, library, catalogue, guide",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7189,6 +7981,7 @@
       "fileName": "guide-16",
       "iconName": "guide",
       "description": "book, library, catalogue, guide",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7198,6 +7991,7 @@
       "fileName": "guide-link-24",
       "iconName": "guide-link",
       "description": "book, library, catalogue, guide, link, arrow",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7207,6 +8001,7 @@
       "fileName": "guide-link-16",
       "iconName": "guide-link",
       "description": "book, library, catalogue, guide, link, arrow",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7216,6 +8011,7 @@
       "fileName": "hammer-24",
       "iconName": "hammer",
       "description": "hammer, build, tool",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7225,6 +8021,7 @@
       "fileName": "hammer-16",
       "iconName": "hammer",
       "description": "hammer, build, tool",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7234,6 +8031,7 @@
       "fileName": "handshake-24",
       "iconName": "handshake",
       "description": "hands, handshake, partners",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7243,6 +8041,7 @@
       "fileName": "handshake-16",
       "iconName": "handshake",
       "description": "hands, handshake, partners",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7252,6 +8051,7 @@
       "fileName": "hard-drive-24",
       "iconName": "hard-drive",
       "description": "hard, drive, disk, storage",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7261,6 +8061,7 @@
       "fileName": "hard-drive-16",
       "iconName": "hard-drive",
       "description": "hard, drive, disk, storage",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7270,6 +8071,7 @@
       "fileName": "hash-24",
       "iconName": "hash",
       "description": "hash, pound, tag",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7279,6 +8081,7 @@
       "fileName": "hash-16",
       "iconName": "hash",
       "description": "hash, pound, tag",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7288,6 +8091,7 @@
       "fileName": "headphones-24",
       "iconName": "headphones",
       "description": "headphones, music, sound",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7297,6 +8101,7 @@
       "fileName": "headphones-16",
       "iconName": "headphones",
       "description": "headphones, music, sound",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7306,6 +8111,7 @@
       "fileName": "heart-24",
       "iconName": "heart",
       "description": "heart, like, love, favorite",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7315,6 +8121,7 @@
       "fileName": "heart-16",
       "iconName": "heart",
       "description": "heart, like, love, favorite",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7324,6 +8131,7 @@
       "fileName": "heart-fill-24",
       "iconName": "heart-fill",
       "description": "heart, liked, loved, favorited",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7333,6 +8141,7 @@
       "fileName": "heart-fill-16",
       "iconName": "heart-fill",
       "description": "heart, liked, loved, favorited",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7342,6 +8151,7 @@
       "fileName": "heart-off-24",
       "iconName": "heart-off",
       "description": "heart, like, love, favorite, disabled, off",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7351,6 +8161,7 @@
       "fileName": "heart-off-16",
       "iconName": "heart-off",
       "description": "heart, like, love, favorite, disabled, off",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7360,6 +8171,7 @@
       "fileName": "help-24",
       "iconName": "help",
       "description": "help, question, support, information, unknown",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7369,6 +8181,7 @@
       "fileName": "help-16",
       "iconName": "help",
       "description": "help, question, support, information, unknown",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7378,6 +8191,7 @@
       "fileName": "hexagon-24",
       "iconName": "hexagon",
       "description": "diamond, test",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7387,6 +8201,7 @@
       "fileName": "hexagon-16",
       "iconName": "hexagon",
       "description": "diamond, test",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7396,6 +8211,7 @@
       "fileName": "hexagon-fill-24",
       "iconName": "hexagon-fill",
       "description": "diamond, test",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7405,6 +8221,7 @@
       "fileName": "hexagon-fill-16",
       "iconName": "hexagon-fill",
       "description": "diamond, test",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7414,6 +8231,7 @@
       "fileName": "history-24",
       "iconName": "history",
       "description": "clock, time, history, schedule",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7423,6 +8241,7 @@
       "fileName": "history-16",
       "iconName": "history",
       "description": "clock, time, history, schedule",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7432,6 +8251,7 @@
       "fileName": "home-24",
       "iconName": "home",
       "description": "home, house",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7441,6 +8261,7 @@
       "fileName": "home-16",
       "iconName": "home",
       "description": "home, house",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7450,6 +8271,7 @@
       "fileName": "hourglass-24",
       "iconName": "hourglass",
       "description": "hourglass, time",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7459,6 +8281,7 @@
       "fileName": "hourglass-16",
       "iconName": "hourglass",
       "description": "hourglass, time",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7468,6 +8291,7 @@
       "fileName": "identity-user-24",
       "iconName": "identity-user",
       "description": "identity, id, user",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7477,6 +8301,7 @@
       "fileName": "identity-user-16",
       "iconName": "identity-user",
       "description": "identity, id, user",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7486,6 +8311,7 @@
       "fileName": "identity-service-24",
       "iconName": "identity-service",
       "description": "identity, id, service, globe",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7495,6 +8321,7 @@
       "fileName": "identity-service-16",
       "iconName": "identity-service",
       "description": "identity, id, service, globe",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7504,6 +8331,7 @@
       "fileName": "image-24",
       "iconName": "image",
       "description": "image, photo, picture, media",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7513,6 +8341,7 @@
       "fileName": "image-16",
       "iconName": "image",
       "description": "image, photo, picture, media",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7522,6 +8351,7 @@
       "fileName": "inbox-24",
       "iconName": "inbox",
       "description": "inbox, tray",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7531,6 +8361,7 @@
       "fileName": "inbox-16",
       "iconName": "inbox",
       "description": "inbox, tray",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7540,6 +8371,7 @@
       "fileName": "info-24",
       "iconName": "info",
       "description": "info, tip, about",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7549,6 +8381,7 @@
       "fileName": "info-16",
       "iconName": "info",
       "description": "info, tip, about",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7558,6 +8391,7 @@
       "fileName": "info-fill-24",
       "iconName": "info-fill",
       "description": "info, tip, about",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7567,6 +8401,7 @@
       "fileName": "info-fill-16",
       "iconName": "info-fill",
       "description": "info, tip, about",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7576,6 +8411,7 @@
       "fileName": "jump-link-24",
       "iconName": "jump-link",
       "description": "jump, go, link, skip",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7585,6 +8421,7 @@
       "fileName": "jump-link-16",
       "iconName": "jump-link",
       "description": "jump, go, link, skip",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7594,6 +8431,7 @@
       "fileName": "key-24",
       "iconName": "key",
       "description": "key, secure, secret",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7603,6 +8441,7 @@
       "fileName": "key-16",
       "iconName": "key",
       "description": "key, secure, secret",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7612,6 +8451,7 @@
       "fileName": "key-values-24",
       "iconName": "key-values",
       "description": "key, value, store, kv",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7621,6 +8461,7 @@
       "fileName": "key-values-16",
       "iconName": "key-values",
       "description": "key, value, store, kv",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7630,6 +8471,7 @@
       "fileName": "keychain-24",
       "iconName": "keychain",
       "description": "keys, keychain",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7639,6 +8481,7 @@
       "fileName": "keychain-16",
       "iconName": "keychain",
       "description": "keys, keychain",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7648,6 +8491,7 @@
       "fileName": "labyrinth-24",
       "iconName": "labyrinth",
       "description": "labyrinth, maze",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7657,6 +8501,7 @@
       "fileName": "labyrinth-16",
       "iconName": "labyrinth",
       "description": "labyrinth, maze",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7666,6 +8511,7 @@
       "fileName": "layers-24",
       "iconName": "layers",
       "description": "layers, stack",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7675,6 +8521,7 @@
       "fileName": "layers-16",
       "iconName": "layers",
       "description": "layers, stack",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7684,6 +8531,7 @@
       "fileName": "layout-24",
       "iconName": "layout",
       "description": "layout, app, window",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7693,6 +8541,7 @@
       "fileName": "layout-16",
       "iconName": "layout",
       "description": "layout, app, window",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7702,6 +8551,7 @@
       "fileName": "learn-24",
       "iconName": "learn",
       "description": "learn, education, college, school",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7711,6 +8561,7 @@
       "fileName": "learn-16",
       "iconName": "learn",
       "description": "learn, education, college, school",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7720,6 +8571,7 @@
       "fileName": "learn-link-24",
       "iconName": "learn-link",
       "description": "learn, education, college, school, go, link",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7729,6 +8581,7 @@
       "fileName": "learn-link-16",
       "iconName": "learn-link",
       "description": "learn, education, college, school, go, link",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7738,6 +8591,7 @@
       "fileName": "line-chart-24",
       "iconName": "line-chart",
       "description": "chart, graph, trend, data",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7747,6 +8601,7 @@
       "fileName": "line-chart-16",
       "iconName": "line-chart",
       "description": "chart, graph, trend, data",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7756,6 +8611,7 @@
       "fileName": "line-chart-up-24",
       "iconName": "line-chart-up",
       "description": "chart, graph, trend, up, data",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7765,6 +8621,7 @@
       "fileName": "line-chart-up-16",
       "iconName": "line-chart-up",
       "description": "chart, graph, trend, up, data",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7774,6 +8631,7 @@
       "fileName": "link-24",
       "iconName": "link",
       "description": "link, url",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7783,6 +8641,7 @@
       "fileName": "link-16",
       "iconName": "link",
       "description": "link, url",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7792,6 +8651,7 @@
       "fileName": "list-24",
       "iconName": "list",
       "description": "list, format, view, group",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7801,6 +8661,7 @@
       "fileName": "list-16",
       "iconName": "list",
       "description": "list, format, view, group",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7810,6 +8671,7 @@
       "fileName": "load-balancer-24",
       "iconName": "load-balancer",
       "description": "load, balancer, arrows",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7819,6 +8681,7 @@
       "fileName": "load-balancer-16",
       "iconName": "load-balancer",
       "description": "load, balancer, arrows",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7828,6 +8691,7 @@
       "fileName": "lock-24",
       "iconName": "lock",
       "description": "lock, secure, security, protection",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7837,6 +8701,7 @@
       "fileName": "lock-16",
       "iconName": "lock",
       "description": "lock, secure, security, protection",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7846,6 +8711,7 @@
       "fileName": "lock-fill-24",
       "iconName": "lock-fill",
       "description": "lock, secure, locked, secured, protected",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7855,6 +8721,7 @@
       "fileName": "lock-fill-16",
       "iconName": "lock-fill",
       "description": "lock, secure, locked, secured, protected",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7864,6 +8731,7 @@
       "fileName": "lock-off-24",
       "iconName": "lock-off",
       "description": "lock, secure, off, disabled, protected",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7873,6 +8741,7 @@
       "fileName": "lock-off-16",
       "iconName": "lock-off",
       "description": "lock, secure, off, disabled, protected",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7882,6 +8751,7 @@
       "fileName": "logs-24",
       "iconName": "logs",
       "description": "logs, events, list",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7891,6 +8761,7 @@
       "fileName": "logs-16",
       "iconName": "logs",
       "description": "logs, events, list",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7900,6 +8771,7 @@
       "fileName": "mail-24",
       "iconName": "mail",
       "description": "mail, email, message, communication",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7909,6 +8781,7 @@
       "fileName": "mail-16",
       "iconName": "mail",
       "description": "mail, email, message, communication",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7918,6 +8791,7 @@
       "fileName": "mail-open-24",
       "iconName": "mail-open",
       "description": "mail, email, message, opened, communication",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7927,6 +8801,7 @@
       "fileName": "mail-open-16",
       "iconName": "mail-open",
       "description": "mail, email, message, opened, communication",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7936,6 +8811,7 @@
       "fileName": "mainframe-24",
       "iconName": "mainframe",
       "description": "mainframe, server",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7945,6 +8821,7 @@
       "fileName": "mainframe-16",
       "iconName": "mainframe",
       "description": "mainframe, server",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7954,6 +8831,7 @@
       "fileName": "map-24",
       "iconName": "map",
       "description": "map, navigate, plan, location",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7963,6 +8841,7 @@
       "fileName": "map-16",
       "iconName": "map",
       "description": "map, navigate, plan, location",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7972,6 +8851,7 @@
       "fileName": "map-pin-24",
       "iconName": "map-pin",
       "description": "map, pin, location",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7981,6 +8861,7 @@
       "fileName": "map-pin-16",
       "iconName": "map-pin",
       "description": "map, pin, location",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -7990,6 +8871,7 @@
       "fileName": "maximize-24",
       "iconName": "maximize",
       "description": "maximize, zoom",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -7999,6 +8881,7 @@
       "fileName": "maximize-16",
       "iconName": "maximize",
       "description": "maximize, zoom",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8008,6 +8891,7 @@
       "fileName": "maximize-alt-24",
       "iconName": "maximize-alt",
       "description": "maximize, zoom",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8017,6 +8901,7 @@
       "fileName": "maximize-alt-16",
       "iconName": "maximize-alt",
       "description": "maximize, zoom",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8026,6 +8911,7 @@
       "fileName": "meh-24",
       "iconName": "meh",
       "description": "emoji, meh, neutral",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8035,6 +8921,7 @@
       "fileName": "meh-16",
       "iconName": "meh",
       "description": "emoji, meh, neutral",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8044,6 +8931,7 @@
       "fileName": "menu-24",
       "iconName": "menu",
       "description": "menu, hamburger, navigation, list",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8053,6 +8941,7 @@
       "fileName": "menu-16",
       "iconName": "menu",
       "description": "menu, hamburger, navigation, list",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8062,6 +8951,7 @@
       "fileName": "mesh-24",
       "iconName": "mesh",
       "description": "mesh, network",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8071,6 +8961,7 @@
       "fileName": "mesh-16",
       "iconName": "mesh",
       "description": "mesh, network",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8080,6 +8971,7 @@
       "fileName": "message-circle-24",
       "iconName": "message-circle",
       "description": "message, chat, conversation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8089,6 +8981,7 @@
       "fileName": "message-circle-16",
       "iconName": "message-circle",
       "description": "message, chat, conversation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8098,6 +8991,7 @@
       "fileName": "message-circle-fill-24",
       "iconName": "message-circle-fill",
       "description": "message, chat, text, conversation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8107,6 +9001,7 @@
       "fileName": "message-circle-fill-16",
       "iconName": "message-circle-fill",
       "description": "message, chat, text, conversation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8116,6 +9011,7 @@
       "fileName": "message-square-24",
       "iconName": "message-square",
       "description": "message, chat, conversation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8125,6 +9021,7 @@
       "fileName": "message-square-16",
       "iconName": "message-square",
       "description": "message, chat, conversation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8134,6 +9031,7 @@
       "fileName": "message-square-fill-24",
       "iconName": "message-square-fill",
       "description": "message, chat, text, conversation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8143,6 +9041,7 @@
       "fileName": "message-square-fill-16",
       "iconName": "message-square-fill",
       "description": "message, chat, text, conversation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8152,6 +9051,7 @@
       "fileName": "mic-24",
       "iconName": "mic",
       "description": "microphone, voice, speak",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8161,6 +9061,7 @@
       "fileName": "mic-16",
       "iconName": "mic",
       "description": "microphone, voice, speak",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8170,6 +9071,7 @@
       "fileName": "mic-off-24",
       "iconName": "mic-off",
       "description": "microphone, off, disabled, voice",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8179,6 +9081,7 @@
       "fileName": "mic-off-16",
       "iconName": "mic-off",
       "description": "microphone, off, disabled, voice",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8188,6 +9091,7 @@
       "fileName": "migrate-24",
       "iconName": "migrate",
       "description": "migrate, migration",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8197,6 +9101,7 @@
       "fileName": "migrate-16",
       "iconName": "migrate",
       "description": "migrate, migration",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8206,6 +9111,7 @@
       "fileName": "minimize-24",
       "iconName": "minimize",
       "description": "minimize, collapse, close",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8215,6 +9121,7 @@
       "fileName": "minimize-16",
       "iconName": "minimize",
       "description": "minimize, collapse, close",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8224,6 +9131,7 @@
       "fileName": "minimize-alt-24",
       "iconName": "minimize-alt",
       "description": "minimize",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8233,6 +9141,7 @@
       "fileName": "minimize-alt-16",
       "iconName": "minimize-alt",
       "description": "minimize",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8242,6 +9151,7 @@
       "fileName": "minus-24",
       "iconName": "minus",
       "description": "minus, remove, delete",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8251,6 +9161,7 @@
       "fileName": "minus-16",
       "iconName": "minus",
       "description": "minus, remove, delete",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8260,6 +9171,7 @@
       "fileName": "minus-circle-24",
       "iconName": "minus-circle",
       "description": "minus, remove, delete, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8269,6 +9181,7 @@
       "fileName": "minus-circle-16",
       "iconName": "minus-circle",
       "description": "minus, remove, delete, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8278,6 +9191,7 @@
       "fileName": "minus-circle-fill-24",
       "iconName": "minus-circle-fill",
       "description": "minus, remove, delete, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8287,6 +9201,7 @@
       "fileName": "minus-circle-fill-16",
       "iconName": "minus-circle-fill",
       "description": "minus, remove, delete, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8296,6 +9211,7 @@
       "fileName": "minus-square-24",
       "iconName": "minus-square",
       "description": "minus, remove, delete, square",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8305,6 +9221,7 @@
       "fileName": "minus-square-16",
       "iconName": "minus-square",
       "description": "minus, remove, delete, square",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8314,6 +9231,7 @@
       "fileName": "minus-square-fill-24",
       "iconName": "minus-square-fill",
       "description": "minus, remove, delete, square",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8323,6 +9241,7 @@
       "fileName": "minus-square-fill-16",
       "iconName": "minus-square-fill",
       "description": "minus, remove, delete, square",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8332,6 +9251,7 @@
       "fileName": "minus-plus-24",
       "iconName": "minus-plus",
       "description": "minus, remove, delete, plus, add, create, change, modify",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8341,6 +9261,7 @@
       "fileName": "minus-plus-16",
       "iconName": "minus-plus",
       "description": "minus, remove, delete, plus, add, create, change, modify",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8350,6 +9271,7 @@
       "fileName": "minus-plus-circle-24",
       "iconName": "minus-plus-circle",
       "description": "minus, remove, delete, plus, add, create, change, modify, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8359,6 +9281,7 @@
       "fileName": "minus-plus-circle-16",
       "iconName": "minus-plus-circle",
       "description": "minus, remove, delete, plus, add, create, change, modify, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8368,6 +9291,7 @@
       "fileName": "minus-plus-square-24",
       "iconName": "minus-plus-square",
       "description": "minus, remove, delete, plus, add, create, change, modify, square",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8377,6 +9301,7 @@
       "fileName": "minus-plus-square-16",
       "iconName": "minus-plus-square",
       "description": "minus, remove, delete, plus, add, create, change, modify, square",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8386,6 +9311,7 @@
       "fileName": "module-24",
       "iconName": "module",
       "description": "module",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8395,6 +9321,7 @@
       "fileName": "module-16",
       "iconName": "module",
       "description": "module",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8404,6 +9331,7 @@
       "fileName": "monitor-24",
       "iconName": "monitor",
       "description": "monitor, display, screen, desktop, computer",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8413,6 +9341,7 @@
       "fileName": "monitor-16",
       "iconName": "monitor",
       "description": "monitor, display, screen, desktop, computer",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8422,6 +9351,7 @@
       "fileName": "moon-24",
       "iconName": "moon",
       "description": "moon, night, dark",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8431,6 +9361,7 @@
       "fileName": "moon-16",
       "iconName": "moon",
       "description": "moon, night, dark",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8440,6 +9371,7 @@
       "fileName": "more-horizontal-24",
       "iconName": "more-horizontal",
       "description": "more, ellipsis",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8449,6 +9381,7 @@
       "fileName": "more-horizontal-16",
       "iconName": "more-horizontal",
       "description": "more, ellipsis",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8458,6 +9391,7 @@
       "fileName": "more-vertical-24",
       "iconName": "more-vertical",
       "description": "more, actions",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8467,6 +9401,7 @@
       "fileName": "more-vertical-16",
       "iconName": "more-vertical",
       "description": "more, actions",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8476,6 +9411,7 @@
       "fileName": "mouse-pointer-24",
       "iconName": "mouse-pointer",
       "description": "mouse, pointer, cursor",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8485,6 +9421,7 @@
       "fileName": "mouse-pointer-16",
       "iconName": "mouse-pointer",
       "description": "mouse, pointer, cursor",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8494,6 +9431,7 @@
       "fileName": "move-24",
       "iconName": "move",
       "description": "move, cursor",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8503,6 +9441,7 @@
       "fileName": "move-16",
       "iconName": "move",
       "description": "move, cursor",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8512,6 +9451,7 @@
       "fileName": "music-24",
       "iconName": "music",
       "description": "music, audio, sound",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8521,6 +9461,7 @@
       "fileName": "music-16",
       "iconName": "music",
       "description": "music, audio, sound",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8530,6 +9471,7 @@
       "fileName": "navigation-24",
       "iconName": "navigation",
       "description": "navigation, location",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8539,6 +9481,7 @@
       "fileName": "navigation-16",
       "iconName": "navigation",
       "description": "navigation, location",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8548,6 +9491,7 @@
       "fileName": "navigation-alt-24",
       "iconName": "navigation-alt",
       "description": "navigation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8557,6 +9501,7 @@
       "fileName": "navigation-alt-16",
       "iconName": "navigation-alt",
       "description": "navigation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8566,6 +9511,7 @@
       "fileName": "network-24",
       "iconName": "network",
       "description": "network, lan, connected",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8575,6 +9521,7 @@
       "fileName": "network-16",
       "iconName": "network",
       "description": "network, lan, connected",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8584,6 +9531,7 @@
       "fileName": "network-alt-24",
       "iconName": "network-alt",
       "description": "network, lan, connection, ethernet, port",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8593,6 +9541,7 @@
       "fileName": "network-alt-16",
       "iconName": "network-alt",
       "description": "network, lan, connection, ethernet, port",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8602,6 +9551,7 @@
       "fileName": "newspaper-24",
       "iconName": "newspaper",
       "description": "newspaper, blog, media",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8611,6 +9561,7 @@
       "fileName": "newspaper-16",
       "iconName": "newspaper",
       "description": "newspaper, blog, media",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8620,6 +9571,7 @@
       "fileName": "node-24",
       "iconName": "node",
       "description": "node, element, point",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8629,6 +9581,7 @@
       "fileName": "node-16",
       "iconName": "node",
       "description": "node, element, point",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8638,6 +9591,7 @@
       "fileName": "octagon-24",
       "iconName": "octagon",
       "description": "octagon",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8647,6 +9601,7 @@
       "fileName": "octagon-16",
       "iconName": "octagon",
       "description": "octagon",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8656,6 +9611,7 @@
       "fileName": "org-24",
       "iconName": "org",
       "description": "organization, team, group, company, global",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8665,6 +9621,7 @@
       "fileName": "org-16",
       "iconName": "org",
       "description": "organization, team, group, company, global",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8674,6 +9631,7 @@
       "fileName": "outline-24",
       "iconName": "outline",
       "description": "outline, document",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8683,6 +9641,7 @@
       "fileName": "outline-16",
       "iconName": "outline",
       "description": "outline, document",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8692,6 +9651,7 @@
       "fileName": "package-24",
       "iconName": "package",
       "description": "package, dependency, box, build",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8701,6 +9661,7 @@
       "fileName": "package-16",
       "iconName": "package",
       "description": "package, dependency, box, build",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8710,6 +9671,7 @@
       "fileName": "paperclip-24",
       "iconName": "paperclip",
       "description": "paperclip, clip, attachment",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8719,6 +9681,7 @@
       "fileName": "paperclip-16",
       "iconName": "paperclip",
       "description": "paperclip, clip, attachment",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8728,6 +9691,7 @@
       "fileName": "path-24",
       "iconName": "path",
       "description": "path, connection, network",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8737,6 +9701,7 @@
       "fileName": "path-16",
       "iconName": "path",
       "description": "path, connection, network",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8746,6 +9711,7 @@
       "fileName": "pause-24",
       "iconName": "pause",
       "description": "pause",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8755,6 +9721,7 @@
       "fileName": "pause-16",
       "iconName": "pause",
       "description": "pause",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8764,6 +9731,7 @@
       "fileName": "pause-circle-24",
       "iconName": "pause-circle",
       "description": "pause, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8773,6 +9741,7 @@
       "fileName": "pause-circle-16",
       "iconName": "pause-circle",
       "description": "pause, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8782,6 +9751,7 @@
       "fileName": "pen-tool-24",
       "iconName": "pen-tool",
       "description": "pen, vector, tool",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8791,6 +9761,7 @@
       "fileName": "pen-tool-16",
       "iconName": "pen-tool",
       "description": "pen, vector, tool",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8800,6 +9771,7 @@
       "fileName": "pencil-tool-24",
       "iconName": "pencil-tool",
       "description": "edit, pencil, tool",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8809,6 +9781,7 @@
       "fileName": "pencil-tool-16",
       "iconName": "pencil-tool",
       "description": "edit, pencil, tool",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8818,6 +9791,7 @@
       "fileName": "phone-24",
       "iconName": "phone",
       "description": "phone, telephone, communication, conversation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8827,6 +9801,7 @@
       "fileName": "phone-16",
       "iconName": "phone",
       "description": "phone, telephone, communication, conversation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8836,6 +9811,7 @@
       "fileName": "phone-call-24",
       "iconName": "phone-call",
       "description": "phone, telephone, communication, conversation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8845,6 +9821,7 @@
       "fileName": "phone-call-16",
       "iconName": "phone-call",
       "description": "phone, telephone, communication, conversation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8854,6 +9831,7 @@
       "fileName": "phone-off-24",
       "iconName": "phone-off",
       "description": "phone, telephone, off, disabled, communication, conversation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8863,6 +9841,7 @@
       "fileName": "phone-off-16",
       "iconName": "phone-off",
       "description": "phone, telephone, off, disabled, communication, conversation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8872,6 +9851,7 @@
       "fileName": "pie-chart-24",
       "iconName": "pie-chart",
       "description": "chart, pie, graph, data",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8881,6 +9861,7 @@
       "fileName": "pie-chart-16",
       "iconName": "pie-chart",
       "description": "chart, pie, graph, data",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8890,6 +9871,7 @@
       "fileName": "pin-24",
       "iconName": "pin",
       "description": "pin, pinned",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8899,6 +9881,7 @@
       "fileName": "pin-16",
       "iconName": "pin",
       "description": "pin, pinned",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8908,6 +9891,7 @@
       "fileName": "pipeline-24",
       "iconName": "pipeline",
       "description": "pipeline",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8917,6 +9901,7 @@
       "fileName": "pipeline-16",
       "iconName": "pipeline",
       "description": "pipeline",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8926,6 +9911,7 @@
       "fileName": "play-24",
       "iconName": "play",
       "description": "play, start, run",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8935,6 +9921,7 @@
       "fileName": "play-16",
       "iconName": "play",
       "description": "play, start, run",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8944,6 +9931,7 @@
       "fileName": "play-circle-24",
       "iconName": "play-circle",
       "description": "play, start, run, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8953,6 +9941,7 @@
       "fileName": "play-circle-16",
       "iconName": "play-circle",
       "description": "play, start, run, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8962,6 +9951,7 @@
       "fileName": "plug-24",
       "iconName": "plug",
       "description": "plug, plugin",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8971,6 +9961,7 @@
       "fileName": "plug-16",
       "iconName": "plug",
       "description": "plug, plugin",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8980,6 +9971,7 @@
       "fileName": "plus-24",
       "iconName": "plus",
       "description": "plus, add, create, new",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -8989,6 +9981,7 @@
       "fileName": "plus-16",
       "iconName": "plus",
       "description": "plus, add, create, new",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -8998,6 +9991,7 @@
       "fileName": "plus-circle-24",
       "iconName": "plus-circle",
       "description": "plus, add, create, new, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9007,6 +10001,7 @@
       "fileName": "plus-circle-16",
       "iconName": "plus-circle",
       "description": "plus, add, create, new, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9016,6 +10011,7 @@
       "fileName": "plus-circle-fill-24",
       "iconName": "plus-circle-fill",
       "description": "plus, add, create, new, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9025,6 +10021,7 @@
       "fileName": "plus-circle-fill-16",
       "iconName": "plus-circle-fill",
       "description": "plus, add, create, new, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9034,6 +10031,7 @@
       "fileName": "plus-square-24",
       "iconName": "plus-square",
       "description": "plus, add, create, new, square",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9043,6 +10041,7 @@
       "fileName": "plus-square-16",
       "iconName": "plus-square",
       "description": "plus, add, create, new, square",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9052,6 +10051,7 @@
       "fileName": "power-24",
       "iconName": "power",
       "description": "power, on, off",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9061,6 +10061,7 @@
       "fileName": "power-16",
       "iconName": "power",
       "description": "power, on, off",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9070,6 +10071,7 @@
       "fileName": "printer-24",
       "iconName": "printer",
       "description": "printer",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9079,6 +10081,7 @@
       "fileName": "printer-16",
       "iconName": "printer",
       "description": "printer",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9088,6 +10091,7 @@
       "fileName": "provider-24",
       "iconName": "provider",
       "description": "provider, service",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9097,6 +10101,7 @@
       "fileName": "provider-16",
       "iconName": "provider",
       "description": "provider, service",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9106,6 +10111,7 @@
       "fileName": "queue-24",
       "iconName": "queue",
       "description": "queue",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9115,6 +10121,7 @@
       "fileName": "queue-16",
       "iconName": "queue",
       "description": "queue",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9124,6 +10131,7 @@
       "fileName": "radio-24",
       "iconName": "radio",
       "description": "radio, sound, signal",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9133,6 +10141,7 @@
       "fileName": "radio-16",
       "iconName": "radio",
       "description": "radio, sound, signal",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9142,6 +10151,7 @@
       "fileName": "random-24",
       "iconName": "random",
       "description": "random, dice, chance",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9151,6 +10161,7 @@
       "fileName": "random-16",
       "iconName": "random",
       "description": "random, dice, chance",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9160,6 +10171,7 @@
       "fileName": "redirect-24",
       "iconName": "redirect",
       "description": "redirect, arrow",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9169,6 +10181,7 @@
       "fileName": "redirect-16",
       "iconName": "redirect",
       "description": "redirect, arrow",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9178,6 +10191,7 @@
       "fileName": "reload-24",
       "iconName": "reload",
       "description": "reload, restart, refresh",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9187,6 +10201,7 @@
       "fileName": "reload-16",
       "iconName": "reload",
       "description": "reload, restart, refresh",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9196,6 +10211,7 @@
       "fileName": "repeat-24",
       "iconName": "repeat",
       "description": "repeat, redo, process, loop",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9205,6 +10221,7 @@
       "fileName": "repeat-16",
       "iconName": "repeat",
       "description": "repeat, redo, process, loop",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9214,6 +10231,7 @@
       "fileName": "replication-direct-24",
       "iconName": "replication-direct",
       "description": "replication, duplication",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9223,6 +10241,7 @@
       "fileName": "replication-direct-16",
       "iconName": "replication-direct",
       "description": "replication, duplication",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9232,6 +10251,7 @@
       "fileName": "replication-perf-24",
       "iconName": "replication-perf",
       "description": "replication, duplication",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9241,6 +10261,7 @@
       "fileName": "replication-perf-16",
       "iconName": "replication-perf",
       "description": "replication, duplication",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9250,6 +10271,7 @@
       "fileName": "rewind-24",
       "iconName": "rewind",
       "description": "rewind, back, previous",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9259,6 +10281,7 @@
       "fileName": "rewind-16",
       "iconName": "rewind",
       "description": "rewind, back, previous",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9268,6 +10291,7 @@
       "fileName": "robot-24",
       "iconName": "robot",
       "description": "service, principal, computer, user",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9277,6 +10301,7 @@
       "fileName": "robot-16",
       "iconName": "robot",
       "description": "service, principal, computer, user",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9286,6 +10311,7 @@
       "fileName": "rocket-24",
       "iconName": "rocket",
       "description": "rocket, launch",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9295,6 +10321,7 @@
       "fileName": "rocket-16",
       "iconName": "rocket",
       "description": "rocket, launch",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9304,6 +10331,7 @@
       "fileName": "rotate-cw-24",
       "iconName": "rotate-cw",
       "description": "rotate",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9313,6 +10341,7 @@
       "fileName": "rotate-cw-16",
       "iconName": "rotate-cw",
       "description": "rotate",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9322,6 +10351,7 @@
       "fileName": "rotate-ccw-24",
       "iconName": "rotate-ccw",
       "description": "rotate",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9331,6 +10361,7 @@
       "fileName": "rotate-ccw-16",
       "iconName": "rotate-ccw",
       "description": "rotate",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9340,6 +10371,7 @@
       "fileName": "rss-24",
       "iconName": "rss",
       "description": "rss, feed",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9349,6 +10381,7 @@
       "fileName": "rss-16",
       "iconName": "rss",
       "description": "rss, feed",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9358,6 +10391,7 @@
       "fileName": "save-24",
       "iconName": "save",
       "description": "save, disk",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9367,6 +10401,7 @@
       "fileName": "save-16",
       "iconName": "save",
       "description": "save, disk",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9376,6 +10411,7 @@
       "fileName": "scissors-24",
       "iconName": "scissors",
       "description": "scissors, cut",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9385,6 +10421,7 @@
       "fileName": "scissors-16",
       "iconName": "scissors",
       "description": "scissors, cut",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9394,6 +10431,7 @@
       "fileName": "search-24",
       "iconName": "search",
       "description": "search, find, magnifier",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9403,6 +10441,7 @@
       "fileName": "search-16",
       "iconName": "search",
       "description": "search, find, magnifier",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9412,6 +10451,7 @@
       "fileName": "send-24",
       "iconName": "send",
       "description": "send, message",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9421,6 +10461,7 @@
       "fileName": "send-16",
       "iconName": "send",
       "description": "send, message",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9430,6 +10471,7 @@
       "fileName": "server-24",
       "iconName": "server",
       "description": "server, data",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9439,6 +10481,7 @@
       "fileName": "server-16",
       "iconName": "server",
       "description": "server, data",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9448,6 +10491,7 @@
       "fileName": "serverless-24",
       "iconName": "serverless",
       "description": "serverless, off, disabled, data",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9457,6 +10501,7 @@
       "fileName": "serverless-16",
       "iconName": "serverless",
       "description": "serverless, off, disabled, data",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9466,6 +10511,7 @@
       "fileName": "server-cluster-24",
       "iconName": "server-cluster",
       "description": "server, data, cluster, network",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9475,6 +10521,7 @@
       "fileName": "server-cluster-16",
       "iconName": "server-cluster",
       "description": "server, data, cluster, network",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9484,6 +10531,7 @@
       "fileName": "settings-24",
       "iconName": "settings",
       "description": "settings, preferences, gear, cog, configuration",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9493,6 +10541,7 @@
       "fileName": "settings-16",
       "iconName": "settings",
       "description": "settings, preferences, gear, cog, configuration",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9502,6 +10551,7 @@
       "fileName": "service-24",
       "iconName": "service",
       "description": "service",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9511,6 +10561,7 @@
       "fileName": "service-16",
       "iconName": "service",
       "description": "service",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9520,6 +10571,7 @@
       "fileName": "share-24",
       "iconName": "share",
       "description": "share",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9529,6 +10581,7 @@
       "fileName": "share-16",
       "iconName": "share",
       "description": "share",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9538,6 +10591,7 @@
       "fileName": "shield-24",
       "iconName": "shield",
       "description": "shield, secure, protect, privacy",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9547,6 +10601,7 @@
       "fileName": "shield-16",
       "iconName": "shield",
       "description": "shield, secure, protect, privacy",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9556,6 +10611,7 @@
       "fileName": "shield-alert-24",
       "iconName": "shield-alert",
       "description": "shield, secure, protect, issue, alert, privacy",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9565,6 +10621,7 @@
       "fileName": "shield-alert-16",
       "iconName": "shield-alert",
       "description": "shield, secure, protect, issue, alert, privacy",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9574,6 +10631,7 @@
       "fileName": "shield-check-24",
       "iconName": "shield-check",
       "description": "shield, secure, protect, check, success, privacy",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9583,6 +10641,7 @@
       "fileName": "shield-check-16",
       "iconName": "shield-check",
       "description": "shield, secure, protect, check, success, privacy",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9592,6 +10651,7 @@
       "fileName": "shield-off-24",
       "iconName": "shield-off",
       "description": "shield, secure, protect, off, disabled, privacy",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9601,6 +10661,7 @@
       "fileName": "shield-off-16",
       "iconName": "shield-off",
       "description": "shield, secure, protect, off, disabled, privacy",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9610,6 +10671,7 @@
       "fileName": "shield-x-24",
       "iconName": "shield-x",
       "description": "shield, secure, protect, error, privacy",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9619,6 +10681,7 @@
       "fileName": "shield-x-16",
       "iconName": "shield-x",
       "description": "shield, secure, protect, error, privacy",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9628,6 +10691,7 @@
       "fileName": "shopping-bag-24",
       "iconName": "shopping-bag",
       "description": "shopping, store, basket",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9637,6 +10701,7 @@
       "fileName": "shopping-bag-16",
       "iconName": "shopping-bag",
       "description": "shopping, store, basket",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9646,6 +10711,7 @@
       "fileName": "shopping-cart-24",
       "iconName": "shopping-cart",
       "description": "shopping, store, basket, cart",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9655,6 +10721,7 @@
       "fileName": "shopping-cart-16",
       "iconName": "shopping-cart",
       "description": "shopping, store, basket, cart",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9664,6 +10731,7 @@
       "fileName": "shuffle-24",
       "iconName": "shuffle",
       "description": "shuffle, random",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9673,6 +10741,7 @@
       "fileName": "shuffle-16",
       "iconName": "shuffle",
       "description": "shuffle, random",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9682,6 +10751,7 @@
       "fileName": "sidebar-24",
       "iconName": "sidebar",
       "description": "layout, sidebar, navigation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9691,6 +10761,7 @@
       "fileName": "sidebar-16",
       "iconName": "sidebar",
       "description": "layout, sidebar, navigation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9700,6 +10771,7 @@
       "fileName": "sidebar-hide-24",
       "iconName": "sidebar-hide",
       "description": "layout, sidebar, hide, collapse, navigation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9709,6 +10781,7 @@
       "fileName": "sidebar-hide-16",
       "iconName": "sidebar-hide",
       "description": "layout, sidebar, hide, collapse, navigation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9718,6 +10791,7 @@
       "fileName": "sidebar-show-24",
       "iconName": "sidebar-show",
       "description": "layout, sidebar, show, expand, navigation",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9727,6 +10801,7 @@
       "fileName": "sidebar-show-16",
       "iconName": "sidebar-show",
       "description": "layout, sidebar, show, expand, navigation",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9736,6 +10811,7 @@
       "fileName": "sign-in-24",
       "iconName": "sign-in",
       "description": "login, signin, enter, access",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9745,6 +10821,7 @@
       "fileName": "sign-in-16",
       "iconName": "sign-in",
       "description": "login, signin, enter, access",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9754,6 +10831,7 @@
       "fileName": "sign-out-24",
       "iconName": "sign-out",
       "description": "logout, signout, leave, exit, access",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9763,6 +10841,7 @@
       "fileName": "sign-out-16",
       "iconName": "sign-out",
       "description": "logout, signout, leave, exit, access",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9772,6 +10851,7 @@
       "fileName": "skip-24",
       "iconName": "skip",
       "description": "skip, deny",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9781,6 +10861,7 @@
       "fileName": "skip-16",
       "iconName": "skip",
       "description": "skip, deny",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9790,6 +10871,7 @@
       "fileName": "skip-forward-24",
       "iconName": "skip-forward",
       "description": "skip, forward, next",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9799,6 +10881,7 @@
       "fileName": "skip-forward-16",
       "iconName": "skip-forward",
       "description": "skip, forward, next",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9808,6 +10891,7 @@
       "fileName": "skip-back-24",
       "iconName": "skip-back",
       "description": "skip, previous, back",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9817,6 +10901,7 @@
       "fileName": "skip-back-16",
       "iconName": "skip-back",
       "description": "skip, previous, back",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9826,6 +10911,7 @@
       "fileName": "slash-24",
       "iconName": "slash",
       "description": "slash",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9835,6 +10921,7 @@
       "fileName": "slash-16",
       "iconName": "slash",
       "description": "slash",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9844,6 +10931,7 @@
       "fileName": "slash-square-24",
       "iconName": "slash-square",
       "description": "slash, square",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9853,6 +10941,7 @@
       "fileName": "slash-square-16",
       "iconName": "slash-square",
       "description": "slash, square",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9862,6 +10951,7 @@
       "fileName": "sliders-24",
       "iconName": "sliders",
       "description": "sliders, options, preferences, customize, options",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9871,6 +10961,7 @@
       "fileName": "sliders-16",
       "iconName": "sliders",
       "description": "sliders, options, preferences, customize, options",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9880,6 +10971,7 @@
       "fileName": "smartphone-24",
       "iconName": "smartphone",
       "description": "phone, device, mobile",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9889,6 +10981,7 @@
       "fileName": "smartphone-16",
       "iconName": "smartphone",
       "description": "phone, device, mobile",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9898,6 +10991,7 @@
       "fileName": "smile-24",
       "iconName": "smile",
       "description": "emoji, smile, positive, happy",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9907,6 +11001,7 @@
       "fileName": "smile-16",
       "iconName": "smile",
       "description": "emoji, smile, positive, happy",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9916,6 +11011,7 @@
       "fileName": "socket-24",
       "iconName": "socket",
       "description": "socket, port",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9925,6 +11021,7 @@
       "fileName": "socket-16",
       "iconName": "socket",
       "description": "socket, port",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9934,6 +11031,7 @@
       "fileName": "sort-asc-24",
       "iconName": "sort-asc",
       "description": "sort, ascending, up",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9943,6 +11041,7 @@
       "fileName": "sort-asc-16",
       "iconName": "sort-asc",
       "description": "sort, ascending, up",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9952,6 +11051,7 @@
       "fileName": "sort-desc-24",
       "iconName": "sort-desc",
       "description": "sort, descending, down",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9961,6 +11061,7 @@
       "fileName": "sort-desc-16",
       "iconName": "sort-desc",
       "description": "sort, descending, down",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9970,6 +11071,7 @@
       "fileName": "speaker-24",
       "iconName": "speaker",
       "description": "speaker, sound",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9979,6 +11081,7 @@
       "fileName": "speaker-16",
       "iconName": "speaker",
       "description": "speaker, sound",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -9988,6 +11091,7 @@
       "fileName": "square-24",
       "iconName": "square",
       "description": "square, rectangle, box, stop",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -9997,6 +11101,7 @@
       "fileName": "square-16",
       "iconName": "square",
       "description": "square, rectangle, box, stop",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10006,6 +11111,7 @@
       "fileName": "square-fill-24",
       "iconName": "square-fill",
       "description": "square, rectangle, box, stop",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10015,6 +11121,7 @@
       "fileName": "square-fill-16",
       "iconName": "square-fill",
       "description": "square, rectangle, box, stop",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10024,6 +11131,7 @@
       "fileName": "star-24",
       "iconName": "star",
       "description": "star, favorite",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10033,6 +11141,7 @@
       "fileName": "star-16",
       "iconName": "star",
       "description": "star, favorite",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10042,6 +11151,7 @@
       "fileName": "star-circle-24",
       "iconName": "star-circle",
       "description": "star, favorite, ring, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10051,6 +11161,7 @@
       "fileName": "star-circle-16",
       "iconName": "star-circle",
       "description": "star, favorite, ring, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10060,6 +11171,7 @@
       "fileName": "star-fill-24",
       "iconName": "star-fill",
       "description": "star, favorite, starred, favorited",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10069,6 +11181,7 @@
       "fileName": "star-fill-16",
       "iconName": "star-fill",
       "description": "star, favorite, starred, favorited",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10078,6 +11191,7 @@
       "fileName": "star-off-24",
       "iconName": "star-off",
       "description": "star, favorite, off, disabled",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10087,6 +11201,7 @@
       "fileName": "star-off-16",
       "iconName": "star-off",
       "description": "star, favorite, off, disabled",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10096,6 +11211,7 @@
       "fileName": "step-24",
       "iconName": "step",
       "description": "step, pipeline",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10105,6 +11221,7 @@
       "fileName": "step-16",
       "iconName": "step",
       "description": "step, pipeline",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10114,6 +11231,7 @@
       "fileName": "stop-circle-24",
       "iconName": "stop-circle",
       "description": "stop, circle, end",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10123,6 +11241,7 @@
       "fileName": "stop-circle-16",
       "iconName": "stop-circle",
       "description": "stop, circle, end",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10132,6 +11251,7 @@
       "fileName": "sun-24",
       "iconName": "sun",
       "description": "sun, day, light, bright",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10141,6 +11261,7 @@
       "fileName": "sun-16",
       "iconName": "sun",
       "description": "sun, day, light, bright",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10150,6 +11271,7 @@
       "fileName": "support-24",
       "iconName": "support",
       "description": "lifebuoy, help, support, question, service, information, assistance",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10159,6 +11281,7 @@
       "fileName": "support-16",
       "iconName": "support",
       "description": "lifebuoy, help, support, question, service, information, assistance",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10168,6 +11291,7 @@
       "fileName": "swap-horizontal-24",
       "iconName": "swap-horizontal",
       "description": "swap, switch, horizontal, arrows, sctm",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10177,6 +11301,7 @@
       "fileName": "swap-horizontal-16",
       "iconName": "swap-horizontal",
       "description": "swap, switch, horizontal, arrows, sctm",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10186,6 +11311,7 @@
       "fileName": "swap-vertical-24",
       "iconName": "swap-vertical",
       "description": "swap, switch, vertical, arrows",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10195,6 +11321,7 @@
       "fileName": "swap-vertical-16",
       "iconName": "swap-vertical",
       "description": "swap, switch, vertical, arrows",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10204,6 +11331,7 @@
       "fileName": "switcher-24",
       "iconName": "switcher",
       "description": "switcher, launcher, apps",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10213,6 +11341,7 @@
       "fileName": "switcher-16",
       "iconName": "switcher",
       "description": "switcher, launcher, apps",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10222,6 +11351,7 @@
       "fileName": "sync-24",
       "iconName": "sync",
       "description": "refresh, syncing",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10231,6 +11361,7 @@
       "fileName": "sync-16",
       "iconName": "sync",
       "description": "refresh, syncing",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10240,6 +11371,7 @@
       "fileName": "sync-alert-24",
       "iconName": "sync-alert",
       "description": "refresh, syncing, issue, alert",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10249,6 +11381,7 @@
       "fileName": "sync-alert-16",
       "iconName": "sync-alert",
       "description": "refresh, syncing, issue, alert",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10258,6 +11391,7 @@
       "fileName": "sync-reverse-24",
       "iconName": "sync-reverse",
       "description": "refresh, syncing, reverse",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10267,6 +11401,7 @@
       "fileName": "sync-reverse-16",
       "iconName": "sync-reverse",
       "description": "refresh, syncing, reverse",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10276,6 +11411,7 @@
       "fileName": "tablet-24",
       "iconName": "tablet",
       "description": "tablet, device, mobile",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10285,6 +11421,7 @@
       "fileName": "tablet-16",
       "iconName": "tablet",
       "description": "tablet, device, mobile",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10294,6 +11431,7 @@
       "fileName": "tag-24",
       "iconName": "tag",
       "description": "tag, label, category",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10303,6 +11441,7 @@
       "fileName": "tag-16",
       "iconName": "tag",
       "description": "tag, label, category",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10312,6 +11451,7 @@
       "fileName": "target-24",
       "iconName": "target",
       "description": "target",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10321,6 +11461,7 @@
       "fileName": "target-16",
       "iconName": "target",
       "description": "target",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10330,6 +11471,7 @@
       "fileName": "terminal-24",
       "iconName": "terminal",
       "description": "terminal, code, cli, programming",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10339,6 +11481,7 @@
       "fileName": "terminal-16",
       "iconName": "terminal",
       "description": "terminal, code, cli, programming",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10348,6 +11491,7 @@
       "fileName": "terminal-screen-24",
       "iconName": "terminal-screen",
       "description": "terminal, code, cli, interactive, programming",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10357,6 +11501,7 @@
       "fileName": "terminal-screen-16",
       "iconName": "terminal-screen",
       "description": "terminal, code, cli, interactive, programming",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10366,6 +11511,7 @@
       "fileName": "test-24",
       "iconName": "test",
       "description": "test, check, delay, waiting",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10375,6 +11521,7 @@
       "fileName": "test-16",
       "iconName": "test",
       "description": "test, check, delay, waiting",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10384,6 +11531,7 @@
       "fileName": "thumbs-up-24",
       "iconName": "thumbs-up",
       "description": "thumbs, up, vote, like",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10393,6 +11541,7 @@
       "fileName": "thumbs-up-16",
       "iconName": "thumbs-up",
       "description": "thumbs, up, vote, like",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10402,6 +11551,7 @@
       "fileName": "thumbs-down-24",
       "iconName": "thumbs-down",
       "description": "thumbs, down, vote, dislike",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10411,6 +11561,7 @@
       "fileName": "thumbs-down-16",
       "iconName": "thumbs-down",
       "description": "thumbs, down, vote, dislike",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10420,6 +11571,7 @@
       "fileName": "toggle-left-24",
       "iconName": "toggle-left",
       "description": "toggle, switch",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10429,6 +11581,7 @@
       "fileName": "toggle-left-16",
       "iconName": "toggle-left",
       "description": "toggle, switch",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10438,6 +11591,7 @@
       "fileName": "toggle-right-24",
       "iconName": "toggle-right",
       "description": "toggle, switch",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10447,6 +11601,7 @@
       "fileName": "toggle-right-16",
       "iconName": "toggle-right",
       "description": "toggle, switch",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10456,6 +11611,7 @@
       "fileName": "token-24",
       "iconName": "token",
       "description": "tokens",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10465,6 +11621,7 @@
       "fileName": "token-16",
       "iconName": "token",
       "description": "tokens",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10474,6 +11631,7 @@
       "fileName": "tools-24",
       "iconName": "tools",
       "description": "tools, toolbox",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10483,6 +11641,7 @@
       "fileName": "tools-16",
       "iconName": "tools",
       "description": "tools, toolbox",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10492,6 +11651,7 @@
       "fileName": "top-24",
       "iconName": "top",
       "description": "top, scroll, up",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10501,6 +11661,7 @@
       "fileName": "top-16",
       "iconName": "top",
       "description": "top, scroll, up",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10510,6 +11671,7 @@
       "fileName": "transform-data-24",
       "iconName": "transform-data",
       "description": "crypto, path, encrypt, transform",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10519,6 +11681,7 @@
       "fileName": "transform-data-16",
       "iconName": "transform-data",
       "description": "crypto, path, encrypt, transform",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10528,6 +11691,7 @@
       "fileName": "trash-24",
       "iconName": "trash",
       "description": "trash, bin, delete",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10537,6 +11701,7 @@
       "fileName": "trash-16",
       "iconName": "trash",
       "description": "trash, bin, delete",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10546,6 +11711,7 @@
       "fileName": "trend-down-24",
       "iconName": "trend-down",
       "description": "trend, down, negative",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10555,6 +11721,7 @@
       "fileName": "trend-down-16",
       "iconName": "trend-down",
       "description": "trend, down, negative",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10564,6 +11731,7 @@
       "fileName": "trend-up-24",
       "iconName": "trend-up",
       "description": "trend, up, positive",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10573,6 +11741,7 @@
       "fileName": "trend-up-16",
       "iconName": "trend-up",
       "description": "trend, up, positive",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10582,6 +11751,7 @@
       "fileName": "triangle-24",
       "iconName": "triangle",
       "description": "triangle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10591,6 +11761,7 @@
       "fileName": "triangle-16",
       "iconName": "triangle",
       "description": "triangle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10600,6 +11771,7 @@
       "fileName": "triangle-fill-24",
       "iconName": "triangle-fill",
       "description": "triangle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10609,6 +11781,7 @@
       "fileName": "triangle-fill-16",
       "iconName": "triangle-fill",
       "description": "triangle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10618,6 +11791,7 @@
       "fileName": "truck-24",
       "iconName": "truck",
       "description": "truck, lorry, vehicle, transport, ship",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10627,6 +11801,7 @@
       "fileName": "truck-16",
       "iconName": "truck",
       "description": "truck, lorry, vehicle, transport, ship",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10636,6 +11811,7 @@
       "fileName": "tv-24",
       "iconName": "tv",
       "description": "tv, video, watch",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10645,6 +11821,7 @@
       "fileName": "tv-16",
       "iconName": "tv",
       "description": "tv, video, watch",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10654,6 +11831,7 @@
       "fileName": "type-24",
       "iconName": "type",
       "description": "type, font, text",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10663,6 +11841,7 @@
       "fileName": "type-16",
       "iconName": "type",
       "description": "type, font, text",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10672,6 +11851,7 @@
       "fileName": "unfold-open-24",
       "iconName": "unfold-open",
       "description": "unfold, open, expand",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10681,6 +11861,7 @@
       "fileName": "unfold-open-16",
       "iconName": "unfold-open",
       "description": "unfold, open, expand",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10690,6 +11871,7 @@
       "fileName": "unfold-close-24",
       "iconName": "unfold-close",
       "description": "fold, close, collapse",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10699,6 +11881,7 @@
       "fileName": "unfold-close-16",
       "iconName": "unfold-close",
       "description": "fold, close, collapse",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10708,6 +11891,7 @@
       "fileName": "unlock-24",
       "iconName": "unlock",
       "description": "lock, unlock, unlocked, unsecure",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10717,6 +11901,7 @@
       "fileName": "unlock-16",
       "iconName": "unlock",
       "description": "lock, unlock, unlocked, unsecure",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10726,6 +11911,7 @@
       "fileName": "upload-24",
       "iconName": "upload",
       "description": "upload, data, file, import",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10735,6 +11921,7 @@
       "fileName": "upload-16",
       "iconName": "upload",
       "description": "upload, data, file, import",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10744,6 +11931,7 @@
       "fileName": "user-24",
       "iconName": "user",
       "description": "user, person, profile",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10753,6 +11941,7 @@
       "fileName": "user-16",
       "iconName": "user",
       "description": "user, person, profile",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10762,6 +11951,7 @@
       "fileName": "user-check-24",
       "iconName": "user-check",
       "description": "user, person, check, success, profile",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10771,6 +11961,7 @@
       "fileName": "user-check-16",
       "iconName": "user-check",
       "description": "user, person, check, success, profile",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10780,6 +11971,7 @@
       "fileName": "user-circle-24",
       "iconName": "user-circle",
       "description": "user, person, avatar, circle, profile",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10789,6 +11981,7 @@
       "fileName": "user-circle-16",
       "iconName": "user-circle",
       "description": "user, person, avatar, circle, profile",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10798,6 +11991,7 @@
       "fileName": "user-circle-fill-24",
       "iconName": "user-circle-fill",
       "description": "user, person, avatar, circle, profile",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10807,6 +12001,7 @@
       "fileName": "user-circle-fill-16",
       "iconName": "user-circle-fill",
       "description": "user, person, avatar, circle, profile",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10816,6 +12011,7 @@
       "fileName": "user-minus-24",
       "iconName": "user-minus",
       "description": "user, person, minus, remove, profile",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10825,6 +12021,7 @@
       "fileName": "user-minus-16",
       "iconName": "user-minus",
       "description": "user, person, minus, remove, profile",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10834,6 +12031,7 @@
       "fileName": "user-plus-24",
       "iconName": "user-plus",
       "description": "user, person, plus, new, create, add, profile",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10843,6 +12041,7 @@
       "fileName": "user-plus-16",
       "iconName": "user-plus",
       "description": "user, person, plus, new, create, add, profile",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10852,6 +12051,7 @@
       "fileName": "user-x-24",
       "iconName": "user-x",
       "description": "user, person, delete, remove, profile",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10861,6 +12061,7 @@
       "fileName": "user-x-16",
       "iconName": "user-x",
       "description": "user, person, delete, remove, profile",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10870,6 +12071,7 @@
       "fileName": "users-24",
       "iconName": "users",
       "description": "users, people, team, group, profile",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10879,6 +12081,7 @@
       "fileName": "users-16",
       "iconName": "users",
       "description": "users, people, team, group, profile",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10888,6 +12091,7 @@
       "fileName": "verified-24",
       "iconName": "verified",
       "description": "verified, badge, authenticated",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10897,6 +12101,7 @@
       "fileName": "verified-16",
       "iconName": "verified",
       "description": "verified, badge, authenticated",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10906,6 +12111,7 @@
       "fileName": "video-24",
       "iconName": "video",
       "description": "video",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10915,6 +12121,7 @@
       "fileName": "video-16",
       "iconName": "video",
       "description": "video",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10924,6 +12131,7 @@
       "fileName": "video-off-24",
       "iconName": "video-off",
       "description": "video, off, disabled",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10933,6 +12141,7 @@
       "fileName": "video-off-16",
       "iconName": "video-off",
       "description": "video, off, disabled",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10942,6 +12151,7 @@
       "fileName": "volume-24",
       "iconName": "volume",
       "description": "volume, low, muted",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10951,6 +12161,7 @@
       "fileName": "volume-16",
       "iconName": "volume",
       "description": "volume, low, muted",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10960,6 +12171,7 @@
       "fileName": "volume-down-24",
       "iconName": "volume-down",
       "description": "volume, down, low, quiet",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10969,6 +12181,7 @@
       "fileName": "volume-down-16",
       "iconName": "volume-down",
       "description": "volume, down, low, quiet",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10978,6 +12191,7 @@
       "fileName": "volume-2-24",
       "iconName": "volume-2",
       "description": "volume, up, high, loud",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -10987,6 +12201,7 @@
       "fileName": "volume-2-16",
       "iconName": "volume-2",
       "description": "volume, up, high, loud",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -10996,6 +12211,7 @@
       "fileName": "volume-x-24",
       "iconName": "volume-x",
       "description": "volume, off, disabled, muted",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11005,6 +12221,7 @@
       "fileName": "volume-x-16",
       "iconName": "volume-x",
       "description": "volume, off, disabled, muted",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11014,6 +12231,7 @@
       "fileName": "wall-24",
       "iconName": "wall",
       "description": "wall, firewall, barrier",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11023,6 +12241,7 @@
       "fileName": "wall-16",
       "iconName": "wall",
       "description": "wall, firewall, barrier",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11032,6 +12251,7 @@
       "fileName": "wand-24",
       "iconName": "wand",
       "description": "wand, magic, enhance, insights",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11041,6 +12261,7 @@
       "fileName": "wand-16",
       "iconName": "wand",
       "description": "wand, magic, enhance, insights",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11050,6 +12271,7 @@
       "fileName": "watch-24",
       "iconName": "watch",
       "description": "watch, time",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11059,6 +12281,7 @@
       "fileName": "watch-16",
       "iconName": "watch",
       "description": "watch, time",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11068,6 +12291,7 @@
       "fileName": "webhook-24",
       "iconName": "webhook",
       "description": "webhook, hook",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11077,6 +12301,7 @@
       "fileName": "webhook-16",
       "iconName": "webhook",
       "description": "webhook, hook",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11086,6 +12311,7 @@
       "fileName": "wifi-24",
       "iconName": "wifi",
       "description": "wifi, internet",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11095,6 +12321,7 @@
       "fileName": "wifi-16",
       "iconName": "wifi",
       "description": "wifi, internet",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11104,6 +12331,7 @@
       "fileName": "wifi-off-24",
       "iconName": "wifi-off",
       "description": "wifi, internet, off, disabled",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11113,6 +12341,7 @@
       "fileName": "wifi-off-16",
       "iconName": "wifi-off",
       "description": "wifi, internet, off, disabled",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11122,6 +12351,7 @@
       "fileName": "wrench-24",
       "iconName": "wrench",
       "description": "wrench, tool, adjust, build",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11131,6 +12361,7 @@
       "fileName": "wrench-16",
       "iconName": "wrench",
       "description": "wrench, tool, adjust, build",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11140,6 +12371,7 @@
       "fileName": "x-24",
       "iconName": "x",
       "description": "cross, delete, remove, cancel",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11149,6 +12381,7 @@
       "fileName": "x-16",
       "iconName": "x",
       "description": "cross, delete, remove, cancel",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11158,6 +12391,7 @@
       "fileName": "x-circle-24",
       "iconName": "x-circle",
       "description": "cross, delete, remove, cancel, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11167,6 +12401,7 @@
       "fileName": "x-circle-16",
       "iconName": "x-circle",
       "description": "cross, delete, remove, cancel, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11176,6 +12411,7 @@
       "fileName": "x-circle-fill-24",
       "iconName": "x-circle-fill",
       "description": "cross, delete, remove, cancel, circle",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11185,6 +12421,7 @@
       "fileName": "x-circle-fill-16",
       "iconName": "x-circle-fill",
       "description": "cross, delete, remove, cancel, circle",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11194,6 +12431,7 @@
       "fileName": "x-diamond-24",
       "iconName": "x-diamond",
       "description": "check, tick, success, diamond",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11203,6 +12441,7 @@
       "fileName": "x-diamond-16",
       "iconName": "x-diamond",
       "description": "check, tick, success, diamond",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11212,6 +12451,7 @@
       "fileName": "x-diamond-fill-24",
       "iconName": "x-diamond-fill",
       "description": "check, tick, success, diamond",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11221,6 +12461,7 @@
       "fileName": "x-diamond-fill-16",
       "iconName": "x-diamond-fill",
       "description": "check, tick, success, diamond",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11230,6 +12471,7 @@
       "fileName": "x-hexagon-24",
       "iconName": "x-hexagon",
       "description": "check, tick, success, diamond",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11239,6 +12481,7 @@
       "fileName": "x-hexagon-16",
       "iconName": "x-hexagon",
       "description": "check, tick, success, diamond",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11248,6 +12491,7 @@
       "fileName": "x-hexagon-fill-24",
       "iconName": "x-hexagon-fill",
       "description": "check, tick, success, diamond",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11257,6 +12501,7 @@
       "fileName": "x-hexagon-fill-16",
       "iconName": "x-hexagon-fill",
       "description": "check, tick, success, diamond",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11266,6 +12511,7 @@
       "fileName": "x-square-24",
       "iconName": "x-square",
       "description": "cross, delete, remove, cancel, square",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11275,6 +12521,7 @@
       "fileName": "x-square-16",
       "iconName": "x-square",
       "description": "cross, delete, remove, cancel, square",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11284,6 +12531,7 @@
       "fileName": "x-square-fill-24",
       "iconName": "x-square-fill",
       "description": "cross, delete, remove, cancel, square",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11293,6 +12541,7 @@
       "fileName": "x-square-fill-16",
       "iconName": "x-square-fill",
       "description": "cross, delete, remove, cancel, square",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11302,6 +12551,7 @@
       "fileName": "zap-24",
       "iconName": "zap",
       "description": "zap, power, run, automate",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11311,6 +12561,7 @@
       "fileName": "zap-16",
       "iconName": "zap",
       "description": "zap, power, run, automate",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11320,6 +12571,7 @@
       "fileName": "zap-off-24",
       "iconName": "zap-off",
       "description": "zap, power, run, automate, off, disabled",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11329,6 +12581,7 @@
       "fileName": "zap-off-16",
       "iconName": "zap-off",
       "description": "zap, power, run, automate, off, disabled",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11338,6 +12591,7 @@
       "fileName": "zoom-in-24",
       "iconName": "zoom-in",
       "description": "zoom, in, maximize",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11347,6 +12601,7 @@
       "fileName": "zoom-in-16",
       "iconName": "zoom-in",
       "description": "zoom, in, maximize",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16
@@ -11356,6 +12611,7 @@
       "fileName": "zoom-out-24",
       "iconName": "zoom-out",
       "description": "zoom, out, minimize",
+      "category": "Core",
       "size": "24",
       "width": 24,
       "height": 24
@@ -11365,6 +12621,7 @@
       "fileName": "zoom-out-16",
       "iconName": "zoom-out",
       "description": "zoom, out, minimize",
+      "category": "Core",
       "size": "16",
       "width": 16,
       "height": 16

--- a/packages/flight-icons/scripts/@types/AssetsCatalog.d.ts
+++ b/packages/flight-icons/scripts/@types/AssetsCatalog.d.ts
@@ -15,6 +15,8 @@ export type AssetCatalogItem = {
     iconName: AssetCoreData[iconName],
     // eg. "bitbucket, atlassian"
     description: AssetCoreData[description],
+    // eg. "products"
+    category: AssetCoreData[category],
     // eg. "16" (but in the future it may become "sm")
     size: string;
     // eg 16

--- a/packages/flight-icons/scripts/@types/AssetsMetadata.d.ts
+++ b/packages/flight-icons/scripts/@types/AssetsMetadata.d.ts
@@ -16,6 +16,8 @@ export type AssetCoreData = {
     iconName: string,
     // the (optional) description contained in the "description" field of the parent component_set
     description
+    // the icon's category (by convention it's the containing frame's name)
+    category: string,
 }
 
 export type AssetsMetadata = {

--- a/packages/flight-icons/scripts/@types/ConfigData.d.ts
+++ b/packages/flight-icons/scripts/@types/ConfigData.d.ts
@@ -4,11 +4,11 @@
  */
 
 export type ConfigData = {
-    // the data of the Figma file we sync with
+    // the metadata for the Figma file we sync with
     figmaFile: {
         id: string,
         page: string,
-        frames: string[],
+        excludeFrames: string[],
     },
     mainFolder: string,
     tempFolder: string,

--- a/packages/flight-icons/scripts/config.ts
+++ b/packages/flight-icons/scripts/config.ts
@@ -6,17 +6,13 @@
 import { ConfigData } from "./@types/ConfigData";
 
 export const config: ConfigData = {
-    // the data of the Figma file we sync with
+    // the metadata for the Figma file we sync with
     figmaFile: {
         // this is the "production" file
-        id: 'TLnoT5AYQfy3tZ0H68BgOr',
-        // this is for testing purpose
-        // id: '2u60imwCVJvSpH0io1O068',
-        // Notice: this simple configuration is under the assumption thet all the assets will be in the same page
-        // if later we will discover we need to be more specific (eg. multiple files, multiple pages, etc.)
-        // we will adopt a more explicit, structured configuration format
+        id: 'TLnoT5AYQfy3tZ0H68BgOr', // if needed use this ID for testing purposes: `2u60imwCVJvSpH0io1O068`
         page: 'Export',
-        frames: ['Core', 'Services', 'Products', 'Animated'],
+        // you can use this filter to exclude specific frames
+        excludeFrames: [],
     },
     // notice: these paths are relative to where the npm script is invoked, not this file!
     mainFolder: '.',

--- a/packages/flight-icons/scripts/sync-parts/getAssetsCatalog.ts
+++ b/packages/flight-icons/scripts/sync-parts/getAssetsCatalog.ts
@@ -30,6 +30,7 @@ export function getAssetsCatalog({ config, assetsMetadata, figmaExportPageNode }
             fileName: getAssetFileName(assetCoreData),
             iconName: assetCoreData.iconName,
             description: assetCoreData.description,
+            category: assetCoreData.category,
             size: assetCoreData.variantProps?.size || '',
             width: component.absoluteBoundingBox.width,
             height: component.absoluteBoundingBox.width,

--- a/packages/flight-icons/scripts/sync-parts/getAssetsMetadata.ts
+++ b/packages/flight-icons/scripts/sync-parts/getAssetsMetadata.ts
@@ -61,6 +61,11 @@ export async function getAssetsMetadata(): Promise<AssetsMetadata> {
                     variantName: component.name,
                     iconName: '',
                     description: '',
+                    category: '',
+                }
+                if (component.containing_frame.name) {
+                    // by convention the category of an icon is the containing frame's name
+                    assetsMetadata[component.node_id].category = component.containing_frame.name;
                 }
                 if (component.containing_frame.containingStateGroup) {
                     const parentComponentSet = componentSetData[component.containing_frame.containingStateGroup.nodeId]

--- a/packages/flight-icons/scripts/sync-parts/getAssetsMetadata.ts
+++ b/packages/flight-icons/scripts/sync-parts/getAssetsMetadata.ts
@@ -31,11 +31,11 @@ export async function getAssetsMetadata(): Promise<AssetsMetadata> {
     const componentSetData: ComponentSetData = {};
     if (componentSetsResponse.meta && componentSetsResponse.meta.component_sets) {
         componentSetsResponse.meta.component_sets.forEach(component_set => {
-            // check that the component is inside the expected page/frame
+            // check that the component_set is inside the expected page/frame
             if (
                 component_set.containing_frame &&
                 component_set.containing_frame.pageName === config.figmaFile.page &&
-                config.figmaFile.frames.includes(component_set.containing_frame.name)
+                !config.figmaFile.excludeFrames.includes(component_set.containing_frame.name)
             ) {
                 componentSetData[component_set.node_id] = {
                     name: component_set.name,
@@ -54,7 +54,7 @@ export async function getAssetsMetadata(): Promise<AssetsMetadata> {
             if (
                 component.containing_frame &&
                 component.containing_frame.pageName === config.figmaFile.page &&
-                config.figmaFile.frames.includes(component.containing_frame.name)
+                !config.figmaFile.excludeFrames.includes(component.containing_frame.name)
             ) {
                 assetsMetadata[component.node_id] = {
                     id: component.node_id,


### PR DESCRIPTION
### :pushpin: Summary

Small PR to add support for the "category" of the icons in our pipeline.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added persistence of the icon “category” (the containing frame’s name) to the icons pipeline
- processed icons to update the `catalog.json` file and make sure the “category” is added to the icons’s metadata

_(Once @andgen404 will release the new categorization, we will run a new sync and release a new version (in this way in the diff we will be able to see that the categories are correctly updated in the `catalog.json` file)._

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3163

***

### 👀 Component checklist

- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
