### PR TITLE
remove unnecessary assertion

### DIFF
--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -6,7 +6,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { assert } from '@ember/debug';
 import { registerDestructor } from '@ember/destroyable';
 
 import type { HdsSideNavBaseSignature } from './base';
@@ -72,13 +71,6 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
     registerDestructor(this, () => {
       this.removeEventListeners();
     });
-
-    if (this.args.hasA11yRefocus) {
-      assert(
-        '@a11yRefocusSkipTo for NavigatorNarrator (a11y-refocus) in "Hds::SideNav" must have a valid value',
-        this.args.a11yRefocusSkipTo !== undefined
-      );
-    }
   }
 
   addEventListeners() {

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -9,7 +9,6 @@ import {
   render,
   click,
   resetOnerror,
-  setupOnerror,
   triggerKeyEvent,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -249,20 +248,5 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     );
     await click('.hds-side-nav__toggle-button');
     assert.ok(toggled);
-  });
-
-  // ASSERTIONS
-
-  test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {
-    const errorMessage =
-      '@a11yRefocusSkipTo for NavigatorNarrator (a11y-refocus) in "Hds::SideNav" must have a valid value';
-    assert.expect(2);
-    setupOnerror(function (error) {
-      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
-    });
-    await render(hbs`<Hds::SideNav @hasA11yRefocus={{true}} />`);
-    assert.throws(function () {
-      throw new Error(errorMessage);
-    });
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will remove an assertion that should never need to fire, because the underlying property has a default value.

While looking at this component's code to add a new feature, I noticed an assertion that should not be necessary. In the [Additional Options](https://github.com/ember-a11y/ember-a11y-refocus?tab=readme-ov-file#additional-options) section of the addon's README, it indicates that if no custom value is provided for `skipTo`, then it defaults to `#main`. 


- no changelog because this is an internal change
- removed the assertion (conditional statement)
- removed the assert import for the component
- removed the related test



:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
