### PR TITLE
Fix outdated GitHub paths for `table` and `pagination` components on website

### DIFF
--- a/website/docs/components/pagination/index.md
+++ b/website/docs/components/pagination/index.md
@@ -4,7 +4,7 @@ description: Used to let users navigate through content broken down into pages. 
 caption: Used to let users navigate through content broken down into pages.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=18709%3A42011&t=pIE459t8qucXP9uR-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/pagination
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/pagination
 related: ['components/table','patterns/filter-patterns', 'patterns/table-multi-select']
 previewImage: assets/illustrations/components/pagination.jpg
 ---

--- a/website/docs/components/table/index.md
+++ b/website/docs/components/table/index.md
@@ -4,7 +4,7 @@ description: Used to display organized, two-dimensional tabular data.
 caption: Used to display organized, two-dimensional tabular data.
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=18814%3A54972&t=XC8SUxxJOFHgqYzK-1
-  github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/table
+  github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/table
 related: ['components/pagination','patterns/filter-patterns','patterns/table-multi-select']
 previewImage: assets/illustrations/components/table.jpg
 navigation:


### PR DESCRIPTION
### :pushpin: Summary

Small PR to fix outdated GitHub paths for `table` and `pagination` components in documentation
