### PR TITLE
`Accordion` - expand/collapse enhancements

### DIFF
--- a/.changeset/six-flowers-joke.md
+++ b/.changeset/six-flowers-joke.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Accordion` - added `@forceState`, `@onClickToggle` arguments
+`Accordion` - added `close` function to `<:content>`

--- a/packages/components/src/components/hds/accordion/index.hbs
+++ b/packages/components/src/components/hds/accordion/index.hbs
@@ -4,5 +4,5 @@
 }}
 
 <div class={{this.classNames}} ...attributes>
-  {{yield (hash Item=(component "hds/accordion/item" size=this.size type=this.type))}}
+  {{yield (hash Item=(component "hds/accordion/item" size=this.size type=this.type forceState=@forceState))}}
 </div>

--- a/packages/components/src/components/hds/accordion/index.ts
+++ b/packages/components/src/components/hds/accordion/index.ts
@@ -10,13 +10,13 @@ import { SIZES, DEFAULT_SIZE, TYPES, DEFAULT_TYPE } from './item/index.ts';
 
 import type { ComponentLike } from '@glint/template';
 import type { HdsAccordionItemSignature } from './item/index.ts';
-import type { HdsAccordionSizes, HdsAccordionTypes } from './types.ts';
+import type { HdsAccordionForceStates, HdsAccordionSizes, HdsAccordionTypes } from './types.ts';
 
 interface HdsAccordionSignature {
   Args: {
     size?: HdsAccordionSizes;
     type?: HdsAccordionTypes;
-    forceState?: 'open' | 'close';
+    forceState?: HdsAccordionForceStates;
   };
   Blocks: {
     default: [

--- a/packages/components/src/components/hds/accordion/index.ts
+++ b/packages/components/src/components/hds/accordion/index.ts
@@ -16,6 +16,7 @@ interface HdsAccordionSignature {
   Args: {
     size?: HdsAccordionSizes;
     type?: HdsAccordionTypes;
+    forceState?: 'open' | 'close';
   };
   Blocks: {
     default: [

--- a/packages/components/src/components/hds/accordion/index.ts
+++ b/packages/components/src/components/hds/accordion/index.ts
@@ -40,7 +40,7 @@ export default class HdsAccordionComponent extends Component<HdsAccordionSignatu
    * @type {HdsAccordionSizes}
    * @default 'medium'
    */
-  get size() {
+  get size(): HdsAccordionSizes {
     const { size = DEFAULT_SIZE } = this.args;
 
     assert(
@@ -60,7 +60,7 @@ export default class HdsAccordionComponent extends Component<HdsAccordionSignatu
    * @type {HdsAccordionTypes}
    * @default 'card'
    */
-  get type() {
+  get type(): HdsAccordionTypes {
     const { type = DEFAULT_TYPE } = this.args;
 
     assert(
@@ -78,7 +78,7 @@ export default class HdsAccordionComponent extends Component<HdsAccordionSignatu
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-accordion'];
 
     // add a class based on the @size argument

--- a/packages/components/src/components/hds/accordion/index.ts
+++ b/packages/components/src/components/hds/accordion/index.ts
@@ -10,7 +10,11 @@ import { SIZES, DEFAULT_SIZE, TYPES, DEFAULT_TYPE } from './item/index.ts';
 
 import type { ComponentLike } from '@glint/template';
 import type { HdsAccordionItemSignature } from './item/index.ts';
-import type { HdsAccordionForceStates, HdsAccordionSizes, HdsAccordionTypes } from './types.ts';
+import type {
+  HdsAccordionForceStates,
+  HdsAccordionSizes,
+  HdsAccordionTypes,
+} from './types.ts';
 
 interface HdsAccordionSignature {
   Args: {

--- a/packages/components/src/components/hds/accordion/item/index.hbs
+++ b/packages/components/src/components/hds/accordion/item/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<Hds::DisclosurePrimitive class={{this.classNames}} @isOpen={{@isOpen}} ...attributes>
+<Hds::DisclosurePrimitive class={{this.classNames}} @isOpen={{(or @isOpen (eq @forceState "open"))}} ...attributes>
   <:toggle as |t|>
     <div class="hds-accordion-item__toggle">
       <Hds::Accordion::Item::Button

--- a/packages/components/src/components/hds/accordion/item/index.hbs
+++ b/packages/components/src/components/hds/accordion/item/index.hbs
@@ -27,7 +27,7 @@
     </div>
   </:toggle>
 
-  <:content>
+  <:content as |c|>
     <Hds::Text::Body
       class="hds-accordion-item__content"
       @tag="div"
@@ -36,7 +36,7 @@
       @color="primary"
       id={{this.contentId}}
     >
-      {{yield to="content"}}
+      {{yield (hash close=c.close) to="content"}}
     </Hds::Text::Body>
   </:content>
 </Hds::DisclosurePrimitive>

--- a/packages/components/src/components/hds/accordion/item/index.hbs
+++ b/packages/components/src/components/hds/accordion/item/index.hbs
@@ -3,7 +3,12 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<Hds::DisclosurePrimitive class={{this.classNames}} @isOpen={{(or @isOpen (eq @forceState "open"))}} @onClickToggle={{@onClickToggle}} ...attributes>
+<Hds::DisclosurePrimitive
+  class={{this.classNames}}
+  @isOpen={{(or @isOpen (eq @forceState "open"))}}
+  @onClickToggle={{@onClickToggle}}
+  ...attributes
+>
   <:toggle as |t|>
     <div class="hds-accordion-item__toggle">
       <Hds::Accordion::Item::Button

--- a/packages/components/src/components/hds/accordion/item/index.hbs
+++ b/packages/components/src/components/hds/accordion/item/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<Hds::DisclosurePrimitive class={{this.classNames}} @isOpen={{(or @isOpen (eq @forceState "open"))}} ...attributes>
+<Hds::DisclosurePrimitive class={{this.classNames}} @isOpen={{(or @isOpen (eq @forceState "open"))}} @onClickToggle={{@onClickToggle}} ...attributes>
   <:toggle as |t|>
     <div class="hds-accordion-item__toggle">
       <Hds::Accordion::Item::Button

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -31,6 +31,8 @@ export interface HdsAccordionItemSignature {
     size?: HdsAccordionSizes;
     type?: HdsAccordionTypes;
     forceState?: HdsAccordionForceStates;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onClickToggle?: (event: MouseEvent, ...args: any[]) => void;
   };
   Blocks: {
     toggle?: [];

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -81,7 +81,7 @@ export default class HdsAccordionItemComponent extends Component<HdsAccordionIte
    * @type {HdsTextSizes}
    * @default 'medium'
    */
-  get toggleTextSize() {
+  get toggleTextSize(): number {
     const size = this.args.size ?? DEFAULT_SIZE;
     return TEXT_SIZE_MAP[size];
   }
@@ -93,7 +93,7 @@ export default class HdsAccordionItemComponent extends Component<HdsAccordionIte
    * @type {HdsAccordionSizes}
    * @default 'medium'
    */
-  get size() {
+  get size(): HdsAccordionSizes {
     const { size = DEFAULT_SIZE } = this.args;
 
     assert(
@@ -113,7 +113,7 @@ export default class HdsAccordionItemComponent extends Component<HdsAccordionIte
    * @type {HdsAccordionTypes}
    * @default 'card'
    */
-  get type() {
+  get type(): HdsAccordionTypes {
     const { type = DEFAULT_TYPE } = this.args;
 
     assert(

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -30,6 +30,7 @@ export interface HdsAccordionItemSignature {
     containsInteractive?: boolean;
     size?: HdsAccordionSizes;
     type?: HdsAccordionTypes;
+    forceState?: 'open' | 'close';
   };
   Blocks: {
     content?: [];

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -8,7 +8,11 @@ import { assert } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
 
 import { HdsAccordionSizeValues, HdsAccordionTypeValues } from '../types.ts';
-import type { HdsAccordionForceStates, HdsAccordionSizes, HdsAccordionTypes } from '../types.ts';
+import type {
+  HdsAccordionForceStates,
+  HdsAccordionSizes,
+  HdsAccordionTypes,
+} from '../types.ts';
 
 export const SIZES: string[] = Object.values(HdsAccordionSizeValues);
 export const DEFAULT_SIZE = HdsAccordionSizeValues.Medium;
@@ -40,7 +44,7 @@ export interface HdsAccordionItemSignature {
       {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         close: (...args: any[]) => void;
-      }
+      },
     ];
   };
   Element: HTMLElement;

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -8,7 +8,7 @@ import { assert } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
 
 import { HdsAccordionSizeValues, HdsAccordionTypeValues } from '../types.ts';
-import type { HdsAccordionSizes, HdsAccordionTypes } from '../types.ts';
+import type { HdsAccordionForceStates, HdsAccordionSizes, HdsAccordionTypes } from '../types.ts';
 
 export const SIZES: string[] = Object.values(HdsAccordionSizeValues);
 export const DEFAULT_SIZE = HdsAccordionSizeValues.Medium;
@@ -30,7 +30,7 @@ export interface HdsAccordionItemSignature {
     containsInteractive?: boolean;
     size?: HdsAccordionSizes;
     type?: HdsAccordionTypes;
-    forceState?: 'open' | 'close';
+    forceState?: HdsAccordionForceStates;
   };
   Blocks: {
     toggle?: [];

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -33,8 +33,13 @@ export interface HdsAccordionItemSignature {
     forceState?: 'open' | 'close';
   };
   Blocks: {
-    content?: [];
     toggle?: [];
+    content: [
+      {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        close: (...args: any[]) => void;
+      }
+    ];
   };
   Element: HTMLElement;
 }

--- a/packages/components/src/components/hds/accordion/types.ts
+++ b/packages/components/src/components/hds/accordion/types.ts
@@ -15,3 +15,9 @@ export enum HdsAccordionSizeValues {
   Large = 'large',
 }
 export type HdsAccordionSizes = `${HdsAccordionSizeValues}`;
+
+export enum HdsAccordionForceStateValues {
+  Open = 'open',
+  Close = 'close',
+}
+export type HdsAccordionForceStates = `${HdsAccordionForceStateValues}`;

--- a/packages/components/src/components/hds/disclosure-primitive/index.hbs
+++ b/packages/components/src/components/hds/disclosure-primitive/index.hbs
@@ -2,7 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class="hds-disclosure-primitive" ...attributes>
+<div class="hds-disclosure-primitive" {{did-update this.onStateChange @isOpen}} ...attributes>
   <div class="hds-disclosure-primitive__toggle">
     {{yield (hash onClickToggle=this.onClickToggle isOpen=this.isOpen) to="toggle"}}
   </div>

--- a/packages/components/src/components/hds/disclosure-primitive/index.ts
+++ b/packages/components/src/components/hds/disclosure-primitive/index.ts
@@ -43,7 +43,7 @@ export default class HdsDisclosurePrimitiveComponent extends Component<HdsDisclo
       // if the state is controlled from outside, the argument overrides the internal state
       return this.args.isOpen ?? this._isOpen;
     } else {
-      // if the state is changes internally, the internal state overrides the argument
+      // if the state changes internally, the internal state overrides the argument
       return this._isOpen !== undefined
         ? this._isOpen
         : Boolean(this.args.isOpen);

--- a/packages/components/src/components/hds/disclosure-primitive/index.ts
+++ b/packages/components/src/components/hds/disclosure-primitive/index.ts
@@ -36,7 +36,7 @@ export interface HdsDisclosurePrimitiveSignature {
 
 export default class HdsDisclosurePrimitiveComponent extends Component<HdsDisclosurePrimitiveSignature> {
   @tracked _isOpen = false;
-  @tracked _isControlled = this.args.isOpen != undefined;
+  @tracked _isControlled = this.args.isOpen !== undefined;
 
   get isOpen() {
     if (this._isControlled) {

--- a/packages/components/src/components/hds/disclosure-primitive/index.ts
+++ b/packages/components/src/components/hds/disclosure-primitive/index.ts
@@ -33,11 +33,37 @@ export interface HdsDisclosurePrimitiveSignature {
 }
 
 export default class HdsDisclosurePrimitiveComponent extends Component<HdsDisclosurePrimitiveSignature> {
-  @tracked isOpen = this.args.isOpen ?? false;
+  @tracked _isOpen = false;
+  @tracked _isControlled = this.args.isOpen != undefined;
+
+  get isOpen() {
+    if (this._isControlled) {
+      // if the state is controlled from outside, the argument overrides the internal state
+      return this.args.isOpen ?? this._isOpen;
+    } else {
+      // if the state is changes internally, the internal state overrides the argument
+      return this._isOpen !== undefined
+        ? this._isOpen
+        : Boolean(this.args.isOpen);
+    }
+  }
+
+  set isOpen(value) {
+    this._isOpen = value || false;
+  }
 
   @action
   onClickToggle(): void {
     this.isOpen = !this.isOpen;
+    this._isControlled = false;
+  }
+
+  @action
+  onStateChange() {
+    if (this.args.isOpen !== undefined) {
+      this.isOpen = this.args.isOpen;
+    }
+    this._isControlled = true;
   }
 
   @action

--- a/packages/components/src/components/hds/disclosure-primitive/index.ts
+++ b/packages/components/src/components/hds/disclosure-primitive/index.ts
@@ -38,7 +38,7 @@ export default class HdsDisclosurePrimitiveComponent extends Component<HdsDisclo
   @tracked _isOpen = false;
   @tracked _isControlled = this.args.isOpen !== undefined;
 
-  get isOpen() {
+  get isOpen(): boolean {
     if (this._isControlled) {
       // if the state is controlled from outside, the argument overrides the internal state
       return this.args.isOpen ?? this._isOpen;
@@ -66,7 +66,7 @@ export default class HdsDisclosurePrimitiveComponent extends Component<HdsDisclo
   }
 
   @action
-  onStateChange() {
+  onStateChange(): void {
     if (this.args.isOpen !== undefined) {
       this.isOpen = this.args.isOpen;
     }

--- a/packages/components/src/components/hds/disclosure-primitive/index.ts
+++ b/packages/components/src/components/hds/disclosure-primitive/index.ts
@@ -44,9 +44,7 @@ export default class HdsDisclosurePrimitiveComponent extends Component<HdsDisclo
       return this.args.isOpen ?? this._isOpen;
     } else {
       // if the state changes internally, the internal state overrides the argument
-      return this._isOpen !== undefined
-        ? this._isOpen
-        : Boolean(this.args.isOpen);
+      return this._isOpen;
     }
   }
 

--- a/packages/components/src/components/hds/disclosure-primitive/index.ts
+++ b/packages/components/src/components/hds/disclosure-primitive/index.ts
@@ -13,6 +13,8 @@ export interface HdsDisclosurePrimitiveSignature {
     isOpen?: boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onClose?: (...args: any[]) => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onClickToggle?: (...args: any[]) => void;
   };
   Blocks: {
     toggle: [
@@ -56,6 +58,13 @@ export default class HdsDisclosurePrimitiveComponent extends Component<HdsDisclo
   onClickToggle(): void {
     this.isOpen = !this.isOpen;
     this._isControlled = false;
+    // we call the "onClickToggle" callback if it exists and it's a function
+    if (
+      this.args.onClickToggle &&
+      typeof this.args.onClickToggle === 'function'
+    ) {
+      this.args.onClickToggle(this.isOpen);
+    }
   }
 
   @action

--- a/showcase/app/controllers/components/accordion.js
+++ b/showcase/app/controllers/components/accordion.js
@@ -11,14 +11,29 @@ export default class AccordionController extends Controller {
   @action
   noop() {}
 
-  @tracked state = 'close';
+  @tracked stateAll = 'close';
+  @tracked stateSingle = 'close';
 
   @action
-  toggleState() {
-    if (this.state === 'open') {
-      this.state = 'close';
+  toggleStateAll() {
+    if (this.stateAll === 'open') {
+      this.stateAll = 'close';
     } else {
-      this.state = 'open';
+      this.stateAll = 'open';
     }
+  }
+
+  @action
+  toggleStateSingle() {
+    if (this.stateSingle === 'open') {
+      this.stateSingle = 'close';
+    } else {
+      this.stateSingle = 'open';
+    }
+  }
+
+  @action
+  onClickToggleSingle(isOpen) {
+    this.stateSingle = isOpen ? 'open' : 'close';
   }
 }

--- a/showcase/app/controllers/components/accordion.js
+++ b/showcase/app/controllers/components/accordion.js
@@ -5,8 +5,20 @@
 
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class AccordionController extends Controller {
   @action
   noop() {}
+
+  @tracked state = 'close';
+
+  @action
+  toggleState() {
+    if (this.state === 'open') {
+      this.state = 'close';
+    } else {
+      this.state = 'open';
+    }
+  }
 }

--- a/showcase/app/controllers/utilities/disclosure-primitive.js
+++ b/showcase/app/controllers/utilities/disclosure-primitive.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class DisclosurePrimitiveController extends Controller {
+  @tracked isOpen = false;
+
+  @action
+  toggleState(state) {
+    if (state === 'open') {
+      this.isOpen = true;
+    } else if (state === 'close') {
+      this.isOpen = false;
+    }
+  }
+}

--- a/showcase/app/controllers/utilities/disclosure-primitive.js
+++ b/showcase/app/controllers/utilities/disclosure-primitive.js
@@ -16,6 +16,13 @@ export default class DisclosurePrimitiveController extends Controller {
       this.isOpen = true;
     } else if (state === 'close') {
       this.isOpen = false;
+    } else {
+      this.isOpen = !this.isOpen;
     }
+  }
+
+  @action
+  onClickToggle(isOpenInternalState) {
+    this.isOpen = isOpenInternalState;
   }
 }

--- a/showcase/app/templates/components/accordion.hbs
+++ b/showcase/app/templates/components/accordion.hbs
@@ -461,19 +461,6 @@
     {{/each}}
   </Shw::Grid>
 
-  <Shw::Text::Body><strong>close</strong></Shw::Text::Body>
-
-  <Shw::Flex {{style gap="2rem" marginBottom="2rem"}} @direction="column" as |SF|>
-    <SF.Item @label="Close action within content">
-      <Hds::Accordion::Item>
-        <:toggle>Item one</:toggle>
-        <:content as |c|>
-          <button type="button" {{style padding=".25rem" marginBottom="1rem"}} {{on "click" c.close}}>Close</button>
-        </:content>
-      </Hds::Accordion::Item>
-    </SF.Item>
-  </Shw::Flex>
-
   <Shw::Divider @level={{2}} />
 
   <Shw::Text::H4>isOpen</Shw::Text::H4>
@@ -571,6 +558,21 @@
       </SG.Item>
     {{/each}}
   </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H4>Close</Shw::Text::H4>
+
+  <Shw::Flex {{style gap="2rem" marginBottom="2rem"}} @direction="column" as |SF|>
+    <SF.Item @label="Close action within content">
+      <Hds::Accordion::Item>
+        <:toggle>Item one</:toggle>
+        <:content as |c|>
+          <button type="button" {{style padding=".25rem" marginBottom="1rem"}} {{on "click" c.close}}>Close</button>
+        </:content>
+      </Hds::Accordion::Item>
+    </SF.Item>
+  </Shw::Flex>
 
   <Shw::Divider @level={{2}} />
 

--- a/showcase/app/templates/components/accordion.hbs
+++ b/showcase/app/templates/components/accordion.hbs
@@ -352,6 +352,40 @@
 
   <Shw::Divider @level={{2}} />
 
+  <Shw::Text::H3>Externally controlled</Shw::Text::H3>
+
+  <Shw::Grid {{style gap="2rem"}} @columns={{2}} as |SG|>
+    <SG.Item @label="Forced state">
+      <button {{style padding=".25rem" marginBottom="1rem"}} type="button" {{on "click" this.toggleState}}>
+        {{if (eq this.state "open") "Collapse all" "Expand all"}}
+      </button>
+      <Hds::Accordion @forceState={{this.state}} as |A|>
+        <A.Item>
+          <:toggle>Item one</:toggle>
+          <:content>
+            <Shw::Placeholder @text="generic content" @height="40" />
+          </:content>
+        </A.Item>
+
+        <A.Item>
+          <:toggle>Item two</:toggle>
+          <:content>
+            <Shw::Placeholder @text="generic content" @height="40" />
+          </:content>
+        </A.Item>
+
+        <A.Item>
+          <:toggle>Item Three</:toggle>
+          <:content>
+            <Shw::Placeholder @text="generic content" @height="40" />
+          </:content>
+        </A.Item>
+      </Hds::Accordion>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Edge cases</Shw::Text::H3>
 
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>

--- a/showcase/app/templates/components/accordion.hbs
+++ b/showcase/app/templates/components/accordion.hbs
@@ -355,7 +355,7 @@
   <Shw::Text::H3>Externally controlled</Shw::Text::H3>
 
   <Shw::Grid {{style gap="2rem"}} @columns={{2}} as |SG|>
-    <SG.Item @label="Forced state">
+    <SG.Item @label="All items">
       <button type="button" {{style padding=".25rem" marginBottom="1rem"}} {{on "click" this.toggleStateAll}}>
         {{if (eq this.stateAll "open") "Collapse all" "Expand all"}}
       </button>
@@ -380,7 +380,7 @@
         </A.Item>
       </Hds::Accordion>
     </SG.Item>
-    <SG.Item @label="Forced state">
+    <SG.Item @label="Single item">
       <button type="button" {{style padding=".25rem" marginBottom="1rem"}} {{on "click" this.toggleStateSingle}}>
         {{if (eq this.stateSingle "open") "Collapse item 2" "Expand item 2"}}
       </button>

--- a/showcase/app/templates/components/accordion.hbs
+++ b/showcase/app/templates/components/accordion.hbs
@@ -356,24 +356,47 @@
 
   <Shw::Grid {{style gap="2rem"}} @columns={{2}} as |SG|>
     <SG.Item @label="Forced state">
-      <button type="button" {{style padding=".25rem" marginBottom="1rem"}} {{on "click" this.toggleState}}>
-        {{if (eq this.state "open") "Collapse all" "Expand all"}}
+      <button type="button" {{style padding=".25rem" marginBottom="1rem"}} {{on "click" this.toggleStateAll}}>
+        {{if (eq this.stateAll "open") "Collapse all" "Expand all"}}
       </button>
-      <Hds::Accordion @forceState={{this.state}} as |A|>
+      <Hds::Accordion @forceState={{this.stateAll}} as |A|>
         <A.Item>
           <:toggle>Item one</:toggle>
           <:content>
             <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
-
         <A.Item>
           <:toggle>Item two</:toggle>
           <:content>
             <Shw::Placeholder @text="generic content" @height="40" />
           </:content>
         </A.Item>
-
+        <A.Item>
+          <:toggle>Item Three</:toggle>
+          <:content>
+            <Shw::Placeholder @text="generic content" @height="40" />
+          </:content>
+        </A.Item>
+      </Hds::Accordion>
+    </SG.Item>
+    <SG.Item @label="Forced state">
+      <button type="button" {{style padding=".25rem" marginBottom="1rem"}} {{on "click" this.toggleStateSingle}}>
+        {{if (eq this.stateSingle "open") "Collapse item 2" "Expand item 2"}}
+      </button>
+      <Hds::Accordion as |A|>
+        <A.Item>
+          <:toggle>Item one</:toggle>
+          <:content>
+            <Shw::Placeholder @text="generic content" @height="40" />
+          </:content>
+        </A.Item>
+        <A.Item @forceState={{this.stateSingle}} @onClickToggle={{this.onClickToggleSingle}}>
+          <:toggle>Item two</:toggle>
+          <:content>
+            <Shw::Placeholder @text="generic content" @height="40" />
+          </:content>
+        </A.Item>
         <A.Item>
           <:toggle>Item Three</:toggle>
           <:content>

--- a/showcase/app/templates/components/accordion.hbs
+++ b/showcase/app/templates/components/accordion.hbs
@@ -356,7 +356,7 @@
 
   <Shw::Grid {{style gap="2rem"}} @columns={{2}} as |SG|>
     <SG.Item @label="Forced state">
-      <button {{style padding=".25rem" marginBottom="1rem"}} type="button" {{on "click" this.toggleState}}>
+      <button type="button" {{style padding=".25rem" marginBottom="1rem"}} {{on "click" this.toggleState}}>
         {{if (eq this.state "open") "Collapse all" "Expand all"}}
       </button>
       <Hds::Accordion @forceState={{this.state}} as |A|>
@@ -437,6 +437,19 @@
       </SG.Item>
     {{/each}}
   </Shw::Grid>
+
+  <Shw::Text::Body><strong>close</strong></Shw::Text::Body>
+
+  <Shw::Flex {{style gap="2rem" marginBottom="2rem"}} @direction="column" as |SF|>
+    <SF.Item @label="Close action within content">
+      <Hds::Accordion::Item>
+        <:toggle>Item one</:toggle>
+        <:content as |c|>
+          <button type="button" {{style padding=".25rem" marginBottom="1rem"}} {{on "click" c.close}}>Close</button>
+        </:content>
+      </Hds::Accordion::Item>
+    </SF.Item>
+  </Shw::Flex>
 
   <Shw::Divider @level={{2}} />
 

--- a/showcase/app/templates/utilities/disclosure-primitive.hbs
+++ b/showcase/app/templates/utilities/disclosure-primitive.hbs
@@ -139,4 +139,24 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Flex as |SF|>
+    <SF.Label>Controlled externally</SF.Label>
+    <SF.Item @grow={{true}}>
+      <button type="button" {{on "click" (fn this.toggleState "open")}}>Open</button>
+      <button type="button" {{on "click" (fn this.toggleState "close")}}>Close</button>
+      <div class="shw-utility-disclosure-primitive-container">
+        <Hds::DisclosurePrimitive @isOpen={{this.isOpen}}>
+          <:toggle as |t|>
+            <button type="button" {{on "click" t.onClickToggle}}>
+              Click me
+              <FlightIcon @name={{if t.isOpen "chevron-up" "chevron-down"}} />
+            </button>
+          </:toggle>
+          <:content>
+            <Shw::Placeholder @text="some generic content here" @width="200" @height="90" @background="#e1f5fe" />
+          </:content>
+        </Hds::DisclosurePrimitive>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
 </section>

--- a/showcase/app/templates/utilities/disclosure-primitive.hbs
+++ b/showcase/app/templates/utilities/disclosure-primitive.hbs
@@ -144,8 +144,9 @@
     <SF.Item @grow={{true}}>
       <button type="button" {{on "click" (fn this.toggleState "open")}}>Open</button>
       <button type="button" {{on "click" (fn this.toggleState "close")}}>Close</button>
+      <button type="button" {{on "click" this.toggleState}}>Toggle</button>
       <div class="shw-utility-disclosure-primitive-container">
-        <Hds::DisclosurePrimitive @isOpen={{this.isOpen}}>
+        <Hds::DisclosurePrimitive @isOpen={{this.isOpen}} @onClickToggle={{this.onClickToggle}}>
           <:toggle as |t|>
             <button type="button" {{on "click" t.onClickToggle}}>
               Click me

--- a/showcase/tests/integration/components/hds/accordion/index-test.js
+++ b/showcase/tests/integration/components/hds/accordion/index-test.js
@@ -291,4 +291,23 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
     await click('.hds-accordion-item__button');
     assert.dom('.hds-accordion-item__content').exists({ count: 1 });
   });
+
+  // close
+
+  test('it should hide the content when an accordion item triggers `close`', async function (assert) {
+    await render(hbs`
+      <Hds::Accordion::Item>
+        <:toggle>Item one</:toggle>
+        <:content as |c|>
+          <button type="button" {{on "click" c.close}}>Close</button>
+        </:content>
+      </Hds::Accordion::Item>
+    `);
+    await click('.hds-accordion-item__button');
+    assert.dom('.hds-accordion-item__content').exists();
+
+    await click('.hds-accordion-item__content button');
+    assert.dom('.hds-accordion-item__content').doesNotExist();
+    assert.dom('.hds-accordion-item__content button').doesNotExist();
+  });
 });

--- a/showcase/tests/integration/components/hds/accordion/index-test.js
+++ b/showcase/tests/integration/components/hds/accordion/index-test.js
@@ -273,7 +273,10 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
       `
     );
     // first item open at rendering
-    assert.dom('.hds-accordion-item__content').exists({ count: 1 });
+    assert
+      .dom('.hds-accordion-item__content')
+      .exists({ count: 1 })
+      .containsText('Content one');
 
     // all items open via forceState (external override to open)
     this.set('forceState', 'open');
@@ -281,7 +284,10 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
 
     // first item closed via toggle (internal override to close)
     await click('.hds-accordion-item__button');
-    assert.dom('.hds-accordion-item__content').exists({ count: 1 });
+    assert
+      .dom('.hds-accordion-item__content')
+      .exists({ count: 1 })
+      .containsText('Content two');
 
     // all items closed via forceState (external override to close)
     this.set('forceState', 'close');
@@ -289,7 +295,10 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
 
     // first item open via toggle  (internal override to open)
     await click('.hds-accordion-item__button');
-    assert.dom('.hds-accordion-item__content').exists({ count: 1 });
+    assert
+      .dom('.hds-accordion-item__content')
+      .exists({ count: 1 })
+      .containsText('Content one');
   });
 
   // close

--- a/showcase/tests/integration/components/hds/accordion/index-test.js
+++ b/showcase/tests/integration/components/hds/accordion/index-test.js
@@ -192,7 +192,8 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
   // OPTIONS
 
   // isOpen
-  test('it displays content initially when @isOpen is set to true, ', async function (assert) {
+
+  test('it displays content initially when @isOpen is set to true', async function (assert) {
     await render(
       hbs`
         <Hds::Accordion as |A|>
@@ -253,5 +254,41 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
     assert
       .dom('.hds-accordion-item__button')
       .hasStyle({ visibility: 'hidden' });
+  });
+
+  // forceState
+  test('it displays the correct content based on @forceState', async function (assert) {
+    await render(
+      hbs`
+        <Hds::Accordion @forceState={{this.forceState}} as |A|>
+          <A.Item @isOpen={{true}}>
+            <:toggle>Item one</:toggle>
+            <:content>Content one</:content>
+          </A.Item>
+          <A.Item @isOpen={{false}}>
+            <:toggle>Item one</:toggle>
+            <:content>Content two</:content>
+          </A.Item>
+        </Hds::Accordion>
+      `
+    );
+    // first item open at rendering
+    assert.dom('.hds-accordion-item__content').exists({ count: 1 });
+
+    // all items open via forceState (external override to open)
+    this.set('forceState', 'open');
+    assert.dom('.hds-accordion-item__content').exists({ count: 2 });
+
+    // first item closed via toggle (internal override to close)
+    await click('.hds-accordion-item__button');
+    assert.dom('.hds-accordion-item__content').exists({ count: 1 });
+
+    // all items closed via forceState (external override to close)
+    this.set('forceState', 'close');
+    assert.dom('.hds-accordion-item__content').doesNotExist();
+
+    // first item open via toggle  (internal override to open)
+    await click('.hds-accordion-item__button');
+    assert.dom('.hds-accordion-item__content').exists({ count: 1 });
   });
 });

--- a/showcase/tests/integration/components/hds/accordion/index-test.js
+++ b/showcase/tests/integration/components/hds/accordion/index-test.js
@@ -310,4 +310,30 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
     assert.dom('.hds-accordion-item__content').doesNotExist();
     assert.dom('.hds-accordion-item__content button').doesNotExist();
   });
+
+  // onClickToggle
+
+  test('it should call onClickToggle function', async function (assert) {
+    let state = 'close';
+    this.set(
+      'onClickToggle',
+      () => (state = state === 'open' ? (state = 'close') : (state = 'open'))
+    );
+    await render(hbs`
+      <Hds::Accordion::Item @forceState={{this.state}} @onClickToggle={{this.onClickToggle}}>
+        <:toggle>Item one</:toggle>
+        <:content>Content one</:content>
+      </Hds::Accordion::Item>
+    `);
+    // closed by default
+    assert.dom('.hds-accordion-item__content').doesNotExist();
+    // toggle to open
+    await click('.hds-accordion-item__button');
+    assert.strictEqual(state, 'open');
+    assert.dom('.hds-accordion-item__content').exists();
+    // toggle to close
+    await click('.hds-accordion-item__button');
+    assert.strictEqual(state, 'close');
+    assert.dom('.hds-accordion-item__content').doesNotExist();
+  });
 });

--- a/showcase/tests/integration/components/hds/disclosure-primitive/index-test.js
+++ b/showcase/tests/integration/components/hds/disclosure-primitive/index-test.js
@@ -177,5 +177,30 @@ module(
       assert.dom('.hds-disclosure-primitive__content').doesNotExist();
       assert.dom('button#test-content-button').doesNotExist();
     });
+
+    // CALLBACK
+
+    test('it should invoke the `onClickToggle` callback', async function (assert) {
+      let opened = false;
+      this.set('onClickToggle', () => (opened = !opened));
+      await render(hbs`
+        <Hds::DisclosurePrimitive @onClickToggle={{this.onClickToggle}} id="test-disclosure-primitive">
+          <:toggle as |t|>
+            <button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} />
+          </:toggle>
+          <:content>
+            <a id="test-disclosure-primitive-link" href="#">test</a>
+          </:content>
+        </Hds::DisclosurePrimitive>
+      `);
+      // toggle to open
+      await click('button#test-toggle-button');
+      assert.true(opened);
+      assert.dom('.hds-disclosure-primitive__content').exists();
+      // toggle to close
+      await click('button#test-toggle-button');
+      assert.false(opened);
+      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
+    });
   }
 );

--- a/showcase/tests/integration/components/hds/disclosure-primitive/index-test.js
+++ b/showcase/tests/integration/components/hds/disclosure-primitive/index-test.js
@@ -56,6 +56,107 @@ module(
       assert.dom('a#test-disclosure-primitive-link').exists();
     });
 
+    // isOpen
+
+    test('it should toggle the "content" when @isOpen is set', async function (assert) {
+      this.set('isOpen', true);
+      await render(hbs`
+      <Hds::DisclosurePrimitive @isOpen={{this.isOpen}} id="test-disclosure-primitive">
+        <:toggle as |t|>
+          <button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} />
+        </:toggle>
+        <:content>
+          <a id="test-disclosure-primitive-link" href="#">test</a>
+        </:content>
+      </Hds::DisclosurePrimitive>
+    `);
+      assert.dom('.hds-disclosure-primitive__content').exists();
+      assert.dom('a#test-disclosure-primitive-link').exists();
+
+      this.set('isOpen', false);
+      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
+      assert.dom('a#test-disclosure-primitive-link').doesNotExist();
+    });
+
+    test('it should allow @isOpen to override an internal _isOpen=true', async function (assert) {
+      await render(hbs`
+      <Hds::DisclosurePrimitive @isOpen={{this.isOpen}} id="test-disclosure-primitive">
+        <:toggle as |t|>
+          <button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} />
+        </:toggle>
+        <:content>
+          <a id="test-disclosure-primitive-link" href="#">test</a>
+        </:content>
+      </Hds::DisclosurePrimitive>
+    `);
+      await click('button#test-toggle-button');
+      assert.dom('.hds-disclosure-primitive__content').exists();
+      assert.dom('a#test-disclosure-primitive-link').exists();
+
+      this.set('isOpen', false);
+      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
+      assert.dom('a#test-disclosure-primitive-link').doesNotExist();
+    });
+
+    test('it should allow @isOpen to override an internal _isOpen=false', async function (assert) {
+      await render(hbs`
+      <Hds::DisclosurePrimitive @isOpen={{this.isOpen}} id="test-disclosure-primitive">
+        <:toggle as |t|>
+          <button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} />
+        </:toggle>
+        <:content>
+          <a id="test-disclosure-primitive-link" href="#">test</a>
+        </:content>
+      </Hds::DisclosurePrimitive>
+    `);
+      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
+      assert.dom('a#test-disclosure-primitive-link').doesNotExist();
+
+      this.set('isOpen', true);
+      assert.dom('.hds-disclosure-primitive__content').exists();
+      assert.dom('a#test-disclosure-primitive-link').exists();
+    });
+
+    test('it should allow the internal _isOpen to override @isOpen=true', async function (assert) {
+      this.set('isOpen', true);
+      await render(hbs`
+      <Hds::DisclosurePrimitive @isOpen={{this.isOpen}} id="test-disclosure-primitive">
+        <:toggle as |t|>
+          <button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} />
+        </:toggle>
+        <:content>
+          <a id="test-disclosure-primitive-link" href="#">test</a>
+        </:content>
+      </Hds::DisclosurePrimitive>
+    `);
+      assert.dom('.hds-disclosure-primitive__content').exists();
+      assert.dom('a#test-disclosure-primitive-link').exists();
+
+      await click('button#test-toggle-button');
+      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
+      assert.dom('a#test-disclosure-primitive-link').doesNotExist();
+    });
+
+    test('it should allow the internal _isOpen to override @isOpen=false', async function (assert) {
+      this.set('isOpen', false);
+      await render(hbs`
+      <Hds::DisclosurePrimitive @isOpen={{this.isOpen}} id="test-disclosure-primitive">
+        <:toggle as |t|>
+          <button type="button" id="test-toggle-button" {{on "click" t.onClickToggle}} />
+        </:toggle>
+        <:content>
+          <a id="test-disclosure-primitive-link" href="#">test</a>
+        </:content>
+      </Hds::DisclosurePrimitive>
+    `);
+      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
+      assert.dom('a#test-disclosure-primitive-link').doesNotExist();
+
+      await click('button#test-toggle-button');
+      assert.dom('.hds-disclosure-primitive__content').exists();
+      assert.dom('a#test-disclosure-primitive-link').exists();
+    });
+
     // CLOSE DISCLOSED CONTENT ON CLICK
 
     test('it should hide the "content" when an interactive element triggers `close`', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

In this PR we propose a set of enhancements to our Accordion component to accommodate the following use cases without introducing any breaking changes:

**Allow consumers to implement an "expand all"/"collapse all" functionality** ([request reference](https://hashicorp.slack.com/archives/C7KTUHNUS/p1691525412883139))
   - we considered embedding the button inside the component but decided that would be too restrictive for our consumers
   - the flexible implementation also allows consumers to control the state (`open`/`close`) of each accordion item from outside the component

Example of usage
  ```hbs
<button type="button" {{on "click" this.toggleState}}>
    {{if (eq this.state "open") "Collapse all" "Expand all"}}
</button>

<Hds::Accordion @forceState={{this.state}} as |A|>
    {{! accordion items }}
</Hds::Accordion>
```

**Expose a function to close an accordion item from within its content** ([request reference](https://hashicorp.slack.com/archives/C7KTUHNUS/p1697824296621389?thread_ts=1691525412.883139&cid=C7KTUHNUS))

Example of usage
```hbs
<Hds::Accordion::Item>
  <:toggle>Item one</:toggle>
  <:content as |c|>
     <button type="button" {{on "click" c.close}}>Close</button>
  </:content>
</Hds::Accordion::Item>
```

### :hammer_and_wrench: Detailed description

 - Updated the `DisclosurePrimitive` to allow external control of the `isOpen` state. We do this by introducing two private properties (`_isOpen`, representing the internal state and `_isControlled` set to `true` every time the `@isOpen` argument is changed externally). Tried to follow the [concepts previously explored](https://hashicorp.atlassian.net/jira/polaris/projects/HDSP/ideas/view/3955253?selectedIssue=HDSP-23&focusedCommentId=435444).
 - Updated the `Accordion::Item` and `Accordion` adding a `@forceState` argument (`open`/`close`) to control the state from outside the component after the initial render.
- Updated the `Accordion::Item` component to forward the `close` action from `DisclosurePrimitive`.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3364](https://hashicorp.atlassian.net/browse/HDS-3364)

***

### 👀 Component checklist

- [x] Make the type adjustments in the relevant `types.ts` files
- [x] Extend test suites to cover the new functionality
- [x] Test/validate the solution with consumers
- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3364]: https://hashicorp.atlassian.net/browse/HDS-3364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ