### PR TITLE
Added conditional statement to icon list grid for h2

### DIFF
--- a/website/app/components/doc/icons-list/grid.hbs
+++ b/website/app/components/doc/icons-list/grid.hbs
@@ -2,8 +2,9 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
-<h2 class="doc-text-h4">{{capitalize @categoryName}}</h2>
+{{#if @categoryName}}
+  <h2 class="doc-text-h4">{{capitalize @categoryName}}</h2>
+{{/if}}
 <ul class="doc-icons-list-grid" role="list">
   {{#each @categoryIcons as |meta|}}
     <Doc::IconsList::Item @meta={{meta}} />

--- a/website/app/components/doc/icons-list/index.hbs
+++ b/website/app/components/doc/icons-list/index.hbs
@@ -10,7 +10,9 @@
     @filterQuery={{@searchQuery}}
     @onInput={{@searchIcons}}
     data-test="icons-filter"
+    aria-describedby="icons-filter-description"
   />
+  <span id="icons-filter-description" class="sr-only">Note: Icon list will automatically update as you type.</span>
   <Doc::Form::SelectGroupType
     @label="Group by"
     @onSelect={{@onSelectGroupType}}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a conditional in the icon grid list template so that the h2 is only rendered to the page if there is content for it.  

Otherwise, the headings rotor list just says "heading level two" with no text in it. This PR resolves that issue.


### :camera_flash: Screenshots

There is no visible change in the browser.


***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
