### PR TITLE
Updated heading structure in BadgeCount docs

### DIFF
--- a/website/docs/components/badge-count/partials/guidelines/guidelines.md
+++ b/website/docs/components/badge-count/partials/guidelines/guidelines.md
@@ -10,7 +10,7 @@ To display version numbers (e.g., “v1.2.0”), collection counts in tabs, or s
 
 To display non-numeric information, consider [Badge](/components/badge).
 
-### Type
+## Type
 
 There are three types of BadgeCounts: filled, inverted, and outlined.
 
@@ -18,14 +18,14 @@ There are three types of BadgeCounts: filled, inverted, and outlined.
 <Hds::BadgeCount @text="3" @type="inverted" />
 <Hds::BadgeCount @text="3" @type="outlined" />
 
-### Color
+## Color
 
 There are two color options for each type: neutral and neutral-dark-mode.
 
 <Hds::BadgeCount @text="3" @color="neutral" />
 <Hds::BadgeCount @text="3" @color="neutral-dark-mode" />
 
-### Size
+## Size
 
 There are three sizes: small, medium, and large.
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes an incorrect heading structure in the `BadgeCount` documentation.

**preview:** https://hds-website-git-hl-badgecount-docs-fix-hashicorp.vercel.app/components/badge-count

### :hammer_and_wrench: Detailed description

"Type", "Color", and "Size" headings were changed from an H3 to an H2. 

### :camera_flash: Screenshots

**Before:**
<img width="202" alt="Screenshot 2024-06-24 at 3 10 19 PM" src="https://github.com/hashicorp/design-system/assets/8553306/795e4aa5-1957-4870-bd14-4f86550179a4">

**After:**
<img width="189" alt="Screenshot 2024-06-24 at 3 10 24 PM" src="https://github.com/hashicorp/design-system/assets/8553306/203967a5-9d9c-44e5-a4cd-98bcf1c06afd">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3440](https://hashicorp.atlassian.net/browse/HDS-3440)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3440]: https://hashicorp.atlassian.net/browse/HDS-3440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ