### PR TITLE
Update blueprints to be TypeScript-ready

### DIFF
--- a/showcase/blueprints/hds-component-test/files/tests/integration/components/hds/__name__/index-test.js
+++ b/showcase/blueprints/hds-component-test/files/tests/integration/components/hds/__name__/index-test.js
@@ -8,9 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module(
-  'Integration | Component | hds/<%= dasherizedModuleName %>/index',
-  function (hooks) {
+module('Integration | Component | hds/<%= dasherizedModuleName %>/index', function (hooks) {
     setupRenderingTest(hooks);
 
     test('it should render the component with a CSS class that matches the component name', async function (assert) {

--- a/showcase/blueprints/hds-component-test/index.js
+++ b/showcase/blueprints/hds-component-test/index.js
@@ -41,7 +41,7 @@ module.exports = {
 
 const updateDummyAppRouter = (options) => {
   const newRouteToAdd = `components/${options.entity.name}`; // we prefix all the component routes with "components"
-  const routerFilePath = `${options.project.root}/app/router.js`;
+  const routerFilePath = `${options.project.root}/app/router.ts`;
   const source = fs.readFileSync(routerFilePath, 'utf-8');
   let oldRoutes = new EmberRouterGenerator(source);
   let newRoutes = oldRoutes['add'](newRouteToAdd, options);

--- a/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.ts
+++ b/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.ts
@@ -16,7 +16,7 @@ export interface Hds<%= classifiedModuleName %>Signature {
   Element: HTMLDivElement;
 }
 
-export default class Hds<%= classifiedModuleName %>IndexComponent extends Component<Hds<%= classifiedModuleName %>Signature> {
+export default class Hds<%= classifiedModuleName %>Component extends Component<Hds<%= classifiedModuleName %>Signature> {
   // UNCOMMENT THIS IF YOU NEED A CONSTRUCTOR
   // constructor() {
   //   super(...arguments);

--- a/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.ts
+++ b/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.ts
@@ -15,6 +15,7 @@ export interface Hds<%= classifiedModuleName %>Signature {
   // The element to which `...attributes` is applied in the component template  
   Element: HTMLDivElement;
 }
+// More info on types and signatures: https://github.com/hashicorp/design-system/blob/main/wiki/TypeScript-Migration.md 
 
 export default class Hds<%= classifiedModuleName %>Component extends Component<Hds<%= classifiedModuleName %>Signature> {
   // UNCOMMENT THIS IF YOU NEED A CONSTRUCTOR

--- a/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.ts
+++ b/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.ts
@@ -5,7 +5,18 @@
 
 import Component from '@glimmer/component';
 
-export default class Hds<%= classifiedModuleName %>IndexComponent extends Component {
+export interface Hds<%= classifiedModuleName %>Signature {
+  // The arguments accepted by the component
+  Args: {};
+  // Any blocks yielded by the component  
+  Blocks: {
+    default: [];
+  };
+  // The element to which `...attributes` is applied in the component template  
+  Element: HTMLDivElement;
+}
+
+export default class Hds<%= classifiedModuleName %>IndexComponent extends Component<Hds<%= classifiedModuleName %>Signature> {
   // UNCOMMENT THIS IF YOU NEED A CONSTRUCTOR
   // constructor() {
   //   super(...arguments);


### PR DESCRIPTION
### :pushpin: Summary

As we started converting components to TypeScript we want to build new components straight in TypeScript to avoid increasing our migration backlog.

In this PR we update our custom Ember blueprints to be TypeScript-ready. In preparation for the components we plan to develop.

### :hammer_and_wrench: Detailed description

Updated the blueprint to generate the backing class in TypeScript and applied a fix where the route was not updated.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3381](https://hashicorp.atlassian.net/browse/HDS-3381)

***
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3381]: https://hashicorp.atlassian.net/browse/HDS-3381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ