### PR TITLE
Add `gap` to `ShwFlexSignature` and `ShwGridSignature`

### DIFF
--- a/showcase/types/global.d.ts
+++ b/showcase/types/global.d.ts
@@ -55,6 +55,7 @@ export interface ShwFlexSignature {
     direction?: string;
     wrap?: boolean;
     label?: string;
+    gap?: string;
   };
   Element: HTMLDivElement;
   Blocks: {
@@ -89,6 +90,7 @@ export interface ShwGridSignature {
   Args: {
     columns: number;
     label?: string;
+    gap?: string;
   };
   Element: HTMLDivElement;
   Blocks: {


### PR DESCRIPTION
### :pushpin: Summary

I missed these when reviewing #2181. These showcase components are not yet converted to TypeScript, but we have signatures for them to make it easier for us to write examples (via intellisense).

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
