### PR TITLE
Removed outdated comments in CSS code

### DIFF
--- a/packages/components/src/styles/@hashicorp/design-system-power-select-overrides.scss
+++ b/packages/components/src/styles/@hashicorp/design-system-power-select-overrides.scss
@@ -120,7 +120,6 @@
       &:focus,
       &.mock-focus {
         border-color: var(--token-color-focus-action-internal);
-        // Notice: Safari doesn't apply a rounded border
         outline: 3px solid var(--token-color-focus-action-external);
         outline-offset: 0;
       }

--- a/packages/components/src/styles/components/form/select.scss
+++ b/packages/components/src/styles/components/form/select.scss
@@ -38,7 +38,6 @@
   &:focus,
   &.mock-focus {
     border-color: var(--token-color-focus-action-internal);
-    // Notice: Safari doesn't apply a rounded border
     outline: 3px solid var(--token-color-focus-action-external);
     outline-offset: 0;
   }

--- a/packages/components/src/styles/components/form/text-input.scss
+++ b/packages/components/src/styles/components/form/text-input.scss
@@ -38,7 +38,6 @@
   &:focus,
   &.mock-focus {
     border-color: var(--token-color-focus-action-internal);
-    // Notice: Safari doesn't apply a rounded border
     outline: 3px solid var(--token-color-focus-action-external);
     outline-offset: 0;
   }

--- a/packages/components/src/styles/components/form/textarea.scss
+++ b/packages/components/src/styles/components/form/textarea.scss
@@ -40,7 +40,6 @@
   &:focus,
   &.mock-focus {
     border-color: var(--token-color-focus-action-internal);
-    // Notice: Safari doesn't apply a rounded border
     outline: 3px solid var(--token-color-focus-action-external);
     outline-offset: 0;
   }


### PR DESCRIPTION
### :pushpin: Summary

Safari started to [support for outline following the curve of border-radius](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes#:~:text=support%20for%20outline%20following%20the%20curve%20of%20border%2Dradius.) since version 16.4, I think we can remove the comments now.

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
