### PR TITLE
Add links to previous version docs

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.4.0
 
+[4.4.0 documentation](https://hds-website-4-4-0.vercel.app/)
+
 ### Minor Changes
 
 Added re-export entries for TypeScript components
@@ -49,6 +51,8 @@ Fix missing TypeScript `declaration`
 <div class="doc-whats-new-changelog-separator"></div>
 
 ## 4.3.0
+
+[4.3.0 documentation](https://hds-website-4-3-0.vercel.app/)
 
 ### Minor Changes
 
@@ -219,6 +223,8 @@ Fixed default export warnings by preventing `types.js` files from being reexport
 
 ## 4.2.0
 
+[4.2.0 documentation](https://hds-website-4-2-0.vercel.app/)
+
 ### Minor Changes
 
 `Link::Inline` - Converted component to TypeScript
@@ -283,6 +289,8 @@ You can still use this version if you import styles as Sass and don't require `d
 
 ## 4.1.0
 
+[4.1.0 documentation](https://hds-website-4-1-0.vercel.app/)
+
 ### Minor Changes
 
 `DismissButton` - Converted component to TypeScript
@@ -329,6 +337,8 @@ Removed `dialog-polyfill` dependency
 - @hashicorp/ember-flight-icons@5.0.1
 
 ## 4.0.0
+
+[4.0.0 documentation](https://hds-website-4-0-0.vercel.app/)
 
 ### Major Changes
 
@@ -470,6 +480,8 @@ Removed `ember-deep-tracked` dependency that was not used
 
 ## 3.6.0
 
+[3.6.0 documentation](https://hds-website-3-6-0.vercel.app/)
+
 ### Minor Changes
 
 _Since this is an update brand colors and product icons, we consider this a `minor` version release_
@@ -480,6 +492,8 @@ _Since this is an update brand colors and product icons, we consider this a `min
 - @hashicorp/ember-flight-icons@4.1.0
 
 ## 3.5.0
+
+[3.5.0 documentation](https://hds-website-3-5-0.vercel.app/)
 
 ### Minor Changes
 

--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -14,6 +14,8 @@
 
 ## 4.4.0
 
+[4.4.0 documentation](https://hds-website-4-4-0.vercel.app/)
+
 **Minor changes**
 
 Added re-export entries for TypeScript components
@@ -61,6 +63,8 @@ Fix missing TypeScript `declaration`
 <div class="doc-whats-new-changelog-separator"></div>
 
 ## 4.3.0
+
+[4.3.0 documentation](https://hds-website-4-3-0.vercel.app/)
 
 **Minor changes**
 
@@ -231,6 +235,8 @@ Fixed default export warnings by preventing `types.js` files from being reexport
 
 ## 4.2.0
 
+[4.2.0 documentation](https://hds-website-4-2-0.vercel.app/)
+
 **Minor changes**
 
 `Link::Inline` - Converted component to TypeScript
@@ -295,6 +301,8 @@ You can still use this version if you import styles as Sass and don't require `d
 
 ## 4.1.0
 
+[4.1.0 documentation](https://hds-website-4-1-0.vercel.app/)
+
 **Minor changes**
 
 `DismissButton` - Converted component to TypeScript
@@ -341,6 +349,8 @@ Removed `dialog-polyfill` dependency
 - @hashicorp/ember-flight-icons@5.0.1
 
 ## 4.0.0
+
+[4.0.0 documentation](https://hds-website-4-0-0.vercel.app/)
 
 **Major changes**
 
@@ -482,6 +492,8 @@ Removed `ember-deep-tracked` dependency that was not used
 
 ## 3.6.0
 
+[3.6.0 documentation](https://hds-website-3-6-0.vercel.app/)
+
 **Minor changes**
 
 _Since this is an update brand colors and product icons, we consider this a `minor` version release_
@@ -492,6 +504,8 @@ _Since this is an update brand colors and product icons, we consider this a `min
 - @hashicorp/ember-flight-icons@4.1.0
 
 ## 3.5.0
+
+[3.5.0 documentation](https://hds-website-3-5-0.vercel.app/)
 
 **Minor changes**
 


### PR DESCRIPTION
### :pushpin: Summary

Adding links to documentation as deployed at different points in time for the latest released versions (3.5.0+).

I couldn't find a way to automate this using the `.changeset/changelog-hds.cjs.js` but open to suggestions.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3355](https://hashicorp.atlassian.net/browse/HDS-3355)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3355]: https://hashicorp.atlassian.net/browse/HDS-3355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ