### PR TITLE
Add linting for `packages/components` and fix Text types

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -42,9 +42,12 @@ jobs:
           cache-dependency-path: yarn.lock
       - name: Install Dependencies
         run: yarn install --immutable
-      - name: Lint
+      - name: Lint Showcase
         run: yarn run lint
         working-directory: showcase
+      - name: Lint Components
+        run: yarn run lint
+        working-directory: packages/components
       - name: Build Icons
         run: yarn build
         working-directory: packages/ember-flight-icons

--- a/packages/components/src/components/hds/copy/snippet/index.hbs
+++ b/packages/components/src/components/hds/copy/snippet/index.hbs
@@ -7,7 +7,7 @@
   type="button"
   class={{this.classNames}}
   {{hds-clipboard text=@textToCopy onSuccess=this.onSuccess onError=this.onError}}
-  aria-label={{concat 'copy ' @textToCopy}}
+  aria-label={{concat "copy " @textToCopy}}
   ...attributes
 >
   <Hds::Text::Code class="hds-copy-snippet__text" @tag="span" @size="100">

--- a/packages/components/src/components/hds/text/types.ts
+++ b/packages/components/src/components/hds/text/types.ts
@@ -24,29 +24,20 @@ export enum HdsTextColorValues {
 }
 export type HdsTextColors = `${HdsTextColorValues}`;
 
-/** Note: If changing this enum, ensure to also update its type union below */
 export enum HdsTextAlignValues {
   Left = 'left',
   Center = 'center',
   Right = 'right',
 }
-export type HdsTextAligns =
-  | HdsTextAlignValues.Left
-  | HdsTextAlignValues.Center
-  | HdsTextAlignValues.Right;
+export type HdsTextAligns = `${HdsTextAlignValues}`;
 
-/** Note: If changing this enum, ensure to also update its type union below */
 export enum HdsTextWeightValues {
   Regular = 'regular',
   Medium = 'medium',
   Semibold = 'semibold',
   Bold = 'bold',
 }
-export type HdsTextWeights =
-  | HdsTextWeightValues.Regular
-  | HdsTextWeightValues.Medium
-  | HdsTextWeightValues.Semibold
-  | HdsTextWeightValues.Bold;
+export type HdsTextWeights = `${HdsTextWeightValues}`;
 
 export enum HdsTextSizeValues {
   FiveHundred = 500,
@@ -60,13 +51,9 @@ type HdsTextSizesNumber =
   `${HdsTextSizeValues}` extends `${infer T extends number}` ? T : never;
 export type HdsTextSizes = HdsTextSizesString | HdsTextSizesNumber;
 
-/** Note: If changing this enum, ensure to also update its type union below */
 export enum HdsTextGroupValues {
   Code = 'code',
   Display = 'display',
   Body = 'body',
 }
-export type HdsTextGroups =
-  | HdsTextGroupValues.Code
-  | HdsTextGroupValues.Display
-  | HdsTextGroupValues.Body;
+export type HdsTextGroups = `${HdsTextGroupValues}`;


### PR DESCRIPTION
### :pushpin: Summary

* Adds a lint step for linting `packages/components` in CI
* Fixes type errors introduced in #1984 

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
