### PR TITLE
Add return types to all functions in TypeScript

### DIFF
--- a/packages/components/src/components/hds/accordion/item/button.ts
+++ b/packages/components/src/components/hds/accordion/item/button.ts
@@ -20,7 +20,7 @@ interface HdsAccordionItemButtonSignature {
 
 export default class HdsAccordionItemButtonComponent extends Component<HdsAccordionItemButtonSignature> {
   @action
-  onClick(event: MouseEvent) {
+  onClick(event: MouseEvent): void {
     if (this.args.onClickToggle) {
       this.args.onClickToggle(event);
     }
@@ -31,7 +31,7 @@ export default class HdsAccordionItemButtonComponent extends Component<HdsAccord
    * @method ItemButton#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-accordion-item__button'];
 
     // add a class based on the @isOpen argument

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -32,7 +32,7 @@ export default class HdsAccordionItemComponent extends Component<HdsAccordionIte
    * @type {string}
    * @default 'Toggle display'
    */
-  get ariaLabel() {
+  get ariaLabel(): string {
     return this.args.ariaLabel ?? 'Toggle display';
   }
 
@@ -41,7 +41,7 @@ export default class HdsAccordionItemComponent extends Component<HdsAccordionIte
    * @type {boolean}
    * @default false
    */
-  get containsInteractive() {
+  get containsInteractive(): boolean {
     return this.args.containsInteractive ?? false;
   }
 
@@ -50,7 +50,7 @@ export default class HdsAccordionItemComponent extends Component<HdsAccordionIte
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-accordion-item'];
 
     // add a class based on the @isOpen argument

--- a/packages/components/src/components/hds/alert/index.ts
+++ b/packages/components/src/components/hds/alert/index.ts
@@ -82,7 +82,7 @@ export default class HdsAlertComponent extends Component<HdsAlertSignature> {
    * @default neutral
    * @description Determines the color scheme for the alert.
    */
-  get color() {
+  get color(): HdsAlertColors {
     const { color = DEFAULT_COLOR } = this.args;
 
     assert(
@@ -98,7 +98,7 @@ export default class HdsAlertComponent extends Component<HdsAlertSignature> {
   /**
    * @param icon
    * @type {string}
-   * @default null
+   * @default false
    * @description The name of the icon to be used.
    */
   get icon(): FlightIconSignature['Args']['name'] | false {
@@ -147,7 +147,7 @@ export default class HdsAlertComponent extends Component<HdsAlertSignature> {
    * @type {string}
    * @description ensures that the correct icon size is used. Automatically calculated.
    */
-  get iconSize() {
+  get iconSize(): '16' | '24' {
     if (this.args.type === 'compact') {
       return '16';
     } else {
@@ -160,7 +160,7 @@ export default class HdsAlertComponent extends Component<HdsAlertSignature> {
    * @method Alert#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-alert'];
 
     // Add a class based on the @type argument
@@ -173,7 +173,7 @@ export default class HdsAlertComponent extends Component<HdsAlertSignature> {
   }
 
   @action
-  didInsert(element: HTMLDivElement) {
+  didInsert(element: HTMLDivElement): void {
     const actions = element.querySelectorAll(
       `${CONTENT_ELEMENT_SELECTOR} button, ${CONTENT_ELEMENT_SELECTOR} a`
     );

--- a/packages/components/src/components/hds/alert/index.ts
+++ b/packages/components/src/components/hds/alert/index.ts
@@ -132,7 +132,8 @@ export default class HdsAlertComponent extends Component<HdsAlertSignature> {
    * @type {function}
    * @default () => {}
    */
-  get onDismiss() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get onDismiss(): ((event: MouseEvent, ...args: any[]) => void) | false {
     const { onDismiss } = this.args;
 
     if (typeof onDismiss === 'function') {

--- a/packages/components/src/components/hds/app-footer/copyright.ts
+++ b/packages/components/src/components/hds/app-footer/copyright.ts
@@ -19,7 +19,7 @@ export default class HdsAppFooterCopyrightComponent extends Component<HdsAppFoot
    * @description The copyright year
    * @default The current year (calculated via `Date()`)
    */
-  get year() {
+  get year(): string | number {
     return this.args.year ?? new Date().getFullYear();
   }
 }

--- a/packages/components/src/components/hds/app-footer/index.ts
+++ b/packages/components/src/components/hds/app-footer/index.ts
@@ -40,7 +40,7 @@ export default class HdsAppFooterComponent extends Component<HdsAppFooterSignatu
    * @type {string}
    * @default 'Footer items'
    */
-  get ariaLabel() {
+  get ariaLabel(): string {
     return this.args.ariaLabel ?? 'Footer items';
   }
 
@@ -50,7 +50,7 @@ export default class HdsAppFooterComponent extends Component<HdsAppFooterSignatu
    * @description The component theme
    * @default 'light'
    */
-  get theme() {
+  get theme(): HdsAppFooterThemeTypes {
     return this.args.theme ?? 'light';
   }
 
@@ -59,7 +59,7 @@ export default class HdsAppFooterComponent extends Component<HdsAppFooterSignatu
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-app-footer'];
 
     // add a class based on the @theme argument

--- a/packages/components/src/components/hds/app-footer/legal-links.ts
+++ b/packages/components/src/components/hds/app-footer/legal-links.ts
@@ -23,7 +23,7 @@ export default class HdsAppFooterLegalLinksComponent extends Component<HdsAppFoo
    * @type {string}
    * @default 'Legal links'
    */
-  get ariaLabel() {
+  get ariaLabel(): string {
     return this.args.ariaLabel ?? 'Legal links';
   }
 
@@ -32,7 +32,7 @@ export default class HdsAppFooterLegalLinksComponent extends Component<HdsAppFoo
    * @type {string}
    * @description The href value of the "Support" link
    */
-  get hrefForSupport() {
+  get hrefForSupport(): string {
     return this.args.hrefForSupport ?? 'https://www.hashicorp.com/support';
   }
 
@@ -41,7 +41,7 @@ export default class HdsAppFooterLegalLinksComponent extends Component<HdsAppFoo
    * @type {string}
    * @description The href value of the "Terms" link
    */
-  get hrefForTerms() {
+  get hrefForTerms(): string {
     return (
       this.args.hrefForTerms ?? 'https://www.hashicorp.com/terms-of-service'
     );
@@ -52,7 +52,7 @@ export default class HdsAppFooterLegalLinksComponent extends Component<HdsAppFoo
    * @type {string}
    * @description The href value of the "Privacy" link
    */
-  get hrefForPrivacy() {
+  get hrefForPrivacy(): string {
     return this.args.hrefForPrivacy ?? 'https://www.hashicorp.com/privacy';
   }
 
@@ -61,7 +61,7 @@ export default class HdsAppFooterLegalLinksComponent extends Component<HdsAppFoo
    * @type {string}
    * @description The href value of the "Security" link
    */
-  get hrefForSecurity() {
+  get hrefForSecurity(): string {
     return this.args.hrefForSecurity ?? 'https://www.hashicorp.com/security';
   }
 
@@ -70,7 +70,7 @@ export default class HdsAppFooterLegalLinksComponent extends Component<HdsAppFoo
    * @type {string}
    * @description The href value of the "Accessibility" link
    */
-  get hrefForAccessibility() {
+  get hrefForAccessibility(): string {
     return (
       this.args.hrefForAccessibility ??
       'https://www.hashicorp.com/accessibility'

--- a/packages/components/src/components/hds/app-footer/status-link.ts
+++ b/packages/components/src/components/hds/app-footer/status-link.ts
@@ -42,7 +42,7 @@ export default class HdsAppFooterStatusLinkComponent extends Component<HdsAppFoo
    * @type {HdsAppFooterStatusTypes}
    * @description The name of the status which the StatusLink is being set to
    */
-  get status() {
+  get status(): HdsAppFooterStatusTypes | undefined {
     let status;
     if (this.args.status) {
       status = this.args.status.toLowerCase();
@@ -63,7 +63,7 @@ export default class HdsAppFooterStatusLinkComponent extends Component<HdsAppFoo
    * @type {string}
    * @description The name for the StatusLink icon
    */
-  get statusIcon() {
+  get statusIcon(): FlightIconSignature['Args']['name'] {
     if (this.status && !this.args.statusIcon) {
       return STATUSES[this.status]?.iconName;
     }
@@ -75,7 +75,7 @@ export default class HdsAppFooterStatusLinkComponent extends Component<HdsAppFoo
    * @method StatusLink#itemStyle
    * @return {string} The "style" attribute to apply to the item.
    */
-  get itemStyle() {
+  get itemStyle(): SafeString | undefined {
     if (this.args.statusIconColor) {
       return htmlSafe(
         `--hds-app-footer-status-icon-color: ${this.args.statusIconColor}`
@@ -90,7 +90,7 @@ export default class HdsAppFooterStatusLinkComponent extends Component<HdsAppFoo
    * @type {string}
    * @description The text content of the StatusLink
    */
-  get text() {
+  get text(): string | undefined {
     if (!this.args.text && this.status) {
       return STATUSES[this.status]?.text;
     }
@@ -102,7 +102,7 @@ export default class HdsAppFooterStatusLinkComponent extends Component<HdsAppFoo
    * @type {string}
    * @description The href value of the StatusLink
    */
-  get href() {
+  get href(): string {
     return this.args.href ?? 'https://status.hashicorp.com';
   }
 
@@ -111,7 +111,7 @@ export default class HdsAppFooterStatusLinkComponent extends Component<HdsAppFoo
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-app-footer__status-link'];
 
     // add a class based on status if no statusIconColor is explicitly specified

--- a/packages/components/src/components/hds/app-frame/index.ts
+++ b/packages/components/src/components/hds/app-frame/index.ts
@@ -40,7 +40,7 @@ export default class HdsAppFrameComponent extends Component<HdsAppFrameSignature
    * @type {boolean}
    * @default true
    */
-  get hasHeader() {
+  get hasHeader(): boolean {
     return this.args.hasHeader ?? true;
   }
 
@@ -51,7 +51,7 @@ export default class HdsAppFrameComponent extends Component<HdsAppFrameSignature
    * @type {boolean}
    * @default true
    */
-  get hasSidebar() {
+  get hasSidebar(): boolean {
     return this.args.hasSidebar ?? true;
   }
 
@@ -62,7 +62,7 @@ export default class HdsAppFrameComponent extends Component<HdsAppFrameSignature
    * @type {boolean}
    * @default true
    */
-  get hasFooter() {
+  get hasFooter(): boolean {
     return this.args.hasFooter ?? true;
   }
 
@@ -73,7 +73,7 @@ export default class HdsAppFrameComponent extends Component<HdsAppFrameSignature
    * @type {boolean}
    * @default true
    */
-  get hasModals() {
+  get hasModals(): boolean {
     return this.args.hasModals ?? true;
   }
 }

--- a/packages/components/src/components/hds/application-state/footer.ts
+++ b/packages/components/src/components/hds/application-state/footer.ts
@@ -29,7 +29,7 @@ export default class HdsApplicationStateFooterComponent extends Component<HdsApp
    * @type {boolean}
    * @default false
    */
-  get hasDivider() {
+  get hasDivider(): boolean {
     return this.args.hasDivider ?? false;
   }
 
@@ -38,7 +38,7 @@ export default class HdsApplicationStateFooterComponent extends Component<HdsApp
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-application-state__footer'];
 
     // add a class based on the existence of @hasDivider argument

--- a/packages/components/src/components/hds/badge-count/index.ts
+++ b/packages/components/src/components/hds/badge-count/index.ts
@@ -43,7 +43,7 @@ export default class HdsBadgeCountComponent extends Component<HdsBadgeCountSigna
    * @type {string}
    * @default 'medium'
    */
-  get size() {
+  get size(): HdsBadgeSizes {
     const { size = DEFAULT_SIZE } = this.args;
 
     assert(
@@ -64,7 +64,7 @@ export default class HdsBadgeCountComponent extends Component<HdsBadgeCountSigna
    * @type {string}
    * @default 'filled'
    */
-  get type() {
+  get type(): HdsBadgeTypes {
     const { type = DEFAULT_TYPE } = this.args;
 
     assert(
@@ -85,7 +85,7 @@ export default class HdsBadgeCountComponent extends Component<HdsBadgeCountSigna
    * @type {string}
    * @default 'neutral'
    */
-  get color() {
+  get color(): HdsBadgeCountColors {
     const { color = DEFAULT_COLOR } = this.args;
 
     assert(
@@ -103,7 +103,7 @@ export default class HdsBadgeCountComponent extends Component<HdsBadgeCountSigna
    * @method BadgeCount#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-badge-count'];
 
     // add a class based on the @size argument

--- a/packages/components/src/components/hds/badge-count/index.ts
+++ b/packages/components/src/components/hds/badge-count/index.ts
@@ -13,8 +13,8 @@ import {
 } from './types.ts';
 import type {
   HdsBadgeCountColors,
-  HdsBadgeSizes,
-  HdsBadgeTypes,
+  HdsBadgeCountSizes,
+  HdsBadgeCountTypes,
 } from './types.ts';
 
 export const SIZES: string[] = Object.values(HdsBadgeCountSizeValues);
@@ -26,8 +26,8 @@ export const DEFAULT_COLOR = HdsBadgeCountColorValues.Neutral;
 
 interface HdsBadgeCountSignature {
   Args: {
-    size?: HdsBadgeSizes;
-    type?: HdsBadgeTypes;
+    size?: HdsBadgeCountSizes;
+    type?: HdsBadgeCountTypes;
     color?: HdsBadgeCountColors;
     text: string;
   };
@@ -43,7 +43,7 @@ export default class HdsBadgeCountComponent extends Component<HdsBadgeCountSigna
    * @type {string}
    * @default 'medium'
    */
-  get size(): HdsBadgeSizes {
+  get size(): HdsBadgeCountSizes {
     const { size = DEFAULT_SIZE } = this.args;
 
     assert(
@@ -64,7 +64,7 @@ export default class HdsBadgeCountComponent extends Component<HdsBadgeCountSigna
    * @type {string}
    * @default 'filled'
    */
-  get type(): HdsBadgeTypes {
+  get type(): HdsBadgeCountTypes {
     const { type = DEFAULT_TYPE } = this.args;
 
     assert(

--- a/packages/components/src/components/hds/badge-count/types.ts
+++ b/packages/components/src/components/hds/badge-count/types.ts
@@ -8,14 +8,14 @@ export enum HdsBadgeCountSizeValues {
   Medium = 'medium',
   Large = 'large',
 }
-export type HdsBadgeSizes = `${HdsBadgeCountSizeValues}`;
+export type HdsBadgeCountSizes = `${HdsBadgeCountSizeValues}`;
 
 export enum HdsBadgeCountTypeValues {
   Filled = 'filled',
   Inverted = 'inverted',
   Outlined = 'outlined',
 }
-export type HdsBadgeTypes = `${HdsBadgeCountTypeValues}`;
+export type HdsBadgeCountTypes = `${HdsBadgeCountTypeValues}`;
 
 export enum HdsBadgeCountColorValues {
   Neutral = 'neutral',

--- a/packages/components/src/components/hds/badge/index.ts
+++ b/packages/components/src/components/hds/badge/index.ts
@@ -43,7 +43,7 @@ export default class HdsBadgeComponent extends Component<HdsBadgeSignature> {
    * @type {HdsBadgeSizes}
    * @default 'medium'
    */
-  get size() {
+  get size(): HdsBadgeSizes {
     const { size = DEFAULT_SIZE } = this.args;
 
     assert(
@@ -64,7 +64,7 @@ export default class HdsBadgeComponent extends Component<HdsBadgeSignature> {
    * @type {HdsBadgeTypes}
    * @default 'filled'
    */
-  get type() {
+  get type(): HdsBadgeTypes {
     const { type = DEFAULT_TYPE } = this.args;
 
     assert(
@@ -85,7 +85,7 @@ export default class HdsBadgeComponent extends Component<HdsBadgeSignature> {
    * @type {HdsBadgeColors}
    * @default 'neutral'
    */
-  get color() {
+  get color(): HdsBadgeColors {
     const { color = DEFAULT_COLOR } = this.args;
 
     assert(
@@ -103,7 +103,7 @@ export default class HdsBadgeComponent extends Component<HdsBadgeSignature> {
    * @type {string}
    * @description The text of the badge. If `isIconOnly` is set to `true`, the text will be visually hidden but still available to assistive technology. If no text value is defined, an error will be thrown.
    */
-  get text() {
+  get text(): string {
     const { text } = this.args;
 
     assert(
@@ -121,7 +121,7 @@ export default class HdsBadgeComponent extends Component<HdsBadgeSignature> {
    * @type {string|null}
    * @default null
    */
-  get icon() {
+  get icon(): FlightIconSignature['Args']['name'] | null {
     return this.args.icon ?? null;
   }
 
@@ -131,7 +131,7 @@ export default class HdsBadgeComponent extends Component<HdsBadgeSignature> {
    * @default false
    * @description Indicates if the badge will only contain an icon; component will also ensure that accessible text is still applied to the component.
    */
-  get isIconOnly() {
+  get isIconOnly(): boolean {
     if (this.icon) {
       return this.args.isIconOnly ?? false;
     }
@@ -143,7 +143,7 @@ export default class HdsBadgeComponent extends Component<HdsBadgeSignature> {
    * @method Badge#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-badge'];
 
     // add a class based on the @size argument

--- a/packages/components/src/components/hds/copy/button/index.ts
+++ b/packages/components/src/components/hds/copy/button/index.ts
@@ -40,7 +40,7 @@ export default class HdsCopyButtonComponent extends Component<HdsCopyButtonSigna
    * @type {string}
    * @description The icon to be displayed for each status; automatically calculated based on the tracked property `status`.
    */
-  get icon() {
+  get icon(): FlightIconSignature['Args']['name'] {
     let icon: FlightIconSignature['Args']['name'] = DEFAULT_ICON;
     if (this.status === 'success') {
       icon = SUCCESS_ICON;
@@ -56,7 +56,7 @@ export default class HdsCopyButtonComponent extends Component<HdsCopyButtonSigna
    * @default medium
    * @description The size of the copy/button; acceptable values are `small` and `medium`
    */
-  get size() {
+  get size(): HdsCopyButtonSizes {
     const { size = DEFAULT_SIZE } = this.args;
 
     assert(
@@ -74,7 +74,7 @@ export default class HdsCopyButtonComponent extends Component<HdsCopyButtonSigna
    * @method CopyButton#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-copy-button'];
 
     // add a class based on the @size argument
@@ -86,7 +86,9 @@ export default class HdsCopyButtonComponent extends Component<HdsCopyButtonSigna
   }
 
   @action
-  onSuccess(args: HdsClipboardModifierSignature['Args']['Named']['onSuccess']) {
+  onSuccess(
+    args: HdsClipboardModifierSignature['Args']['Named']['onSuccess']
+  ): void {
     this.status = 'success';
     this.resetStatusDelayed();
 
@@ -98,7 +100,9 @@ export default class HdsCopyButtonComponent extends Component<HdsCopyButtonSigna
   }
 
   @action
-  onError(args: HdsClipboardModifierSignature['Args']['Named']['onError']) {
+  onError(
+    args: HdsClipboardModifierSignature['Args']['Named']['onError']
+  ): void {
     this.status = 'error';
     this.resetStatusDelayed();
 
@@ -109,10 +113,10 @@ export default class HdsCopyButtonComponent extends Component<HdsCopyButtonSigna
     }
   }
 
-  resetStatusDelayed() {
+  resetStatusDelayed(): void {
     clearTimeout(this.timer);
     // make it fade back to the default state
-    this.timer = setTimeout(() => {
+    this.timer = setTimeout((): void => {
       this.status = DEFAULT_STATUS;
     }, 1500);
   }

--- a/packages/components/src/components/hds/copy/snippet/index.ts
+++ b/packages/components/src/components/hds/copy/snippet/index.ts
@@ -37,10 +37,10 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
   @tracked timer: ReturnType<typeof setTimeout> | undefined;
 
   /**
-   * @param textToCopy
-   * @type {string | number | bigint | undefined} ???
+   * @method textToShow
+   * @return {string}
    */
-  get textToShow() {
+  get textToShow(): string {
     const { textToCopy = '' } = this.args;
 
     if (typeof textToCopy === 'string') {
@@ -53,10 +53,10 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
   /**
    * @param icon
    * @type {string}
-   * @default DEFAULT_ICON
+   * @default clipboard-copy
    * @description Determines the icon to be used, based on the success state. Note that this is auto-tracked because it depends on a tracked property (status).
    */
-  get icon() {
+  get icon(): FlightIconSignature['Args']['name'] {
     let icon: FlightIconSignature['Args']['name'] = DEFAULT_ICON;
     if (this.status === 'success') {
       icon = SUCCESS_ICON;
@@ -72,7 +72,7 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
    * @default primary
    * @description Determines the color of button to be used; acceptable values are `primary` and `secondary`
    */
-  get color() {
+  get color(): HdsCopySnippetColors {
     const { color = DEFAULT_COLOR } = this.args;
 
     assert(
@@ -91,7 +91,7 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
    * @default false
    * @description Indicates that the component should take up the full width of the parent container.
    */
-  get isFullWidth() {
+  get isFullWidth(): boolean {
     return this.args.isFullWidth ?? false;
   }
 
@@ -101,7 +101,7 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
    * @default false
    * @description Indicates that the component should be truncated instead of wrapping text and using multiple lines.
    */
-  get isTruncated() {
+  get isTruncated(): boolean {
     return this.args.isTruncated ?? false;
   }
 
@@ -110,7 +110,7 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
    * @method CopySnippet#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-copy-snippet'];
 
     // add a class based on the @color argument
@@ -133,7 +133,9 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
   }
 
   @action
-  onSuccess(args: HdsClipboardModifierSignature['Args']['Named']['onSuccess']) {
+  onSuccess(
+    args: HdsClipboardModifierSignature['Args']['Named']['onSuccess']
+  ): void {
     this.status = 'success';
     this.resetStatusDelayed();
 
@@ -145,7 +147,9 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
   }
 
   @action
-  onError(args: HdsClipboardModifierSignature['Args']['Named']['onError']) {
+  onError(
+    args: HdsClipboardModifierSignature['Args']['Named']['onError']
+  ): void {
     this.status = 'error';
     this.resetStatusDelayed();
 
@@ -156,10 +160,10 @@ export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSig
     }
   }
 
-  resetStatusDelayed() {
+  resetStatusDelayed(): void {
     clearTimeout(this.timer);
     // make it fade back to the default state
-    this.timer = setTimeout(() => {
+    this.timer = setTimeout((): void => {
       this.status = DEFAULT_STATUS;
     }, 1500);
   }

--- a/packages/components/src/components/hds/disclosure-primitive/index.ts
+++ b/packages/components/src/components/hds/disclosure-primitive/index.ts
@@ -36,14 +36,14 @@ export default class HdsDisclosurePrimitiveComponent extends Component<HdsDisclo
   @tracked isOpen = this.args.isOpen ?? false;
 
   @action
-  onClickToggle() {
+  onClickToggle(): void {
     this.isOpen = !this.isOpen;
   }
 
   @action
-  close() {
+  close(): void {
     // we schedule this afterRender to avoid an error in tests caused by updating `isOpen` multiple times in the same computation
-    schedule('afterRender', () => {
+    schedule('afterRender', (): void => {
       this.isOpen = false;
       // we call the "onClose" callback if it exists (and is a function)
       if (this.args.onClose && typeof this.args.onClose === 'function') {

--- a/packages/components/src/components/hds/dismiss-button/index.ts
+++ b/packages/components/src/components/hds/dismiss-button/index.ts
@@ -18,7 +18,7 @@ export default class HdsDismissButtonComponent extends Component<HdsDismissButto
    * @type {string}
    * @default 'Dismiss'
    */
-  get ariaLabel() {
+  get ariaLabel(): string {
     return this.args.ariaLabel ?? 'Dismiss';
   }
 }

--- a/packages/components/src/components/hds/icon-tile/index.ts
+++ b/packages/components/src/components/hds/icon-tile/index.ts
@@ -49,7 +49,7 @@ export default class HdsIconTileComponent extends Component<HdsIconTileSignature
    * @type {string}
    * @default 'medium'
    */
-  get size() {
+  get size(): HdsIconTileSizes {
     const { size = DEFAULT_SIZE } = this.args;
 
     assert(
@@ -70,7 +70,7 @@ export default class HdsIconTileComponent extends Component<HdsIconTileSignature
    * @type {string}
    * @default 'neutral'
    */
-  get color() {
+  get color(): string {
     let { color = DEFAULT_COLOR } = this.args;
 
     // if it's a "logo" then we overwrite any @color parameter passed
@@ -113,7 +113,7 @@ export default class HdsIconTileComponent extends Component<HdsIconTileSignature
    * @default 16
    * @description ensures that the correct icon size is used. Automatically calculated.
    */
-  get iconSize() {
+  get iconSize(): '16' | '24' {
     if (this.args.size === 'small') {
       return '16';
     } else {
@@ -128,7 +128,7 @@ export default class HdsIconTileComponent extends Component<HdsIconTileSignature
    * @type {string|null}
    * @default null
    */
-  get logo() {
+  get logo(): HdsIconTileProducts | null {
     const { logo } = this.args;
 
     if (logo) {
@@ -148,7 +148,7 @@ export default class HdsIconTileComponent extends Component<HdsIconTileSignature
    * @method IconTile#entity
    * @return {string} The kind of entity we're dealing with ("logo" or "icon")
    */
-  get entity() {
+  get entity(): string | undefined {
     let entity;
 
     assert(
@@ -178,7 +178,7 @@ export default class HdsIconTileComponent extends Component<HdsIconTileSignature
    * @type {string|null}
    * @default null
    */
-  get iconSecondary() {
+  get iconSecondary(): FlightIconSignature['Args']['name'] | null {
     return this.args.iconSecondary ?? null;
   }
 
@@ -188,7 +188,7 @@ export default class HdsIconTileComponent extends Component<HdsIconTileSignature
    * @return {string} The "class" attribute to apply to the component.
    */
   // hds-icon-tile {{this.entityClass}} {{this.sizeClass}} {{this.colorClass}}"
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-icon-tile'];
 
     // add a class based on its entity argument

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -32,7 +32,7 @@ export default class HdsInteractiveComponent extends Component<HdsInteractiveSig
    * @type boolean
    * @default true
    */
-  get isHrefExternal() {
+  get isHrefExternal(): boolean {
     return this.args.isHrefExternal ?? true;
   }
 
@@ -43,12 +43,12 @@ export default class HdsInteractiveComponent extends Component<HdsInteractiveSig
    * @type boolean
    * @default false
    */
-  get isRouteExternal() {
+  get isRouteExternal(): boolean {
     return this.args.isRouteExternal ?? false;
   }
 
   @action
-  onKeyUp(event: KeyboardEvent) {
+  onKeyUp(event: KeyboardEvent): void {
     if (event.key === ' ' || event.code === 'Space') {
       (event.target as HTMLElement).click();
     }

--- a/packages/components/src/components/hds/link/inline.ts
+++ b/packages/components/src/components/hds/link/inline.ts
@@ -42,7 +42,7 @@ export default class HdsLinkInlineComponent extends Component<HdsLinkInlineSigna
    * @default primary
    * @description Determines the color of link to be used; acceptable values are `primary` and `secondary`
    */
-  get color() {
+  get color(): HdsLinkColors {
     const { color = DEFAULT_COLOR } = this.args;
 
     assert(
@@ -57,11 +57,11 @@ export default class HdsLinkInlineComponent extends Component<HdsLinkInlineSigna
 
   /**
    * @param iconPosition
-   * @type {string}
+   * @type {HdsLinkIconPositions}
    * @default leading
    * @description Positions the icon before or after the text; allowed values are `leading` or `trailing`
    */
-  get iconPosition() {
+  get iconPosition(): HdsLinkIconPositions {
     const { iconPosition = DEFAULT_ICONPOSITION } = this.args;
 
     assert(
@@ -79,7 +79,7 @@ export default class HdsLinkInlineComponent extends Component<HdsLinkInlineSigna
    * @method LinkInline#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-link-inline'];
 
     // add a class based on the @color argument

--- a/packages/components/src/components/hds/link/standalone.ts
+++ b/packages/components/src/components/hds/link/standalone.ts
@@ -50,7 +50,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @type {string}
    * @description The text of the link. If no text value is defined an error will be thrown.
    */
-  get text() {
+  get text(): string {
     const { text } = this.args;
 
     assert(
@@ -67,7 +67,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @default primary
    * @description Determines the color of link to be used; acceptable values are `primary` and `secondary`
    */
-  get color() {
+  get color(): HdsLinkColors {
     const { color = DEFAULT_COLOR } = this.args;
 
     assert(
@@ -86,7 +86,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @default null
    * @description The name of the icon to be used. An icon name must be defined.
    */
-  get icon() {
+  get icon(): FlightIconSignature['Args']['name'] {
     const { icon } = this.args;
 
     assert(
@@ -99,11 +99,11 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
 
   /**
    * @param iconPosition
-   * @type {string}
+   * @type {HdsLinkIconPositions}
    * @default leading
    * @description Positions the icon before or after the text; allowed values are `leading` or `trailing`
    */
-  get iconPosition() {
+  get iconPosition(): HdsLinkIconPositions {
     const { iconPosition = DEFAULT_ICONPOSITION } = this.args;
 
     assert(
@@ -118,11 +118,11 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
 
   /**
    * @param size
-   * @type {string}
+   * @type {HdsLinkStandaloneSizes}
    * @default medium
    * @description The size of the standalone link; acceptable values are `small`, `medium`, and `large`
    */
-  get size() {
+  get size(): HdsLinkStandaloneSizes {
     const { size = DEFAULT_SIZE } = this.args;
 
     assert(
@@ -141,7 +141,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @default 16
    * @description ensures that the correct icon size is used. Automatically calculated.
    */
-  get iconSize() {
+  get iconSize(): '24' | '16' {
     if (this.args.size === 'large') {
       return '24';
     } else {
@@ -154,7 +154,7 @@ export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandal
    * @method LinkStandalone#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-link-standalone'];
 
     // add a class based on the @size argument

--- a/packages/components/src/components/hds/reveal/toggle/button.ts
+++ b/packages/components/src/components/hds/reveal/toggle/button.ts
@@ -21,7 +21,7 @@ export default class HdsRevealToggleButtonComponent extends Component<HdsRevealT
    * @method ToggleButton#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-reveal__toggle-button'];
 
     // add a class based on the @isOpen argument

--- a/packages/components/src/components/hds/separator/index.ts
+++ b/packages/components/src/components/hds/separator/index.ts
@@ -25,10 +25,10 @@ export default class HdsSeparatorComponent extends Component<HdsSeparatorSignatu
    * Accepted values: 24, 0
    *
    * @param spacing
-   * @type {string}
-   * @default 'default'
+   * @type {HdsSeparatorSpacing}
+   * @default 24
    */
-  get spacing() {
+  get spacing(): HdsSeparatorSpacing {
     const { spacing = DEFAULT_SPACING } = this.args;
 
     assert(
@@ -46,7 +46,7 @@ export default class HdsSeparatorComponent extends Component<HdsSeparatorSignatu
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-separator'];
 
     // add a class based on the @spacing argument

--- a/packages/components/src/components/hds/side-nav/header/home-link.ts
+++ b/packages/components/src/components/hds/side-nav/header/home-link.ts
@@ -24,7 +24,7 @@ export default class HdsSideNavHeaderHomeLinkComponent extends Component<HdsSide
    * @type {string}
    * @description The value of `aria-label`
    */
-  get ariaLabel() {
+  get ariaLabel(): string {
     const { ariaLabel } = this.args;
 
     assert(

--- a/packages/components/src/components/hds/side-nav/header/icon-button.ts
+++ b/packages/components/src/components/hds/side-nav/header/icon-button.ts
@@ -23,7 +23,7 @@ export default class HdsSideNavHeaderIconButtonComponent extends Component<HdsSi
    * @type {string}
    * @description The value of `aria-label`
    */
-  get ariaLabel() {
+  get ariaLabel(): string {
     const { ariaLabel } = this.args;
 
     assert(

--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -69,7 +69,7 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
     super(owner, args);
     this.desktopMQ = window.matchMedia(`(min-width:${this.desktopMQVal})`);
     this.addEventListeners();
-    registerDestructor(this, () => {
+    registerDestructor(this, (): void => {
       this.removeEventListeners();
     });
 
@@ -81,7 +81,7 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
     }
   }
 
-  addEventListeners() {
+  addEventListeners(): void {
     document.addEventListener('keydown', this.escapePress, true);
     this.desktopMQ.addEventListener('change', this.updateDesktopVariable, true);
     // if not instantiated as minimized via arguments
@@ -95,7 +95,7 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
     }
   }
 
-  removeEventListeners() {
+  removeEventListeners(): void {
     document.removeEventListener('keydown', this.escapePress, true);
     this.desktopMQ.removeEventListener(
       'change',
@@ -104,11 +104,11 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
     );
   }
 
-  get shouldTrapFocus() {
+  get shouldTrapFocus(): boolean {
     return this.isResponsive && !this.isDesktop && !this.isMinimized;
   }
 
-  get showToggleButton() {
+  get showToggleButton(): boolean {
     return (this.isResponsive && !this.isDesktop) || this.isCollapsible;
   }
 
@@ -117,14 +117,14 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
    * @type {string}
    * @default 'close menu'
    */
-  get ariaLabel() {
+  get ariaLabel(): string {
     if (this.isMinimized) {
       return this.args.ariaLabel ?? 'Open menu';
     }
     return this.args.ariaLabel ?? 'Close menu';
   }
 
-  get classNames() {
+  get classNames(): string {
     const classes = []; // `hds-side-nav` is already set by the "Hds::SideNav::Base" component
 
     // add specific class names for the different possible states
@@ -149,17 +149,17 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
   }
 
   @action
-  escapePress(event: KeyboardEvent) {
+  escapePress(event: KeyboardEvent): void {
     if (event.key === 'Escape' && !this.isMinimized && !this.isDesktop) {
       this.isMinimized = true;
     }
   }
 
   @action
-  toggleMinimizedStatus() {
+  toggleMinimizedStatus(): void {
     this.isMinimized = !this.isMinimized;
 
-    this.containersToHide.forEach((element) => {
+    this.containersToHide.forEach((element): void => {
       if (this.isMinimized) {
         element.setAttribute('inert', '');
       } else {
@@ -175,14 +175,14 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
   }
 
   @action
-  didInsert(element: HTMLElement) {
+  didInsert(element: HTMLElement): void {
     this.containersToHide = element.querySelectorAll(
       '.hds-side-nav-hide-when-minimized'
     );
   }
 
   @action
-  setTransition(phase: string, event: TransitionEvent) {
+  setTransition(phase: string, event: TransitionEvent): void {
     // we only want to respond to `width` animation/transitions
     if (event.propertyName !== 'width') {
       return;
@@ -195,7 +195,7 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
   }
 
   @action
-  updateDesktopVariable(event: MediaQueryListEvent) {
+  updateDesktopVariable(event: MediaQueryListEvent): void {
     this.isDesktop = event.matches;
 
     // automatically minimize on narrow viewports (when not in desktop mode)

--- a/packages/components/src/components/hds/side-nav/portal/target.ts
+++ b/packages/components/src/components/hds/side-nav/portal/target.ts
@@ -40,7 +40,7 @@ export default class HdsSideNavPortalTargetComponent extends Component<HdsSideNa
   @tracked numSubnavs = 0;
   @tracked lastPanelEl: Element | undefined;
 
-  static get prefersReducedMotionOverride() {
+  static get prefersReducedMotionOverride(): boolean {
     return Ember.testing;
   }
 
@@ -48,7 +48,7 @@ export default class HdsSideNavPortalTargetComponent extends Component<HdsSideNa
     '(prefers-reduced-motion: reduce)'
   );
 
-  get prefersReducedMotion() {
+  get prefersReducedMotion(): boolean {
     return (
       HdsSideNavPortalTargetComponent.prefersReducedMotionOverride ||
       (this.prefersReducedMotionMQ && this.prefersReducedMotionMQ.matches)
@@ -56,17 +56,17 @@ export default class HdsSideNavPortalTargetComponent extends Component<HdsSideNa
   }
 
   @action
-  panelsChanged(portalCount: number) {
+  panelsChanged(portalCount: number): void {
     this.numSubnavs = portalCount;
   }
 
   @action
-  didUpdateSubnav(element: HTMLElement, [count]: [number]) {
+  didUpdateSubnav(element: HTMLElement, [count]: [number]): void {
     this.animateSubnav(element, [count]);
   }
 
   @action
-  animateSubnav(element: HTMLElement, [count]: [number]) {
+  animateSubnav(element: HTMLElement, [count]: [number]): void {
     /*
      * Here is what the layout looks like for this setup
      *
@@ -137,7 +137,7 @@ export default class HdsSideNavPortalTargetComponent extends Component<HdsSideNa
       }
     );
 
-    anim.finished.then(() => {
+    anim.finished.then((): void => {
       // uncomment this if we need/want to scroll the element to the top
       // targetElement.scrollIntoView(true);
       if (activeIndex > 0) {

--- a/packages/components/src/components/hds/stepper/step/indicator.ts
+++ b/packages/components/src/components/hds/stepper/step/indicator.ts
@@ -28,7 +28,7 @@ export default class HdsStepperStepIndicatorComponent extends Component<HdsStepp
    * @default "incomplete"
    */
 
-  get status() {
+  get status(): HdsStepperStatuses {
     const { status = DEFAULT_STATUS } = this.args;
 
     assert(
@@ -47,7 +47,7 @@ export default class HdsStepperStepIndicatorComponent extends Component<HdsStepp
    * @default false
    */
 
-  get isInteractive() {
+  get isInteractive(): boolean {
     return this.args.isInteractive || false;
   }
 
@@ -56,7 +56,7 @@ export default class HdsStepperStepIndicatorComponent extends Component<HdsStepp
    * @method IndicatorStep#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-stepper-indicator-step'];
 
     // Based on the @status arg

--- a/packages/components/src/components/hds/stepper/task/indicator.ts
+++ b/packages/components/src/components/hds/stepper/task/indicator.ts
@@ -10,6 +10,7 @@ import {
   HdsStepperStatusesValues,
   HdsStepperStatusToIconsValues,
 } from '../types.ts';
+import type { FlightIconSignature } from '@hashicorp/ember-flight-icons/components/flight-icon';
 import type { HdsStepperStatuses } from '../types.ts';
 
 export const DEFAULT_STATUS = HdsStepperStatusesValues.Incomplete;
@@ -32,7 +33,7 @@ export default class HdsStepperTaskIndicatorComponent extends Component<HdsStepp
    * @default "incomplete"
    */
 
-  get status() {
+  get status(): HdsStepperStatuses {
     const { status = DEFAULT_STATUS } = this.args;
 
     assert(
@@ -51,7 +52,7 @@ export default class HdsStepperTaskIndicatorComponent extends Component<HdsStepp
    * @default false
    */
 
-  get isInteractive() {
+  get isInteractive(): boolean {
     return this.args.isInteractive || false;
   }
 
@@ -60,7 +61,7 @@ export default class HdsStepperTaskIndicatorComponent extends Component<HdsStepp
    * @type {string}
    */
 
-  get iconName() {
+  get iconName(): FlightIconSignature['Args']['name'] {
     return MAPPING_STATUS_TO_ICONS[this.status];
   }
 
@@ -69,7 +70,7 @@ export default class HdsStepperTaskIndicatorComponent extends Component<HdsStepp
    * @method IndicatorTask#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-stepper-indicator-task'];
 
     // Based on the @status arg

--- a/packages/components/src/components/hds/tabs/index.ts
+++ b/packages/components/src/components/hds/tabs/index.ts
@@ -102,7 +102,7 @@ export default class HdsTabsComponent extends Component<HdsTabsSignature> {
   }
 
   @action
-  didInsert() {
+  didInsert(): void {
     assert(
       'The number of Tabs must be equal to the number of Panels',
       this.tabNodes.length === this.panelNodes.length
@@ -112,20 +112,20 @@ export default class HdsTabsComponent extends Component<HdsTabsSignature> {
       this.selectedTabIndex = this.tabIds.indexOf(this.selectedTabId);
     }
 
-    schedule('afterRender', () => {
+    schedule('afterRender', (): void => {
       this.setTabIndicator();
     });
   }
 
   @action
-  didUpdateSelectedTabIndex() {
-    schedule('afterRender', () => {
+  didUpdateSelectedTabIndex(): void {
+    schedule('afterRender', (): void => {
       this.setTabIndicator();
     });
   }
 
   @action
-  didUpdateSelectedTabId() {
+  didUpdateSelectedTabId(): void {
     // if the selected tab is set dynamically (eg. in a `each` loop)
     // the `Tab` nodes will be re-inserted/rendered, which means the `this.selectedTabId` variable changes
     // but the parent `Tabs` component has already been rendered/inserted but doesn't re-render
@@ -137,14 +137,14 @@ export default class HdsTabsComponent extends Component<HdsTabsSignature> {
   }
 
   @action
-  didUpdateParentVisibility() {
-    schedule('afterRender', () => {
+  didUpdateParentVisibility(): void {
+    schedule('afterRender', (): void => {
       this.setTabIndicator();
     });
   }
 
   @action
-  didInsertTab(element: HTMLButtonElement, isSelected?: boolean) {
+  didInsertTab(element: HTMLButtonElement, isSelected?: boolean): void {
     this.tabNodes = [...this.tabNodes, element];
     this.tabIds = [...this.tabIds, element.id];
     if (isSelected) {
@@ -153,7 +153,7 @@ export default class HdsTabsComponent extends Component<HdsTabsSignature> {
   }
 
   @action
-  didUpdateTab(tabIndex: number, isSelected?: boolean) {
+  didUpdateTab(tabIndex: number, isSelected?: boolean): void {
     if (isSelected) {
       this.selectedTabIndex = tabIndex;
     }
@@ -161,25 +161,31 @@ export default class HdsTabsComponent extends Component<HdsTabsSignature> {
   }
 
   @action
-  willDestroyTab(element: HTMLButtonElement) {
-    this.tabNodes = this.tabNodes.filter((node) => node.id !== element.id);
-    this.tabIds = this.tabIds.filter((tabId) => tabId !== element.id);
+  willDestroyTab(element: HTMLButtonElement): void {
+    this.tabNodes = this.tabNodes.filter(
+      (node): boolean => node.id !== element.id
+    );
+    this.tabIds = this.tabIds.filter((tabId): boolean => tabId !== element.id);
   }
 
   @action
-  didInsertPanel(element: HTMLElement, panelId: string) {
+  didInsertPanel(element: HTMLElement, panelId: string): void {
     this.panelNodes = [...this.panelNodes, element];
     this.panelIds = [...this.panelIds, panelId];
   }
 
   @action
-  willDestroyPanel(element: HTMLElement) {
-    this.panelNodes = this.panelNodes.filter((node) => node.id !== element.id);
-    this.panelIds = this.panelIds.filter((panelId) => panelId !== element.id);
+  willDestroyPanel(element: HTMLElement): void {
+    this.panelNodes = this.panelNodes.filter(
+      (node): boolean => node.id !== element.id
+    );
+    this.panelIds = this.panelIds.filter(
+      (panelId): boolean => panelId !== element.id
+    );
   }
 
   @action
-  onClick(event: MouseEvent, tabIndex: number) {
+  onClick(event: MouseEvent, tabIndex: number): void {
     this.selectedTabIndex = tabIndex;
     this.setTabIndicator();
 
@@ -190,7 +196,7 @@ export default class HdsTabsComponent extends Component<HdsTabsSignature> {
   }
 
   @action
-  onKeyUp(tabIndex: number, event: KeyboardEvent) {
+  onKeyUp(tabIndex: number, event: KeyboardEvent): void {
     const leftArrow = 'ArrowLeft';
     const rightArrow = 'ArrowRight';
     const enterKey = 'Enter';
@@ -218,13 +224,13 @@ export default class HdsTabsComponent extends Component<HdsTabsSignature> {
   }
 
   // Focus tab for keyboard & mouse navigation:
-  focusTab(tabIndex: number, event: KeyboardEvent) {
+  focusTab(tabIndex: number, event: KeyboardEvent): void {
     event.preventDefault();
     this.tabNodes[tabIndex]?.focus();
   }
 
-  setTabIndicator() {
-    next(() => {
+  setTabIndicator(): void {
+    next((): void => {
       const tabElem = this.tabNodes[this.selectedTabIndex];
 
       if (tabElem != null) {

--- a/packages/components/src/components/hds/tabs/panel.ts
+++ b/packages/components/src/components/hds/tabs/panel.ts
@@ -36,7 +36,7 @@ export default class HdsTabsPanelComponent extends Component<HdsTabsPanelSignatu
 
   elementId?: string;
 
-  get nodeIndex() {
+  get nodeIndex(): number | undefined {
     return this.args.panelIds
       ? this.args.panelIds.indexOf(this.panelId)
       : undefined;
@@ -61,7 +61,7 @@ export default class HdsTabsPanelComponent extends Component<HdsTabsPanelSignatu
   }
 
   @action
-  didInsertNode(element: HTMLElement) {
+  didInsertNode(element: HTMLElement): void {
     const { didInsertNode } = this.args;
 
     if (typeof didInsertNode === 'function') {
@@ -71,7 +71,7 @@ export default class HdsTabsPanelComponent extends Component<HdsTabsPanelSignatu
   }
 
   @action
-  willDestroyNode(element: HTMLElement) {
+  willDestroyNode(element: HTMLElement): void {
     const { willDestroyNode } = this.args;
 
     if (typeof willDestroyNode === 'function') {

--- a/packages/components/src/components/hds/tabs/tab.ts
+++ b/packages/components/src/components/hds/tabs/tab.ts
@@ -52,7 +52,7 @@ export default class HdsTabsTabComponent extends Component<HdsTabsTabSignature> 
   }
 
   @action
-  didInsertNode(element: HTMLButtonElement, positional: [boolean?]) {
+  didInsertNode(element: HTMLButtonElement, positional: [boolean?]): void {
     const { didInsertNode } = this.args;
 
     const isSelected = positional[0];
@@ -63,7 +63,7 @@ export default class HdsTabsTabComponent extends Component<HdsTabsTabSignature> 
   }
 
   @action
-  didUpdateNode() {
+  didUpdateNode(): void {
     const { didUpdateNode } = this.args;
 
     if (typeof didUpdateNode === 'function' && this.nodeIndex !== undefined) {
@@ -72,7 +72,7 @@ export default class HdsTabsTabComponent extends Component<HdsTabsTabSignature> 
   }
 
   @action
-  willDestroyNode(element: HTMLButtonElement) {
+  willDestroyNode(element: HTMLButtonElement): void {
     const { willDestroyNode } = this.args;
 
     if (typeof willDestroyNode === 'function') {
@@ -81,7 +81,7 @@ export default class HdsTabsTabComponent extends Component<HdsTabsTabSignature> 
   }
 
   @action
-  onClick(event: MouseEvent) {
+  onClick(event: MouseEvent): false | undefined {
     const { onClick } = this.args;
 
     if (typeof onClick === 'function' && this.nodeIndex !== undefined) {
@@ -92,7 +92,7 @@ export default class HdsTabsTabComponent extends Component<HdsTabsTabSignature> 
   }
 
   @action
-  onKeyUp(event: KeyboardEvent) {
+  onKeyUp(event: KeyboardEvent): false | undefined {
     const { onKeyUp } = this.args;
 
     if (typeof onKeyUp === 'function' && this.nodeIndex !== undefined) {
@@ -107,7 +107,7 @@ export default class HdsTabsTabComponent extends Component<HdsTabsTabSignature> 
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-tabs__tab'];
 
     if (this.isSelected) {

--- a/packages/components/src/components/hds/tabs/tab.ts
+++ b/packages/components/src/components/hds/tabs/tab.ts
@@ -92,13 +92,11 @@ export default class HdsTabsTabComponent extends Component<HdsTabsTabSignature> 
   }
 
   @action
-  onKeyUp(event: KeyboardEvent): false | undefined {
+  onKeyUp(event: KeyboardEvent): void {
     const { onKeyUp } = this.args;
 
     if (typeof onKeyUp === 'function' && this.nodeIndex !== undefined) {
       onKeyUp(this.nodeIndex, event);
-    } else {
-      return false;
     }
   }
 

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -45,7 +45,7 @@ export default class HdsTagComponent extends Component<HdsTagSignature> {
    * @type {string}
    * @description The text of the tag. If no text value is defined, an error will be thrown.
    */
-  get text() {
+  get text(): string {
     const { text } = this.args;
 
     assert('@text for "Hds::Tag" must have a valid value', text !== undefined);
@@ -58,7 +58,7 @@ export default class HdsTagComponent extends Component<HdsTagSignature> {
    * @type {string}
    * @default 'Dismiss'
    */
-  get ariaLabel() {
+  get ariaLabel(): string {
     const tagAriaLabel = this.args.ariaLabel ?? 'Dismiss';
     return tagAriaLabel + ' ' + this.args.text;
   }
@@ -69,7 +69,7 @@ export default class HdsTagComponent extends Component<HdsTagSignature> {
    * @default primary
    * @description Determines the color of link to be used; acceptable values are `primary` and `secondary`
    */
-  get color() {
+  get color(): HdsTagColors | false {
     if (this.args.href || this.args.route) {
       const { color = DEFAULT_COLOR } = this.args;
       assert(
@@ -93,7 +93,7 @@ export default class HdsTagComponent extends Component<HdsTagSignature> {
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-tag'];
 
     // add a class based on the @color argument

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -30,7 +30,8 @@ export default class HdsTagComponent extends Component<HdsTagSignature> {
    * @type {function}
    * @default () => {}
    */
-  get onDismiss() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get onDismiss(): ((event: MouseEvent, ...args: any[]) => void) | false {
     const { onDismiss } = this.args;
 
     if (typeof onDismiss === 'function') {

--- a/packages/components/src/components/hds/text/body.ts
+++ b/packages/components/src/components/hds/text/body.ts
@@ -81,11 +81,11 @@ export default class HdsTextBodyComponent extends Component<HdsTextBodySignature
    * Sets the "size" for the text
    * Accepted values: see AVAILABLE_SIZES
    *
-   * @type {string}
-   *
    * @param size
+   * @type {HdsTextBodySizes}
+   *
    */
-  get size() {
+  get size(): HdsTextBodySizes {
     let { size = DEFAULT_SIZE } = this.args;
 
     // let's be a bit forgiving with the consumers
@@ -107,11 +107,11 @@ export default class HdsTextBodyComponent extends Component<HdsTextBodySignature
    * Sets the "weight" for the text
    * Accepted values: see AVAILABLE_WEIGHTS_PER_SIZE
    *
-   * @type {string}
+   * @param weight
+   * @type {HdsTextWeights}
    *
-   * @param variant
    */
-  get weight() {
+  get weight(): HdsTextWeights {
     const { weight = DEFAULT_WEIGHT } = this.args;
 
     const availableWeights = AVAILABLE_WEIGHTS_PER_SIZE[this.size];

--- a/packages/components/src/components/hds/text/code.ts
+++ b/packages/components/src/components/hds/text/code.ts
@@ -75,11 +75,11 @@ export default class HdsTextCodeComponent extends Component<HdsTextCodeSignature
    * Sets the "size" for the text
    * Accepted values: see AVAILABLE_SIZES
    *
-   * @type {string}
+   * @type {HdsTextCodeSizes}
    *
    * @param size
    */
-  get size() {
+  get size(): HdsTextCodeSizes {
     let { size = DEFAULT_SIZE } = this.args;
 
     // let's be a bit forgiving with the consumers
@@ -105,7 +105,7 @@ export default class HdsTextCodeComponent extends Component<HdsTextCodeSignature
    *
    * @param variant
    */
-  get weight() {
+  get weight(): HdsTextCodeWeight {
     const { weight = DEFAULT_WEIGHT } = this.args;
 
     const availableWeights = AVAILABLE_WEIGHTS_PER_SIZE[this.size];

--- a/packages/components/src/components/hds/text/display.ts
+++ b/packages/components/src/components/hds/text/display.ts
@@ -22,7 +22,7 @@ export const DEFAULT_SIZE = HdsTextSizeValues.TwoHundred;
 // Filter out reverse mappings from enum
 // https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings
 export const AVAILABLE_SIZES = Object.values(HdsTextSizeValues).filter(
-  (v) => typeof v === 'number'
+  (v): boolean => typeof v === 'number'
 );
 
 export type HdsTextDisplayWeight = Extract<
@@ -81,11 +81,11 @@ export default class HdsTextDisplayComponent extends Component<HdsTextDisplaySig
    * Sets the "size" for the text
    * Accepted values: see AVAILABLE_SIZES
    *
-   * @type {string}
+   * @type {HdsTextSizes}
    *
    * @param size
    */
-  get size() {
+  get size(): HdsTextSizes {
     let { size = DEFAULT_SIZE } = this.args;
 
     // let's be a bit forgiving with the consumers
@@ -107,11 +107,11 @@ export default class HdsTextDisplayComponent extends Component<HdsTextDisplaySig
    * Sets the "weight" for the text
    * Accepted values: see AVAILABLE_WEIGHTS_PER_SIZE
    *
-   * @type {string}
+   * @type {HdsTextDisplayWeight}
    *
    * @param variant
    */
-  get weight() {
+  get weight(): HdsTextDisplayWeight {
     let { weight } = this.args;
 
     if (weight) {

--- a/packages/components/src/components/hds/text/index.ts
+++ b/packages/components/src/components/hds/text/index.ts
@@ -27,7 +27,7 @@ export interface HdsTextSignature {
     tag?: HdsTextTags;
     weight?: HdsTextWeights;
     align?: HdsTextAligns;
-    color?: string | HdsTextColors;
+    color?: HdsTextColors | string | undefined;
     group: HdsTextGroups;
   };
   Element: AvailableElements;
@@ -41,7 +41,7 @@ export default class HdsTextComponent extends Component<HdsTextSignature> {
    * Get a tag to render based on the `@tag` argument passed or the value of `this.size` (via mapping)
    *
    * @method #componentTag
-   * @return {string} The html tag to use in the dynamic render of the component
+   * @return {HdsTextTags} The html tag to use in the dynamic render of the component
    */
   get componentTag(): HdsTextTags {
     const { tag = 'span' } = this.args;
@@ -53,11 +53,10 @@ export default class HdsTextComponent extends Component<HdsTextSignature> {
    * Sets the "variant" (style) for the text
    * Accepted values: see AVAILABLE_VARIANTS
    *
-   * @type {string}
-   *
    * @param variant
+   * @type {string}
    */
-  get variant() {
+  get variant(): string {
     const { group, size } = this.args;
 
     // notice: for performance reasons we don't do any other extra check on these values
@@ -70,9 +69,9 @@ export default class HdsTextComponent extends Component<HdsTextSignature> {
    * Accepted values: see AVAILABLE_ALIGNS
    *
    * @param align
-   * @type {string}
+   * @type {HdsTextAligns}
    */
-  get align() {
+  get align(): HdsTextAligns | undefined {
     const { align } = this.args;
 
     if (align) {
@@ -92,13 +91,13 @@ export default class HdsTextComponent extends Component<HdsTextSignature> {
    * Accepted values: see AVAILABLE_COLORS
    *
    * @param color
-   * @type {string}
+   * @type {HdsTextColors}
    */
-  get predefinedColor() {
+  get predefinedColor(): HdsTextColors | undefined {
     const { color } = this.args;
 
     if (color && AVAILABLE_COLORS.includes(color)) {
-      return color;
+      return color as HdsTextColors;
     } else {
       return undefined;
     }
@@ -108,13 +107,13 @@ export default class HdsTextComponent extends Component<HdsTextSignature> {
    * Sets the color of the text as custom value (via inline style)
    *
    * @param color
-   * @type {string}
+   * @type {HdsTextColors}
    */
-  get customColor() {
+  get customColor(): HdsTextColors | undefined {
     const { color } = this.args;
 
     if (color && !AVAILABLE_COLORS.includes(color)) {
-      return color;
+      return color as HdsTextColors;
     } else {
       return undefined;
     }
@@ -125,7 +124,7 @@ export default class HdsTextComponent extends Component<HdsTextSignature> {
    * @method #classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-text'];
 
     // add a (helper) class based on the "group + size" variant

--- a/packages/components/src/components/hds/text/index.ts
+++ b/packages/components/src/components/hds/text/index.ts
@@ -107,9 +107,9 @@ export default class HdsTextComponent extends Component<HdsTextSignature> {
    * Sets the color of the text as custom value (via inline style)
    *
    * @param color
-   * @type {HdsTextColors}
+   * @type {string}
    */
-  get customColor(): HdsTextColors | undefined {
+  get customColor(): string | undefined {
     const { color } = this.args;
 
     if (color && !AVAILABLE_COLORS.includes(color)) {

--- a/packages/components/src/helpers/hds-link-to-models.ts
+++ b/packages/components/src/helpers/hds-link-to-models.ts
@@ -20,7 +20,7 @@ import { assert } from '@ember/debug';
 export function hdsLinkToModels<T>([model, models]: [
   T | undefined,
   T[] | undefined
-]) {
+]): T[] {
   assert(
     'You cannot provide both the `@model` and `@models` arguments to the component.',
     !model || !models

--- a/packages/components/src/helpers/hds-link-to-query.ts
+++ b/packages/components/src/helpers/hds-link-to-query.ts
@@ -19,7 +19,9 @@ import { helper } from '@ember/component/helper';
 // this is a workaround for https://github.com/emberjs/ember.js/issues/19693
 // don't remove until we drop support for ember 3.27 and 3.28
 
-export function hdsLinkToQuery([query]: [Record<string, string> | undefined]) {
+export function hdsLinkToQuery([query]: [
+  Record<string, string> | undefined
+]): Record<string, string> {
   return query ?? {};
 }
 

--- a/packages/components/src/modifiers/hds-clipboard.ts
+++ b/packages/components/src/modifiers/hds-clipboard.ts
@@ -23,7 +23,7 @@ export interface HdsClipboardModifierSignature {
   };
 }
 
-export const getTextToCopy = (text: TextToCopy) => {
+export const getTextToCopy = (text: TextToCopy): string => {
   let textToCopy: string = '';
 
   if (text) {
@@ -44,7 +44,9 @@ export const getTextToCopy = (text: TextToCopy) => {
   return textToCopy;
 };
 
-export const getTargetElement = (target: string | Node) => {
+export const getTargetElement = (
+  target: string | Node
+): HTMLElement | undefined => {
   let targetElement: HTMLElement | null;
 
   if (typeof target === 'string') {
@@ -73,7 +75,9 @@ export const getTargetElement = (target: string | Node) => {
   return targetElement;
 };
 
-export const getTextToCopyFromTargetElement = (targetElement: TargetToCopy) => {
+export const getTextToCopyFromTargetElement = (
+  targetElement: TargetToCopy
+): string => {
   let textToCopy: string = '';
 
   if (targetElement instanceof HTMLElement) {
@@ -100,7 +104,9 @@ export const getTextToCopyFromTargetElement = (targetElement: TargetToCopy) => {
   return textToCopy;
 };
 
-export const writeTextToClipboard = async (textToCopy: string) => {
+export const writeTextToClipboard = async (
+  textToCopy: string
+): Promise<boolean> => {
   // finally copy the text to the clipboard using the Clipboard API
   // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
   if (textToCopy) {
@@ -127,7 +133,7 @@ export const writeTextToClipboard = async (textToCopy: string) => {
 export const copyToClipboard = async (
   text?: TextToCopy,
   target?: TargetToCopy
-) => {
+): Promise<boolean> => {
   let textToCopy: string = '';
 
   if (text) {
@@ -151,7 +157,7 @@ export const copyToClipboard = async (
 // see: https://github.com/ember-modifier/ember-modifier#function-based-modifiers
 
 export default modifier<HdsClipboardModifierSignature>(
-  (element, _positional, named) => {
+  (element, _positional, named): (() => void) => {
     assert(
       '`hds-clipboard` modifier - the modifier must be applied to an element',
       element
@@ -159,7 +165,7 @@ export default modifier<HdsClipboardModifierSignature>(
 
     const { text, target, onSuccess, onError } = named;
 
-    const onClick = async (event: MouseEvent) => {
+    const onClick = async (event: MouseEvent): Promise<void> => {
       const trigger = event.currentTarget;
       const success = await copyToClipboard(text, target);
 
@@ -179,7 +185,7 @@ export default modifier<HdsClipboardModifierSignature>(
     element.addEventListener('click', onClick);
 
     // this (teardown) function is run when the element is removed
-    return () => {
+    return (): void => {
       element.removeEventListener('click', onClick);
     };
   }

--- a/wiki/TypeScript-Migration.md
+++ b/wiki/TypeScript-Migration.md
@@ -70,6 +70,7 @@ The following steps are recommended for migrating components to TypeScript.
       ```
 
     - Try to be as specific as possible with the `Element` type used by the component; if splattributes (`...attributes`) are used within the component template, the element with splattributes is considered the main element
+    - Functions should have explicitly declared return types to enhances code readability and maintainability
 
 6. Update the template registry
 


### PR DESCRIPTION
### :pushpin: Summary

Add return types to all functions in TypeScript files and update the migration docs to recommend defining return types.

**Note**: going through the codebase for this change it seems that the FlightIcon sizes `'16' | '24'` should be declared as a type. Can do that in a follow-up, but don't want to step on toes with the component migration.

### :link: External links

Follow-up on https://github.com/hashicorp/design-system/pull/2168#discussion_r1652829925.

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
