### PR TITLE
`AppFooter`: Add `ExtraBefore` & `ExtraAfter` examples to docs

### DIFF
--- a/website/app/styles/pages/components/app-footer.scss
+++ b/website/app/styles/pages/components/app-footer.scss
@@ -11,4 +11,11 @@
     padding: 8px;
     background: var(--token-color-palette-neutral-700);
   }
+
+  .doc-app-footer-demo-custom-content-layout {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    outline: 1px dashed #ccc;
+  }
 }

--- a/website/docs/components/app-footer/partials/code/component-api.md
+++ b/website/docs/components/app-footer/partials/code/component-api.md
@@ -18,7 +18,7 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
     The `AppFooter::Link` component (see below).
   </C.Property>
   <C.Property @name="<[AF].Item>" @type="yielded component">
-    The generic `AppFooter::Item` component (see below).
+    The `AppFooter::Item` component which is used for custom non-link content (see below).
   </C.Property>
   <C.Property @name="<[AF].ExtraAfter>" @type="yielded component">
     Container that yields its content after the `<ul>` list of links and items.

--- a/website/docs/components/app-footer/partials/code/how-to-use.md
+++ b/website/docs/components/app-footer/partials/code/how-to-use.md
@@ -37,6 +37,7 @@ You can add custom links in addition to or instead of including `LegalLinks`.
 ### Item
 
 `Item` components can be used to include meta text or other non-link content.
+
 ```handlebars
 <Hds::AppFooter as |AF|>
   <AF.Item>
@@ -51,7 +52,44 @@ You can add custom links in addition to or instead of including `LegalLinks`.
 </Hds::AppFooter>
 ```
 
+### ExtraBefore & ExtraAfter
+
+Custom content can be added either before or after the `AppFooter` main content. The layout of this content is inline with other content by default.
+
+```handlebars
+<Hds::AppFooter as |AF|>
+  <AF.ExtraBefore>
+    <Doc::Placeholder @text="Extra Content Before" @height="2em" {{style width="fit-content" color="#636363" background="#ffd6d6"}} />
+  </AF.ExtraBefore>
+  <AF.LegalLinks />
+  <AF.ExtraAfter>
+    <Doc::Placeholder @text="Extra Content After" @height="2em" {{style width="fit-content" color="#636363" background="#ffd6d6"}} />
+  </AF.ExtraAfter>
+</Hds::AppFooter>
+```
+
+#### Custom layout
+
+Add your own styles to customize the layout of the extra content areas.
+
+```handlebars
+<Hds::AppFooter as |AF|>
+  <AF.ExtraBefore>
+    <div class="doc-app-footer-demo-custom-content-layout">
+      <Doc::Placeholder @text="Extra Content Before" @height="2em" {{style width="fit-content" color="#636363" background="#ffd6d6"}} />
+    </div>
+  </AF.ExtraBefore>
+  <AF.LegalLinks />
+  <AF.ExtraAfter>
+    <div class="doc-app-footer-demo-custom-content-layout">
+      <Doc::Placeholder @text="Extra Content After" @height="2em" {{style width="fit-content" color="#636363" background="#ffd6d6"}} />
+    </div>
+  </AF.ExtraAfter>
+</Hds::AppFooter>
+```
+
 ### Theme
+
 Both a `light` and  a `dark` theme are included.
 
 ```handlebars


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds examples demoing use of `ExtraBefore` & `ExtraAfter` content areas to the `AppFooter` documentation. Also removes/replaces one reference to "generic" content.

**Preview:** https://hds-website-git-update-appfooter-docs-hashicorp.vercel.app/components/app-footer?tab=code#extrabefore--extraafter

<!-- 
### :hammer_and_wrench: Detailed description

If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots

Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
* Related Terraform PR: https://github.com/hashicorp/atlas/pull/19399

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets]~~(https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
