### PR TITLE
`doc-track-event` modifier

### DIFF
--- a/website/app/components/doc/link-with-icon/index.hbs
+++ b/website/app/components/doc/link-with-icon/index.hbs
@@ -9,7 +9,7 @@
     @route={{@route}}
     @models={{this.models}}
     ...attributes
-    {{on "click" (fn this.eventTracking.trackEvent @eventName)}}
+    {{doc-track-event @eventName}}
   >
     {{@label}}
     <FlightIcon class="doc-link-with-icon__icon" @name={{@icon}} />
@@ -21,7 +21,7 @@
     href={{@href}}
     target="_blank"
     rel="noopener noreferrer"
-    {{on "click" (fn this.eventTracking.trackEvent @eventName)}}
+    {{doc-track-event @eventName}}
     ...attributes
   >
     {{@label}}

--- a/website/app/modifiers/doc-track-event.js
+++ b/website/app/modifiers/doc-track-event.js
@@ -1,0 +1,34 @@
+import Modifier from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
+import { inject as service } from '@ember/service';
+
+function handleClick(eventName) {
+  window.fathom?.trackEvent(eventName);
+}
+
+function cleanup(instance) {
+  instance.eventName = null;
+  instance.element.removeEventListener('click', handleClick);
+}
+
+export default class DocTrackEvent extends Modifier {
+  @service fastboot;
+
+  element = null;
+  eventName = null;
+
+  modify(element, [eventName]) {
+    if (!this.fastboot.isFastBoot && window.fathom && eventName) {
+      this.addEventListener(element, eventName);
+
+      registerDestructor(this, cleanup);
+    }
+  }
+
+  addEventListener(element, eventName) {
+    this.element = element;
+    this.eventName = eventName;
+
+    element.addEventListener('click', handleClick(eventName));
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -122,6 +122,7 @@
     "remark-rehype": "^11.0.0",
     "resolve": "^1.22.8",
     "showdown": "^2.1.0",
+    "sinon": "^18.0.0",
     "stylelint": "^16.3.1",
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard-scss": "^13.1.0",

--- a/website/tests/integration/modifiers/doc-track-event-test.js
+++ b/website/tests/integration/modifiers/doc-track-event-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { click } from '@ember/test-helpers';
+import sinon from 'sinon';
+
+module('Integration | Modifier | doc-track-event', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let originalFathom;
+  let trackEventSpy;
+
+  hooks.beforeEach(function () {
+    originalFathom = window.fathom;
+    trackEventSpy = sinon.spy();
+    window.fathom = {
+      trackEvent: trackEventSpy,
+    };
+  });
+
+  hooks.afterEach(function () {
+    window.fathom = originalFathom;
+  });
+
+  test('it adds click event listener and calls handleClick', async function (assert) {
+    await render(hbs`<div {{doc-track-event 'testEvent'}}></div>`);
+    await click('div');
+
+    assert.ok(trackEventSpy.calledOnceWith('testEvent'));
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4825,6 +4825,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinonjs/commons@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@sinonjs/commons@npm:3.0.1"
+  dependencies:
+    type-detect: "npm:4.0.8"
+  checksum: a0af217ba7044426c78df52c23cedede6daf377586f3ac58857c565769358ab1f44ebf95ba04bbe38814fba6e316ca6f02870a009328294fc2c555d0f85a7117
+  languageName: node
+  linkType: hard
+
 "@sinonjs/fake-timers@npm:^10.0.2":
   version: 10.3.0
   resolution: "@sinonjs/fake-timers@npm:10.3.0"
@@ -4854,7 +4863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/text-encoding@npm:^0.7.1":
+"@sinonjs/text-encoding@npm:^0.7.1, @sinonjs/text-encoding@npm:^0.7.2":
   version: 0.7.2
   resolution: "@sinonjs/text-encoding@npm:0.7.2"
   checksum: ec713fb44888c852d84ca54f6abf9c14d036c11a5d5bfab7825b8b9d2b22127dbe53412c68f4dbb0c05ea5ed61c64679bd2845c177d81462db41e0d3d7eca499
@@ -11514,6 +11523,13 @@ __metadata:
   version: 5.1.0
   resolution: "diff@npm:5.1.0"
   checksum: f4557032a98b2967fe27b1a91dfcf8ebb6b9a24b1afe616b5c2312465100b861e9b8d4da374be535f2d6b967ce2f53826d7f6edc2a0d32b2ab55abc96acc2f9d
+  languageName: node
+  linkType: hard
+
+"diff@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "diff@npm:5.2.0"
+  checksum: 01b7b440f83a997350a988e9d2f558366c0f90f15be19f4aa7f1bb3109a4e153dfc3b9fbf78e14ea725717017407eeaa2271e3896374a0181e8f52445740846d
   languageName: node
   linkType: hard
 
@@ -18592,6 +18608,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"just-extend@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "just-extend@npm:6.2.0"
+  checksum: 1f487b074b9e5773befdd44dc5d1b446f01f24f7d4f1f255d51c0ef7f686e8eb5f95d983b792b9ca5c8b10cd7e60a924d64103725759eddbd7f18bcb22743f92
+  languageName: node
+  linkType: hard
+
 "keyv@npm:^3.0.0":
   version: 3.1.0
   resolution: "keyv@npm:3.1.0"
@@ -20665,6 +20688,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nise@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "nise@npm:6.0.0"
+  dependencies:
+    "@sinonjs/commons": "npm:^3.0.0"
+    "@sinonjs/fake-timers": "npm:^11.2.2"
+    "@sinonjs/text-encoding": "npm:^0.7.2"
+    just-extend: "npm:^6.2.0"
+    path-to-regexp: "npm:^6.2.1"
+  checksum: a11be5fd21ece95c80fda14a2cf80350404acc895467fc5104dc9ea9c0630614fcc83e10591ead96796b31aa2f3ccb7dc9198ed940d0f3e91e760bf5104d41a8
+  languageName: node
+  linkType: hard
+
 "no-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "no-case@npm:3.0.4"
@@ -21695,6 +21731,13 @@ __metadata:
   version: 6.2.1
   resolution: "path-to-regexp@npm:6.2.1"
   checksum: 1e266be712d1a08086ee77beab12a1804842ec635dfed44f9ee1ba960a0e01cec8063fb8c92561115cdc0ce73158cdc7766e353ffa039340b4a85b370084c4d4
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^6.2.1":
+  version: 6.2.2
+  resolution: "path-to-regexp@npm:6.2.2"
+  checksum: f7d11c1a9e02576ce0294f4efdc523c11b73894947afdf7b23a0d0f7c6465d7a7772166e770ddf1495a8017cc0ee99e3e8a15ed7302b6b948b89a6dd4eea895e
   languageName: node
   linkType: hard
 
@@ -24321,6 +24364,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sinon@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "sinon@npm:18.0.0"
+  dependencies:
+    "@sinonjs/commons": "npm:^3.0.1"
+    "@sinonjs/fake-timers": "npm:^11.2.2"
+    "@sinonjs/samsam": "npm:^8.0.0"
+    diff: "npm:^5.2.0"
+    nise: "npm:^6.0.0"
+    supports-color: "npm:^7"
+  checksum: 4c491798e2b7bb0e60357eb19820956229fb4356af7b00498f7a30dcbfe186597c816c331d8acd1771cb32510adde7657eeee0172fbd0baecdbb00e1d8c6806f
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -25436,7 +25493,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
+"supports-color@npm:^7, supports-color@npm:^7.0.0, supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -27483,6 +27540,7 @@ __metadata:
     remark-rehype: "npm:^11.0.0"
     resolve: "npm:^1.22.8"
     showdown: "npm:^2.1.0"
+    sinon: "npm:^18.0.0"
     stylelint: "npm:^16.3.1"
     stylelint-config-rational-order: "npm:^0.1.2"
     stylelint-config-standard-scss: "npm:^13.1.0"


### PR DESCRIPTION
### :pushpin: Summary

Adds the `doc-track-event` modifier which can be used to track an event in fathom when clicking an element.

### :hammer_and_wrench: Detailed description

TODO
