### PR TITLE
Contribution: Updating documentation order

### DIFF
--- a/website/docs/about/contribution.md
+++ b/website/docs/about/contribution.md
@@ -31,10 +31,7 @@ If you’d like to add a new icon to the [icon library](/icons/library), follow 
 
 ### Contribute in code
 
-To work in one of the Helios code packages, consult the corresponding `CONTRIBUTING.md` file for:
-- [Tokens](https://github.com/hashicorp/design-system/blob/main/packages/tokens/CONTRIBUTING.md)
-- [Ember Flight Icons](https://github.com/hashicorp/design-system/blob/main/packages/ember-flight-icons/CONTRIBUTING.md)
-- [Components](https://github.com/hashicorp/design-system/blob/main/packages/components/CONTRIBUTING.md)
+To work in one of the Helios code packages, consult the corresponding `CONTRIBUTING.md` file for [Tokens](https://github.com/hashicorp/design-system/blob/main/packages/tokens/CONTRIBUTING.md), [Ember Flight Icons](https://github.com/hashicorp/design-system/blob/main/packages/ember-flight-icons/CONTRIBUTING.md), and [Components](https://github.com/hashicorp/design-system/blob/main/packages/components/CONTRIBUTING.md)
 
 Review the [Engineering Checklist for new components](https://github.com/hashicorp/design-system/blob/main/packages/components/NEW-COMPONENT-CHECKLIST.md#engineering-checklist) if you’re working on a new component.
 

--- a/website/docs/about/contribution.md
+++ b/website/docs/about/contribution.md
@@ -50,7 +50,7 @@ Our collaborative process is intended to be a guideline, not a playbook. Each co
 
 ### Submit a new request
 
-Before submitting a new request, check that the issue doesn’t already exist in our [backlog](https://hashicorp.atlassian.net/jira/polaris/projects/HDSP/ideas/view/3955253). If no request exists, create a new issue using our [intake form](https://go.hashi.co/hds-support). Creating an issue allows us to track and prioritize all requests in one central location easily.
+Before submitting a new request, check that the issue doesn’t already exist in our [backlog](https://go.hashi.co/hds-rollout). If no request exists, create a new issue using our [intake form](https://go.hashi.co/hds-support). Creating an issue allows us to track and prioritize all requests in one central location easily.
 
 Alternatively, if you just have a question or you’re not sure your project is right for collaboration, reach out to the Design Systems Team in [#team-design-systems](https://hashicorp.slack.com/archives/C7KTUHNUS).
 

--- a/website/docs/about/contribution.md
+++ b/website/docs/about/contribution.md
@@ -31,7 +31,7 @@ If you’d like to add a new icon to the [icon library](/icons/library), follow 
 
 ### Contribute in code
 
-To work in one of the Helios code packages, consult the corresponding `CONTRIBUTING.md` file for [Tokens](https://github.com/hashicorp/design-system/blob/main/packages/tokens/CONTRIBUTING.md), [Ember Flight Icons](https://github.com/hashicorp/design-system/blob/main/packages/ember-flight-icons/CONTRIBUTING.md), and [Components](https://github.com/hashicorp/design-system/blob/main/packages/components/CONTRIBUTING.md)
+To work in one of the Helios code packages, consult the corresponding `CONTRIBUTING.md` file for [Tokens](https://github.com/hashicorp/design-system/blob/main/packages/tokens/CONTRIBUTING.md), [Ember Flight Icons](https://github.com/hashicorp/design-system/blob/main/packages/ember-flight-icons/CONTRIBUTING.md), and [Components](https://github.com/hashicorp/design-system/blob/main/packages/components/CONTRIBUTING.md).
 
 Review the [Engineering Checklist for new components](https://github.com/hashicorp/design-system/blob/main/packages/components/NEW-COMPONENT-CHECKLIST.md#engineering-checklist) if you’re working on a new component.
 

--- a/website/docs/about/contribution.md
+++ b/website/docs/about/contribution.md
@@ -25,6 +25,21 @@ Possible forms of collaboration include, but are not limited to:
 
 We support a small number of autonomous but coordinated direct contributions. These include bug fixes in the code, new icons, documentation improvements, and small enhancements to existing components.
 
+### Contribute a new icon in Figma
+
+If you’d like to add a new icon to the [icon library](/icons/library), follow the steps in the [Figma library README](https://www.figma.com/file/MYiw4kiVpunIMMw0sBkE1t/%E2%9C%8F%EF%B8%8F-Flight-Development?node-id=566%3A1129&t=Bbflj3UUaWVyhamn-4).
+
+### Contribute in code
+
+To work in one of the Helios code packages, consult the corresponding `CONTRIBUTING.md` file for:
+- [Tokens](https://github.com/hashicorp/design-system/blob/main/packages/tokens/CONTRIBUTING.md)
+- [Ember Flight Icons](https://github.com/hashicorp/design-system/blob/main/packages/ember-flight-icons/CONTRIBUTING.md)
+- [Components](https://github.com/hashicorp/design-system/blob/main/packages/components/CONTRIBUTING.md)
+
+Review the [Engineering Checklist for new components](https://github.com/hashicorp/design-system/blob/main/packages/components/NEW-COMPONENT-CHECKLIST.md#engineering-checklist) if you’re working on a new component.
+
+If you need to test the component in one of our consumers’ codebases, review the [instructions for testing a component in Cloud UI](https://github.com/hashicorp/design-system/blob/main/packages/components/HOW-TO-TEST-A-COMPONENT-IN-CLOUD-UI.md).
+
 ### Why large direct contributions are not currently accepted
 
 Adding new components or patterns to Helios takes significant time and consideration of use cases across all our products. As a team, we also strive to maintain a high bar for consistency in implementation and delivery across both design and code to ensure a systematic and high-quality experience for our consumers when using Helios in their work. This combination of factors means that large direct contributions are not pragmatic for us to support at this time, however, we've developed the collaboration process outlined here to help enable teams to work directly with us to support their needs.  
@@ -35,7 +50,7 @@ Our collaborative process is intended to be a guideline, not a playbook. Each co
 
 ### Submit a new request
 
-Before submitting a new request, check that the issue doesn’t already exist in our [backlog](https://hashicorp.atlassian.net/jira/software/c/projects/HDS/boards/1082). If no request exists, create a new issue using our [intake form](https://go.hashi.co/hds-support). Creating an issue allows us to track and prioritize all requests in one central location easily.
+Before submitting a new request, check that the issue doesn’t already exist in our [backlog](https://hashicorp.atlassian.net/jira/polaris/projects/HDSP/ideas/view/3955253). If no request exists, create a new issue using our [intake form](https://go.hashi.co/hds-support). Creating an issue allows us to track and prioritize all requests in one central location easily.
 
 Alternatively, if you just have a question or you’re not sure your project is right for collaboration, reach out to the Design Systems Team in [#team-design-systems](https://hashicorp.slack.com/archives/C7KTUHNUS).
 
@@ -92,22 +107,6 @@ Once reviewed and approved, the feature can be implemented and released in Helio
 - The product team will:
     - Follow the guidance provided by the Design Systems Team in the follow-up work related to the collaboration effort
     - Have a clear plan to adopt the artifacts produced during the collaboration
-
-### Contribute a new icon in Figma
-
-If you’d like to add a new icon to the [icon library](/icons/library), follow the steps in the [Figma library README](https://www.figma.com/file/MYiw4kiVpunIMMw0sBkE1t/%E2%9C%8F%EF%B8%8F-Flight-Development?node-id=566%3A1129&t=Bbflj3UUaWVyhamn-4).
-
-### Contribute in code
-
-To work in one of the Helios code packages, consult the corresponding `CONTRIBUTING.md` file for:
-- [Tokens](https://github.com/hashicorp/design-system/blob/main/packages/tokens/CONTRIBUTING.md)
-- [Ember Flight Icons](https://github.com/hashicorp/design-system/blob/main/packages/ember-flight-icons/CONTRIBUTING.md)
-- [Components](https://github.com/hashicorp/design-system/blob/main/packages/components/CONTRIBUTING.md)
-
-Review the [Engineering Checklist for new components](https://github.com/hashicorp/design-system/blob/main/packages/components/NEW-COMPONENT-CHECKLIST.md#engineering-checklist) if you’re working on a new component.
-
-If you need to test the component in one of our consumers’ codebases, review the [instructions for testing a component in Cloud UI](https://github.com/hashicorp/design-system/blob/main/packages/components/HOW-TO-TEST-A-COMPONENT-IN-CLOUD-UI.md).
-
 
 ## Resources
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the documentation on the Contribution. Changes include: 

- moving the "Contribute a new icon in Figma" and "Contribute in code" sections up into the "Direct contributions" section because they are forms of direct contribution and not a part of our collaborative process.
- updating the "backlog" link to point to our [Roadmap](https://hashicorp.atlassian.net/jira/polaris/projects/HDSP/ideas/view/3955253)

**preview:** https://hds-website-git-hl-contribution-organization-hashicorp.vercel.app/about/contribution

### :camera_flash: Screenshots

**before:**
<img width="274" alt="Screenshot 2024-06-24 at 3 27 04 PM" src="https://github.com/hashicorp/design-system/assets/8553306/a8841a96-d906-4785-92d5-ad5a172d4333">

**after:**
<img width="254" alt="Screenshot 2024-06-24 at 3 26 53 PM" src="https://github.com/hashicorp/design-system/assets/8553306/58e1dd8b-8624-44ac-8a32-ad2b80ddbb54">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3387](https://hashicorp.atlassian.net/browse/HDS-3387)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3387]: https://hashicorp.atlassian.net/browse/HDS-3387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ