### PR TITLE
Remove `dialog-polyfill` dependency

### DIFF
--- a/.changeset/twenty-goats-type.md
+++ b/.changeset/twenty-goats-type.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Removed `dialog-polyfill` dependency

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,6 @@
     "@embroider/addon-shim": "^1.8.7",
     "@hashicorp/design-system-tokens": "^2.0.0",
     "@hashicorp/ember-flight-icons": "^5.0.0",
-    "dialog-polyfill": "^0.5.6",
     "ember-a11y-refocus": "^3.0.2",
     "ember-cli-sass": "^11.0.1",
     "ember-composable-helpers": "^5.0.0",

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -85,10 +85,5 @@ export default {
   // You can augment this if you need to.
   output: addon.output(),
   plugins: plugins,
-  external: [
-    'dialog-polyfill',
-    'dialog-polyfill/dist/dialog-polyfill.css',
-    'ember-modifier',
-    'prismjs',
-  ],
+  external: ['ember-modifier', 'prismjs'],
 };

--- a/packages/components/src/components/hds/flyout/index.js
+++ b/packages/components/src/components/hds/flyout/index.js
@@ -87,23 +87,6 @@ export default class HdsFlyoutIndexComponent extends Component {
         this.body.style.getPropertyValue('overflow');
     }
 
-    // Register `<dialog>` element for polyfilling if no native support is available
-    if (!element.showModal) {
-      Promise.all([
-        import('dialog-polyfill'),
-        import('dialog-polyfill/dist/dialog-polyfill.css'),
-      ])
-        .then(([dialogPolyfill]) => {
-          const dialog = dialogPolyfill.default;
-          if (dialog.registerDialog) {
-            dialog.registerDialog(element);
-            // This unscoped class is defined in the dialog polyfill: https://github.com/GoogleChrome/dialog-polyfill/blob/master/dist/dialog-polyfill.css#L33
-            element.classList.add('fixed');
-          }
-        })
-        .catch({});
-    }
-
     // Register "onClose" callback function to be called when a native 'close' event is dispatched
     this.element.addEventListener('close', this.registerOnCloseCallback, true);
 

--- a/packages/components/src/components/hds/modal/index.js
+++ b/packages/components/src/components/hds/modal/index.js
@@ -128,23 +128,6 @@ export default class HdsModalIndexComponent extends Component {
         this.body.style.getPropertyValue('overflow');
     }
 
-    // Register `<dialog>` element for polyfilling if no native support is available
-    if (!element.showModal) {
-      Promise.all([
-        import('dialog-polyfill'),
-        import('dialog-polyfill/dist/dialog-polyfill.css'),
-      ])
-        .then(([dialogPolyfill]) => {
-          const dialog = dialogPolyfill.default;
-          if (dialog.registerDialog) {
-            dialog.registerDialog(element);
-            // This unscoped class is defined in the dialog polyfill: https://github.com/GoogleChrome/dialog-polyfill/blob/master/dist/dialog-polyfill.css#L33
-            element.classList.add('fixed');
-          }
-        })
-        .catch({});
-    }
-
     // Register "onClose" callback function to be called when a native 'close' event is dispatched
     this.element.addEventListener('close', this.registerOnCloseCallback, true);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3555,7 +3555,6 @@ __metadata:
     "@types/ember-resolver": "npm:^9.0.0"
     "@types/qunit": "npm:^2.19.7"
     "@types/rsvp": "npm:^4.0.6"
-    dialog-polyfill: "npm:^0.5.6"
     ember-a11y-refocus: "npm:^3.0.2"
     ember-cli-sass: "npm:^11.0.1"
     ember-composable-helpers: "npm:^5.0.0"
@@ -10994,13 +10993,6 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.0"
   checksum: 3cc5f903d02d279d6dc4aa71ab6ed9898b9f4d1f861cc5421ce7357893c21b9520de78afb203c92bd650a6977ad0ca98195453a0707a39958cf5fea3b0a8ddd8
-  languageName: node
-  linkType: hard
-
-"dialog-polyfill@npm:^0.5.6":
-  version: 0.5.6
-  resolution: "dialog-polyfill@npm:0.5.6"
-  checksum: 42428793b04fd2e0a67dfb75838703488d7d05f73663c3251441ad6ed154b8dc71d65ed03d5a0ba4a83c6167c2e6f791cbe1574d0dca37dac1405ce3816033ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: Summary

Remove the `dialog-polyfill` dependency as it's no longer in use (was initially added to aid support for Safari 14)

### :hammer_and_wrench: Detailed description

The `<dialog>` element is now supported by all versions listed in our [browser support matrix](https://helios.hashicorp.design/getting-started/for-engineers#browser-support) and beyond (for almost a year now) so the polyfill is no longer used or needed.

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
