### PR TITLE
bugfix(components): fix flaky tests by restoring waiters usage from @ember/test-waiters

### DIFF
--- a/.changeset/ten-falcons-run.md
+++ b/.changeset/ten-falcons-run.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Fix flaky tests by making sure @ember/test-waiters run in all environments
+`Modal`, `Flyout` - Fixed flaky tests by running `@ember/test-waiters` in all environments

--- a/.changeset/ten-falcons-run.md
+++ b/.changeset/ten-falcons-run.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix flaky tests by making sure @ember/test-waiters run in all environments

--- a/packages/components/src/components/hds/flyout/index.js
+++ b/packages/components/src/components/hds/flyout/index.js
@@ -9,14 +9,8 @@ import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import { getElementId } from '../../../utils/hds-get-element-id';
 import { buildWaiter } from '@ember/test-waiters';
-import { DEBUG } from '@glimmer/env';
 
-let waiter;
-
-// Notice: this code will get stripped out in production builds (DEBUG evaluates to `true` in dev/test builds, but `false` in prod builds)
-if (DEBUG) {
-  waiter = buildWaiter('@hashicorp/design-system-components:flyout');
-}
+let waiter = buildWaiter('@hashicorp/design-system-components:flyout');
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_HAS_OVERLAY = true;
@@ -127,7 +121,7 @@ export default class HdsFlyoutIndexComponent extends Component {
     // allow ember test helpers to be aware of when the `close` event fires
     // when using `click` or other helpers from '@ember/test-helpers'
     // Notice: this code will get stripped out in production builds (DEBUG evaluates to `true` in dev/test builds, but `false` in prod builds)
-    if (DEBUG && this.element.open) {
+    if (this.element.open) {
       let token = waiter.beginAsync();
       let listener = () => {
         waiter.endAsync(token);

--- a/packages/components/src/components/hds/modal/index.js
+++ b/packages/components/src/components/hds/modal/index.js
@@ -9,14 +9,8 @@ import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import { getElementId } from '../../../utils/hds-get-element-id';
 import { buildWaiter } from '@ember/test-waiters';
-import { DEBUG } from '@glimmer/env';
 
-let waiter;
-
-// Notice: this code will get stripped out in production builds (DEBUG evaluates to `true` in dev/test builds, but `false` in prod builds)
-if (DEBUG) {
-  waiter = buildWaiter('@hashicorp/design-system-components:modal');
-}
+let waiter = buildWaiter('@hashicorp/design-system-components:modal');
 
 export const DEFAULT_SIZE = 'medium';
 export const DEFAULT_COLOR = 'neutral';
@@ -168,7 +162,7 @@ export default class HdsModalIndexComponent extends Component {
     // allow ember test helpers to be aware of when the `close` event fires
     // when using `click` or other helpers from '@ember/test-helpers'
     // Notice: this code will get stripped out in production builds (DEBUG evaluates to `true` in dev/test builds, but `false` in prod builds)
-    if (DEBUG && this.element.open) {
+    if (this.element.open) {
       let token = waiter.beginAsync();
       let listener = () => {
         waiter.endAsync(token);


### PR DESCRIPTION
### :pushpin: Summary


Makes `@ember/test-waiters` run again in the test environment.

### :hammer_and_wrench: Detailed description


Since @hashicorp/design-system-components became a V2 Ember Addon, it no longer gets some of the default babel plugins when compiling its output to the `dist` folder that gets included in the npm package. One of those packages is [babel-plugin-debug-macros][1], which compiles the following code in development/testing environments from:

```javascript
import { DEBUG } from '@glimmer/env';

if (DEBUG) {
  doThing();
}
```

to the following compiled version:

```javascript
if (true) {
  doThing();
}
```

in production environments it gets compiled to:

```javascript
if (false) {
  doThing();
}
```

which then gets stripped out.

Since this babel plugin is no longer included and V2 addons don't seem to use the same build pipeline as V1 addons, what happens today is that the waiters we added for Flyout and Modal never get set up since `DEBUG` from `@glimmer/env` is always false in the runtime version.

It turns out that [@ember/test-waiters][2] does not have a huge performance impact in production code, since the version of the library that gets included in production builds is essentially a collection of no-ops. From the `@ember/test-waiters` README:

> When in production mode, we make this instance inert and essentially no cost to
> invoke. Since test waiters are intended to be called from application or addon
> code, but are only required to be active when in tests, this process of making
> the instance inert is important. Even though code is still invoked, this has a
> negligible impact on performance.

We can remove our usage of `DEBUG` since it is un-necessary and doesn't save that much in terms of code size or runtime performance.

[1]: https://github.com/ember-cli/babel-plugin-debug-macros
[2]: https://www.npmjs.com/package/@ember/test-waiters

### :link: External links

- [JIRA](https://hashicorp.atlassian.net/browse/TF-14041)
- [Related Slack Convo](https://hashicorp.slack.com/archives/C7KTUHNUS/p1705001922424289)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
