### PR TITLE
Adjust guidance for forms in Modal

### DIFF
--- a/website/docs/components/modal/index.js
+++ b/website/docs/components/modal/index.js
@@ -25,4 +25,9 @@ export default class Index extends Component {
   deactivateModal(modal) {
     this[modal] = false;
   }
+
+  @action
+  submitForm() {
+    this.formModalActive = false;
+  }
 }

--- a/website/docs/components/modal/partials/code/how-to-use.md
+++ b/website/docs/components/modal/partials/code/how-to-use.md
@@ -26,7 +26,11 @@ When a Modal is opened with the keyboard, the focus is automatically set to the 
 />
 
 {{#if this.basicModalActive}}
-  <Hds::Modal id="basic-modal" @onClose={{fn this.deactivateModal "basicModalActive"}} as |M|>
+  <Hds::Modal
+    id="basic-modal"
+    @onClose={{fn this.deactivateModal "basicModalActive"}}
+    as |M|
+  >
     <M.Header>
       Modal title
     </M.Header>
@@ -42,7 +46,9 @@ When a Modal is opened with the keyboard, the focus is automatically set to the 
 
 ### Form within a Modal dialog
 
-If a Modal dialog contains interactive elements, such as a form, the initial focus should be set on the first input, which is the first focusable element within the form. This can be achieved by setting the `autofocus` property on the first form element.
+If a Modal dialog presents a form, the initial focus should be set on the first input, as the first focusable element in the form. This can be achieved by setting the `autofocus` property on the first form input.
+
+The `<form>` element should be placed in the `Hds::Modal::Body` subcomponent. We also recommend to associate it to the submit button using the `form` attribute, as shown below.
 
 When the Modal dialog contains information that might be lost on close, use a confirmation message before discarding it.
 
@@ -63,7 +69,7 @@ When the Modal dialog contains information that might be lost on close, use a co
       Why do you want to leave the beta?
     </M.Header>
     <M.Body>
-      <form name="leaving-beta-form">
+      <form id="leaving-beta-form" {{on "submit" (fn this.submitForm)}}>
         <Hds::Form::Select::Field autofocus @width="100%" as |F|>
           <F.Label>Select the primary reason</F.Label>
           <F.Options>
@@ -77,9 +83,7 @@ When the Modal dialog contains information that might be lost on close, use a co
     </M.Body>
     <M.Footer as |F|>
       <Hds::ButtonSet>
-        <Hds::Button type="submit" @text="Leave Beta"
-          {{on "click" (fn this.deactivateModal "formModalActive")}}
-        />
+        <Hds::Button type="submit" form="leaving-beta-form" @text="Leave Beta" />
         <Hds::Button type="button" @text="Cancel" @color="secondary"
           {{on "click" F.close}}
         />


### PR DESCRIPTION
### :pushpin: Summary

Follow up on a (2 months old now 🙈) discussion on Slack around a recommended pattern for forms in Modal dialogs. The guidance could potentially be applied to the Flyout component, but I restrained from doing so as we don't recommend using forms in Flyouts.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3144](https://hashicorp.atlassian.net/browse/HDS-3144)

***
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3144]: https://hashicorp.atlassian.net/browse/HDS-3144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ