### PR TITLE
Change start command in docs to include build step

### DIFF
--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -40,7 +40,7 @@ The associated test application is located at the root of the monorepo, in `show
 ## Running the `showcase` application
 
 * `cd showcase`
-* `ember s`
+* `yarn run start`
 * Visit the application at [http://localhost:4200](http://localhost:4200).
 
 For more information on using ember-cli, visit [https://cli.emberjs.com/release/](https://cli.emberjs.com/release/).


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will change the instructions for running the Showcase application in the CONTRIBUTING document in the components package.

The command changes from `ember start` to `yarn run start`. Unless a contributor has already built the dependent packages, `ember start` won't work. Alternatively, `yarn run start` will work the first time because it first runs `yarn build:packages`. 
