### PR TITLE
Adds `aria-describedby` to the icon filter input

### DIFF
--- a/website/app/components/doc/icons-list/index.hbs
+++ b/website/app/components/doc/icons-list/index.hbs
@@ -10,7 +10,9 @@
     @filterQuery={{@searchQuery}}
     @onInput={{@searchIcons}}
     data-test="icons-filter"
+    aria-describedby="icons-filter-description"
   />
+  <span id="icons-filter-description" class="sr-only">Note: Icon list will automatically update as you type.</span>
   <Doc::Form::SelectGroupType
     @label="Group by"
     @onSelect={{@onSelectGroupType}}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds `aria-describedby` to the icon input filter that points to a message for users with screen readers to inform them that the icon list will automatically update as they type.  I noticed it was missing while reviewing #2162 

### :hammer_and_wrench: Detailed description

- added `aria-describedby` attribute to the component invocation
- added an accompanying non-visible message for users with a screen reader

### :camera_flash: Screenshots

There is no visible change to the page, only the DOM:
![CleanShot 2024-06-13 at 10 02 12](https://github.com/hashicorp/design-system/assets/4587451/51e91b62-50d7-4ded-b7a9-77b021c82bbe)



***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
