### PR TITLE
Adds WCAG 2.2 and removes SC 4.1.1

### DIFF
--- a/website/app/components/doc/wcag-list/index.js
+++ b/website/app/components/doc/wcag-list/index.js
@@ -502,6 +502,36 @@ const CRITERIA = [
   },
   {
     type: 'success-criteria',
+    id: 'wcag-2-4-11',
+    title: 'Focus Not Obscured (Minimum) (Level AA)',
+    number: '2.4.11',
+    url: 'https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html',
+    level: 'AA',
+    description:
+      'When a user interface component receives keyboard focus, the component is not entirely hidden due to author-created content.',
+  },
+  {
+    type: 'success-criteria',
+    id: 'wcag-2-4-12',
+    title: 'Focus Not Obscured (Enhanced) (Level AAA)',
+    number: '2.4.12',
+    url: 'https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-enhanced.html',
+    level: 'AAA',
+    description:
+      'When a user interface component receives keyboard focus, no part of the component is hidden by author-created content.',
+  },
+  {
+    type: 'success-criteria',
+    id: 'wcag-2-4-13',
+    title: 'Focus Appearance (Level AAA)',
+    number: '2.4.13',
+    url: 'https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance.html',
+    level: 'AAA',
+    description:
+      'When the keyboard focus indicator is visible, an area of the focus indicator meets all requirements.',
+  },
+  {
+    type: 'success-criteria',
     id: 'wcag-2-5-1',
     title: 'Pointer Gestures (Level A)',
     number: '2.5.1',
@@ -557,6 +587,26 @@ const CRITERIA = [
     url: 'https://www.w3.org/WAI/WCAG21/Understanding/concurrent-input-mechanisms.html',
     level: 'AAA',
     description: '',
+  },
+  {
+    type: 'success-criteria',
+    id: 'wcag-2-5-7',
+    title: 'Dragging Movements (Level AA)',
+    number: '2.5.7',
+    url: 'https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html',
+    level: 'AA',
+    description:
+      'All functionality that uses a dragging movement for operation can be achieved by a single pointer without dragging, unless dragging is essential or the functionality is determined by the user agent and not modified by the author.',
+  },
+  {
+    type: 'success-criteria',
+    id: 'wcag-2-5-8',
+    title: 'Target Size Minimum (Level AA)',
+    number: '2.5.8',
+    url: 'https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html',
+    level: 'AA',
+    description:
+      'The size of the target for pointer inputs is at least 24 by 24 CSS pixels, with a few exceptions.',
   },
   {
     type: 'success-criteria',
@@ -665,6 +715,16 @@ const CRITERIA = [
   },
   {
     type: 'success-criteria',
+    id: 'wcag-3-2-6',
+    title: 'Consistent Help (Level A)',
+    number: '3.2.6',
+    url: 'https://www.w3.org/WAI/WCAG21/Understanding/consistent-help.html',
+    level: 'A',
+    description:
+      'If a web page contains help mechanisms, and those help mechanisms are repeated on multiple web pages, the help mechanisms are consistent.',
+  },
+  {
+    type: 'success-criteria',
     id: 'wcag-3-3-1',
     title: 'Error Identification (Level A)',
     number: '3.3.1',
@@ -723,13 +783,32 @@ const CRITERIA = [
   },
   {
     type: 'success-criteria',
-    id: 'wcag-4-1-1',
-    title: 'Parsing (Level A)',
-    number: '4.1.1',
-    url: 'https://www.w3.org/WAI/WCAG21/Understanding/parsing.html',
+    id: 'wcag-3-3-7',
+    title: 'Redundant Entry (Level A)',
+    number: '3.3.7',
+    url: 'https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html',
     level: 'A',
     description:
-      'In content implemented using markup languages, elements have complete start and end tags, elements are nested according to their specifications, elements do not contain duplicate attributes, and any IDs are unique.',
+      'Information previously entered by or provided to the user that is required to be entered again in the same process is either auto-populated or available for the user to select',
+  },
+  {
+    type: 'success-criteria',
+    id: 'wcag-3-3-8',
+    title: 'Accessible Authentication (Minimum) (Level AA)',
+    number: '3.3.8',
+    url: 'https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html',
+    level: 'AA',
+    description:
+      'A cognitive function test (such as remembering a password or solving a puzzle) is not required for any step in an authentication process (with some exceptions).',
+  },
+  {
+    type: 'success-criteria',
+    id: 'wcag-3-3-9',
+    title: 'Accessible Authentication (Enhanced) (Level AAA)',
+    number: '3.3.9',
+    url: 'https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced.html',
+    level: 'AAA',
+    description: '',
   },
   {
     type: 'success-criteria',

--- a/website/docs/components/accordion/partials/accessibility/accessibility.md
+++ b/website/docs/components/accordion/partials/accessibility/accessibility.md
@@ -35,7 +35,7 @@ When `containsInteractive`, the focus will first move to the toggle button, then
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.4.3" "2.4.6" "2.4.7" "2.5.3" "3.2.1" "3.2.4" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.4.3" "2.4.6" "2.4.7" "2.5.3" "3.2.1" "3.2.4" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/alert/partials/accessibility/accessibility.md
+++ b/website/docs/components/alert/partials/accessibility/accessibility.md
@@ -16,7 +16,7 @@ Since alerts are not required to receive focus, it should not be required that t
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.2" "4.1.3" }} />
 
 ---
 

--- a/website/docs/components/button/partials/accessibility/accessibility.md
+++ b/website/docs/components/button/partials/accessibility/accessibility.md
@@ -22,7 +22,7 @@ Users with assistive technology (AT) or keyboard-only users rely on the semantic
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.4.7" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.4.7" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/flyout/partials/accessibility/accessibility.md
+++ b/website/docs/components/flyout/partials/accessibility/accessibility.md
@@ -15,7 +15,7 @@ The dismiss button should receive focus as the first interactive element in the 
 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.3.3" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.5" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.1.4" "2.4.2" "2.4.3" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.3.1" "3.3.2" "3.3.3" "3.3.4" "4.1.1" "4.1.2" "4.1.3" }} />
+<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.3.3" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.5" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.1.4" "2.4.2" "2.4.3" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.3.1" "3.3.2" "3.3.3" "3.3.4" "4.1.2" "4.1.3" }} />
 
 ---
 

--- a/website/docs/components/form/checkbox/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/checkbox/partials/accessibility/accessibility.md
@@ -26,7 +26,7 @@ If a link is used within a label, helper text, or error text, it will not be pre
 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/form/file-input/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/file-input/partials/accessibility/accessibility.md
@@ -8,7 +8,7 @@ When used as recommended, there should not be any WCAG conformance issues with t
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/form/masked-input/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/masked-input/partials/accessibility/accessibility.md
@@ -42,7 +42,7 @@ If a link is used within a label, helper text, or error text, it will not be pre
 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/form/primitives/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/primitives/partials/accessibility/accessibility.md
@@ -12,7 +12,7 @@ If a link is used within a label, helper text, or error text, it will not be pre
 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
@@ -41,7 +41,7 @@ Navigate between Radio Cards. As the card is focused it also becomes selected.
 This section is for reference only, some descriptions have been truncated for brevity.
 
 This component intends to conform to the following WCAG Success Criteria:
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/form/radio/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio/partials/accessibility/accessibility.md
@@ -23,7 +23,7 @@
 This section is for reference only, some descriptions have been truncated for brevity.
 
 This component intends to conform to the following WCAG Success Criteria:
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/form/select/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/select/partials/accessibility/accessibility.md
@@ -20,7 +20,7 @@
 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/form/text-input/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/text-input/partials/accessibility/accessibility.md
@@ -20,7 +20,7 @@ If a link is used within a label, helper text, or error text, it will not be pre
 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/form/textarea/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/textarea/partials/accessibility/accessibility.md
@@ -20,7 +20,7 @@ If a link is used within a label, helper text, or error text, it will not be pre
 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/form/toggle/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/toggle/partials/accessibility/accessibility.md
@@ -14,7 +14,7 @@ If a link is used within a label, helper text, or error text, it will not be pre
 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/modal/partials/accessibility/accessibility.md
+++ b/website/docs/components/modal/partials/accessibility/accessibility.md
@@ -25,7 +25,7 @@ If the Modal body contains interactive content, such as input fields, the first 
 
 This section is for reference only, some descriptions have been truncated for brevity. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.3.3" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.5" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.1.4" "2.4.2" "2.4.3" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.3.1" "3.3.2" "3.3.3" "3.3.4" "4.1.1" "4.1.2" "4.1.3" }} />
+<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.3.3" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.5" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.1.4" "2.4.2" "2.4.3" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.3.1" "3.3.2" "3.3.3" "3.3.4" "4.1.2" "4.1.3" }} />
 
 ---
 

--- a/website/docs/components/pagination/partials/accessibility/accessibility.md
+++ b/website/docs/components/pagination/partials/accessibility/accessibility.md
@@ -29,7 +29,7 @@ Trigger button to navigate to another page.
 
 This section is for reference only. This component intends to conform to the following WCAG success criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.2" "4.1.3" }} />
 
 ---
 

--- a/website/docs/components/reveal/partials/accessibility/accessibility.md
+++ b/website/docs/components/reveal/partials/accessibility/accessibility.md
@@ -8,7 +8,7 @@ Reveal is conformant if the text does not change when the user interacts with th
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.4.3" "2.4.6" "2.4.7" "2.5.3" "3.2.1" "3.2.4" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.1.1" "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.4.3" "2.4.6" "2.4.7" "2.5.3" "3.2.1" "3.2.4" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/segmented-group/partials/accessibility/accessibility.md
+++ b/website/docs/components/segmented-group/partials/accessibility/accessibility.md
@@ -8,7 +8,7 @@ You must make sure each `TextInput` or `Select` segment has an accessible name, 
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.3.4" "1.3.5" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "2.4.6" "2.4.7" "3.2.1" "3.2.2" "3.2.4" "3.3.1" "3.3.2" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/table/partials/accessibility/accessibility.md
+++ b/website/docs/components/table/partials/accessibility/accessibility.md
@@ -34,7 +34,7 @@ When providing additional or alternative styles to the table element, do not cha
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.1.4" "2.4.3" "2.4.7" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.1.4" "2.4.3" "2.4.7" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/tabs/partials/accessibility/accessibility.md
+++ b/website/docs/components/tabs/partials/accessibility/accessibility.md
@@ -41,7 +41,7 @@ Move to interactive element within the content area
 
 ## Applicable WCAG Success Criteria
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.4.6" "2.4.7" "3.2.1" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.4" "1.4.10" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.1.2" "2.4.6" "2.4.7" "3.2.1" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/tag/partials/accessibility/accessibility.md
+++ b/website/docs/components/tag/partials/accessibility/accessibility.md
@@ -13,7 +13,7 @@ When used as recommended, there should not be any accessibility issues with this
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.4.1" "1.4.3" "1.4.4" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.4.7" "3.2.1" "4.1.1" "4.1.2" }} />
+<Doc::WcagList @criteriaList={{array "1.4.1" "1.4.3" "1.4.4" "1.4.11" "1.4.12" "1.4.13" "2.1.1" "2.4.7" "3.2.1" "4.1.2" }} />
 
 ---
 

--- a/website/docs/components/toast/partials/accessibility/accessibility.md
+++ b/website/docs/components/toast/partials/accessibility/accessibility.md
@@ -12,7 +12,7 @@ Animations on Toasts will not take place if the user has `prefers-reduced-motion
 
 This section is for reference only. This component intends to conform to the following WCAG Success Criteria:
 
-<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.1" "4.1.2" "4.1.3" }} />
+<Doc::WcagList @criteriaList={{array "1.3.1" "1.3.2" "1.4.1" "1.4.3" "1.4.10" "1.4.11" "1.4.12" "2.1.1" "2.1.2" "2.2.1" "2.5.3" "4.1.2" "4.1.3" }} />
 
 ---
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the WCAG Success Criteria list to include WCAG 2.2 Success Criteria and removes SC 4.1.1, which was deprecated.


<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2808](https://hashicorp.atlassian.net/browse/HDS-2808)


***
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2808]: https://hashicorp.atlassian.net/browse/HDS-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ