### PR TITLE
Avoid copywrite on type declaration files

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -14,6 +14,8 @@ project {
     "**/*rc.js",
     # Distribution files
     "**/dist/**",
+    # Type declarations
+    "**/*.d.ts",
     # SVG icons packed as `tsx` files
     "packages/flight-icons/svg-react/*",
     # Handlebars components sensitive to white-space


### PR DESCRIPTION
### :pushpin: Summary

Triggered by https://github.com/hashicorp/design-system/pull/1982 – we don't want copywrite on these typescript generated files.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
