### PR TITLE
Remove references to `dialog-polyfill` in documentation pages for `Flyout` and `Modal`

### DIFF
--- a/website/docs/components/flyout/partials/code/how-to-use.md
+++ b/website/docs/components/flyout/partials/code/how-to-use.md
@@ -1,6 +1,6 @@
 ## Browser support
 
-The Flyout component leverages the `<dialog>` element which is [currently supported by all major browser vendors](https://caniuse.com/dialog). To ensure support on older browser versions (for example, Safari 14 or Internet Explorer 11) we rely on [a polyfill](https://github.com/GoogleChrome/dialog-polyfill) that is automatically loaded when needed.
+The Flyout component leverages the `<dialog>` element which is [currently supported by all major browser vendors](https://caniuse.com/dialog).
 
 ## Page scroll
 

--- a/website/docs/components/modal/partials/code/how-to-use.md
+++ b/website/docs/components/modal/partials/code/how-to-use.md
@@ -1,6 +1,6 @@
 ## Browser support
 
-The Modal component leverages the `<dialog>` element which is [currently supported by all major browser vendors](https://caniuse.com/dialog). To ensure support on older browser versions (for example, Safari 14 or Internet Explorer 11) we rely on [a polyfill](https://github.com/GoogleChrome/dialog-polyfill) that is automatically loaded when needed.
+The Modal component leverages the `<dialog>` element which is [currently supported by all major browser vendors](https://caniuse.com/dialog).
 
 ## Page scroll
 


### PR DESCRIPTION
### :pushpin: Summary

Since the `dialog-polyfill` was removed in https://github.com/hashicorp/design-system/pull/1977 we can also remove references to it in the documentation pages of the `Flyout` and `Modal` components.

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
