### PR TITLE
`ButtonSet`:  Convert to TypeScript (HDS-2686)

### DIFF
--- a/.changeset/strange-hairs-judge.md
+++ b/.changeset/strange-hairs-judge.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`ButtonSet` - Converted component to TypeScript

--- a/packages/components/src/components/hds/button-set/index.hbs
+++ b/packages/components/src/components/hds/button-set/index.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/button-set/index.ts
+++ b/packages/components/src/components/hds/button-set/index.ts
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import templateOnlyComponent from '@ember/component/template-only';
+import Component from '@glimmer/component';
 
-const HdsButtonSetComponent = templateOnlyComponent();
+interface HdsButtonSetSignature {
+  Blocks: { default: [] };
+  Element: HTMLDivElement;
+}
 
-export default HdsButtonSetComponent;
+export default class HdsButtonSetComponent extends Component<HdsButtonSetSignature> {}

--- a/packages/components/src/components/hds/button-set/index.ts
+++ b/packages/components/src/components/hds/button-set/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import templateOnlyComponent from '@ember/component/template-only';
+
+const HdsButtonSetComponent = templateOnlyComponent();
+
+export default HdsButtonSetComponent;

--- a/packages/components/src/components/hds/button-set/index.ts
+++ b/packages/components/src/components/hds/button-set/index.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-
+import TemplateOnlyComponent from '@ember/component/template-only';
 interface HdsButtonSetSignature {
   Blocks: { default: [] };
   Element: HTMLDivElement;
 }
+const HdsButtonSetComponent = TemplateOnlyComponent<HdsButtonSetSignature>();
 
-export default class HdsButtonSetComponent extends Component<HdsButtonSetSignature> {}
+export default HdsButtonSetComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -18,6 +18,7 @@ import type HdsAppFooterStatusLinkComponent from './components/hds/app-footer/st
 import type HdsBadgeComponent from './components/hds/badge';
 import type HdsBadgeCountComponent from './components/hds/badge-count';
 import type HdsButtonComponent from './components/hds/button';
+import type HdsButtonSetComponent from './components/hds/button-set';
 import type HdsAppFrameComponent from './components/hds/app-frame';
 import type HdsAppFrameFooterComponent from './components/hds/app-frame/parts/footer';
 import type HdsAppFrameHeaderComponent from './components/hds/app-frame/parts/header';
@@ -136,6 +137,11 @@ export default interface HdsComponentsRegistry {
   'Hds::Button': typeof HdsButtonComponent;
   'hds/button': typeof HdsButtonComponent;
   HdsButton: typeof HdsButtonComponent;
+
+  // ButtonSet
+  'Hds::ButtonSet': typeof HdsButtonSetComponent;
+  'hds/button-set': typeof HdsButtonSetComponent;
+  HdsButtonSet: typeof HdsButtonSetComponent;
 
   // Card
   'Hds::Card': typeof HdsCardContainerComponent;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR converts the ButtonSet component to TypeScript.

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

- Jira ticket: [HDS-2686](https://hashicorp.atlassian.net/browse/HDS-2686)

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2686]: https://hashicorp.atlassian.net/browse/HDS-2686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ