### PR TITLE
Tracking events for icon library

### DIFF
--- a/website/app/modifiers/doc-track-event.js
+++ b/website/app/modifiers/doc-track-event.js
@@ -9,14 +9,10 @@ import { inject as service } from '@ember/service';
 import { assert } from '@ember/debug';
 
 export default class DocTrackEvent extends Modifier {
-  @service fastboot;
+  @service eventTracking;
 
   modify(element, _positional, named) {
-    if (
-      // Only attempt to do something if we are in the right environment
-      this.fastboot.isFastBoot ||
-      window.fathom == null
-    ) {
+    if (!this.eventTracking.isEnabled) {
       // comment this line if you want to test in your local environment
       return;
     }
@@ -29,8 +25,7 @@ export default class DocTrackEvent extends Modifier {
     );
 
     const handleTriggerEvent = () => {
-      // https://usefathom.com/docs/features/events
-      window.fathom?.trackEvent(eventName);
+      this.eventTracking.trackEvent(eventName);
     };
 
     element.addEventListener(triggerEvent, handleTriggerEvent);

--- a/website/app/modifiers/doc-track-event.js
+++ b/website/app/modifiers/doc-track-event.js
@@ -12,9 +12,14 @@ export default class DocTrackEvent extends Modifier {
   @service eventTracking;
 
   modify(element, _positional, named) {
+<<<<<<< HEAD
     // if the tracking is disabled, do not add the event listener
     if (!this.eventTracking.isEnabled) {
       // comment this line if you want the tracking function in the `eventTracking` service to be called even if the tracking is disabled
+=======
+    if (!this.eventTracking.isEnabled) {
+      // comment this line if you want to test in your local environment
+>>>>>>> fb12260377205fed34a98ff052b6dd89950bd685
       return;
     }
 

--- a/website/app/modifiers/doc-track-event.js
+++ b/website/app/modifiers/doc-track-event.js
@@ -12,8 +12,9 @@ export default class DocTrackEvent extends Modifier {
   @service eventTracking;
 
   modify(element, _positional, named) {
+    // if the tracking is disabled, do not add the event listener
     if (!this.eventTracking.isEnabled) {
-      // comment this line if you want to test in your local environment
+      // comment this line if you want the tracking function in the `eventTracking` service to be called even if the tracking is disabled
       return;
     }
 

--- a/website/app/modifiers/doc-track-event.js
+++ b/website/app/modifiers/doc-track-event.js
@@ -12,14 +12,9 @@ export default class DocTrackEvent extends Modifier {
   @service eventTracking;
 
   modify(element, _positional, named) {
-<<<<<<< HEAD
     // if the tracking is disabled, do not add the event listener
     if (!this.eventTracking.isEnabled) {
       // comment this line if you want the tracking function in the `eventTracking` service to be called even if the tracking is disabled
-=======
-    if (!this.eventTracking.isEnabled) {
-      // comment this line if you want to test in your local environment
->>>>>>> fb12260377205fed34a98ff052b6dd89950bd685
       return;
     }
 

--- a/website/app/services/event-tracking.js
+++ b/website/app/services/event-tracking.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
+export default class EventService extends Service {
+  @service fastboot;
+
+  // Only attempt to do something if we are in the right environment
+  isEnabled = !this.fastboot.isFastBoot && window.fathom;
+
+  @action
+  trackEvent(eventName) {
+    if (this.isEnabled && eventName != null) {
+      // https://usefathom.com/docs/features/events
+      window.fathom.trackEvent(eventName);
+    }
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -78,6 +78,7 @@
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^4.0.2",
     "ember-fetch": "^8.1.2",
+    "ember-get-config": "^2.1.1",
     "ember-load-initializers": "^2.1.2",
     "ember-math-helpers": "^3.0.0",
     "ember-meta": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28044,6 +28044,7 @@ __metadata:
     ember-cli-terser: "npm:^4.0.2"
     ember-concurrency: "npm:^4.0.2"
     ember-fetch: "npm:^8.1.2"
+    ember-get-config: "npm:^2.1.1"
     ember-load-initializers: "npm:^2.1.2"
     ember-math-helpers: "npm:^3.0.0"
     ember-meta: "npm:^2.0.0"


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add tracking events to the icon library page.

### :hammer_and_wrench: Detailed description

- When a user searches (debounced by 1s), we track `Icon Library - Search - SEARCH_QUERY`
- When a user selects icon size, we track `Icon Library - Size Selector - SELECTED_SIZE`
- When a user selects how they want to group icons, we track `Icon Library - Group by Selector - GROUP_BY`

### :link: External links

https://hashicorp.atlassian.net/browse/HDS-3382
