### PR TITLE
HDS-2703: `Hds::Link::Inline` - Covert to Typescript

### DIFF
--- a/.changeset/big-hornets-allow.md
+++ b/.changeset/big-hornets-allow.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Link::Inline` - Converted component to TypeScript

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -195,6 +195,7 @@
       "./components/hds/form/visibility-toggle/index.js": "./dist/_app_/components/hds/form/visibility-toggle/index.js",
       "./components/hds/icon-tile/index.js": "./dist/_app_/components/hds/icon-tile/index.js",
       "./components/hds/interactive/index.js": "./dist/_app_/components/hds/interactive/index.js",
+      "./components/hds/interactive/types.js": "./dist/_app_/components/hds/interactive/types.js",
       "./components/hds/link/inline.js": "./dist/_app_/components/hds/link/inline.js",
       "./components/hds/link/standalone.js": "./dist/_app_/components/hds/link/standalone.js",
       "./components/hds/link/types.js": "./dist/_app_/components/hds/link/types.js",

--- a/packages/components/src/components/hds/link/inline.hbs
+++ b/packages/components/src/components/hds/link/inline.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{! IMPORTANT: we removed the newlines before/after the yield to reduce the issues with unexpected whitespaces (see https://github.com/hashicorp/design-system/pull/231#issuecomment-1123502499) }}
 {{! IMPORTANT: we need to add "squishies" here (~) because otherwise the whitespace added by Ember becomes visible in the link (being an inline element) - See https://handlebarsjs.com/guide/expressions.html#whitespace-control }}
 <Hds::Interactive

--- a/packages/components/src/components/hds/link/inline.ts
+++ b/packages/components/src/components/hds/link/inline.ts
@@ -5,15 +5,17 @@
 
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import { HdsLinkColorValues, HdsLinkIconPositionValues } from './types.ts';
+import type { HdsLinkInlineSignature } from './types.ts';
 
-export const DEFAULT_ICONPOSITION = 'trailing';
-export const DEFAULT_COLOR = 'primary';
-export const ICONPOSITIONS = ['leading', 'trailing'];
-export const COLORS = ['primary', 'secondary'];
+export const DEFAULT_ICONPOSITION = HdsLinkIconPositionValues.Trailing;
+export const DEFAULT_COLOR = HdsLinkColorValues.Primary;
+export const ICONPOSITIONS: string[] = Object.values(HdsLinkIconPositionValues);
+export const COLORS: string[] = Object.values(HdsLinkColorValues);
 
-export default class HdsLinkInlineComponent extends Component {
-  constructor() {
-    super(...arguments);
+export default class HdsLinkInlineComponent extends Component<HdsLinkInlineSignature> {
+  constructor(owner: unknown, args: HdsLinkInlineSignature['Args']) {
+    super(owner, args);
     if (!(this.args.href || this.args.route)) {
       assert('@href or @route must be defined for <Hds::Link::Inline>');
     }
@@ -26,7 +28,7 @@ export default class HdsLinkInlineComponent extends Component {
    * @description Determines the color of link to be used; acceptable values are `primary` and `secondary`
    */
   get color() {
-    let { color = DEFAULT_COLOR } = this.args;
+    const { color = DEFAULT_COLOR } = this.args;
 
     assert(
       `@color for "Hds::Link::Inline" must be one of the following: ${COLORS.join(
@@ -45,7 +47,7 @@ export default class HdsLinkInlineComponent extends Component {
    * @description Positions the icon before or after the text; allowed values are `leading` or `trailing`
    */
   get iconPosition() {
-    let { iconPosition = DEFAULT_ICONPOSITION } = this.args;
+    const { iconPosition = DEFAULT_ICONPOSITION } = this.args;
 
     assert(
       `@iconPosition for "Hds::Link::Inline" must be one of the following: ${ICONPOSITIONS.join(
@@ -63,7 +65,7 @@ export default class HdsLinkInlineComponent extends Component {
    * @return {string} The "class" attribute to apply to the component.
    */
   get classNames() {
-    let classes = ['hds-link-inline'];
+    const classes = ['hds-link-inline'];
 
     // add a class based on the @color argument
     classes.push(`hds-link-inline--color-${this.color}`);

--- a/packages/components/src/components/hds/link/types.ts
+++ b/packages/components/src/components/hds/link/types.ts
@@ -35,3 +35,18 @@ export interface HdsLinkStandaloneSignature {
   };
   Element: HdsInteractiveSignature['Element'];
 }
+
+export interface HdsLinkInlineSignature {
+  Args: HdsInteractiveSignature['Args'] & {
+    color?: HdsLinkColors;
+    href?: string;
+    icon?: string;
+    iconPosition?: HdsLinkIconPositions;
+    isHrefExternal?: boolean;
+    isRouteExternal?: boolean;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: HdsInteractiveSignature['Element'];
+}

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -6,6 +6,7 @@
 import type HdsButtonIndexComponent from './components/hds/button';
 import type HdsDismissButtonIndexComponent from './components/hds/dismiss-button';
 import type HdsInteractiveIndexComponent from './components/hds/interactive';
+import type HdsLinkInlineComponent from './components/hds/link/inline';
 import type HdsLinkStandaloneComponent from './components/hds/link/standalone';
 import type HdsTextIndexComponent from './components/hds/text';
 import type HdsTextBodyComponent from './components/hds/text/body';
@@ -31,6 +32,11 @@ export default interface HdsComponentsRegistry {
   'Hds::Interactive': typeof HdsInteractiveIndexComponent;
   'hds/interactive': typeof HdsInteractiveIndexComponent;
   HdsInteractive: typeof HdsInteractiveIndexComponent;
+
+  // Link Inline
+  'Hds::Link::Inline': typeof HdsLinkInlineComponent;
+  'hds/link/inline': typeof HdsLinkInlineComponent;
+  HdsLinkInline: typeof HdsLinkInlineComponent;
 
   // Link Standalone
   'Hds::Link::Standalone': typeof HdsLinkStandaloneComponent;

--- a/packages/components/unpublished-development-types/@hashicorp/ember-flight-icons/flight-icon.d.ts
+++ b/packages/components/unpublished-development-types/@hashicorp/ember-flight-icons/flight-icon.d.ts
@@ -5,7 +5,7 @@ declare module '@hashicorp/ember-flight-icons/components/flight-icon' {
     Args: {
       size?: string;
       color?: string;
-      name: string | null;
+      name?: string;
       stretched?: boolean;
     };
     Element: SVGElement;


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

Converts `Hds::Link::Standalone` to Typescript

### :hammer_and_wrench: Detailed description

- Converts `Hds::Link::Inline` to Typescript
- Updates `FlightIcon` `name` to be a optional string instead of a required `string | null`. It was not a fan of receiving optionally undefined names (which it handles in it's constructor).

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2703](https://hashicorp.atlassian.net/browse/HDS-2703)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2704]: https://hashicorp.atlassian.net/browse/HDS-2704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ