### PR TITLE
Website - Standardize and improve how we document "named blocks", yielded content, and contextual components

### DIFF
--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -4,18 +4,17 @@
 }}
 
 <div class="doc-component-api__property">
-  <div class="doc-component-api__property-info">
-    <code class="doc-component-api__property-name">{{@name}}</code>
-    {{#if @type}}
-      <code class="doc-component-api__property-type">{{@type}}</code>
-    {{/if}}
-    {{#if @required}}
-      <Doc::Badge @type="critical-inverted">Required</Doc::Badge>
-    {{/if}}
-    {{#if @deprecated}}
-      <Doc::Badge @type="warning" @size="medium">Deprecated</Doc::Badge>
-    {{/if}}
-  </div>
+  {{#if @name}}
+    <div class="doc-component-api__property-info">
+      <code class="doc-component-api__property-name">{{@name}}</code>
+      {{#if @type}}
+        <code class="doc-component-api__property-type">{{@type}}</code>
+      {{/if}}
+      {{#if @required}}
+        <Doc::Badge @type="critical-inverted">Required</Doc::Badge>
+      {{/if}}
+    </div>
+  {{/if}}
   {{#if (or @values @valueNote)}}
     {{#if @values}}
       <ul class="doc-component-api__property-values" role="list">

--- a/website/app/styles/doc-components/component-api.scss
+++ b/website/app/styles/doc-components/component-api.scss
@@ -12,6 +12,7 @@
 // SET OF PROPERTIES
 
 .doc-component-api {
+  margin-top: 16px;
   margin-bottom: 24px;
   border: 1px solid var(--doc-color-gray-500);
   border-radius: 3px;
@@ -90,6 +91,10 @@
 .doc-component-api__property-description {
   @include doc-font-style-body-small ();
   padding: 20px 0 0 0;
+
+  &:only-child {
+    padding-top: 0;
+  }
 }
 
 

--- a/website/docs/components/accordion/partials/code/component-api.md
+++ b/website/docs/components/accordion/partials/code/component-api.md
@@ -18,7 +18,7 @@ The `Accordion` component serves as a wrapper to group one or more `Accordion::I
   </C.Property>
 </Doc::ComponentApi>
 
-### Contextual Components
+### Contextual components
 
 #### [A].Item
 

--- a/website/docs/components/accordion/partials/code/component-api.md
+++ b/website/docs/components/accordion/partials/code/component-api.md
@@ -5,6 +5,9 @@
 The `Accordion` component serves as a wrapper to group one or more `Accordion::Item` components.
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<[A].Item>" @type="yielded component">
+    `Accordion::Item` yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium" />
   <C.Property @name="type" @type="enum" @values={{array "card" "flush" }} @default="card" />
   <C.Property @name="forceState" @type="enum" @values={{array "open" "close" }}>
@@ -17,18 +20,28 @@ The `Accordion` component serves as a wrapper to group one or more `Accordion::I
 
 ### Contextual Components
 
-#### Accordion::Item
+#### [A].Item
+
+The `Accordion::Item` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="<:toggle>" @type="named block">
     A named block that works as a “toggle” for the `Accordion::Item`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="yield">
+        Elements passed as children are yielded as inner content of the "toggle" block.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="<:content>" @type="named block">
     A named block for the content that is shown/hidden upon toggling.
-    <Doc::ComponentApi as |CC|>
-      <CC.Property @name="[C].close" @type="function">
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="yield">
+        Elements passed as children are yielded as inner content of the "content" block.
+      </C.Property>
+      <C.Property @name="[C].close" @type="function">
         A function to programmatically close the `Accordion::Item`.
-      </CC.Property>
+      </C.Property>
     </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="ariaLabel" @type="string" @default="&quot;Toggle display&quot;">
@@ -47,7 +60,7 @@ The `Accordion` component serves as a wrapper to group one or more `Accordion::I
     Controls the state of an `Accordion::Item` after the initial render by overriding its current state.
   </C.Property>
   <C.Property @name="onClickToggle" @type="function">
-     Callback function invoked when the toggle is clicked.
+    Callback function invoked when the toggle is clicked.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/accordion/partials/code/component-api.md
+++ b/website/docs/components/accordion/partials/code/component-api.md
@@ -26,7 +26,7 @@ The `Accordion` component serves as a wrapper to group one or more `Accordion::I
   <C.Property @name="<:content>" @type="named block">
     A named block for the content that is shown/hidden upon toggling.
     <Doc::ComponentApi as |CC|>
-      <CC.Property @name="[:content].close" @type="function">
+      <CC.Property @name="[C].close" @type="function">
         A function to programmatically close the `Accordion::Item`.
       </CC.Property>
     </Doc::ComponentApi>

--- a/website/docs/components/alert/partials/code/component-api.md
+++ b/website/docs/components/alert/partials/code/component-api.md
@@ -1,6 +1,23 @@
 ## Component API
 
+### Alert
+
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<[A].Title>" @type="yielded component">
+    `Alert::Title` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[A].Description>" @type="yielded component">
+    `Alert::Description` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[A].Button>" @type="yielded component">
+    `Button` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[A].LinkStandalone>" @type="yielded component">
+    `Link::Standalone` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[A].Generic>" @type="yielded component">
+    A generic container yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="type" @required={{true}} @type="enum" @values={{array "page" "inline" "compact"}}>
     Sets the type of alert.
   </C.Property>
@@ -20,22 +37,61 @@
 
 ### Contextual components
 
-Title, description, actions, and generic content are passed into the alert as yielded components, using the `Title`, `Description`, `Button`, `LinkStandalone`, `Generic` keys.
+#### [A].Title
+
+The `Alert::Title` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[A].Title>" @type="yielded component">
-    A container that yields its content inside the `"title"` block. Content inherits its style.<br/><br/>This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "title" block.
   </C.Property>
-  <C.Property @name="<[A].Description>" @type="yielded component">
-    A container that yields its content inside the `"description"` block. Content inherits its style.<br/><br/>Accepts complex content, such as logic/conditionals, HTML elements, other Ember components, etc. Styling is applied for simple HTML elements, such as `strong`, `em`, `a`, `code/pre`. Application teams will need to style the rest of the content.<br/><br/>This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
-  <C.Property @name="<[A].Button>" @type="yielded component">
-    A yielded `Hds::Button` component. It exposes the same API of the [`Button` component](/components/button), apart from the `@size` argument, which is pre-defined to be `small`, and the `@color` argument that accepts only `secondary` or `tertiary`.
+</Doc::ComponentApi>
+
+#### [A].Description
+
+The `Alert::Description` component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "description" block.
+    <br/>Accepts complex content, such as logic/conditionals, HTML elements, other Ember components, etc.
+    <br/>Text content inherits its style. Predefined styling is applied for simple HTML elements, such as `strong`, `em`, `a`, `code/pre`, while consumers will need to style other HTML tags if used as children.
   </C.Property>
-  <C.Property @name="<[A].LinkStandalone>" @type="yielded component">
-    A yielded `Hds::Link::Standalone` component. It exposes the same API of the [`Link::Standalone` component](/components/link/standalone), apart from the `@size` argument, which is pre-defined to be `small`.
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
-  <C.Property @name="<[A].Generic>" @type="yielded component">
-    A component that yields its content.
+</Doc::ComponentApi>
+
+#### [A].Button
+
+The `Button` component, yielded as contextual component inside the `"actions"` block of the Alert.
+
+<Doc::ComponentApi as |C|>
+  <C.Property>
+    It exposes the same API of the [`Button`](/components/button) component, apart from the `@size` argument, which is pre-defined to be `small`, and the `@color` argument that accepts only `secondary` or `tertiary`.
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [A].LinkStandalone
+
+The `Link::Standalone` component, yielded as contextual component inside the `"actions"` block of the Alert.
+
+<Doc::ComponentApi as |C|>
+  <C.Property>
+    It exposes the same API of the [`Link::Standalone`](/components/link/standalone) component, apart from the `@size` argument, which is pre-defined to be
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [A].Generic
+
+A generic container, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded after all the other elements.
+    <br/>The content is unstyled by default, so consumers will need to take care of layout and style of the content.
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/app-footer/partials/code/component-api.md
+++ b/website/docs/components/app-footer/partials/code/component-api.md
@@ -9,16 +9,16 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
     A generic container yielded as contextual component. Its content is injected before the `<ul>` list of links and items.
   </C.Property>
   <C.Property @name="<[AF].StatusLink>" @type="yielded component">
-    The yielded `AppFooter::StatusLink` contextual component ([see below](#appfooterstatuslink)).
+    The yielded `AppFooter::StatusLink` contextual component (see below).
   </C.Property>
   <C.Property @name="<[AF].LegalLinks>" @type="yielded component">
-    The yielded  `AppFooter::LegalLinks` contextual component ([see below]((#appfooterlegallinks)).
+    The yielded  `AppFooter::LegalLinks` contextual component (see below).
   </C.Property>
   <C.Property @name="<[AF].Link>" @type="yielded component">
-    The yielded `AppFooter::Link` contextual component ([see below](#appfooterlink)).
+    The yielded `AppFooter::Link` contextual component (see below).
   </C.Property>
   <C.Property @name="<[AF].Item>" @type="yielded component">
-    The yielded  `AppFooter::Item` contextual component ([see below](#appfooteritem)). Used for custom non-link content.
+    The yielded  `AppFooter::Item` contextual component (see below). Used for custom non-link content.
   </C.Property>
   <C.Property @name="<[AF].ExtraAfter>" @type="yielded component">
     A generic container yielded as contextual component. Its content is injected after the `<ul>` list of links and items.

--- a/website/docs/components/app-footer/partials/code/component-api.md
+++ b/website/docs/components/app-footer/partials/code/component-api.md
@@ -114,7 +114,7 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
     Controls if the “LinkTo” is external to the Ember engine, in which case it will use a `<LinkToExternal>` for the `@route`.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded to the content of the `<a>` HTML element.
+    Elements passed as children are yielded as inner content of the `<a>` HTML element.
   </C.Property>
    <C.Property @name="icon" @type="string">
     Use this parameter to show an icon. Any [icon](/icons/library) name is acceptable.
@@ -131,7 +131,7 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements passed as children are yielded to the content of the `<li>` HTML element.
+    Elements passed as children are yielded as inner content of the `<li>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/app-footer/partials/code/component-api.md
+++ b/website/docs/components/app-footer/partials/code/component-api.md
@@ -6,22 +6,22 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="<[AF].ExtraBefore>" @type="yielded component">
-    Container that yields its content before the `<ul>` list of links and items.
+    A generic container yielded as contextual component. Its content is injected before the `<ul>` list of links and items.
   </C.Property>
   <C.Property @name="<[AF].StatusLink>" @type="yielded component">
-    The `AppFooter::StatusLink` component (see below).
+    The yielded `AppFooter::StatusLink` contextual component ([see below](#appfooterstatuslink)).
   </C.Property>
   <C.Property @name="<[AF].LegalLinks>" @type="yielded component">
-    The `AppFooter::LegalLinks` component (see below).
+    The yielded  `AppFooter::LegalLinks` contextual component ([see below]((#appfooterlegallinks)).
   </C.Property>
   <C.Property @name="<[AF].Link>" @type="yielded component">
-    The `AppFooter::Link` component (see below).
+    The yielded `AppFooter::Link` contextual component ([see below](#appfooterlink)).
   </C.Property>
   <C.Property @name="<[AF].Item>" @type="yielded component">
-    The `AppFooter::Item` component which is used for custom non-link content (see below).
+    The yielded  `AppFooter::Item` contextual component ([see below](#appfooteritem)). Used for custom non-link content.
   </C.Property>
   <C.Property @name="<[AF].ExtraAfter>" @type="yielded component">
-    Container that yields its content after the `<ul>` list of links and items.
+    A generic container yielded as contextual component. Its content is injected after the `<ul>` list of links and items.
   </C.Property>
   <C.Property @name="theme" @type="string"  @values={{array "light" "dark" }} @default="light">
     Set the overall theme used by the component and its children.
@@ -37,7 +37,11 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
   </C.Property>
 </Doc::ComponentApi>
 
-### AppFooter::StatusLink
+### Contextual components
+
+#### [AF].StatusLink
+
+The `AppFooter::StatusLink` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="status" @type="string" @values={{array "operational" "degraded" "maintenance" "outage" }}>
@@ -69,7 +73,9 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
   </C.Property>
 </Doc::ComponentApi>
 
-### AppFooter::LegalLinks
+#### [AF].LegalLinks
+
+The `AppFooter::LegalLinks` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="hrefForSupport" @type="string" @default="&quot;https://www.hashicorp.com/support&quot;">
@@ -98,9 +104,14 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
   </C.Property>
 </Doc::ComponentApi>
 
-### AppFooter::Link
+#### [AF].Link
+
+The `AppFooter::Link` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of an `<a>` HTML element.
+  </C.Property>
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
@@ -113,10 +124,7 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
   <C.Property @name="isRouteExternal" @type="boolean" @default="false">
     Controls if the “LinkTo” is external to the Ember engine, in which case it will use a `<LinkToExternal>` for the `@route`.
   </C.Property>
-  <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<a>` HTML element.
-  </C.Property>
-   <C.Property @name="icon" @type="string">
+  <C.Property @name="icon" @type="string">
     Use this parameter to show an icon. Any [icon](/icons/library) name is acceptable.
   </C.Property>
   <C.Property @name="iconPosition" @type="enum" @values={{array "leading" "trailing" }} @default="trailing">
@@ -127,11 +135,13 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
   </C.Property>
 </Doc::ComponentApi>
 
-### AppFooter::Item
+#### [AF].Item
+
+The `AppFooter::Item` component, yielded as contextual component. Used for custom non-link content.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<li>` HTML element.
+    Elements passed as children are yielded as inner content of an `<li>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/application-state/partials/code/component-api.md
+++ b/website/docs/components/application-state/partials/code/component-api.md
@@ -17,7 +17,7 @@
   </C.Property>
 </Doc::ComponentApi>
 
-### Contextual Components
+### Contextual components
 
 #### [A].Header
 

--- a/website/docs/components/application-state/partials/code/component-api.md
+++ b/website/docs/components/application-state/partials/code/component-api.md
@@ -1,6 +1,17 @@
 ## Component API
 
+### ApplicationState
+
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<[A].Header>" @type="yielded component">
+    `ApplicationState::Header` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[A].Body>" @type="yielded component">
+    `ApplicationState::Body` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[A].Footer>" @type="yielded component">
+    `ApplicationState::Footer` yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
@@ -9,6 +20,8 @@
 ### Contextual Components
 
 #### [A].Header
+
+The `ApplicationState::Header` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="errorCode" @type="string">
@@ -22,21 +35,26 @@
 
 #### [A].Body
 
-Supports block invocation for custom content (see [Block Content](https://guides.emberjs.com/release/components/block-content/) in Ember docs).
+The `ApplicationState::Body` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Supports block invocation for custom content (see [Block Content](https://guides.emberjs.com/release/components/block-content/) in Ember docs).
+  </C.Property>
   <C.Property @name="text" @type="string">
     Note: use `@text` for an inline invocation only. This component does not support `@text` on the component invocation if it is used as a block.
   </C.Property>
 </Doc::ComponentApi>
-  
+
 #### [A].Footer
+
+The `ApplicationState::Footer` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="hasDivider" @type="boolean" @default="false" @values={{array "true" "false"}}>
     Indicates if there should be a visible divider above the footer.
   </C.Property>
   <C.Property @name="<[F].LinkStandalone>" @type="yielded component">
-    A yielded `Hds::Link::Standalone` component. It exposes the same API of the [`Link::Standalone` component](/components/link/standalone).
+    The `Link::Standalone` component, yielded as contextual component inside the `"footer"` block of the ApplicationState. It exposes the same API of the [`Link::Standalone` component](/components/link/standalone).
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/breadcrumb/partials/code/component-api.md
+++ b/website/docs/components/breadcrumb/partials/code/component-api.md
@@ -53,7 +53,7 @@ The Breadcrumb component is composed of three different parts, each with their o
     Set on the truncation toggle button. Accepts a localized string.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this child component are yielded to the content of the [MenuPrimitive](/utilities/menu-primitive) component (used to show/hide the yielded Breadcrumb Items via a "toggle" button).
+    Elements passed as children are yielded to the content of the [MenuPrimitive](/utilities/menu-primitive) component (used to show/hide the yielded Breadcrumb Items via a "toggle" button).
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/button-set/partials/code/component-api.md
+++ b/website/docs/components/button-set/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### ButtonSet
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/card/partials/code/component-api.md
+++ b/website/docs/components/card/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### Card
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="level" @type="enum" @values={{array "base" "mid" "high" }} @default="base">
     Controls the level of elevation (amount of "shadow" effect).

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -2,7 +2,15 @@
 
 This component uses [prism.js](https://prismjs.com/) under the hood.
 
+### CodeBlock
+
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<[CB].Title>" @type="yielded component">
+    `ContentBlock::Title` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[CB].Description>" @type="yielded component">
+    `ContentBlock::Description` yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="value" @type="string">
     The text/code content for the `CodeBlock`. The component encodes this argument before displaying it.
   </C.Property>
@@ -31,11 +39,28 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
 
 ### Contextual components
 
+#### [CB].Title
+
+The `CodeBlock::Title` component, yielded as contextual component.
+
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[A].Title>" @type="yielded component">
-    A container that yields its content inside the `"title"` block. Content inherits its style.<br/><br/>Accepts complex content, such as logic/conditionals, HTML elements, other Ember components, etc. Styling is applied for simple HTML elements, such as `strong`, `em`, `a`, `code/pre`. Application teams will need to style the rest of the content.<br/><br/>This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  <C.Property @name="yield">
+    Accepts complex content, such as logic/conditionals, HTML elements, other Ember components, etc. Content inherits its style. Styling is applied for simple HTML elements, such as `strong`, `em`, `a`, `code/pre`. Consumers will need to style other HTML tags if used as children.
   </C.Property>
-  <C.Property @name="<[A].Description>" @type="yielded component">
-    A container that yields its content inside the `"description"` block. Content inherits its style.<br/><br/>Accepts complex content, such as logic/conditionals, HTML elements, other Ember components, etc. Styling is applied for simple HTML elements, such as `strong`, `em`, `a`, `code/pre`. Application teams will need to style the rest of the content.<br/><br/>This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [CB].Description
+
+The `CodeBlock::Description` component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Accepts complex content, such as logic/conditionals, HTML elements, other Ember components, etc. Content inherits its style. Styling is applied for simple HTML elements, such as `strong`, `em`, `a`, `code/pre`. Consumers will need to style other HTML tags if used as children
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/copy/button/partials/code/component-api.md
+++ b/website/docs/components/copy/button/partials/code/component-api.md
@@ -2,6 +2,8 @@
 
 This component uses the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) under the hood.
 
+### Copy::Button
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" }} @default="medium"/>
     <C.Property @name="isIconOnly" @type="boolean" @default="false">

--- a/website/docs/components/copy/snippet/partials/code/component-api.md
+++ b/website/docs/components/copy/snippet/partials/code/component-api.md
@@ -2,6 +2,8 @@
 
 This component uses the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) under the hood.
 
+### Copy::Snippet
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
   <C.Property @name="isFullWidth" @type="boolean" @default="false">

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -184,7 +184,7 @@ The `Dropdown::ListItem::Separator` component, yielded as contextual component.
 
 The `Dropdown::ListItem::Interactive` component, yielded as contextual component.
 
-It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
+It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API, please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="text" @required={{true}} @type="string">
@@ -225,7 +225,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
 
 The `Dropdown::ListItem::CopyItem` component, yielded as contextual component.
 
-It internally uses the [`Copy::Snippet`](/components/copy/snippet) component. For more details about this component API please refer to [its documentation page](/components/copy/snippet?tab=code#component-api).
+It internally uses the [`Copy::Snippet`](/components/copy/snippet) component. For more details about this component API, please refer to [its documentation page](/components/copy/snippet?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="copyItemTitle" @type="string">

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -46,7 +46,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements nested in this child component are yielded inside the Dropdown header/footer.
+    Elements passed as children are yielded as inner content of the Dropdown header/footer.
   </C.Property>
   <C.Property @name="hasDivider" @type="boolean" @default="false" />
   <C.Property @name="...attributes">
@@ -188,7 +188,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Content to be used in the item.
+    Elements passed as children are yielded as inner content of the element.
   </C.Property>
   <C.Property @name="selected" @type="boolean" @default="false">
     Displays a checkmark symbol indicating the current selection.
@@ -222,7 +222,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Content to be used in the item as label for the input control.
+    Elements passed as children are yielded as inner content of the element, to be used in the item as label for the input control.
   </C.Property>
   <C.Property @name="id" @type="string">
     Input control’s `id` attribute.
@@ -251,7 +251,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Content to be used in the item as label for the input control.
+    Elements passed as children are yielded as inner content of the element, to be used in the item as label for the input control.
   </C.Property>
   <C.Property @name="id" @type="string">
     Input control’s `id` attribute.
@@ -280,7 +280,7 @@ If the Dropdown content exceeds the height of the container, the header and foot
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements nested in this child component are yielded inside the ListItem. When using the “generic” ListItem, the product team is responsible for implementing the layout and accessibility.
+    Elements passed as children are yielded as inner content of the ListItem. When using the “generic” ListItem, the product team is responsible for implementing the layout and accessibility.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -17,6 +17,45 @@ The Dropdown component is composed of different child components each with their
 ### Dropdown
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<[DD].ToggleButton>" @type="yielded component">
+    `Dropdown::Toggle::Button` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].ToggleIcon>" @type="yielded component">
+    `Dropdown::Toggle::Icon` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].Header>" @type="yielded component">
+    `Dropdown::Header` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].Title>" @type="yielded component">
+    `Dropdown::ListItem::Title` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].Description>" @type="yielded component">
+    `Dropdown::ListItem::Description` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].Separator>" @type="yielded component">
+    `Dropdown::ListItem::Separator` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].Interactive>" @type="yielded component">
+    `Dropdown::ListItem::Interactive` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].CopyItem>" @type="yielded component">
+    `Dropdown::ListItem::CopyItem` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].Checkmark>" @type="yielded component">
+    `Dropdown::ListItem::Checkmark` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].Checkbox>" @type="yielded component">
+    `Dropdown::ListItem::Checkbox` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].Radio>" @type="yielded component">
+    `Dropdown::ListItem::Radio` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].Generic>" @type="yielded component">
+    `Dropdown::ListItem::Generic` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[DD].Footer>" @type="yielded component">
+    `Dropdown::Footer` yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="listPosition" @type="string" @values={{array "bottom-left" "bottom-right" "top-left" "top-right" }} @default="bottom-right"/>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the Dropdown List has a `min-width` of `200px` and a `max-width` of `400px`, so it adapts to the content size. If a `@width` parameter is provided then the list will have a fixed width.
@@ -40,21 +79,11 @@ The Dropdown component is composed of different child components each with their
   </C.Property>
 </Doc::ComponentApi>
 
-#### Dropdown::Header and Dropdown::Footer
+### Contextual components
 
-If the Dropdown content exceeds the height of the container, the header and footer remain fixed while the list of items adjusts its height.
+#### [DD].ToggleButton
 
-<Doc::ComponentApi as |C|>
-  <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the Dropdown header/footer.
-  </C.Property>
-  <C.Property @name="hasDivider" @type="boolean" @default="false" />
-  <C.Property @name="...attributes">
-    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
-  </C.Property>
-</Doc::ComponentApi>
-
-### Toggle::Button
+The `Dropdown::Toggle::Button` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="text" @required={{true}} @type="string">
@@ -79,7 +108,9 @@ If the Dropdown content exceeds the height of the container, the header and foot
   </C.Property>
 </Doc::ComponentApi>
 
-### Toggle::Icon
+#### [DD].ToggleIcon
+
+The `Dropdown::Toggle::Icon` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="text" @required={{true}} @type="string">
@@ -97,7 +128,63 @@ If the Dropdown content exceeds the height of the container, the header and foot
   </C.Property>
 </Doc::ComponentApi>
 
-### ListItem::Interactive
+#### [DD].Header / [DD].Footer
+
+The `Dropdown::Header` / `Dropdown::Footer` components, yielded as contextual components.
+
+Note: if the Dropdown content exceeds the height of the container, the header and footer remain fixed while the list of items adjusts its height.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the Dropdown header/footer.
+  </C.Property>
+  <C.Property @name="hasDivider" @type="boolean" @default="false" />
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [DD].Title
+
+The `Dropdown::ListItem::Title` component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="text" @required={{true}} @type="string">
+    Text to be used for the title. If no text value is defined, an error will be thrown.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [DD].Description
+
+The `Dropdown::ListItem::Description` component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="text" @required={{true}} @type="string">
+    Text to be used for the description. If no text value is defined, an error will be thrown.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [DD].Separator
+
+The `Dropdown::ListItem::Separator` component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [DD].Interactive
+
+The `Dropdown::ListItem::Interactive` component, yielded as contextual component.
+
+It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="text" @required={{true}} @type="string">
@@ -134,37 +221,11 @@ If the Dropdown content exceeds the height of the container, the header and foot
   </C.Property>
 </Doc::ComponentApi>
 
-### ListItem::Title
+#### [DD].CopyItem
 
-<Doc::ComponentApi as |C|>
-  <C.Property @name="text" @required={{true}} @type="string">
-    Text to be used for the title. If no text value is defined, an error will be thrown.
-  </C.Property>
-  <C.Property @name="...attributes">
-    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
-  </C.Property>
-</Doc::ComponentApi>
+The `Dropdown::ListItem::CopyItem` component, yielded as contextual component.
 
-### ListItem::Description
-
-<Doc::ComponentApi as |C|>
-  <C.Property @name="text" @required={{true}} @type="string">
-    Text to be used for the description. If no text value is defined, an error will be thrown.
-  </C.Property>
-  <C.Property @name="...attributes">
-    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
-  </C.Property>
-</Doc::ComponentApi>
-
-### ListItem::Separator
-
-<Doc::ComponentApi as |C|>
-  <C.Property @name="...attributes">
-    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
-  </C.Property>
-</Doc::ComponentApi>
-
-### ListItem::CopyItem
+It internally uses the [`Copy::Snippet`](/components/copy/snippet) component. For more details about this component API please refer to [its documentation page](/components/copy/snippet?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="copyItemTitle" @type="string">
@@ -184,7 +245,9 @@ If the Dropdown content exceeds the height of the container, the header and foot
   </C.Property>
 </Doc::ComponentApi>
 
-### ListItem::Checkmark
+#### [DD].Checkmark
+
+The `Dropdown::ListItem::Checkmark` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
@@ -218,7 +281,9 @@ If the Dropdown content exceeds the height of the container, the header and foot
   </C.Property>
 </Doc::ComponentApi>
 
-### ListItem::Checkbox
+#### [DD].Checkbox
+
+The `Dropdown::ListItem::Checkbox` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
@@ -247,7 +312,9 @@ If the Dropdown content exceeds the height of the container, the header and foot
   </C.Property>
 </Doc::ComponentApi>
 
-### ListItem::Radio
+#### [DD].Radio
+
+The `Dropdown::ListItem::Radio` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
@@ -276,7 +343,9 @@ If the Dropdown content exceeds the height of the container, the header and foot
   </C.Property>
 </Doc::ComponentApi>
 
-### ListItem::Generic
+#### [DD].Generic
+
+The `Dropdown::ListItem::Generic` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -17,43 +17,43 @@ The Dropdown component is composed of different child components each with their
 ### Dropdown
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[DD].ToggleButton>" @type="yielded component">
+  <C.Property @name="<[D].ToggleButton>" @type="yielded component">
     `Dropdown::Toggle::Button` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].ToggleIcon>" @type="yielded component">
+  <C.Property @name="<[D].ToggleIcon>" @type="yielded component">
     `Dropdown::Toggle::Icon` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].Header>" @type="yielded component">
+  <C.Property @name="<[D].Header>" @type="yielded component">
     `Dropdown::Header` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].Title>" @type="yielded component">
+  <C.Property @name="<[D].Title>" @type="yielded component">
     `Dropdown::ListItem::Title` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].Description>" @type="yielded component">
+  <C.Property @name="<[D].Description>" @type="yielded component">
     `Dropdown::ListItem::Description` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].Separator>" @type="yielded component">
+  <C.Property @name="<[D].Separator>" @type="yielded component">
     `Dropdown::ListItem::Separator` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].Interactive>" @type="yielded component">
+  <C.Property @name="<[D].Interactive>" @type="yielded component">
     `Dropdown::ListItem::Interactive` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].CopyItem>" @type="yielded component">
+  <C.Property @name="<[D].CopyItem>" @type="yielded component">
     `Dropdown::ListItem::CopyItem` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].Checkmark>" @type="yielded component">
+  <C.Property @name="<[D].Checkmark>" @type="yielded component">
     `Dropdown::ListItem::Checkmark` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].Checkbox>" @type="yielded component">
+  <C.Property @name="<[D].Checkbox>" @type="yielded component">
     `Dropdown::ListItem::Checkbox` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].Radio>" @type="yielded component">
+  <C.Property @name="<[D].Radio>" @type="yielded component">
     `Dropdown::ListItem::Radio` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].Generic>" @type="yielded component">
+  <C.Property @name="<[D].Generic>" @type="yielded component">
     `Dropdown::ListItem::Generic` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[DD].Footer>" @type="yielded component">
+  <C.Property @name="<[D].Footer>" @type="yielded component">
     `Dropdown::Footer` yielded as contextual component (see below).
   </C.Property>
   <C.Property @name="listPosition" @type="string" @values={{array "bottom-left" "bottom-right" "top-left" "top-right" }} @default="bottom-right"/>
@@ -81,7 +81,7 @@ The Dropdown component is composed of different child components each with their
 
 ### Contextual components
 
-#### [DD].ToggleButton
+#### [D].ToggleButton
 
 The `Dropdown::Toggle::Button` component, yielded as contextual component.
 
@@ -108,7 +108,7 @@ The `Dropdown::Toggle::Button` component, yielded as contextual component.
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].ToggleIcon
+#### [D].ToggleIcon
 
 The `Dropdown::Toggle::Icon` component, yielded as contextual component.
 
@@ -128,7 +128,7 @@ The `Dropdown::Toggle::Icon` component, yielded as contextual component.
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].Header / [DD].Footer
+#### [D].Header / [D].Footer
 
 The `Dropdown::Header` / `Dropdown::Footer` components, yielded as contextual components.
 
@@ -144,7 +144,7 @@ Note: if the Dropdown content exceeds the height of the container, the header an
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].Title
+#### [D].Title
 
 The `Dropdown::ListItem::Title` component, yielded as contextual component.
 
@@ -157,7 +157,7 @@ The `Dropdown::ListItem::Title` component, yielded as contextual component.
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].Description
+#### [D].Description
 
 The `Dropdown::ListItem::Description` component, yielded as contextual component.
 
@@ -170,7 +170,7 @@ The `Dropdown::ListItem::Description` component, yielded as contextual component
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].Separator
+#### [D].Separator
 
 The `Dropdown::ListItem::Separator` component, yielded as contextual component.
 
@@ -180,7 +180,7 @@ The `Dropdown::ListItem::Separator` component, yielded as contextual component.
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].Interactive
+#### [D].Interactive
 
 The `Dropdown::ListItem::Interactive` component, yielded as contextual component.
 
@@ -221,7 +221,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].CopyItem
+#### [D].CopyItem
 
 The `Dropdown::ListItem::CopyItem` component, yielded as contextual component.
 
@@ -245,7 +245,7 @@ It internally uses the [`Copy::Snippet`](/components/copy/snippet) component. Fo
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].Checkmark
+#### [D].Checkmark
 
 The `Dropdown::ListItem::Checkmark` component, yielded as contextual component.
 
@@ -281,7 +281,7 @@ The `Dropdown::ListItem::Checkmark` component, yielded as contextual component.
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].Checkbox
+#### [D].Checkbox
 
 The `Dropdown::ListItem::Checkbox` component, yielded as contextual component.
 
@@ -312,7 +312,7 @@ The `Dropdown::ListItem::Checkbox` component, yielded as contextual component.
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].Radio
+#### [D].Radio
 
 The `Dropdown::ListItem::Radio` component, yielded as contextual component.
 
@@ -343,7 +343,7 @@ The `Dropdown::ListItem::Radio` component, yielded as contextual component.
   </C.Property>
 </Doc::ComponentApi>
 
-#### [DD].Generic
+#### [D].Generic
 
 The `Dropdown::ListItem::Generic` component, yielded as contextual component.
 

--- a/website/docs/components/flyout/partials/code/component-api.md
+++ b/website/docs/components/flyout/partials/code/component-api.md
@@ -1,6 +1,20 @@
 ## Component API
 
+### Flyout
+
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<[F].Header>" @type="yielded component">
+    `Flyout::Header` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[F].Description>" @type="yielded component">
+    `Flyout::Header` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[F].Body>" @type="yielded component">
+    `Flyout::Header` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[F].Footer>" @type="yielded component">
+    `Flyout::Header` yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="size" @type="enum" @values={{array "medium" "large" }} @default="medium">
     Sets the width of the Flyout.
   </C.Property>
@@ -17,11 +31,9 @@
 
 ### Contextual components
 
-The title, description and the content are passed into the Flyout as yielded components, using the `Header`, `Description`, `Body`, and `Footer` keys.
+#### [F].Header
 
-#### Flyout::Header
-
-It is a container that yields its content as the title of the Flyout.
+The `Flyout::Header` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="icon" @type="string">
@@ -29,31 +41,54 @@ It is a container that yields its content as the title of the Flyout.
   </C.Property>
   <C.Property @name="tagline" @type="string">
     A string that helps the user maintain context when a Flyout is open.
-    <br/><br/>
-    This is **not** the title text, but a small piece of text above the title text.
+    <br/>This is **not** the title text, but a small piece of text above the title text.
+  </C.Property>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "title" block.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>
 
-#### Flyout::Description
+#### [F].Description
 
-A container that yields its content as the description of the Flyout.
-
-This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
-
-#### Flyout::Body
-
-The body is an unstyled, generic container that yields as the main content of the Flyout component. When the yielded content exceeds the available space, a scrollbar is introduced to the container.
-
-This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
-
-#### Flyout::Footer
-
-A container that yields its content as the footer of the Flyout component. We recommend using it exclusively for declarative content or actions using the [ButtonSet](/components/button-set) component. If a tertiary action is presented, it will always be aligned at the end of the row.
+The `Flyout::Description` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "description" block.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [F].Body
+
+The `Flyout::Body` component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "body" block.
+    <br/>The content is unstyled by default, so consumers will need to take care of layout and style of the content.
+    <br/>When the content exceeds the available space, a scrollbar is introduced to the container.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [F].Footer
+
+The `Flyout::Footer` component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "footer" block.
+    <br/>We recommend using it exclusively for declarative content or actions using the [ButtonSet](/components/button-set) component.
+    <br/>If a tertiary action is presented, it will always be aligned at the end of the row.
+  </C.Property>
   <C.Property @name="close" @type="function">
     Function to programmatically close the Flyout. If an `onClose` callback function is provided it will be invoked when the Flyout is closed.
   </C.Property>

--- a/website/docs/components/flyout/partials/code/component-api.md
+++ b/website/docs/components/flyout/partials/code/component-api.md
@@ -90,7 +90,7 @@ The `Flyout::Footer` component, yielded as contextual component.
     <br/>If a tertiary action is presented, it will always be aligned at the end of the row.
   </C.Property>
   <C.Property @name="close" @type="function">
-    Function to programmatically close the Flyout. If an `onClose` callback function is provided it will be invoked when the Flyout is closed.
+    Function to programmatically close the Flyout. If an `onClose` callback function is provided, it will be invoked when the Flyout is closed.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/form/primitives/partials/code/component-api.md
+++ b/website/docs/components/form/primitives/partials/code/component-api.md
@@ -13,7 +13,7 @@
     Appends an `Optional` indicator next to the label text when user input is optional.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<label>` HTML element.
+    Elements passed as children are yielded as inner content of a `<label>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -92,7 +92,7 @@
     Appends an `Optional` indicator next to the label text when user input is optional.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<legend>` HTML element.
+    Elements passed as children are yielded as inner content of a `<legend>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/form/primitives/partials/code/component-api.md
+++ b/website/docs/components/form/primitives/partials/code/component-api.md
@@ -13,7 +13,7 @@
     Appends an `Optional` indicator next to the label text when user input is optional.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the `<label>` element.
+    Elements passed as children are yielded as inner content of the `<label>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -27,7 +27,7 @@
     The ID of the form control associated with the helper text. This is used to populate the element’s `id` HTML attribute (with a `helper-text-` prefix). This HelperText ID can then be referenced in the `aria-describedby` attribute of the form control.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the element.
+    Elements passed as children are yielded as inner content of the element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -50,7 +50,7 @@
     The minimum number of characters required for the associated form element, used to determine the shortfall value.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the element. We only recommend using the block content for providing custom messages. The following variables are available within the block: `currentLength` (the current number of characters in the associated form control), `maxLength` (the maximum number of characters allowed in the associated form control), `minLength` (the minimum number of characters required in the associated form control), `remaining` (the difference between `maxLength` and `currentLength`), and `shortfall` (the difference between `currentLength` and `minLength`).
+    Elements passed as children are yielded as inner content of the element. We only recommend using the block content for providing custom messages. The following variables are available within the block: `currentLength` (the current number of characters in the associated form control), `maxLength` (the maximum number of characters allowed in the associated form control), `minLength` (the minimum number of characters required in the associated form control), `remaining` (the difference between `maxLength` and `currentLength`), and `shortfall` (the difference between `currentLength` and `minLength`).
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -64,7 +64,7 @@
     The ID of the form control associated with the error. This is used to populate the element’s `id` HTML attribute (with an `error-` prefix). This Error ID can then be referenced in the `aria-describedby` attribute of the form control.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the element.
+    Elements passed as children are yielded as inner content of the element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -92,7 +92,7 @@
     Appends an `Optional` indicator next to the label text when user input is optional.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the `<legend>` element.
+    Elements passed as children are yielded as inner content of the `<legend>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/icon-tile/partials/code/component-api.md
+++ b/website/docs/components/icon-tile/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### IconTile
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
   <C.Property @name="color" @type="enum" @values={{array "neutral" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "waypoint" }} @default="neutral">

--- a/website/docs/components/link/inline/partials/code/component-api.md
+++ b/website/docs/components/link/inline/partials/code/component-api.md
@@ -21,7 +21,7 @@
     Controls if the “LinkTo” is external to the Ember engine, in which case it will use a `<LinkToExternal>` for the `@route`.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded to the content of the `<a>` HTML element.
+    Elements passed as children are yielded as inner content of the `<a>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/link/inline/partials/code/component-api.md
+++ b/website/docs/components/link/inline/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### Link::Inline
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
   <C.Property @name="icon" @type="string">
@@ -21,7 +23,7 @@
     Controls if the “LinkTo” is external to the Ember engine, in which case it will use a `<LinkToExternal>` for the `@route`.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<a>` HTML element.
+    Elements passed as children are yielded as inner content of an `<a>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/link/standalone/partials/code/component-api.md
+++ b/website/docs/components/link/standalone/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### Link::Standalone
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
   <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>

--- a/website/docs/components/modal/partials/code/component-api.md
+++ b/website/docs/components/modal/partials/code/component-api.md
@@ -81,7 +81,7 @@ The `Modal::Footer` component, yielded as contextual component.
     <br/>If a tertiary action is presented, it will always be aligned at the end of the row.
   </C.Property>
   <C.Property @name="close" @type="function">
-    Function to programmatically close the Modal. If an `onClose` callback function is provided it will be invoked when the Modal is closed.
+    Function to programmatically close the Modal. If an `onClose` callback function is provided, it will be invoked when the Modal is closed.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/modal/partials/code/component-api.md
+++ b/website/docs/components/modal/partials/code/component-api.md
@@ -1,6 +1,17 @@
 ## Component API
 
+### Modal
+
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<[M].Header>" @type="yielded component">
+    `Flyout::Header` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[M].Body>" @type="yielded component">
+    `Flyout::Header` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[M].Footer>" @type="yielded component">
+    `Flyout::Header` yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium">
     Sets the width of the Modal.
   </C.Property>
@@ -23,11 +34,9 @@
 
 ### Contextual components
 
-The title, the content of the Modal dialog, and the actions are passed into the Modal as yielded components, using the `Header`, `Body`, `Footer` keys.
+#### [M].Header
 
-#### Modal::Header
-
-A container that yields its content as the title of the Modal.
+The `Modal::Header` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="icon" @type="string">
@@ -35,25 +44,42 @@ A container that yields its content as the title of the Modal.
   </C.Property>
   <C.Property @name="tagline" @type="string">
     String that helps the user maintain context when a Modal dialog is open.
-    <br/><br/>
-     This is **not** the title text, but a small piece of text above the title text.
+    <br/>This is **not** the title text, but a small piece of text above the title text.
+  </C.Property>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "title" block.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>
 
-#### Modal::Body
 
-The body is an unstyled, generic container that yields as the main content of the Modal. When the yielded content exceeds the available space, a scrollbar is introduced to the container.
+#### [M].Body
 
-This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
-
-#### Modal::Footer
-
-A container that yields its content as the footer of the Modal. We recommend using it exclusively for actions using the [ButtonSet](/components/button-set) component. If a tertiary action is presented, it will always be aligned at the end of the row.
+The `Modal::Body` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "body" block.
+    <br/>The content is unstyled by default, so consumers will need to take care of layout and style of the content.
+    <br/>When the content exceeds the available space, a scrollbar is introduced to the container.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [M].Footer
+
+The `Modal::Footer` component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "footer" block.
+    <br/>We recommend using it exclusively for actions using the [ButtonSet](/components/button-set) component.
+    <br/>If a tertiary action is presented, it will always be aligned at the end of the row.
+  </C.Property>
   <C.Property @name="close" @type="function">
     Function to programmatically close the Modal. If an `onClose` callback function is provided it will be invoked when the Modal is closed.
   </C.Property>

--- a/website/docs/components/page-header/partials/code/component-api.md
+++ b/website/docs/components/page-header/partials/code/component-api.md
@@ -19,7 +19,7 @@ The `PageHeader::Title` component, yielded as contextual component.
     Elements passed as children are yielded as inner content of an `<h1>` HTML element.
   </C.Property>
   <C.Property @name="close" @type="function">
-    Function to programmatically close the Modal. If an `onClose` callback function is provided it will be invoked when the Modal is closed.
+    Function to programmatically close the Modal. If an `onClose` callback function is provided, it will be invoked when the Modal is closed.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/page-header/partials/code/component-api.md
+++ b/website/docs/components/page-header/partials/code/component-api.md
@@ -1,6 +1,6 @@
 ## Component API
 
-The Page Header is flexible and exposes a number of contextual components to support many different composition methods.
+### PageHeader
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="...attributes">
@@ -10,41 +10,110 @@ The Page Header is flexible and exposes a number of contextual components to sup
 
 ### Contextual components
 
+#### [PH].Title
+
+The `PageHeader::Title` component, yielded as contextual component.
+
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[PH].Title>" @type="yielded component">
-    Yields text and structured content within an `<h1>`
-    <br/><br/>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of an `<h1>` HTML element.
+  </C.Property>
+  <C.Property @name="close" @type="function">
+    Function to programmatically close the Modal. If an `onClose` callback function is provided it will be invoked when the Modal is closed.
+  </C.Property>
+  <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
-  <C.Property @name="<[PH].Breadcrumb>" @type="yielded component">
-    A container that yields its content inside the "breadcrumb" block. Conventionally used to add a [Breadcrumb](/components/breadcrumb) component.
+</Doc::ComponentApi>
+
+#### [PH].Breadcrumb
+
+A generic container, yielded as contextual component.
+
+Conventionally used to add a [Breadcrumb](/components/breadcrumb) component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "breadcrumb" block.
   </C.Property>
-  <C.Property @name="<[PH].IconTile>" @type="yielded component">
-    A yielded `HDS::IconTile` component. It exposes the same API of the [IconTile component](/components/icon-tile?tab=code#component-api), apart from the `@size` argument, which is pre-defined to be `medium`.
+</Doc::ComponentApi>
+
+#### [PH].IconTile
+
+A yielded `HDS::IconTile` component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property>
+    It exposes the same API of the [`IconTile`](/components/icon-tile?tab=code#component-api) component, apart from the `@size` argument, which is pre-defined to be `medium`.
   </C.Property>
-  <C.Property @name="<[PH].Badges>" @type="yielded component">
-    A container that yields its content inside the "badges" block. Intended to indicate status via one or more [Badge](/components/badge) components.
-    <br/><br/>
+</Doc::ComponentApi>
+
+#### [PH].Badges
+
+The `PageHeader::Badges` component, yielded as contextual component.
+
+Intended to indicate status via one or more [Badge](/components/badge) components.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "badges" block, as a list of badges.
+  </C.Property>
+  <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
-  <C.Property @name="<[PH].Subtitle>" @type="yielded component">
-    A container that yields its content inside of the "metadata" block. The content can be a simple string or a more complex/structured one. The content inherits the text style.
-    <br/><br/>
+</Doc::ComponentApi>
+
+#### [PH].Subtitle
+
+The `PageHeader::Subtitle` component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "metadata/subtitle" block.
+    <br/>The content can be a simple string or a more complex/structured one. The content inherits the text style.
+  </C.Property>
+  <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
-  <C.Property @name="<[PH].Description>" @type="yielded component">
-    A container that yields its content inside of the "metadata" block. The content can be a simple string or a more complex/structured one. The content inherits the text style.
-    <br/><br/>
+</Doc::ComponentApi>
+
+#### [PH].Description
+
+The `PageHeader::Description` component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "metadata/description" block.
+    <br/>The content can be a simple string or a more complex/structured one. The content inherits the text style.
+  </C.Property>
+  <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
-  <C.Property @name="<[PH].Generic>" @type="yielded component">
-    A container that yields its content inside of the "metadata" block. The content can be a simple string or a more complex/structured one. The content does not inherit any text style.
-    <br/><br/>
-    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+</Doc::ComponentApi>
+
+#### [PH].Generic
+
+A generic container, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "metadata" block, after the "subtitle" and "description".
+    <br/>The content can be a simple string or a more complex/structured one.
+    <br/>The content **does not** inherit any text style.
   </C.Property>
-  <C.Property @name="<[PH].Actions>" @type="yielded component">
-    A container that yields its content inside of the "actions" block. Intended for actions and buttons pertaining to the main page.
-    <br/><br/>
+</Doc::ComponentApi>
+
+#### [PH].Actions
+
+The `PageHeader::Actions` component, yielded as contextual component.
+
+Intended for actions and buttons pertaining to the main page.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of the "actions" block
+  </C.Property>
+  <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/reveal/partials/code/component-api.md
+++ b/website/docs/components/reveal/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### Reveal
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="text" @required={{true}} @type="string">
     Plain text string that will appear on the toggle button which controls the hiding and showing of the content. If no text value is defined an error will be thrown.

--- a/website/docs/components/rich-tooltip/partials/code/component-api.md
+++ b/website/docs/components/rich-tooltip/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### RichTooltip
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="[RT].Toggle" @type="yielded component">
     The `RichTooltip::Toggle` component (see below).
@@ -41,11 +43,11 @@
 
 ### Contextual components
 
-The Toggle and Bubble elements are passed into the Rich Tooltip as yielded components, using the `Toggle` and `Bubble` keys.
+#### [RT].Toggle
 
-#### RichTooltip::Toggle
+The `RichTooltip::Toggle` component, yielded as contextual component.
 
-Standard toggle element to use, consisting of a text string and an optional icon, to ensure that the toggle is perceivable, visually consistent, and can be used inline with other content or standalone as part of the layout flow.
+The standard toggle element to use consists of a text string and an optional icon, to ensure that the toggle is perceivable, visually consistent, and can be used inline with other content or standalone as part of the layout flow.
 
 It can also be used with generic content, in which case consumers will need to ensure the component is used in a [conformant accessible way](/components/rich-tooltip?tab=accessibility).
 
@@ -83,9 +85,11 @@ It can also be used with generic content, in which case consumers will need to e
   </C.Property>
 </Doc::ComponentApi>
 
-#### RichTooltip::Bubble
+#### [RT].Bubble
 
-Generic container that yields its content inside the "tooltip" popover element.
+The `RichTooltip::Bubble` component, yielded as contextual component.
+
+Most of the arguments are forwarded as `anchoredPositionOptions` to the underlying [`PopoverPrimitive`](/utilities/popover-primitive#popoverprimitive) utility.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">

--- a/website/docs/components/rich-tooltip/partials/code/component-api.md
+++ b/website/docs/components/rich-tooltip/partials/code/component-api.md
@@ -72,7 +72,7 @@ It can also be used with generic content, in which case consumers will need to e
   <C.Property @name="isInline" @type="boolean" @default="false" @values={{array "true" "false"}}>
     Sets the display for the HTML `<button>` element which is used in the "toggle". If `true`, it sets the element’s display to `inline-flex`. (Note: a `<button>` can’t have an `inline` layout.)
   </C.Property>
-  <C.Property @name="yield" @type="yield">
+  <C.Property @name="yield">
     It’s possible to yield generic content to the "toggle" element, instead of using the `@text` argument. This should be used only in special edge cases where including text or an icon in the toggle doesn’t work for the specific context or design.
     <br />
     <br />

--- a/website/docs/components/segmented-group/partials/code/component-api.md
+++ b/website/docs/components/segmented-group/partials/code/component-api.md
@@ -3,19 +3,19 @@
 ### SegmentedGroup
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[S].Button>" @type="yielded component">
+  <C.Property @name="<[SD].Button>" @type="yielded component">
     `Button` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[S].Dropdown>" @type="yielded component">
+  <C.Property @name="<[SD].Dropdown>" @type="yielded component">
     `Dropdown` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[S].Select>" @type="yielded component">
+  <C.Property @name="<[SD].Select>" @type="yielded component">
     `Form::Select::Base` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[S].TextInput>" @type="yielded component">
+  <C.Property @name="<[SD].TextInput>" @type="yielded component">
     `Form::TextInput::Base` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[S].Generic>" @type="yielded component">
+  <C.Property @name="<[SD].Generic>" @type="yielded component">
     A generic container yielded as contextual component (see below).
   </C.Property>
   <C.Property @name="...attributes">
@@ -27,7 +27,7 @@
 
 The following predefined segments can be passed into the Segmented Group as yielded contextual components: `Button`, `Dropdown`, `Select`, `TextInput`. For bespoke Segments use the `Generic` contextual component and style it accordingly.
 
-#### [S].Button
+#### [SD].Button
 
 The [`Button`](/components/button) component, yielded as contextual component.
 
@@ -37,7 +37,7 @@ The [`Button`](/components/button) component, yielded as contextual component.
   </C.Property>
 </Doc::ComponentApi>
 
-#### [S].Dropdown
+#### [SD].Dropdown
 
 The [`Dropdown`](/components/dropdown) component, yielded as contextual component.
 
@@ -47,7 +47,7 @@ The [`Dropdown`](/components/dropdown) component, yielded as contextual componen
   </C.Property>
 </Doc::ComponentApi>
 
-#### [S].Select
+#### [SD].Select
 
 The [`Form::Select::Base`](/components/form/select) component, yielded as contextual component.
 
@@ -57,7 +57,7 @@ The [`Form::Select::Base`](/components/form/select) component, yielded as contex
   </C.Property>
 </Doc::ComponentApi>
 
-#### [S].TextInput
+#### [SD].TextInput
 
 The [`Form::TextInput::Base`](/components/form/text-input) component, yielded as contextual component.
 

--- a/website/docs/components/segmented-group/partials/code/component-api.md
+++ b/website/docs/components/segmented-group/partials/code/component-api.md
@@ -1,6 +1,23 @@
 ## Component API
 
+### SegmentedGroup
+
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<[S].Button>" @type="yielded component">
+    `Button` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[S].Dropdown>" @type="yielded component">
+    `Dropdown` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[S].Select>" @type="yielded component">
+    `Form::Select::Base` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[S].TextInput>" @type="yielded component">
+    `Form::TextInput::Base` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[S].Generic>" @type="yielded component">
+    A generic container yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
@@ -8,22 +25,55 @@
 
 ### Contextual components
 
-The following predefined Segments can be passed into the Segmented Group as yielded components: `Button`, `Dropdown`, `Select`, `TextInput`. For bespoke Segments use the `Generic` block and style it accordingly.
+The following predefined segments can be passed into the Segmented Group as yielded contextual components: `Button`, `Dropdown`, `Select`, `TextInput`. For bespoke Segments use the `Generic` contextual component and style it accordingly.
+
+#### [S].Button
+
+The [`Button`](/components/button) component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[S].Button>" @type="yielded component">
-    For details about its API, check the [`Button`](/components/button?tab=code#component-api) component.
+  <C.Property>
+    It exposes the same API of the [`Button`](/components/button?tab=code#component-api) component.
   </C.Property>
-  <C.Property @name="<[S].Dropdown>" @type="yielded component">
-    For details about its API, check the [`Dropdown`](/components/dropdown?tab=code#component-api) component.
+</Doc::ComponentApi>
+
+#### [S].Dropdown
+
+The [`Dropdown`](/components/dropdown) component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property>
+    It exposes the same API of the [`Dropdown`](/components/dropdown?tab=code#component-api) component.
   </C.Property>
-  <C.Property @name="<[S].Select>" @type="yielded component">
-    For details about its API, check the [`Form::Select::Base`](/components/form/select?tab=code#formselectbase-1) component.
+</Doc::ComponentApi>
+
+#### [S].Select
+
+The [`Form::Select::Base`](/components/form/select) component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property>
+    It exposes the same API of the [`Form::Select::Base`](/components/form/select?tab=code#formselectbase-1) component.
   </C.Property>
-  <C.Property @name="<[S].TextInput>" @type="yielded component">
-    For details about its API, check the [`Form::TextInput::Base`](/components/form/text-input?tab=code#formtextinputbase-1) component.
+</Doc::ComponentApi>
+
+#### [S].TextInput
+
+The [`Form::TextInput::Base`](/components/form/text-input) component, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property>
+      It exposes the same API of the [`Form::TextInput::Base`](/components/form/text-input?tab=code#formtextinputbase-1) component.
   </C.Property>
-  <C.Property @name="<[S].Generic>" @type="yielded component">
-    A component that yields its content. The content does not inherit any styles.
+</Doc::ComponentApi>
+
+#### [S].Generic
+
+A generic container, yielded as contextual component.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded after all the other elements.
+    <br/>The content is unstyled by default, so consumers will need to take care of layout and style of the content.
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/separator/partials/code/component-api.md
+++ b/website/docs/components/separator/partials/code/component-api.md
@@ -1,7 +1,11 @@
 ## Component API
 
+### Separator
+
 <Doc::ComponentApi as |C|>
-  <C.Property @name="spacing" @type="string" @values={{array "0" "24" }} @default="24"/>
+  <C.Property @name="spacing" @type="string" @values={{array "0" "24" }} @default="24">
+    The vertical margin of the separator.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -230,7 +230,7 @@ The `SideNav::List::Item` component can be used to contain generic content.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the `<li>` element.
+    Elements passed as children are yielded as inner content of the `<li>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -268,7 +268,7 @@ The `SideNav::List::Title` component is used to display a title for related `Sid
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the element.
+    Elements passed as children are yielded as inner content of the element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -311,7 +311,7 @@ The `SideNav::List::Link` component uses the generic `Hds::Interactive` componen
     This controls if the “LinkTo” is external to the Ember engine, in which case it will use a `<LinkToExternal>` for the `@route`.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the element (after the leading icon/text/badge/count block, before the trailing icon).
+    Elements passed as children are yielded as inner content of the link (after the leading icon/text/badge/count block, before the trailing icon).
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -98,7 +98,9 @@ This is the basic component (layout only).
 
 ### SideNav::Header::HomeLink
 
-The `SideNav::Header::HomeLink` component uses the generic `Hds::Interactive` component. For more details about this utility component please refer to [its documentation page](/utilities/interactive).
+The `SideNav::Header::HomeLink` component.
+
+It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="icon" @type="string">
@@ -129,7 +131,9 @@ The `SideNav::Header::HomeLink` component uses the generic `Hds::Interactive` co
 
 ### SideNav::Header::IconButton
 
-The `SideNav::Header::IconButton` component uses the generic `Hds::Interactive` component. For more details about this utility component please refer to [its documentation page](/utilities/interactive).
+The `SideNav::Header::IconButton` component.
+
+It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="icon" @type="string" @required={{true}}>
@@ -195,14 +199,13 @@ The content yielded in the component is injected inside a `Hds::SideNav::List` e
   </C.Property>
 </Doc::ComponentApi>
 
-
 ### SideNav::List
 
-The `SideNav::List` component is used to wrap and contain the `SideNav::List::Title`, `SideNav::List::Link`, `SideNav::List::BackLink` and `SideNav::List::Item` components.
+The `SideNav::List` component is used to wrap and contain the `SideNav::List::Title`, `SideNav::List::Link`, `SideNav::List::BackLink` and `SideNav::List::Item` components, exposed as yielde contextual components.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="<[L].ExtraBefore>" @type="yielded component">
-    Container that yields its content before the `<ul>` list of items (but inside the `<nav>` wrapper)
+    A generic container yielded as contextual component. Its content is injected before the `<ul>` list of items (but inside the `<nav>` wrapper)
   </C.Property>
   <C.Property @name="<[L].Item>" @type="yielded component">
     The generic `SideNav::List::Item` component (see below).
@@ -217,29 +220,35 @@ The `SideNav::List` component is used to wrap and contain the `SideNav::List::Ti
     The `SideNav::List::Link` component (see below).
   </C.Property>
   <C.Property @name="<[L].ExtraAfter>" @type="yielded component">
-    Container that yields its content after the `<ul>` list of items (but inside the `<nav>` wrapper)
+    A generic container yielded as contextual component. Its content is injected after the `<ul>` list of items (but inside the `<nav>` wrapper)
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>
 
-### SideNav::List::Item
+#### Contextual components
 
-The `SideNav::List::Item` component can be used to contain generic content.
+##### [L].Item
+
+The `SideNav::List::Item` component, yielded as contextual component.
+
+It can be used to contain generic content.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<li>` HTML element.
+    Elements passed as children are yielded as inner content of an `<li>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>
 
-### SideNav::List::BackLink
+##### [L].BackLink
 
-The `SideNav::List::BackLink` component uses the generic `Hds::Interactive` component. For more details about this utility component please refer to [its documentation page](/utilities/interactive).
+The `SideNav::List::BackLink` component, yielded as contextual component.
+
+It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="text" @type="string">
@@ -262,9 +271,11 @@ The `SideNav::List::BackLink` component uses the generic `Hds::Interactive` comp
   </C.Property>
 </Doc::ComponentApi>
 
-### SideNav::List::Title
+##### [L].Title
 
-The `SideNav::List::Title` component is used to display a title for related `SideNav::List::Link` components.
+The `SideNav::List::Title` component, yielded as contextual component.
+
+Used to display a title for related `SideNav::List::Link` components.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
@@ -275,9 +286,11 @@ The `SideNav::List::Title` component is used to display a title for related `Sid
   </C.Property>
 </Doc::ComponentApi>
 
-### SideNav::List::Link
+##### [L].Link
 
-The `SideNav::List::Link` component uses the generic `Hds::Interactive` component. For more details about this utility component please refer to [its documentation page](/utilities/interactive).
+The `SideNav::List::Link` component, yielded as contextual component.
+
+It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="icon" @type="string">

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -100,7 +100,7 @@ This is the basic component (layout only).
 
 The `SideNav::Header::HomeLink` component.
 
-It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
+It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API, please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="icon" @type="string">
@@ -133,7 +133,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
 
 The `SideNav::Header::IconButton` component.
 
-It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
+It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API, please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="icon" @type="string" @required={{true}}>
@@ -201,7 +201,7 @@ The content yielded in the component is injected inside a `Hds::SideNav::List` e
 
 ### SideNav::List
 
-The `SideNav::List` component is used to wrap and contain the `SideNav::List::Title`, `SideNav::List::Link`, `SideNav::List::BackLink` and `SideNav::List::Item` components, exposed as yielde contextual components.
+The `SideNav::List` component is used to wrap and contain the `SideNav::List::Title`, `SideNav::List::Link`, `SideNav::List::BackLink` and `SideNav::List::Item` components, exposed as yielded contextual components.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="<[L].ExtraBefore>" @type="yielded component">
@@ -248,7 +248,7 @@ It can be used to contain generic content.
 
 The `SideNav::List::BackLink` component, yielded as contextual component.
 
-It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
+It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API, please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="text" @type="string">
@@ -290,7 +290,7 @@ Used to display a title for related `SideNav::List::Link` components.
 
 The `SideNav::List::Link` component, yielded as contextual component.
 
-It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
+It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API, please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="icon" @type="string">

--- a/website/docs/components/stepper/partials/code/component-api.md
+++ b/website/docs/components/stepper/partials/code/component-api.md
@@ -17,6 +17,9 @@ We provide two separate but related Stepper Indicator components that serve diff
   <C.Property @name="text" @type="string">
     Corresponds with the numerical value of the item’s index in an array of multiple steps.
   </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
 </Doc::ComponentApi>
 
 ### Stepper::Task::Indicator
@@ -27,5 +30,8 @@ We provide two separate but related Stepper Indicator components that serve diff
   </C.Property>
   <C.Property @name="isInteractive" @type="boolean" @default="false">
     Sets interactivity of `Task::Indicator`.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -122,7 +122,7 @@ This component can contain `Hds::Table::Th`, `Hds::Table::ThSort`, or `Hds::Tabl
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the `<tr>` element.
+    Elements passed as children are yielded as inner content of the `<tr>` HTML element.
   </C.Property>
   <C.Property @name="isSelected" @type="boolean" @default="false">
     Sets the initial selection state for the row (used in conjunction with setting `isSelectable` on the `Table`).
@@ -161,7 +161,7 @@ If the `Th` component is passed as the first cell of a table body row, `scope="r
     If set to `true`, it visually hides the column’s text content (it will still be available to screen readers for accessibility).
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the `<th>` element.
+    Elements passed as children are yielded as inner content of the `<th>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -189,7 +189,7 @@ This is the component that supports column sorting; use instead of `Hds::Table::
     Callback function invoked when the sort button is clicked. By default, the sort is set by the column’s key.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside a `<button>` nested in a `<th>` element. For this reason, you should avoid providing interactive elements as children (interactive controls should never be nested for accessibility reasons).
+    Elements passed as children are yielded as inner content of a `<button>` nested in a `<th>` HTML element. For this reason, you should avoid providing interactive elements as children (interactive controls should never be nested for accessibility reasons).
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -205,7 +205,7 @@ Note: This component is not eligible to receive interactions (e.g., it cannot ha
     Determines the horizontal content alignment (sometimes referred to as text alignment) for the cell (make sure it is also set for the column header).
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside the `<td>` element.
+    Elements passed as children are yielded as inner content of the `<td>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -122,7 +122,7 @@ This component can contain `Hds::Table::Th`, `Hds::Table::ThSort`, or `Hds::Tabl
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<tr>` HTML element.
+    Elements passed as children are yielded as inner content of a `<tr>` HTML element.
   </C.Property>
   <C.Property @name="isSelected" @type="boolean" @default="false">
     Sets the initial selection state for the row (used in conjunction with setting `isSelectable` on the `Table`).
@@ -161,7 +161,7 @@ If the `Th` component is passed as the first cell of a table body row, `scope="r
     If set to `true`, it visually hides the column’s text content (it will still be available to screen readers for accessibility).
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<th>` HTML element.
+    Elements passed as children are yielded as inner content of a `<th>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -205,7 +205,7 @@ Note: This component is not eligible to receive interactions (e.g., it cannot ha
     Determines the horizontal content alignment (sometimes referred to as text alignment) for the cell (make sure it is also set for the column header).
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<td>` HTML element.
+    Elements passed as children are yielded as inner content of a `<td>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/table/partials/code/component-api.md
+++ b/website/docs/components/table/partials/code/component-api.md
@@ -6,28 +6,28 @@ The Table component itself is where most of the options will be applied. However
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="<:head>" @type="named block">
-    This is a named block where the content for the table head (`<thead>`) is rendered. Note: most consumers are unlikely to need to use this named block directly.<br />
-    It yields these internal properties:
+    A named block where the content for the table head (`<thead>`) is rendered.
+    <br/>
+    Note: most consumers are unlikely to need to use this named block directly.
     <Doc::ComponentApi as |C|>
-      <C.Property @name="H.setSortBy" @type="yielded function">
+      <C.Property @name="[H].setSortBy" @type="function">
       The function used internally by the table to set the `sortBy` and `sortOrder` tracked values.
       </C.Property>
-      <C.Property @name="H.sortBy" @type="yielded value">
-        The value of the internal `sortBy` tracked variable.
+      <C.Property @name="[H].sortBy" @type="string">
+        Hook into this property to access the state of the internal `sortBy` tracked variable.
       </C.Property>
-      <C.Property @name="H.sortOrder" @type="yielded value">
-        The value of the internal `sortOrder` tracked variable.
+      <C.Property @name="[H].sortOrder" @type="string">
+        Hook into this property to access the state of the internal `sortOrder` tracked variable.
       </C.Property>
     </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="<:body>" @type="named block">
-    This is a named block where the content for the table body (`<tbody>`) is rendered.<br />
-    It yields these internal properties:
+    This is a named block where the content for the table body (`<tbody>`) is rendered.
     <Doc::ComponentApi as |C|>
-      <C.Property @name="B.sortBy" @type="yielded value">
+      <C.Property @name="[B].sortBy" @type="string">
         The value of the internal `sortBy` tracked variable.
       </C.Property>
-      <C.Property @name="B.sortOrder" @type="yielded value">
+      <C.Property @name="[B].sortOrder" @type="string">
         The value of the internal `sortOrder` tracked variable.
       </C.Property>
     </Doc::ComponentApi>

--- a/website/docs/components/tabs/partials/code/component-api.md
+++ b/website/docs/components/tabs/partials/code/component-api.md
@@ -41,7 +41,7 @@ The Tabs component is composed of different parts, with their own APIs:
     Customizes the initial tab to display when the page is loaded. The first tab is selected on page load by default.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside a `button` element.
+    Elements passed as children are yielded as inner content of a `<button>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -52,7 +52,7 @@ The Tabs component is composed of different parts, with their own APIs:
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">
-    Elements passed as children of this component are yielded inside a `section` element.
+    Elements passed as children are yielded as inner content of a `<section>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/tabs/partials/code/component-api.md
+++ b/website/docs/components/tabs/partials/code/component-api.md
@@ -1,14 +1,14 @@
 ## Component API
 
-The Tabs component is composed of different parts, with their own APIs:
-
-- `Tabs` container
-- `Tab` child components
-- `Panel` child components corresponding to each Tab
-
-### Tabs API
+### Tabs
 
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<[T].Tab>" @type="yielded component">
+    `Tabs::Tab` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[T].Panel>" @type="yielded component">
+    `Tabs::Panel` yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="size" @type="enum" @values={{array "medium" "large" }} @default="medium">
     Sets the size of the `Tabs`.
   </C.Property>
@@ -28,7 +28,11 @@ The Tabs component is composed of different parts, with their own APIs:
   </C.Property>
 </Doc::ComponentApi>
 
-### Tabs::Tab API
+### Contextual components
+
+#### [T].Tab
+
+The `Tabs::Tab` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="icon">
@@ -48,7 +52,9 @@ The Tabs component is composed of different parts, with their own APIs:
   </C.Property>
 </Doc::ComponentApi>
 
-### Tabs::Panel API
+#### [T].Panel
+
+The `Tabs::Panel` component, yielded as contextual component.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">

--- a/website/docs/components/tag/partials/code/component-api.md
+++ b/website/docs/components/tag/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### Tag
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary">
     Sets the color of a link when `@route` or `@href` are set.

--- a/website/docs/components/text/partials/code/component-api.md
+++ b/website/docs/components/text/partials/code/component-api.md
@@ -27,7 +27,7 @@ The `Text` component is used through these specialized variants: `Hds::Text::Dis
     The color of the text expressed as one of the possible [foreground color](/foundations/colors?tab=palette#foreground-1) names. As a fallback solution to handle special cases, a valid CSS color string (hex, rgb, rgba, etc.) is also accepted (in this case the color will be applied via an inline style). If no `@color` argument is provided, the component will inherit its color from the parent container/context.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<[@tag]>` HTML element.
+    Elements passed as children are yielded as inner content of a `<[@tag]>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -53,7 +53,7 @@ The `Text` component is used through these specialized variants: `Hds::Text::Dis
     The color of the text expressed as one of the possible [foreground color](/foundations/colors?tab=palette#foreground-1) names. As a fallback solution to handle special cases, a valid CSS color string (hex, rgb, rgba, etc.) is also accepted (in this case the color will be applied via an inline style). If no `@color` argument is provided, the component will inherit its color from the parent container/context.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<[@tag]>` HTML element.
+    Elements passed as children are yielded as inner content of a `<[@tag]>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -79,7 +79,7 @@ The `Text` component is used through these specialized variants: `Hds::Text::Dis
     The color of the text expressed as one of the possible [foreground color](/foundations/colors?tab=palette#foreground-1) names. As a fallback solution to handle special cases, a valid CSS color string (hex, rgb, rgba, etc.) is also accepted (in this case the color will be applied via an inline style). If no `@color` argument is provided, the component will inherit its color from the parent container/context.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded as inner content of the `<[@tag]>` HTML element.
+    Elements passed as children are yielded as inner content of a `<[@tag]>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/text/partials/code/component-api.md
+++ b/website/docs/components/text/partials/code/component-api.md
@@ -27,7 +27,7 @@ The `Text` component is used through these specialized variants: `Hds::Text::Dis
     The color of the text expressed as one of the possible [foreground color](/foundations/colors?tab=palette#foreground-1) names. As a fallback solution to handle special cases, a valid CSS color string (hex, rgb, rgba, etc.) is also accepted (in this case the color will be applied via an inline style). If no `@color` argument is provided, the component will inherit its color from the parent container/context.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded to the content of the `<@tag>` HTML element.
+    Elements passed as children are yielded as inner content of the `<[@tag]>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -53,7 +53,7 @@ The `Text` component is used through these specialized variants: `Hds::Text::Dis
     The color of the text expressed as one of the possible [foreground color](/foundations/colors?tab=palette#foreground-1) names. As a fallback solution to handle special cases, a valid CSS color string (hex, rgb, rgba, etc.) is also accepted (in this case the color will be applied via an inline style). If no `@color` argument is provided, the component will inherit its color from the parent container/context.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded to the content of the `<@tag>` HTML element.
+    Elements passed as children are yielded as inner content of the `<[@tag]>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -79,7 +79,7 @@ The `Text` component is used through these specialized variants: `Hds::Text::Dis
     The color of the text expressed as one of the possible [foreground color](/foundations/colors?tab=palette#foreground-1) names. As a fallback solution to handle special cases, a valid CSS color string (hex, rgb, rgba, etc.) is also accepted (in this case the color will be applied via an inline style). If no `@color` argument is provided, the component will inherit its color from the parent container/context.
   </C.Property>
   <C.Property @name="yield">
-    Elements passed as children are yielded to the content of the `<@tag>` HTML element.
+    Elements passed as children are yielded as inner content of the `<[@tag]>` HTML element.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/layouts/app-frame/partials/code/component-api.md
+++ b/website/docs/layouts/app-frame/partials/code/component-api.md
@@ -1,6 +1,23 @@
 ## Component API
 
+### AppFrame
+
 <Doc::ComponentApi as |C|>
+  <C.Property @name="<[AF].Header>" @type="yielded component">
+    `AppFrame::Header` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[AF].Sidebar>" @type="yielded component">
+    `AppFrame::Sidebar` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[AF].Main>" @type="yielded component">
+    `AppFrame::Main` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[AF].Footer>" @type="yielded component">
+    `AppFrame::Footer` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[AF].Modals>" @type="yielded component">
+    `AppFrame::Modals` yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="hasHeader" @type="boolean" @default="true">
     Controls the rendering of the `header` container.
   </C.Property>
@@ -20,34 +37,77 @@
 
 ### Contextual components
 
-The frame's elements acting as containers are passed into the `AppFrame` as yielded components, using the `Header`, `Sidebar`, `Main`, `Footer`, and `Modals` keys.
+#### [AF].Header
+
+The `AppFrame::Header` component, yielded as contextual component.
+
+To be used as container for the application's top navigation.
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[Frame].Header>" @type="yielded component">
-    Optional container that yields its content inside the `<header>` element.<br/><br/>This sub-component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of an `<header>` HTML element.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>
 
+#### [AF].Sidebar
+
+The `AppFrame::Sidebar` component, yielded as contextual component.
+
+To be used as container for the application's sidebar navigation.
+
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[Frame].Sidebar>" @type="yielded component">
-    Optional container that yields its content inside the `<aside>` element.<br/><br/>This sub-component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of an `<aside>` HTML element.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>
 
+#### [AF].Main
+
+The `AppFrame::Main` component, yielded as contextual component.
+
+To be used as container for the application's main page content.
+
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[Frame].Main>" @type="yielded component">
-    Required container that yields its content inside the `<main>` element.<br/><br/>This sub-component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of a `<main>` HTML element.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>
 
+#### [AF].Footer
+
+The `AppFrame::Footer` component, yielded as contextual component.
+
+To be used as container for the application's footer.
+
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[Frame].Footer>" @type="yielded component">
-    Required container that yields its content inside the `<footer>` element.<br/><br/>This sub-component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of a `<footer>` HTML element.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>
 
+#### [AF].Modals
+
+The `AppFrame::Modals` component, yielded as contextual component.
+
+To be used as container for modal elements.
+
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[Frame].Modals>" @type="yielded component">
-    Required container that yields its content inside a special `<div>` element that can be used to contain modal elements.<br/><br/>This sub-component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of a `<div>` HTML element.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/utilities/disclosure-primitive/partials/code/component-api.md
+++ b/website/docs/utilities/disclosure-primitive/partials/code/component-api.md
@@ -3,18 +3,22 @@
 <Doc::ComponentApi as |C|>
   <C.Property @name="<:toggle>" @type="named block">
     A named block that works as "toggle" for the DisclosurePrimitive.
-  </C.Property>
-  <C.Property @name="[:toggle].onClickToggle" @type="event handler">
-    A function to be called by the interactive element to toggle visibility of the content.
-  </C.Property>
-  <C.Property @name="[:toggle].isOpen" @type="tracked property">
-    Hook into this tracked property to access the state of `isOpen`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="[T].onClickToggle" @type="function">
+        A function to be called by the interactive element to toggle visibility of the content.
+      </C.Property>
+      <C.Property @name="[T].isOpen" @type="boolead">
+        Hook into this property to access the state of the internal `isOpen` tracked variable.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="<:content>" @type="named block">
     A named block for the content that is shown/hidden upon toggling.
-  </C.Property>
-  <C.Property @name="[:content].close" @type="function">
-    A function to programmatically close the DisclosurePrimitive.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="[C].close" @type="function">
+        A function to programmatically close the DisclosurePrimitive.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="isOpen" @default="false" @type="boolean">
     Toggles the visibility of the content when the toggle button is interacted with. To display content on page load, set the value to true.

--- a/website/docs/utilities/dismiss-button/partials/code/component-api.md
+++ b/website/docs/utilities/dismiss-button/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### DismissButton
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="ariaLabel" @type="string" @default="dismiss">
     Accepts a localized string.

--- a/website/docs/utilities/interactive/partials/code/component-api.md
+++ b/website/docs/utilities/interactive/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### Interactive
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.

--- a/website/docs/utilities/menu-primitive/partials/code/component-api.md
+++ b/website/docs/utilities/menu-primitive/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### MenuPrimitive
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="<:toggle>" @type="named block">
     A named block that works as "toggle" for the MenuPrimitive.

--- a/website/docs/utilities/menu-primitive/partials/code/component-api.md
+++ b/website/docs/utilities/menu-primitive/partials/code/component-api.md
@@ -3,18 +3,22 @@
 <Doc::ComponentApi as |C|>
   <C.Property @name="<:toggle>" @type="named block">
     A named block that works as "toggle" for the MenuPrimitive.
-  </C.Property>
-  <C.Property @name="[:toggle].onClickToggle" @type="event handler">
-    A function to be called by the interactive element to toggle visibility of the content.
-  </C.Property>
-  <C.Property @name="[:toggle].isOpen" @type="tracked property">
-    Hook into this tracked property to access the state of `isOpen`.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="[T].onClickToggle" @type="function">
+        A function to be called by the interactive element to toggle visibility of the content.
+      </C.Property>
+      <C.Property @name="[T].isOpen" @type="boolean">
+        Hook into this tracked property to access the state of `isOpen`.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="<:content>" @type="named block">
     A named block for the content that is shown/hidden upon toggling.
-  </C.Property>
-  <C.Property @name="[:content].close" @type="function">
-    A function to programmatically close the MenuPrimitive.
+    <Doc::ComponentApi as |C|>
+      <C.Property @name="[C].close" @type="function">
+        A function to programmatically close the MenuPrimitive.
+      </C.Property>
+    </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="onClose" @type="function">
     A callback function invoked when the MenuPrimitive is closed (if provided).

--- a/website/docs/utilities/popover-primitive/partials/code/component-api.md
+++ b/website/docs/utilities/popover-primitive/partials/code/component-api.md
@@ -1,5 +1,7 @@
 ## Component API
 
+### PopoverPrimitive
+
 <Doc::ComponentApi as |C|>
   <C.Property @name="isOpen" @type="boolean" @default="false" @values={{array "true" "false"}}>
     Controls if the popover should be rendered initially opened.


### PR DESCRIPTION
### :pushpin: Summary

This is an attempt to bring some standardization (and in the process improvement where necessary) on how we document 
- named blocks
- yielded content
- contextual component

This attempt has been sparkled by @MelSumner (see [thread here](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1720461683681729)) in the context of #1945 (see [preview here](https://hds-website-git-dialog-primitive-non-breaking-58ad01-hashicorp.vercel.app/components/flyout?tab=code#contextual-components))

### :hammer_and_wrench: Detailed description

In this PR I have extensively changed/reworked the documentation in the "Component API" blocks for a lot of components (see list below). I haven't touched yet the form-related components (I'll do it once we converge/decide if the format proposed in this PR is OK)

### 👀 Previews:

- 👉 [Accordion](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/accordion?tab=code#component-api)
- 👉 [Alert](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/alert?tab=code#component-api)
- 👉 [App Footer](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/app-footer?tab=code#component-api)
- 👉 [Application State](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/application-state?tab=code#component-api)
- 👉 [Code Block](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/code-block?tab=code#component-api)
- 👉 [Dropdown](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/dropdown?tab=code#component-api)
- 👉 [Flyout](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/flyout?tab=code#component-api)
- 👉 [Modal](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/modal?tab=code#component-api)
- 👉 [Page Header](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/page-header?tab=code#component-api)
- 👉 [Rich Tooltip](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/rich-tooltip?tab=code#component-api)
- 👉 [Segmented Group](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/segmented-group?tab=code#component-api)
- 👉 [Separator](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/separator?tab=code#component-api)
- 👉 [Side Nav](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/side-nav?tab=code#component-api)
- 👉 [Tabs](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/components/tabs?tab=code#component-api)
- 👉 [AppFrame](https://hds-website-git-website-documentation-contextu-7c291f-hashicorp.vercel.app/layouts/app-frame?tab=code#component-api)

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3549

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
