### PR TITLE
Add deprecation warning to `PowerSelect` style overrides

### DIFF
--- a/website/docs/overrides/power-select/partials/code/how-to-use.md
+++ b/website/docs/overrides/power-select/partials/code/how-to-use.md
@@ -1,9 +1,12 @@
+!!! Warning
+
+The PowerSelect style overrides are deprecated and will be removed in a future major release. We recommend migrating PowerSelect instances to [SuperSelect](/components/form/super-select).
+
+!!!
+
 [PowerSelect](https://ember-power-select.com) is a popular Ember add-on aiming to overcome some limitations of the `<select>` tag. We only provide style overrides for this add-on to keep it in line with other form components.
 
-!!! Info
-
 These style overrides assume the PowerSelect component is set up in your project using the **default theme**.
-!!!
 
 To use this component in your application, follow [the getting started guide on the add-on website](https://ember-power-select.com), then add the PowerSelect overrides.
 


### PR DESCRIPTION
### :pushpin: Summary

Adding a deprecation warning to `PowerSelect` style overrides recommending the migration to SuperSelect.

To avoid having two banners very close to each other I demoted the requirement of using a default team for the overrides from a note to a standard paragraph.

### :link: External links

https://docs.google.com/document/d/1xXxMv70KCOEmAe_l8mfzrnbQ3EGrw3v6Qt107RPyWuA/edit?disco=AAABOn5WKEU

***
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
