### PR TITLE
Replace details/summary in website side nav with button and list

### DIFF
--- a/website/app/components/doc/table-of-contents/collapsible-item.hbs
+++ b/website/app/components/doc/table-of-contents/collapsible-item.hbs
@@ -1,12 +1,12 @@
 <div class="doc-table-of-contents__folder">
   <button
     type="button"
-    aria-controls={{this.contentId}}
+    aria-controls={{if this.isOpen this.contentId: ""}}
     aria-expanded={{this.isOpen}}
-    class="doc-table-of-contents__button {{if this.isOpen 'open'}}"
+    class={{this.classNames}}
     {{on "click" this.toggleIsOpen}}
   >{{@name}}</button>
   {{#if this.isOpen}}
-    <Doc::TableOfContents @structuredPageTree={{@item.children}} @depth={{add @depth 1}} id={{this.contentId}} />
+    <Doc::TableOfContents @structuredPageTree={{@item.children}} @depth={{@depth}} id={{this.contentId}} />
   {{/if}}
 </div>

--- a/website/app/components/doc/table-of-contents/collapsible-item.hbs
+++ b/website/app/components/doc/table-of-contents/collapsible-item.hbs
@@ -2,7 +2,7 @@
   <button
     type="button"
     aria-expanded={{this.isOpen}}
-    class="doc-table-of-contents__summary {{if this.isOpen 'open'}}"
+    class="doc-table-of-contents__button {{if this.isOpen 'open'}}"
     {{on "click" this.toggleIsOpen}}
   >{{@name}}</button>
   {{#if this.isOpen}}

--- a/website/app/components/doc/table-of-contents/collapsible-item.hbs
+++ b/website/app/components/doc/table-of-contents/collapsible-item.hbs
@@ -1,15 +1,12 @@
-<Hds::DisclosurePrimitive class="doc-table-of-contents__folder" @isOpen={{@item.isOpen}}>
-  <:toggle as |t|>
-    <button
-      type="button"
-      aria-controls={{this.contentId}}
-      aria-expanded={{if t.isOpen "true" "false"}}
-      class="doc-table-of-contents__button {{if t.isOpen 'open'}}"
-      {{on "click" t.onClickToggle}}
-    >{{@name}}</button>
-  </:toggle>
-
-  <:content>
-    <Doc::TableOfContents id={{this.contentId}} @structuredPageTree={{@item.children}} @depth={{add @depth 1}} />
-  </:content>
-</Hds::DisclosurePrimitive>
+<div class="doc-table-of-contents__folder">
+  <button
+    type="button"
+    aria-controls={{this.contentId}}
+    aria-expanded={{this.isOpen}}
+    class="doc-table-of-contents__button {{if this.isOpen 'open'}}"
+    {{on "click" this.toggleIsOpen}}
+  >{{@name}}</button>
+  {{#if this.isOpen}}
+    <Doc::TableOfContents @structuredPageTree={{@item.children}} @depth={{add @depth 1}} id={{this.contentId}} />
+  {{/if}}
+</div>

--- a/website/app/components/doc/table-of-contents/collapsible-item.hbs
+++ b/website/app/components/doc/table-of-contents/collapsible-item.hbs
@@ -1,0 +1,11 @@
+<div class="doc-table-of-contents__folder">
+  <button
+    type="button"
+    aria-expanded={{this.isOpen}}
+    class="doc-table-of-contents__summary {{if this.isOpen 'open'}}"
+    {{on "click" this.toggleIsOpen}}
+  >{{@name}}</button>
+  {{#if this.isOpen}}
+    <Doc::TableOfContents @structuredPageTree={{@item.children}} @depth={{add @depth 1}} />
+  {{/if}}
+</div>

--- a/website/app/components/doc/table-of-contents/collapsible-item.hbs
+++ b/website/app/components/doc/table-of-contents/collapsible-item.hbs
@@ -1,11 +1,15 @@
-<div class="doc-table-of-contents__folder">
-  <button
-    type="button"
-    aria-expanded={{this.isOpen}}
-    class="doc-table-of-contents__button {{if this.isOpen 'open'}}"
-    {{on "click" this.toggleIsOpen}}
-  >{{@name}}</button>
-  {{#if this.isOpen}}
-    <Doc::TableOfContents @structuredPageTree={{@item.children}} @depth={{add @depth 1}} />
-  {{/if}}
-</div>
+<Hds::DisclosurePrimitive class="doc-table-of-contents__folder" @isOpen={{@item.isOpen}}>
+  <:toggle as |t|>
+    <button
+      type="button"
+      aria-controls={{this.contentId}}
+      aria-expanded={{if t.isOpen "true" "false"}}
+      class="doc-table-of-contents__button {{if t.isOpen 'open'}}"
+      {{on "click" t.onClickToggle}}
+    >{{@name}}</button>
+  </:toggle>
+
+  <:content>
+    <Doc::TableOfContents id={{this.contentId}} @structuredPageTree={{@item.children}} @depth={{add @depth 1}} />
+  </:content>
+</Hds::DisclosurePrimitive>

--- a/website/app/components/doc/table-of-contents/collapsible-item.hbs
+++ b/website/app/components/doc/table-of-contents/collapsible-item.hbs
@@ -2,7 +2,7 @@
   <button
     type="button"
     aria-controls={{if this.isOpen this.contentId: ""}}
-    aria-expanded={{this.isOpen}}
+    aria-expanded={{if this.isOpen "true" "false"}}
     class={{this.classNames}}
     {{on "click" this.toggleIsOpen}}
   >{{@name}}</button>

--- a/website/app/components/doc/table-of-contents/collapsible-item.js
+++ b/website/app/components/doc/table-of-contents/collapsible-item.js
@@ -5,6 +5,21 @@
 
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 export default class HdsRevealComponent extends Component {
+  @tracked isOpen = this.args.item.isOpen;
+  @action toggleIsOpen() {
+    this.isOpen = !this.isOpen;
+  }
+
   contentId = 'content-' + guidFor(this);
+
+  get classNames() {
+    const classes = ['doc-table-of-contents__button'];
+    if (this.isOpen) {
+      classes.push('open');
+    }
+    return classes.join(' ');
+  }
 }

--- a/website/app/components/doc/table-of-contents/collapsible-item.js
+++ b/website/app/components/doc/table-of-contents/collapsible-item.js
@@ -4,12 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
-
-export default class DocTableOfContentsCollapsibleItemComponent extends Component {
-  @tracked isOpen = this.args.item.isOpen;
-  @action toggleIsOpen() {
-    this.isOpen = !this.isOpen;
-  }
+import { guidFor } from '@ember/object/internals';
+export default class HdsRevealComponent extends Component {
+  contentId = 'content-' + guidFor(this);
 }

--- a/website/app/components/doc/table-of-contents/collapsible-item.js
+++ b/website/app/components/doc/table-of-contents/collapsible-item.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class DocTableOfContentsCollapsibleItemComponent extends Component {
+  @tracked isOpen = this.args.item.isOpen;
+  @action toggleIsOpen() {
+    this.isOpen = !this.isOpen;
+  }
+}

--- a/website/app/components/doc/table-of-contents/collapsible-item.js
+++ b/website/app/components/doc/table-of-contents/collapsible-item.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-export default class HdsRevealComponent extends Component {
+export default class DocTocCollapsibleItemComponent extends Component {
   @tracked isOpen = this.args.item.isOpen;
   @action toggleIsOpen() {
     this.isOpen = !this.isOpen;
@@ -18,7 +18,7 @@ export default class HdsRevealComponent extends Component {
   get classNames() {
     const classes = ['doc-table-of-contents__button'];
     if (this.isOpen) {
-      classes.push('open');
+      classes.push('doc-table-of-contents__button--open');
     }
     return classes.join(' ');
   }

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -5,7 +5,7 @@
 
 {{! template-lint-configure no-inline-styles {"allowDynamicStyles": true} }}
 
-<ul class="doc-table-of-contents" role="list">
+<ul class="doc-table-of-contents" role="list" ...attributes>
   {{#each-in @structuredPageTree as |key item|}}
     <li class="doc-table-of-contents__item doc-table-of-contents__item--depth-{{@depth}}">
       {{#if item.pageURL}}

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -32,10 +32,7 @@
           <div class="doc-table-of-contents__heading">{{humanize key}}</div>
           <Doc::TableOfContents @structuredPageTree={{item}} @depth={{add @depth 1}} />
         {{else}}
-          <details class="doc-table-of-contents__folder" open={{item.isOpen}}>
-            <summary class="doc-table-of-contents__summary">{{humanize key}}</summary>
-            <Doc::TableOfContents @structuredPageTree={{item.children}} @depth={{add @depth 1}} />
-          </details>
+          <Doc::TableOfContents::CollapsibleItem @item={{item}} @depth={{add @depth 1}} @name={{humanize key}} />
         {{/if}}
       {{/if}}
     </li>

--- a/website/app/styles/doc-components/table-of-contents.scss
+++ b/website/app/styles/doc-components/table-of-contents.scss
@@ -57,7 +57,7 @@ $doc-toc-item-inset: 8px;
     display: none;
   }
 
-  &.open {
+  &.doc-table-of-contents__button--open {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='%23727374' fill-rule='evenodd' d='M3.235 5.205a.75.75 0 011.06.03L8 9.158l3.705-3.923a.75.75 0 011.09 1.03l-4.25 4.5a.75.75 0 01-1.09 0l-4.25-4.5a.75.75 0 01.03-1.06z' clip-rule='evenodd'/%3E%3C/svg%3E");
   }
 }

--- a/website/app/styles/doc-components/table-of-contents.scss
+++ b/website/app/styles/doc-components/table-of-contents.scss
@@ -57,8 +57,7 @@ $doc-toc-item-inset: 8px;
     display: none;
   }
 
-  // it's using a `<detail>` HMTL tag
-  [open] > & {
+  &.open {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='%23727374' fill-rule='evenodd' d='M3.235 5.205a.75.75 0 011.06.03L8 9.158l3.705-3.923a.75.75 0 011.09 1.03l-4.25 4.5a.75.75 0 01-1.09 0l-4.25-4.5a.75.75 0 01.03-1.06z' clip-rule='evenodd'/%3E%3C/svg%3E");
   }
 }

--- a/website/app/styles/doc-components/table-of-contents.scss
+++ b/website/app/styles/doc-components/table-of-contents.scss
@@ -38,7 +38,7 @@ $doc-toc-item-inset: 8px;
   padding: 0 $doc-toc-item-inset 12px $doc-toc-item-inset;
 }
 
-.doc-table-of-contents__summary {
+.doc-table-of-contents__button {
   @include doc-font-style-navigation();
   display: block;
   width: 100%;

--- a/website/tests/acceptance/sidebar-test.js
+++ b/website/tests/acceptance/sidebar-test.js
@@ -86,8 +86,40 @@ module('Acceptance | Sidebar filter', function (hooks) {
     await visit('/components');
 
     assert.dom('.doc-table-of-contents__folder').exists({ count: 3 });
+    assert.dom('.doc-table-of-contents__button').exists({ count: 3 });
+    assert
+      .dom('.doc-table-of-contents__button')
+      .hasAttribute('aria-expanded', 'false');
 
-    await click('.doc-table-of-contents__folder');
+    assert
+      .dom('.doc-table-of-contents__button.doc-table-of-contents__button--open')
+      .exists({ count: 0 });
+
+    assert
+      .dom(
+        '.doc-page-sidebar__table-of-contents a[href="/components/copy/button"]'
+      )
+      .exists({ count: 0 });
+
+    await click('.doc-table-of-contents__button');
+    assert
+      .dom('.doc-table-of-contents__button')
+      .hasAttribute('aria-expanded', 'true');
+    assert
+      .dom(
+        '.doc-page-sidebar__table-of-contents a[href="/components/copy/button"]'
+      )
+      .exists();
+
+    await click('.doc-table-of-contents__button');
+    assert
+      .dom('.doc-table-of-contents__button')
+      .hasAttribute('aria-expanded', 'false');
+    assert
+      .dom(
+        '.doc-page-sidebar__table-of-contents a[href="/components/copy/button"]'
+      )
+      .exists({ count: 0 });
   });
 
   // QUERY PARAMS
@@ -102,7 +134,12 @@ module('Acceptance | Sidebar filter', function (hooks) {
   test('the "folder" container of the "current route" link should be opened by default', async function (assert) {
     await visit('/components/form/radio-card');
     assert
-      .dom('.doc-table-of-content__button.doc-table-of-contents__button--open')
+      .dom('.doc-table-of-contents__button.doc-table-of-contents__button--open')
       .exists({ count: 1 });
+    assert
+      .dom(
+        '.doc-page-sidebar__table-of-contents a[href="/components/form/radio-card"]'
+      )
+      .exists();
   });
 });

--- a/website/tests/acceptance/sidebar-test.js
+++ b/website/tests/acceptance/sidebar-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { fillIn, visit } from '@ember/test-helpers';
+import { fillIn, visit, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 
 module('Acceptance | Sidebar filter', function (hooks) {
@@ -29,15 +29,19 @@ module('Acceptance | Sidebar filter', function (hooks) {
 
   test('should show the "Checkbox" link in the sidebar (under an opened parent container) if filtering using its "page title" (case insensitive)', async function (assert) {
     await visit('/components');
-    let link = this.element.querySelector(
-      '.doc-page-sidebar__table-of-contents a[href="/components/form/checkbox"]'
-    );
-    assert.dom(link).exists();
-    assert.dom('.doc-table-of-contents__folder[open]').exists({ count: 0 });
+    assert
+      .dom(
+        '.doc-page-sidebar__table-of-contents a[href="/components/form/checkbox"]'
+      )
+      .exists({ count: 0 });
+    assert.dom('.doc-table-of-contents__summary.open').exists({ count: 0 });
     await fillIn('.doc-page-sidebar__filter input[type="search"]', 'ChEcKbOx');
-    assert.dom(link).exists();
-    // notice: we can't use `.hasAttribute('open')` here because it returns always false
-    assert.dom('.doc-table-of-contents__folder[open]').exists({ count: 1 });
+    assert
+      .dom(
+        '.doc-page-sidebar__table-of-contents a[href="/components/form/checkbox"]'
+      )
+      .exists();
+    assert.dom('.doc-table-of-contents__summary.open').exists({ count: 1 });
   });
 
   test('should still show the filter input after filtering', async function (assert) {
@@ -74,15 +78,23 @@ module('Acceptance | Sidebar filter', function (hooks) {
       .exists();
   });
 
+  test('should expand subsection when click a parent container', async function (assert) {
+    await visit('/components');
+
+    assert.dom('.doc-table-of-contents__folder').exists({ count: 3 });
+
+    await click('.doc-table-of-contents__folder');
+  });
+
   // QUERY PARAMS
 
   test('all "folder" containers should be closed by default if the "current route" link is not inside any of them', async function (assert) {
     await visit('/components/alert');
-    assert.dom('.doc-table-of-contents__folder[open]').exists({ count: 0 });
+    assert.dom('.doc-table-of-contents__summary.open').exists({ count: 0 });
   });
 
   test('the "folder" container of the "current route" link should be opened by default', async function (assert) {
     await visit('/components/form/radio-card');
-    assert.dom('.doc-table-of-contents__folder[open]').exists({ count: 1 });
+    assert.dom('.doc-table-of-contents__summary.open').exists({ count: 1 });
   });
 });

--- a/website/tests/acceptance/sidebar-test.js
+++ b/website/tests/acceptance/sidebar-test.js
@@ -34,14 +34,18 @@ module('Acceptance | Sidebar filter', function (hooks) {
         '.doc-page-sidebar__table-of-contents a[href="/components/form/checkbox"]'
       )
       .exists({ count: 0 });
-    assert.dom('.doc-table-of-contents__summary.open').exists({ count: 0 });
+    assert
+      .dom('.doc-table-of-contents__button.doc-table-of-contents__button--open')
+      .exists({ count: 0 });
     await fillIn('.doc-page-sidebar__filter input[type="search"]', 'ChEcKbOx');
     assert
       .dom(
         '.doc-page-sidebar__table-of-contents a[href="/components/form/checkbox"]'
       )
       .exists();
-    assert.dom('.doc-table-of-contents__summary.open').exists({ count: 1 });
+    assert
+      .dom('.doc-table-of-contents__button.doc-table-of-contents__button--open')
+      .exists({ count: 1 });
   });
 
   test('should still show the filter input after filtering', async function (assert) {
@@ -90,11 +94,15 @@ module('Acceptance | Sidebar filter', function (hooks) {
 
   test('all "folder" containers should be closed by default if the "current route" link is not inside any of them', async function (assert) {
     await visit('/components/alert');
-    assert.dom('.doc-table-of-contents__summary.open').exists({ count: 0 });
+    assert
+      .dom('.doc-table-of-contents__button.doc-table-of-contents__button--open')
+      .exists({ count: 0 });
   });
 
   test('the "folder" container of the "current route" link should be opened by default', async function (assert) {
     await visit('/components/form/radio-card');
-    assert.dom('.doc-table-of-contents__summary.open').exists({ count: 1 });
+    assert
+      .dom('.doc-table-of-content__button.doc-table-of-contents__button--open')
+      .exists({ count: 1 });
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

This  PR replaces the `<detail>` and `<summary>` elements that handle the collapsible sections in the website side navigation with `<button>`s that show and hide a `<ul>`. 

REMAINING WORK:
- [x]  make the tests for the new component 
- [x]  should I rename the class `.doc-table-of-contents__summary` to be `.doc-table-of-contents__button` now that it is no longer on a summary element?

### :hammer_and_wrench: Detailed description

To do this, I added a new component `<Doc::TableOfContents::CollapsibleItem>`.

Other changes I made for this work were:
- Updating the CSS to not use the open property of the <detail> for styling and instead use a class
- Updating the existing tests in the side bar navigation test file to match the new markup + add tests for the new component.

### :camera_flash: Screenshots
 Nothing visually changed, but here is the markup before:
![Screenshot 2024-07-12 at 6 09 15 PM](https://github.com/user-attachments/assets/35194e45-516a-40cf-94d3-3dde1c29afc1)

and here is the markup after:
![Screenshot 2024-07-12 at 6 09 33 PM](https://github.com/user-attachments/assets/93b332c5-35e6-4f9e-ad67-5603f6691a1d)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-1308](https://hashicorp.atlassian.net/browse/HDS-1308)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-1308]: https://hashicorp.atlassian.net/browse/HDS-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ