### PR TITLE
add image compression github action

### DIFF
--- a/.github/workflows/ci-compress-images.yml
+++ b/.github/workflows/ci-compress-images.yml
@@ -1,0 +1,29 @@
+name: Compress Images
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '00 23 * * 0'
+
+env:
+  NODE_VERSION: '20.x'
+
+jobs:
+  build:
+    name: Compress Images & Open PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Compress Images
+        id: calibre
+        uses: calibreapp/image-actions@790ef463cba7b26ed3b1c80c1449deb72d4c0bcc # main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          compressOnly: true
+      - name: Open a PR if images can be compressed
+        if: steps.calibre.outputs.markdown != ''
+        uses: peter-evans/create-pull-request@70a41aba780001da0a30141984ae2a0c95d8704e # v6.0.2
+        with:
+          title: 'Compressed Image Assets'
+          branch-suffix: timestamp
+          commit-message: 'compressed image assets'
+          body: ${{ steps.calibre.outputs.markdown }}


### PR DESCRIPTION
### :pushpin: Summary

Introduces a GitHub action using [calibreapp/image-actions](https://github.com/calibreapp/image-actions) that can be invoked to open a PR with optimized image assets.

### :hammer_and_wrench: Detailed description

For the moment this is more intended to be used to experiment with the right setup, so the action will only happen if it is invoked directly. Future options for this could include either running it on a schedule or having it run against PRs that change files in a specific directory (i.e. `/website`). The latter may prove most useful since otherwise there is no way to scope this action to a specific folder hence by default it'll try to compress images across the entire monorepo which may be undesirable depending on which file types it picks up.

### :link: External links

Jira ticket: [HDS-1353](https://hashicorp.atlassian.net/browse/HDS-1353)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1353]: https://hashicorp.atlassian.net/browse/HDS-1353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ