### PR TITLE
Website - Update frontmatter logic to handle deprecation/update status

### DIFF
--- a/website/app/components/doc/cards/card.hbs
+++ b/website/app/components/doc/cards/card.hbs
@@ -6,14 +6,14 @@
 <li class={{this.classNames}} ...attributes>
   {{#if @route}}
     <LinkTo class="doc-cards-card__link" @route={{@route}} @model={{@model}}>
-      {{#if @status.deprecated}}
-        <Doc::Badge class="doc-cards-card__badge" @type="warning-inverted" @size="medium">Deprecated</Doc::Badge>
-      {{else if @status.updated}}
-        <Doc::Badge class="doc-cards-card__badge" @type="neutral-inverted" @size="medium">Updated</Doc::Badge>
-      {{/if}}
       <img class="doc-cards-card__image" src={{@image}} alt="" role="presentation" />
       <div class="doc-cards-card__details">
         <p class="doc-cards-card__title">{{@title}}</p>
+        {{#if @status.deprecated}}
+          <Doc::Badge class="doc-cards-card__badge" @type="warning-inverted" @size="medium">Deprecated</Doc::Badge>
+        {{else if @status.updated}}
+          <Doc::Badge class="doc-cards-card__badge" @type="neutral-inverted" @size="medium">Updated</Doc::Badge>
+        {{/if}}
         <p class="doc-cards-card_description">{{@caption}}</p>
       </div>
     </LinkTo>
@@ -23,6 +23,11 @@
       <img class="doc-cards-card__image" src={{@image}} alt="" role="presentation" />
       <div class="doc-cards-card__details">
         <p class="doc-cards-card__title">{{@title}}</p>
+        {{#if @status.deprecated}}
+          <Doc::Badge class="doc-cards-card__badge" @type="warning-inverted" @size="medium">Deprecated</Doc::Badge>
+        {{else if @status.updated}}
+          <Doc::Badge class="doc-cards-card__badge" @type="neutral-inverted" @size="medium">Updated</Doc::Badge>
+        {{/if}}
         <p class="doc-cards-card_description">{{@caption}}</p>
       </div>
     </a>

--- a/website/app/components/doc/cards/card.hbs
+++ b/website/app/components/doc/cards/card.hbs
@@ -6,6 +6,12 @@
 <li class={{this.classNames}} ...attributes>
   {{#if @route}}
     <LinkTo class="doc-cards-card__link" @route={{@route}} @model={{@model}}>
+      {{#if @status.deprecated}}
+        <Doc::Badge class="doc-cards-card__badge" @type="warning-inverted" @size="medium">Deprecated</Doc::Badge>
+      {{/if}}
+      {{#if @status.updated}}
+        <Doc::Badge class="doc-cards-card__badge" @type="neutral-inverted" @size="medium">Updated</Doc::Badge>
+      {{/if}}
       <img class="doc-cards-card__image" src={{@image}} alt="" role="presentation" />
       <div class="doc-cards-card__details">
         <p class="doc-cards-card__title">{{@title}}</p>

--- a/website/app/components/doc/cards/card.hbs
+++ b/website/app/components/doc/cards/card.hbs
@@ -8,8 +8,7 @@
     <LinkTo class="doc-cards-card__link" @route={{@route}} @model={{@model}}>
       {{#if @status.deprecated}}
         <Doc::Badge class="doc-cards-card__badge" @type="warning-inverted" @size="medium">Deprecated</Doc::Badge>
-      {{/if}}
-      {{#if @status.updated}}
+      {{else if @status.updated}}
         <Doc::Badge class="doc-cards-card__badge" @type="neutral-inverted" @size="medium">Updated</Doc::Badge>
       {{/if}}
       <img class="doc-cards-card__image" src={{@image}} alt="" role="presentation" />

--- a/website/app/components/doc/cards/deck.hbs
+++ b/website/app/components/doc/cards/deck.hbs
@@ -10,6 +10,7 @@
         @image={{card.image}}
         @title={{card.title}}
         @caption={{card.caption}}
+        @status={{card.status}}
         @route={{card.route}}
         @model={{card.model}}
         @href={{card.href}}

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -12,6 +12,9 @@
     {{#if @required}}
       <code class="doc-component-api__property-required">required</code>
     {{/if}}
+    {{#if @deprecated}}
+      <Doc::Badge class="doc-component-api__property-deprecated" @type="warning" @size="medium">Deprecated</Doc::Badge>
+    {{/if}}
   </div>
   {{#if (or @values @valueNote)}}
     {{#if @values}}

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -10,10 +10,10 @@
       <code class="doc-component-api__property-type">{{@type}}</code>
     {{/if}}
     {{#if @required}}
-      <code class="doc-component-api__property-required">required</code>
+      <Doc::Badge @type="critical-inverted">Required</Doc::Badge>
     {{/if}}
     {{#if @deprecated}}
-      <Doc::Badge class="doc-component-api__property-deprecated" @type="warning" @size="medium">Deprecated</Doc::Badge>
+      <Doc::Badge @type="warning" @size="medium">Deprecated</Doc::Badge>
     {{/if}}
   </div>
   {{#if (or @values @valueNote)}}

--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -43,7 +43,7 @@
   {{/if}}
   {{#if (has-block)}}
     <div class="doc-component-api__property-description">
-      {{yield}}
+      {{yield (hash Banner=(component "doc/banner" type="warning"))}}
     </div>
   {{/if}}
 </div>

--- a/website/app/components/doc/page/cover.hbs
+++ b/website/app/components/doc/page/cover.hbs
@@ -6,6 +6,9 @@
 <div class="doc-page-cover" ...attributes>
   <div class="doc-page-cover__title-extra-wrapper">
     <h1 class="doc-page-cover__title">{{@title}}</h1>
+    {{#if @status}}
+      <Doc::Badge @type={{@status.type}}>{{@status.label}}</Doc::Badge>
+    {{/if}}
     <div class="doc-page-cover__extra">
       {{#if this.links}}
         {{#each-in this.links as |service url|}}

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -22,8 +22,7 @@
             {{item.pageAttributes.title}}
             {{#if item.pageAttributes.status.deprecated}}
               <Doc::Badge @type="warning-inverted" @size="medium">Deprecated</Doc::Badge>
-            {{/if}}
-            {{#if item.pageAttributes.status.updated}}
+            {{else if item.pageAttributes.status.updated}}
               <Doc::Badge @type="neutral-inverted" @size="medium">Updated</Doc::Badge>
             {{/if}}
           {{/if}}

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -20,6 +20,12 @@
             {{item.pageAttributes.navigation.label}}
           {{else}}
             {{item.pageAttributes.title}}
+            {{#if item.pageAttributes.status.deprecated}}
+              <Doc::Badge @type="warning-inverted" @size="medium">Deprecated</Doc::Badge>
+            {{/if}}
+            {{#if item.pageAttributes.status.updated}}
+              <Doc::Badge @type="neutral-inverted" @size="medium">Updated</Doc::Badge>
+            {{/if}}
           {{/if}}
         </LinkTo>
       {{else}}

--- a/website/app/controllers/components.js
+++ b/website/app/controllers/components.js
@@ -25,6 +25,7 @@ export default class ComponentsController extends Controller {
               page.pageAttributes?.navigation?.label ||
               page.pageAttributes.title,
             caption: page.pageAttributes.caption,
+            status: page.pageAttributes.status,
             route: 'show',
             model: page.pageURL,
           };

--- a/website/app/controllers/foundations.js
+++ b/website/app/controllers/foundations.js
@@ -25,6 +25,7 @@ export default class FoundationsController extends Controller {
               page.pageAttributes?.navigation?.label ||
               page.pageAttributes.title,
             caption: page.pageAttributes.caption,
+            status: page.pageAttributes.status,
             route: 'show',
             model: page.pageURL,
           };

--- a/website/app/controllers/patterns.js
+++ b/website/app/controllers/patterns.js
@@ -25,6 +25,7 @@ export default class PatternsController extends Controller {
               page.pageAttributes?.navigation?.label ||
               page.pageAttributes.title,
             caption: page.pageAttributes.caption,
+            status: page.pageAttributes.status,
             route: 'show',
             model: page.pageURL,
           };

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -85,6 +85,29 @@ export default class ShowController extends Controller {
     return this.model.frontmatter?.description ?? false;
   }
 
+  get status() {
+    if (this.model.frontmatter?.status) {
+      let type;
+      let version;
+      let label;
+      if (this.model.frontmatter?.status?.deprecated) {
+        type = 'warning';
+        label = 'Deprecated';
+        version = this.model.frontmatter?.status?.deprecated;
+      } else if (this.model.frontmatter?.status?.updated) {
+        type = 'neutral';
+        label = 'Updated';
+        version = this.model.frontmatter?.status?.updated;
+      }
+      if (version.match(/^\d+\.\d+\.\d+$/)) {
+        label += ` in v${version}`;
+      }
+      return { type, label };
+    } else {
+      return false;
+    }
+  }
+
   get extra() {
     let { links } = this.model.frontmatter;
     return { links };

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -104,7 +104,7 @@ export default class ShowController extends Controller {
       }
       return { type, label };
     } else {
-      return false;
+      return null;
     }
   }
 

--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -90,6 +90,7 @@ export default class ShowRoute extends Route {
           'layout',
           'previewImage', // this is needed by the `head-data` to generate the `og:image` in the page <head>
           'navigation',
+          'status',
         ];
         frontmatterAttributes.forEach((attribute) => {
           if (attribute in res.data.attributes) {

--- a/website/app/styles/doc-components/cards/card.scss
+++ b/website/app/styles/doc-components/cards/card.scss
@@ -57,11 +57,19 @@
 }
 
 .doc-cards-card__link {
+  position: relative;
   display: flex;
   width: 100%;
   height: 100%;
   text-decoration: none;
   border-radius: inherit; // needed to propagate down
+  isolation: isolate;
+}
+
+.doc-cards-card__badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
 }
 
 .doc-cards-card__image {

--- a/website/app/styles/doc-components/component-api.scss
+++ b/website/app/styles/doc-components/component-api.scss
@@ -59,12 +59,6 @@
   color: var(--doc-color-gray-100);
 }
 
-.doc-component-api__property-required {
-  @include doc-font-style-code ();
-  display: inline-block;
-  color: #ba2226; // it's an HDS color, so we use its corresponding hex value
-}
-
 // second row - values
 
 .doc-component-api__property-values {

--- a/website/app/styles/doc-components/table-of-contents.scss
+++ b/website/app/styles/doc-components/table-of-contents.scss
@@ -65,7 +65,10 @@ $doc-toc-item-inset: 8px;
 
 .doc-table-of-contents__link {
   @include doc-font-style-navigation();
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
   padding-top: $doc-toc-item-inset;
   padding-right: $doc-toc-item-inset;
   padding-bottom: $doc-toc-item-inset;

--- a/website/app/templates/show.hbs
+++ b/website/app/templates/show.hbs
@@ -6,6 +6,7 @@
       @title={{this.title}}
       @description={{this.description}}
       @tabs={{this.tabs}}
+      @status={{this.status}}
       @extra={{this.extra}}
     />
   {{/if}}

--- a/website/docs/overrides/power-select/index.md
+++ b/website/docs/overrides/power-select/index.md
@@ -5,6 +5,8 @@ caption: Style overrides for the ember-power-select addon.
 previewImage: assets/illustrations/overrides/power-select.jpg
 navigation:
   keywords: ['select', 'dropdown', 'menu']
+status:
+  deprecated: 4.3.0
 ---
 
 <section data-tab="Code">
@@ -13,4 +15,8 @@ navigation:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.3.0.md"
 </section>

--- a/website/docs/overrides/power-select/partials/version-history/4.3.0.md
+++ b/website/docs/overrides/power-select/partials/version-history/4.3.0.md
@@ -1,0 +1,9 @@
+## 4.3.0
+
+### Deprecated
+
+In this version we have released the [SuperSelect](/components/form/super-select) component, as replacement for the `PowerSelect` Ember addon component. For this reason we now consider the PowerSelect style overrides as deprecated and will be removed in a future major release.
+
+#### How to migrate
+
+We now recommend migrating the existing PowerSelect instances to the SuperSelect component, which being built on top of PowerSelect, provides the same [Component API](/components/form/super-select?tab=code#component-api) but with much better accessibility.

--- a/website/lib/markdown/markdown-to-jsonapi.js
+++ b/website/lib/markdown/markdown-to-jsonapi.js
@@ -26,6 +26,7 @@ class MarkdownToJsonApi extends PersistentFilter {
         'layout',
         'previewImage',
         'navigation',
+        'status',
       ],
     };
 

--- a/website/lib/markdown/table-of-contents.js
+++ b/website/lib/markdown/table-of-contents.js
@@ -102,6 +102,7 @@ class TableOfContents extends Plugin {
           'caption',
           'navigation',
           'previewImage',
+          'status',
         ]);
       } else {
         console.log('File NOT found!', fullFilePath);


### PR DESCRIPTION
### :pushpin: Summary

This PR is the implementation of the work done by @majedelass in https://hashicorp.atlassian.net/browse/HDS-3296 to add deprecation (and update) information across the website (sidenav, cards, pages, component API)

### :hammer_and_wrench: Detailed description

In this PR I have:
- added processing of `status` entry in frontmatter metadata
- added the "status" badge to the sidenav (TOC)
- added the "status" badge to the lists of cards
- added the "status" badge to “show” page (cover) - _this is the main page for components, foundations, patterns, etc_
- added the "status" badge (for deprecation only) to the Component API properties component
- added “deprecated” status (and version history) to `PowerSelect` overrides
- added fake “updated” status (and version history) to `Accordion` component (for demo purpose, this will be removed begore merging)

### 👀 Previews:

**Components cards:** 
- see badges on top of cards ~~`Accordion` and~~ `PowerSelect`: 👉 [ **link**](https://hds-website-git-website-update-frontmatter-add-e2df27-hashicorp.vercel.app/components)

**PowerSelect**
- see deprecation badge in the page cover: 👉 [**link**](https://hds-website-git-website-update-frontmatter-add-e2df27-hashicorp.vercel.app/overrides/power-select)
- see version history tab: 👉 [**link**](https://hds-website-git-website-update-frontmatter-add-e2df27-hashicorp.vercel.app/overrides/power-select?tab=version%20history)

**~~Accordion~~** (fake, demo)
- ~~see update badge in the page cover: 👉 [**link**](https://hds-website-git-website-update-frontmatter-add-e2df27-hashicorp.vercel.app/components/accordion)~~
- ~~see deprecation badge in Component API: 👉 [**link**](https://hds-website-git-website-update-frontmatter-add-e2df27-hashicorp.vercel.app/components/accordion?tab=code#aaccordionitem)~~

### :camera_flash: Screenshots

Badge in sidenav and cards:
![image](https://github.com/hashicorp/design-system/assets/686239/bfa43837-2c41-489c-a705-7ea7c8810175)

Updated badge in page cover
![image](https://github.com/hashicorp/design-system/assets/686239/0fa50456-f204-4d05-bb06-524be813777e)

Deprecated badge in page cover
![image](https://github.com/hashicorp/design-system/assets/686239/f28d2dcc-4e97-49f7-9371-cd2db96c1046)

Deprecated badge in Component API
![image](https://github.com/hashicorp/design-system/assets/686239/4a30d3d8-ae8e-4fa0-b60a-8f19597d410c)

Version history example
![image](https://github.com/hashicorp/design-system/assets/686239/14b3dd11-f592-45b2-8b2c-2f101c2d1358)

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3526
Figma file: https://www.figma.com/design/3VZiWIbcxIahVfVohQzhPk/Majed's-Playground?node-id=215-7302&t=kSCzl3Fug6hbb47E-1

***

### 👀 Component checklist

- [ ]  🚨 **IMPORTANT** 🚨 - Remove fake status and version history from `Accordion` component page

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
