### PR TITLE
Put all component registry declarations in template-registry

### DIFF
--- a/packages/components/src/components/hds/button/index.ts
+++ b/packages/components/src/components/hds/button/index.ts
@@ -190,10 +190,3 @@ export default class HdsButtonIndexComponent extends Component<HdsButtonSignatur
     return classes.join(' ');
   }
 }
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Hds::Button': typeof HdsButtonIndexComponent;
-    'hds/button': typeof HdsButtonIndexComponent;
-  }
-}

--- a/packages/components/src/components/hds/dismiss-button/index.ts
+++ b/packages/components/src/components/hds/dismiss-button/index.ts
@@ -22,11 +22,3 @@ export default class HdsDismissButtonIndexComponent extends Component<HdsDismiss
     return this.args.ariaLabel ?? 'Dismiss';
   }
 }
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Hds::DismissButton': typeof HdsDismissButtonIndexComponent;
-    'hds/dismiss-button': typeof HdsDismissButtonIndexComponent;
-    'HdsDismissButton': typeof HdsDismissButtonIndexComponent;
-  }
-}

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -12,9 +12,9 @@ export interface HdsInteractiveSignature {
     isHrefExternal?: boolean;
     isRouteExternal?: boolean;
     route?: string;
-    models?: unknown;
-    model?: unknown;
-    query?: unknown;
+    models?: Array<string | number>;
+    model?: string | number;
+    query?: Record<string, string>;
     'current-when'?: string;
     replace?: boolean;
   };
@@ -52,12 +52,5 @@ export default class HdsInteractiveIndexComponent extends Component<HdsInteracti
     if (event.key === ' ' || event.code === 'Space') {
       (event.target as HTMLElement).click();
     }
-  }
-}
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Hds::Interactive': typeof HdsInteractiveIndexComponent;
-    'hds/interactive': typeof HdsInteractiveIndexComponent;
   }
 }

--- a/packages/components/src/helpers/hds-link-to-models.ts
+++ b/packages/components/src/helpers/hds-link-to-models.ts
@@ -17,7 +17,7 @@ import { assert } from '@ember/debug';
  * ```
  */
 
-export function hdsLinkToModels<T>([model, models]: [T, T[]]) {
+export function hdsLinkToModels<T>([model, models]: [T | undefined, T[] | undefined]) {
   assert(
     'You cannot provide both the `@model` and `@models` arguments to the component.',
     !model || !models
@@ -34,10 +34,3 @@ export function hdsLinkToModels<T>([model, models]: [T, T[]]) {
 
 const hdsLinkToModelsHelper = helper(hdsLinkToModels);
 export default hdsLinkToModelsHelper;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'hds-link-to-models': typeof hdsLinkToModelsHelper;
-  }
-}
-  

--- a/packages/components/src/helpers/hds-link-to-query.ts
+++ b/packages/components/src/helpers/hds-link-to-query.ts
@@ -25,9 +25,3 @@ export function hdsLinkToQuery([query]: [Record<string, string> | undefined]) {
 
 const hdsLinkToQueryHelper = helper(hdsLinkToQuery);
 export default hdsLinkToQueryHelper;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'hds-link-to-query': typeof hdsLinkToQueryHelper;
-  }
-}

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -3,12 +3,30 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import type HdsLinkToModelsHelper from './helpers/hds-link-to-models';
 import type HdsButtonIndexComponent from './components/hds/button';
 import type HdsDismissButtonIndexComponent from './components/hds/dismiss-button';
 import type HdsInteractiveIndexComponent from './components/hds/interactive';
+import type HdsLinkToQueryHelper from './helpers/hds-link-to-query';
 
 export default interface HdsComponentsRegistry {
-  HdsButtonComponent: typeof HdsButtonIndexComponent;
-  HdsDismissComponent: typeof HdsDismissButtonIndexComponent;
   HdsInteractiveComponent: typeof HdsInteractiveIndexComponent;
+  // Button
+  'Hds::Button': typeof HdsButtonIndexComponent;
+  'hds/button': typeof HdsButtonIndexComponent;
+  HdsButton: typeof HdsButtonIndexComponent;
+
+  // Dismiss button
+  'Hds::DismissButton': typeof HdsDismissButtonIndexComponent;
+  'hds/dismiss-button': typeof HdsDismissButtonIndexComponent;
+  HdsDismissButton: typeof HdsDismissButtonIndexComponent;
+
+  // Interactive
+  'Hds::Interactive': typeof HdsInteractiveIndexComponent;
+  'hds/interactive': typeof HdsInteractiveIndexComponent;
+  HdsInteractive: typeof HdsInteractiveIndexComponent;
+
+  // Helpers
+  'hds-link-to-models': typeof HdsLinkToModelsHelper;
+  'hds-link-to-query': typeof HdsLinkToQueryHelper;
 }

--- a/packages/components/src/types/global.d.ts
+++ b/packages/components/src/types/global.d.ts
@@ -5,9 +5,10 @@ declare module 'ember-truth-helpers';
 import { LinkTo } from "@ember/routing";
 
 import type EmberTruthRegistry from 'ember-truth-helpers/template-registry';
+import type HdsComponentsRegistry from '../template-registry';
 
 declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry extends EmberTruthRegistry /*, other addon registries */ {
+  export default interface Registry extends EmberTruthRegistry, HdsComponentsRegistry /*, other addon registries */ {
     // local entries
     "LinkToExternal": typeof LinkTo;
   }


### PR DESCRIPTION
### :pushpin: Summary

Previously component registry declarations were colocated with component classes, and then also (but kind of differently) added to a central template-registry that consumers can use.

This PR puts all registry declarations in the one central template-registry

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
