### PR TITLE
`CopySnippet`: convert to TypeScript (HDS-2689)

### DIFF
--- a/.changeset/small-boats-tie.md
+++ b/.changeset/small-boats-tie.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`CopySnippet` - Converted component to TypeScript

--- a/packages/components/src/components/hds/copy/snippet/index.hbs
+++ b/packages/components/src/components/hds/copy/snippet/index.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/copy/snippet/index.hbs
+++ b/packages/components/src/components/hds/copy/snippet/index.hbs
@@ -10,7 +10,7 @@
   ...attributes
 >
   <Hds::Text::Code class="hds-copy-snippet__text" @tag="span" @size="100">
-    {{this.textToCopy}}
+    {{this.textToShow}}
   </Hds::Text::Code>
   <FlightIcon @name={{this.icon}} class="hds-copy-snippet__icon" />
 </button>

--- a/packages/components/src/components/hds/copy/snippet/index.hbs
+++ b/packages/components/src/components/hds/copy/snippet/index.hbs
@@ -10,7 +10,7 @@
   ...attributes
 >
   <Hds::Text::Code class="hds-copy-snippet__text" @tag="span" @size="100">
-    {{@textToCopy}}
+    {{this.textToCopy}}
   </Hds::Text::Code>
   <FlightIcon @name={{this.icon}} class="hds-copy-snippet__icon" />
 </button>

--- a/packages/components/src/components/hds/copy/snippet/index.ts
+++ b/packages/components/src/components/hds/copy/snippet/index.ts
@@ -23,10 +23,10 @@ interface HdsCopySnippetSignature {
   Args: {
     color?: HdsCopySnippetColors;
     isFullWidth?: boolean;
-    isTruncated?: boolean;
-    onError?: HdsClipboardModifierSignature['Args']['Named']['onError'];
-    onSuccess?: HdsClipboardModifierSignature['Args']['Named']['onSuccess'];
     textToCopy: HdsClipboardModifierSignature['Args']['Named']['text'];
+    isTruncated?: boolean;
+    onSuccess?: HdsClipboardModifierSignature['Args']['Named']['onSuccess'];
+    onError?: HdsClipboardModifierSignature['Args']['Named']['onError'];
   };
   Element: HTMLButtonElement;
 }
@@ -39,7 +39,7 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
    * @param textToCopy
    * @type {string | number | bigint | undefined} ???
    */
-  get textToCopy() {
+  get textToShow() {
     const { textToCopy = '' } = this.args;
 
     if (typeof textToCopy === 'string') {
@@ -132,8 +132,7 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
   }
 
   @action
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onSuccess(args: any) {
+  onSuccess(args: HdsClipboardModifierSignature['Args']['Named']['onSuccess']) {
     this.status = 'success';
     this.resetStatusDelayed();
 
@@ -145,8 +144,7 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
   }
 
   @action
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onError(args: any) {
+  onError(args: HdsClipboardModifierSignature['Args']['Named']['onError']) {
     this.status = 'error';
     this.resetStatusDelayed();
 

--- a/packages/components/src/components/hds/copy/snippet/index.ts
+++ b/packages/components/src/components/hds/copy/snippet/index.ts
@@ -9,9 +9,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { HdsCopySnippetColorValues } from './types';
 import type { HdsCopySnippetColors } from './types';
-import type { ModifierSignature } from '../../../../modifiers/hds-clipboard.ts';
+import type { HdsClipboardModifierSignature } from '../../../../modifiers/hds-clipboard.ts';
 
-// export const DEFAULT_COLOR = 'primary';
 export const DEFAULT_COLOR = HdsCopySnippetColorValues.Primary;
 export const COLORS: string[] = Object.values(HdsCopySnippetColorValues);
 
@@ -25,9 +24,9 @@ interface HdsCopySnippetSignature {
     color?: HdsCopySnippetColors;
     isFullWidth?: boolean;
     isTruncated?: boolean;
-    onError?: ModifierSignature['Args']['Named']['onError'];
-    onSuccess?: ModifierSignature['Args']['Named']['onSuccess'];
-    textToCopy: ModifierSignature['Args']['Named']['text'];
+    onError?: HdsClipboardModifierSignature['Args']['Named']['onError'];
+    onSuccess?: HdsClipboardModifierSignature['Args']['Named']['onSuccess'];
+    textToCopy: HdsClipboardModifierSignature['Args']['Named']['text'];
   };
   Element: HTMLButtonElement;
 }

--- a/packages/components/src/components/hds/copy/snippet/index.ts
+++ b/packages/components/src/components/hds/copy/snippet/index.ts
@@ -7,8 +7,8 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { HdsCopySnippetColorValues } from './types';
-import type { HdsCopySnippetColors } from './types';
+import { HdsCopySnippetColorValues } from './types.ts';
+import type { HdsCopySnippetColors } from './types.ts';
 import type { HdsClipboardModifierSignature } from '../../../../modifiers/hds-clipboard.ts';
 
 export const DEFAULT_COLOR = HdsCopySnippetColorValues.Primary;
@@ -34,6 +34,20 @@ interface HdsCopySnippetSignature {
 export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSignature> {
   @tracked status = DEFAULT_STATUS;
   @tracked timer: ReturnType<typeof setTimeout> | undefined;
+
+  /**
+   * @param textToCopy
+   * @type {string | number | bigint | undefined} ???
+   */
+  get textToCopy() {
+    const { textToCopy = '' } = this.args;
+
+    if (typeof textToCopy === 'string') {
+      return textToCopy;
+    } else {
+      return textToCopy.toString();
+    }
+  }
 
   /**
    * @param icon

--- a/packages/components/src/components/hds/copy/snippet/index.ts
+++ b/packages/components/src/components/hds/copy/snippet/index.ts
@@ -7,10 +7,14 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { HdsCopySnippetColorValues } from './types';
 import type { HdsCopySnippetColors } from './types';
+import type { ModifierSignature } from '../../../../modifiers/hds-clipboard.ts';
 
-export const DEFAULT_COLOR = 'primary';
-export const COLORS = ['primary', 'secondary'];
+// export const DEFAULT_COLOR = 'primary';
+export const DEFAULT_COLOR = HdsCopySnippetColorValues.Primary;
+export const COLORS: string[] = Object.values(HdsCopySnippetColorValues);
+
 export const DEFAULT_ICON = 'clipboard-copy';
 export const SUCCESS_ICON = 'clipboard-checked';
 export const ERROR_ICON = 'clipboard-x';
@@ -21,11 +25,9 @@ interface HdsCopySnippetSignature {
     color?: HdsCopySnippetColors;
     isFullWidth?: boolean;
     isTruncated?: boolean;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onError?: (...args: any[]) => void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onSuccess?: (...args: any[]) => void;
-    textToCopy: string;
+    onError?: ModifierSignature['Args']['Named']['onError'];
+    onSuccess?: ModifierSignature['Args']['Named']['onSuccess'];
+    textToCopy: ModifierSignature['Args']['Named']['text'];
   };
   Element: HTMLButtonElement;
 }

--- a/packages/components/src/components/hds/copy/snippet/index.ts
+++ b/packages/components/src/components/hds/copy/snippet/index.ts
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import type { HdsCopySnippetColors } from './types';
 
 export const DEFAULT_COLOR = 'primary';
 export const COLORS = ['primary', 'secondary'];
@@ -15,9 +16,23 @@ export const SUCCESS_ICON = 'clipboard-checked';
 export const ERROR_ICON = 'clipboard-x';
 export const DEFAULT_STATUS = 'idle';
 
-export default class HdsCopySnippetIndexComponent extends Component {
+interface HdsCopySnippetSignature {
+  Args: {
+    color?: HdsCopySnippetColors;
+    isFullWidth?: boolean;
+    isTruncated?: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onError?: (...args: any[]) => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onSuccess?: (...args: any[]) => void;
+    textToCopy: string;
+  };
+  Element: HTMLButtonElement;
+}
+
+export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSignature> {
   @tracked status = DEFAULT_STATUS;
-  @tracked timer;
+  @tracked timer: ReturnType<typeof setTimeout> | undefined;
 
   /**
    * @param icon
@@ -42,7 +57,7 @@ export default class HdsCopySnippetIndexComponent extends Component {
    * @description Determines the color of button to be used; acceptable values are `primary` and `secondary`
    */
   get color() {
-    let { color = DEFAULT_COLOR } = this.args;
+    const { color = DEFAULT_COLOR } = this.args;
 
     assert(
       `@color for "Hds::Copy::Snippet" must be one of the following: ${COLORS.join(
@@ -80,7 +95,7 @@ export default class HdsCopySnippetIndexComponent extends Component {
    * @return {string} The "class" attribute to apply to the component.
    */
   get classNames() {
-    let classes = ['hds-copy-snippet'];
+    const classes = ['hds-copy-snippet'];
 
     // add a class based on the @color argument
     classes.push(`hds-copy-snippet--color-${this.color}`);
@@ -102,11 +117,12 @@ export default class HdsCopySnippetIndexComponent extends Component {
   }
 
   @action
-  onSuccess(args) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onSuccess(args: any) {
     this.status = 'success';
     this.resetStatusDelayed();
 
-    let { onSuccess } = this.args;
+    const { onSuccess } = this.args;
 
     if (typeof onSuccess === 'function') {
       onSuccess(args);
@@ -114,11 +130,12 @@ export default class HdsCopySnippetIndexComponent extends Component {
   }
 
   @action
-  onError(args) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onError(args: any) {
     this.status = 'error';
     this.resetStatusDelayed();
 
-    let { onError } = this.args;
+    const { onError } = this.args;
 
     if (typeof onError === 'function') {
       onError(args);

--- a/packages/components/src/components/hds/copy/snippet/types.ts
+++ b/packages/components/src/components/hds/copy/snippet/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export enum HdsCopySnippetColorValues {
+  Primary = 'primary',
+  Secondary = 'secondary',
+}
+export type HdsCopySnippetColors = `${HdsCopySnippetColorValues}`;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -27,6 +27,7 @@ import type HdsAppFrameModalsComponent from './components/hds/app-frame/parts/mo
 import type HdsAppFrameSidebarComponent from './components/hds/app-frame/parts/sidebar';
 import type HdsCardContainerComponent from './components/hds/card/container.ts';
 import type HdsCopyButtonComponent from './components/hds/copy/button/index';
+import type HdsCopySnippetComponent from './components/hds/copy/snippet';
 import type HdsDisclosurePrimitiveComponent from './components/hds/disclosure-primitive';
 import type HdsDismissButtonComponent from './components/hds/dismiss-button';
 import type HdsIconTileComponent from './components/hds/icon-tile';
@@ -133,6 +134,10 @@ export default interface HdsComponentsRegistry {
   // Copy Button
   'Hds::Copy::Button': typeof HdsCopyButtonComponent;
   'hds/copy/button': typeof HdsCopyButtonComponent;
+
+  // Copy Snippet
+  'Hds::Copy::Snippet': typeof HdsCopySnippetComponent;
+  'hds/copy/snippet': typeof HdsCopySnippetComponent;
 
   // Disclosure Primitive
   'Hds::DisclosurePrimitive': typeof HdsDisclosurePrimitiveComponent;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR converts the `CopySnippet` to TypeScript.

The CopySnippet depends upon:
* https://github.com/hashicorp/design-system/pull/2120

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-2689](https://hashicorp.atlassian.net/browse/HDS-2689)

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2689]: https://hashicorp.atlassian.net/browse/HDS-2689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ