### PR TITLE
`Hds::Icon` Codemod

### DIFF
--- a/.changeset/tricky-eagles-protect.md
+++ b/.changeset/tricky-eagles-protect.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-codemods": minor
+---
+
+Adds v4/icon codemod to convert FlightIcon components to Hds::Icon

--- a/.changeset/tricky-eagles-protect.md
+++ b/.changeset/tricky-eagles-protect.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-codemods": minor
 ---
 
-Adds v4/icon codemod to convert FlightIcon components to Hds::Icon
+Adds v4/icon codemod to convert `FlightIcon` components to `Hds::Icon`

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -31,7 +31,7 @@ node ./packages/codemods/bin/cli.js v3/dropdown path/to/some/glob/**/*.hbs
 <!--TRANSFORMS_START-->
 * [v4/contextual-components](transforms/v4/contextual-components/README.md)
 * [v4/table](transforms/v4/table/README.md)
-* [v4/contextual-components](transforms/v4/icon/README.md)
+* [v4/icon](transforms/v4/icon/README.md)
 <!--TRANSFORMS_END-->
 
 ## Contributing

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -31,6 +31,7 @@ node ./packages/codemods/bin/cli.js v3/dropdown path/to/some/glob/**/*.hbs
 <!--TRANSFORMS_START-->
 * [v4/contextual-components](transforms/v4/contextual-components/README.md)
 * [v4/table](transforms/v4/table/README.md)
+* [v4/contextual-components](transforms/v4/icon/README.md)
 <!--TRANSFORMS_END-->
 
 ## Contributing

--- a/packages/codemods/transforms/v4/icon/README.md
+++ b/packages/codemods/transforms/v4/icon/README.md
@@ -1,0 +1,31 @@
+# v4/icon
+
+## Usage
+
+To run this codemod in your project using `npx`, you would run the following:
+
+```bash
+npx @hashicorp/design-system-codemods v4/icon path/to/some/glob/**/*.hbs
+```
+
+## Local usage
+
+To run this codemod in this repository (even before publishing it), you would run the following from the root directory of this repository:
+
+```bash
+node ./packages/codemods/bin/cli.js v4/icon path/to/some/glob/**/*.hbs
+```
+
+## Input
+
+```hbs
+<FlightIcon @name="test" @isInlineBlock={{false}} />
+<FlightIcon @name="test" @isInlineBlock={{true}} />
+```
+
+## Output
+
+```hbs
+<Hds::Icon @name="test" />
+<Hds::Icon @name="test" @isInline={{true}} />
+```

--- a/packages/codemods/transforms/v4/icon/README.md
+++ b/packages/codemods/transforms/v4/icon/README.md
@@ -31,3 +31,21 @@ node ./packages/codemods/bin/cli.js v4/icon path/to/some/glob/**/*.hbs
 <Hds::Icon @name="test" />
 <Hds::Icon @name="test" @isInline={{true}} />
 ```
+
+## Optional arguments
+
+### `--preserve-layout`
+
+Adding this argument when running the codemod will force any `FlightIcon` component without the `@isInlineBlock` argument set to have the `@isInline` argument set to `true` when it is converted to the `Hds::Icon` component. This can be used to preserve the old default `display: inline-block` styling of the icon. It is strongly suggested that this option only be used as a final resort as doing so makes it difficult to determine which icons *actually* need to display inline.
+
+### Input
+
+```hbs
+<FlightIcon @name="test" />
+```
+
+### Output
+
+```hbs
+<Hds::Icon @name="test" @isInline={{true}} />
+```

--- a/packages/codemods/transforms/v4/icon/README.md
+++ b/packages/codemods/transforms/v4/icon/README.md
@@ -19,6 +19,7 @@ node ./packages/codemods/bin/cli.js v4/icon path/to/some/glob/**/*.hbs
 ## Input
 
 ```hbs
+<FlightIcon @name="test" />
 <FlightIcon @name="test" @isInlineBlock={{false}} />
 <FlightIcon @name="test" @isInlineBlock={{true}} />
 ```
@@ -26,6 +27,7 @@ node ./packages/codemods/bin/cli.js v4/icon path/to/some/glob/**/*.hbs
 ## Output
 
 ```hbs
+<Hds::Icon @name="test" />
 <Hds::Icon @name="test" />
 <Hds::Icon @name="test" @isInline={{true}} />
 ```

--- a/packages/codemods/transforms/v4/icon/__testfixtures__/basic.input.hbs
+++ b/packages/codemods/transforms/v4/icon/__testfixtures__/basic.input.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<FlightIcon @name='test' />

--- a/packages/codemods/transforms/v4/icon/__testfixtures__/basic.output.hbs
+++ b/packages/codemods/transforms/v4/icon/__testfixtures__/basic.output.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Icon @name='test' />

--- a/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-dynamic.input.hbs
+++ b/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-dynamic.input.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<FlightIcon @name="test" @isInlineBlock={{this.isInline}} />

--- a/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-dynamic.output.hbs
+++ b/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-dynamic.output.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Icon @name="test" @isInline={{this.isInline}} />

--- a/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-false.input.hbs
+++ b/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-false.input.hbs
@@ -3,4 +3,4 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<FlightIcon @name='test' @isInlineBlock={{true}} />
+<FlightIcon @name='test' @isInlineBlock={{false}} />

--- a/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-false.input.hbs
+++ b/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-false.input.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<FlightIcon @name='test' @isInlineBlock={{true}} />

--- a/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-false.output.hbs
+++ b/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-false.output.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Icon @name='test' />

--- a/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-true.input.hbs
+++ b/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-true.input.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<FlightIcon @name='test' @isInlineBlock={{true}} />

--- a/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-true.output.hbs
+++ b/packages/codemods/transforms/v4/icon/__testfixtures__/is-inline-block-true.output.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Hds::Icon @name='test' @isInline={{true}} />

--- a/packages/codemods/transforms/v4/icon/index.js
+++ b/packages/codemods/transforms/v4/icon/index.js
@@ -24,13 +24,15 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
 
           // @isInlineBlock attr has been set on the element
           if (attr) {
-            if (attr.value !== false) {
+            const isHandlebarsAttr = attr.value.type === 'MustacheStatement';
+
+            if (isHandlebarsAttr && attr.value.path.original !== false) {
               // rename attribute as @isInline, keep value
               const updatedAttr = b.attr('@isInline', attr.value);
               outputAttrs.push(updatedAttr);
             }
 
-            // if the value is false, we don't need to add the attribute
+            // if the value is false or not handlebars, we don't need to add the attribute
           } else if (preserveLayout) {
             // FlightIcon has a default display of inline-block
             // Hds::Icon has a default display of block

--- a/packages/codemods/transforms/v4/icon/index.js
+++ b/packages/codemods/transforms/v4/icon/index.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+module.exports = function ({ source /*, path*/ }, { parse, visit }) {
+  const ast = parse(source);
+
+  const updateIsInlineBlockAttribute = (attributes) => {
+    const indexOfIsInlineBlockAttr = attributes.findIndex((a) => a.name === '@isInlineBlock');
+    const hasIsInlineBlockAttr = indexOfIsInlineBlockAttr !== -1;
+
+    // @isInlineBlock attr has been set on the element
+    if (hasIsInlineBlockAttr) {
+      const isInlineBlockAttr = attributes[indexOfIsInlineBlockAttr];
+      const isInlineBlockAttrIsTrue = isInlineBlockAttr.value === 'true';
+
+      // @isInlineBlock is set to "true"
+      if (isInlineBlockAttrIsTrue) {
+        // the default for isInline is false, so we need to set it to true
+        isInlineBlockAttr.name = '@isInline';
+        isInlineBlockAttr.value = 'true';
+      }
+      // @isInlineBlock is set to "false"
+      else {
+        // this is the default, so we can remove the attribute
+        attributes.splice(indexOfIsInlineBlockAttr, 1);
+      }
+    }
+
+    return attributes;
+  };
+
+  return visit(ast, (env) => {
+    let { builders: build } = env.syntax;
+
+    return {
+      ElementNode(node) {
+        if (node.tag === 'FlightIcon') {
+          return [
+            build.element(
+              { name: 'Hds::Icon', selfClosing: true },
+              {
+                attrs: updateIsInlineBlockAttribute(node.attributes),
+                children: [],
+                modifiers: node.modifiers,
+                blockParams: node.blockParams,
+              }
+            ),
+          ];
+        }
+      },
+    };
+  });
+};
+
+module.exports.type = 'hbs';

--- a/packages/codemods/transforms/v4/icon/index.js
+++ b/packages/codemods/transforms/v4/icon/index.js
@@ -8,10 +8,9 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
 
   const updateIsInlineBlockAttribute = (attributes) => {
     const indexOfIsInlineBlockAttr = attributes.findIndex((a) => a.name === '@isInlineBlock');
-    const hasIsInlineBlockAttr = indexOfIsInlineBlockAttr !== -1;
 
     // @isInlineBlock attr has been set on the element
-    if (hasIsInlineBlockAttr) {
+    if (indexOfIsInlineBlockAttr !== -1) {
       const isInlineBlockAttr = attributes[indexOfIsInlineBlockAttr];
       const isInlineBlockAttrIsTrue = isInlineBlockAttr.value === 'true';
 

--- a/packages/codemods/transforms/v4/icon/index.js
+++ b/packages/codemods/transforms/v4/icon/index.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-const { preserveLayout } = JSON.parse(process.env.CODEMOD_CLI_ARGS);
-
 module.exports = function ({ source /*, path*/ }, { parse, visit }) {
   const ast = parse(source);
+
+  const { preserveLayout } = JSON.parse(process.env.CODEMOD_CLI_ARGS);
 
   return visit(ast, (env) => {
     let { builders: b } = env.syntax;
@@ -19,15 +19,16 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
 
           // look up for `@isInlineBlock`
           const attr = node.attributes.find((a) => a.name === '@isInlineBlock');
-          const { value } = attr;
 
           // @isInlineBlock attr has been set on the element
-          if (attr && value) {
-            if (value === true) {
+          if (attr && attr.value) {
+            if (attr.value === true) {
               // rename attribute as @isInline, keep value
-              const updatedAttr = b.attr('@isInline', value);
+              const updatedAttr = b.attr('@isInline', attr.value);
               outputAttrs.push(updatedAttr);
             }
+
+            // if the value is false, we don't need to add the attribute
           } else if (preserveLayout) {
             // FlightIcon has a default display of inline-block
             // Hds::Icon has a default display of block
@@ -38,7 +39,7 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
 
           return [
             b.element(
-              { name: node.tag, selfClosing: true },
+              { name: 'Hds::Icon', selfClosing: true },
               {
                 attrs: outputAttrs,
                 children: node.children,

--- a/packages/codemods/transforms/v4/icon/index.js
+++ b/packages/codemods/transforms/v4/icon/index.js
@@ -12,17 +12,24 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
     // @isInlineBlock attr has been set on the element
     if (indexOfIsInlineBlockAttr !== -1) {
       const isInlineBlockAttr = attributes[indexOfIsInlineBlockAttr];
-      const isInlineBlockAttrIsTrue = isInlineBlockAttr.value === 'true';
 
-      // @isInlineBlock is set to "true"
-      if (isInlineBlockAttrIsTrue) {
-        // the default for isInline is false, so we need to set it to true
-        isInlineBlockAttr.name = '@isInline';
-        isInlineBlockAttr.value = 'true';
+      // value is a mustache statement, such as {{this.isInlineBlock}}
+      if (isInlineBlockAttr.value.type === 'MustacheStatement') {
+        const isInlineBlockAttrValue = isInlineBlockAttr.value.path.original;
+
+        // @isInlineBlock is set to {{false}}
+        if (isInlineBlockAttrValue === false) {
+          // {{false}} is the default value for @isInline, so we can remove the attribute
+          attributes.splice(indexOfIsInlineBlockAttr, 1);
+        }
+        // @isInlineBlock is {{true}}, or any other mustache statement
+        else {
+          // rename attribute as @isInline, keep value
+          isInlineBlockAttr.name = '@isInline';
+        }
       }
-      // @isInlineBlock is set to "false"
+      // @isInlineBlock is a non-mustache value
       else {
-        // this is the default, so we can remove the attribute
         attributes.splice(indexOfIsInlineBlockAttr, 1);
       }
     }

--- a/packages/codemods/transforms/v4/icon/index.js
+++ b/packages/codemods/transforms/v4/icon/index.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+const CODEMOD_ANALYSIS = process.env.CODEMOD_ANALYSIS;
+
 module.exports = function ({ source /*, path*/ }, { parse, visit }) {
   const ast = parse(source);
 
@@ -21,8 +23,8 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
           const attr = node.attributes.find((a) => a.name === '@isInlineBlock');
 
           // @isInlineBlock attr has been set on the element
-          if (attr && attr.value) {
-            if (attr.value === true) {
+          if (attr) {
+            if (attr.value !== false) {
               // rename attribute as @isInline, keep value
               const updatedAttr = b.attr('@isInline', attr.value);
               outputAttrs.push(updatedAttr);
@@ -33,21 +35,23 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
             // FlightIcon has a default display of inline-block
             // Hds::Icon has a default display of block
             // we can pass this flag in order to keep the display the same during the conversion
-            const newAttr = b.attr('@isInline', true);
+            const newAttr = b.attr('@isInline', b.mustache(b.boolean(true)));
             outputAttrs.push(newAttr);
           }
 
-          return [
-            b.element(
-              { name: 'Hds::Icon', selfClosing: true },
-              {
-                attrs: outputAttrs,
-                children: node.children,
-                modifiers: node.modifiers,
-                blockParams: node.blockParams,
-              }
-            ),
-          ];
+          if (!CODEMOD_ANALYSIS) {
+            return [
+              b.element(
+                { name: 'Hds::Icon', selfClosing: true },
+                {
+                  attrs: outputAttrs,
+                  children: node.children,
+                  modifiers: node.modifiers,
+                  blockParams: node.blockParams,
+                }
+              ),
+            ];
+          }
         }
       },
     };

--- a/packages/codemods/transforms/v4/icon/test.js
+++ b/packages/codemods/transforms/v4/icon/test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+'use strict';
+
+const { runTransformTest } = require('codemod-cli');
+
+runTransformTest({
+  name: 'v4/icon',
+});


### PR DESCRIPTION
### :pushpin: Summary

This PR is part of https://github.com/hashicorp/design-system/pull/2207

The proposed functionality for this codemod is to:

1. Update component invocation from `FlightIcon` to `Hds::Icon`
2. Remove instances of `@isInlineBlock={{false}}` as this is now the default behavior
3. Replace instances of `@isInlineBlock={{true}}` (if any) with `@isInline={{true}}`

### Links

[Issue #3532](https://hashicorp.atlassian.net/browse/HDS-3532) 
