### PR TITLE
Bump components test timeout from 10s to 20s

### DIFF
--- a/showcase/testem.js
+++ b/showcase/testem.js
@@ -10,6 +10,7 @@ module.exports = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
+  browser_disconnect_timeout: 20,
   browser_start_timeout: 120,
   browser_args: {
     Chrome: {


### PR DESCRIPTION
### :pushpin: Summary

Increase `browser_disconnect_timeout` to `20s` in `showcase` tests as `Acceptance | Component | hds/form/primitives: components/form/primitives` [often fails](https://github.com/hashicorp/design-system/actions/runs/8325764014/job/22780078430) with time out.  We took [a similar approach](https://github.com/hashicorp/design-system/pull/1943) for the `website` tests, so this change would align the configuration of the two.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
