### PR TITLE
HDS-2717: `Hds::Toast` - Converts to Typescript

### DIFF
--- a/.changeset/soft-buttons-burn.md
+++ b/.changeset/soft-buttons-burn.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Toast` - Converted component to TypeScript

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -256,6 +256,7 @@
       "./components/hds/text/index.js": "./dist/_app_/components/hds/text/index.js",
       "./components/hds/text/types.js": "./dist/_app_/components/hds/text/types.js",
       "./components/hds/toast/index.js": "./dist/_app_/components/hds/toast/index.js",
+      "./components/hds/toast/types.js": "./dist/_app_/components/hds/toast/types.js",
       "./components/hds/tooltip-button/index.js": "./dist/_app_/components/hds/tooltip-button/index.js",
       "./components/hds/yield/index.js": "./dist/_app_/components/hds/yield/index.js",
       "./components/hds/yield/types.js": "./dist/_app_/components/hds/yield/types.js",

--- a/packages/components/src/components/hds/alert/types.ts
+++ b/packages/components/src/components/hds/alert/types.ts
@@ -24,7 +24,8 @@ export interface HdsAlertSignature {
     type: HdsAlertTypes;
     color?: HdsAlertColors;
     icon?: string | false;
-    onDismiss?: () => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onDismiss?: (event: MouseEvent, ...args: any[]) => void;
   };
   Blocks: {
     default: [

--- a/packages/components/src/components/hds/toast/index.hbs
+++ b/packages/components/src/components/hds/toast/index.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/toast/index.ts
+++ b/packages/components/src/components/hds/toast/index.ts
@@ -1,0 +1,4 @@
+import Component from '@glimmer/component';
+import type { HdsToastSignature } from './types.ts';
+
+export default class HdsToastComponent extends Component<HdsToastSignature> {}

--- a/packages/components/src/components/hds/toast/index.ts
+++ b/packages/components/src/components/hds/toast/index.ts
@@ -1,4 +1,6 @@
-import Component from '@glimmer/component';
+import TemplateOnlyComponent from '@ember/component/template-only';
 import type { HdsToastSignature } from './types.ts';
 
-export default class HdsToastComponent extends Component<HdsToastSignature> {}
+const HdsToastComponent = TemplateOnlyComponent<HdsToastSignature>();
+
+export default HdsToastComponent;

--- a/packages/components/src/components/hds/toast/types.ts
+++ b/packages/components/src/components/hds/toast/types.ts
@@ -1,0 +1,5 @@
+import type { HdsAlertSignature } from '../alert/types.ts';
+
+export interface HdsToastSignature extends Omit<HdsAlertSignature, 'Args'> {
+  Args: Omit<HdsAlertSignature['Args'], 'type'>;
+}

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -7,6 +7,7 @@ import type HdsAlertIndexComponent from './components/hds/alert';
 import type HdsAlertDescriptionComponent from './components/hds/alert/description';
 import type HdsAlertTitleComponent from './components/hds/alert/title';
 import type HdsButtonIndexComponent from './components/hds/button';
+import type HdsCardContainerComponent from './components/hds/card/container.ts';
 import type HdsDismissButtonIndexComponent from './components/hds/dismiss-button';
 import type HdsInteractiveIndexComponent from './components/hds/interactive';
 import type HdsLinkInlineComponent from './components/hds/link/inline';
@@ -14,11 +15,11 @@ import type HdsLinkStandaloneComponent from './components/hds/link/standalone';
 import type HdsTextIndexComponent from './components/hds/text';
 import type HdsTextBodyComponent from './components/hds/text/body';
 import type HdsTextDisplayComponent from './components/hds/text/display';
+import type HdsToastComponent from './components/hds/toast';
 import type HdsTextCodeComponent from './components/hds/text/code';
 import type HdsYieldComponent from './components/hds/yield';
 import type HdsLinkToModelsHelper from './helpers/hds-link-to-models';
 import type HdsLinkToQueryHelper from './helpers/hds-link-to-query';
-import type HdsCardContainerComponent from './components/hds/card/container.ts';
 
 export default interface HdsComponentsRegistry {
   // Alert
@@ -80,6 +81,11 @@ export default interface HdsComponentsRegistry {
   'Hds::Text::Code': typeof HdsTextCodeComponent;
   'hds/text/code': typeof HdsTextCodeComponent;
   HdsTextCode: typeof HdsTextCodeComponent;
+
+  // Toast
+  'Hds::Toast': typeof HdsToastComponent;
+  'hds/toast': typeof HdsToastComponent;
+  HdsToast: typeof HdsToastComponent;
 
   // Yield
   'Hds::Yield': typeof HdsYieldComponent;

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -20,6 +20,9 @@
       "@hashicorp/design-system-components/*": [
         "src/*"
       ],
+      "@ember/component/template-only": [
+        "../../../node_modules/ember-source/types/stable/@ember/component/template-only"
+      ],
       "*": [
         "types/*"
       ]


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->
Converts `Hds::Toast` to Typescript

### :hammer_and_wrench: Detailed description
- Converts `Hds::Toast` to Typescript
  - I initially tried the recommended approach of using `templateOnlyComponent` to type the `Toast` component as it had no backing class. However, I was getting Typescript errors when trying to pass it the type signature stating that `templateOnlyComponent` does not take type arguments. It seems like that only became available in later version of Ember. I thought it would be fine given this is an embroider addon but idk, typescript was not happy! Willing to revisit this if anyone has any ideas.
- Updates the `Hds::Alert` `onDismiss` argument type to take the `MouseEvent` and then any number of args with `any` value. I originally had this set to `() => void`, which works great if you never want to handle arguments on the action handler, but it falls on it's face if you do. I thought it would be better to switch to always handle an event, and then any number of arguments of any value, as you can pass in whatever you would like with a `(fn)` helper. I used `any` here because you can't type the handler functions additional args if you set it to `unknown`




<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots
<img width="1797" alt="Screenshot 2024-03-26 at 2 59 49 AM" src="https://github.com/hashicorp/design-system/assets/5448834/f805802a-f6fb-4008-aebb-c282957b7f17">
<!-- Screenshots always help, especially if this PR will change what renders to the browser -->
<img width="1012" alt="Screenshot 2024-03-26 at 3 05 11 AM" src="https://github.com/hashicorp/design-system/assets/5448834/1d001eaa-5ba6-478b-a0ad-6543faedfc78">
<img width="1012" alt="Screenshot 2024-03-26 at 3 05 19 AM" src="https://github.com/hashicorp/design-system/assets/5448834/d5a5a7ef-578d-4e4a-bde9-130ad8f403f0">



### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2717](https://hashicorp.atlassian.net/browse/HDS-2717)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2717]: https://hashicorp.atlassian.net/browse/HDS-2717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ