### PR TITLE
Re-organize "showcase" index page to follow same order as "website"

### DIFF
--- a/showcase/app/templates/index.hbs
+++ b/showcase/app/templates/index.hbs
@@ -253,6 +253,14 @@ SPDX-License-Identifier: MPL-2.0
         </LinkTo>
       </li>
     </ol>
+    <Shw::Text::H2>Overrides</Shw::Text::H2>
+    <ol class="shw-text-body">
+      <li>
+        <LinkTo @route="overrides.power-select">
+          PowerSelect
+        </LinkTo>
+      </li>
+    </ol>
     <Shw::Text::H2>Utilities</Shw::Text::H2>
     <ol class="shw-text-body">
       <li>
@@ -273,14 +281,6 @@ SPDX-License-Identifier: MPL-2.0
       <li>
         <LinkTo @route="utilities.menu-primitive">
           MenuPrimitive
-        </LinkTo>
-      </li>
-    </ol>
-    <Shw::Text::H2>Overrides</Shw::Text::H2>
-    <ol class="shw-text-body">
-      <li>
-        <LinkTo @route="overrides.power-select">
-          PowerSelect
         </LinkTo>
       </li>
     </ol>


### PR DESCRIPTION
### :pushpin: Summary

Tiny PR to keep the same order/organization of the links to "components" pages for the "website" and the "showcase" (foundations → components → layouts → overrides → utilities)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
