### PR TITLE
integrates `excludeAllQueryParams` feature from `ember-a11y-refocus`

### DIFF
--- a/.changeset/angry-ghosts-repeat.md
+++ b/.changeset/angry-ghosts-repeat.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-Adds option to exclude query params from route transition/focus management
+`SideNav` - Adds option to exclude query params from route transition/focus management

--- a/.changeset/angry-ghosts-repeat.md
+++ b/.changeset/angry-ghosts-repeat.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Adds option to exclude query params from route transition/focus management

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
     "@hashicorp/ember-flight-icons": "^5.0.3",
     "@oddbird/popover-polyfill": "^0.4.3",
     "decorator-transforms": "^1.1.0",
-    "ember-a11y-refocus": "^3.0.2",
+    "ember-a11y-refocus": "^4.1.0",
     "ember-cli-sass": "^11.0.1",
     "ember-composable-helpers": "^5.0.0",
     "ember-element-helper": "^0.8.5",

--- a/packages/components/src/components/hds/side-nav/index.hbs
+++ b/packages/components/src/components/hds/side-nav/index.hbs
@@ -20,6 +20,7 @@
         @skipTo="#{{@a11yRefocusSkipTo}}"
         @skipText={{@a11yRefocusSkipText}}
         @navigationText={{@a11yRefocusNavigationText}}
+        @excludeAllQueryParams={{@a11yRefocusExcludeAllQueryParams}}
       />
     {{/if}}
     {{#if this.showToggleButton}}

--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -21,6 +21,7 @@ interface HdsSideNavSignature {
     a11yRefocusSkipText?: string;
     a11yRefocusNavigationText?: string;
     a11yRefocusRouteChangeValidator?: string;
+    a11yRefocusExcludeAllQueryParams?: boolean;
     ariaLabel?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onToggleMinimizedStatus?: (arg: boolean) => void;

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -44,6 +44,9 @@ This is the full-fledged component (responsive and animated).
       <C.Property @name="a11yRefocusRouteChangeValidator" @type="string">
         Pass-through property for the `routeChangeValidator` argument - Custom function used to define which route changes should trigger the refocusing behavior for the navigator narrator. - For details see [Customizing the definition of a route change](https://github.com/ember-a11y/ember-a11y-refocus#customizing-the-definition-of-a-route-change).
       </C.Property>
+      <C.Property @name="a11yRefocusExcludeAllQueryParams" @type="boolean">
+        Pass-through property for the `excludeAllQueryParams` argument - Can be used when you need to completely opt out of all transition focus management for all query params. Use with caution; you'll typically want to reach for a custom route change validator function instead.
+      </C.Property>
     </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="ariaLabel" @type="string">

--- a/website/package.json
+++ b/website/package.json
@@ -57,7 +57,7 @@
     "broccoli-multifilter": "https://github.com/broccolijs/broccoli-multifilter.git#commit=3ae609df0cfb1dae0da04ae041eb75c7115c9838",
     "cspell": "^7.3.8",
     "dotenv": "^16.3.1",
-    "ember-a11y-refocus": "^3.0.2",
+    "ember-a11y-refocus": "^4.1.0",
     "ember-a11y-testing": "^6.1.1",
     "ember-auto-import": "^2.6.3",
     "ember-basic-dropdown": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3738,7 +3738,7 @@ __metadata:
     babel-plugin-ember-template-compilation: "npm:^2.2.4"
     concurrently: "npm:^8.2.2"
     decorator-transforms: "npm:^1.1.0"
-    ember-a11y-refocus: "npm:^3.0.2"
+    ember-a11y-refocus: "npm:^4.1.0"
     ember-basic-dropdown: "npm:^8.1.0"
     ember-cli-sass: "npm:^11.0.1"
     ember-composable-helpers: "npm:^5.0.0"
@@ -11823,13 +11823,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-a11y-refocus@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "ember-a11y-refocus@npm:3.0.2"
+"ember-a11y-refocus@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "ember-a11y-refocus@npm:4.1.0"
   dependencies:
     ember-cli-babel: "npm:^7.26.11"
     ember-cli-htmlbars: "npm:^6.0.1"
-  checksum: 10/c47f03e47f007145870ace66dc4d2b4d714aeda89a9e9fdfed570af23759b41d5b84c5b6265781c9a55e4ee85a48942c8b5c17d822d717d2b0b2b2d3ca6f94de
+  checksum: 10/16c8df41f42e58ec3fcd5166f3641c4a8cd076c0858b74bf6ce226a44e4a39f275fbdff4ad28dae1978e7a995f4ac4603576dc2940b9cdd18d42153a6c070235
   languageName: node
   linkType: hard
 
@@ -27533,7 +27533,7 @@ __metadata:
     broccoli-multifilter: "https://github.com/broccolijs/broccoli-multifilter.git#commit=3ae609df0cfb1dae0da04ae041eb75c7115c9838"
     cspell: "npm:^7.3.8"
     dotenv: "npm:^16.3.1"
-    ember-a11y-refocus: "npm:^3.0.2"
+    ember-a11y-refocus: "npm:^4.1.0"
     ember-a11y-testing: "npm:^6.1.1"
     ember-auto-import: "npm:^2.6.3"
     ember-basic-dropdown: "npm:^8.1.0"


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds the new `excludeAllQueryParams` option from `ember-a11y-refocus`. 

### :hammer_and_wrench: Detailed description

- upgrades the dependency to 4.1.0 in components and website
- adds the flag
- updates the docs
- adds a changeset

### :camera_flash: Screenshots

![CleanShot 2024-06-12 at 14 08 18](https://github.com/hashicorp/design-system/assets/4587451/762c8cd1-26d2-4445-acf1-b38f65e5cd62)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3369](https://hashicorp.atlassian.net/browse/HDS-3369)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3369]: https://hashicorp.atlassian.net/browse/HDS-3369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ