### PR TITLE
Standardize type declarations for existing components

### DIFF
--- a/.changeset/lemon-masks-carry.md
+++ b/.changeset/lemon-masks-carry.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Alert`, `Badge`, `BadgeCount`, `Button`, `Card::Container`, `DisclosurePrimitive`, `DismissButton`, `IconTile`, `Interactive`, `Link::Inline`, `Link::Standalone`, `Tag`, `Text` - Standardized class names and signatures
+

--- a/packages/components/src/components/hds/alert/index.ts
+++ b/packages/components/src/components/hds/alert/index.ts
@@ -60,7 +60,7 @@ export interface HdsAlertSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsAlertIndexComponent extends Component<HdsAlertSignature> {
+export default class HdsAlertComponent extends Component<HdsAlertSignature> {
   @tracked role = 'alert';
   @tracked ariaLabelledBy?: string;
 

--- a/packages/components/src/components/hds/alert/index.ts
+++ b/packages/components/src/components/hds/alert/index.ts
@@ -12,7 +12,7 @@ import { tracked } from '@glimmer/tracking';
 import { HdsAlertColorValues, HdsAlertTypeValues } from './types.ts';
 
 import type { ComponentLike, WithBoundArgs } from '@glint/template';
-import type HdsButtonIndexComponent from '../button';
+import type HdsButtonComponent from '../button';
 import type HdsLinkStandaloneComponent from '../link/standalone';
 import type { HdsYieldSignature } from '../yield';
 import type { HdsAlertColors, HdsAlertTypes } from './types.ts';
@@ -53,7 +53,7 @@ export interface HdsAlertSignature {
           typeof HdsLinkStandaloneComponent,
           'size'
         >;
-        Button?: WithBoundArgs<typeof HdsButtonIndexComponent, 'size'>;
+        Button?: WithBoundArgs<typeof HdsButtonComponent, 'size'>;
       }
     ];
   };

--- a/packages/components/src/components/hds/badge-count/index.ts
+++ b/packages/components/src/components/hds/badge-count/index.ts
@@ -24,17 +24,17 @@ export const DEFAULT_SIZE = HdsBadgeCountSizeValues.Medium;
 export const DEFAULT_TYPE = HdsBadgeCountTypeValues.Filled;
 export const DEFAULT_COLOR = HdsBadgeCountColorValues.Neutral;
 
-interface HdsBadgeCountIndexSignature {
+interface HdsBadgeCountSignature {
   Args: {
-    text: string;
     size?: HdsBadgeSizes;
     type?: HdsBadgeTypes;
     color?: HdsBadgeCountColors;
+    text: string;
   };
   Element: HTMLDivElement;
 }
 
-export default class HdsBadgeCountIndexComponent extends Component<HdsBadgeCountIndexSignature> {
+export default class HdsBadgeCountComponent extends Component<HdsBadgeCountSignature> {
   /**
    * Sets the size for the component
    * Accepted sizes: small, medium, large

--- a/packages/components/src/components/hds/badge/index.ts
+++ b/packages/components/src/components/hds/badge/index.ts
@@ -5,6 +5,7 @@
 
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+
 import {
   HdsBadgeColorValues,
   HdsBadgeSizeValues,
@@ -22,17 +23,17 @@ export const DEFAULT_COLOR = HdsBadgeColorValues.Neutral;
 
 export interface HdsBadgeSignature {
   Args: {
-    text: string;
-    color?: HdsBadgeColors;
-    icon?: string | null;
-    isIconOnly?: boolean;
     size?: HdsBadgeSizes;
     type?: HdsBadgeTypes;
+    color?: HdsBadgeColors;
+    text: string;
+    icon?: string | null;
+    isIconOnly?: boolean;
   };
   Element: HTMLDivElement;
 }
 
-export default class HdsBadgeIndexComponent extends Component<HdsBadgeSignature> {
+export default class HdsBadgeComponent extends Component<HdsBadgeSignature> {
   /**
    * Sets the size for the component
    * Accepted values: small, medium, large

--- a/packages/components/src/components/hds/button/index.ts
+++ b/packages/components/src/components/hds/button/index.ts
@@ -26,13 +26,13 @@ export interface HdsButtonSignature {
     icon?: string;
     iconPosition?: HdsButtonIconPosition;
     isIconOnly?: boolean;
-    isInline?: boolean;
     isFullWidth?: boolean;
+    isInline?: boolean;
   };
   Element: HdsInteractiveSignature['Element'];
 }
 
-export default class HdsButtonIndexComponent extends Component<HdsButtonSignature> {
+export default class HdsButtonComponent extends Component<HdsButtonSignature> {
   /**
    * @param text
    * @type {string}

--- a/packages/components/src/components/hds/card/container.ts
+++ b/packages/components/src/components/hds/card/container.ts
@@ -33,13 +33,13 @@ export interface HdsCardContainerSignature {
     levelActive?: HdsCardLevel;
     levelHover?: HdsCardLevel;
     background?: HdsCardBackground;
-    overflow?: HdsCardOverflow;
     hasBorder?: boolean;
+    overflow?: HdsCardOverflow;
   };
-  Element: HTMLDivElement;
   Blocks: {
     default: [];
   };
+  Element: HTMLDivElement;
 }
 
 export default class HdsCardContainerComponent extends Component<HdsCardContainerSignature> {

--- a/packages/components/src/components/hds/dismiss-button/index.ts
+++ b/packages/components/src/components/hds/dismiss-button/index.ts
@@ -12,7 +12,7 @@ export interface HdsDismissButtonSignature {
   Element: HTMLButtonElement;
 }
 
-export default class HdsDismissButtonIndexComponent extends Component<HdsDismissButtonSignature> {
+export default class HdsDismissButtonComponent extends Component<HdsDismissButtonSignature> {
   /**
    * @param ariaLabel
    * @type {string}

--- a/packages/components/src/components/hds/icon-tile/index.ts
+++ b/packages/components/src/components/hds/icon-tile/index.ts
@@ -31,14 +31,14 @@ export interface HdsIconTileSignature {
   Args: {
     size?: HdsIconTileSizes;
     color?: HdsIconTileColors;
-    icon?: string | null;
     logo?: HdsIconTileProducts;
+    icon?: string | null;
     iconSecondary?: string;
   };
   Element: HTMLDivElement;
 }
 
-export default class HdsIconTileIndexComponent extends Component<HdsIconTileSignature> {
+export default class HdsIconTileComponent extends Component<HdsIconTileSignature> {
   /**
    * Sets the size for the component
    * Accepted values: small, medium, large

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -24,7 +24,7 @@ export interface HdsInteractiveSignature {
   Element: HTMLAnchorElement | HTMLButtonElement;
 }
 
-export default class HdsInteractiveIndexComponent extends Component<HdsInteractiveSignature> {
+export default class HdsInteractiveComponent extends Component<HdsInteractiveSignature> {
   /**
    * Determines if a @href value is "external" (it adds target="_blank" rel="noopener noreferrer")
    *

--- a/packages/components/src/components/hds/link/inline.ts
+++ b/packages/components/src/components/hds/link/inline.ts
@@ -18,11 +18,8 @@ export const COLORS: string[] = Object.values(HdsLinkColorValues);
 export interface HdsLinkInlineSignature {
   Args: HdsInteractiveSignature['Args'] & {
     color?: HdsLinkColors;
-    href?: string;
     icon?: string;
     iconPosition?: HdsLinkIconPositions;
-    isHrefExternal?: boolean;
-    isRouteExternal?: boolean;
   };
   Blocks: {
     default: [];

--- a/packages/components/src/components/hds/link/standalone.ts
+++ b/packages/components/src/components/hds/link/standalone.ts
@@ -20,14 +20,11 @@ import type {
 
 export interface HdsLinkStandaloneSignature {
   Args: HdsInteractiveSignature['Args'] & {
-    icon: string;
-    text: string;
-    color?: HdsLinkColors;
-    href?: string;
-    iconPosition?: HdsLinkIconPositions;
-    isHrefExternal?: boolean;
-    isRouteExternal?: boolean;
     size?: HdsLinkStandaloneSizes;
+    color?: HdsLinkColors;
+    text: string;
+    icon: string;
+    iconPosition?: HdsLinkIconPositions;
   };
   Element: HdsInteractiveSignature['Element'];
 }

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -13,18 +13,18 @@ import type { HdsInteractiveSignature } from '../interactive/';
 export const COLORS: string[] = Object.values(HdsTagColorValues);
 export const DEFAULT_COLOR = HdsTagColorValues.Primary;
 
-interface HdsTagIndexSignature {
+interface HdsTagSignature {
   Args: HdsInteractiveSignature['Args'] & {
+    color?: HdsTagColors;
     text: string;
     ariaLabel?: string;
-    color?: HdsTagColors;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onDismiss?: (event: MouseEvent, ...args: any[]) => void;
   };
   Element: HTMLSpanElement;
 }
 
-export default class HdsTagIndexComponent extends Component<HdsTagIndexSignature> {
+export default class HdsTagComponent extends Component<HdsTagSignature> {
   /**
    * @param onDismiss
    * @type {function}

--- a/packages/components/src/components/hds/text/body.ts
+++ b/packages/components/src/components/hds/text/body.ts
@@ -61,10 +61,10 @@ export const AVAILABLE_WEIGHTS_PER_SIZE: Record<
 export interface HdsTextBodySignature {
   Args: {
     size?: HdsTextBodySizes;
-    color?: string | HdsTextColors;
     tag?: HdsTextTags;
-    align?: HdsTextAligns;
     weight?: HdsTextBodyWeight;
+    align?: HdsTextAligns;
+    color?: string | HdsTextColors;
   };
   Element:
     | HTMLSpanElement

--- a/packages/components/src/components/hds/text/code.ts
+++ b/packages/components/src/components/hds/text/code.ts
@@ -55,10 +55,10 @@ export const AVAILABLE_WEIGHTS_PER_SIZE: Record<
 export interface HdsTextCodeSignature {
   Args: {
     size?: HdsTextCodeSizes;
-    color?: string | HdsTextColors;
     tag?: HdsTextTags;
-    align?: HdsTextAligns;
     weight?: HdsTextCodeWeight;
+    align?: HdsTextAligns;
+    color?: string | HdsTextColors;
   };
   Element:
     | HTMLSpanElement

--- a/packages/components/src/components/hds/text/display.ts
+++ b/packages/components/src/components/hds/text/display.ts
@@ -61,10 +61,10 @@ export const AVAILABLE_WEIGHTS_PER_SIZE: Record<
 export interface HdsTextDisplaySignature {
   Args: {
     size?: HdsTextSizes;
-    color?: string | HdsTextColors;
     tag?: HdsTextTags;
-    align?: HdsTextAligns;
     weight?: HdsTextDisplayWeight;
+    align?: HdsTextAligns;
+    color?: string | HdsTextColors;
   };
   Element:
     | HTMLSpanElement

--- a/packages/components/src/components/hds/text/index.ts
+++ b/packages/components/src/components/hds/text/index.ts
@@ -21,14 +21,14 @@ export const AVAILABLE_ALIGNS: string[] = Object.values(HdsTextAlignValues);
 // A union of all types in the HTMLElementTagNameMap interface
 type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
 
-export interface HdsTextIndexSignature {
+export interface HdsTextSignature {
   Args: {
     size: HdsTextSizes;
-    group: HdsTextGroups;
-    color?: string | HdsTextColors;
     tag?: HdsTextTags;
-    align?: HdsTextAligns;
     weight?: HdsTextWeights;
+    align?: HdsTextAligns;
+    color?: string | HdsTextColors;
+    group: HdsTextGroups;
   };
   Element: AvailableElements;
   Blocks: {
@@ -36,7 +36,7 @@ export interface HdsTextIndexSignature {
   };
 }
 
-export default class HdsTextIndexComponent extends Component<HdsTextIndexSignature> {
+export default class HdsTextComponent extends Component<HdsTextSignature> {
   /**
    * Get a tag to render based on the `@tag` argument passed or the value of `this.size` (via mapping)
    *

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import type HdsAlertIndexComponent from './components/hds/alert';
+import type HdsAlertComponent from './components/hds/alert';
 import type HdsAlertDescriptionComponent from './components/hds/alert/description';
 import type HdsAlertTitleComponent from './components/hds/alert/title';
 import type HdsBadgeIndexComponent from './components/hds/badge';
@@ -30,9 +30,9 @@ import type HdsLinkToQueryHelper from './helpers/hds-link-to-query';
 
 export default interface HdsComponentsRegistry {
   // Alert
-  'Hds::Alert': typeof HdsAlertIndexComponent;
-  'hds/alert': typeof HdsAlertIndexComponent;
-  HdsAlert: typeof HdsAlertIndexComponent;
+  'Hds::Alert': typeof HdsAlertComponent;
+  'hds/alert': typeof HdsAlertComponent;
+  HdsAlert: typeof HdsAlertComponent;
 
   'Hds::Alert::Description': typeof HdsAlertDescriptionComponent;
   'hds/alert/description': typeof HdsAlertDescriptionComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -6,7 +6,7 @@
 import type HdsAlertComponent from './components/hds/alert';
 import type HdsAlertDescriptionComponent from './components/hds/alert/description';
 import type HdsAlertTitleComponent from './components/hds/alert/title';
-import type HdsBadgeIndexComponent from './components/hds/badge';
+import type HdsBadgeComponent from './components/hds/badge';
 import type HdsBadgeCountIndexComponent from './components/hds/badge-count';
 import type HdsButtonComponent from './components/hds/button';
 import type HdsCardContainerComponent from './components/hds/card/container.ts';
@@ -43,9 +43,9 @@ export default interface HdsComponentsRegistry {
   HdsAlertTitle: typeof HdsAlertTitleComponent;
 
   // Badge
-  'Hds::Badge': typeof HdsBadgeIndexComponent;
-  'hds/badge': typeof HdsBadgeIndexComponent;
-  HdsBadge: typeof HdsBadgeIndexComponent;
+  'Hds::Badge': typeof HdsBadgeComponent;
+  'hds/badge': typeof HdsBadgeComponent;
+  HdsBadge: typeof HdsBadgeComponent;
 
   // BadgeCount
   'Hds::Badge::Count': typeof HdsBadgeCountIndexComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -8,7 +8,7 @@ import type HdsAlertDescriptionComponent from './components/hds/alert/descriptio
 import type HdsAlertTitleComponent from './components/hds/alert/title';
 import type HdsBadgeIndexComponent from './components/hds/badge';
 import type HdsBadgeCountIndexComponent from './components/hds/badge-count';
-import type HdsButtonIndexComponent from './components/hds/button';
+import type HdsButtonComponent from './components/hds/button';
 import type HdsCardContainerComponent from './components/hds/card/container.ts';
 import type HdsDisclosurePrimitiveComponent from './components/hds/disclosure-primitive';
 import type HdsDismissButtonIndexComponent from './components/hds/dismiss-button';
@@ -53,9 +53,9 @@ export default interface HdsComponentsRegistry {
   HdsBadgeCount: typeof HdsBadgeCountIndexComponent;
 
   // Button
-  'Hds::Button': typeof HdsButtonIndexComponent;
-  'hds/button': typeof HdsButtonIndexComponent;
-  HdsButton: typeof HdsButtonIndexComponent;
+  'Hds::Button': typeof HdsButtonComponent;
+  'hds/button': typeof HdsButtonComponent;
+  HdsButton: typeof HdsButtonComponent;
 
   // Card
   'Hds::Card': typeof HdsCardContainerComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -11,7 +11,7 @@ import type HdsBadgeCountComponent from './components/hds/badge-count';
 import type HdsButtonComponent from './components/hds/button';
 import type HdsCardContainerComponent from './components/hds/card/container.ts';
 import type HdsDisclosurePrimitiveComponent from './components/hds/disclosure-primitive';
-import type HdsDismissButtonIndexComponent from './components/hds/dismiss-button';
+import type HdsDismissButtonComponent from './components/hds/dismiss-button';
 import type HdsIconTileIndexComponent from './components/hds/icon-tile';
 import type HdsInteractiveComponent from './components/hds/interactive';
 import type HdsLinkInlineComponent from './components/hds/link/inline';
@@ -68,9 +68,9 @@ export default interface HdsComponentsRegistry {
   HdsDisclosurePrimitive: typeof HdsDisclosurePrimitiveComponent;
 
   // Dismiss button
-  'Hds::DismissButton': typeof HdsDismissButtonIndexComponent;
-  'hds/dismiss-button': typeof HdsDismissButtonIndexComponent;
-  HdsDismissButton: typeof HdsDismissButtonIndexComponent;
+  'Hds::DismissButton': typeof HdsDismissButtonComponent;
+  'hds/dismiss-button': typeof HdsDismissButtonComponent;
+  HdsDismissButton: typeof HdsDismissButtonComponent;
 
   // IconTile
   'Hds::IconTile': typeof HdsIconTileIndexComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -18,7 +18,7 @@ import type HdsLinkInlineComponent from './components/hds/link/inline';
 import type HdsLinkStandaloneComponent from './components/hds/link/standalone';
 import type HdsRevealComponent from './components/hds/reveal';
 import type HdsRevealToggleButtonComponent from './components/hds/reveal/toggle/button';
-import type HdsTextIndexComponent from './components/hds/text';
+import type HdsTextComponent from './components/hds/text';
 import type HdsTextBodyComponent from './components/hds/text/body';
 import type HdsTextDisplayComponent from './components/hds/text/display';
 import type HdsTagComponent from './components/hds/tag';
@@ -102,9 +102,9 @@ export default interface HdsComponentsRegistry {
   HdsRevealToggleButtonComponent: typeof HdsRevealToggleButtonComponent;
 
   // Text
-  'Hds::Text': typeof HdsTextIndexComponent;
-  'hds/text': typeof HdsTextIndexComponent;
-  HdsText: typeof HdsTextIndexComponent;
+  'Hds::Text': typeof HdsTextComponent;
+  'hds/text': typeof HdsTextComponent;
+  HdsText: typeof HdsTextComponent;
   'Hds::Text::Body': typeof HdsTextBodyComponent;
   'hds/text/body': typeof HdsTextBodyComponent;
   HdsTextBody: typeof HdsTextBodyComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -13,7 +13,7 @@ import type HdsCardContainerComponent from './components/hds/card/container.ts';
 import type HdsDisclosurePrimitiveComponent from './components/hds/disclosure-primitive';
 import type HdsDismissButtonIndexComponent from './components/hds/dismiss-button';
 import type HdsIconTileIndexComponent from './components/hds/icon-tile';
-import type HdsInteractiveIndexComponent from './components/hds/interactive';
+import type HdsInteractiveComponent from './components/hds/interactive';
 import type HdsLinkInlineComponent from './components/hds/link/inline';
 import type HdsLinkStandaloneComponent from './components/hds/link/standalone';
 import type HdsRevealComponent from './components/hds/reveal';
@@ -78,9 +78,9 @@ export default interface HdsComponentsRegistry {
   HdsIconTile: typeof HdsIconTileIndexComponent;
 
   // Interactive
-  'Hds::Interactive': typeof HdsInteractiveIndexComponent;
-  'hds/interactive': typeof HdsInteractiveIndexComponent;
-  HdsInteractive: typeof HdsInteractiveIndexComponent;
+  'Hds::Interactive': typeof HdsInteractiveComponent;
+  'hds/interactive': typeof HdsInteractiveComponent;
+  HdsInteractive: typeof HdsInteractiveComponent;
 
   // Link Inline
   'Hds::Link::Inline': typeof HdsLinkInlineComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -12,7 +12,7 @@ import type HdsButtonComponent from './components/hds/button';
 import type HdsCardContainerComponent from './components/hds/card/container.ts';
 import type HdsDisclosurePrimitiveComponent from './components/hds/disclosure-primitive';
 import type HdsDismissButtonComponent from './components/hds/dismiss-button';
-import type HdsIconTileIndexComponent from './components/hds/icon-tile';
+import type HdsIconTileComponent from './components/hds/icon-tile';
 import type HdsInteractiveComponent from './components/hds/interactive';
 import type HdsLinkInlineComponent from './components/hds/link/inline';
 import type HdsLinkStandaloneComponent from './components/hds/link/standalone';
@@ -73,9 +73,9 @@ export default interface HdsComponentsRegistry {
   HdsDismissButton: typeof HdsDismissButtonComponent;
 
   // IconTile
-  'Hds::IconTile': typeof HdsIconTileIndexComponent;
-  'hds/icon-tile': typeof HdsIconTileIndexComponent;
-  HdsIconTile: typeof HdsIconTileIndexComponent;
+  'Hds::IconTile': typeof HdsIconTileComponent;
+  'hds/icon-tile': typeof HdsIconTileComponent;
+  HdsIconTile: typeof HdsIconTileComponent;
 
   // Interactive
   'Hds::Interactive': typeof HdsInteractiveComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -7,7 +7,7 @@ import type HdsAlertComponent from './components/hds/alert';
 import type HdsAlertDescriptionComponent from './components/hds/alert/description';
 import type HdsAlertTitleComponent from './components/hds/alert/title';
 import type HdsBadgeComponent from './components/hds/badge';
-import type HdsBadgeCountIndexComponent from './components/hds/badge-count';
+import type HdsBadgeCountComponent from './components/hds/badge-count';
 import type HdsButtonComponent from './components/hds/button';
 import type HdsCardContainerComponent from './components/hds/card/container.ts';
 import type HdsDisclosurePrimitiveComponent from './components/hds/disclosure-primitive';
@@ -48,9 +48,9 @@ export default interface HdsComponentsRegistry {
   HdsBadge: typeof HdsBadgeComponent;
 
   // BadgeCount
-  'Hds::Badge::Count': typeof HdsBadgeCountIndexComponent;
-  'hds/badge-count': typeof HdsBadgeCountIndexComponent;
-  HdsBadgeCount: typeof HdsBadgeCountIndexComponent;
+  'Hds::Badge::Count': typeof HdsBadgeCountComponent;
+  'hds/badge-count': typeof HdsBadgeCountComponent;
+  HdsBadgeCount: typeof HdsBadgeCountComponent;
 
   // Button
   'Hds::Button': typeof HdsButtonComponent;

--- a/website/docs/components/badge-count/partials/code/component-api.md
+++ b/website/docs/components/badge-count/partials/code/component-api.md
@@ -1,8 +1,8 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
   <C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
+  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
   <C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" }} @default="neutral"/>
   <C.Property @name="text" @type="string">
     Text value that renders in the Badge Count.

--- a/website/docs/components/badge/partials/code/component-api.md
+++ b/website/docs/components/badge/partials/code/component-api.md
@@ -1,9 +1,9 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" "highlight" "critical" "success" "warning" }} @default="neutral"/>
   <C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" "highlight" "critical" "success" "warning" }} @default="neutral"/>
   <C.Property @name="text" @type="string">
     The text of the Badge or value of the screen-reader only element if `isIconOnly` is set to `true`. If no text value is defined an error will be thrown.
   </C.Property>

--- a/website/docs/components/button/partials/code/component-api.md
+++ b/website/docs/components/button/partials/code/component-api.md
@@ -20,14 +20,14 @@
   <C.Property @name="isFullWidth" @type="boolean" @default="false">
     Indicates that a button should take up the full width of the parent container.
   </C.Property>
+  <C.Property @name="isInline" @type="boolean" @default="false">
+    If an `@isInline` parameter is provided, then the element will be displayed as `inline-block` (useful to achieve specific layouts). Otherwise, it will have a `block` layout.
+  </C.Property>
   <C.Property @name="href">
     URL parameter that is passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean" @default="false">
     Controls if the `<a>` link is external and so for security reasons we need to add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it.
-  </C.Property>
-  <C.Property @name="isInline" @type="boolean" @default="false">
-    If an `@isInline` parameter is provided, then the element will be displayed as `inline-block` (useful to achieve specific layouts). Otherwise, it will have a `block` layout.
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo/LinkToExternal>` component.

--- a/website/docs/components/icon-tile/partials/code/component-api.md
+++ b/website/docs/components/icon-tile/partials/code/component-api.md
@@ -2,6 +2,9 @@
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "waypoint" }} @default="neutral">
+    The `@color` parameter is overwritten if a `@logo` parameter is passed, in which case the product “brand“ color is used.
+  </C.Property>
   <C.Property @name="logo" @type="enum" @values={{array "hcp" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "vault-radar" "waypoint" }}>
     Use this parameter to show a product logo.
   </C.Property>
@@ -10,9 +13,6 @@
   </C.Property>
   <C.Property @name="iconSecondary" @type="string">
     Use this parameter to show an extra “badge” with icon on top of the tile. Any [icon](/icons/library) name is acceptable. The color of the secondary icon is predefined and can’t be changed.
-  </C.Property>
-  <C.Property @name="color" @type="enum" @values={{array "neutral" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "waypoint" }} @default="neutral">
-    The `@color` parameter is overwritten if a `@logo` parameter is passed, in which case the product “brand“ color is used.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/link/standalone/partials/code/component-api.md
+++ b/website/docs/components/link/standalone/partials/code/component-api.md
@@ -1,16 +1,16 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
+  <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
+  <C.Property @name="text" @required="true" @type="string">
+    The text of the link. If no text value is defined an error will be thrown.
+  </C.Property>
   <C.Property @name="icon" @required="true" @type="string">
     Use this parameter to show an icon. Any [icon](/icons/library) name is acceptable. `icon` is required to ensure the component conforms to accessibility best practices.
   </C.Property>
   <C.Property @name="iconPosition" @type="enum" @values={{array "leading" "trailing" }} @default="leading">
     Positions the icon before or after the text.
-  </C.Property>
-  <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
-  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
-  <C.Property @name="text" @required="true" @type="string">
-    The text of the link. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.

--- a/website/docs/components/tag/partials/code/component-api.md
+++ b/website/docs/components/tag/partials/code/component-api.md
@@ -1,6 +1,9 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary">
+    Sets the color of a link when `@route` or `@href` are set.
+  </C.Property>
   <C.Property @name="text" @type="string">
     The text of the Tag; or link text when the `@route` or `@href` are set. If no text value is defined an error will be thrown.
   </C.Property>
@@ -18,9 +21,6 @@
   </C.Property>
   <C.Property @name="isRouteExternal" @type="boolean" @default="false">
     Controls if the “LinkTo” is external to the Ember engine, in which case it will use a `<LinkToExternal>` for the @route.
-  </C.Property>
-  <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary">
-    Sets the color of a link when `@route` or `@href` are set.
   </C.Property>
   <C.Property @name="onDismiss" @type="function">
     Enables the dismiss feature. When a function is passed, the "dismiss" button is displayed.

--- a/website/docs/utilities/disclosure-primitive/partials/code/component-api.md
+++ b/website/docs/utilities/disclosure-primitive/partials/code/component-api.md
@@ -16,6 +16,9 @@
   <C.Property @name="[:content].close" @type="function">
     A function to programmatically close the DisclosurePrimitive.
   </C.Property>
+  <C.Property @name="isOpen" @default="false" @type="boolean">
+    Toggles the visibility of the content when the toggle button is interacted with. To display content on page load, set the value to true.
+  </C.Property>
   <C.Property @name="onClose" @type="function">
     A callback function invoked when the DisclosurePrimitive is closed (if provided).
   </C.Property>


### PR DESCRIPTION
### :pushpin: Summary

Per discussion and agreement today, I've reviewed components already converted to TypeScript to follow as much as possible the patterns we have agreed upon.

### :hammer_and_wrench: Detailed description

In this PR I have:

`Hds::Interactive` - Aligned type declaration to agreed patterns

- Updated class name (removed `Index` from the name)

`Hds::Button` - Aligned type declaration to agreed patterns

- Updated class name (removed `Index` from the name)
- Updated “Component API” documentation
- Sorted signature arguments to match documentation

`Hds::Alert` - Aligned type declaration to agreed patterns

- Updated class name (removed `Index` from the name)

`Hds::Badge` - Aligned type declaration to agreed patterns

- Updated class name (removed `Index` from the name)
- Updated “Component API” documentation to be consistent with `Button` and `BadgeCount`
- Sorted signature arguments to match documentation

`Hds::BadgeCount` - Aligned type declaration to agreed patterns

- Updated class and signature names (removed `Index` from the names)
- Updated “Component API” documentation to match signature and be consistent with `Button` and `Badge`

`Hds::Card::Container` - Aligned type declaration to agreed patterns

- Sorted signature arguments to match documentation

`Hds:DisclosurePrimitive` - Updated documentation

- Added missing `isOpen` argument to the "Component API" section

`Hds::DismissButton` - Aligned type declaration to agreed patterns

- Updated class name (removed `Index` from the name)

`Hds::IconTile` - Aligned type declaration to agreed patterns

- Updated class name (removed `Index` from the name)
- Updated “Component API” documentation
- Sorted signature arguments to match documentation

`Hds::Link::Inline` - Aligned type declaration to agreed patterns

- Remove extra args (they are already provided by the `Interactive` signature)

`Hds::Link::Standalone` - Aligned type declaration to agreed patterns

- Updated “Component API” documentation to be consistent with `Link::Inline` and `Badge/BadgeCount`
- Sorted signature arguments to match documentation
- Remove extra args (they are already provided by the `Interactive` signature)

`Hds::Tag` - Aligned type declaration to agreed patterns

- Updated class and signature names (removed `Index` from the names)
- Updated “Component API” documentation to match signature and be consistent with `Button`, `Badge`, etc.

`Hds::Text` - Aligned type declaration to agreed patterns for text components

- Updated class and signature names (removed `Index` from the names)
- Sorted signature arguments to match documentation

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
