### PR TITLE
Web: icon library "group by" feature (HDS-3288)

### DIFF
--- a/website/app/components/doc/form/select-group-type.hbs
+++ b/website/app/components/doc/form/select-group-type.hbs
@@ -1,0 +1,15 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{!-- TODO: Make a generic select then re-use for "GroupType" & "Size" selects --}}
+<div class="doc-form-select">
+  {{#let (unique-id) as |selectId|}}
+    <Doc::Form::Label @for={{selectId}} @label={{@label}} />
+    <select class="doc-form-select__control" id={{selectId}} {{on "change" @onSelect}}>
+      <option value="alphabetical" selected={{eq @selectedValue "alphabetical"}}>Alphabetical</option>
+      <option value="category" selected={{eq @selectedValue "category"}}>Category</option>
+    </select>
+  {{/let}}
+</div>

--- a/website/app/components/doc/form/select-group-type.hbs
+++ b/website/app/components/doc/form/select-group-type.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{!-- TODO: Make a generic select then re-use for "GroupType" & "Size" selects --}}
+{{! TODO: Make a generic select then re-use for "GroupType" & "Size" selects }}
 <div class="doc-form-select">
   {{#let (unique-id) as |selectId|}}
     <Doc::Form::Label @for={{selectId}} @label={{@label}} />

--- a/website/app/components/doc/icons-list/index.hbs
+++ b/website/app/components/doc/icons-list/index.hbs
@@ -11,7 +11,11 @@
     @onInput={{@searchIcons}}
     data-test="icons-filter"
   />
-  <Doc::Form::SelectGroupType @label="Group by" @onSelect={{@onSelectGroupType}} @selectedValue={{@selectedGroupType}} />
+  <Doc::Form::SelectGroupType
+    @label="Group by"
+    @onSelect={{@onSelectGroupType}}
+    @selectedValue={{@selectedGroupType}}
+  />
   <Doc::Form::Select @label="Size" @onSelect={{@onSelectIconSize}} @selectedValue={{@selectedIconSize}} />
 </div>
 

--- a/website/app/components/doc/icons-list/index.hbs
+++ b/website/app/components/doc/icons-list/index.hbs
@@ -19,9 +19,6 @@
   <Doc::Form::Select @label="Size" @onSelect={{@onSelectIconSize}} @selectedValue={{@selectedIconSize}} />
 </div>
 
-{{! temporary for testing: }}
-<h2>{{@selectedGroupType}}</h2>
-
 {{#each-in @groupedIcons as |categoryName categoryIcons|}}
   <Doc::IconsList::Grid @categoryName={{categoryName}} @categoryIcons={{categoryIcons}} />
 {{else}}

--- a/website/app/components/doc/icons-list/index.hbs
+++ b/website/app/components/doc/icons-list/index.hbs
@@ -11,8 +11,12 @@
     @onInput={{@searchIcons}}
     data-test="icons-filter"
   />
-  <Doc::Form::Select @label="Size" @onSelect={{@onSelect}} @selectedValue={{@selectedIconSize}} />
+  <Doc::Form::SelectGroupType @label="Group by" @onSelect={{@onSelectGroupType}} @selectedValue={{@selectedGroupType}} />
+  <Doc::Form::Select @label="Size" @onSelect={{@onSelectIconSize}} @selectedValue={{@selectedIconSize}} />
 </div>
+
+{{! temporary for testing: }}
+<h2>{{@selectedGroupType}}</h2>
 
 {{#each-in @groupedIcons as |categoryName categoryIcons|}}
   <Doc::IconsList::Grid @categoryName={{categoryName}} @categoryIcons={{categoryIcons}} />

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -13,7 +13,7 @@
           class="doc-table-of-contents__link"
           @route="show"
           @model={{item.pageURL}}
-          @query={{hash tab=null searchQuery=null selectedIconSize=null}}
+          @query={{hash tab=null searchQuery=null selectedGroupType=null selectedIconSize=null}}
           @current-when={{"show"}}
         >
           {{#if item.pageAttributes.navigation.label}}

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -47,6 +47,7 @@ export default class ShowController extends Controller {
     'preserveScrollPosition',
     // these are used for the searches/filters in the website
     'searchQuery',
+    'selectedGroupType',
     'selectedIconSize',
     // these are used in the "pagination > how to use" demos
     'demoCurrentPage',

--- a/website/app/styles/doc-components/form/select.scss
+++ b/website/app/styles/doc-components/form/select.scss
@@ -10,7 +10,6 @@
 
 .doc-form-select__control {
   @include doc-font-style-body();
-  width: 120px;
   height: 44px;
   padding: 2px 48px 2px 12px; // optically tweaked to match designs
   color: var(--doc-color-gray-200);

--- a/website/app/styles/doc-components/icons-list/index.scss
+++ b/website/app/styles/doc-components/icons-list/index.scss
@@ -13,7 +13,7 @@
 
 .doc-icons-list-filter {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
   gap: 24px;
   align-items: flex-end;
   margin-bottom: 24px;

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -86,15 +86,7 @@ export default class Index extends Component {
         return a.iconName.localeCompare(b.iconName);
       });
 
-      filteredIcons.forEach((icon) => {
-        const category = '';
-        if (!filteredGroupedIcons[category]) {
-          filteredGroupedIcons[category] = [];
-        }
-        filteredGroupedIcons[category].push(icon);
-      });
-
-      // Sort icons by category then iconName:
+      // Sort icons by category, then iconName:
     } else if (this.selectedGroupType === 'category') {
       filteredIcons
         .sort((a, b) => {
@@ -106,15 +98,17 @@ export default class Index extends Component {
           }
           return 0;
         });
-      // Group all filtered icons by category
-      filteredIcons.forEach((icon) => {
-        const category = icon.category;
-        if (!filteredGroupedIcons[category]) {
-          filteredGroupedIcons[category] = [];
-        }
-        filteredGroupedIcons[category].push(icon);
-      });
     }
+
+    // Group icons by category if category type is selected, otherwise group all icons under same "category"
+    filteredIcons.forEach((icon) => {
+      const category =
+        this.selectedGroupType === 'category' ? icon.category : '';
+      if (!filteredGroupedIcons[category]) {
+        filteredGroupedIcons[category] = [];
+      }
+      filteredGroupedIcons[category].push(icon);
+    });
 
     // 3) Return icons filtered by search, size &, group type
     return filteredGroupedIcons;

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -34,6 +34,10 @@ export default class Index extends Component {
     return this.router.currentRoute.queryParams['searchQuery'];
   }
 
+  get selectedGroupType() {
+    return this.router.currentRoute.queryParams['selectedGroupType'] || 'alphabetical';
+  }
+
   get selectedIconSize() {
     return this.router.currentRoute.queryParams['selectedIconSize'] || '24';
   }
@@ -97,6 +101,16 @@ export default class Index extends Component {
   }
 
   @action
+  selectGroupType(event) {
+    this.router.transitionTo({
+      queryParams: {
+        searchQuery: this.searchQuery,
+        selectedGroupType: event.target.value,
+      },
+    });
+  }
+
+  @action
   selectIconSize(event) {
     this.router.transitionTo({
       queryParams: {
@@ -112,6 +126,7 @@ export default class Index extends Component {
     this.router.transitionTo({
       queryParams: {
         searchQuery: searchQuery !== '' ? searchQuery : null,
+        selectedGroupType: this.selectedGroupType,
         selectedIconSize: this.selectedIconSize,
       },
     });

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -46,9 +46,10 @@ export default class Index extends Component {
   }
 
   get filteredGroupedIcons() {
-    let filteredIcons = [];
-    const filteredGroupedIcons = {};
+    let filteredIcons = []; // icons filtered in the search
+    const filteredGroupedIcons = {}; // icons grouped by category (after being filtered in the search)
 
+    // 1) Filter icons by search &/or size:
     // Filters all icons based on the search query
     if (this.searchQuery) {
       // check if the query is for an exact match (prefixed with `icon:`)
@@ -78,28 +79,45 @@ export default class Index extends Component {
       );
     }
 
-    // alphabetize the filtered icons by category and then by name
-    filteredIcons
-      .sort((a, b) => {
-        return a.category.localeCompare(b.category);
-      })
-      .sort((a, b) => {
-        if (a.category === b.category) {
-          a.iconName.localeCompare(b.iconName);
-        }
+    // 2) Sort icons by Group Type:
+    // Sort alphabetically by iconName:
+    if (this.selectedGroupType === 'alphabetical') {
+      filteredIcons.sort((a, b) => {
+        return a.iconName.localeCompare(b.iconName);
+      });
+      console.log('filteredIcons: ', filteredIcons);
 
-        return 0;
+      filteredIcons.forEach((icon) => {
+        const category = '';
+        if (!filteredGroupedIcons[category]) {
+          filteredGroupedIcons[category] = [];
+        }
+        filteredGroupedIcons[category].push(icon);
       });
 
-    // Group all filtered icons by category
-    filteredIcons.forEach((icon) => {
-      const category = icon.category;
-      if (!filteredGroupedIcons[category]) {
-        filteredGroupedIcons[category] = [];
-      }
-      filteredGroupedIcons[category].push(icon);
-    });
+      // Sort icons by category then iconName:
+    } else if (this.selectedGroupType === 'category') {
+      filteredIcons
+        .sort((a, b) => {
+          return a.category.localeCompare(b.category);
+        })
+        .sort((a, b) => {
+          if (a.category === b.category) {
+            a.iconName.localeCompare(b.iconName);
+          }
+          return 0;
+        });
+      // Group all filtered icons by category
+      filteredIcons.forEach((icon) => {
+        const category = icon.category;
+        if (!filteredGroupedIcons[category]) {
+          filteredGroupedIcons[category] = [];
+        }
+        filteredGroupedIcons[category].push(icon);
+      });
+    }
 
+    // 3) Return icons filtered by search, size &, group type
     return filteredGroupedIcons;
   }
 

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -85,7 +85,6 @@ export default class Index extends Component {
       filteredIcons.sort((a, b) => {
         return a.iconName.localeCompare(b.iconName);
       });
-      console.log('filteredIcons: ', filteredIcons);
 
       filteredIcons.forEach((icon) => {
         const category = '';

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -35,7 +35,10 @@ export default class Index extends Component {
   }
 
   get selectedGroupType() {
-    return this.router.currentRoute.queryParams['selectedGroupType'] || 'alphabetical';
+    return (
+      this.router.currentRoute.queryParams['selectedGroupType'] ||
+      'alphabetical'
+    );
   }
 
   get selectedIconSize() {
@@ -105,6 +108,7 @@ export default class Index extends Component {
     this.router.transitionTo({
       queryParams: {
         searchQuery: this.searchQuery,
+        selectedIconSize: this.selectedIconSize,
         selectedGroupType: event.target.value,
       },
     });
@@ -115,6 +119,7 @@ export default class Index extends Component {
     this.router.transitionTo({
       queryParams: {
         searchQuery: this.searchQuery,
+        selectedGroupType: this.selectedGroupType,
         selectedIconSize: event.target.value,
       },
     });

--- a/website/docs/icons/library/index.md
+++ b/website/docs/icons/library/index.md
@@ -12,7 +12,9 @@ previewImage: assets/illustrations/icons/library.jpg
 <!-- algolia-ignore-start -->
 <Doc::IconsList
   @groupedIcons={{this.filteredGroupedIcons}}
-  @onSelect={{this.selectIconSize}}
+  @onSelectGroupType={{this.selectGroupType}}
+  @selectedGroupType={{this.selectedGroupType}}
+  @onSelectIconSize={{this.selectIconSize}}
   @selectedIconSize={{this.selectedIconSize}}
   @searchQuery={{this.searchQuery}}
   @searchIcons={{this.searchIcons}}

--- a/website/tests/acceptance/icon-test.js
+++ b/website/tests/acceptance/icon-test.js
@@ -16,7 +16,7 @@ module('Acceptance | Icon Search', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      '/icons/library?searchQuery=loading&selectedIconSize=24'
+      '/icons/library?searchQuery=loading&selectedGroupType=alphabetical&selectedIconSize=24'
     );
 
     assert.dom('.doc-icons-list-grid-item').exists({ count: 2 });
@@ -36,11 +36,13 @@ module('Acceptance | Icon Search', function (hooks) {
   });
 
   test('should load content based on category in query param, with case-insensitive results', async function (assert) {
-    await visit('/icons/library?searchQuery=AniMaTed&selectedIconSize=24');
+    await visit(
+      '/icons/library?searchQuery=AniMaTed&selectedGroupType=category&selectedIconSize=24'
+    );
 
     assert.strictEqual(
       currentURL(),
-      '/icons/library?searchQuery=AniMaTed&selectedIconSize=24'
+      '/icons/library?searchQuery=AniMaTed&selectedGroupType=category&selectedIconSize=24'
     );
 
     assert.dom('.doc-icons-list-grid-item').exists({ count: 4 });
@@ -63,13 +65,18 @@ module('Acceptance | Icon Search', function (hooks) {
   });
 
   test('should clear search results if input is cleared', async function (assert) {
-    await visit('/icons/library?searchQuery=loading&selectedIconSize=16');
+    await visit(
+      '/icons/library?searchQuery=loading&selectedGroupType=alphabetical&selectedIconSize=16'
+    );
 
     await fillIn('.doc-icons-list-filter input[type="search"]', '');
 
     // naive way of seeing if all the results come back
     assert.dom('[data-test-icon="activity"]').exists();
-    assert.strictEqual(currentURL(), '/icons/library?selectedIconSize=16');
+    assert.strictEqual(
+      currentURL(),
+      '/icons/library?selectedGroupType=alphabetical&selectedIconSize=16'
+    );
   });
 
   test('should show message when no results are found', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a "group by" select to the "Icon library" page allowing users to display icons either alphabetically all together or by grouped together by category.

**Preview:** https://hds-website-git-hds-3288-icon-library-groupby-feature-hashicorp.vercel.app/icons/library

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?
-->

### :camera_flash: Screenshots

<img width="1203" alt="image" src="https://github.com/hashicorp/design-system/assets/108769823/0df1be13-4512-426d-b11e-1a88a27b9025">

### :link: External links

- Jira ticket: [HDS-3288](https://hashicorp.atlassian.net/browse/HDS-3288)
- Figma file: https://www.figma.com/design/ZtKpPlvuvi9kEUaRaHSqwj/HDS-Website-[Icon-Library]?node-id=6469-170520&t=SYcBpLDgZkauMAgi-0

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets]~~(https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3288]: https://hashicorp.atlassian.net/browse/HDS-3288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ