### PR TITLE
Website - Update `Doc::Badge` component to support new variants

### DIFF
--- a/website/app/components/doc/badge/index.js
+++ b/website/app/components/doc/badge/index.js
@@ -13,6 +13,12 @@ export const TYPES = [
   'warning',
   'critical',
   'outlined',
+  'neutral-inverted',
+  'information-inverted',
+  'success-inverted',
+  'warning-inverted',
+  'critical-inverted',
+  'outlined-inverted',
 ];
 
 export default class DocBadgeComponent extends Component {
@@ -30,11 +36,18 @@ export default class DocBadgeComponent extends Component {
     return this.args.type ?? 'neutral';
   }
 
+  get size() {
+    return this.args.size ?? 'large';
+  }
+
   get classNames() {
     let classes = ['doc-badge'];
 
     // add a class based on the @type argument
     classes.push(`doc-badge--type-${this.type}`);
+
+    // add a class based on the @size argument
+    classes.push(`doc-badge--size-${this.size}`);
 
     return classes.join(' ');
   }

--- a/website/app/styles/doc-components/badge.scss
+++ b/website/app/styles/doc-components/badge.scss
@@ -12,14 +12,25 @@
   display: inline-flex;
   align-items: center;
   max-width: 100%;
-  height: 26px;
-  padding: 3px 12px 4px 12px;
-  font-weight: 600;
-  font-size: 14px;
   line-height: 1;
   border-radius: 100px;
 }
 
+// sizes
+
+.doc-badge--size-large { // default
+  height: 26px;
+  padding: 3px 12px 4px 12px;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.doc-badge--size-medium {
+  height: 24px;
+  padding: 3px 8px 4px 8px;
+  font-weight: 500;
+  font-size: 12px;
+}
 
 // types
 
@@ -28,9 +39,19 @@
   background-color: var(--doc-color-gray-200);
 }
 
+.doc-badge--type-neutral-inverted {
+  color: var(--doc-color-black);
+  background-color: var(--doc-color-gray-500);
+}
+
 .doc-badge--type-information {
   color: var(--doc-color-feedback-information-400);
   background-color: var(--doc-color-feedback-information-100);
+}
+
+.doc-badge--type-information-inverted {
+  color: var(--doc-color-feedback-information-100);
+  background-color: var(--doc-color-feedback-information-400);
 }
 
 .doc-badge--type-success {
@@ -38,9 +59,19 @@
   background-color: var(--doc-color-feedback-success-100);
 }
 
+.doc-badge--type-success-inverted {
+  color: var(--doc-color-feedback-success-100);
+  background-color: var(--doc-color-feedback-success-400);
+}
+
 .doc-badge--type-warning {
   color: var(--doc-color-feedback-warning-400);
   background-color: var(--doc-color-feedback-warning-100);
+}
+
+.doc-badge--type-warning-inverted {
+  color: var(--doc-color-feedback-warning-100);
+  background-color: var(--doc-color-feedback-warning-400);
 }
 
 .doc-badge--type-critical {
@@ -48,7 +79,8 @@
   background-color: var(--doc-color-feedback-critical-100);
 }
 
-.doc-badge--type-outlined {
-  color: var(--doc-color-gray-300);
-  border: 1px solid var(--doc-color-gray-400);
+.doc-badge--type-critical-inverted {
+  color: var(--doc-color-feedback-critical-100);
+  background-color: var(--doc-color-feedback-critical-400);
 }
+

--- a/website/docs/testing/components/badge.md
+++ b/website/docs/testing/components/badge.md
@@ -17,7 +17,46 @@ layout:
 <Doc::Badge @type="success">success</Doc::Badge>
 <Doc::Badge @type="warning">warning</Doc::Badge>
 <Doc::Badge @type="critical">critical</Doc::Badge>
-<Doc::Badge @type="outlined">outlined</Doc::Badge>
+
+Inverted versions:
+
+<Doc::Badge @type="neutral-inverted">neutral-inverted</Doc::Badge>
+<Doc::Badge @type="information-inverted">information-inverted</Doc::Badge>
+<Doc::Badge @type="success-inverted">success-inverted</Doc::Badge>
+<Doc::Badge @type="warning-inverted">warning-inverted</Doc::Badge>
+<Doc::Badge @type="critical-inverted">critical-inverted</Doc::Badge>
+
+-----
+
+**Badge "sizes"**
+
+Large (default):
+
+<Doc::Badge @type="neutral">neutral</Doc::Badge>
+<Doc::Badge @type="information">information</Doc::Badge>
+<Doc::Badge @type="success">success</Doc::Badge>
+<Doc::Badge @type="warning">warning</Doc::Badge>
+<Doc::Badge @type="critical">critical</Doc::Badge>
+<br />
+<Doc::Badge @type="neutral-inverted">neutral-inverted</Doc::Badge>
+<Doc::Badge @type="information-inverted">information-inverted</Doc::Badge>
+<Doc::Badge @type="success-inverted">success-inverted</Doc::Badge>
+<Doc::Badge @type="warning-inverted">warning-inverted</Doc::Badge>
+<Doc::Badge @type="critical-inverted">critical-inverted</Doc::Badge>
+
+Medium:
+
+<Doc::Badge @type="neutral" @size="medium">neutral</Doc::Badge>
+<Doc::Badge @type="information" @size="medium">information</Doc::Badge>
+<Doc::Badge @type="success" @size="medium">success</Doc::Badge>
+<Doc::Badge @type="warning" @size="medium">warning</Doc::Badge>
+<Doc::Badge @type="critical" @size="medium">critical</Doc::Badge>
+<br />
+<Doc::Badge @type="neutral-inverted" @size="medium">neutral-inverted</Doc::Badge>
+<Doc::Badge @type="information-inverted" @size="medium">information-inverted</Doc::Badge>
+<Doc::Badge @type="success-inverted" @size="medium">success-inverted</Doc::Badge>
+<Doc::Badge @type="warning-inverted" @size="medium">warning-inverted</Doc::Badge>
+<Doc::Badge @type="critical-inverted" @size="medium">critical-inverted</Doc::Badge>
 
 ------
 


### PR DESCRIPTION
### :pushpin: Summary

This PR updates the `Doc::Badge` component to support new variants, so they can be used to highlight deprecated elements

👉 👉 👉 **Preview**: https://hds-website-git-website-update-badges-hashicorp.vercel.app/testing/components/badge

### :camera_flash: Screenshots

<img width="728" alt="screenshot_3924" src="https://github.com/hashicorp/design-system/assets/686239/312df431-1a30-4a51-baa4-2c7ed67bd4d1">

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3525
Figma file: https://www.figma.com/design/Ky0qWjvHZR3je1lCBlzNB1/branch/S5KlbLljmucWHMTalrStWl/HDS-Website-%5BInitial-Build%5D?m=auto&node-id=826-64401&t=2iEPrbQ8Nv9e7xhD-1

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
