### PR TITLE
@trivago/prettier-plugin-sort-imports

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -65,6 +65,7 @@
     "@glint/environment-ember-loose": "^1.3.0",
     "@glint/template": "^1.3.0",
     "@rollup/plugin-babel": "^6.0.4",
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@tsconfig/ember": "^3.0.2",
     "@types/ember-qunit": "^6.1.1",
     "@types/ember-resolver": "^9.0.0",

--- a/packages/components/src/components/hds/accordion/item/button.js
+++ b/packages/components/src/components/hds/accordion/item/button.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsAccordionItemButtonComponent extends Component {

--- a/packages/components/src/components/hds/accordion/item/index.js
+++ b/packages/components/src/components/hds/accordion/item/index.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export default class HdsAccordionItemIndexComponent extends Component {
   /**

--- a/packages/components/src/components/hds/app-footer/copyright.js
+++ b/packages/components/src/components/hds/app-footer/copyright.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsAppFooterCopyrightComponent extends Component {

--- a/packages/components/src/components/hds/app-footer/index.js
+++ b/packages/components/src/components/hds/app-footer/index.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsAppFooterIndexComponent extends Component {

--- a/packages/components/src/components/hds/app-footer/legal-links.js
+++ b/packages/components/src/components/hds/app-footer/legal-links.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsAppFooterLegalLinksComponent extends Component {

--- a/packages/components/src/components/hds/app-footer/status-link.js
+++ b/packages/components/src/components/hds/app-footer/status-link.js
@@ -2,10 +2,9 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
-import { htmlSafe } from '@ember/template';
 import { assert } from '@ember/debug';
+import { htmlSafe } from '@ember/template';
+import Component from '@glimmer/component';
 
 export const STATUSES = {
   operational: {

--- a/packages/components/src/components/hds/app-frame/index.js
+++ b/packages/components/src/components/hds/app-frame/index.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsAppFrameIndexComponent extends Component {

--- a/packages/components/src/components/hds/application-state/footer.js
+++ b/packages/components/src/components/hds/application-state/footer.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsApplicationStateFooterComponent extends Component {

--- a/packages/components/src/components/hds/badge-count/index.js
+++ b/packages/components/src/components/hds/badge-count/index.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_TYPE = 'filled';

--- a/packages/components/src/components/hds/badge/index.js
+++ b/packages/components/src/components/hds/badge/index.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_TYPE = 'filled';

--- a/packages/components/src/components/hds/breadcrumb/index.js
+++ b/packages/components/src/components/hds/breadcrumb/index.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 const NOOP = () => {};

--- a/packages/components/src/components/hds/breadcrumb/item.js
+++ b/packages/components/src/components/hds/breadcrumb/item.js
@@ -2,10 +2,9 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
-import { htmlSafe } from '@ember/template';
 import { assert } from '@ember/debug';
+import { htmlSafe } from '@ember/template';
+import Component from '@glimmer/component';
 
 export default class HdsBreadcrumbItemComponent extends Component {
   /**

--- a/packages/components/src/components/hds/breadcrumb/truncation.js
+++ b/packages/components/src/components/hds/breadcrumb/truncation.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsBreadcrumbTruncationComponent extends Component {

--- a/packages/components/src/components/hds/button/index.ts
+++ b/packages/components/src/components/hds/button/index.ts
@@ -2,10 +2,9 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
-import { assert } from '@ember/debug';
 import { type HdsInteractiveSignature } from '../interactive';
+import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_COLOR = 'primary';

--- a/packages/components/src/components/hds/card/container.js
+++ b/packages/components/src/components/hds/card/container.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_LEVEL = 'base';
 export const DEFAULT_BACKGROUND = 'neutral-primary';

--- a/packages/components/src/components/hds/dismiss-button/index.ts
+++ b/packages/components/src/components/hds/dismiss-button/index.ts
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export interface HdsDismissButtonSignature {

--- a/packages/components/src/components/hds/dropdown/list-item/checkbox.js
+++ b/packages/components/src/components/hds/dropdown/list-item/checkbox.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { getElementId } from '../../../../utils/hds-get-element-id';
+import Component from '@glimmer/component';
 
 export default class HdsDropdownListItemCheckboxComponent extends Component {
   /**

--- a/packages/components/src/components/hds/dropdown/list-item/checkmark.js
+++ b/packages/components/src/components/hds/dropdown/list-item/checkmark.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsDropdownListItemCheckmarkComponent extends Component {

--- a/packages/components/src/components/hds/dropdown/list-item/copy-item.js
+++ b/packages/components/src/components/hds/dropdown/list-item/copy-item.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsDropdownListItemCopyItemComponent extends Component {
   /**

--- a/packages/components/src/components/hds/dropdown/list-item/description.js
+++ b/packages/components/src/components/hds/dropdown/list-item/description.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsDropdownListItemDescriptionComponent extends Component {
   /**

--- a/packages/components/src/components/hds/dropdown/list-item/interactive.js
+++ b/packages/components/src/components/hds/dropdown/list-item/interactive.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_COLOR = 'action';
 export const COLORS = ['action', 'critical'];

--- a/packages/components/src/components/hds/dropdown/list-item/radio.js
+++ b/packages/components/src/components/hds/dropdown/list-item/radio.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { getElementId } from '../../../../utils/hds-get-element-id';
+import Component from '@glimmer/component';
 
 export default class HdsDropdownListItemRadioComponent extends Component {
   /**

--- a/packages/components/src/components/hds/dropdown/list-item/title.js
+++ b/packages/components/src/components/hds/dropdown/list-item/title.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsDropdownListItemTitleComponent extends Component {
   /**

--- a/packages/components/src/components/hds/dropdown/toggle/button.js
+++ b/packages/components/src/components/hds/dropdown/toggle/button.js
@@ -2,10 +2,9 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_COLOR = 'primary';

--- a/packages/components/src/components/hds/form/character-count/index.js
+++ b/packages/components/src/components/hds/form/character-count/index.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 const ID_PREFIX = 'character-count-';

--- a/packages/components/src/components/hds/form/error/index.js
+++ b/packages/components/src/components/hds/form/error/index.js
@@ -2,8 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
+
 export const ID_PREFIX = 'error-';
 
 const NOOP = () => {};

--- a/packages/components/src/components/hds/form/helper-text/index.js
+++ b/packages/components/src/components/hds/form/helper-text/index.js
@@ -2,8 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
+
 export const ID_PREFIX = 'helper-text-';
 
 const NOOP = () => {};

--- a/packages/components/src/components/hds/form/indicator/index.js
+++ b/packages/components/src/components/hds/form/indicator/index.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsFormIndicatorIndexComponent extends Component {

--- a/packages/components/src/components/hds/form/label/index.js
+++ b/packages/components/src/components/hds/form/label/index.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsFormLabelIndexComponent extends Component {

--- a/packages/components/src/components/hds/form/legend/index.js
+++ b/packages/components/src/components/hds/form/legend/index.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsFormLegendIndexComponent extends Component {

--- a/packages/components/src/components/hds/form/select/base.js
+++ b/packages/components/src/components/hds/form/select/base.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsFormSelectBaseComponent extends Component {

--- a/packages/components/src/components/hds/form/text-input/base.js
+++ b/packages/components/src/components/hds/form/text-input/base.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 // notice: we don't support all the possible HTML types, only a subset
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

--- a/packages/components/src/components/hds/form/textarea/base.js
+++ b/packages/components/src/components/hds/form/textarea/base.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsFormTextareaBaseComponent extends Component {

--- a/packages/components/src/components/hds/icon-tile/index.js
+++ b/packages/components/src/components/hds/icon-tile/index.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_COLOR = 'neutral';

--- a/packages/components/src/components/hds/link/inline.js
+++ b/packages/components/src/components/hds/link/inline.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_ICONPOSITION = 'trailing';
 export const DEFAULT_COLOR = 'primary';

--- a/packages/components/src/components/hds/link/standalone.js
+++ b/packages/components/src/components/hds/link/standalone.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_ICONPOSITION = 'leading';
 export const DEFAULT_COLOR = 'primary';

--- a/packages/components/src/components/hds/pagination/info/index.js
+++ b/packages/components/src/components/hds/pagination/info/index.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsPaginationInfoComponent extends Component {

--- a/packages/components/src/components/hds/reveal/index.js
+++ b/packages/components/src/components/hds/reveal/index.js
@@ -2,10 +2,9 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export default class HdsRevealIndexComponent extends Component {
   /**

--- a/packages/components/src/components/hds/reveal/toggle/button.js
+++ b/packages/components/src/components/hds/reveal/toggle/button.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import Component from '@glimmer/component';
 
 export default class HdsDropdownToggleButtonComponent extends Component {

--- a/packages/components/src/components/hds/separator/index.js
+++ b/packages/components/src/components/hds/separator/index.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SPACING = '24';
 export const SPACING = ['24', '0'];

--- a/packages/components/src/components/hds/side-nav/header/home-link.js
+++ b/packages/components/src/components/hds/side-nav/header/home-link.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsSideNavHeaderHomeLinkComponent extends Component {
   /**

--- a/packages/components/src/components/hds/side-nav/header/icon-button.js
+++ b/packages/components/src/components/hds/side-nav/header/icon-button.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsSideNavHeaderIconButtonComponent extends Component {
   /**

--- a/packages/components/src/components/hds/stepper/step/indicator.js
+++ b/packages/components/src/components/hds/stepper/step/indicator.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_STATUS = 'incomplete';
 export const STATUSES = ['incomplete', 'progress', 'processing', 'complete'];

--- a/packages/components/src/components/hds/stepper/task/indicator.js
+++ b/packages/components/src/components/hds/stepper/task/indicator.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_STATUS = 'incomplete';
 export const STATUSES = ['incomplete', 'progress', 'processing', 'complete'];

--- a/packages/components/src/components/hds/table/td.js
+++ b/packages/components/src/components/hds/table/td.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 const ALIGNMENTS = ['left', 'center', 'right'];
 const DEFAULT_ALIGN = 'left';

--- a/packages/components/src/components/hds/table/th-button-sort.js
+++ b/packages/components/src/components/hds/table/th-button-sort.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 const NOOP = () => {};
 

--- a/packages/components/src/components/hds/table/th-button-tooltip.js
+++ b/packages/components/src/components/hds/table/th-button-tooltip.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export default class HdsTableThButtonTooltipComponent extends Component {
   /**

--- a/packages/components/src/components/hds/table/th-sort.js
+++ b/packages/components/src/components/hds/table/th-sort.js
@@ -2,10 +2,9 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 const ALIGNMENTS = ['left', 'center', 'right'];
 const DEFAULT_ALIGN = 'left';

--- a/packages/components/src/components/hds/table/th.js
+++ b/packages/components/src/components/hds/table/th.js
@@ -2,10 +2,9 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 const ALIGNMENTS = ['left', 'center', 'right'];
 const DEFAULT_ALIGN = 'left';

--- a/packages/components/src/components/hds/table/tr.js
+++ b/packages/components/src/components/hds/table/tr.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsTableTrComponent extends Component {
   /**

--- a/packages/components/src/components/hds/tag/index.js
+++ b/packages/components/src/components/hds/tag/index.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_COLOR = 'primary';
 export const COLORS = ['primary', 'secondary'];

--- a/packages/components/src/components/hds/text/body.ts
+++ b/packages/components/src/components/hds/text/body.ts
@@ -2,9 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
-import { assert } from '@ember/debug';
 import { HdsTextSizeValues, HdsTextWeightValues } from './types.ts';
 import type {
   HdsTextAligns,
@@ -12,6 +9,8 @@ import type {
   HdsTextTags,
   HdsTextWeights,
 } from './types.ts';
+import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 // notice: only some combinations of size + font-weight are allowed (per design specs)
 // see: https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=1262%3A9192

--- a/packages/components/src/components/hds/text/code.ts
+++ b/packages/components/src/components/hds/text/code.ts
@@ -2,9 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
-import { assert } from '@ember/debug';
 import { HdsTextSizeValues, HdsTextWeightValues } from './types.ts';
 import type {
   HdsTextAligns,
@@ -12,6 +9,8 @@ import type {
   HdsTextTags,
   HdsTextWeights,
 } from './types.ts';
+import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 // notice: only some combinations of size + font-weight are allowed (per design specs)
 // see: https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=1262%3A9192

--- a/packages/components/src/components/hds/text/display.ts
+++ b/packages/components/src/components/hds/text/display.ts
@@ -2,9 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
-import { assert } from '@ember/debug';
 import { HdsTextSizeValues, HdsTextWeightValues } from './types.ts';
 import type {
   HdsTextAligns,
@@ -13,6 +10,8 @@ import type {
   HdsTextTags,
   HdsTextWeights,
 } from './types.ts';
+import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 // notice: only some combinations of size + font-weight are allowed (per design specs)
 // see: https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=1262%3A9192

--- a/packages/components/src/components/hds/text/index.ts
+++ b/packages/components/src/components/hds/text/index.ts
@@ -2,9 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
-import { assert } from '@ember/debug';
 import { HdsTextAlignValues, HdsTextColorValues } from './types.ts';
 import type {
   HdsTextAligns,
@@ -14,6 +11,8 @@ import type {
   HdsTextTags,
   HdsTextWeights,
 } from './types.ts';
+import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const AVAILABLE_COLORS: string[] = Object.values(HdsTextColorValues);
 export const AVAILABLE_ALIGNS: string[] = Object.values(HdsTextAlignValues);

--- a/packages/components/src/components/hds/tooltip-button/index.js
+++ b/packages/components/src/components/hds/tooltip-button/index.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const PLACEMENTS = [
   'top',

--- a/packages/components/src/helpers/hds-link-to-models.ts
+++ b/packages/components/src/helpers/hds-link-to-models.ts
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import { helper } from '@ember/component/helper';
 import { assert } from '@ember/debug';
 

--- a/packages/components/src/helpers/hds-link-to-query.ts
+++ b/packages/components/src/helpers/hds-link-to-query.ts
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import { helper } from '@ember/component/helper';
 
 /*

--- a/packages/components/src/modifiers/hds-clipboard.js
+++ b/packages/components/src/modifiers/hds-clipboard.js
@@ -2,9 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import { modifier } from 'ember-modifier';
 import { assert, warn } from '@ember/debug';
+import { modifier } from 'ember-modifier';
 
 export const getTextToCopy = (text) => {
   let textToCopy;

--- a/packages/components/src/modifiers/hds-tooltip.js
+++ b/packages/components/src/modifiers/hds-tooltip.js
@@ -2,14 +2,11 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 // Note: the majority of this code is a porting of the existing tooltip implementation in Cloud UI
 // (which was initially implemented in Structure)
-
-import Modifier from 'ember-modifier';
 import { assert } from '@ember/debug';
 import { registerDestructor } from '@ember/destroyable';
-
+import Modifier from 'ember-modifier';
 import tippy, { followCursor } from 'tippy.js';
 // used by custom SVG arrow:
 import 'tippy.js/dist/svg-arrow.css';

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -2,17 +2,16 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import type HdsButtonIndexComponent from './components/hds/button';
 import type HdsDismissButtonIndexComponent from './components/hds/dismiss-button';
 import type HdsInteractiveIndexComponent from './components/hds/interactive';
-import type HdsLinkToModelsHelper from './helpers/hds-link-to-models';
-import type HdsLinkToQueryHelper from './helpers/hds-link-to-query';
 import type HdsTextIndexComponent from './components/hds/text';
 import type HdsTextBodyComponent from './components/hds/text/body';
-import type HdsTextDisplayComponent from './components/hds/text/display';
 import type HdsTextCodeComponent from './components/hds/text/code';
+import type HdsTextDisplayComponent from './components/hds/text/display';
 import type HdsYieldComponent from './components/hds/yield';
+import type HdsLinkToModelsHelper from './helpers/hds-link-to-models';
+import type HdsLinkToQueryHelper from './helpers/hds-link-to-query';
 
 export default interface HdsComponentsRegistry {
   HdsInteractiveComponent: typeof HdsInteractiveIndexComponent;

--- a/packages/components/src/utils/hds-get-element-id.js
+++ b/packages/components/src/utils/hds-get-element-id.js
@@ -2,7 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 import { guidFor } from '@ember/object/internals';
 
 export function getElementId(element) {

--- a/packages/components/unpublished-development-types/global.d.ts
+++ b/packages/components/unpublished-development-types/global.d.ts
@@ -1,15 +1,13 @@
-import '@glint/environment-ember-loose';
-
+import type HdsComponentsRegistry from '../src/template-registry';
 import { LinkTo } from '@ember/routing';
-
-import type EmberTruthRegistry from 'ember-truth-helpers/template-registry';
+import '@glint/environment-ember-loose';
 import type EmberElementHelperRegistry from 'ember-element-helper/template-registry';
 import type EmberStyleModifier from 'ember-style-modifier';
+import type EmberTruthRegistry from 'ember-truth-helpers/template-registry';
 
 export default interface EmberStyleModifierRegistry {
   style: typeof EmberStyleModifier;
 }
-import type HdsComponentsRegistry from '../src/template-registry';
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,7 +329,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.23.6, @babel/generator@npm:^7.7.2":
+"@babel/generator@npm:7.17.7":
+  version: 7.17.7
+  resolution: "@babel/generator@npm:7.17.7"
+  dependencies:
+    "@babel/types": "npm:^7.17.0"
+    jsesc: "npm:^2.5.1"
+    source-map: "npm:^0.5.0"
+  checksum: 3303afa2b1310e67071d6c998121b2af1038d6450df266d24fe9a86329fb6288b8ab38bb71787917b3f81a1c4edbc5bc7e6735683fe1d0aa288b33e93daacd60
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.23.0, @babel/generator@npm:^7.23.6, @babel/generator@npm:^7.7.2":
   version: 7.23.6
   resolution: "@babel/generator@npm:7.23.6"
   dependencies:
@@ -554,7 +565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.22.20":
+"@babel/helper-validator-identifier@npm:^7.16.7, @babel/helper-validator-identifier@npm:^7.22.20":
   version: 7.22.20
   resolution: "@babel/helper-validator-identifier@npm:7.22.20"
   checksum: df882d2675101df2d507b95b195ca2f86a3ef28cb711c84f37e79ca23178e13b9f0d8b522774211f51e40168bf5142be4c1c9776a150cddb61a0d5bf3e95750b
@@ -607,6 +618,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 6be3a63d3c9d07b035b5a79c022327cb7e16cbd530140ecb731f19a650c794c315a72c699a22413ebeafaff14aa8f53435111898d59e01a393d741b85629fa7d
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.20.5, @babel/parser@npm:^7.23.0":
+  version: 7.24.0
+  resolution: "@babel/parser@npm:7.24.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 3e5ebb903a6f71629a9d0226743e37fe3d961e79911d2698b243637f66c4df7e3e0a42c07838bc0e7cc9fcd585d9be8f4134a145b9459ee4a459420fb0d1360b
   languageName: node
   linkType: hard
 
@@ -1825,6 +1845,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:7.23.2":
+  version: 7.23.2
+  resolution: "@babel/traverse@npm:7.23.2"
+  dependencies:
+    "@babel/code-frame": "npm:^7.22.13"
+    "@babel/generator": "npm:^7.23.0"
+    "@babel/helper-environment-visitor": "npm:^7.22.20"
+    "@babel/helper-function-name": "npm:^7.23.0"
+    "@babel/helper-hoist-variables": "npm:^7.22.5"
+    "@babel/helper-split-export-declaration": "npm:^7.22.6"
+    "@babel/parser": "npm:^7.23.0"
+    "@babel/types": "npm:^7.23.0"
+    debug: "npm:^4.1.0"
+    globals: "npm:^11.1.0"
+  checksum: e4fcb8f8395804956df4ae1301230a14b6eb35b74a7058a0e0b40f6f4be7281e619e6dafe400e833d4512da5d61cf17ea177d04b00a8f7cf3d8d69aff83ca3d8
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.14.5, @babel/traverse@npm:^7.23.7, @babel/traverse@npm:^7.4.5":
   version: 7.23.7
   resolution: "@babel/traverse@npm:7.23.7"
@@ -1843,6 +1881,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/types@npm:7.17.0":
+  version: 7.17.0
+  resolution: "@babel/types@npm:7.17.0"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.16.7"
+    to-fast-properties: "npm:^2.0.0"
+  checksum: 535ccef360d0c74e2bb685050f3a45e6ab30f66c740bbdd0858148ed502043f1ae2006a9d0269ac3b7356b690091ae313efd912e408bc0198d80a14b2a6f1537
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.13, @babel/types@npm:^7.12.6, @babel/types@npm:^7.20.7, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.23.6, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.7.2, @babel/types@npm:^7.8.3":
   version: 7.23.6
   resolution: "@babel/types@npm:7.23.6"
@@ -1851,6 +1899,17 @@ __metadata:
     "@babel/helper-validator-identifier": "npm:^7.22.20"
     to-fast-properties: "npm:^2.0.0"
   checksum: 07e70bb94d30b0231396b5e9a7726e6d9227a0a62e0a6830c0bd3232f33b024092e3d5a7d1b096a65bbf2bb43a9ab4c721bf618e115bfbb87b454fa060f88cbf
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.17.0":
+  version: 7.24.0
+  resolution: "@babel/types@npm:7.24.0"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.23.4"
+    "@babel/helper-validator-identifier": "npm:^7.22.20"
+    to-fast-properties: "npm:^2.0.0"
+  checksum: a0b4875ce2e132f9daff0d5b27c7f4c4fcc97f2b084bdc5834e92c9d32592778489029e65d99d00c406da612d87b72d7a236c0afccaa1435c028d0c94c9b6da4
   languageName: node
   linkType: hard
 
@@ -3553,6 +3612,7 @@ __metadata:
     "@hashicorp/design-system-tokens": "npm:^2.1.0"
     "@hashicorp/ember-flight-icons": "npm:^5.0.1"
     "@rollup/plugin-babel": "npm:^6.0.4"
+    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
     "@tsconfig/ember": "npm:^3.0.2"
     "@types/ember-qunit": "npm:^6.1.1"
     "@types/ember-resolver": "npm:^9.0.0"
@@ -4833,6 +4893,26 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+  languageName: node
+  linkType: hard
+
+"@trivago/prettier-plugin-sort-imports@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "@trivago/prettier-plugin-sort-imports@npm:4.3.0"
+  dependencies:
+    "@babel/generator": "npm:7.17.7"
+    "@babel/parser": "npm:^7.20.5"
+    "@babel/traverse": "npm:7.23.2"
+    "@babel/types": "npm:7.17.0"
+    javascript-natural-sort: "npm:0.7.1"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@vue/compiler-sfc": 3.x
+    prettier: 2.x - 3.x
+  peerDependenciesMeta:
+    "@vue/compiler-sfc":
+      optional: true
+  checksum: eb25cbeeaf85d3acd54019d1f3563447337a2faee7a35558adb69dff44ce3b93714a5b64ba4d0374f3df3191c32c993d441493fdc43a2c97c9b8a0e3d58702cf
   languageName: node
   linkType: hard
 
@@ -17158,6 +17238,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"javascript-natural-sort@npm:0.7.1":
+  version: 0.7.1
+  resolution: "javascript-natural-sort@npm:0.7.1"
+  checksum: 7bf6eab67871865d347f09a95aa770f9206c1ab0226bcda6fdd9edec340bf41111a7f82abac30556aa16a21cfa3b2b1ca4a362c8b73dd5ce15220e5d31f49d79
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-changed-files@npm:29.7.0"
@@ -23969,7 +24056,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.5.6, source-map@npm:^0.5.7":
+"source-map@npm:^0.5.0, source-map@npm:^0.5.6, source-map@npm:^0.5.7":
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
   checksum: 9b4ac749ec5b5831cad1f8cc4c19c4298ebc7474b24a0acf293e2f040f03f8eeccb3d01f12aa0f90cf46d555c887e03912b83a042c627f419bda5152d89c5269


### PR DESCRIPTION
### :pushpin: Summary
Testing out the [@trivago/prettier-plugin-sort-imports](https://github.com/trivago/prettier-plugin-sort-imports) 

### :hammer_and_wrench: Detailed description
[We want to ensure our imports are correctly sorted!](https://hashicorp.slack.com/archives/C06NMSYDZPA/p1710781531458099) - this PR adds the prettier-polugin-sort-imports package to try and help us out with that!

### :link: External links
- [HDS Typescript Opinions](https://docs.google.com/document/d/17T9v7pYUNrm2TtcZE2le_fbX30Jop-iG3um7b0trRlg/edit#heading=h.5o7x9abotu5m)
- [Slack thread](https://hashicorp.slack.com/archives/C06NMSYDZPA/p1710781531458099)

### Pros/Cons
- ✅ Sorts imports for us right out of the box 
- ❌ Removes trailing comment after trademark comments
- ❌ Does NOT separate types from imports ([source](https://github.com/hashicorp/design-system/compare/ts/badge...test-prettier-on-branch?expand=1#diff-2b3c55471dede449cd2784ca4f4bab97ed6d5fcfc057f591dd622f66b7e7d7ba))

### References
![image](https://github.com/hashicorp/design-system/assets/4359781/261d375b-4821-4827-9f68-51cb2c61f750)
