### PR TITLE
update hero links

### DIFF
--- a/website/app/templates/index.hbs
+++ b/website/app/templates/index.hbs
@@ -11,16 +11,21 @@
         consistent, accessible, and delightful product experiences.</p>
       <div class="doc-page-home__hero-links">
         <Doc::LinkWithIcon
-          @route="show"
-          @model="getting-started/for-designers"
-          @label="Start designing with Helios"
+          @href="https://go.hashi.co/hds-rollout"
+          @label="Helios Roadmap"
           @icon="arrow-right"
           @isAnimated={{true}}
         />
         <Doc::LinkWithIcon
           @route="show"
-          @model="getting-started/for-engineers"
-          @label="Install Helios in your project"
+          @model="whats-new/release-notes"
+          @label="Release Notes"
+          @icon="arrow-right"
+          @isAnimated={{true}}
+        />
+        <Doc::LinkWithIcon
+          @href="https://go.hashi.co/hds-feedback"
+          @label="Share Feedback"
           @icon="arrow-right"
           @isAnimated={{true}}
         />

--- a/website/app/templates/index.hbs
+++ b/website/app/templates/index.hbs
@@ -11,12 +11,6 @@
         consistent, accessible, and delightful product experiences.</p>
       <div class="doc-page-home__hero-links">
         <Doc::LinkWithIcon
-          @href="https://go.hashi.co/hds-rollout"
-          @label="Helios Roadmap"
-          @icon="arrow-right"
-          @isAnimated={{true}}
-        />
-        <Doc::LinkWithIcon
           @route="show"
           @model="whats-new/release-notes"
           @label="Release Notes"
@@ -24,9 +18,15 @@
           @isAnimated={{true}}
         />
         <Doc::LinkWithIcon
+          @href="https://go.hashi.co/hds-rollout"
+          @label="Helios Roadmap"
+          @icon="external-link"
+          @isAnimated={{true}}
+        />
+        <Doc::LinkWithIcon
           @href="https://go.hashi.co/hds-feedback"
           @label="Share Feedback"
-          @icon="arrow-right"
+          @icon="external-link"
           @isAnimated={{true}}
         />
       </div>


### PR DESCRIPTION
### :pushpin: Summary

Update the "hero" links on the Helios home page to be more useful for where we're at with Helios at the moment.

### :camera_flash: Screenshots

<img width="587" alt="Screenshot 2024-05-03 at 05 24 01" src="https://github.com/hashicorp/design-system/assets/1672302/7832e43b-9032-498f-b7ea-68b097af1d09">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3299](https://hashicorp.atlassian.net/browse/HDS-3299)

***


[HDS-3299]: https://hashicorp.atlassian.net/browse/HDS-3299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ