### PR TITLE
Website: Make icon category search case-insensitive (HDS-3226)

### DIFF
--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -17,6 +17,8 @@ export default class Index extends Component {
 
   allIcons = catalog.assets.map(
     ({ iconName, fileName, size, description, category }) => {
+      category = category.toLowerCase(); // category names in json begin with uppercase letter
+
       return {
         iconName: `${iconName}`,
         name: `${fileName}`,
@@ -60,7 +62,7 @@ export default class Index extends Component {
         filteredIcons = this.allIcons.filter(
           (i) =>
             i.size === this.selectedIconSize &&
-            i.searchable.indexOf(this.searchQuery) !== -1
+            i.searchable.indexOf(this.searchQuery.toLowerCase()) !== -1
         );
       }
     } else {

--- a/website/tests/acceptance/icon-test.js
+++ b/website/tests/acceptance/icon-test.js
@@ -35,15 +35,15 @@ module('Acceptance | Icon Search', function (hooks) {
     assert.dom('.doc-copy-button__visible-value').hasText('cpu');
   });
 
-  test('should load content based on category in query param', async function (assert) {
-    await visit('/icons/library?searchQuery=animated&selectedIconSize=24');
+  test('should load content based on category in query param, with case-insensitive results', async function (assert) {
+    await visit('/icons/library?searchQuery=AniMaTed&selectedIconSize=24');
 
     assert.strictEqual(
       currentURL(),
-      '/icons/library?searchQuery=animated&selectedIconSize=24'
+      '/icons/library?searchQuery=AniMaTed&selectedIconSize=24'
     );
 
-    assert.dom('.doc-icons-list-grid-item').exists({ count: 2 });
+    assert.dom('.doc-icons-list-grid-item').exists({ count: 4 });
     assert.dom('.doc-text-h4').hasText('Animated');
   });
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will make icon category search case insensitive

**Preview:** https://hds-website-git-hds-3226-make-icon-search-case-6a386c-hashicorp.vercel.app/icons/library

<!-- 
### :hammer_and_wrench: Detailed description

If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3226](https://hashicorp.atlassian.net/browse/HDS-3226)
<!-- Figma file: [if it applies] -->

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- [ ] ~~A changelog entry was added via~~ [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3226]: https://hashicorp.atlassian.net/browse/HDS-3226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ