### PR TITLE
Fathom Event Tracking

### DIFF
--- a/website/app/components/doc/link-with-icon/index.hbs
+++ b/website/app/components/doc/link-with-icon/index.hbs
@@ -4,13 +4,26 @@
 }}
 
 {{#if @route}}
-  <LinkTo class={{this.classNames}} @route={{@route}} @models={{this.models}} ...attributes>
+  <LinkTo
+    class={{this.classNames}}
+    @route={{@route}}
+    @models={{this.models}}
+    ...attributes
+    {{on "click" (fn this.eventTracking.trackEvent @eventName)}}
+  >
     {{@label}}
     <FlightIcon class="doc-link-with-icon__icon" @name={{@icon}} />
   </LinkTo>
 {{/if}}
 {{#if @href}}
-  <a class={{this.classNames}} href={{@href}} target="_blank" rel="noopener noreferrer" ...attributes>
+  <a
+    class={{this.classNames}}
+    href={{@href}}
+    target="_blank"
+    rel="noopener noreferrer"
+    {{on "click" (fn this.eventTracking.trackEvent @eventName)}}
+    ...attributes
+  >
     {{@label}}
     <FlightIcon class="doc-link-with-icon__icon" @name={{@icon}} />
   </a>

--- a/website/app/components/doc/link-with-icon/index.js
+++ b/website/app/components/doc/link-with-icon/index.js
@@ -4,8 +4,11 @@
  */
 
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class DocLinkWithIconComponent extends Component {
+  @service eventTracking;
+
   get models() {
     // we need to use this trick to overcome the problem of `<LinkTo>` going beserk if we pass
     // a `@model` argument which is undefined (while an empty `@models` array is OK)

--- a/website/app/services/event-tracking.js
+++ b/website/app/services/event-tracking.js
@@ -1,0 +1,16 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
+export default class EventService extends Service {
+  @service fastboot;
+
+  @action
+  trackEvent(eventName) {
+    // Only attempt to do something if we are in the right environment
+    if (!this.fastboot.isFastBoot && window.fathom && eventName) {
+      // https://usefathom.com/docs/features/events
+      window.fathom.trackEvent(eventName);
+    }
+  }
+}

--- a/website/app/templates/index.hbs
+++ b/website/app/templates/index.hbs
@@ -47,6 +47,7 @@
             @fillParent={{true}}
             @isAnimated={{true}}
             aria-label={{concat "Explore " card.title ": " card.description}}
+            @eventName={{concat "Card - " card.title}}
           />
         </li>
       {{/each}}

--- a/website/app/templates/index.hbs
+++ b/website/app/templates/index.hbs
@@ -16,18 +16,21 @@
           @label="Release Notes"
           @icon="arrow-right"
           @isAnimated={{true}}
+          @eventName="Hero - Release Notes"
         />
         <Doc::LinkWithIcon
           @href="https://go.hashi.co/hds-rollout"
           @label="Helios Roadmap"
           @icon="external-link"
           @isAnimated={{true}}
+          @eventName="Hero - Roadmap"
         />
         <Doc::LinkWithIcon
           @href="https://go.hashi.co/hds-feedback"
           @label="Share Feedback"
           @icon="external-link"
           @isAnimated={{true}}
+          @eventName="Hero - Feedback"
         />
       </div>
     </div>


### PR DESCRIPTION
### :pushpin: Summary

This PR creates an event tracking service to send events to Fathom and wires up a few proposed events as a starting point

### :hammer_and_wrench: Detailed description

Under the hood this is built using a Service which can be injected wherever we want to track events. I tried to keep the naming relatively agnostic as, in theory, Fathom could be replaced at some point.

### :camera_flash: Screenshots
<img width="1062" alt="Screenshot 2024-05-17 at 14 32 51" src="https://github.com/hashicorp/design-system/assets/1672302/43bedc9d-fe9f-498d-a6cb-afd5fabaa5f8">


***


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
