### PR TITLE
Button docs: update "Types" heading to "Colors"

### DIFF
--- a/website/docs/components/button/partials/guidelines/guidelines.md
+++ b/website/docs/components/button/partials/guidelines/guidelines.md
@@ -25,7 +25,7 @@ Full-width buttons fill 100% of the parent container. Use full-width Buttons spa
 
 <Hds::Button @size="large" @isFullWidth={{true}} @text="Full-width button" />
 
-## Types
+## Colors
 
 ### Primary
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the "Types" heading in the Guidelines documentation for the `Button` component to "Colors" to reflect what is in the ember component. This change also has a counterpart in Figma that is currently being reviewed.

**Preview**: https://hds-website-git-hl-button-docs-fix-hashicorp.vercel.app/components/button#colors

### :link: External links

<!-- Issues, RFC, etc. -->
Jira link: [HDS-3418](https://hashicorp.atlassian.net/browse/HDS-3418)
Figma file: [https://www.figma.com/design/noyY6dUMDYjmySpHcMjhkN/branch/okCJ0NG78C60shsjLyTJMW/HDS-Product---Components?t=5GDzvduWgKkO7jFj-0](https://www.figma.com/design/noyY6dUMDYjmySpHcMjhkN/branch/okCJ0NG78C60shsjLyTJMW/HDS-Product---Components?t=5GDzvduWgKkO7jFj-0)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3418]: https://hashicorp.atlassian.net/browse/HDS-3418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ