### PR TITLE
Add scoll to top feature to website

### DIFF
--- a/website/app/components/doc/page/content.hbs
+++ b/website/app/components/doc/page/content.hbs
@@ -6,3 +6,4 @@
 <div class={{this.classNames}} ...attributes>
   {{yield}}
 </div>
+<Doc::ScrollToTop />

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -1,5 +1,11 @@
 {{#if this.isButtonVisible}}
-  <button aria-label="Scroll back to top" class="doc-scroll-to-top" type="button" tabindex="0" {{on "click" this.scrollToTop}}>
+  <button
+    aria-label="Scroll back to top"
+    class="doc-scroll-to-top"
+    type="button"
+    tabindex="0"
+    {{on "click" this.scrollToTop}}
+  >
     <FlightIcon @name="arrow-up" @color="white" @size="24" />
   </button>
 {{/if}}

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -1,5 +1,5 @@
 {{#if this.isButtonVisible}}
-  <button class="doc-scroll-to-top" type="button" {{on "click" this.scrollToTop}}>
+  <button class="doc-scroll-to-top" type="button" tabindex="0" {{on "click" this.scrollToTop}}>
     <FlightIcon @name="arrow-up" @color="white" @size="24" />
   </button>
 {{/if}}

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -1,5 +1,5 @@
 {{#if this.isButtonVisible}}
-  <button class="doc-scroll-to-top" type="button" tabindex="0" {{on "click" this.scrollToTop}}>
+  <button aria-label="Back to Top" class="doc-scroll-to-top" type="button" tabindex="0" {{on "click" this.scrollToTop}}>
     <FlightIcon @name="arrow-up" @color="white" @size="24" />
   </button>
 {{/if}}

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -1,5 +1,5 @@
 {{#if this.isButtonVisible}}
-  <button aria-label="Back to Top" class="doc-scroll-to-top" type="button" tabindex="0" {{on "click" this.scrollToTop}}>
+  <button aria-label="Scroll back to top" class="doc-scroll-to-top" type="button" tabindex="0" {{on "click" this.scrollToTop}}>
     <FlightIcon @name="arrow-up" @color="white" @size="24" />
   </button>
 {{/if}}

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -1,11 +1,9 @@
-{{#if this.isButtonVisible}}
-  <button
-    aria-label="Scroll back to top"
-    class="doc-scroll-to-top"
-    type="button"
-    tabindex="0"
-    {{on "click" this.scrollToTop}}
-  >
-    <FlightIcon @name="arrow-up" @color="white" @size="24" @isInlineBlock={{false}} />
-  </button>
-{{/if}}
+<button
+  aria-label="Scroll back to top"
+  class="doc-scroll-to-top {{if this.isButtonVisible 'doc-scroll-to-top--is-visible'}}"
+  type="button"
+  tabindex="0"
+  {{on "click" this.scrollToTop}}
+>
+  <FlightIcon @name="arrow-up" @color="white" @size="24" @isInlineBlock={{false}} />
+</button>

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -6,6 +6,6 @@
     tabindex="0"
     {{on "click" this.scrollToTop}}
   >
-    <FlightIcon @name="arrow-up" @color="white" @size="24" />
+    <FlightIcon @name="arrow-up" @color="white" @size="24" @isInlineBlock={{false}} />
   </button>
 {{/if}}

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -1,3 +1,5 @@
-<button class="doc-scroll-to-top" type="button" {{on "click" this.scrollToTop}}>
-  <FlightIcon @name="arrow-up" @color="white" @size="24" />
-</button>
+{{#if this.isButtonVisible}}
+  <button class="doc-scroll-to-top" type="button" {{on "click" this.scrollToTop}}>
+    <FlightIcon @name="arrow-up" @color="white" @size="24" />
+  </button>
+{{/if}}

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -2,7 +2,7 @@
   aria-label="Scroll back to top"
   class="doc-scroll-to-top {{if this.isButtonVisible 'doc-scroll-to-top--is-visible'}}"
   type="button"
-  tabindex="0"
+  tabindex={{if this.isButtonVisible 0 -1}}
   {{on "click" this.scrollToTop}}
 >
   <FlightIcon @name="arrow-up" @color="white" @size="24" @isInlineBlock={{false}} />

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -1,0 +1,3 @@
+<button class="doc-scroll-to-top" type="button" {{on "click" this.scrollToTop}}>
+  <FlightIcon @name="arrow-up" @color="white" @size="24" />
+</button>

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -14,45 +14,39 @@ export default class DocScrollToTopComponent extends Component {
 
   constructor() {
     super(...arguments);
-    this.addScrollListener();
+    if (!this.fastboot.isFastBoot) {
+      this.addScrollListener();
+    }
   }
 
   willDestroy() {
     super.willDestroy(...arguments);
-    this.removeScrollListener();
+    if (!this.fastboot.isFastBoot) {
+      this.removeScrollListener();
+    }
   }
 
   @action
   scrollToTop() {
-    if (!this.fastboot.isFastBoot) {
-      window.scrollTo({
-        top: 0,
-        behavior: 'smooth',
-      });
-    }
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
   @action
   checkScroll() {
-    if (window.scrollY > 200) {
-      this.isButtonVisible = true;
-    } else {
-      this.isButtonVisible = false;
-    }
+    this.isButtonVisible = window.scrollY > 200;
   }
 
   @action
   addScrollListener() {
     if (!this.fastboot.isFastBoot) {
-      this.scrollFunction = () => this.checkScroll();
-      window.addEventListener('scroll', this.scrollFunction);
+      window.addEventListener('scroll', this.checkScroll);
     }
   }
 
   @action
   removeScrollListener() {
     if (!this.fastboot.isFastBoot) {
-      window.removeEventListener('scroll', this.scrollFunction);
+      window.removeEventListener('scroll', this.checkScroll);
     }
   }
 }

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class DocScrollToTopComponent extends Component {
+  @action scrollToTop() {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  }
+}

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -38,15 +38,11 @@ export default class DocScrollToTopComponent extends Component {
 
   @action
   addScrollListener() {
-    if (!this.fastboot.isFastBoot) {
-      window.addEventListener('scroll', this.checkScroll);
-    }
+    window.addEventListener('scroll', this.checkScroll);
   }
 
   @action
   removeScrollListener() {
-    if (!this.fastboot.isFastBoot) {
-      window.removeEventListener('scroll', this.checkScroll);
-    }
+    window.removeEventListener('scroll', this.checkScroll);
   }
 }

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -5,12 +5,54 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class DocScrollToTopComponent extends Component {
-  @action scrollToTop() {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    });
+  @service fastboot;
+  @tracked isButtonVisible = false;
+
+  constructor() {
+    super(...arguments);
+    this.addScrollListener();
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.removeScrollListener();
+  }
+
+  @action
+  scrollToTop() {
+    if (!this.fastboot.isFastBoot) {
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      });
+    }
+  }
+
+  @action
+  checkScroll() {
+    if (window.scrollY > 200) {
+      this.isButtonVisible = true;
+    } else {
+      this.isButtonVisible = false;
+    }
+  }
+
+  @action
+  addScrollListener() {
+    if (!this.fastboot.isFastBoot) {
+      this.scrollFunction = () => this.checkScroll();
+      window.addEventListener('scroll', this.scrollFunction);
+    }
+  }
+
+  @action
+  removeScrollListener() {
+    if (!this.fastboot.isFastBoot) {
+      window.removeEventListener('scroll', this.scrollFunction);
+    }
   }
 }

--- a/website/app/styles/doc-components/index.scss
+++ b/website/app/styles/doc-components/index.scss
@@ -20,6 +20,7 @@
 @import "link-with-icon";
 @import "meta-row";
 @import "placeholder";
+@import "scroll-to-top";
 @import "table-of-contents";
 @import "token-preview";
 @import "tokens-list";

--- a/website/app/styles/doc-components/scroll-to-top.scss
+++ b/website/app/styles/doc-components/scroll-to-top.scss
@@ -8,22 +8,22 @@
   width: 44px;
   height: 44px;
   padding: 8px 8px 4px 8px;
-  background-color: rgba(52, 53, 54, 0.8);
-  box-shadow: 0px 8px 12px 0px rgba(37, 38, 45, 0.08);
+  background-color: rgba(52, 53, 54, 80%);
   border: 2px solid transparent;
   border-radius: 50%;
+  box-shadow: 0 8px 12px 0 rgba(37, 38, 45, 8%);
   cursor: pointer;
   transition: bottom 150ms linear;
 
   &:hover {
-    background-color: rgba(29, 30, 31, 0.8);
-    box-shadow: 0px 16px 28px 0px rgba(37, 38, 45, 0.12);
     bottom: 43px;
+    background-color: rgba(29, 30, 31, 80%);
+    box-shadow: 0 16px 28px 0 rgba(37, 38, 45, 12%);
   }
 
   &:focus {
     border-color: white;
     outline: none;
-    box-shadow: 0px 0px 0px 3px var(--doc-focus-ring-color);
+    box-shadow: 0 0 0 3px var(--doc-focus-ring-color);
   }
 }

--- a/website/app/styles/doc-components/scroll-to-top.scss
+++ b/website/app/styles/doc-components/scroll-to-top.scss
@@ -1,5 +1,3 @@
-@use "../typography/mixins" as *;
-
 .doc-scroll-to-top {
   position: fixed;
   right: 40px;
@@ -7,7 +5,7 @@
   z-index: 99;
   width: 44px;
   height: 44px;
-  padding: 8px 8px 4px 8px;
+  padding: 8px;
   background-color: rgba(52, 53, 54, 80%);
   border: 2px solid transparent;
   border-radius: 50%;
@@ -16,14 +14,13 @@
   transition: bottom 150ms linear;
 
   &:hover {
-    bottom: 43px;
     background-color: rgba(29, 30, 31, 80%);
     box-shadow: 0 16px 28px 0 rgba(37, 38, 45, 12%);
+    transform: translate3d(0, -3px, 0);
   }
 
   &:focus {
-    border-color: white;
-    outline: none;
-    box-shadow: 0 0 0 3px var(--doc-focus-ring-color);
+    border-color: #fff;
+    outline: 3px solid var(--doc-focus-ring-color);
   }
 }

--- a/website/app/styles/doc-components/scroll-to-top.scss
+++ b/website/app/styles/doc-components/scroll-to-top.scss
@@ -12,8 +12,7 @@
   box-shadow: 0 8px 12px 0 rgba(37, 38, 45, 8%);
   cursor: pointer;
   opacity: 0;
-  transition: bottom 150ms linear;
-  transition: opacity .5s ease-in-out;
+  transition: bottom 150ms ease-in-out, opacity .5s ease-in-out;
 
   &:hover {
     background-color: rgba(29, 30, 31, 80%);

--- a/website/app/styles/doc-components/scroll-to-top.scss
+++ b/website/app/styles/doc-components/scroll-to-top.scss
@@ -1,0 +1,21 @@
+@use "../typography/mixins" as *;
+
+.doc-scroll-to-top {
+  position: fixed;
+  right: 40px;
+  bottom: 40px;
+  z-index: 99;
+  width: 50px;
+  height: 50px;
+  padding: 10px;
+  background-color: black;
+  border: 2px solid transparent;
+  border-radius: 50%;
+  cursor: pointer;
+
+  &:focus {
+    border-color: white;
+    outline: none;
+    box-shadow: 0 0 0 3px var(--doc-focus-ring-color), 0 0 10px rgba(0, 0, 0, 20%);
+  }
+}

--- a/website/app/styles/doc-components/scroll-to-top.scss
+++ b/website/app/styles/doc-components/scroll-to-top.scss
@@ -5,17 +5,25 @@
   right: 40px;
   bottom: 40px;
   z-index: 99;
-  width: 50px;
-  height: 50px;
-  padding: 10px;
-  background-color: black;
+  width: 44px;
+  height: 44px;
+  padding: 8px 8px 4px 8px;
+  background-color: rgba(52, 53, 54, 0.8);
+  box-shadow: 0px 8px 12px 0px rgba(37, 38, 45, 0.08);
   border: 2px solid transparent;
   border-radius: 50%;
   cursor: pointer;
+  transition: bottom 150ms linear;
+
+  &:hover {
+    background-color: rgba(29, 30, 31, 0.8);
+    box-shadow: 0px 16px 28px 0px rgba(37, 38, 45, 0.12);
+    bottom: 43px;
+  }
 
   &:focus {
     border-color: white;
     outline: none;
-    box-shadow: 0 0 0 3px var(--doc-focus-ring-color), 0 0 10px rgba(0, 0, 0, 20%);
+    box-shadow: 0px 0px 0px 3px var(--doc-focus-ring-color);
   }
 }

--- a/website/app/styles/doc-components/scroll-to-top.scss
+++ b/website/app/styles/doc-components/scroll-to-top.scss
@@ -12,7 +12,10 @@
   box-shadow: 0 8px 12px 0 rgba(37, 38, 45, 8%);
   cursor: pointer;
   opacity: 0;
-  transition: bottom 150ms ease-in-out, opacity .5s ease-in-out;
+  transition-timing-function: ease-in-out;
+  transition-duration: 150ms;
+  transition-property: transform, opacity;
+  pointer-events: none;
 
   &:hover {
     background-color: rgba(29, 30, 31, 80%);
@@ -28,4 +31,5 @@
 
 .doc-scroll-to-top--is-visible {
   opacity: 1;
+  pointer-events: initial;
 }

--- a/website/app/styles/doc-components/scroll-to-top.scss
+++ b/website/app/styles/doc-components/scroll-to-top.scss
@@ -6,7 +6,7 @@
   width: 44px;
   height: 44px;
   padding: 8px;
-  background-color: rgba(52, 53, 54, 80%);
+  background-color: var(--doc-color-gray-100);
   border: 2px solid transparent;
   border-radius: 50%;
   box-shadow: 0 8px 12px 0 rgba(37, 38, 45, 8%);
@@ -18,7 +18,7 @@
   pointer-events: none;
 
   &:hover {
-    background-color: rgba(29, 30, 31, 80%);
+    background-color: var(--doc-color-gray-200);
     box-shadow: 0 16px 28px 0 rgba(37, 38, 45, 12%);
     transform: translate3d(0, -3px, 0);
   }
@@ -30,6 +30,6 @@
 }
 
 .doc-scroll-to-top--is-visible {
-  opacity: 1;
+  opacity: 0.9; // we want to peek the content below the button
   pointer-events: initial;
 }

--- a/website/app/styles/doc-components/scroll-to-top.scss
+++ b/website/app/styles/doc-components/scroll-to-top.scss
@@ -11,7 +11,9 @@
   border-radius: 50%;
   box-shadow: 0 8px 12px 0 rgba(37, 38, 45, 8%);
   cursor: pointer;
+  opacity: 0;
   transition: bottom 150ms linear;
+  transition: opacity .5s ease-in-out;
 
   &:hover {
     background-color: rgba(29, 30, 31, 80%);
@@ -23,4 +25,8 @@
     border-color: #fff;
     outline: 3px solid var(--doc-focus-ring-color);
   }
+}
+
+.doc-scroll-to-top--is-visible {
+  opacity: 1;
 }


### PR DESCRIPTION
### :pushpin: Summary

This PR introduces a feature to the website that affords users a button that can be clicked to return to the top of the current page. 

### :hammer_and_wrench: Detailed description

Implementation choices:
* Only appears after user has scrolled some (configurable) distance down the page
* Appears on any page using the `<Doc::Page::Content>` component, which is pretty much every page except the homepage

### :camera_flash: Screenshots

![scroll](https://github.com/hashicorp/design-system/assets/1672302/d40b0af5-abc9-4c6b-9bc6-1c32fedc5313)


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3298](https://hashicorp.atlassian.net/browse/HDS-3298)
[Figma file](https://www.figma.com/file/Ky0qWjvHZR3je1lCBlzNB1/HDS-website?type=design&node-id=1305-116325&mode=design&t=CgwVTcyQ84atmUzD-0)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3298]: https://hashicorp.atlassian.net/browse/HDS-3298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ