### PR TITLE
clear search-related query params from sidebar links

### DIFF
--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -13,7 +13,7 @@
           class="doc-table-of-contents__link"
           @route="show"
           @model={{item.pageURL}}
-          @query={{hash tab=null}}
+          @query={{hash tab=null searchQuery=null selectedIconSize=null}}
           @current-when={{"show"}}
         >
           {{#if item.pageAttributes.navigation.label}}


### PR DESCRIPTION
### :pushpin: Summary

Fixes a bug where icon and token search query params were persisting between transitions

### :hammer_and_wrench: Detailed description
I tried a couple of solutions but this one seemed to be the most reliable. It manually ensures there are no query params for search set on the links generated in the sidenav and follows a similar change we made to avoid the same issue with query params for tabs in https://github.com/hashicorp/design-system/pull/868.

#### To test
* Navigate to [icon library](https://hds-website-qes3qx8t2-hashicorp.vercel.app/)
* Enter a search term and/or change the icon size. Something to add query params.
* Navigate to another page in the sidebar
* Navigate back to icon library
* Confirm search query and icon size query params have reset

### :camera_flash: Screenshots

#### Before
![before](https://github.com/hashicorp/design-system/assets/1672302/73bfb59b-1523-48ef-a4e1-7ddbf21d2125)

#### After
![after](https://github.com/hashicorp/design-system/assets/1672302/42d2ca25-b3f3-4623-923b-3edd8019c276)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3311](https://hashicorp.atlassian.net/browse/HDS-3311)


[HDS-3311]: https://hashicorp.atlassian.net/browse/HDS-3311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ