### PR TITLE
`AppFooter`: Update placeholders in examples to remove inline styles

### DIFF
--- a/website/app/styles/pages/components/app-footer.scss
+++ b/website/app/styles/pages/components/app-footer.scss
@@ -18,4 +18,9 @@
     width: 100%;
     outline: 1px dashed #ccc;
   }
+
+  .doc-app-footer-demo-placeholder {
+    color: #636363;
+    background: #ffd6d6;
+  }
 }

--- a/website/docs/components/app-footer/partials/code/how-to-use.md
+++ b/website/docs/components/app-footer/partials/code/how-to-use.md
@@ -59,11 +59,11 @@ Custom content can be added either before or after the `AppFooter` main content.
 ```handlebars
 <Hds::AppFooter as |AF|>
   <AF.ExtraBefore>
-    <Doc::Placeholder @text="Extra Content Before" @height="2em" {{style width="fit-content" color="#636363" background="#ffd6d6"}} />
+    <Doc::Placeholder @text="Extra Content Before" @height="2em" @width="fit-content" class="doc-app-footer-demo-placeholder" />
   </AF.ExtraBefore>
   <AF.LegalLinks />
   <AF.ExtraAfter>
-    <Doc::Placeholder @text="Extra Content After" @height="2em" {{style width="fit-content" color="#636363" background="#ffd6d6"}} />
+    <Doc::Placeholder @text="Extra Content After" @height="2em" @width="fit-content" class="doc-app-footer-demo-placeholder" />
   </AF.ExtraAfter>
 </Hds::AppFooter>
 ```
@@ -76,13 +76,13 @@ Add your own styles to customize the layout of the extra content areas.
 <Hds::AppFooter as |AF|>
   <AF.ExtraBefore>
     <div class="doc-app-footer-demo-custom-content-layout">
-      <Doc::Placeholder @text="Extra Content Before" @height="2em" {{style width="fit-content" color="#636363" background="#ffd6d6"}} />
+      <Doc::Placeholder @text="Extra Content Before" @height="2em" @width="fit-content" class="doc-app-footer-demo-placeholder" />
     </div>
   </AF.ExtraBefore>
   <AF.LegalLinks />
   <AF.ExtraAfter>
     <div class="doc-app-footer-demo-custom-content-layout">
-      <Doc::Placeholder @text="Extra Content After" @height="2em" {{style width="fit-content" color="#636363" background="#ffd6d6"}} />
+      <Doc::Placeholder @text="Extra Content After" @height="2em" @width="fit-content" class="doc-app-footer-demo-placeholder" />
     </div>
   </AF.ExtraAfter>
 </Hds::AppFooter>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates placeholders used in AppFooter example code to remove inline styles.

<!-- 
### :hammer_and_wrench: Detailed description

If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser

### :link: External links

Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]
-->

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets]~~(https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
