### PR TITLE
`Flyout`: Add interpolation to Sass size variable (HDS-3206)

### DIFF
--- a/.changeset/khaki-trees-sit.md
+++ b/.changeset/khaki-trees-sit.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-BugFix: Fixed issue with Sass variable for Flyout width failing in some cases
+`Flyout` - Fixed issue with Sass operators failing in old versions of Sass

--- a/.changeset/khaki-trees-sit.md
+++ b/.changeset/khaki-trees-sit.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+BugFix: Fixed issue with Sass variable for Flyout width failing in some cases

--- a/packages/components/src/styles/components/flyout.scss
+++ b/packages/components/src/styles/components/flyout.scss
@@ -10,11 +10,11 @@
 $hds-flyout-max-width: calc(100vw - var(--hds-app-sidenav-width-minimized) / 2 );
 
 @mixin hds-flyout-position($size) {
-  width: min($size, #{$hds-flyout-max-width});
+  width: min(#{$size}, #{$hds-flyout-max-width});
   max-width: $hds-flyout-max-width;
 
   &[open] {
-    margin-left: calc(100% - min($size, #{$hds-flyout-max-width}));
+    margin-left: calc(100% - min(#{$size}, #{$hds-flyout-max-width}));
   }
 }
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR uses Sass interpolation to the `$size` variable used to set the Flyout width and margin

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

**BUG:**. 
Sass `$size` variable appears in the inspected styles (meaning that it is broken since it should have been replaced with the pixel value):
<img width="1491" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/20c5e0d9-f06d-486a-b133-1f74ff1ca3fd">

**FIX:**
<img width="1488" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/d5b6b727-35e8-4e2e-b9ae-2d06a2574936">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3206](https://hashicorp.atlassian.net/browse/HDS-3206)
Figma file: [if it applies]

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3206]: https://hashicorp.atlassian.net/browse/HDS-3206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ