### PR TITLE
Changelog updates after manual release

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,16 @@
 # @hashicorp/design-system-components
 
+## 4.5.3
+
+### Patch Changes
+
+**🔄 Updated dependencies:**
+
+- @hashicorp/ember-flight-icons@5.1.2
+
 ## 4.5.2
+
+**🚨 Caution: This version has been deprecated 🚨**
 
 ### Patch Changes
 
@@ -9,6 +19,8 @@
 - @hashicorp/ember-flight-icons@5.1.1
 
 ## 4.5.1
+
+**🚨 Caution: This version has been deprecated 🚨**
 
 ### Patch Changes
 
@@ -19,6 +31,8 @@ Fixed syncing of `<F.Error />` ids to the `aria-describedby` attribute
 <div class="doc-whats-new-changelog-separator"></div>
 
 ## 4.5.0
+
+**🚨 Caution: This version has been deprecated 🚨**
 
 [4.5.0 documentation](https://hds-website-4-5-0.vercel.app/)
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/design-system-components",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "Helios Design System Components",
   "keywords": [
     "hashicorp",
@@ -39,7 +39,7 @@
     "@embroider/addon-shim": "^1.8.7",
     "@floating-ui/dom": "^1.6.3",
     "@hashicorp/design-system-tokens": "^2.1.0",
-    "@hashicorp/ember-flight-icons": "^5.1.1",
+    "@hashicorp/ember-flight-icons": "^5.1.2",
     "@oddbird/popover-polyfill": "^0.4.3",
     "decorator-transforms": "^1.1.0",
     "ember-a11y-refocus": "^4.1.0",

--- a/packages/ember-flight-icons/CHANGELOG.md
+++ b/packages/ember-flight-icons/CHANGELOG.md
@@ -1,16 +1,20 @@
 # @hashicorp/ember-flight-icons
 
-## 5.1.1
+## 5.1.2
 
 ### Patch Changes
 
 This version is a re-release of `@hashicorp/ember-flight-icons@5.1.0` containing the missing `dist`
 
-<small class="doc-whats-new-changelog-metadata">[#2199](https://github.com/hashicorp/design-system/pull/2199)</small>
-
 <div class="doc-whats-new-changelog-separator"></div>
 
+## 5.1.1
+
+**🚨 Caution: This version has been deprecated 🚨**
+
 ## 5.1.0
+
+**🚨 Caution: This version has been deprecated 🚨**
 
 ### Minor Changes
 

--- a/packages/ember-flight-icons/package.json
+++ b/packages/ember-flight-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/ember-flight-icons",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "The Ember addon for the HashiCorp Flight SVG icon set",
   "keywords": [
     "ember-addon",

--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -12,7 +12,17 @@
   </a>
 </p>
 
+## 4.5.3
+
+**Patch changes**
+
+**🔄 Updated dependencies:**
+
+- @hashicorp/ember-flight-icons@5.1.2
+
 ## 4.5.2
+
+**🚨 Caution: This version has been deprecated 🚨**
 
 **Patch changes**
 
@@ -21,6 +31,8 @@
 - @hashicorp/ember-flight-icons@5.1.1
 
 ## 4.5.1
+
+**🚨 Caution: This version has been deprecated 🚨**
 
 **Patch changes**
 
@@ -31,6 +43,8 @@ Fixed syncing of `<F.Error />` ids to the `aria-describedby` attribute
 <div class="doc-whats-new-changelog-separator"></div>
 
 ## 4.5.0
+
+**🚨 Caution: This version has been deprecated 🚨**
 
 [4.5.0 documentation](https://hds-website-4-5-0.vercel.app/)
 
@@ -795,57 +809,6 @@ Added `@ember/string` as a direct dependency
 **🔄 Updated dependencies:**
 
 - @hashicorp/ember-flight-icons@4.0.3
-
-## 3.1.0
-
-**Minor changes**
-
-`CodeBlock` - Added new component
-
-<small class="doc-whats-new-changelog-metadata">[#1687](https://github.com/hashicorp/design-system/pull/1687)</small>
-
-<div class="doc-whats-new-changelog-separator"></div>
-
-**Patch changes**
-
-Upgraded the following dependencies:
-
-- `@ember/test-waiters` from `3.0.2` to `3.1.0`
-- `ember-cli-htmlbars` from `6.2.0` to `6.3.0`
-- `ember-focus-trap` from `1.0.2` to `1.1.0`
-- `ember-keyboard` from `8.2.0` to `8.2.1`
-- `sass` from `1.62.1` to `1.69.5`
-
-<small class="doc-whats-new-changelog-metadata">[#1756](https://github.com/hashicorp/design-system/pull/1756)</small>
-
-<div class="doc-whats-new-changelog-separator"></div>
-
-`Breadcrumb` - Added support for external links
-
-<small class="doc-whats-new-changelog-metadata">[#1774](https://github.com/hashicorp/design-system/pull/1774)</small>
-
-<div class="doc-whats-new-changelog-separator"></div>
-
-Upgraded the following dependencies:
-
-- `ember-cached-decorator-polyfill` from `0.1.4` to `1.0.2`
-- `ember-cli-babel` from `7.26.11` to `8.2.0`
-- `ember-cli-sass` from `10.0.1` to `11.0.1`
-- `ember-composable-helpers` from `4.5.0` to `5.0.0`
-
-<small class="doc-whats-new-changelog-metadata">[#1761](https://github.com/hashicorp/design-system/pull/1761)</small>
-
-<div class="doc-whats-new-changelog-separator"></div>
-
-`Button` - Fixed `HdsInteractiveSignature` type import
-
-<small class="doc-whats-new-changelog-metadata">[#1769](https://github.com/hashicorp/design-system/pull/1769)</small>
-
-<div class="doc-whats-new-changelog-separator"></div>
-
-**🔄 Updated dependencies:**
-
-- @hashicorp/ember-flight-icons@4.0.2
 
 
 ---

--- a/website/docs/whats-new/release-notes/partials/ember-flight-icons.md
+++ b/website/docs/whats-new/release-notes/partials/ember-flight-icons.md
@@ -12,17 +12,21 @@
   </a>
 </p>
 
-## 5.1.1
+## 5.1.2
 
 **Patch changes**
 
 This version is a re-release of `@hashicorp/ember-flight-icons@5.1.0` containing the missing `dist`
 
-<small class="doc-whats-new-changelog-metadata">[#2199](https://github.com/hashicorp/design-system/pull/2199)</small>
-
 <div class="doc-whats-new-changelog-separator"></div>
 
+## 5.1.1
+
+**🚨 Caution: This version has been deprecated 🚨**
+
 ## 5.1.0
+
+**🚨 Caution: This version has been deprecated 🚨**
 
 **Minor changes**
 
@@ -242,14 +246,6 @@ Added opt in flag to allow consumers to move sprite loading out of index.html
 **🔄 Updated dependencies:**
 
 - @hashicorp/flight-icons@2.17.0
-
-## 3.0.8
-
-**Patch changes**
-
-**🔄 Updated dependencies:**
-
-- @hashicorp/flight-icons@2.16.0
 
 
 ---

--- a/yarn.lock
+++ b/yarn.lock
@@ -4116,7 +4116,7 @@ __metadata:
     "@glint/environment-ember-loose": "npm:^1.4.0"
     "@glint/template": "npm:^1.4.0"
     "@hashicorp/design-system-tokens": "npm:^2.1.0"
-    "@hashicorp/ember-flight-icons": "npm:^5.1.1"
+    "@hashicorp/ember-flight-icons": "npm:^5.1.2"
     "@oddbird/popover-polyfill": "npm:^0.4.3"
     "@rollup/plugin-babel": "npm:^6.0.4"
     "@tsconfig/ember": "npm:^3.0.8"
@@ -4200,7 +4200,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hashicorp/ember-flight-icons@npm:^5.1.1, @hashicorp/ember-flight-icons@workspace:^, @hashicorp/ember-flight-icons@workspace:packages/ember-flight-icons":
+"@hashicorp/ember-flight-icons@npm:^5.1.2, @hashicorp/ember-flight-icons@workspace:^, @hashicorp/ember-flight-icons@workspace:packages/ember-flight-icons":
   version: 0.0.0-use.local
   resolution: "@hashicorp/ember-flight-icons@workspace:packages/ember-flight-icons"
   dependencies:


### PR DESCRIPTION
### :pushpin: Summary

On Friday, we [deprecated a few broken packages and manually released new versions](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1719602393005429?thread_ts=1719580865.659719&cid=C025N5V4PFZ) of `@hashicorp/ember-flight-icons` and `@hashicorp/design-system-components`.

We operate the following changes to align our automated changelog entries and package versions:
 - bumped versions in `package.json` for both packages (this was done offline before pushing the packages to npm, but should be synced on `main` so we have correct values for the next automated releases)
 - updated changelog entries to reflect deprecations
 - added changelog entries for the latest versions
 - re-generated markdown files for the changelog page in `website`

Alongside this PR, I will also [update the releases on GitHub](https://github.com/hashicorp/design-system/releases).

***
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
