### PR TITLE
Replaced `@required="true"` with `@required={{true}}` in `<Doc::ComponentApi>` properties declarations

### DIFF
--- a/website/docs/components/alert/partials/code/component-api.md
+++ b/website/docs/components/alert/partials/code/component-api.md
@@ -1,7 +1,7 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @required="true" @type="enum" @values={{array "page" "inline" "compact"}}>
+  <C.Property @name="type" @required={{true}} @type="enum" @values={{array "page" "inline" "compact"}}>
     Sets the type of alert.
   </C.Property>
   <C.Property @name="color" @type="enum" @values={{array "neutral" "highlight" "success" "warning" "critical"}} @default="neutral">

--- a/website/docs/components/button/partials/code/component-api.md
+++ b/website/docs/components/button/partials/code/component-api.md
@@ -3,7 +3,7 @@
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
   <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" "tertiary" "critical" }} @default="primary"/>
-  <C.Property @name="text" @required="true" @type="string">
+  <C.Property @name="text" @required={{true}} @type="string">
     Text of the button or value of `aria-label` if `isIconOnly` is set to `true`. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="icon" @type="string">

--- a/website/docs/components/copy/button/partials/code/component-api.md
+++ b/website/docs/components/copy/button/partials/code/component-api.md
@@ -10,7 +10,7 @@ This component uses the [Clipboard API](https://developer.mozilla.org/en-US/docs
   <C.Property @name="isFullWidth" @type="boolean" @default="false">
     Indicates that a button should take up the full width of the parent container.
   </C.Property>
-  <C.Property @name="text" @required="true" @type="string">
+  <C.Property @name="text" @required={{true}} @type="string">
     The text of the button or value of `aria-label` if `isIconOnly` is set to `true`. If no text value is defined, an error will be thrown.
   </C.Property>
   <C.Property @name="textToCopy" @type="string | number">

--- a/website/docs/components/copy/snippet/partials/code/component-api.md
+++ b/website/docs/components/copy/snippet/partials/code/component-api.md
@@ -7,7 +7,7 @@ This component uses the [Clipboard API](https://developer.mozilla.org/en-US/docs
   <C.Property @name="isFullWidth" @type="boolean" @default="false">
     Indicates that the component should take up the full width of the parent container.
   </C.Property>
-  <C.Property @name="textToCopy" @type="string | number" @required="true">
+  <C.Property @name="textToCopy" @type="string | number" @required={{true}}>
     The value to be copied.
   </C.Property>
   <C.Property @name="isTruncated" @type="boolean" @default="false">

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -57,7 +57,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
 ### Toggle::Button
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="text" @required="true" @type="string">
+  <C.Property @name="text" @required={{true}} @type="string">
     Text of the ToggleButton. If no text value is defined, an error will be thrown.
   </C.Property>
   <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
@@ -82,7 +82,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
 ### Toggle::Icon
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="text" @required="true" @type="string">
+  <C.Property @name="text" @required={{true}} @type="string">
     Value of `aria-label` for the ToggleIcon. If no text value is defined, an error will be thrown.
   </C.Property>
   <C.Property @name="icon" @type="string">
@@ -100,7 +100,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
 ### ListItem::Interactive
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="text" @required="true" @type="string">
+  <C.Property @name="text" @required={{true}} @type="string">
     Text to be used in the item. If no text value is defined, an error will be thrown.
   </C.Property>
   <C.Property @name="color" @type="enum" @values={{array "action" "critical" }} @default="action">
@@ -137,7 +137,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
 ### ListItem::Title
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="text" @required="true" @type="string">
+  <C.Property @name="text" @required={{true}} @type="string">
     Text to be used for the title. If no text value is defined, an error will be thrown.
   </C.Property>
   <C.Property @name="...attributes">
@@ -148,7 +148,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
 ### ListItem::Description
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="text" @required="true" @type="string">
+  <C.Property @name="text" @required={{true}} @type="string">
     Text to be used for the description. If no text value is defined, an error will be thrown.
   </C.Property>
   <C.Property @name="...attributes">
@@ -170,7 +170,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
   <C.Property @name="copyItemTitle" @type="string">
     Displays a title above the text to be copied.
   </C.Property>
-  <C.Property @name="text" @required="true" @type="string">
+  <C.Property @name="text" @required={{true}} @type="string">
     Text to be copied. If no text value is defined, an error will be thrown.
     <br><br>
     _Notice: this argument is forwarded (as `textToCopy`) to the [`Copy::Snippet` component](/components/copy/snippet?tab=code#component-api)._

--- a/website/docs/components/link/standalone/partials/code/component-api.md
+++ b/website/docs/components/link/standalone/partials/code/component-api.md
@@ -3,10 +3,10 @@
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
   <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
-  <C.Property @name="text" @required="true" @type="string">
+  <C.Property @name="text" @required={{true}} @type="string">
     The text of the link. If no text value is defined an error will be thrown.
   </C.Property>
-  <C.Property @name="icon" @required="true" @type="string">
+  <C.Property @name="icon" @required={{true}} @type="string">
     Use this parameter to show an icon. Any [icon](/icons/library) name is acceptable. `icon` is required to ensure the component conforms to accessibility best practices.
   </C.Property>
   <C.Property @name="iconPosition" @type="enum" @values={{array "leading" "trailing" }} @default="leading">

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -25,7 +25,7 @@ These Pagination sub-elements may be used directly if you need to cover a very s
 <C.Property @name="ariaLabel" @type="string" @default="Pagination">
     Accepts a localized string.
 </C.Property>
-<C.Property @name="totalItems" @required="true" @type="number">
+<C.Property @name="totalItems" @required={{true}} @type="number">
 Pass the total number of items to be paginated. If no value is defined an error will be thrown.
 </C.Property>
 <C.Property @name="showLabels" @type="boolean" @default="false">
@@ -114,13 +114,13 @@ This component supports use of [`...attributes`](https://guides.emberjs.com/rele
 #### Pagination::Info
 
 <Doc::ComponentApi as |C|>
-<C.Property @name="itemsRangeStart" @required="true" @type="string|number">
+<C.Property @name="itemsRangeStart" @required={{true}} @type="string|number">
 The "start" value of the range in the informational text.
 </C.Property>
-<C.Property @name="itemsRangeEnd" @required="true" @type="string|number">
+<C.Property @name="itemsRangeEnd" @required={{true}} @type="string|number">
 The "end" value of the range in the informational text.
 </C.Property>
-<C.Property @name="totalItems" @required="true" @type="string|number">
+<C.Property @name="totalItems" @required={{true}} @type="string|number">
 The "out of" total items in the informational text. Not required if `showTotalItems` is set to `false`.
 </C.Property>
 <C.Property @name="showTotalItems" @type="boolean" @default="true">
@@ -131,7 +131,7 @@ Controls the visibility of the total items in the informational text.
 #### Pagination::Nav::Arrow
 
 <Doc::ComponentApi as |C|>
-<C.Property @name="direction" @required="true" @type="enum" @values={{array "prev" "next"}}>
+<C.Property @name="direction" @required={{true}} @type="enum" @values={{array "prev" "next"}}>
 Sets the "direction" of the icon and label in the control.
 </C.Property>
 <C.Property @name="route/models/model/query/replace">
@@ -153,7 +153,7 @@ This component supports use of [`...attributes`](https://guides.emberjs.com/rele
 #### Pagination::Nav::Number
 
 <Doc::ComponentApi as |C|>
-<C.Property @name="page" @required="true" @type="number">
+<C.Property @name="page" @required={{true}} @type="number">
 The value that should go in the control as page number.
 </C.Property>
 <C.Property @name="isSelected" @type="boolean" @default="false">
@@ -181,7 +181,7 @@ This component supports use of [`...attributes`](https://guides.emberjs.com/rele
 #### Pagination::SizeSelector
 
 <Doc::ComponentApi as |C|>
-<C.Property @name="pageSizes" @required="true" @type="array of integers">
+<C.Property @name="pageSizes" @required={{true}} @type="array of integers">
 Set the page sizes users can select from. If no value is defined an error will be thrown. Example: `@pageSizes=\{{array 5 20 30}}`
 </C.Property>
 <C.Property @name="selectedSize" @type="integer">

--- a/website/docs/components/reveal/partials/code/component-api.md
+++ b/website/docs/components/reveal/partials/code/component-api.md
@@ -1,7 +1,7 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="text" @required="true" @type="string">
+  <C.Property @name="text" @required={{true}} @type="string">
     Plain text string that will appear on the toggle button which controls the hiding and showing of the content. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="textWhenOpen" @type="string">

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -119,7 +119,7 @@ The `SideNav::Header::HomeLink` component uses the generic `Hds::Interactive` co
   <C.Property @name="isRouteExternal" @type="boolean" @default="false">
     This controls if the “LinkTo” is external to the Ember engine, in which case it will use a `<LinkToExternal>` for the `@route`.
   </C.Property>
-  <C.Property @name="ariaLabel" @type="string" @required="true">
+  <C.Property @name="ariaLabel" @type="string" @required={{true}}>
     The value of the aria-label. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="...attributes">
@@ -132,7 +132,7 @@ The `SideNav::Header::HomeLink` component uses the generic `Hds::Interactive` co
 The `SideNav::Header::IconButton` component uses the generic `Hds::Interactive` component. For more details about this utility component please refer to [its documentation page](/utilities/interactive).
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="icon" @type="string" @required="true">
+  <C.Property @name="icon" @type="string" @required={{true}}>
     Used to show an icon. Any [icon](/icons/library) name is accepted.
   </C.Property>
   <C.Property @name="href">
@@ -147,7 +147,7 @@ The `SideNav::Header::IconButton` component uses the generic `Hds::Interactive` 
   <C.Property @name="isRouteExternal" @type="boolean" @default="false">
     This controls if the “LinkTo” is external to the Ember engine, in which case it will use a `<LinkToExternal>` for the `@route`.
   </C.Property>
-  <C.Property @name="ariaLabel" @type="string" @required="true">
+  <C.Property @name="ariaLabel" @type="string" @required={{true}}>
     The value of the `aria-label`. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -38,7 +38,7 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="columns" @type="array">
     Array `hash` that defines each column with key-value properties that describe each column. Options:
     <Doc::ComponentApi as |C|>
-      <C.Property @name="label" @type="string" @required="true">
+      <C.Property @name="label" @type="string" @required={{true}}>
       The column’s label.
       </C.Property>
       <C.Property @name="key" @type="string">

--- a/website/docs/icons/usage-guidelines/partials/code/component-api.md
+++ b/website/docs/icons/usage-guidelines/partials/code/component-api.md
@@ -1,7 +1,7 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="name" @type="string" @required="true">
+  <C.Property @name="name" @type="string" @required={{true}}>
     The name of the icon you wish to use. If the value does not match an existing icon name, an error will be thrown. Search for existing icon names in [the Icon library](icons/library).
   </C.Property>
   <C.Property @name="color" @type="string" @default="currentColor">


### PR DESCRIPTION
### :pushpin: Summary

Small PR to fix the way in which we declare the `@required` argument in the `<Doc::ComponentApi>` properties declarations (for context, if we declared `@required="false"` that would be interpreted as `true`)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
