### PR TITLE
Re-map class-name color token in CodeBlock

### DIFF
--- a/.changeset/olive-hotels-know.md
+++ b/.changeset/olive-hotels-know.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`CodeBlock` - Re-mapped class-name variable to color-blue

--- a/packages/components/src/styles/components/code-block/theme.scss
+++ b/packages/components/src/styles/components/code-block/theme.scss
@@ -58,7 +58,7 @@
   --hds-code-block-color-boolean: var(--hds-code-block-color-purple);
   --hds-code-block-color-builtin: var(--hds-code-block-color-orange);
   --hds-code-block-color-char: var(--hds-code-block-color-orange);
-  --hds-code-block-color-class-name: var(--hds-code-block-color-green);
+  --hds-code-block-color-class-name: var(--hds-code-block-color-blue);
   --hds-code-block-color-comment: var(--hds-code-block-color-foreground-faint);
   --hds-code-block-color-control: var(--hds-code-block-color-cyan);
   --hds-code-block-color-constant: var(--hds-code-block-color-purple);


### PR DESCRIPTION
### :pushpin: Summary

Draft/Example PR. As far as I can tell, this change only affects our JavaScript examples in the showcase.

Showcase 👉 https://hds-showcase-git-jt-code-block-class-name-hashicorp.vercel.app/components/code-block#highlight-lines

### :camera_flash: Screenshots

**Before**
<img width="1076" alt="Screenshot 2024-03-26 at 12 24 01 PM" src="https://github.com/hashicorp/design-system/assets/2200899/83a0c7a7-783b-4a8b-a143-f600a8d2cbc0">

**After**
<img width="1104" alt="Screenshot 2024-03-26 at 12 08 28 PM" src="https://github.com/hashicorp/design-system/assets/2200899/5c274936-5ff6-428e-a889-482543262ccb">

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
