### PR TITLE
Web: Update token search to match icon search (HDS-3209)

### DIFF
--- a/website/app/components/doc/tokens-list/grid.hbs
+++ b/website/app/components/doc/tokens-list/grid.hbs
@@ -4,13 +4,10 @@
 }}
 
 {{#if @categoryTokens}}
-  <h2 class="doc-text-h2">{{capitalize @category}}</h2>
+  <h2 class="doc-text-h4">{{capitalize @categoryName}}</h2>
   <ul class="doc-tokens-list" role="list">
     {{#each @categoryTokens as |token|}}
       <Doc::TokensList::Item @token={{token}} />
     {{/each}}
   </ul>
-{{else}}
-  <h2 class="doc-text-h5">{{capitalize @category}}</h2>
-  <p class="doc-text-body-small" data-test-target="token-not-found">No tokens found in this category</p>
 {{/if}}

--- a/website/app/components/doc/tokens-list/index.hbs
+++ b/website/app/components/doc/tokens-list/index.hbs
@@ -12,8 +12,8 @@
   />
 </div>
 
-{{#each-in @groupedTokens as |category categoryTokens|}}
-  <Doc::TokensList::Grid @category={{category}} @categoryTokens={{categoryTokens}} />
+{{#each-in @groupedTokens as |categoryName categoryTokens|}}
+  <Doc::TokensList::Grid @categoryName={{categoryName}} @categoryTokens={{categoryTokens}} />
 {{else}}
-  <p class="doc-text-body">No tokens found 🤷‍♀️</p>
+  <p class="doc-text-body" data-test-target="no-tokens-found">No tokens found. 🤷‍♀️</p>
 {{/each-in}}

--- a/website/app/styles/doc-components/tokens-list.scss
+++ b/website/app/styles/doc-components/tokens-list.scss
@@ -7,12 +7,15 @@
 
 @use "../breakpoints" as breakpoint;
 
+.doc-tokens-list-filter {
+  margin-bottom: 24px;
+}
 
 .doc-tokens-list {
   display: flex;
   flex-direction: column;
   gap: 16px 0;
-  margin: 1.5rem 0;
+  margin: 0;
   padding: 0;
   list-style: none;
 

--- a/website/docs/foundations/tokens/index.js
+++ b/website/docs/foundations/tokens/index.js
@@ -26,18 +26,27 @@ export default class Index extends Component {
     super(...arguments);
     this.groupedTokens = {};
     // prepare the tokens grouped by category
-    TOKENS_RAW.forEach((token) => {
-      const category = token.attributes.category;
-      if (!this.groupedTokens[category]) {
-        this.groupedTokens[category] = [];
-      }
-      // add an extra "aliases" attribute if other tokens are alias of it
-      const aliases = getAliases(token, TOKENS_RAW);
-      if (aliases.length > 0) {
-        token.aliases = aliases;
-      }
-      this.groupedTokens[category].push(token);
-    });
+    // alphabetize the filtered icons by category and then by name
+    TOKENS_RAW.sort((a, b) => {
+      return a.attributes.category.localeCompare(b.attributes.category);
+    })
+      .sort((a, b) => {
+        return a.attributes.category === b.attributes.category
+          ? a.name.localeCompare(b.name)
+          : 0;
+      })
+      .forEach((token) => {
+        const category = token.attributes.category;
+        if (!this.groupedTokens[category]) {
+          this.groupedTokens[category] = [];
+        }
+        // add an extra "aliases" attribute if other tokens are alias of it
+        const aliases = getAliases(token, TOKENS_RAW);
+        if (aliases.length > 0) {
+          token.aliases = aliases;
+        }
+        this.groupedTokens[category].push(token);
+      });
   }
 
   get searchQuery() {
@@ -53,8 +62,12 @@ export default class Index extends Component {
             t.name.indexOf(this.searchQuery) !== -1 ||
             t.value.indexOf(this.searchQuery) !== -1
         );
-        filteredGroupedTokens[category] =
-          filteredTokens.length > 0 ? filteredTokens : false;
+
+        if (filteredTokens.length > 0) {
+          filteredGroupedTokens[category] = filteredTokens;
+        } else {
+          delete filteredGroupedTokens[category];
+        }
       });
     } else {
       filteredGroupedTokens = this.groupedTokens;

--- a/website/docs/foundations/tokens/index.js
+++ b/website/docs/foundations/tokens/index.js
@@ -26,27 +26,18 @@ export default class Index extends Component {
     super(...arguments);
     this.groupedTokens = {};
     // prepare the tokens grouped by category
-    // alphabetize the filtered icons by category and then by name
-    TOKENS_RAW.sort((a, b) => {
-      return a.attributes.category.localeCompare(b.attributes.category);
-    })
-      .sort((a, b) => {
-        return a.attributes.category === b.attributes.category
-          ? a.name.localeCompare(b.name)
-          : 0;
-      })
-      .forEach((token) => {
-        const category = token.attributes.category;
-        if (!this.groupedTokens[category]) {
-          this.groupedTokens[category] = [];
-        }
-        // add an extra "aliases" attribute if other tokens are alias of it
-        const aliases = getAliases(token, TOKENS_RAW);
-        if (aliases.length > 0) {
-          token.aliases = aliases;
-        }
-        this.groupedTokens[category].push(token);
-      });
+    TOKENS_RAW.forEach((token) => {
+      const category = token.attributes.category;
+      if (!this.groupedTokens[category]) {
+        this.groupedTokens[category] = [];
+      }
+      // add an extra "aliases" attribute if other tokens are alias of it
+      const aliases = getAliases(token, TOKENS_RAW);
+      if (aliases.length > 0) {
+        token.aliases = aliases;
+      }
+      this.groupedTokens[category].push(token);
+    });
   }
 
   get searchQuery() {

--- a/website/tests/acceptance/token-test.js
+++ b/website/tests/acceptance/token-test.js
@@ -38,6 +38,6 @@ module('Acceptance | Token Search', function (hooks) {
   test('should show message when no results are found', async function (assert) {
     await visit('/foundations/tokens?searchQuery=wubalubadubdub');
 
-    assert.dom('[data-test-target="token-not-found"]').exists();
+    assert.dom('[data-test-target="no-tokens-found"]').exists();
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR alphabetizes token search results, removes display of empty categories, and updates margins & category text size to match icon search.

- **Preview:** https://hds-website-git-hds-3209-update-token-search-hashicorp.vercel.app/foundations/tokens
- **Compare to icon search:** https://helios.hashicorp.design/icons/library

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3209](https://hashicorp.atlassian.net/browse/HDS-3209)

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets]~~(https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3209]: https://hashicorp.atlassian.net/browse/HDS-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ