### PR TITLE
Add link to release notes to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 For guidelines on how to use Helios, see our [documentation website](https://helios.hashicorp.design).
 
+## Release notes
+
+[A changelog for code and Figma changes is kept on the Helios website](https://helios.hashicorp.design/whats-new/release-notes)
+
 ## Packages
 
 ### `packages/components` [![npm version](https://badge.fury.io/js/%40hashicorp%2Fdesign-system-components.svg)](https://badge.fury.io/js/%40hashicorp%2Fdesign-system-components)


### PR DESCRIPTION
Reading back some old feedback a suggestion was made that we could try to surface the changelog more with the project Readme being one such place we could do this. This seems like a reasonable suggestion, so I've added it here.