### PR TITLE
`Hds::Icon` Groundwork

### DIFF
--- a/.changeset/fuzzy-suits-call.md
+++ b/.changeset/fuzzy-suits-call.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": major
+"@hashicorp/design-system-codemods": minor
+---
+
+Add new Hds::Icon component which will eventually replace usage of FlightIcon

--- a/.changeset/fuzzy-suits-call.md
+++ b/.changeset/fuzzy-suits-call.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-Add new Hds::Icon component which will eventually replace usage of FlightIcon
+Loads the `hds-icon` sprite in the `components` package, and ensures it is only loaded once.

--- a/.changeset/fuzzy-suits-call.md
+++ b/.changeset/fuzzy-suits-call.md
@@ -1,6 +1,5 @@
 ---
-"@hashicorp/design-system-components": major
-"@hashicorp/design-system-codemods": minor
+"@hashicorp/design-system-components": minor
 ---
 
 Add new Hds::Icon component which will eventually replace usage of FlightIcon

--- a/packages/components/addon-main.cjs
+++ b/packages/components/addon-main.cjs
@@ -9,7 +9,13 @@ const flightIconSprite = require('@hashicorp/flight-icons/svg-sprite/svg-sprite-
 module.exports = {
   ...addonV1Shim(__dirname),
   contentFor(type, config) {
-    if (!config.emberFlightIcons?.lazyEmbed && type === 'body-footer') {
+    if (
+      !config.emberFlightIcons?.lazyEmbed &&
+      !config.__flightIconsSpriteLoaded &&
+      type === 'body-footer'
+    ) {
+      config.__flightIconsSpriteLoaded = true;
+
       return flightIconSprite;
     }
   },

--- a/packages/components/addon-main.cjs
+++ b/packages/components/addon-main.cjs
@@ -4,4 +4,13 @@
  */
 
 const { addonV1Shim } = require('@embroider/addon-shim');
-module.exports = addonV1Shim(__dirname);
+const flightIconSprite = require('@hashicorp/flight-icons/svg-sprite/svg-sprite-module');
+
+module.exports = {
+  ...addonV1Shim(__dirname),
+  contentFor(type, config) {
+    if (!config.emberFlightIcons?.lazyEmbed && type === 'body-footer') {
+      return flightIconSprite;
+    }
+  },
+};

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,6 +40,7 @@
     "@floating-ui/dom": "^1.6.3",
     "@hashicorp/design-system-tokens": "^2.1.0",
     "@hashicorp/ember-flight-icons": "^5.1.2",
+    "@hashicorp/flight-icons": "^3.4.0",
     "decorator-transforms": "^1.1.0",
     "ember-a11y-refocus": "^4.1.0",
     "ember-cli-sass": "^11.0.1",

--- a/packages/components/src/instance-initializers/load-sprite.ts
+++ b/packages/components/src/instance-initializers/load-sprite.ts
@@ -9,7 +9,7 @@ import type ApplicationInstance from '@ember/application/instance';
 export async function initialize(
   appInstance: ApplicationInstance & {
     __flightIconsSpriteLoaded?: boolean;
-  },
+  }
 ) {
   if (
     config?.emberFlightIcons?.lazyEmbed &&

--- a/packages/components/src/instance-initializers/load-sprite.ts
+++ b/packages/components/src/instance-initializers/load-sprite.ts
@@ -13,6 +13,7 @@ export async function initialize(
 ) {
   if (
     config?.emberFlightIcons?.lazyEmbed &&
+    // we use this flag to avoid loading the sprite multiple times
     appInstance.__flightIconsSpriteLoaded !== true
   ) {
     const { default: svgSprite } = await import(
@@ -29,6 +30,7 @@ export async function initialize(
       window.document?.body?.insertAdjacentHTML('beforeend', svgSprite);
     }
 
+    // set the flag to avoid loading the sprite multiple times
     appInstance.__flightIconsSpriteLoaded = true;
   }
 }

--- a/packages/components/src/instance-initializers/load-sprite.ts
+++ b/packages/components/src/instance-initializers/load-sprite.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import config from 'ember-get-config';
+import type ApplicationInstance from '@ember/application/instance';
+
+export async function initialize(
+  appInstance: ApplicationInstance & {
+    __flightIconsSpriteLoaded?: boolean;
+  }
+) {
+  if (
+    config?.emberFlightIcons?.lazyEmbed &&
+    appInstance.__flightIconsSpriteLoaded !== true
+  ) {
+    const { default: svgSprite } = await import(
+      '@hashicorp/flight-icons/svg-sprite/svg-sprite-module'
+    );
+
+    // in test environments we can inject the sprite directly into the ember testing container
+    // to avoid issues with tools like Percy that only consider content inside that element
+    if (config.environment === 'test') {
+      window.document
+        ?.getElementById('ember-testing')
+        ?.insertAdjacentHTML('afterbegin', svgSprite);
+    } else {
+      window.document?.body?.insertAdjacentHTML('beforeend', svgSprite);
+    }
+
+    appInstance.__flightIconsSpriteLoaded = true;
+  }
+}
+
+export default {
+  initialize,
+};

--- a/packages/components/src/instance-initializers/load-sprite.ts
+++ b/packages/components/src/instance-initializers/load-sprite.ts
@@ -9,7 +9,7 @@ import type ApplicationInstance from '@ember/application/instance';
 export async function initialize(
   appInstance: ApplicationInstance & {
     __flightIconsSpriteLoaded?: boolean;
-  }
+  },
 ) {
   if (
     config?.emberFlightIcons?.lazyEmbed &&

--- a/packages/ember-flight-icons/addon-main.cjs
+++ b/packages/ember-flight-icons/addon-main.cjs
@@ -8,7 +8,13 @@ const flightIconSprite = require('@hashicorp/flight-icons/svg-sprite/svg-sprite-
 module.exports = {
   ...addonV1Shim(__dirname),
   contentFor(type, config) {
-    if (!config.emberFlightIcons?.lazyEmbed && type === 'body-footer') {
+    if (
+      !config.emberFlightIcons?.lazyEmbed &&
+      !config.__flightIconsSpriteLoaded &&
+      type === 'body-footer'
+    ) {
+      config.__flightIconsSpriteLoaded = true;
+
       return flightIconSprite;
     }
   },

--- a/packages/ember-flight-icons/src/instance-initializers/load-sprite.js
+++ b/packages/ember-flight-icons/src/instance-initializers/load-sprite.js
@@ -5,8 +5,12 @@
 
 import config from 'ember-get-config';
 
-export async function initialize() {
-  if (config?.emberFlightIcons?.lazyEmbed) {
+export async function initialize(appInstance) {
+  if (
+    config?.emberFlightIcons?.lazyEmbed &&
+    // we use this flag to avoid loading the sprite multiple times
+    appInstance.__flightIconsSpriteLoaded !== true
+  ) {
     const { default: svgSprite } = await import(
       '@hashicorp/flight-icons/svg-sprite/svg-sprite-module'
     );
@@ -20,6 +24,9 @@ export async function initialize() {
     } else {
       window.document?.body?.insertAdjacentHTML('beforeend', svgSprite);
     }
+
+    // set the flag to avoid loading the sprite multiple times
+    appInstance.__flightIconsSpriteLoaded = true;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,6 +4110,7 @@ __metadata:
     "@glint/template": "npm:^1.4.0"
     "@hashicorp/design-system-tokens": "npm:^2.1.0"
     "@hashicorp/ember-flight-icons": "npm:^5.1.2"
+    "@hashicorp/flight-icons": "npm:^3.4.0"
     "@rollup/plugin-babel": "npm:^6.0.4"
     "@tsconfig/ember": "npm:^3.0.8"
     "@types/ember-qunit": "npm:^6.1.1"


### PR DESCRIPTION
### :pushpin: Summary

This PR is part of https://github.com/hashicorp/design-system/pull/2207

If merged, this PR will:

- Install `@hashicorp/flight-icons` as a direct dependency of `components`
- Port the load-sprite instance initialization functionality over from `ember-flight-icons` to `components`
- Ensure that the load-sprite initializer only runs once. (In existing and new instance initializers)

### :link: External links

<!-- Issues, RFC, etc. -->
Feature branch PR: [2207](https://github.com/hashicorp/design-system/pull/2207)
Jira ticket: [HDS-3515](https://hashicorp.atlassian.net/browse/HDS-3515)

***


[HDS-3515]: https://hashicorp.atlassian.net/browse/HDS-3515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ