### PR TITLE
Showcase - Remove `@wrap` argument from `Shw::Flex`

### DIFF
--- a/showcase/app/components/shw/flex/index.js
+++ b/showcase/app/components/shw/flex/index.js
@@ -14,11 +14,6 @@ export default class FlexIndexComponent extends Component {
     // add a class based on the @direction argument
     classes.push(`shw-flex--direction-${this.direction}`);
 
-    // add a class based on the @wrap argument
-    if (this.args.wrap) {
-      classes.push('shw-flex--wrap');
-    }
-
     return classes.join(' ');
   }
 }

--- a/showcase/app/styles/showcase-components/flex.scss
+++ b/showcase/app/styles/showcase-components/flex.scss
@@ -12,10 +12,6 @@
   }
 }
 
-.shw-flex--wrap {
-  flex-wrap: wrap;
-}
-
 .shw-flex__items {
   display: flex;
   gap: var(--shw-layout-gap-base);

--- a/showcase/app/templates/components/text.hbs
+++ b/showcase/app/templates/components/text.hbs
@@ -84,7 +84,7 @@
   <Shw::Text::H2>Color</Shw::Text::H2>
 
   <Shw::Text::H4 @tag="h3">Color inheritance</Shw::Text::H4>
-  <Shw::Flex @direction="row" @wrap={{true}} {{style gap="2rem"}} as |SF|>
+  <Shw::Flex @direction="row" {{style gap="2rem"}} as |SF|>
     <SF.Item @label="parent with no specific color">
       <div>
         <Hds::Text::Body @size="300" @tag="p">Lorem ipsum dolor</Hds::Text::Body>
@@ -98,7 +98,7 @@
   </Shw::Flex>
 
   <Shw::Text::H4 @tag="h3">Pre-defined colors</Shw::Text::H4>
-  <Shw::Flex @direction="row" @wrap={{true}} {{style gap="2rem"}} as |SF|>
+  <Shw::Flex @direction="row" {{style gap="2rem"}} as |SF|>
     {{#each this.model.AVAILABLE_COLORS as |color|}}
       <SF.Item @label={{color}}>
         <div class="shw-component-text-sample-color--{{color}}">
@@ -111,7 +111,7 @@
   </Shw::Flex>
 
   <Shw::Text::H4 @tag="h3">Custom colors</Shw::Text::H4>
-  <Shw::Flex @direction="row" @wrap={{true}} {{style gap="2rem"}} as |SF|>
+  <Shw::Flex @direction="row" {{style gap="2rem"}} as |SF|>
     <SF.Item @label="text with #e91e63 color">
       <Hds::Text::Body @size="300" @tag="p" @color="#e91e63">Lorem ipsum dolor</Hds::Text::Body>
     </SF.Item>


### PR DESCRIPTION
### :pushpin: Summary

Small PR that removes the `@wrap` argument from `Shw::Flex` component (it's not needed, and is applied to the wrong container too 🤦‍♂️)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
