### PR TITLE
HDS-2704: convert `Hds::Link::Standalone` to typescript

### DIFF
--- a/.changeset/green-donkeys-rule.md
+++ b/.changeset/green-donkeys-rule.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Link::Standlone` - Converted component to TypeScript

--- a/.changeset/green-donkeys-rule.md
+++ b/.changeset/green-donkeys-rule.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`Link::Standlone` - Converted component to TypeScript
+`Link::Standalone` - Converted component to TypeScript

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -197,6 +197,7 @@
       "./components/hds/interactive/index.js": "./dist/_app_/components/hds/interactive/index.js",
       "./components/hds/link/inline.js": "./dist/_app_/components/hds/link/inline.js",
       "./components/hds/link/standalone.js": "./dist/_app_/components/hds/link/standalone.js",
+      "./components/hds/link/types.js": "./dist/_app_/components/hds/link/types.js",
       "./components/hds/menu-primitive/index.js": "./dist/_app_/components/hds/menu-primitive/index.js",
       "./components/hds/modal/body.js": "./dist/_app_/components/hds/modal/body.js",
       "./components/hds/modal/footer.js": "./dist/_app_/components/hds/modal/footer.js",

--- a/packages/components/src/components/hds/button/index.ts
+++ b/packages/components/src/components/hds/button/index.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import { type HdsInteractiveSignature } from '../interactive';
+import type { HdsInteractiveSignature } from '../interactive/types.ts';
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_COLOR = 'primary';

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -5,26 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-
-export interface HdsInteractiveArgs {
-  href?: string;
-  isHrefExternal?: boolean;
-  isRouteExternal?: boolean;
-  route?: string;
-  models?: Array<string | number>;
-  model?: string | number;
-  query?: Record<string, string>;
-  'current-when'?: string;
-  replace?: boolean;
-}
-
-export interface HdsInteractiveSignature {
-  Args: HdsInteractiveArgs;
-  Blocks: {
-    default: [];
-  };
-  Element: HTMLAnchorElement | HTMLButtonElement;
-}
+import type { HdsInteractiveSignature } from './types';
 
 export default class HdsInteractiveIndexComponent extends Component<HdsInteractiveSignature> {
   /**

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -6,18 +6,20 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
+export interface HdsInteractiveArgs {
+  href?: string;
+  isHrefExternal?: boolean;
+  isRouteExternal?: boolean;
+  route?: string;
+  models?: Array<string | number>;
+  model?: string | number;
+  query?: Record<string, string>;
+  'current-when'?: string;
+  replace?: boolean;
+}
+
 export interface HdsInteractiveSignature {
-  Args: {
-    href?: string;
-    isHrefExternal?: boolean;
-    isRouteExternal?: boolean;
-    route?: string;
-    models?: Array<string | number>;
-    model?: string | number;
-    query?: Record<string, string>;
-    'current-when'?: string;
-    replace?: boolean;
-  };
+  Args: HdsInteractiveArgs;
   Blocks: {
     default: [];
   };

--- a/packages/components/src/components/hds/interactive/types.ts
+++ b/packages/components/src/components/hds/interactive/types.ts
@@ -1,0 +1,19 @@
+export interface HdsInteractiveArgs {
+  href?: string;
+  isHrefExternal?: boolean;
+  isRouteExternal?: boolean;
+  route?: string;
+  models?: Array<string | number>;
+  model?: string | number;
+  query?: Record<string, string>;
+  'current-when'?: string;
+  replace?: boolean;
+}
+
+export interface HdsInteractiveSignature {
+  Args: HdsInteractiveArgs;
+  Blocks: {
+    default: [];
+  };
+  Element: HTMLAnchorElement | HTMLButtonElement;
+}

--- a/packages/components/src/components/hds/interactive/types.ts
+++ b/packages/components/src/components/hds/interactive/types.ts
@@ -1,17 +1,15 @@
-export interface HdsInteractiveArgs {
-  href?: string;
-  isHrefExternal?: boolean;
-  isRouteExternal?: boolean;
-  route?: string;
-  models?: Array<string | number>;
-  model?: string | number;
-  query?: Record<string, string>;
-  'current-when'?: string;
-  replace?: boolean;
-}
-
 export interface HdsInteractiveSignature {
-  Args: HdsInteractiveArgs;
+  Args: {
+    href?: string;
+    isHrefExternal?: boolean;
+    isRouteExternal?: boolean;
+    route?: string;
+    models?: Array<string | number>;
+    model?: string | number;
+    query?: Record<string, string>;
+    'current-when'?: string;
+    replace?: boolean;
+  };
   Blocks: {
     default: [];
   };

--- a/packages/components/src/components/hds/link/standalone.hbs
+++ b/packages/components/src/components/hds/link/standalone.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 <Hds::Interactive
   class={{this.classNames}}
   @current-when={{@current-when}}

--- a/packages/components/src/components/hds/link/standalone.ts
+++ b/packages/components/src/components/hds/link/standalone.ts
@@ -5,17 +5,26 @@
 
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import {
+  HdsLinkIconPositionValues,
+  HdsLinkColorValues,
+  HdsLinkStandaloneSizeValues,
+} from './types';
+import type {
+  HdsLinkStandaloneSignature,
+  HdsLinkStandaloneArgs,
+} from './types';
 
-export const DEFAULT_ICONPOSITION = 'leading';
-export const DEFAULT_COLOR = 'primary';
-export const DEFAULT_SIZE = 'medium';
-export const ICONPOSITIONS = ['leading', 'trailing'];
-export const COLORS = ['primary', 'secondary'];
-export const SIZES = ['small', 'medium', 'large'];
+export const DEFAULT_ICONPOSITION = HdsLinkIconPositionValues.Leading;
+export const DEFAULT_COLOR = HdsLinkColorValues.Primary;
+export const DEFAULT_SIZE = HdsLinkStandaloneSizeValues.Medium;
+export const ICONPOSITIONS: string[] = Object.values(HdsLinkIconPositionValues);
+export const COLORS: string[] = Object.values(HdsLinkColorValues);
+export const SIZES: string[] = Object.values(HdsLinkStandaloneSizeValues);
 
-export default class HdsLinkStandaloneComponent extends Component {
-  constructor() {
-    super(...arguments);
+export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandaloneSignature> {
+  constructor(owner: unknown, args: HdsLinkStandaloneArgs) {
+    super(owner, args);
     if (!(this.args.href || this.args.route)) {
       assert('@href or @route must be defined for <Hds::Link::Standalone>');
     }

--- a/packages/components/src/components/hds/link/standalone.ts
+++ b/packages/components/src/components/hds/link/standalone.ts
@@ -9,11 +9,11 @@ import {
   HdsLinkIconPositionValues,
   HdsLinkColorValues,
   HdsLinkStandaloneSizeValues,
-} from './types';
+} from './types.ts';
 import type {
   HdsLinkStandaloneSignature,
   HdsLinkStandaloneArgs,
-} from './types';
+} from './types.ts';
 
 export const DEFAULT_ICONPOSITION = HdsLinkIconPositionValues.Leading;
 export const DEFAULT_COLOR = HdsLinkColorValues.Primary;

--- a/packages/components/src/components/hds/link/standalone.ts
+++ b/packages/components/src/components/hds/link/standalone.ts
@@ -10,10 +10,7 @@ import {
   HdsLinkColorValues,
   HdsLinkStandaloneSizeValues,
 } from './types.ts';
-import type {
-  HdsLinkStandaloneSignature,
-  HdsLinkStandaloneArgs,
-} from './types.ts';
+import type { HdsLinkStandaloneSignature } from './types.ts';
 
 export const DEFAULT_ICONPOSITION = HdsLinkIconPositionValues.Leading;
 export const DEFAULT_COLOR = HdsLinkColorValues.Primary;
@@ -23,7 +20,7 @@ export const COLORS: string[] = Object.values(HdsLinkColorValues);
 export const SIZES: string[] = Object.values(HdsLinkStandaloneSizeValues);
 
 export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandaloneSignature> {
-  constructor(owner: unknown, args: HdsLinkStandaloneArgs) {
+  constructor(owner: unknown, args: HdsLinkStandaloneSignature['Args']) {
     super(owner, args);
     if (!(this.args.href || this.args.route)) {
       assert('@href or @route must be defined for <Hds::Link::Standalone>');

--- a/packages/components/src/components/hds/link/standalone.ts
+++ b/packages/components/src/components/hds/link/standalone.ts
@@ -36,7 +36,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @description The text of the link. If no text value is defined an error will be thrown.
    */
   get text() {
-    let { text } = this.args;
+    const { text } = this.args;
 
     assert(
       '@text for "Hds::Link::Standalone" must have a valid value',
@@ -53,7 +53,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @description Determines the color of link to be used; acceptable values are `primary` and `secondary`
    */
   get color() {
-    let { color = DEFAULT_COLOR } = this.args;
+    const { color = DEFAULT_COLOR } = this.args;
 
     assert(
       `@color for "Hds::Link::Standalone" must be one of the following: ${COLORS.join(
@@ -72,7 +72,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @description The name of the icon to be used. An icon name must be defined.
    */
   get icon() {
-    let { icon } = this.args;
+    const { icon } = this.args;
 
     assert(
       '@icon for "Hds::Link::Standalone" must have a valid value',
@@ -89,7 +89,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @description Positions the icon before or after the text; allowed values are `leading` or `trailing`
    */
   get iconPosition() {
-    let { iconPosition = DEFAULT_ICONPOSITION } = this.args;
+    const { iconPosition = DEFAULT_ICONPOSITION } = this.args;
 
     assert(
       `@iconPosition for "Hds::Link::Standalone" must be one of the following: ${ICONPOSITIONS.join(
@@ -108,7 +108,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @description The size of the standalone link; acceptable values are `small`, `medium`, and `large`
    */
   get size() {
-    let { size = DEFAULT_SIZE } = this.args;
+    const { size = DEFAULT_SIZE } = this.args;
 
     assert(
       `@size for "Hds::Link::Standalone" must be one of the following: ${SIZES.join(
@@ -140,7 +140,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @return {string} The "class" attribute to apply to the component.
    */
   get classNames() {
-    let classes = ['hds-link-standalone'];
+    const classes = ['hds-link-standalone'];
 
     // add a class based on the @size argument
     classes.push(`hds-link-standalone--size-${this.size}`);

--- a/packages/components/src/components/hds/link/types.ts
+++ b/packages/components/src/components/hds/link/types.ts
@@ -1,4 +1,4 @@
-import type { HdsInteractiveArgs } from '../interactive/types.ts';
+import type { HdsInteractiveSignature } from '../interactive/types.ts';
 
 export enum HdsLinkIconPositionValues {
   Leading = 'leading',
@@ -22,18 +22,16 @@ export enum HdsLinkStandaloneSizeValues {
 
 export type HdsLinkStandaloneSizes = `${HdsLinkStandaloneSizeValues}`;
 
-export interface HdsLinkStandaloneArgs extends HdsInteractiveArgs {
-  icon: string;
-  text: string;
-  color?: HdsLinkColors;
-  href?: string;
-  iconPosition?: HdsLinkIconPositions;
-  isHrefExternal?: boolean;
-  isRouteExternal?: boolean;
-  size?: HdsLinkStandaloneSizes;
-}
-
 export interface HdsLinkStandaloneSignature {
-  Args: HdsLinkStandaloneArgs;
-  Element: HTMLAnchorElement | HTMLButtonElement;
+  Args: HdsInteractiveSignature['Args'] & {
+    icon: string;
+    text: string;
+    color?: HdsLinkColors;
+    href?: string;
+    iconPosition?: HdsLinkIconPositions;
+    isHrefExternal?: boolean;
+    isRouteExternal?: boolean;
+    size?: HdsLinkStandaloneSizes;
+  };
+  Element: HTMLAnchorElement;
 }

--- a/packages/components/src/components/hds/link/types.ts
+++ b/packages/components/src/components/hds/link/types.ts
@@ -1,0 +1,39 @@
+import type { HdsInteractiveArgs } from '../interactive';
+
+export enum HdsLinkIconPositionValues {
+  Leading = 'leading',
+  Trailing = 'trailing',
+}
+
+export type HdsLinkIconPositions = `${HdsLinkIconPositionValues}`;
+
+export enum HdsLinkColorValues {
+  Primary = 'primary',
+  Secondary = 'secondary',
+}
+
+export type HdsLinkColors = `${HdsLinkColorValues}`;
+
+export enum HdsLinkStandaloneSizeValues {
+  Small = 'small',
+  Medium = 'medium',
+  Large = 'large',
+}
+
+export type HdsLinkStandaloneSizes = `${HdsLinkStandaloneSizeValues}`;
+
+export interface HdsLinkStandaloneArgs extends HdsInteractiveArgs {
+  icon: string;
+  text: string;
+  color?: HdsLinkColors;
+  href?: string;
+  iconPosition?: HdsLinkIconPositions;
+  isHrefExternal?: boolean;
+  isRouteExternal?: boolean;
+  size?: HdsLinkStandaloneSizes;
+}
+
+export interface HdsLinkStandaloneSignature {
+  Args: HdsLinkStandaloneArgs;
+  Element: HTMLAnchorElement | HTMLButtonElement;
+}

--- a/packages/components/src/components/hds/link/types.ts
+++ b/packages/components/src/components/hds/link/types.ts
@@ -33,5 +33,5 @@ export interface HdsLinkStandaloneSignature {
     isRouteExternal?: boolean;
     size?: HdsLinkStandaloneSizes;
   };
-  Element: HTMLAnchorElement;
+  Element: HdsInteractiveSignature['Element'];
 }

--- a/packages/components/src/components/hds/link/types.ts
+++ b/packages/components/src/components/hds/link/types.ts
@@ -1,4 +1,4 @@
-import type { HdsInteractiveArgs } from '../interactive';
+import type { HdsInteractiveArgs } from '../interactive/types.ts';
 
 export enum HdsLinkIconPositionValues {
   Leading = 'leading',

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -6,13 +6,14 @@
 import type HdsButtonIndexComponent from './components/hds/button';
 import type HdsDismissButtonIndexComponent from './components/hds/dismiss-button';
 import type HdsInteractiveIndexComponent from './components/hds/interactive';
-import type HdsLinkToModelsHelper from './helpers/hds-link-to-models';
-import type HdsLinkToQueryHelper from './helpers/hds-link-to-query';
+import type HdsLinkStandaloneComponent from './components/hds/link/standalone';
 import type HdsTextIndexComponent from './components/hds/text';
 import type HdsTextBodyComponent from './components/hds/text/body';
 import type HdsTextDisplayComponent from './components/hds/text/display';
 import type HdsTextCodeComponent from './components/hds/text/code';
 import type HdsYieldComponent from './components/hds/yield';
+import type HdsLinkToModelsHelper from './helpers/hds-link-to-models';
+import type HdsLinkToQueryHelper from './helpers/hds-link-to-query';
 
 export default interface HdsComponentsRegistry {
   HdsInteractiveComponent: typeof HdsInteractiveIndexComponent;
@@ -30,6 +31,11 @@ export default interface HdsComponentsRegistry {
   'Hds::Interactive': typeof HdsInteractiveIndexComponent;
   'hds/interactive': typeof HdsInteractiveIndexComponent;
   HdsInteractive: typeof HdsInteractiveIndexComponent;
+
+  // Link Standalone
+  'Hds::Link::Standalone': typeof HdsLinkStandaloneComponent;
+  'hds/link/standalone': typeof HdsLinkStandaloneComponent;
+  HdsLinkStandalone: typeof HdsLinkStandaloneComponent;
 
   // Text
   'Hds::Text': typeof HdsTextIndexComponent;


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

Converts `Hds::Link::Standalone` to Typescript

### :hammer_and_wrench: Detailed description

- Converts `Hds::Link::Standalone` to Typescript
- Moves `Hds::Interactive` types to separate type file as per guidelines
- I kept this focussed to the `Hds::Link::Standalone` component. I imagine some types may be shared with `Hds::Link::Inline` and so there may be some type naming changes when I complete conversion in a second PR

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2704](https://hashicorp.atlassian.net/browse/HDS-2704)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2704]: https://hashicorp.atlassian.net/browse/HDS-2704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ