### PR TITLE
Template Registry - Remove redundant entries

### DIFF
--- a/.changeset/lucky-stingrays-call.md
+++ b/.changeset/lucky-stingrays-call.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Template Registry - Removed redundant entries

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -51,185 +51,144 @@ export default interface HdsComponentsRegistry {
   // Accordion
   'Hds::Accordion': typeof HdsAccordionComponent;
   'hds/accordion': typeof HdsAccordionComponent;
-  HdsAccordion: typeof HdsAccordionComponent;
 
   'Hds::Accordion::Item': typeof HdsAccordionItemComponent;
   'hds/accordion/item': typeof HdsAccordionItemComponent;
-  HdsAccordionItem: typeof HdsAccordionItemComponent;
 
   'Hds::Accordion::Item::Button': typeof HdsAccordionItemButtonComponent;
   'hds/accordion/item/button': typeof HdsAccordionItemButtonComponent;
-  HdsAccordionItemButton: typeof HdsAccordionItemButtonComponent;
 
   // Alert
   'Hds::Alert': typeof HdsAlertComponent;
   'hds/alert': typeof HdsAlertComponent;
-  HdsAlert: typeof HdsAlertComponent;
 
   'Hds::Alert::Description': typeof HdsAlertDescriptionComponent;
   'hds/alert/description': typeof HdsAlertDescriptionComponent;
-  HdsAlertDescription: typeof HdsAlertDescriptionComponent;
 
   'Hds::Alert::Title': typeof HdsAlertTitleComponent;
   'hds/alert/title': typeof HdsAlertTitleComponent;
-  HdsAlertTitle: typeof HdsAlertTitleComponent;
 
   // AppFooter
   'Hds::AppFooter': typeof HdsAppFooterComponent;
   'hds/app-footer': typeof HdsAppFooterComponent;
-  HdsAppFooter: typeof HdsAppFooterComponent;
 
   'Hds::AppFooter::Copyright': typeof HdsAppFooterCopyrightComponent;
   'hds/app-footer/copyright': typeof HdsAppFooterCopyrightComponent;
-  HdsAppFooterCopyright: typeof HdsAppFooterCopyrightComponent;
 
   'Hds::AppFooter::Item': typeof HdsAppFooterItemComponent;
   'hds/app-footer/item': typeof HdsAppFooterItemComponent;
-  HdsAppFooterItem: typeof HdsAppFooterItemComponent;
 
   'Hds::AppFooter::LegalLinks': typeof HdsAppFooterLegalLinksComponent;
   'hds/app-footer/legal-links': typeof HdsAppFooterLegalLinksComponent;
-  HdsAppFooterLegalLinks: typeof HdsAppFooterLegalLinksComponent;
 
   'Hds::AppFooter::Link': typeof HdsAppFooterLinkComponent;
   'hds/app-footer/link': typeof HdsAppFooterLinkComponent;
-  HdsAppFooterLink: typeof HdsAppFooterLinkComponent;
 
   'Hds::AppFooter::StatusLink': typeof HdsAppFooterStatusLinkComponent;
   'hds/app-footer/status-link': typeof HdsAppFooterStatusLinkComponent;
-  HdsAppFooterStatusLink: typeof HdsAppFooterStatusLinkComponent;
 
   // App Frame
   'Hds::AppFrame': typeof HdsAppFrameComponent;
   'hds/app-frame': typeof HdsAppFrameComponent;
-  HdsAppFrame: typeof HdsAppFrameComponent;
 
   'Hds::AppFrame::Footer': typeof HdsAppFrameFooterComponent;
   'hds/app-frame/parts/footer': typeof HdsAppFrameFooterComponent;
-  HdsAppFrameFooter: typeof HdsAppFrameFooterComponent;
 
   'Hds::AppFrame::Header': typeof HdsAppFrameHeaderComponent;
   'hds/app-frame/parts/header': typeof HdsAppFrameHeaderComponent;
-  HdsAppFrameHeader: typeof HdsAppFrameHeaderComponent;
 
   'Hds::AppFrame::Main': typeof HdsAppFrameMainComponent;
   'hds/app-frame/parts/main': typeof HdsAppFrameMainComponent;
-  HdsAppFrameMain: typeof HdsAppFrameMainComponent;
 
   'Hds::AppFrame::Modals': typeof HdsAppFrameModalsComponent;
   'hds/app-frame/parts/modals': typeof HdsAppFrameModalsComponent;
-  HdsAppFrameModals: typeof HdsAppFrameModalsComponent;
 
   'Hds::AppFrame::Sidebar': typeof HdsAppFrameSidebarComponent;
   'hds/app-frame/parts/sidebar': typeof HdsAppFrameSidebarComponent;
-  HdsAppFrameSidebar: typeof HdsAppFrameSidebarComponent;
 
   // Badge
   'Hds::Badge': typeof HdsBadgeComponent;
   'hds/badge': typeof HdsBadgeComponent;
-  HdsBadge: typeof HdsBadgeComponent;
 
   // BadgeCount
   'Hds::BadgeCount': typeof HdsBadgeCountComponent;
   'hds/badge-count': typeof HdsBadgeCountComponent;
-  HdsBadgeCount: typeof HdsBadgeCountComponent;
 
   // Button
   'Hds::Button': typeof HdsButtonComponent;
   'hds/button': typeof HdsButtonComponent;
-  HdsButton: typeof HdsButtonComponent;
 
   // ButtonSet
   'Hds::ButtonSet': typeof HdsButtonSetComponent;
   'hds/button-set': typeof HdsButtonSetComponent;
-  HdsButtonSet: typeof HdsButtonSetComponent;
 
   // Card
   'Hds::Card': typeof HdsCardContainerComponent;
   'hds/card': typeof HdsCardContainerComponent;
-  HdsCard: typeof HdsCardContainerComponent;
 
   // Disclosure Primitive
   'Hds::DisclosurePrimitive': typeof HdsDisclosurePrimitiveComponent;
   'hds/disclosure-primitive': typeof HdsDisclosurePrimitiveComponent;
-  HdsDisclosurePrimitive: typeof HdsDisclosurePrimitiveComponent;
 
   // Dismiss button
   'Hds::DismissButton': typeof HdsDismissButtonComponent;
   'hds/dismiss-button': typeof HdsDismissButtonComponent;
-  HdsDismissButton: typeof HdsDismissButtonComponent;
 
   // IconTile
   'Hds::IconTile': typeof HdsIconTileComponent;
   'hds/icon-tile': typeof HdsIconTileComponent;
-  HdsIconTile: typeof HdsIconTileComponent;
 
   // Interactive
   'Hds::Interactive': typeof HdsInteractiveComponent;
   'hds/interactive': typeof HdsInteractiveComponent;
-  HdsInteractive: typeof HdsInteractiveComponent;
 
   // Link Inline
   'Hds::Link::Inline': typeof HdsLinkInlineComponent;
   'hds/link/inline': typeof HdsLinkInlineComponent;
-  HdsLinkInline: typeof HdsLinkInlineComponent;
 
   // Link Standalone
   'Hds::Link::Standalone': typeof HdsLinkStandaloneComponent;
   'hds/link/standalone': typeof HdsLinkStandaloneComponent;
-  HdsLinkStandalone: typeof HdsLinkStandaloneComponent;
 
   // Reveal
   'Hds::Reveal': typeof HdsRevealComponent;
   'hds/reveal': typeof HdsRevealComponent;
-  HdsReveal: typeof HdsRevealComponent;
 
   'Hds::Reveal::Toggle::Button': typeof HdsRevealToggleButtonComponent;
   'hds/reveal/toggle/button': typeof HdsRevealToggleButtonComponent;
-  HdsRevealToggleButtonComponent: typeof HdsRevealToggleButtonComponent;
 
   // Separator
   'Hds::Separator': typeof HdsSeparatorComponent;
   'hds/separator': typeof HdsSeparatorComponent;
-  HdsSeparator: typeof HdsSeparatorComponent;
 
   // Stepper
   'Hds::Stepper::Step::Indicator': typeof HdsStepperStepIndicatorComponent;
   'hds/stepper/step/indicator': typeof HdsStepperStepIndicatorComponent;
-  HdsStepperStepIndicator: typeof HdsStepperStepIndicatorComponent;
 
   'Hds::Stepper::Task::Indicator': typeof HdsStepperTaskIndicatorComponent;
   'hds/stepper/task/indicator': typeof HdsStepperTaskIndicatorComponent;
-  HdsStepperTaskIndicator: typeof HdsStepperTaskIndicatorComponent;
 
   // Text
   'Hds::Text': typeof HdsTextComponent;
   'hds/text': typeof HdsTextComponent;
-  HdsText: typeof HdsTextComponent;
   'Hds::Text::Body': typeof HdsTextBodyComponent;
   'hds/text/body': typeof HdsTextBodyComponent;
-  HdsTextBody: typeof HdsTextBodyComponent;
   'Hds::Text::Display': typeof HdsTextDisplayComponent;
   'hds/text/display': typeof HdsTextDisplayComponent;
-  HdsTextDisplay: typeof HdsTextDisplayComponent;
   'Hds::Text::Code': typeof HdsTextCodeComponent;
   'hds/text/code': typeof HdsTextCodeComponent;
-  HdsTextCode: typeof HdsTextCodeComponent;
 
   // Tag
   'Hds::Tag': typeof HdsTagComponent;
   'hds/tag': typeof HdsTagComponent;
-  HdsTag: typeof HdsTagComponent;
 
   // Toast
   'Hds::Toast': typeof HdsToastComponent;
   'hds/toast': typeof HdsToastComponent;
-  HdsToast: typeof HdsToastComponent;
 
   // Yield
   'Hds::Yield': typeof HdsYieldComponent;
   'hds/yield': typeof HdsYieldComponent;
-  HdsYield: typeof HdsYieldComponent;
 
   // Helpers
   'hds-link-to-models': typeof HdsLinkToModelsHelper;


### PR DESCRIPTION
### :pushpin: Summary

While discussing with @aklkv he told explained me that there are redundant entries in the `template-registry.ts` file, in particular all the ones that have this syntax: `HdsXyz: typeof HdsXyzComponent`. The reason is that the `template-registry.ts` is used only to determine types/signatures of components used in the **_templates_** (HBS) and this means there's no use for such pattern (`HdsXyz`). In the `gjs/gts` files the components are imported so their signature are explicit.

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed redundant entries in the template registry

***

### 👀 Component checklist

- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
