### PR TITLE
Add missing `.ts` extensions to “helpers” imports in `template-registry.ts`

### DIFF
--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -73,8 +73,8 @@ import type HdsToastComponent from './components/hds/toast';
 import type HdsTextCodeComponent from './components/hds/text/code';
 import type HdsYieldComponent from './components/hds/yield';
 
-import type HdsLinkToModelsHelper from './helpers/hds-link-to-models';
-import type HdsLinkToQueryHelper from './helpers/hds-link-to-query';
+import type HdsLinkToModelsHelper from './helpers/hds-link-to-models.ts';
+import type HdsLinkToQueryHelper from './helpers/hds-link-to-query.ts';
 
 import type HdsClipboardModifier from './modifiers/hds-clipboard.ts';
 


### PR DESCRIPTION

### :pushpin: Summary

context: https://hashicorp.slack.com/archives/C06NMSYDZPA/p1715874435457859?thread_ts=1715872354.358549&cid=C06NMSYDZPA

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
