### PR TITLE
`Dropdown::ListItem::Checkmark` - Fix icon spacing

### DIFF
--- a/.changeset/chilled-news-sort.md
+++ b/.changeset/chilled-news-sort.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Dropdown::ListItem::Checkmark` - Fixed issue with leading icon spacing

--- a/packages/components/src/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/checkmark.hbs
@@ -21,7 +21,7 @@
     aria-selected={{if @selected "true" "false"}}
   >
     {{#if @icon}}
-      <span class="hds-dropdown-list-item__interactive-icon">
+      <span class="hds-dropdown-list-item__interactive-icon hds-dropdown-list-item__interactive-icon--leading">
         <FlightIcon @name={{@icon}} @isInlineBlock={{false}} />
       </span>
     {{/if}}


### PR DESCRIPTION
### :hammer_and_wrench: Detailed description

In this PR I have:
- added missing CSS class to the `hds-dropdown-list-item__interactive-icon` element
    - the regression happened in https://github.com/hashicorp/design-system/pull/2042

### :camera_flash: Screenshots

Fixed:
<img width="653" alt="screenshot_3746" src="https://github.com/hashicorp/design-system/assets/686239/0c52ff0f-fd07-4f24-9844-aaa6ac38ecdb">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3304

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
