### PR TITLE
Fix link to Figma Component

### DIFF
--- a/website/docs/components/rich-tooltip/index.md
+++ b/website/docs/components/rich-tooltip/index.md
@@ -3,7 +3,7 @@ title: Rich Tooltip
 description: The Rich Tooltip component provides additional information to users in a concise and unobtrusive way while supporting more complex and structured content.
 caption: Provides additional structured informational content for a UI element.
 links:
-  figma: {link to the "RichTooltip" page in the components Figma library}
+  figma: https://www.figma.com/design/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?m=auto&node-id=54420%3A1460&t=76JkjDorz1nOezBV-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/rich-tooltip
 related: ['components/tooltip', 'components/modal']
 previewImage: assets/illustrations/components/rich-tooltip.jpg


### PR DESCRIPTION
### :pushpin: Summary

I failed to add the link to the component in Figma prior to release, but this adds it.
