### PR TITLE
Add changelog entry for 5.1.1

### DIFF
--- a/.changeset/good-hornets-press.md
+++ b/.changeset/good-hornets-press.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/ember-flight-icons": patch
+---
+
+This version is a re-release of `@hashicorp/ember-flight-icons@5.1.0` containing the missing `dist`


### PR DESCRIPTION
### :pushpin: Summary

We [deprecated `@hashicorp/ember-flight-icons@5.1.0`](https://www.npmjs.com/package/@hashicorp/ember-flight-icons/v/5.1.0?activeTab=code) and want to re-release as `5.1.1` after the prepublish script was fixed in #2196.

We're aiming to use the automated changeset for this patch release, hence the changelog entry.

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
