### PR TITLE
`Dropdown::ListItem::Interactive` - Add support for trailing icon

### DIFF
--- a/.changeset/six-wombats-press.md
+++ b/.changeset/six-wombats-press.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Dropdown` - Added support for trailing icon in `ListItem::Interactive` subcomponent

--- a/packages/components/src/components/hds/dropdown/list-item/interactive.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/interactive.hbs
@@ -6,7 +6,7 @@
 <li class={{this.classNames}}>
   {{#if @isLoading}}
     <div class="hds-dropdown-list-item__interactive-loading-wrapper" ...attributes>
-      <div class="hds-dropdown-list-item__interactive-icon">
+      <div class="hds-dropdown-list-item__interactive-icon hds-dropdown-list-item__interactive-icon--leading">
         <FlightIcon @name="loading" @isInlineBlock={{false}} />
       </div>
       <Hds::Text::Body @tag="div" @size="100" @weight="regular" class="hds-dropdown-list-item__interactive-text">
@@ -26,13 +26,18 @@
       ...attributes
     >
       {{#if @icon}}
-        <span class="hds-dropdown-list-item__interactive-icon">
+        <span class="hds-dropdown-list-item__interactive-icon hds-dropdown-list-item__interactive-icon--leading">
           <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
         </span>
       {{/if}}
       <Hds::Text::Body class="hds-dropdown-list-item__interactive-text" @tag="span" @size="200" @weight="medium">
         {{this.text}}
       </Hds::Text::Body>
+      {{#if @trailingIcon}}
+        <span class="hds-dropdown-list-item__interactive-icon hds-dropdown-list-item__interactive-icon--trailing">
+          <FlightIcon @name={{@trailingIcon}} @isInlineBlock={{false}} />
+        </span>
+      {{/if}}
     </Hds::Interactive>
   {{/if}}
 </li>

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -411,7 +411,14 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 .hds-dropdown-list-item__interactive-icon {
   display: block;
   margin-top: 2px;
+}
+
+.hds-dropdown-list-item__interactive-icon--leading {
   margin-right: 8px;
+}
+
+.hds-dropdown-list-item__interactive-icon--trailing {
+  margin-left: 8px;
 }
 
 .hds-dropdown-list-item__interactive-text {

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -445,6 +445,43 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Text::H4>Icons</Shw::Text::H4>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="No icon (default)">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @text="Basic" />
+        </ul>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Leading icon">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @icon="settings" @text="Settings" />
+        </ul>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Trailing icon">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @trailingIcon="external-link" @text="Documentation" />
+        </ul>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Leading + Trailing icons">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive
+            @icon="terraform-color"
+            @trailingIcon="external-link"
+            @text="Terraform"
+          />
+        </ul>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Text::H4>Colors</Shw::Text::H4>
 
   <Shw::Flex as |SF|>

--- a/showcase/tests/integration/components/hds/dropdown/list-item/interactive-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/interactive-test.js
@@ -71,13 +71,26 @@ module(
         .hasClass('hds-dropdown-list-item--color-critical');
     });
 
-    // ICON
+    // ICONS
 
-    test('if an icon is declared the flight icon should render in the component', async function (assert) {
+    test('if an `@icon` is declared a leading icon should be rendered', async function (assert) {
       await render(
         hbs`<Hds::Dropdown::ListItem::Interactive @icon="clipboard-copy" @text="interactive" />`
       );
       assert.dom('.flight-icon.flight-icon-clipboard-copy').exists();
+    });
+    test('if an `@trailingIcon` is declared a trailing icon should be rendered', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Interactive @trailingIcon="external-link" @text="interactive" />`
+      );
+      assert.dom('.flight-icon.flight-icon-external-link').exists();
+    });
+    test('if both an `@icon` and an `@trailingIcon` are declared both the leading and trailing icons should be rendered', async function (assert) {
+      await render(
+        hbs`<Hds::Dropdown::ListItem::Interactive @icon="clipboard-copy" @trailingIcon="external-link" @text="interactive" />`
+      );
+      assert.dom('.flight-icon.flight-icon-clipboard-copy').exists();
+      assert.dom('.flight-icon.flight-icon-external-link').exists();
     });
 
     // CONTENT

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -104,7 +104,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
     Text to be used in the item. If no text value is defined, an error will be thrown.
   </C.Property>
   <C.Property @name="color" @type="enum" @values={{array "action" "critical" }} @default="action">
-    Color applied to the text and (optional) icons. Acceptable values: “action” or “critical”.
+    Color applied to the text and (optional) icons.
   </C.Property>
   <C.Property @name="icon" @type="string">
     Leading icon. Acceptable value: any [icon](/icons/library) name.

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -104,10 +104,13 @@ If the Dropdown content exceeds the height of the container, the header and foot
     Text to be used in the item. If no text value is defined, an error will be thrown.
   </C.Property>
   <C.Property @name="color" @type="enum" @values={{array "action" "critical" }} @default="action">
-    Acceptable values: “action” or “critical”.
+    Color applied to the text and (optional) icons. Acceptable values: “action” or “critical”.
   </C.Property>
   <C.Property @name="icon" @type="string">
-    Acceptable value: any [icon](/icons/library) name.
+    Leading icon. Acceptable value: any [icon](/icons/library) name.
+  </C.Property>
+  <C.Property @name="trailingIcon" @type="string">
+    Trailing icon. Acceptable value: any [icon](/icons/library) name.
   </C.Property>
   <C.Property @name="isLoading" @type="boolean" @default="false">
     Controls if the item is in “loading” state. When in this state, the item is not actually interactive, but you can pass the other expected arguments for the item (they’re simply ignored).

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -187,6 +187,15 @@ If you add an event handler (no `@href` or `@route`), a `<button>` element will 
 </Doc::ListContainer>
 ```
 
+You can pass an `@icon` argument to add a leading icon:
+
+```handlebars
+{{!-- The Doc::ListContainer component is just to help the component render properly --}}
+<Doc::ListContainer class="hds-dropdown__list">
+  <Hds::Dropdown::ListItem::Interactive {{on "click" this.myAction}} @text="Run command" @icon="build" />
+</Doc::ListContainer>
+```
+
 #### Rendering a link with `@href`
 
 !!! Info
@@ -202,6 +211,15 @@ If you pass an `@href` argument, a link (`<a>` element) will be generated:
 {{!-- The Doc::ListContainer component is just to help the component render properly --}}
 <Doc::ListContainer class="hds-dropdown__list">
   <Hds::Dropdown::ListItem::Interactive @href="https://www.hashicorp.com/request-demo/terraform" @text="Request a demo" />
+</Doc::ListContainer>
+```
+
+You can pass a `@trailingIcon` argument to indicate that the link points to an external resource:
+
+```handlebars
+{{!-- The Doc::ListContainer component is just to help the component render properly --}}
+<Doc::ListContainer class="hds-dropdown__list">
+  <Hds::Dropdown::ListItem::Interactive @href="https://www.hashicorp.com/request-demo/terraform" @text="Request a demo" @trailingIcon="external-link" />
 </Doc::ListContainer>
 ```
 

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -214,7 +214,7 @@ If you pass an `@href` argument, a link (`<a>` element) will be generated:
 </Doc::ListContainer>
 ```
 
-To indicate that the link points to an external resource you can use `@trailingIcon` and assign it an icon name like `external-link`, `docs-link`, `guide-link`, or `learn-link`.
+To indicate that the link points to an external resource, you can use `@trailingIcon` and assign it an icon name like `external-link`, `docs-link`, `guide-link`, or `learn-link`.
 
 ```handlebars
 {{!-- The Doc::ListContainer component is just to help the component render properly --}}

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -214,7 +214,7 @@ If you pass an `@href` argument, a link (`<a>` element) will be generated:
 </Doc::ListContainer>
 ```
 
-You can pass a `@trailingIcon` argument to indicate that the link points to an external resource:
+To indicate that the link points to an external resource you can use `@trailingIcon` and assign it an icon name like `external-link`, `docs-link`, `guide-link`, or `learn-link`.
 
 ```handlebars
 {{!-- The Doc::ListContainer component is just to help the component render properly --}}

--- a/website/docs/components/dropdown/partials/guidelines/guidelines.md
+++ b/website/docs/components/dropdown/partials/guidelines/guidelines.md
@@ -283,7 +283,7 @@ Be careful not to misuse or overuse the Generic ListItem. Relying on this escape
 Icons in ListItems are optional. Generally, we recommend letting the text speak for itself, but icons can add value in the following situations:
 
 - When they reinforce the content, e.g., `edit` for an edit or rename action. 
-- When using Interactive ListItems: using trailingIcons to indicate a link is external.
+- When using Interactive ListItems, a `trailingIcon` can indicate that a link is external.
 - When using Critical ListItems; read more about [how color blind users see critical actions](/components/dropdown?tab=accessibility) in our UIs.
 - To avoid inconsistent icon use within the same List. Instead use icons in all ListItems. Doing so keeps the text aligned so the eye can scan the list of options more easily.
 

--- a/website/docs/components/dropdown/partials/guidelines/guidelines.md
+++ b/website/docs/components/dropdown/partials/guidelines/guidelines.md
@@ -283,6 +283,7 @@ Be careful not to misuse or overuse the Generic ListItem. Relying on this escape
 Icons in ListItems are optional. Generally, we recommend letting the text speak for itself, but icons can add value in the following situations:
 
 - When they reinforce the content, e.g., `edit` for an edit or rename action. 
+- When using Interactive ListItems: using trailingIcons to indicate a link is external.
 - When using Critical ListItems; read more about [how color blind users see critical actions](/components/dropdown?tab=accessibility) in our UIs.
 - To avoid inconsistent icon use within the same List. Instead use icons in all ListItems. Doing so keeps the text aligned so the eye can scan the list of options more easily.
 
@@ -294,6 +295,7 @@ Use icons consistently and when they reinforce the content.
   <Doc::ListContainer class="hds-dropdown__list">
     <Hds::Dropdown::ListItem::Interactive @text="Rename cluster" @color="action" @icon="edit" />
     <Hds::Dropdown::ListItem::Interactive @text="Restore cluster" @color="action" @icon="reload" />
+    <Hds::Dropdown::ListItem::Interactive @text="Reference cluster" @color="action" @icon="github" @trailingIcon="external-link" />
     <Hds::Dropdown::ListItem::Separator />
     <Hds::Dropdown::ListItem::Interactive @text="Delete cluster" @color="critical" @icon="trash" />
   </Doc::ListContainer>


### PR DESCRIPTION
### :pushpin: Summary

This PR introduces the support for an additional trailing icon to the `Dropdown::ListItem::Interactive` subcomponent

### :hammer_and_wrench: Detailed description

In this PR I have:
- added support for `@trailingIcon` in the `Dropdown::ListItem::Interactive` sub-component
- added demo of combinations of `@icon`/`@trailingIcon` in showcase
- updated integration tests for `Dropdown::ListItem::Interactive`
- updated documentation

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3205

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
