### PR TITLE
`Tabs` documentation - Update to the output of the `logClickedTab` function to demo the arguments provided

### DIFF
--- a/showcase/app/controllers/components/tabs.js
+++ b/showcase/app/controllers/components/tabs.js
@@ -44,9 +44,9 @@ export default class TabsController extends Controller {
   }
 
   @action
-  logClickedTab(event) {
+  logClickedTab(event, index) {
     const tabId = event.target.id;
-    console.log(`Tab with ID "${tabId}" clicked!`);
+    console.log(`Tab with ID "${tabId}" and index "${index}" clicked!`);
   }
 
   // =============================

--- a/website/docs/components/tabs/index.js
+++ b/website/docs/components/tabs/index.js
@@ -45,8 +45,8 @@ export default class Index extends Component {
   }
 
   @action
-  logClickedTab(event) {
+  logClickedTab(event, index) {
     const tabId = event.target.id;
-    console.log(`Tab with ID "${tabId}" clicked!`);
+    console.log(`Tab with ID "${tabId}" and index "${index}" clicked!`);
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

Context: https://hashicorp.slack.com/archives/C7KTUHNUS/p1717015038457629

The intent is to make it more explicit in the demo that the callback receives two arguments, `event` and `index`.
### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
