### PR TITLE
Add examples of `Tag` components with long text to the showcase

### DIFF
--- a/showcase/app/templates/components/tag.hbs
+++ b/showcase/app/templates/components/tag.hbs
@@ -42,6 +42,8 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H2>States</Shw::Text::H2>
 
   <Shw::Grid @columns={{4}} {{style width="max-content"}} as |SG|>
@@ -51,6 +53,8 @@
       </SG.Item>
     {{/each}}
   </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H2>Colors</Shw::Text::H2>
 
@@ -94,6 +98,8 @@
       {{/each}}
     </Shw::Grid>
   {{/each}}
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H2>Containers</Shw::Text::H2>
 

--- a/showcase/app/templates/components/tag.hbs
+++ b/showcase/app/templates/components/tag.hbs
@@ -26,9 +26,19 @@
       <Hds::Tag @text="My link tag" @route="components.tag" />
     </SF.Item>
   </Shw::Flex>
-  <Shw::Flex as |SF|>
+
+  <Shw::Flex @label="Inline with other text" as |SF|>
     <SF.Item>
-      <p>This is a paragraph: <Hds::Tag @text="My text tag" /></p>
+      <Hds::Text::Body @size="200" @tag="p">This is a paragraph: <Hds::Tag @text="My text tag" /></Hds::Text::Body>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex @label="With long text" as |SF|>
+    <SF.Item {{style width="200px"}}>
+      <Hds::Tag @text="This is a very long text that should go on multiple lines" @onDismiss={{this.noop}} />
+    </SF.Item>
+    <SF.Item {{style width="200px"}}>
+      <Hds::Tag @text="This is a very long text that should go on multiple lines" />
     </SF.Item>
   </Shw::Flex>
 
@@ -97,6 +107,7 @@
             <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
             <Hds::Tag @text="My slightly longer tag" @onDismiss={{this.noop}} />
             <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
+            <Hds::Tag @text="This is a very long text that should go on multiple lines" @onDismiss={{this.noop}} />
           </div>
         </SG.Item>
       {{/each}}


### PR DESCRIPTION
### :pushpin: Summary

While reviewing the `SuperSelect` component I noticed that we don't have examples of the `Tag` instances with long text in the showcase.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added `Tag` examples with long text
- added dividers for better visual scanning

_As you can see, the background of the button overlaps the border of the `Tag`. Unfortunately there's not much we can do, because the width of the button is fixed so it can't be half of a circle._

👉 👉 👉 Preview: https://hds-showcase-git-tag-showcase-long-text-hashicorp.vercel.app/components/tag

### :camera_flash: Screenshots

<img width="1037" alt="screenshot_3714" src="https://github.com/hashicorp/design-system/assets/686239/61a7261e-fc2f-4b38-85bb-595b4b5a4380">
<img width="475" alt="screenshot_3713" src="https://github.com/hashicorp/design-system/assets/686239/b4e23652-5338-465d-ad5b-0b6dfb29f353">

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
