### PR TITLE
Remove Popover API polyfill

### DIFF
--- a/.changeset/new-buckets-fry.md
+++ b/.changeset/new-buckets-fry.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Removed `popover-polyfill` dependency and instantiating code

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,6 @@
     "@floating-ui/dom": "^1.6.3",
     "@hashicorp/design-system-tokens": "^2.1.0",
     "@hashicorp/ember-flight-icons": "^5.1.2",
-    "@oddbird/popover-polyfill": "^0.4.3",
     "decorator-transforms": "^1.1.0",
     "ember-a11y-refocus": "^4.1.0",
     "ember-cli-sass": "^11.0.1",

--- a/packages/components/src/styles/components/rich-tooltip.scss
+++ b/packages/components/src/styles/components/rich-tooltip.scss
@@ -231,11 +231,6 @@
     }
   }
 
-  // polyfilled `:popover-open` selector
-  // see: https://github.com/oddbird/popover-polyfill?tab=readme-ov-file#caveats
-  &[popover].\:popover-open {
-    opacity: 1;
-  }
 
   @starting-style {
     &[popover].\:popover-open {

--- a/website/docs/utilities/popover-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/popover-primitive/partials/code/how-to-use.md
@@ -13,8 +13,6 @@ Under the hood, the component uses the [native web Popover API](https://develope
 
 The primitive also uses the [Floating UI](https://floating-ui.com/) third-party library to provide anchoring as well as automatic positioning and collision detection functionality.
 
-For older browsers (in particular Firefox 124 and older) that don't support the Popover API, it uses a [Popover Polyfill](https://github.com/oddbird/popover-polyfill) library to emulate the native behaviour.
-
 !!! Insight
 
 **Learn more**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4117,7 +4117,6 @@ __metadata:
     "@glint/template": "npm:^1.4.0"
     "@hashicorp/design-system-tokens": "npm:^2.1.0"
     "@hashicorp/ember-flight-icons": "npm:^5.1.2"
-    "@oddbird/popover-polyfill": "npm:^0.4.3"
     "@rollup/plugin-babel": "npm:^6.0.4"
     "@tsconfig/ember": "npm:^3.0.8"
     "@types/ember-qunit": "npm:^6.1.1"
@@ -4798,13 +4797,6 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 10/f3a7ab3a31de65e42aeb6ed03ed035ef123d2de7af4deb9d4a003d27acc8618b57d9fb9d259fe6c28ca538032a028f37337264388ba27d26d37fff7dde22476e
-  languageName: node
-  linkType: hard
-
-"@oddbird/popover-polyfill@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@oddbird/popover-polyfill@npm:0.4.3"
-  checksum: 10/edae2d175485a0759cbbb3c9754d99f7ba005f4c0f666db665d5679010e30e4ec4fecae602975fc04eef146715707542a5beb6cccb2bb09baed319101782441b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: Summary

Now that [Firefox officially supports the Popover API](https://caniuse.com/?search=popover) we don't need anymore a polyfill (it was introduced in https://github.com/hashicorp/design-system/pull/2069 for the RichTooltip)

<img width="1378" alt="screenshot_3921" src="https://github.com/hashicorp/design-system/assets/686239/3ffcd0c7-7d5a-4ce2-8983-80e18d12a120">

### :hammer_and_wrench: Detailed description

In this PR I have:
- remove `@oddbird/popover-polyfill` dependency
- remove code related to `@oddbird/popover-polyfill`
- removed reference to `@oddbird/popover-polyfill` in documentation

Notice: as [agreed with the team previously](https://hashicorp.atlassian.net/browse/HDS-3276?focusedCommentId=452192) "we will consider the removal of the polyfill a non-breaking change, since we are supposed to support the last 2 major versions, and by July there will be probably 4 version supporting the API" so I've used a `patch` in the changeset, similar to what we did in https://github.com/hashicorp/design-system/pull/1977

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3276

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
