### PR TITLE
Removed structure reference from the badge documentation.

### DIFF
--- a/website/docs/components/badge/partials/guidelines/guidelines.md
+++ b/website/docs/components/badge/partials/guidelines/guidelines.md
@@ -109,13 +109,6 @@ For example:
 - use large Badges when inline with a heading
 - use small or medium Badges in tables, depending on the data density
 
-!!! Insight
-
-**Structure migration tip**
-
-Use small Badges in place of Structure Badges.
-!!!
-
 ## Icon
 
 Badges come in a few icon and text combinations; text only, icon only, and icon + text (where the icon is in the leading position). Use icons intentionally and only when they provide the user with extra value.


### PR DESCRIPTION
### :pushpin: Summary
Removed Structure reference from our doc

### :hammer_and_wrench: Detailed description
I scanned our doc site to see if there are anymore trailing Structure references beyond this single point, and there seems to be none.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3016](https://hashicorp.atlassian.net/browse/HDS-3016)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3016]: https://hashicorp.atlassian.net/browse/HDS-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ