### PR TITLE
Web: Add categories for filtered icon search (HDS-3064)

### DIFF
--- a/website/app/components/doc/icons-list/grid.hbs
+++ b/website/app/components/doc/icons-list/grid.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<h2 class="doc-text-h2">{{capitalize @category}}</h2>
+<h2 class="doc-text-h4">{{capitalize @categoryName}}</h2>
 <ul class="doc-icons-list-grid" role="list">
   {{#each @categoryIcons as |meta|}}
     <Doc::IconsList::Item @meta={{meta}} />

--- a/website/app/components/doc/icons-list/grid.hbs
+++ b/website/app/components/doc/icons-list/grid.hbs
@@ -3,13 +3,14 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
+<h2 class="doc-text-h2">{{capitalize @category}}</h2>
 <ul class="doc-icons-list-grid" role="list">
-  {{#each @icons as |meta|}}
+  {{#each @categoryIcons as |meta|}}
     <Doc::IconsList::Item @meta={{meta}} />
   {{else}}
-    <div class="doc-icons-list-grid__not-found">
+    <li class="doc-icons-list-grid__not-found">
       <FlightIcon @name="alert-circle" />
       No icons found
-    </div>
+    </li>
   {{/each}}
 </ul>

--- a/website/app/components/doc/icons-list/grid.hbs
+++ b/website/app/components/doc/icons-list/grid.hbs
@@ -7,10 +7,5 @@
 <ul class="doc-icons-list-grid" role="list">
   {{#each @categoryIcons as |meta|}}
     <Doc::IconsList::Item @meta={{meta}} />
-  {{else}}
-    <li class="doc-icons-list-grid__not-found">
-      <FlightIcon @name="alert-circle" />
-      No icons found
-    </li>
   {{/each}}
 </ul>

--- a/website/app/components/doc/icons-list/index.hbs
+++ b/website/app/components/doc/icons-list/index.hbs
@@ -4,22 +4,18 @@
 }}
 
 <div class="doc-icons-list-filter">
-  <div class="doc-icons-list-filter__search">
-    <Doc::Form::Filter
-      @label="Filter"
-      @placeholder="Type a name or keyword (e.g. arrow)"
-      @filterQuery={{@searchQuery}}
-      @onInput={{@searchIcons}}
-      data-test="icons-filter"
-    />
-  </div>
-  <div class="doc-icons-list-filter__select">
-    <Doc::Form::Select @label="Size" @onSelect={{@onSelect}} @selectedValue={{@selectedIconSize}} />
-  </div>
+  <Doc::Form::Filter
+    @label="Filter"
+    @placeholder="Type a name or keyword (e.g. arrow)"
+    @filterQuery={{@searchQuery}}
+    @onInput={{@searchIcons}}
+    data-test="icons-filter"
+  />
+  <Doc::Form::Select @label="Size" @onSelect={{@onSelect}} @selectedValue={{@selectedIconSize}} />
 </div>
 
-{{#each-in @groupedIcons as |category categoryIcons|}}
-  <Doc::IconsList::Grid @category={{category}} @categoryIcons={{categoryIcons}} />
+{{#each-in @groupedIcons as |categoryName categoryIcons|}}
+  <Doc::IconsList::Grid @categoryName={{categoryName}} @categoryIcons={{categoryIcons}} />
 {{else}}
   <p class="doc-text-body doc-icons-list-filter__not-found">No icons found. 🤷‍♀️</p>
 {{/each-in}}

--- a/website/app/components/doc/icons-list/index.hbs
+++ b/website/app/components/doc/icons-list/index.hbs
@@ -4,9 +4,6 @@
 }}
 
 <div class="doc-icons-list-filter">
-  <div class="doc-icons-list-filter__select">
-    <Doc::Form::Select @label="Size" @onSelect={{@onSelect}} @selectedValue={{@selectedIconSize}} />
-  </div>
   <div class="doc-icons-list-filter__search">
     <Doc::Form::Filter
       @label="Filter"
@@ -16,6 +13,13 @@
       data-test="icons-filter"
     />
   </div>
+  <div class="doc-icons-list-filter__select">
+    <Doc::Form::Select @label="Size" @onSelect={{@onSelect}} @selectedValue={{@selectedIconSize}} />
+  </div>
 </div>
 
-<Doc::IconsList::Grid @icons={{@icons}} />
+{{#each-in @groupedIcons as |category categoryIcons|}}
+  <Doc::IconsList::Grid @category={{category}} @categoryIcons={{categoryIcons}} />
+{{else}}
+  <p class="doc-text-body">No icons found. 🤷‍♀️</p>
+{{/each-in}}

--- a/website/app/components/doc/icons-list/index.hbs
+++ b/website/app/components/doc/icons-list/index.hbs
@@ -21,5 +21,5 @@
 {{#each-in @groupedIcons as |category categoryIcons|}}
   <Doc::IconsList::Grid @category={{category}} @categoryIcons={{categoryIcons}} />
 {{else}}
-  <p class="doc-text-body">No icons found. 🤷‍♀️</p>
+  <p class="doc-text-body doc-icons-list-filter__not-found">No icons found. 🤷‍♀️</p>
 {{/each-in}}

--- a/website/app/styles/doc-components/icons-list/index.scss
+++ b/website/app/styles/doc-components/icons-list/index.scss
@@ -13,7 +13,7 @@
 
 .doc-icons-list-filter {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: 1fr auto;
   gap: 24px;
   align-items: flex-end;
   margin-bottom: 24px;
@@ -34,14 +34,14 @@
 }
 
 // controls
+// Q: Remove? These styles don't have any effect
+// .doc-icons-list-filter__select {
+//   width: 120px;
+// }
 
-.doc-icons-list-filter__select {
-  width: 120px;
-}
-
-.doc-icons-list-filter__search {
-  width: auto;
-}
+// .doc-icons-list-filter__search {
+//   width: auto;
+// }
 
 
 // GRID

--- a/website/app/styles/doc-components/icons-list/index.scss
+++ b/website/app/styles/doc-components/icons-list/index.scss
@@ -33,16 +33,6 @@
   white-space: nowrap;
 }
 
-// controls
-// Q: Remove? These styles don't have any effect
-// .doc-icons-list-filter__select {
-//   width: 120px;
-// }
-
-// .doc-icons-list-filter__search {
-//   width: auto;
-// }
-
 
 // GRID
 
@@ -63,7 +53,6 @@
     grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   }
 }
-
 
 // item
 

--- a/website/app/styles/doc-components/icons-list/index.scss
+++ b/website/app/styles/doc-components/icons-list/index.scss
@@ -142,12 +142,3 @@
     visibility: visible;
   }
 }
-
-// not found
-
-.doc-icons-list-grid__not-found {
-  @include doc-font-style-body();
-  display: flex;
-  gap: 12px;
-  align-items: center;
-}

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -36,8 +36,11 @@ export default class Index extends Component {
     return this.router.currentRoute.queryParams['selectedIconSize'] || '24';
   }
 
-  // Performs search & returns all icons which match search query
-  get filteredIcons() {
+  get filteredGroupedIcons() {
+    let filteredIcons = [];
+    const filteredGroupedIcons = {};
+
+    // Filters all icons based on the search query
     if (this.searchQuery) {
       // check if the query is for an exact match (prefixed with `icon:`)
       if (this.searchQuery.match(/^icon:/)) {
@@ -49,24 +52,25 @@ export default class Index extends Component {
             i.iconName === exactIconName && i.size === this.selectedIconSize
           );
         });
-        return icon ? [icon] : [];
+
+        if (icon) {
+          filteredIcons.push(icon);
+        }
       } else {
-        return this.allIcons.filter(
+        filteredIcons = this.allIcons.filter(
           (i) =>
             i.size === this.selectedIconSize &&
             i.searchable.indexOf(this.searchQuery) !== -1
         );
       }
     } else {
-      return this.allIcons.filter((i) => i.size === this.selectedIconSize);
+      filteredIcons = this.allIcons.filter(
+        (i) => i.size === this.selectedIconSize
+      );
     }
-  }
 
-  // Groups all filtered icons by category
-  get filteredGroupedIcons() {
-    const filteredGroupedIcons = {};
-
-    this.filteredIcons.forEach((icon) => {
+    // Groups all filtered icons by category
+    filteredIcons.forEach((icon) => {
       const category = icon.category;
       if (!filteredGroupedIcons[category]) {
         filteredGroupedIcons[category] = [];

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -69,7 +69,12 @@ export default class Index extends Component {
       );
     }
 
-    // Groups all filtered icons by category
+    // alphabetize the filtered icons
+    filteredIcons.sort((a, b) => {
+      return a.iconName.localeCompare(b.iconName);
+    });
+
+    // Group all filtered icons by category
     filteredIcons.forEach((icon) => {
       const category = icon.category;
       if (!filteredGroupedIcons[category]) {
@@ -78,7 +83,14 @@ export default class Index extends Component {
       filteredGroupedIcons[category].push(icon);
     });
 
-    return filteredGroupedIcons;
+    // alphabetize the grouped icon categories
+    const alphabetizedCategories = Object.keys(filteredGroupedIcons).sort();
+    const alphabetizedGroupedIcons = {};
+
+    for (const category of alphabetizedCategories) {
+      alphabetizedGroupedIcons[category] = filteredGroupedIcons[category];
+    }
+    return alphabetizedGroupedIcons;
   }
 
   @action

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -50,7 +50,7 @@ export default class Index extends Component {
   }
 
   get filteredGroupedIcons() {
-    let filteredGroupedIcons = {};
+    const filteredGroupedIcons = {};
 
     if (this.searchQuery) {
       // check if the query is for an exact match (prefixed with `icon:`)

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -64,7 +64,7 @@ export default class Index extends Component {
           );
         });
         if (icon) {
-          filteredGroupedIcons = { [icon.category]: [icon] };
+          return { [icon.category]: [icon] };
         }
       } else {
         Object.keys(this.groupedIcons).forEach((category) => {

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -69,10 +69,18 @@ export default class Index extends Component {
       );
     }
 
-    // alphabetize the filtered icons
-    filteredIcons.sort((a, b) => {
-      return a.iconName.localeCompare(b.iconName);
-    });
+    // alphabetize the filtered icons by category and then by name
+    filteredIcons
+      .sort((a, b) => {
+        return a.category.localeCompare(b.category);
+      })
+      .sort((a, b) => {
+        if (a.category === b.category) {
+          a.iconName.localeCompare(b.iconName);
+        }
+
+        return 0;
+      });
 
     // Group all filtered icons by category
     filteredIcons.forEach((icon) => {
@@ -83,14 +91,7 @@ export default class Index extends Component {
       filteredGroupedIcons[category].push(icon);
     });
 
-    // alphabetize the grouped icon categories
-    const alphabetizedCategories = Object.keys(filteredGroupedIcons).sort();
-    const alphabetizedGroupedIcons = {};
-
-    for (const category of alphabetizedCategories) {
-      alphabetizedGroupedIcons[category] = filteredGroupedIcons[category];
-    }
-    return alphabetizedGroupedIcons;
+    return filteredGroupedIcons;
   }
 
   @action

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -15,19 +15,6 @@ const DEBOUNCE_MS = 250;
 export default class Index extends Component {
   @service router;
 
-  constructor() {
-    super(...arguments);
-    this.groupedIcons = {};
-    // prepare the icons grouped by category
-    this.allIcons.forEach((icon) => {
-      const category = icon.category;
-      if (!this.groupedIcons[category]) {
-        this.groupedIcons[category] = [];
-      }
-      this.groupedIcons[category].push(icon);
-    });
-  }
-
   allIcons = catalog.assets.map(
     ({ iconName, fileName, size, description, category }) => {
       return {
@@ -49,9 +36,8 @@ export default class Index extends Component {
     return this.router.currentRoute.queryParams['selectedIconSize'] || '24';
   }
 
-  get filteredGroupedIcons() {
-    const filteredGroupedIcons = {};
-
+  // Performs search & returns all icons which match search query
+  get filteredIcons() {
     if (this.searchQuery) {
       // check if the query is for an exact match (prefixed with `icon:`)
       if (this.searchQuery.match(/^icon:/)) {
@@ -63,30 +49,30 @@ export default class Index extends Component {
             i.iconName === exactIconName && i.size === this.selectedIconSize
           );
         });
-        if (icon) {
-          return { [icon.category]: [icon] };
-        }
+        return icon ? [icon] : [];
       } else {
-        Object.keys(this.groupedIcons).forEach((category) => {
-          const filteredIcons = this.groupedIcons[category].filter(
-            (i) =>
-              i.searchable.indexOf(this.searchQuery) !== -1 &&
-              i.size === this.selectedIconSize
-          );
-          if (filteredIcons.length > 0) {
-            filteredGroupedIcons[category] = filteredIcons;
-          }
-        });
+        return this.allIcons.filter(
+          (i) =>
+            i.size === this.selectedIconSize &&
+            i.searchable.indexOf(this.searchQuery) !== -1
+        );
       }
     } else {
-      Object.keys(this.groupedIcons).forEach((category) => {
-        const filteredIcons = this.groupedIcons[category].filter(
-          (i) => i.size === this.selectedIconSize
-        );
-        filteredGroupedIcons[category] =
-          filteredIcons.length > 0 ? filteredIcons : false;
-      });
+      return this.allIcons.filter((i) => i.size === this.selectedIconSize);
     }
+  }
+
+  // Groups all filtered icons by category
+  get filteredGroupedIcons() {
+    const filteredGroupedIcons = {};
+
+    this.filteredIcons.forEach((icon) => {
+      const category = icon.category;
+      if (!filteredGroupedIcons[category]) {
+        filteredGroupedIcons[category] = [];
+      }
+      filteredGroupedIcons[category].push(icon);
+    });
 
     return filteredGroupedIcons;
   }

--- a/website/docs/icons/library/index.md
+++ b/website/docs/icons/library/index.md
@@ -11,7 +11,7 @@ previewImage: assets/illustrations/icons/library.jpg
 
 <!-- algolia-ignore-start -->
 <Doc::IconsList
-  @icons={{this.filteredIcons}}
+  @groupedIcons={{this.filteredGroupedIcons}}
   @onSelect={{this.selectIconSize}}
   @selectedIconSize={{this.selectedIconSize}}
   @searchQuery={{this.searchQuery}}

--- a/website/tests/acceptance/icon-test.js
+++ b/website/tests/acceptance/icon-test.js
@@ -32,7 +32,19 @@ module('Acceptance | Icon Search', function (hooks) {
 
     assert.dom('.doc-icons-list-grid-item').exists({ count: 1 });
     assert.dom('.flight-icon-cpu').exists({ count: 1 });
-    assert.dom('.doc-copy-button__visible-value ').hasText('cpu');
+    assert.dom('.doc-copy-button__visible-value').hasText('cpu');
+  });
+
+  test('should load content based on category in query param', async function (assert) {
+    await visit('/icons/library?searchQuery=animated&selectedIconSize=24');
+
+    assert.strictEqual(
+      currentURL(),
+      '/icons/library?searchQuery=animated&selectedIconSize=24'
+    );
+
+    assert.dom('.doc-icons-list-grid-item').exists({ count: 2 });
+    assert.dom('.doc-text-h2').hasText('Animated');
   });
 
   test('should load a specific icon based on query param', async function (assert) {

--- a/website/tests/acceptance/icon-test.js
+++ b/website/tests/acceptance/icon-test.js
@@ -63,14 +63,14 @@ module('Acceptance | Icon Search', function (hooks) {
   test('should show message when no results are found', async function (assert) {
     await visit('/icons/library?searchQuery=wubalubadubdub');
 
-    assert.dom('.doc-icons-list-grid__not-found').exists();
+    assert.dom('.doc-icons-list-filter__not-found').exists();
     assert.dom('[data-test-icon="activity"]').doesNotExist();
   });
 
   test('should show message when no results are found for a specific icon', async function (assert) {
     await visit('/icons/library?searchQuery=icon%3awubalubadubdub');
 
-    assert.dom('.doc-icons-list-grid__not-found').exists();
+    assert.dom('.doc-icons-list-filter__not-found').exists();
     assert.dom('[data-test-icon="activity"]').doesNotExist();
   });
 

--- a/website/tests/acceptance/icon-test.js
+++ b/website/tests/acceptance/icon-test.js
@@ -44,7 +44,7 @@ module('Acceptance | Icon Search', function (hooks) {
     );
 
     assert.dom('.doc-icons-list-grid-item').exists({ count: 2 });
-    assert.dom('.doc-text-h2').hasText('Animated');
+    assert.dom('.doc-text-h4').hasText('Animated');
   });
 
   test('should load a specific icon based on query param', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds categories to filtered icon search.

**Preview:** https://hds-website-git-hds-3064-web-icon-filter-feature-hashicorp.vercel.app/icons/library

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<img width="1026" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/f401fed7-2eb1-4a86-a36b-647d24c5315f">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3064](https://hashicorp.atlassian.net/browse/HDS-3064)
Figma file: [if it applies]

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3064]: https://hashicorp.atlassian.net/browse/HDS-3064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ