### PR TITLE
Fix issue with `TemplateOnlyComponent`

### DIFF
--- a/packages/components/src/components/hds/alert/description.ts
+++ b/packages/components/src/components/hds/alert/description.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import TemplateOnlyComponent from '@ember/component/template-only';
 
 export interface HdsAlertDescriptionSignature {
   Blocks: {
@@ -12,4 +12,7 @@ export interface HdsAlertDescriptionSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsAlertDescriptionComponent extends Component<HdsAlertDescriptionSignature> {}
+const HdsAlertDescriptionComponent =
+  TemplateOnlyComponent<HdsAlertDescriptionSignature>();
+
+export default HdsAlertDescriptionComponent;

--- a/packages/components/src/components/hds/alert/title.ts
+++ b/packages/components/src/components/hds/alert/title.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import TemplateOnlyComponent from '@ember/component/template-only';
 
 export interface HdsAlertTitleSignature {
   Blocks: {
@@ -12,4 +12,6 @@ export interface HdsAlertTitleSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsAlertTitleComponent extends Component<HdsAlertTitleSignature> {}
+const HdsAlertTitleComponent = TemplateOnlyComponent<HdsAlertTitleSignature>();
+
+export default HdsAlertTitleComponent;

--- a/packages/components/src/components/hds/toast/index.ts
+++ b/packages/components/src/components/hds/toast/index.ts
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import TemplateOnlyComponent from '@ember/component/template-only';
 import type { HdsAlertSignature } from '../alert/';
 
 export interface HdsToastSignature extends Omit<HdsAlertSignature, 'Args'> {
   Args: Omit<HdsAlertSignature['Args'], 'type'>;
 }
 
-export default class HdsToastComponent extends Component<HdsToastSignature> {}
+const HdsToastComponent = TemplateOnlyComponent<HdsToastSignature>();
+
+export default HdsToastComponent;

--- a/packages/components/src/components/hds/yield/index.ts
+++ b/packages/components/src/components/hds/yield/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import TemplateOnlyComponent from '@ember/component/template-only';
 
 export interface HdsYieldSignature {
   Blocks: {
@@ -11,4 +11,6 @@ export interface HdsYieldSignature {
   };
 }
 
-export default class HdsYieldComponent extends Component<HdsYieldSignature> {}
+const HdsYieldComponent = TemplateOnlyComponent<HdsYieldSignature>();
+
+export default HdsYieldComponent;

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -18,7 +18,13 @@
     "emitDeclarationOnly": true,
     "noEmit": false,
     "skipLibCheck": true,
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // Resolve template-only from ember-source instead of @types/ember__component@v3
+    "paths": {
+      "@ember/component/template-only": [
+        "../../node_modules/ember-source/types/stable/@ember/component/template-only.d.ts"
+      ],
+    }
   },
   "include": ["src/**/*", "unpublished-development-types/**/*"],
   "glint": {


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

### :hammer_and_wrench: Detailed description

Reapply the fix used in https://github.com/hashicorp/design-system/pull/2023/commits/9abb66b892b431f22fe932e0f391fd87dc1c77e0 to resolve `template-only` from `ember-source` instead of `@types/ember__component@v3`

### :link: External links

Related https://github.com/hashicorp/design-system/pull/2099/files#r1602068543

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
