### PR TITLE
adding prettier-plugin-organize-imports

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -82,6 +82,7 @@
     "eslint-plugin-qunit": "^8.0.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",
+    "prettier-plugin-organize-imports": "^3.2.4",
     "rollup": "^4.9.0",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-scss": "^4.0.0",

--- a/packages/components/src/components/hds/accordion/item/index.js
+++ b/packages/components/src/components/hds/accordion/item/index.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export default class HdsAccordionItemIndexComponent extends Component {
   /**

--- a/packages/components/src/components/hds/alert/index.js
+++ b/packages/components/src/components/hds/alert/index.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { assert } from '@ember/debug';
+import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export const TYPES = ['page', 'inline', 'compact'];

--- a/packages/components/src/components/hds/app-footer/status-link.js
+++ b/packages/components/src/components/hds/app-footer/status-link.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { htmlSafe } from '@ember/template';
 import { assert } from '@ember/debug';
+import { htmlSafe } from '@ember/template';
+import Component from '@glimmer/component';
 
 export const STATUSES = {
   operational: {

--- a/packages/components/src/components/hds/badge-count/index.js
+++ b/packages/components/src/components/hds/badge-count/index.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_TYPE = 'filled';

--- a/packages/components/src/components/hds/badge/index.js
+++ b/packages/components/src/components/hds/badge/index.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_TYPE = 'filled';

--- a/packages/components/src/components/hds/breadcrumb/item.js
+++ b/packages/components/src/components/hds/breadcrumb/item.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { htmlSafe } from '@ember/template';
 import { assert } from '@ember/debug';
+import { htmlSafe } from '@ember/template';
+import Component from '@glimmer/component';
 
 export default class HdsBreadcrumbItemComponent extends Component {
   /**

--- a/packages/components/src/components/hds/button/index.ts
+++ b/packages/components/src/components/hds/button/index.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 import { type HdsInteractiveSignature } from '../interactive';
 
 export const DEFAULT_SIZE = 'medium';

--- a/packages/components/src/components/hds/card/container.js
+++ b/packages/components/src/components/hds/card/container.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_LEVEL = 'base';
 export const DEFAULT_BACKGROUND = 'neutral-primary';

--- a/packages/components/src/components/hds/code-block/index.js
+++ b/packages/components/src/components/hds/code-block/index.js
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 import { next, schedule } from '@ember/runloop';
 import { htmlSafe } from '@ember/template';
-import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 import Prism from 'prismjs';
 
-import 'prismjs/plugins/line-numbers/prism-line-numbers';
 import 'prismjs/plugins/line-highlight/prism-line-highlight';
+import 'prismjs/plugins/line-numbers/prism-line-numbers';
 
 import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-go';
@@ -28,8 +28,8 @@ import 'prismjs/components/prism-yaml';
 // These imports are required to overcome a global variable clash in Helios website
 // where language import are overriden by the Prism instance in `CodeBlock`
 // Note that `prism-handlebars` is dependant on `prism-markup-templating`
-import 'prismjs/components/prism-markup-templating';
 import 'prismjs/components/prism-handlebars';
+import 'prismjs/components/prism-markup-templating';
 
 export default class HdsCodeBlockIndexComponent extends Component {
   @tracked prismCode = '';

--- a/packages/components/src/components/hds/copy/button/index.js
+++ b/packages/components/src/components/hds/copy/button/index.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 export const DEFAULT_SIZE = 'medium';
 export const SIZES = ['small', 'medium'];

--- a/packages/components/src/components/hds/copy/snippet/index.js
+++ b/packages/components/src/components/hds/copy/snippet/index.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 export const DEFAULT_COLOR = 'primary';
 export const COLORS = ['primary', 'secondary'];

--- a/packages/components/src/components/hds/disclosure-primitive/index.js
+++ b/packages/components/src/components/hds/disclosure-primitive/index.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { schedule } from '@ember/runloop';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 export default class HdsDisclosurePrimitiveComponent extends Component {
   @tracked isOpen = this.args.isOpen ?? false;

--- a/packages/components/src/components/hds/dropdown/index.js
+++ b/packages/components/src/components/hds/dropdown/index.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
 
 export const DEFAULT_POSITION = 'bottom-right';
 export const POSITIONS = [

--- a/packages/components/src/components/hds/dropdown/list-item/copy-item.js
+++ b/packages/components/src/components/hds/dropdown/list-item/copy-item.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsDropdownListItemCopyItemComponent extends Component {
   /**

--- a/packages/components/src/components/hds/dropdown/list-item/description.js
+++ b/packages/components/src/components/hds/dropdown/list-item/description.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsDropdownListItemDescriptionComponent extends Component {
   /**

--- a/packages/components/src/components/hds/dropdown/list-item/interactive.js
+++ b/packages/components/src/components/hds/dropdown/list-item/interactive.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_COLOR = 'action';
 export const COLORS = ['action', 'critical'];

--- a/packages/components/src/components/hds/dropdown/list-item/title.js
+++ b/packages/components/src/components/hds/dropdown/list-item/title.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsDropdownListItemTitleComponent extends Component {
   /**

--- a/packages/components/src/components/hds/dropdown/toggle/button.js
+++ b/packages/components/src/components/hds/dropdown/toggle/button.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_COLOR = 'primary';

--- a/packages/components/src/components/hds/dropdown/toggle/icon.js
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export const DEFAULT_SIZE = 'medium';

--- a/packages/components/src/components/hds/flyout/index.js
+++ b/packages/components/src/components/hds/flyout/index.js
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { assert } from '@ember/debug';
-import { getElementId } from '../../../utils/hds-get-element-id';
+import { action } from '@ember/object';
 import { buildWaiter } from '@ember/test-waiters';
+import Component from '@glimmer/component';
 import { DEBUG } from '@glimmer/env';
+import { tracked } from '@glimmer/tracking';
+import { getElementId } from '../../../utils/hds-get-element-id';
 
 let waiter;
 

--- a/packages/components/src/components/hds/form/field/index.js
+++ b/packages/components/src/components/hds/form/field/index.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { schedule } from '@ember/runloop';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { getElementId } from '../../../../utils/hds-get-element-id';
 import { setAriaDescribedBy } from '../../../../utils/hds-set-aria-described-by';
 

--- a/packages/components/src/components/hds/form/fieldset/index.js
+++ b/packages/components/src/components/hds/form/fieldset/index.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { getElementId } from '../../../../utils/hds-get-element-id';
 import { setAriaDescribedBy } from '../../../../utils/hds-set-aria-described-by';
 

--- a/packages/components/src/components/hds/form/masked-input/base.js
+++ b/packages/components/src/components/hds/form/masked-input/base.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { getElementId } from '../../../../utils/hds-get-element-id';
 
 export default class HdsFormMaskedInputBaseComponent extends Component {

--- a/packages/components/src/components/hds/form/radio-card/index.js
+++ b/packages/components/src/components/hds/form/radio-card/index.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import { schedule } from '@ember/runloop';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
-import { assert } from '@ember/debug';
-import { schedule } from '@ember/runloop';
 import { setAriaDescribedBy } from '../../../../utils/hds-set-aria-described-by';
 
 export const DEFAULT_CONTROL_POSITION = 'bottom';

--- a/packages/components/src/components/hds/form/text-input/base.js
+++ b/packages/components/src/components/hds/form/text-input/base.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 // notice: we don't support all the possible HTML types, only a subset
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

--- a/packages/components/src/components/hds/form/text-input/field.js
+++ b/packages/components/src/components/hds/form/text-input/field.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 
 export default class HdsFormTextInputFieldComponent extends Component {
   @tracked isPasswordMasked = true;

--- a/packages/components/src/components/hds/icon-tile/index.js
+++ b/packages/components/src/components/hds/icon-tile/index.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_COLOR = 'neutral';

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import Component from '@glimmer/component';
 
 export interface HdsInteractiveSignature {
   Args: {

--- a/packages/components/src/components/hds/link/inline.js
+++ b/packages/components/src/components/hds/link/inline.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_ICONPOSITION = 'trailing';
 export const DEFAULT_COLOR = 'primary';

--- a/packages/components/src/components/hds/link/standalone.js
+++ b/packages/components/src/components/hds/link/standalone.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_ICONPOSITION = 'leading';
 export const DEFAULT_COLOR = 'primary';

--- a/packages/components/src/components/hds/menu-primitive/index.js
+++ b/packages/components/src/components/hds/menu-primitive/index.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { schedule } from '@ember/runloop';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 export default class HdsMenuPrimitiveComponent extends Component {
   @tracked isOpen; // notice: if in the future we need to add a "@isOpen" prop to control the status from outside (eg to have the MenuPrimitive opened on render) just add  "this.args.isOpen" here to initalize the variable

--- a/packages/components/src/components/hds/modal/index.js
+++ b/packages/components/src/components/hds/modal/index.js
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { assert } from '@ember/debug';
-import { getElementId } from '../../../utils/hds-get-element-id';
+import { action } from '@ember/object';
 import { buildWaiter } from '@ember/test-waiters';
+import Component from '@glimmer/component';
 import { DEBUG } from '@glimmer/env';
+import { tracked } from '@glimmer/tracking';
+import { getElementId } from '../../../utils/hds-get-element-id';
 
 let waiter;
 

--- a/packages/components/src/components/hds/pagination/compact/index.js
+++ b/packages/components/src/components/hds/pagination/compact/index.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
-import { assert } from '@ember/debug';
 
 // for context about the decision to use these values, see:
 // https://hashicorp.slack.com/archives/C03A0N1QK8S/p1673546329082759

--- a/packages/components/src/components/hds/pagination/nav/arrow.js
+++ b/packages/components/src/components/hds/pagination/nav/arrow.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
 
 export const DIRECTIONS = ['prev', 'next'];
 

--- a/packages/components/src/components/hds/pagination/nav/number.js
+++ b/packages/components/src/components/hds/pagination/nav/number.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
 
 export default class HdsPaginationControlNumberComponent extends Component {
   get page() {

--- a/packages/components/src/components/hds/pagination/numbered/index.js
+++ b/packages/components/src/components/hds/pagination/numbered/index.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
-import { assert } from '@ember/debug';
 
 // for context about the decision to use these values, see:
 // https://hashicorp.slack.com/archives/C03A0N1QK8S/p1673546329082759

--- a/packages/components/src/components/hds/pagination/size-selector/index.js
+++ b/packages/components/src/components/hds/pagination/size-selector/index.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export default class HdsPaginationSizeSelectorComponent extends Component {
   /**

--- a/packages/components/src/components/hds/reveal/index.js
+++ b/packages/components/src/components/hds/reveal/index.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export default class HdsRevealIndexComponent extends Component {
   /**

--- a/packages/components/src/components/hds/separator/index.js
+++ b/packages/components/src/components/hds/separator/index.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_SPACING = '24';
 export const SPACING = ['24', '0'];

--- a/packages/components/src/components/hds/side-nav/header/home-link.js
+++ b/packages/components/src/components/hds/side-nav/header/home-link.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsSideNavHeaderHomeLinkComponent extends Component {
   /**

--- a/packages/components/src/components/hds/side-nav/header/icon-button.js
+++ b/packages/components/src/components/hds/side-nav/header/icon-button.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsSideNavHeaderIconButtonComponent extends Component {
   /**

--- a/packages/components/src/components/hds/side-nav/index.js
+++ b/packages/components/src/components/hds/side-nav/index.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import { registerDestructor } from '@ember/destroyable';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 export default class HdsSideNavComponent extends Component {
   @tracked isResponsive = this.args.isResponsive ?? true; // controls if the component reacts to viewport changes

--- a/packages/components/src/components/hds/side-nav/portal/target.js
+++ b/packages/components/src/components/hds/side-nav/portal/target.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
 import { DEBUG } from '@glimmer/env';
+import { tracked } from '@glimmer/tracking';
 import Ember from 'ember';
 
 export default class SidenavPortalTarget extends Component {

--- a/packages/components/src/components/hds/stepper/step/indicator.js
+++ b/packages/components/src/components/hds/stepper/step/indicator.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_STATUS = 'incomplete';
 export const STATUSES = ['incomplete', 'progress', 'processing', 'complete'];

--- a/packages/components/src/components/hds/stepper/task/indicator.js
+++ b/packages/components/src/components/hds/stepper/task/indicator.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_STATUS = 'incomplete';
 export const STATUSES = ['incomplete', 'progress', 'processing', 'complete'];

--- a/packages/components/src/components/hds/table/index.js
+++ b/packages/components/src/components/hds/table/index.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
-import { assert } from '@ember/debug';
 
 export const DENSITIES = ['short', 'medium', 'tall'];
 const DEFAULT_DENSITY = 'medium';

--- a/packages/components/src/components/hds/table/td.js
+++ b/packages/components/src/components/hds/table/td.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 const ALIGNMENTS = ['left', 'center', 'right'];
 const DEFAULT_ALIGN = 'left';

--- a/packages/components/src/components/hds/table/th-button-sort.js
+++ b/packages/components/src/components/hds/table/th-button-sort.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 const NOOP = () => {};
 

--- a/packages/components/src/components/hds/table/th-button-tooltip.js
+++ b/packages/components/src/components/hds/table/th-button-tooltip.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export default class HdsTableThButtonTooltipComponent extends Component {
   /**

--- a/packages/components/src/components/hds/table/th-selectable.js
+++ b/packages/components/src/components/hds/table/th-selectable.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class HdsTableThSelectableComponent extends Component {

--- a/packages/components/src/components/hds/table/th-sort.js
+++ b/packages/components/src/components/hds/table/th-sort.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 const ALIGNMENTS = ['left', 'center', 'right'];
 const DEFAULT_ALIGN = 'left';

--- a/packages/components/src/components/hds/table/th.js
+++ b/packages/components/src/components/hds/table/th.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 const ALIGNMENTS = ['left', 'center', 'right'];
 const DEFAULT_ALIGN = 'left';

--- a/packages/components/src/components/hds/table/tr.js
+++ b/packages/components/src/components/hds/table/tr.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export default class HdsTableTrComponent extends Component {
   /**

--- a/packages/components/src/components/hds/tabs/index.js
+++ b/packages/components/src/components/hds/tabs/index.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { assert, warn } from '@ember/debug';
+import { action } from '@ember/object';
+import { next, schedule } from '@ember/runloop';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
-import { assert, warn } from '@ember/debug';
-import { next, schedule } from '@ember/runloop';
 
 export const DEFAULT_SIZE = 'medium';
 export const SIZES = ['medium', 'large'];

--- a/packages/components/src/components/hds/tabs/panel.js
+++ b/packages/components/src/components/hds/tabs/panel.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export default class HdsTabsPanelComponent extends Component {
   /**

--- a/packages/components/src/components/hds/tabs/tab.js
+++ b/packages/components/src/components/hds/tabs/tab.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
 
 export default class HdsTabsTabComponent extends Component {
   /**

--- a/packages/components/src/components/hds/tag/index.js
+++ b/packages/components/src/components/hds/tag/index.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const DEFAULT_COLOR = 'primary';
 export const COLORS = ['primary', 'secondary'];

--- a/packages/components/src/components/hds/text/body.ts
+++ b/packages/components/src/components/hds/text/body.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import { HdsTextSizeValues, HdsTextWeightValues } from './types.ts';
+import Component from '@glimmer/component';
 import type {
   HdsTextAligns,
   HdsTextColors,
   HdsTextTags,
   HdsTextWeights,
 } from './types.ts';
+import { HdsTextSizeValues, HdsTextWeightValues } from './types.ts';
 
 // notice: only some combinations of size + font-weight are allowed (per design specs)
 // see: https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=1262%3A9192

--- a/packages/components/src/components/hds/text/code.ts
+++ b/packages/components/src/components/hds/text/code.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import { HdsTextSizeValues, HdsTextWeightValues } from './types.ts';
+import Component from '@glimmer/component';
 import type {
   HdsTextAligns,
   HdsTextColors,
   HdsTextTags,
   HdsTextWeights,
 } from './types.ts';
+import { HdsTextSizeValues, HdsTextWeightValues } from './types.ts';
 
 // notice: only some combinations of size + font-weight are allowed (per design specs)
 // see: https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=1262%3A9192

--- a/packages/components/src/components/hds/text/display.ts
+++ b/packages/components/src/components/hds/text/display.ts
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import { HdsTextSizeValues, HdsTextWeightValues } from './types.ts';
+import Component from '@glimmer/component';
 import type {
   HdsTextAligns,
   HdsTextColors,
@@ -13,6 +12,7 @@ import type {
   HdsTextTags,
   HdsTextWeights,
 } from './types.ts';
+import { HdsTextSizeValues, HdsTextWeightValues } from './types.ts';
 
 // notice: only some combinations of size + font-weight are allowed (per design specs)
 // see: https://www.figma.com/file/oQsMzMMnynfPWpMEt91OpH/HDS-Product---Foundations?node-id=1262%3A9192

--- a/packages/components/src/components/hds/text/index.ts
+++ b/packages/components/src/components/hds/text/index.ts
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import { HdsTextAlignValues, HdsTextColorValues } from './types.ts';
+import Component from '@glimmer/component';
 import type {
   HdsTextAligns,
   HdsTextColors,
@@ -14,6 +13,7 @@ import type {
   HdsTextTags,
   HdsTextWeights,
 } from './types.ts';
+import { HdsTextAlignValues, HdsTextColorValues } from './types.ts';
 
 export const AVAILABLE_COLORS: string[] = Object.values(HdsTextColorValues);
 export const AVAILABLE_ALIGNS: string[] = Object.values(HdsTextAlignValues);

--- a/packages/components/src/components/hds/tooltip-button/index.js
+++ b/packages/components/src/components/hds/tooltip-button/index.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
 
 export const PLACEMENTS = [
   'top',

--- a/packages/components/src/modifiers/hds-clipboard.js
+++ b/packages/components/src/modifiers/hds-clipboard.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { modifier } from 'ember-modifier';
 import { assert, warn } from '@ember/debug';
+import { modifier } from 'ember-modifier';
 
 export const getTextToCopy = (text) => {
   let textToCopy;

--- a/packages/components/src/modifiers/hds-tooltip.js
+++ b/packages/components/src/modifiers/hds-tooltip.js
@@ -6,9 +6,9 @@
 // Note: the majority of this code is a porting of the existing tooltip implementation in Cloud UI
 // (which was initially implemented in Structure)
 
-import Modifier from 'ember-modifier';
 import { assert } from '@ember/debug';
 import { registerDestructor } from '@ember/destroyable';
+import Modifier from 'ember-modifier';
 
 import tippy, { followCursor } from 'tippy.js';
 // used by custom SVG arrow:

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -6,13 +6,13 @@
 import type HdsButtonIndexComponent from './components/hds/button';
 import type HdsDismissButtonIndexComponent from './components/hds/dismiss-button';
 import type HdsInteractiveIndexComponent from './components/hds/interactive';
-import type HdsLinkToModelsHelper from './helpers/hds-link-to-models';
-import type HdsLinkToQueryHelper from './helpers/hds-link-to-query';
 import type HdsTextIndexComponent from './components/hds/text';
 import type HdsTextBodyComponent from './components/hds/text/body';
-import type HdsTextDisplayComponent from './components/hds/text/display';
 import type HdsTextCodeComponent from './components/hds/text/code';
+import type HdsTextDisplayComponent from './components/hds/text/display';
 import type HdsYieldComponent from './components/hds/yield';
+import type HdsLinkToModelsHelper from './helpers/hds-link-to-models';
+import type HdsLinkToQueryHelper from './helpers/hds-link-to-query';
 
 export default interface HdsComponentsRegistry {
   HdsInteractiveComponent: typeof HdsInteractiveIndexComponent;

--- a/packages/components/unpublished-development-types/global.d.ts
+++ b/packages/components/unpublished-development-types/global.d.ts
@@ -2,14 +2,14 @@ import '@glint/environment-ember-loose';
 
 import { LinkTo } from '@ember/routing';
 
-import type EmberTruthRegistry from 'ember-truth-helpers/template-registry';
 import type EmberElementHelperRegistry from 'ember-element-helper/template-registry';
 import type EmberStyleModifier from 'ember-style-modifier';
+import type EmberTruthRegistry from 'ember-truth-helpers/template-registry';
+import type HdsComponentsRegistry from '../src/template-registry';
 
 export default interface EmberStyleModifierRegistry {
   style: typeof EmberStyleModifier;
 }
-import type HdsComponentsRegistry from '../src/template-registry';
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,6 +3580,7 @@ __metadata:
     eslint-plugin-qunit: "npm:^8.0.1"
     npm-run-all: "npm:^4.1.5"
     prettier: "npm:^2.8.8"
+    prettier-plugin-organize-imports: "npm:^3.2.4"
     prismjs: "npm:^1.29.0"
     rollup: "npm:^4.9.0"
     rollup-plugin-copy: "npm:^3.5.0"
@@ -21580,6 +21581,23 @@ __metadata:
   dependencies:
     fast-diff: "npm:^1.1.2"
   checksum: 00ce8011cf6430158d27f9c92cfea0a7699405633f7f1d4a45f07e21bf78e99895911cbcdc3853db3a824201a7c745bd49bfea8abd5fb9883e765a90f74f8392
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-organize-imports@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "prettier-plugin-organize-imports@npm:3.2.4"
+  peerDependencies:
+    "@volar/vue-language-plugin-pug": ^1.0.4
+    "@volar/vue-typescript": ^1.0.4
+    prettier: ">=2.0"
+    typescript: ">=2.9"
+  peerDependenciesMeta:
+    "@volar/vue-language-plugin-pug":
+      optional: true
+    "@volar/vue-typescript":
+      optional: true
+  checksum: 93c98d365af500aa4c72f5330d82c20a20d0e7661a9692e6f26a76a2f4f88b99e0f85dcb8871e98b6d687d6e19ea5f1dcc937f9e29fd0778e888675ecafed233
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: Summary
Similar to https://github.com/hashicorp/design-system/pull/2007, trying out a different plugin: 

### :hammer_and_wrench: Detailed description
[We want to ensure our imports are correctly sorted!](https://hashicorp.slack.com/archives/C06NMSYDZPA/p1710781531458099) - this PR adds the [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports) package to try and help us out with that!

### :link: External links
- [HDS Typescript Opinions](https://docs.google.com/document/d/17T9v7pYUNrm2TtcZE2le_fbX30Jop-iG3um7b0trRlg/edit#heading=h.5o7x9abotu5m)
- [Slack thread](https://hashicorp.slack.com/archives/C06NMSYDZPA/p1710781531458099)

### Pros/Cons
- ✅ Sorts imports right out of the box
- ✅ Does NOT remove the trailing empty line after trademark comments\
- ✅ Can remove unused imports ([we can turn off this setting as well if we'd like](https://www.npmjs.com/package/prettier-plugin-organize-imports#skip-destructive-code-actions))
- ❌ Does NOT separate types from imports

### References
![image](https://github.com/hashicorp/design-system/assets/4359781/5286a971-f49c-4f37-9ccc-d11d96c71222)
