### PR TITLE
Ember `FlightIcon` component - Remove extra whitespace

### DIFF
--- a/.changeset/slimy-bears-mix.md
+++ b/.changeset/slimy-bears-mix.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/ember-flight-icons": patch
+---
+
+`FlightIcon` component - Removed initial whitespace (newline) from template

--- a/packages/ember-flight-icons/src/components/flight-icon.hbs
+++ b/packages/ember-flight-icons/src/components/flight-icon.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <svg
   class={{this.classNames}}
   ...attributes


### PR DESCRIPTION
### :pushpin: Summary

While working on the `RichTooltip` I noticed that when the `FlightIcon` was used inside the inline text an extra space appeared between the previous `<span>` element and the icon. 

Looking at the template file, actually there was a newline before the actual code, that could be safely removed.

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed the extra whitespace (newline) in the template file for the `ember-flight-icon` component

### :camera_flash: Screenshots

**Before:**
<img width="400" alt="screenshot_3654" src="https://github.com/hashicorp/design-system/assets/686239/ca8f3db7-82c9-44f9-8a05-cd96300d7879">

**After:**
<img width="400" alt="screenshot_3655" src="https://github.com/hashicorp/design-system/assets/686239/30cbf17d-e3ce-4d43-90c1-bf874f56a5e0">


***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
