### PR TITLE
`Hds::BadgeCount` - Fix typo in template registry declaration

### DIFF
--- a/.changeset/tiny-apes-sin.md
+++ b/.changeset/tiny-apes-sin.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::BadgeCount` - Fixed typo in template registry declaration

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -98,6 +98,7 @@ export default interface HdsComponentsRegistry {
   'Hds::AppFooter::StatusLink': typeof HdsAppFooterStatusLinkComponent;
   'hds/app-footer/status-link': typeof HdsAppFooterStatusLinkComponent;
   HdsAppFooterStatusLink: typeof HdsAppFooterStatusLinkComponent;
+
   // App Frame
   'Hds::AppFrame': typeof HdsAppFrameComponent;
   'hds/app-frame': typeof HdsAppFrameComponent;
@@ -129,7 +130,7 @@ export default interface HdsComponentsRegistry {
   HdsBadge: typeof HdsBadgeComponent;
 
   // BadgeCount
-  'Hds::Badge::Count': typeof HdsBadgeCountComponent;
+  'Hds::BadgeCount': typeof HdsBadgeCountComponent;
   'hds/badge-count': typeof HdsBadgeCountComponent;
   HdsBadgeCount: typeof HdsBadgeCountComponent;
 


### PR DESCRIPTION
### :pushpin: Summary

In #2088 I mistyped `Hds::Badge::Count` instead of `Hds::BadgeCount` in the `template-registry.ts` file

***

### 👀 Component checklist

- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
