### PR TITLE
`Tooltip` - Fix max-width

### DIFF
--- a/.changeset/chilly-avocados-serve.md
+++ b/.changeset/chilly-avocados-serve.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Tooltip` - Fixed max-width applied to the "bubble" (it was `304px`, now is `280px` per design specs)

--- a/packages/components/src/styles/components/tooltip.scss
+++ b/packages/components/src/styles/components/tooltip.scss
@@ -75,7 +75,7 @@
     z-index: 1;
     // This needs to go here because Tippy generates a javascript
     // max-width on .tippy-box.
-    max-width: var(--token-tooltip-max-width);
+    max-width: calc(var(--token-tooltip-max-width) - 2 * var(--token-tooltip-padding-horizontal));
     // prevent this container from potentially inheriting other values
     // such as `white-space: nowrap` that would cause content overflow
     white-space: normal;

--- a/showcase/app/templates/components/tooltip.hbs
+++ b/showcase/app/templates/components/tooltip.hbs
@@ -198,7 +198,7 @@
     <SG.Item @label="text-align = left" {{style text-align="left"}}>
       <Shw::Outliner>
         <Hds::TooltipButton
-          @text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+          @text="Lorem ipsum dolor sit amet consectetur adipiscing elit"
           @placement="bottom"
           @extraTippyOptions={{hash showOnCreate=true}}
           aria-label="Information"
@@ -211,7 +211,7 @@
     <SG.Item @label="text-align = center" {{style text-align="center"}}>
       <Shw::Outliner>
         <Hds::TooltipButton
-          @text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+          @text="Lorem ipsum dolor sit amet consectetur adipiscing elit"
           @placement="bottom"
           @extraTippyOptions={{hash showOnCreate=true}}
           aria-label="Information"
@@ -224,7 +224,7 @@
     <SG.Item @label="text-align = right" {{style text-align="right"}}>
       <Shw::Outliner>
         <Hds::TooltipButton
-          @text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+          @text="Lorem ipsum dolor sit amet consectetur adipiscing elit"
           @placement="bottom"
           @extraTippyOptions={{hash showOnCreate=true}}
           aria-label="Information"


### PR DESCRIPTION
### :pushpin: Summary

While working on the `RichTooltip` I noticed that there is a difference between the (max) width of the `Tooltip` in Figma, and the `max-width` of the `Hds::Tooltip` in code. 

The difference is because the max width is applied to the content of the tooltip, and so we have to take into account also the padding of the "bubble" that acts as container.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated `max-width` property for the tooltip content to take into account the padding
- updated showcase to keep tooltips content on two lines

### :camera_flash: Screenshots

<img width="1778" alt="screenshot_3656" src="https://github.com/hashicorp/design-system/assets/686239/c43e0a4e-9476-443c-bdd4-5802f0c42d4d">

<img width="1786" alt="screenshot_3657" src="https://github.com/hashicorp/design-system/assets/686239/a578dd18-b1a7-4fa1-b7a6-12299babbe4c">

### :link: External links

Figma file: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=32036-51885&mode=design

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
