### PR TITLE
Bump “required” text color up to next darkest to pass a11y contrast

### DIFF
--- a/website/app/styles/doc-components/component-api.scss
+++ b/website/app/styles/doc-components/component-api.scss
@@ -62,7 +62,7 @@
 .doc-component-api__property-required {
   @include doc-font-style-code ();
   display: inline-block;
-  color: #f25054; // it's an HDS color, so we use its corresponding hex value
+  color: #ba2226; // it's an HDS color, so we use its corresponding hex value
 }
 
 // second row - values


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will increase contrast of "required" text in the Code tab API section so it will pass a11y contrast checks.

<!--
### :hammer_and_wrench: Detailed description

 If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

With update, passes quick test using Lighthouse:
<img width="768" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/b77028d2-dc13-47b1-ad9f-c2daee7b6861">

<!-- 
### :link: External links

Issues, RFC, etc.
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]  -->

***

### 👀 Component checklist

- [ ] ~~Percy was checked for any visual regression~~
- [ ] ~~A changelog entry was added via [Changesets]~~(https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
