### PR TITLE
Update aliases for `<Hds::Dropdown>` and `<Hds::SegmentedGroup>` 

### DIFF
--- a/showcase/app/templates/components/app-footer.hbs
+++ b/showcase/app/templates/components/app-footer.hbs
@@ -78,11 +78,11 @@
       <SF.Item @label="With theme selector as Extra Content Before">
         <Hds::AppFooter as |AF|>
           <AF.ExtraBefore>
-            <Hds::Dropdown as |dd|>
-              <dd.ToggleButton @text="Theme" @color="secondary" @size="small" />
-              <dd.Interactive @icon="monitor" {{on "click" dd.close}} @text="System" />
-              <dd.Interactive @icon="moon" {{on "click" dd.close}} @text="Dark" />
-              <dd.Interactive @icon="sun" {{on "click" dd.close}} @text="Light" />
+            <Hds::Dropdown as |D|>
+              <D.ToggleButton @text="Theme" @color="secondary" @size="small" />
+              <D.Interactive @icon="monitor" {{on "click" D.close}} @text="System" />
+              <D.Interactive @icon="moon" {{on "click" D.close}} @text="Dark" />
+              <D.Interactive @icon="sun" {{on "click" D.close}} @text="Light" />
             </Hds::Dropdown>
           </AF.ExtraBefore>
           <AF.StatusLink @status="operational" />

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -13,31 +13,31 @@
 
   <Shw::Flex as |SF|>
     <SF.Item @label="Bottom left">
-      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
-        <dd.ToggleButton @color="secondary" @text="Menu" />
-        <dd.Interactive @href="#" @text="Create" />
-        <dd.Interactive @href="#" @text="Edit" />
+      <Hds::Dropdown @listPosition="bottom-left" as |D|>
+        <D.ToggleButton @color="secondary" @text="Menu" />
+        <D.Interactive @href="#" @text="Create" />
+        <D.Interactive @href="#" @text="Edit" />
       </Hds::Dropdown>
     </SF.Item>
     <SF.Item @label="Bottom right (default)">
-      <Hds::Dropdown as |dd|>
-        <dd.ToggleButton @color="secondary" @text="Menu" />
-        <dd.Interactive @href="#" @text="Create" />
-        <dd.Interactive @href="#" @text="Edit" />
+      <Hds::Dropdown as |D|>
+        <D.ToggleButton @color="secondary" @text="Menu" />
+        <D.Interactive @href="#" @text="Create" />
+        <D.Interactive @href="#" @text="Edit" />
       </Hds::Dropdown>
     </SF.Item>
     <SF.Item @label="Top left">
-      <Hds::Dropdown @listPosition="top-left" as |dd|>
-        <dd.ToggleButton @color="secondary" @text="Menu" />
-        <dd.Interactive @href="#" @text="Create" />
-        <dd.Interactive @href="#" @text="Edit" />
+      <Hds::Dropdown @listPosition="top-left" as |D|>
+        <D.ToggleButton @color="secondary" @text="Menu" />
+        <D.Interactive @href="#" @text="Create" />
+        <D.Interactive @href="#" @text="Edit" />
       </Hds::Dropdown>
     </SF.Item>
     <SF.Item @label="Top right">
-      <Hds::Dropdown @listPosition="top-right" as |dd|>
-        <dd.ToggleButton @color="secondary" @text="Menu" />
-        <dd.Interactive @href="#" @text="Create" />
-        <dd.Interactive @href="#" @text="Edit" />
+      <Hds::Dropdown @listPosition="top-right" as |D|>
+        <D.ToggleButton @color="secondary" @text="Menu" />
+        <D.Interactive @href="#" @text="Create" />
+        <D.Interactive @href="#" @text="Edit" />
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
@@ -47,19 +47,19 @@
   <Shw::Flex as |SF|>
     <SF.Item @label="Block">
       <div class="shw-component-dropdown-display-sample">
-        <Hds::Dropdown @listPosition="bottom-left" as |dd|>
-          <dd.ToggleButton @color="secondary" @text="Menu" />
-          <dd.Interactive @href="#" @text="Create" />
-          <dd.Interactive @href="#" @text="Edit" />
+        <Hds::Dropdown @listPosition="bottom-left" as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Interactive @href="#" @text="Create" />
+          <D.Interactive @href="#" @text="Edit" />
         </Hds::Dropdown>
       </div>
     </SF.Item>
     <SF.Item @label="Inline">
       <div class="shw-component-dropdown-display-sample">
-        <Hds::Dropdown @listPosition="bottom-left" @isInline={{true}} as |dd|>
-          <dd.ToggleButton @color="secondary" @text="Menu" />
-          <dd.Interactive @href="#" @text="Create" />
-          <dd.Interactive @href="#" @text="Edit" />
+        <Hds::Dropdown @listPosition="bottom-left" @isInline={{true}} as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Interactive @href="#" @text="Create" />
+          <D.Interactive @href="#" @text="Edit" />
         </Hds::Dropdown>
       </div>
     </SF.Item>
@@ -858,12 +858,12 @@
   </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
-      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
-        <dd.ToggleButton @text="Checkmark" @color="secondary" />
-        <dd.Checkmark @count="11">virtualbox</dd.Checkmark>
-        <dd.Checkmark @count="1" @selected={{true}}>vmware</dd.Checkmark>
-        <dd.Checkmark @count="10">docker</dd.Checkmark>
-        <dd.Checkmark @count="0">hyperv</dd.Checkmark>
+      <Hds::Dropdown @listPosition="bottom-left" as |D|>
+        <D.ToggleButton @text="Checkmark" @color="secondary" />
+        <D.Checkmark @count="11">virtualbox</D.Checkmark>
+        <D.Checkmark @count="1" @selected={{true}}>vmware</D.Checkmark>
+        <D.Checkmark @count="10">docker</D.Checkmark>
+        <D.Checkmark @count="0">hyperv</D.Checkmark>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
@@ -1016,12 +1016,12 @@
   </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
-      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
-        <dd.ToggleButton @text="Checkbox" @color="secondary" />
-        <dd.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</dd.Checkbox>
-        <dd.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</dd.Checkbox>
-        <dd.Checkbox name="checkbox-item-dropdown" @count="10">docker</dd.Checkbox>
-        <dd.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</dd.Checkbox>
+      <Hds::Dropdown @listPosition="bottom-left" as |D|>
+        <D.ToggleButton @text="Checkbox" @color="secondary" />
+        <D.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</D.Checkbox>
+        <D.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</D.Checkbox>
+        <D.Checkbox name="checkbox-item-dropdown" @count="10">docker</D.Checkbox>
+        <D.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</D.Checkbox>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
@@ -1174,12 +1174,12 @@
   </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Interactive">
-      <Hds::Dropdown @listPosition="bottom-left" as |dd|>
-        <dd.ToggleButton @text="Radio" @color="secondary" />
-        <dd.Radio name="radio-item-dropdown" @count="11">virtualbox</dd.Radio>
-        <dd.Radio name="radio-item-dropdown" @count="1" checked>vmware</dd.Radio>
-        <dd.Radio name="radio-item-dropdown" @count="10">docker</dd.Radio>
-        <dd.Radio name="radio-item-dropdown" @count="0">hyperv</dd.Radio>
+      <Hds::Dropdown @listPosition="bottom-left" as |D|>
+        <D.ToggleButton @text="Radio" @color="secondary" />
+        <D.Radio name="radio-item-dropdown" @count="11">virtualbox</D.Radio>
+        <D.Radio name="radio-item-dropdown" @count="1" checked>vmware</D.Radio>
+        <D.Radio name="radio-item-dropdown" @count="10">docker</D.Radio>
+        <D.Radio name="radio-item-dropdown" @count="0">hyperv</D.Radio>
       </Hds::Dropdown>
     </SF.Item>
   </Shw::Flex>
@@ -1418,10 +1418,10 @@
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
     <SG.Item @label="With fixed width">
       <div class="shw-component-dropdown-fixed-height-container">
-        <Hds::Dropdown @listPosition="bottom-left" @width="200px" as |dd|>
-          <dd.ToggleButton @color="secondary" @text="Menu" />
-          <dd.Interactive @href="#" @text="Lorem ipsum dolor sit amet" />
-          <dd.Interactive @href="#" @text="Consectetur adipisicing elit" />
+        <Hds::Dropdown @listPosition="bottom-left" @width="200px" as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Interactive @href="#" @text="Lorem ipsum dolor sit amet" />
+          <D.Interactive @href="#" @text="Consectetur adipisicing elit" />
         </Hds::Dropdown>
       </div>
     </SG.Item>

--- a/showcase/app/templates/components/page-header.hbs
+++ b/showcase/app/templates/components/page-header.hbs
@@ -74,11 +74,11 @@ SPDX-License-Identifier: MPL-2.0
       <Hds::PageHeader as |PH|>
         <PH.Title>Page title</PH.Title>
         <PH.Actions>
-          <Hds::Dropdown as |DD|>
-            <DD.ToggleButton @text="Manage" @color="secondary" />
-            <DD.Interactive @text="Manage cluster externally" />
-            <DD.Interactive @text="Launch desktop" />
-            <DD.Interactive @text="Delete" @color="critical" @icon="trash" />
+          <Hds::Dropdown as |D|>
+            <D.ToggleButton @text="Manage" @color="secondary" />
+            <D.Interactive @text="Manage cluster externally" />
+            <D.Interactive @text="Launch desktop" />
+            <D.Interactive @text="Delete" @color="critical" @icon="trash" />
           </Hds::Dropdown>
           <Hds::Button @text="Create" @icon="plus" @iconPosition="leading" @color="primary" />
         </PH.Actions>
@@ -184,11 +184,11 @@ SPDX-License-Identifier: MPL-2.0
         </PH.Breadcrumb>
         <PH.IconTile @icon="users" @color="terraform" />
         <PH.Actions>
-          <Hds::Dropdown as |DD|>
-            <DD.ToggleButton @text="Manage users" @color="secondary" />
-            <DD.Interactive @text="Assign roles" @icon="user" />
-            <DD.Interactive @text="Batch edit" @icon="edit" />
-            <DD.Interactive @text="Delete user" @icon="trash" />
+          <Hds::Dropdown as |D|>
+            <D.ToggleButton @text="Manage users" @color="secondary" />
+            <D.Interactive @text="Assign roles" @icon="user" />
+            <D.Interactive @text="Batch edit" @icon="edit" />
+            <D.Interactive @text="Delete user" @icon="trash" />
           </Hds::Dropdown>
           <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
         </PH.Actions>
@@ -235,11 +235,11 @@ SPDX-License-Identifier: MPL-2.0
         <PH.Title>Boundary cluster access control and clusters</PH.Title>
         <PH.IconTile @icon="boundary-color" @color="boundary" />
         <PH.Actions>
-          <Hds::Dropdown as |DD|>
-            <DD.ToggleButton @text="Manage users" @color="secondary" />
-            <DD.Interactive @text="Assign roles" @icon="user" />
-            <DD.Interactive @text="Batch edit" @icon="edit" />
-            <DD.Interactive @text="Delete user" @icon="trash" />
+          <Hds::Dropdown as |D|>
+            <D.ToggleButton @text="Manage users" @color="secondary" />
+            <D.Interactive @text="Assign roles" @icon="user" />
+            <D.Interactive @text="Batch edit" @icon="edit" />
+            <D.Interactive @text="Delete user" @icon="trash" />
           </Hds::Dropdown>
           <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
         </PH.Actions>

--- a/showcase/app/templates/components/segmented-group.hbs
+++ b/showcase/app/templates/components/segmented-group.hbs
@@ -15,13 +15,13 @@
 
   <Shw::Grid @columns={{4}} as |SG|>
     <SG.Item @label="Button only">
-      <Hds::SegmentedGroup as |S|>
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Input only">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-text-input-lone-item" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-text-input-lone-item" />
       </Hds::SegmentedGroup>
     </SG.Item>
   </Shw::Grid>
@@ -32,33 +32,33 @@
 
   <Shw::Grid @columns={{4}} as |SG|>
     <SG.Item @label="Button trailing">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-text-input-button-trailing" />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-text-input-button-trailing" />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Button leading">
-      <Hds::SegmentedGroup as |S|>
-        <S.Button @color="secondary" @text="Button" />
-        <S.TextInput aria-label="segmented-text-input-button-leading" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Button @color="secondary" @text="Button" />
+        <SGR.TextInput aria-label="segmented-text-input-button-leading" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Dropdown trailing">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-text-input-dropdown-trailing" />
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
-        </S.Dropdown>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-text-input-dropdown-trailing" />
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" />
+          <D.Interactive @href="#" @text="Dropdown Item" />
+        </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Dropdown leading">
-      <Hds::SegmentedGroup as |S|>
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
-        </S.Dropdown>
-        <S.TextInput aria-label="segmented-text-input-dropdown-leading" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" />
+          <D.Interactive @href="#" @text="Dropdown Item" />
+        </SGR.Dropdown>
+        <SGR.TextInput aria-label="segmented-text-input-dropdown-leading" />
       </Hds::SegmentedGroup>
     </SG.Item>
   </Shw::Grid>
@@ -67,45 +67,45 @@
 
   <Shw::Grid @columns={{3}} as |SG|>
     <SG.Item @label="Text">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-text-input" />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-text-input" />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Search">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput @type="search" aria-label="segmented-search-input" />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput @type="search" aria-label="segmented-search-input" />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Date">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput @type="date" aria-label="segmented-date-input" />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput @type="date" aria-label="segmented-date-input" />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Time">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput @type="time" aria-label="segmented-time-input" />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput @type="time" aria-label="segmented-time-input" />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Password">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput @type="password" aria-label="segmented-password-input" />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput @type="password" aria-label="segmented-password-input" />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Select">
-      <Hds::SegmentedGroup as |S|>
-        <S.Select aria-label="segmented-select" as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Select aria-label="segmented-select" as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
-        <S.Button @color="secondary" @text="Button" />
+          </SEL.Options>
+        </SGR.Select>
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
   </Shw::Grid>
@@ -116,102 +116,102 @@
 
   <Shw::Grid @columns={{3}} as |SG|>
     <SG.Item @label="Input, Button, Button">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-input-button-button" />
-        <S.Button @color="secondary" @text="Button" />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-input-button-button" />
+        <SGR.Button @color="secondary" @text="Button" />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Input, Button, Dropdown">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-input-button-dropdown" />
-        <S.Button @color="secondary" @text="Button" />
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Header @hasDivider={{true}}>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-input-button-dropdown" />
+        <SGR.Button @color="secondary" @text="Button" />
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" />
+          <D.Header @hasDivider={{true}}>
             <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
-          </DD.Header>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</DD.Checkbox>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</DD.Checkbox>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="10">docker</DD.Checkbox>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</DD.Checkbox>
-          <DD.Footer @hasDivider={{true}}>
+          </D.Header>
+          <D.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</D.Checkbox>
+          <D.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</D.Checkbox>
+          <D.Checkbox name="checkbox-item-dropdown" @count="10">docker</D.Checkbox>
+          <D.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</D.Checkbox>
+          <D.Footer @hasDivider={{true}}>
             <Hds::ButtonSet>
               <Hds::Button @text="Apply" @isFullWidth={{true}} @size="small" />
               <Hds::Button @text="Cancel" @color="secondary" @isFullWidth={{true}} @size="small" />
             </Hds::ButtonSet>
-          </DD.Footer>
-        </S.Dropdown>
+          </D.Footer>
+        </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Input, Dropdown, Button">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-input-dropdown-button" />
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Header @hasDivider={{true}}>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-input-dropdown-button" />
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" />
+          <D.Header @hasDivider={{true}}>
             <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
-          </DD.Header>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</DD.Checkbox>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</DD.Checkbox>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="10">docker</DD.Checkbox>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</DD.Checkbox>
-          <DD.Footer @hasDivider={{true}}>
+          </D.Header>
+          <D.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</D.Checkbox>
+          <D.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</D.Checkbox>
+          <D.Checkbox name="checkbox-item-dropdown" @count="10">docker</D.Checkbox>
+          <D.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</D.Checkbox>
+          <D.Footer @hasDivider={{true}}>
             <Hds::ButtonSet>
               <Hds::Button @text="Apply" @isFullWidth={{true}} @size="small" />
               <Hds::Button @text="Cancel" @color="secondary" @isFullWidth={{true}} @size="small" />
             </Hds::ButtonSet>
-          </DD.Footer>
-        </S.Dropdown>
-        <S.Button @color="secondary" @text="Button" />
+          </D.Footer>
+        </SGR.Dropdown>
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Input, Input, Button">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-input-input-button-1" />
-        <S.TextInput aria-label="segmented-input-input-button-2" />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-input-input-button-1" />
+        <SGR.TextInput aria-label="segmented-input-input-button-2" />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Input, Select, Button">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-input-select-button-1" />
-        <S.Select aria-label="segmented-input-select-button-2" as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-input-select-button-1" />
+        <SGR.Select aria-label="segmented-input-select-button-2" as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
-        <S.Button @color="secondary" @text="Button" />
+          </SEL.Options>
+        </SGR.Select>
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Input, Select, Dropdown">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-input-select-dropdown-1" />
-        <S.Select aria-label="segmented-input-select-dropdown-2" as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-input-select-dropdown-1" />
+        <SGR.Select aria-label="segmented-input-select-dropdown-2" as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Header @hasDivider={{true}}>
+          </SEL.Options>
+        </SGR.Select>
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" />
+          <D.Header @hasDivider={{true}}>
             <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
-          </DD.Header>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</DD.Checkbox>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</DD.Checkbox>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="10">docker</DD.Checkbox>
-          <DD.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</DD.Checkbox>
-          <DD.Footer @hasDivider={{true}}>
+          </D.Header>
+          <D.Checkbox name="checkbox-item-dropdown" @count="11">virtualbox</D.Checkbox>
+          <D.Checkbox name="checkbox-item-dropdown" @count="1" checked>vmware</D.Checkbox>
+          <D.Checkbox name="checkbox-item-dropdown" @count="10">docker</D.Checkbox>
+          <D.Checkbox name="checkbox-item-dropdown" @count="0">hyperv</D.Checkbox>
+          <D.Footer @hasDivider={{true}}>
             <Hds::ButtonSet>
               <Hds::Button @text="Apply" @isFullWidth={{true}} @size="small" />
               <Hds::Button @text="Cancel" @color="secondary" @isFullWidth={{true}} @size="small" />
             </Hds::ButtonSet>
-          </DD.Footer>
-        </S.Dropdown>
+          </D.Footer>
+        </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
   </Shw::Grid>
@@ -222,30 +222,30 @@
 
   <Shw::Grid @columns={{3}} as |SG|>
     <SG.Item @label="Trailing">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-text-input-generic-trailing" />
-        <S.Generic>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-text-input-generic-trailing" />
+        <SGR.Generic>
           <Shw::Placeholder @text="generic content" @width="160" @height="36" @background="#e1f5fe" />
-        </S.Generic>
+        </SGR.Generic>
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Leading">
-      <Hds::SegmentedGroup as |S|>
-        <S.Generic>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Generic>
           <Shw::Placeholder @text="generic content" @width="250" @height="36" @background="#e1f5fe" />
-        </S.Generic>
-        <S.Button @color="secondary" @text="Button" />
+        </SGR.Generic>
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Trailing & leading">
-      <Hds::SegmentedGroup as |S|>
-        <S.Generic>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Generic>
           <Shw::Placeholder @text="generic content" @width="125" @height="36" @background="#e1f5fe" />
-        </S.Generic>
-        <S.Button @color="secondary" @text="Button" />
-        <S.Generic>
+        </SGR.Generic>
+        <SGR.Button @color="secondary" @text="Button" />
+        <SGR.Generic>
           <Shw::Placeholder @text="generic content" @width="125" @height="36" @background="#e1f5fe" />
-        </S.Generic>
+        </SGR.Generic>
       </Hds::SegmentedGroup>
     </SG.Item>
   </Shw::Grid>
@@ -258,9 +258,9 @@
     <F.Label>This is the label</F.Label>
     <F.HelperText>This is the helper text</F.HelperText>
     <F.Control>
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput id={{F.id}} aria-describedby={{F.ariaDescribedBy}} />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput id={{F.id}} aria-describedby={{F.ariaDescribedBy}} />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </F.Control>
     <F.Error>This is the error</F.Error>
@@ -274,87 +274,87 @@
 
   <Shw::Grid @columns={{4}} as |SG|>
     <SG.Item @label="Button focused">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-text-input-trailing-button-focused" />
-        <S.Button @color="secondary" @text="Button" mock-state-value="focus" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-text-input-trailing-button-focused" />
+        <SGR.Button @color="secondary" @text="Button" mock-state-value="focus" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Dropdown focused">
-      <Hds::SegmentedGroup as |S|>
-        <S.Select aria-label="segmented-select-trailing-dropdown-focused" as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Select aria-label="segmented-select-trailing-dropdown-focused" as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" mock-state-value="focus" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
-        </S.Dropdown>
+          </SEL.Options>
+        </SGR.Select>
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" mock-state-value="focus" />
+          <D.Interactive @href="#" @text="Dropdown Item" />
+        </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Button disabled">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-text-input-trailing-button-disabled" />
-        <S.Button @color="secondary" @text="Button" disabled />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-text-input-trailing-button-disabled" />
+        <SGR.Button @color="secondary" @text="Button" disabled />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Dropdown disabled">
-      <Hds::SegmentedGroup as |S|>
-        <S.Select aria-label="segmented-text-input-trailing-dropdown-disabled" as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Select aria-label="segmented-text-input-trailing-dropdown-disabled" as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" disabled />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
-        </S.Dropdown>
+          </SEL.Options>
+        </SGR.Select>
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" disabled />
+          <D.Interactive @href="#" @text="Dropdown Item" />
+        </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Input focused">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-leading-text-input-focused" mock-state-value="focus" />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-leading-text-input-focused" mock-state-value="focus" />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Select focused">
-      <Hds::SegmentedGroup as |S|>
-        <S.Select aria-label="segmented-leading-select-focused" mock-state-value="focus" as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Select aria-label="segmented-leading-select-focused" mock-state-value="focus" as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
-        </S.Dropdown>
+          </SEL.Options>
+        </SGR.Select>
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" />
+          <D.Interactive @href="#" @text="Dropdown Item" />
+        </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Input disabled">
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput aria-label="segmented-leading-text-input-disabled" disabled />
-        <S.Button @color="secondary" @text="Button" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-leading-text-input-disabled" disabled />
+        <SGR.Button @color="secondary" @text="Button" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Select disabled">
-      <Hds::SegmentedGroup as |S|>
-        <S.Select aria-label="segmented-leading-select-disabled" disabled as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Select aria-label="segmented-leading-select-disabled" disabled as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
-        </S.Dropdown>
+          </SEL.Options>
+        </SGR.Select>
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" />
+          <D.Interactive @href="#" @text="Dropdown Item" />
+        </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
   </Shw::Grid>
@@ -365,87 +365,87 @@
 
   <Shw::Grid @columns={{4}} as |SG|>
     <SG.Item @label="Button focused">
-      <Hds::SegmentedGroup as |S|>
-        <S.Button @color="secondary" @text="Button" mock-state-value="focus" />
-        <S.TextInput aria-label="segmented-text-input-leading-button-focused" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Button @color="secondary" @text="Button" mock-state-value="focus" />
+        <SGR.TextInput aria-label="segmented-text-input-leading-button-focused" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Dropdown focused">
-      <Hds::SegmentedGroup as |S|>
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" mock-state-value="focus" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
-        </S.Dropdown>
-        <S.Select aria-label="segmented-select-leading-dropdown-focused" as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" mock-state-value="focus" />
+          <D.Interactive @href="#" @text="Dropdown Item" />
+        </SGR.Dropdown>
+        <SGR.Select aria-label="segmented-select-leading-dropdown-focused" as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
+          </SEL.Options>
+        </SGR.Select>
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Button disabled">
-      <Hds::SegmentedGroup as |S|>
-        <S.Button @color="secondary" @text="Button" disabled />
-        <S.TextInput aria-label="segmented-text-input-leading-button-disabled" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Button @color="secondary" @text="Button" disabled />
+        <SGR.TextInput aria-label="segmented-text-input-leading-button-disabled" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Dropdown disabled">
-      <Hds::SegmentedGroup as |S|>
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" disabled />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
-        </S.Dropdown>
-        <S.Select aria-label="segmented-select-leading-dropdown-disabled" as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" disabled />
+          <D.Interactive @href="#" @text="Dropdown Item" />
+        </SGR.Dropdown>
+        <SGR.Select aria-label="segmented-select-leading-dropdown-disabled" as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
+          </SEL.Options>
+        </SGR.Select>
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Input focused">
-      <Hds::SegmentedGroup as |S|>
-        <S.Button @color="secondary" @text="Button" />
-        <S.TextInput aria-label="segmented-trailing-text-input-focused" mock-state-value="focus" />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Button @color="secondary" @text="Button" />
+        <SGR.TextInput aria-label="segmented-trailing-text-input-focused" mock-state-value="focus" />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Select focused">
-      <Hds::SegmentedGroup as |S|>
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
-        </S.Dropdown>
-        <S.Select aria-label="segmented-trailing-select-focused" mock-state-value="focus" as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" />
+          <D.Interactive @href="#" @text="Dropdown Item" />
+        </SGR.Dropdown>
+        <SGR.Select aria-label="segmented-trailing-select-focused" mock-state-value="focus" as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
+          </SEL.Options>
+        </SGR.Select>
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Input disabled">
-      <Hds::SegmentedGroup as |S|>
-        <S.Button @color="secondary" @text="Button" />
-        <S.TextInput aria-label="segmented-trailing-text-input-disabled" disabled />
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Button @color="secondary" @text="Button" />
+        <SGR.TextInput aria-label="segmented-trailing-text-input-disabled" disabled />
       </Hds::SegmentedGroup>
     </SG.Item>
     <SG.Item @label="Select disabled">
-      <Hds::SegmentedGroup as |S|>
-        <S.Dropdown as |DD|>
-          <DD.ToggleButton @color="secondary" @text="Dropdown" />
-          <DD.Interactive @href="#" @text="Dropdown Item" />
-        </S.Dropdown>
-        <S.Select aria-label="segmented-trailing-select-disabled" disabled as |FS|>
-          <FS.Options>
+      <Hds::SegmentedGroup as |SGR|>
+        <SGR.Dropdown as |D|>
+          <D.ToggleButton @color="secondary" @text="Dropdown" />
+          <D.Interactive @href="#" @text="Dropdown Item" />
+        </SGR.Dropdown>
+        <SGR.Select aria-label="segmented-trailing-select-disabled" disabled as |SEL|>
+          <SEL.Options>
             <option>Select</option>
             <option>Another option</option>
             <option>Yet another one</option>
-          </FS.Options>
-        </S.Select>
+          </SEL.Options>
+        </SGR.Select>
       </Hds::SegmentedGroup>
     </SG.Item>
   </Shw::Grid>

--- a/showcase/app/templates/components/table.hbs
+++ b/showcase/app/templates/components/table.hbs
@@ -1650,9 +1650,9 @@
             </B.Td>
             <B.Td><Hds::Badge @text="Badge" /></B.Td>
             <B.Td>
-              <Hds::Dropdown as |dd|>
-                <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-                <dd.Interactive @route="components.table" @text="Dropdown" />
+              <Hds::Dropdown as |D|>
+                <D.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
+                <D.Interactive @route="components.table" @text="Dropdown" />
               </Hds::Dropdown>
             </B.Td>
             <B.Td>
@@ -1692,9 +1692,9 @@
             </B.Td>
             <B.Td><Hds::Badge @text="Badge" /></B.Td>
             <B.Td>
-              <Hds::Dropdown as |dd|>
-                <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-                <dd.Interactive @route="components.table" @text="Dropdown" />
+              <Hds::Dropdown as |D|>
+                <D.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
+                <D.Interactive @route="components.table" @text="Dropdown" />
               </Hds::Dropdown>
             </B.Td>
             <B.Td>
@@ -1734,9 +1734,9 @@
             </B.Td>
             <B.Td><Hds::Badge @text="Badge" /></B.Td>
             <B.Td>
-              <Hds::Dropdown as |dd|>
-                <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-                <dd.Interactive @route="components.table" @text="Dropdown" />
+              <Hds::Dropdown as |D|>
+                <D.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
+                <D.Interactive @route="components.table" @text="Dropdown" />
               </Hds::Dropdown>
             </B.Td>
             <B.Td>

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -20,9 +20,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
 
   test('it renders the "toggle" sub-components', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.ToggleIcon @icon="user" @text="toggle icon" id="test-toggle-icon" />
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.ToggleIcon @icon="user" @text="toggle icon" id="test-toggle-icon" />
       </Hds::Dropdown>
     `);
     assert.dom('#test-dropdown #test-toggle-button').exists();
@@ -30,15 +30,15 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
   });
   test('it renders the "list-item" sub-components', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Description @text="description" id="test-list-item-description" />
-        <dd.Generic>
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Description @text="description" id="test-list-item-description" />
+        <D.Generic>
           <div id="test-list-item-generic" />
-        </dd.Generic>
-        <dd.Interactive @route="components.dropdown" @text="interactive" id="test-list-item-interactive" />
-        <dd.Separator id="test-list-item-separator" />
-        <dd.Title @text="title" id="test-list-item-title" />
+        </D.Generic>
+        <D.Interactive @route="components.dropdown" @text="interactive" id="test-list-item-interactive" />
+        <D.Separator id="test-list-item-separator" />
+        <D.Title @text="title" id="test-list-item-title" />
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
@@ -51,10 +51,10 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
   });
   test('it renders the "header"/"footer" sub-components', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Header id="test-header">Header</dd.Header>
-        <dd.Footer id="test-footer">Footer</dd.Footer>
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Header id="test-header">Header</D.Header>
+        <D.Footer id="test-footer">Footer</D.Footer>
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
@@ -64,10 +64,10 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
 
   test('it renders the "header"/"footer" sub-components with separators', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Header @hasDivider={{true}} id="test-header">Header</dd.Header>
-        <dd.Footer @hasDivider={{true}} id="test-footer">Footer</dd.Footer>
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Header @hasDivider={{true}} id="test-header">Header</D.Header>
+        <D.Footer @hasDivider={{true}} id="test-footer">Footer</D.Footer>
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
@@ -83,9 +83,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
 
   test('it should render the content aligned on the right by default', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Interactive @route="components.dropdown" @text="interactive" />
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Interactive @route="components.dropdown" @text="interactive" />
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
@@ -95,9 +95,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
   });
   test('it should render the content aligned on the left if the value of @listPosition is "bottom-left"', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" @listPosition="bottom-left" as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Interactive @route="components.dropdown" @text="interactive" />
+      <Hds::Dropdown id="test-dropdown" @listPosition="bottom-left" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Interactive @route="components.dropdown" @text="interactive" />
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
@@ -107,9 +107,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
   });
   test('it should render the element as `inline` if the value of @isInline is "true"', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" @isInline={{true}} as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Interactive @route="components.dropdown" @text="interactive" />
+      <Hds::Dropdown id="test-dropdown" @isInline={{true}} as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Interactive @route="components.dropdown" @text="interactive" />
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
@@ -120,9 +120,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
 
   test('it should render the content with a fixed width if a @width value is passed', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown @width="248px" id="test-dropdown" as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Interactive @route="components.dropdown" @text="interactive" />
+      <Hds::Dropdown @width="248px" id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Interactive @route="components.dropdown" @text="interactive" />
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
@@ -133,9 +133,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
 
   test('it should hide the content when an interactive element triggers `close`', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Interactive @text="interactive" id="test-list-item-interactive" {{on "click" dd.close}} />
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Interactive @text="interactive" id="test-list-item-interactive" {{on "click" D.close}} />
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
@@ -148,9 +148,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
 
   test('it should render a list of items without a role if no selectable items are passed in', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Interactive @text="interactive" id="test-list-item-interactive" {{on "click" dd.close}} />
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Interactive @text="interactive" id="test-list-item-interactive" {{on "click" D.close}} />
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
@@ -158,9 +158,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
   });
   test('it should render a list of items with a `listbox` role, refering an existing `id` via `aria-labelledby` if selectable items are passed in', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" as |dd|>
-        <dd.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <dd.Checkmark>Checkmark</dd.Checkmark>
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Checkmark>Checkmark</D.Checkmark>
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
@@ -171,9 +171,9 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
   });
   test('it should render a list of items with a `listbox` role, refering an generated `id` via `aria-labelledby` if selectable items are passed in', async function (assert) {
     await render(hbs`
-      <Hds::Dropdown id="test-dropdown" as |dd|>
-        <dd.ToggleButton @text="toggle button" />
-        <dd.Checkmark>Checkmark</dd.Checkmark>
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" />
+        <D.Checkmark>Checkmark</D.Checkmark>
       </Hds::Dropdown>
     `);
     const button = this.element.querySelector('.hds-dropdown-toggle-button');

--- a/showcase/tests/integration/components/hds/segmented-group/index-test.js
+++ b/showcase/tests/integration/components/hds/segmented-group/index-test.js
@@ -20,15 +20,15 @@ module('Integration | Component | hds/segmented-group/index', function (hooks) {
 
   test('it renders the contextual components with CSS modifier classes', async function (assert) {
     await render(
-      hbs`<Hds::SegmentedGroup as |S|>
-            <S.Button id="segmented-button" @color="secondary" @text="Button" />
-            <S.Dropdown id="segmented-dropdown" as |DD|>
+      hbs`<Hds::SegmentedGroup as |SG|>
+            <SG.Button id="segmented-button" @color="secondary" @text="Button" />
+            <SG.Dropdown id="segmented-dropdown" as |DD|>
               <DD.ToggleButton @color="secondary" @text="Toggle" />
               <DD.Interactive @href="#" @text="Dropdown Item" />
-            </S.Dropdown>
-            <S.Select id="segmented-select"/>
-            <S.TextInput id="segmented-input" />
-            <S.Generic><span id="segmented-generic"></span></S.Generic>
+            </SG.Dropdown>
+            <SG.Select id="segmented-select"/>
+            <SG.TextInput id="segmented-input" />
+            <SG.Generic><span id="segmented-generic"></span></SG.Generic>
           </Hds::SegmentedGroup>`
     );
     assert.dom('#segmented-button').hasClass('hds-button');

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -1,17 +1,17 @@
 ## How to use this component
 
-To make the invocation more flexible and intuitive, we provide contextual components for Toggles, ListItems, Header and Footer. For example, `<Hds::Dropdown::ListItem::Separator />` would be contextually expressed as `<dd.Separator />`.
+To make the invocation more flexible and intuitive, we provide contextual components for Toggles, ListItems, Header and Footer. For example, `<Hds::Dropdown::ListItem::Separator />` would be contextually expressed as `<D.Separator />`.
 
 ```handlebars
-<Hds::Dropdown as |dd|>
-  <dd.ToggleButton @text="Menu" />
-  <dd.Title @text="Title Text" />
-  <dd.Description @text="Descriptive text goes here." />
-  <dd.Interactive @href="#" @text="Add" />
-  <dd.Interactive @href="#" @text="Add More" />
-  <dd.Interactive @href="#" @text="Add Another Thing Too" />
-  <dd.Separator />
-  <dd.Interactive @route="components" @icon="trash" @text="Delete" @color="critical" />
+<Hds::Dropdown as |D|>
+  <D.ToggleButton @text="Menu" />
+  <D.Title @text="Title Text" />
+  <D.Description @text="Descriptive text goes here." />
+  <D.Interactive @href="#" @text="Add" />
+  <D.Interactive @href="#" @text="Add More" />
+  <D.Interactive @href="#" @text="Add Another Thing Too" />
+  <D.Separator />
+  <D.Interactive @route="components" @icon="trash" @text="Delete" @color="critical" />
 </Hds::Dropdown>
 ```
 
@@ -20,28 +20,28 @@ To make the invocation more flexible and intuitive, we provide contextual compon
 The basic invocation of ToggleButton requires `@text` to be passed. By default, it renders a primary button with a chevron icon.
 
 ```handlebars
-<Hds::Dropdown as |dd|>
-  <dd.ToggleButton @text="Text Toggle" />
-  <dd.Interactive @route="components" @text="Item One" />
-  <dd.Interactive @route="components" @text="Item Two" />
-  <dd.Interactive @route="components" @text="Item Three" />
-  <dd.Interactive @text="Item Four (closes on click)" {{on "click" dd.close}} />
-  <dd.Separator />
-  <dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+<Hds::Dropdown as |D|>
+  <D.ToggleButton @text="Text Toggle" />
+  <D.Interactive @route="components" @text="Item One" />
+  <D.Interactive @route="components" @text="Item Two" />
+  <D.Interactive @route="components" @text="Item Three" />
+  <D.Interactive @text="Item Four (closes on click)" {{on "click" D.close}} />
+  <D.Separator />
+  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
 </Hds::Dropdown>
 ```
 
 Alternatively, pass `secondary` to `@color` to display a secondary button with a chevron icon.
 
 ```handlebars
-<Hds::Dropdown as |dd|>
-  <dd.ToggleButton @text="Text Toggle" @color="secondary" />
-  <dd.Interactive @route="components" @text="Item One" />
-  <dd.Interactive @route="components" @text="Item Two" />
-  <dd.Interactive @route="components" @text="Item Three" />
-  <dd.Interactive @text="Item Four (closes on click)" {{on "click" dd.close}} />
-  <dd.Separator />
-  <dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+<Hds::Dropdown as |D|>
+  <D.ToggleButton @text="Text Toggle" @color="secondary" />
+  <D.Interactive @route="components" @text="Item One" />
+  <D.Interactive @route="components" @text="Item Two" />
+  <D.Interactive @route="components" @text="Item Three" />
+  <D.Interactive @text="Item Four (closes on click)" {{on "click" D.close}} />
+  <D.Separator />
+  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
 </Hds::Dropdown>
 ```
 
@@ -53,13 +53,13 @@ Overflow menus are often found in the last column of a [Tables](/components/tabl
 `@hasChevron={{false}}`. `@text` is still required, because it supplies the `aria-label` for ToggleIcon.
 
 ```handlebars
-<Hds::Dropdown as |dd|>
-  <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} />
-  <dd.Interactive @route="components" @text="Create" />
-  <dd.Interactive @route="components" @text="Read" />
-  <dd.Interactive @route="components" @text="Update" />
-  <dd.Separator />
-  <dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+<Hds::Dropdown as |D|>
+  <D.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} />
+  <D.Interactive @route="components" @text="Create" />
+  <D.Interactive @route="components" @text="Read" />
+  <D.Interactive @route="components" @text="Update" />
+  <D.Separator />
+  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
 </Hds::Dropdown>
 ```
 
@@ -68,13 +68,13 @@ Overflow menus are often found in the last column of a [Tables](/components/tabl
 `@text` is still required, because it supplies the `aria-label` for ToggleIcon.
 
 ```handlebars
-<Hds::Dropdown as |dd|>
-  <dd.ToggleIcon @icon="user" @text="user menu" />
-  <dd.Title @text="Signed In" />
-  <dd.Description @text="email@domain.com" />
-  <dd.Separator />
-  <dd.Interactive @route="components" @text="Settings and Preferences" />
-  <dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+<Hds::Dropdown as |D|>
+  <D.ToggleIcon @icon="user" @text="user menu" />
+  <D.Title @text="Signed In" />
+  <D.Description @text="email@domain.com" />
+  <D.Separator />
+  <D.Interactive @route="components" @text="Settings and Preferences" />
+  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
 </Hds::Dropdown>
 ```
 
@@ -83,13 +83,13 @@ Overflow menus are often found in the last column of a [Tables](/components/tabl
 Pass any [icon](/icons/library) name to `@icon` to change the icon used in ToggleIcon. `@text` is still required, because it supplies the `aria-label` for ToggleIcon.
 
 ```handlebars
-<Hds::Dropdown as |dd|>
-  <dd.ToggleIcon @icon="settings" @text="settings menu" />
-  <dd.Title @text="Signed In" />
-  <dd.Description @text="email@domain.com" />
-  <dd.Separator />
-  <dd.Interactive @route="components" @text="Settings and Preferences" />
-  <dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+<Hds::Dropdown as |D|>
+  <D.ToggleIcon @icon="settings" @text="settings menu" />
+  <D.Title @text="Signed In" />
+  <D.Description @text="email@domain.com" />
+  <D.Separator />
+  <D.Interactive @route="components" @text="Settings and Preferences" />
+  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
 </Hds::Dropdown>
 ```
 
@@ -98,14 +98,14 @@ Pass any [icon](/icons/library) name to `@icon` to change the icon used in Toggl
 By default, the list is positioned below the button, aligned to the right. To change the list position pass `bottom-left`, `top-left`, or `top-right` to `@listPosition` on the Dropdown component.
 
 ```handlebars
-<Hds::Dropdown @listPosition="bottom-left" as |dd|>
-  <dd.ToggleButton @text="Text Toggle" />
-  <dd.Interactive @route="components" @text="Item One" />
-  <dd.Interactive @route="components" @text="Item Two" />
-  <dd.Interactive @route="components" @text="Item Three" />
-  <dd.Interactive @text="Item Four (closes on click)" {{on "click" dd.close}} />
-  <dd.Separator />
-  <dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+<Hds::Dropdown @listPosition="bottom-left" as |D|>
+  <D.ToggleButton @text="Text Toggle" />
+  <D.Interactive @route="components" @text="Item One" />
+  <D.Interactive @route="components" @text="Item Two" />
+  <D.Interactive @route="components" @text="Item Three" />
+  <D.Interactive @text="Item Four (closes on click)" {{on "click" D.close}} />
+  <D.Separator />
+  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
 </Hds::Dropdown>
 ```
 
@@ -113,11 +113,11 @@ In contexts where the Dropdown needs to be _inline_, to inherit the alignment fr
 
 ```handlebars
 <div class="doc-dropdown-mock-text-align-right">
-  <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
-    <dd.ToggleButton @text="Text Toggle" @color="secondary" />
-    <dd.Interactive @route="components" @text="Item One" />
-    <dd.Interactive @route="components" @text="Item Two" />
-    <dd.Interactive @route="components" @text="Item Three" />
+  <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |D|>
+    <D.ToggleButton @text="Text Toggle" @color="secondary" />
+    <D.Interactive @route="components" @text="Item One" />
+    <D.Interactive @route="components" @text="Item Two" />
+    <D.Interactive @route="components" @text="Item Three" />
   </Hds::Dropdown>
 </div>
 ```
@@ -133,15 +133,15 @@ The `@height` argument actually sets a `max-height` which prevents the list from
 !!!
 
 ```handlebars
-<Hds::Dropdown @isInline={{true}} @height="170px" @width="250px" as |dd|>
-  <dd.ToggleButton @text="Text Toggle" />
-  <dd.Interactive @route="components" @text="Item One" />
-  <dd.Interactive @route="components" @text="Item Two" />
-  <dd.Interactive @route="components" @text="Item Three" />
-  <dd.Interactive @route="components" @text="Item Four" />
-  <dd.Interactive @route="components" @text="Item Five" />
-  <dd.Interactive @route="components" @text="Item Six" />
-  <dd.Interactive @route="components" @text="Item Seven" />
+<Hds::Dropdown @isInline={{true}} @height="170px" @width="250px" as |D|>
+  <D.ToggleButton @text="Text Toggle" />
+  <D.Interactive @route="components" @text="Item One" />
+  <D.Interactive @route="components" @text="Item Two" />
+  <D.Interactive @route="components" @text="Item Three" />
+  <D.Interactive @route="components" @text="Item Four" />
+  <D.Interactive @route="components" @text="Item Five" />
+  <D.Interactive @route="components" @text="Item Six" />
+  <D.Interactive @route="components" @text="Item Seven" />
 </Hds::Dropdown>
 ```
 
@@ -150,24 +150,24 @@ The `@height` argument actually sets a `max-height` which prevents the list from
 It is possible that you may want to add a list footer for things like a set of buttons for a filter control:
 
 ```handlebars
-<Hds::Dropdown @height="284px" as |dd|>
-  <dd.ToggleButton @icon="tag" @text="Tags" @color="secondary" />
-  <dd.Checkbox>access</dd.Checkbox>
-  <dd.Checkbox>homework</dd.Checkbox>
-  <dd.Checkbox>discovery</dd.Checkbox>
-  <dd.Checkbox>memories</dd.Checkbox>
-  <dd.Checkbox>music</dd.Checkbox>
-  <dd.Checkbox>pharell</dd.Checkbox>
-  <dd.Checkbox>punk</dd.Checkbox>
-  <dd.Checkbox>random</dd.Checkbox>
-  <dd.Checkbox>robots</dd.Checkbox>
-  <dd.Checkbox>tag</dd.Checkbox>
-  <dd.Footer @hasDivider={{true}}>
+<Hds::Dropdown @height="284px" as |D|>
+  <D.ToggleButton @icon="tag" @text="Tags" @color="secondary" />
+  <D.Checkbox>access</D.Checkbox>
+  <D.Checkbox>homework</D.Checkbox>
+  <D.Checkbox>discovery</D.Checkbox>
+  <D.Checkbox>memories</D.Checkbox>
+  <D.Checkbox>music</D.Checkbox>
+  <D.Checkbox>pharell</D.Checkbox>
+  <D.Checkbox>punk</D.Checkbox>
+  <D.Checkbox>random</D.Checkbox>
+  <D.Checkbox>robots</D.Checkbox>
+  <D.Checkbox>tag</D.Checkbox>
+  <D.Footer @hasDivider={{true}}>
     <Hds::ButtonSet>
       <Hds::Button @text="Apply filters" @isFullWidth={{true}} @size="small" />
       <Hds::Button @text="Cancel" @color="secondary" @size="small" />
     </Hds::ButtonSet>
-  </dd.Footer>
+  </D.Footer>
 </Hds::Dropdown>
 ```
 
@@ -236,10 +236,10 @@ There may be use cases when it’s necessary to put an item in a “loading” s
 Pass the argument `@isLoading={{true}}` to the item. This will show a “loading” icon (even if an argument `@icon` is provided) and sets the item as non-interactive until the value of `@isLoading` is set to `false` again.
 
 ```handlebars
-<Hds::Dropdown as |dd|>
-  <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} />
-  <dd.Interactive @route="components" @isLoading={{true}} @text="Edit cluster" @color="action" @icon="edit" />
-  <dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+<Hds::Dropdown as |D|>
+  <D.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} />
+  <D.Interactive @route="components" @isLoading={{true}} @text="Edit cluster" @color="action" @icon="edit" />
+  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
 </Hds::Dropdown>
 ```
 
@@ -250,13 +250,13 @@ To enable users to copy a snippet of code (eg. URLs, secrets, code blocks, etc.)
 Using the `@isTruncated` argument it is possible to constrain the text to one-line and truncate it if it does not fit the available space. Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
 
 ```handlebars
-<Hds::Dropdown as |dd|>
-  <dd.ToggleButton @listPosition="bottom-left" @text="Create run task" @color="secondary" />
-  <dd.Title @text="Integrate with Terraform Cloud" />
-  <dd.Description @text="Create a new run task in Terraform using the URL and key below." />
-  <dd.CopyItem @text="https://api.cloud.hashicorp.com" @copyItemTitle="Endpoint URL" />
-  <dd.CopyItem @text="91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d" @copyItemTitle="HMAC Key" />
-  <dd.CopyItem @isTruncated={{false}} @text="91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d" @copyItemTitle="HMAC Key (without truncation)" />
+<Hds::Dropdown as |D|>
+  <D.ToggleButton @listPosition="bottom-left" @text="Create run task" @color="secondary" />
+  <D.Title @text="Integrate with Terraform Cloud" />
+  <D.Description @text="Create a new run task in Terraform using the URL and key below." />
+  <D.CopyItem @text="https://api.cloud.hashicorp.com" @copyItemTitle="Endpoint URL" />
+  <D.CopyItem @text="91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d" @copyItemTitle="HMAC Key" />
+  <D.CopyItem @isTruncated={{false}} @text="91ee1e8ef65b337f0e70d793f456c71d91ee1e8ef65b337f0e70d793f456c71d" @copyItemTitle="HMAC Key (without truncation)" />
 </Hds::Dropdown>
 ```
 
@@ -267,13 +267,13 @@ Using the `@isTruncated` argument, it is possible to disable the truncation appl
 For switching context (e.g., organization switchers, project switchers, etc.) use `ListItem::Checkmark`.
 
 ```handlebars
-<Hds::Dropdown @listPosition="bottom-left" as |dd|>
-  <dd.ToggleButton @text="HCP Design Sandbox" @color="secondary" />
-  <dd.Checkmark>ACME Org</dd.Checkmark>
-  <dd.Checkmark @selected={{true}}>HCP Design Sandbox</dd.Checkmark>
-  <dd.Footer @hasDivider={{true}}>
+<Hds::Dropdown @listPosition="bottom-left" as |D|>
+  <D.ToggleButton @text="HCP Design Sandbox" @color="secondary" />
+  <D.Checkmark>ACME Org</D.Checkmark>
+  <D.Checkmark @selected={{true}}>HCP Design Sandbox</D.Checkmark>
+  <D.Footer @hasDivider={{true}}>
     <Hds::Link::Standalone @icon="list" @text="All Organizations" @color="secondary" @href="#" />
-  </dd.Footer>
+  </D.Footer>
 </Hds::Dropdown>
 ```
 
@@ -282,15 +282,15 @@ For switching context (e.g., organization switchers, project switchers, etc.) us
 For multi-selection within a form or larger filter pattern use `ListItem::Checkbox`.
 
 ```handlebars
-<Hds::Dropdown @listPosition="bottom-left" as |dd|>
-  <dd.ToggleButton @count="2" @text="Status" @color="secondary" />
-  <dd.Checkbox @count="4">Failing</dd.Checkbox>
-  <dd.Checkbox @count="2" checked>Active</dd.Checkbox>
-  <dd.Checkbox @count="1">Starting</dd.Checkbox>
-  <dd.Checkbox @count="3" checked>Pending</dd.Checkbox>
-  <dd.Footer @hasDivider={{true}}>
+<Hds::Dropdown @listPosition="bottom-left" as |D|>
+  <D.ToggleButton @count="2" @text="Status" @color="secondary" />
+  <D.Checkbox @count="4">Failing</D.Checkbox>
+  <D.Checkbox @count="2" checked>Active</D.Checkbox>
+  <D.Checkbox @count="1">Starting</D.Checkbox>
+  <D.Checkbox @count="3" checked>Pending</D.Checkbox>
+  <D.Footer @hasDivider={{true}}>
     <Hds::Button @text="Apply filters" @isFullWidth={{true}} @size="small" />
-  </dd.Footer>
+  </D.Footer>
 </Hds::Dropdown>
 ```
 
@@ -299,15 +299,15 @@ For multi-selection within a form or larger filter pattern use `ListItem::Checkb
 For single selection within a form or larger filter pattern use `ListItem::Radio`.
 
 ```handlebars
-<Hds::Dropdown @listPosition="bottom-left" as |dd|>
-  <dd.ToggleButton @text="Status" @color="secondary" />
-  <dd.Radio name="status" @count="4">Failing</dd.Radio>
-  <dd.Radio name="status" @count="2" checked>Active</dd.Radio>
-  <dd.Radio name="status" @count="1">Starting</dd.Radio>
-  <dd.Radio name="status" @count="3">Pending</dd.Radio>
-  <dd.Footer @hasDivider={{true}}>
+<Hds::Dropdown @listPosition="bottom-left" as |D|>
+  <D.ToggleButton @text="Status" @color="secondary" />
+  <D.Radio name="status" @count="4">Failing</D.Radio>
+  <D.Radio name="status" @count="2" checked>Active</D.Radio>
+  <D.Radio name="status" @count="1">Starting</D.Radio>
+  <D.Radio name="status" @count="3">Pending</D.Radio>
+  <D.Footer @hasDivider={{true}}>
     <Hds::Button @text="Apply filters" @isFullWidth={{true}} @size="small" />
-  </dd.Footer>
+  </D.Footer>
 </Hds::Dropdown>
 ```
 
@@ -321,12 +321,12 @@ When using the “generic” ListItem, the product team is responsible for imple
 `ListItem::Generic` allows you to pass custom elements to the Dropdown.
 
 ```handlebars
-<Hds::Dropdown @listPosition="bottom-left" as |dd|>
-  <dd.ToggleButton @text="Text Toggle" @color="secondary" />
-  <dd.Title @text="Integrate with Terraform Cloud" />
-  <dd.Description @text="Create a new run task in Terraform using the URL and key below." />
-  <dd.Generic>
+<Hds::Dropdown @listPosition="bottom-left" as |D|>
+  <D.ToggleButton @text="Text Toggle" @color="secondary" />
+  <D.Title @text="Integrate with Terraform Cloud" />
+  <D.Description @text="Create a new run task in Terraform using the URL and key below." />
+  <D.Generic>
     <Hds::Link::Standalone @text="Watch tutorial video" @icon="film" @href="/" />
-  </dd.Generic>
+  </D.Generic>
 </Hds::Dropdown>
 ```

--- a/website/docs/components/dropdown/partials/guidelines/guidelines.md
+++ b/website/docs/components/dropdown/partials/guidelines/guidelines.md
@@ -4,7 +4,7 @@
 
 - To display a list of actions or links under a single button toggle.
 - To allow singular or multiple selection outside of a form, such as within filtering.
-- To provide the user with a way to easily switch context within the application. 
+- To provide the user with a way to easily switch context within the application.
 
 ### When not to use
 
@@ -17,19 +17,19 @@
 Toggles come in two variant types: **button** and **icon**.
 
 <Doc::Layout @spacing="24px">
-  <Hds::Dropdown as |dd|>
-    <dd.ToggleButton @text="Primary" />
-    <dd.Interactive @text="Item One" />
-    <dd.Interactive @text="Item Two" />
-    <dd.Interactive @text="Item Three" />
-    <dd.Interactive @text="Item Four" />
+  <Hds::Dropdown as |D|>
+    <D.ToggleButton @text="Primary" />
+    <D.Interactive @text="Item One" />
+    <D.Interactive @text="Item Two" />
+    <D.Interactive @text="Item Three" />
+    <D.Interactive @text="Item Four" />
   </Hds::Dropdown>
-  <Hds::Dropdown as |dd|>
-    <dd.ToggleIcon @icon="user" @text="user menu" />
-    <dd.Interactive @text="Item One" />
-    <dd.Interactive @text="Item Two" />
-    <dd.Interactive @text="Item Three" />
-    <dd.Interactive @text="Item Four" />
+  <Hds::Dropdown as |D|>
+    <D.ToggleIcon @icon="user" @text="user menu" />
+    <D.Interactive @text="Item One" />
+    <D.Interactive @text="Item Two" />
+    <D.Interactive @text="Item Three" />
+    <D.Interactive @text="Item Four" />
   </Hds::Dropdown>
 </Doc::Layout>
 
@@ -39,40 +39,40 @@ ToggleButtons come in two sizes: **small** and **medium**. This allows for place
 
 <Doc::Layout @spacing="24px" @direction="vertical">
   <Hds::ButtonSet>
-    <Hds::Dropdown as |dd|>
-      <dd.ToggleButton @text="Primary" @size="small"/>
-      <dd.Interactive @text="Item One" />
-      <dd.Interactive @text="Item Two" />
-      <dd.Interactive @text="Item Three" />
-      <dd.Interactive @text="Item Four" />
+    <Hds::Dropdown as |D|>
+      <D.ToggleButton @text="Primary" @size="small"/>
+      <D.Interactive @text="Item One" />
+      <D.Interactive @text="Item Two" />
+      <D.Interactive @text="Item Three" />
+      <D.Interactive @text="Item Four" />
     </Hds::Dropdown>
-    <Hds::Dropdown as |dd|>
-      <dd.ToggleButton @text="Secondary" @color="secondary" @size="small" />
-      <dd.Interactive @text="Item One" />
-      <dd.Interactive @text="Item Two" />
-      <dd.Interactive @text="Item Three" />
-      <dd.Interactive @text="Item Four" />
+    <Hds::Dropdown as |D|>
+      <D.ToggleButton @text="Secondary" @color="secondary" @size="small" />
+      <D.Interactive @text="Item One" />
+      <D.Interactive @text="Item Two" />
+      <D.Interactive @text="Item Three" />
+      <D.Interactive @text="Item Four" />
     </Hds::Dropdown>
   </Hds::ButtonSet>
   <Hds::ButtonSet>
-    <Hds::Dropdown as |dd|>
-      <dd.ToggleButton @text="Primary" />
-      <dd.Interactive @text="Item One" />
-      <dd.Interactive @text="Item Two" />
-      <dd.Interactive @text="Item Three" />
-      <dd.Interactive @text="Item Four" />
+    <Hds::Dropdown as |D|>
+      <D.ToggleButton @text="Primary" />
+      <D.Interactive @text="Item One" />
+      <D.Interactive @text="Item Two" />
+      <D.Interactive @text="Item Three" />
+      <D.Interactive @text="Item Four" />
     </Hds::Dropdown>
-    <Hds::Dropdown as |dd|>
-      <dd.ToggleButton @text="Secondary" @color="secondary" />
-      <dd.Interactive @text="Item One" />
-      <dd.Interactive @text="Item Two" />
-      <dd.Interactive @text="Item Three" />
-      <dd.Interactive @text="Item Four" />
+    <Hds::Dropdown as |D|>
+      <D.ToggleButton @text="Secondary" @color="secondary" />
+      <D.Interactive @text="Item One" />
+      <D.Interactive @text="Item Two" />
+      <D.Interactive @text="Item Three" />
+      <D.Interactive @text="Item Four" />
     </Hds::Dropdown>
   </Hds::ButtonSet>
 </Doc::Layout>
 
-ToggleIcons come in two sizes: **small** and **medium**. 
+ToggleIcons come in two sizes: **small** and **medium**.
 
 !!! Info
 
@@ -80,19 +80,19 @@ While we provide a small size variant, we recommend only using this for the Over
 !!!
 
 <Doc::Layout @spacing="24px">
-  <Hds::Dropdown as |dd|>
-    <dd.ToggleIcon @icon="more-horizontal" @size="small" @text="Overflow Options" @hasChevron={{false}} />
-    <dd.Interactive @text="Item One" />
-    <dd.Interactive @text="Item Two" />
-    <dd.Interactive @text="Item Three" />
-    <dd.Interactive @text="Item Four" />
-  </Hds::Dropdown>  
-  <Hds::Dropdown as |dd|>
-    <dd.ToggleIcon @icon="user" @text="user menu" />
-    <dd.Interactive @text="Item One" />
-    <dd.Interactive @text="Item Two" />
-    <dd.Interactive @text="Item Three" />
-    <dd.Interactive @text="Item Four" />
+  <Hds::Dropdown as |D|>
+    <D.ToggleIcon @icon="more-horizontal" @size="small" @text="Overflow Options" @hasChevron={{false}} />
+    <D.Interactive @text="Item One" />
+    <D.Interactive @text="Item Two" />
+    <D.Interactive @text="Item Three" />
+    <D.Interactive @text="Item Four" />
+  </Hds::Dropdown>
+  <Hds::Dropdown as |D|>
+    <D.ToggleIcon @icon="user" @text="user menu" />
+    <D.Interactive @text="Item One" />
+    <D.Interactive @text="Item Two" />
+    <D.Interactive @text="Item Three" />
+    <D.Interactive @text="Item Four" />
   </Hds::Dropdown>
 </Doc::Layout>
 
@@ -112,7 +112,7 @@ We strongly recommend providing visible chevrons on most instances of ToggleIcon
 
 ### Placement
 
-Lists can be positioned to the left or right of the Toggle, and above or below the Toggle to fit more appropriately within the UI. Lists do not currently have collision detection. 
+Lists can be positioned to the left or right of the Toggle, and above or below the Toggle to fit more appropriately within the UI. Lists do not currently have collision detection.
 
 ![Dropdown list placement examples](/assets/components/dropdown/dropdown-placement.png =963x*)
 
@@ -178,7 +178,7 @@ The height of the ListContainer is automatically determined based on the content
 
 ### Header
 
-A Header provides a fixed space at the top of the List. Typically, Headers house a search feature that allows the user to search/filter through the available options in the list. This is great for really long lists when filtering on complex datasets. 
+A Header provides a fixed space at the top of the List. Typically, Headers house a search feature that allows the user to search/filter through the available options in the list. This is great for really long lists when filtering on complex datasets.
 
 <div class="hds-dropdown__content">
   <Hds::Dropdown::Header @hasDivider={{true}}>
@@ -219,13 +219,13 @@ A Footer provides a fixed space at the bottom of the List. Typically, Footers ho
 
 ### Types
 
-For maximum flexibility, we offer a variety of ListItems options. 
+For maximum flexibility, we offer a variety of ListItems options.
 
 #### Interactive ListItems
 
 Use Interactive ListItems for actions (buttons) or links.
 
-- Use `Interactive - Critical` for destructive actions. 
+- Use `Interactive - Critical` for destructive actions.
 - Use `Interactive - Action` for everything else.
 
 ![Interactive ListItem types](/assets/components/dropdown/dropdown-listitem-types-interactive.png =449x*)
@@ -234,7 +234,7 @@ Use Interactive ListItems for actions (buttons) or links.
 
 Selection ListItems allow the user to select one or more options within a Dropdown.
 
-- Use `Checkmark` for switching context, e.g., organization switchers, project switchers, etc. Use for single selection only, as it doesn't provide enough indication that multi-selection is possible. For multi-selection, use `Checkbox`. 
+- Use `Checkmark` for switching context, e.g., organization switchers, project switchers, etc. Use for single selection only, as it doesn't provide enough indication that multi-selection is possible. For multi-selection, use `Checkbox`.
 - Use `Checkbox` for multi-selection within a form or larger filter pattern.
 - Use `Radio` for single selection within a form or larger filter pattern.
 
@@ -242,14 +242,14 @@ Selection ListItems allow the user to select one or more options within a Dropdo
 
 !!! Do
 
-Use `Checkmark` for context switching. 
+Use `Checkmark` for context switching.
 
 ![Example of proper checkmark list items](/assets/components/dropdown/dropdown-interactive-contextswitcher-do.png =280x*)
 !!!
 
 !!! Dont
 
-Don't use `Checkmark` instead of `Radio` in larger filter patterns.  
+Don't use `Checkmark` instead of `Radio` in larger filter patterns.
 
 ![Example of incorrect checkmark list items](/assets/components/dropdown/dropdown-interactive-filter-dont.png =768x*)
 !!!
@@ -269,7 +269,7 @@ Users may not understand why something is taking additional time to load. If pos
 
 #### Generic
 
-The Generic ListItem allows you to add custom content in place of a ListItem. It includes predefined left and right padding to ensure proper alignment with other ListItems in the List. 
+The Generic ListItem allows you to add custom content in place of a ListItem. It includes predefined left and right padding to ensure proper alignment with other ListItems in the List.
 
 !!! Warning
 
@@ -282,7 +282,7 @@ Be careful not to misuse or overuse the Generic ListItem. Relying on this escape
 
 Icons in ListItems are optional. Generally, we recommend letting the text speak for itself, but icons can add value in the following situations:
 
-- When they reinforce the content, e.g., `edit` for an edit or rename action. 
+- When they reinforce the content, e.g., `edit` for an edit or rename action.
 - When using Interactive ListItems, a `trailingIcon` can indicate that a link is external.
 - When using Critical ListItems; read more about [how color blind users see critical actions](/components/dropdown?tab=accessibility) in our UIs.
 - To avoid inconsistent icon use within the same List. Instead use icons in all ListItems. Doing so keeps the text aligned so the eye can scan the list of options more easily.

--- a/website/docs/components/page-header/partials/code/how-to-use.md
+++ b/website/docs/components/page-header/partials/code/how-to-use.md
@@ -56,13 +56,13 @@ Pass custom metadata to the component with a `generic` contextual component that
   <PH.Title>Page title</PH.Title>
   <PH.IconTile @icon="folder" />
   <PH.Actions>
-    <Hds::Dropdown as |DD|>
-      <DD.ToggleButton @text="Manage" @color="secondary" />
-      <DD.Interactive @route="components" @text="Item One" />
-      <DD.Interactive @route="components" @text="Item Two" />
-      <DD.Interactive @route="components" @text="Item Three" />
-      <DD.Separator />
-      <DD.Interactive
+    <Hds::Dropdown as |D|>
+      <D.ToggleButton @text="Manage" @color="secondary" />
+      <D.Interactive @route="components" @text="Item One" />
+      <D.Interactive @route="components" @text="Item Two" />
+      <D.Interactive @route="components" @text="Item Three" />
+      <D.Separator />
+      <D.Interactive
         @route="components"
         @text="Delete"
         @color="critical"

--- a/website/docs/components/segmented-group/partials/code/how-to-use.md
+++ b/website/docs/components/segmented-group/partials/code/how-to-use.md
@@ -3,37 +3,37 @@
 ### Within a filter pattern
 
 ```handlebars
-<Hds::SegmentedGroup as |S|>
-  <S.TextInput @type="search" placeholder="Search" aria-label="Search" />
-  <S.Dropdown as |DD|>
-    <DD.ToggleButton @color="secondary" @text="Across" @count="2" />
-    <DD.Checkbox checked>Metadata</DD.Checkbox>
-    <DD.Checkbox checked>Tags</DD.Checkbox>
-    <DD.Checkbox>Service name</DD.Checkbox>
-  </S.Dropdown>
-</Hds::SegmentedGroup> 
+<Hds::SegmentedGroup as |SG|>
+  <SG.TextInput @type="search" placeholder="Search" aria-label="Search" />
+  <SG.Dropdown as |D|>
+    <D.ToggleButton @color="secondary" @text="Across" @count="2" />
+    <D.Checkbox checked>Metadata</D.Checkbox>
+    <D.Checkbox checked>Tags</D.Checkbox>
+    <D.Checkbox>Service name</D.Checkbox>
+  </SG.Dropdown>
+</Hds::SegmentedGroup>
 ```
 
 For complex filters we recommend grouping related filter criteria into a Segmented Group.
 
 ```handlebars
-<Hds::SegmentedGroup as |S|>
-  <S.Dropdown as |DD|>
-    <DD.ToggleButton @color="secondary" @text="Health status" />
-    <DD.Checkbox>Passing</DD.Checkbox>
-    <DD.Checkbox>Warning</DD.Checkbox>
-    <DD.Checkbox>Failing</DD.Checkbox>
-  </S.Dropdown>
-  <S.Dropdown as |DD|>
-    <DD.ToggleButton @color="secondary" @text="Source" />
-    <DD.Checkbox>Consul</DD.Checkbox>
-    <DD.Checkbox>Kubernetes</DD.Checkbox>
-  </S.Dropdown>
-  <S.Dropdown as |DD|>
-    <DD.ToggleButton @color="secondary" @text="Type" />
-    <DD.Checkbox>Service</DD.Checkbox>
-    <DD.Checkbox>Debug service</DD.Checkbox>
-  </S.Dropdown>
+<Hds::SegmentedGroup as |SG|>
+  <SG.Dropdown as |D|>
+    <D.ToggleButton @color="secondary" @text="Health status" />
+    <D.Checkbox>Passing</D.Checkbox>
+    <D.Checkbox>Warning</D.Checkbox>
+    <D.Checkbox>Failing</D.Checkbox>
+  </SG.Dropdown>
+  <SG.Dropdown as |D|>
+    <D.ToggleButton @color="secondary" @text="Source" />
+    <D.Checkbox>Consul</D.Checkbox>
+    <D.Checkbox>Kubernetes</D.Checkbox>
+  </SG.Dropdown>
+  <SG.Dropdown as |D|>
+    <D.ToggleButton @color="secondary" @text="Type" />
+    <D.Checkbox>Service</D.Checkbox>
+    <D.Checkbox>Debug service</D.Checkbox>
+  </SG.Dropdown>
 </Hds::SegmentedGroup>
 ```
 
@@ -46,9 +46,9 @@ When used within a form we recommend using component composition, passing a `Seg
   <F.Label>New API Key</F.Label>
   <F.HelperText>Your org must have at least one key and at most five keys</F.HelperText>
   <F.Control>
-    <Hds::SegmentedGroup as |S|>
-      <S.TextInput id={{F.id}} aria-describedby={{F.ariaDescribedBy}} size="32" />
-      <S.Button @color="secondary" @text="Generate" />
+    <Hds::SegmentedGroup as |SG|>
+      <SG.TextInput id={{F.id}} aria-describedby={{F.ariaDescribedBy}} size="32" />
+      <SG.Button @color="secondary" @text="Generate" />
     </Hds::SegmentedGroup>
   </F.Control>
 </Hds::Form::Field>
@@ -59,10 +59,10 @@ When used within a form we recommend using component composition, passing a `Seg
 Use the `Generic` block to pass custom Segments to the group". The predefined Segments adjust their styles automatically depending on their placement within the group. You will need to ensure similar styling for your custom Segment.
 
 ```handlebars
-<Hds::SegmentedGroup as |S|>
-  <S.TextInput aria-label="input leading generic segment" size="32" />
-  <S.Generic>
+<Hds::SegmentedGroup as |SG|>
+  <SG.TextInput aria-label="input leading generic segment" size="32" />
+  <SG.Generic>
     <Doc::Placeholder @text="generic segment" @height="36" @background="#eee" />
-  </S.Generic>
+  </SG.Generic>
 </Hds::SegmentedGroup>
 ```

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -745,14 +745,14 @@ In this example we’re visually hiding the label in the last column by passing 
       <B.Td>{{B.data.album}}</B.Td>
       <B.Td>{{B.data.year}}</B.Td>
       <B.Td>
-          <Hds::Dropdown as |dd|>
-            <dd.ToggleIcon
+          <Hds::Dropdown as |D|>
+            <D.ToggleIcon
               @icon="more-horizontal"
               @text="Overflow Options"
               @hasChevron={{false}}
               @size="small"
             />
-            <dd.Interactive
+            <D.Interactive
               @href="#"
               @text="Delete"
               @color="critical"
@@ -787,18 +787,18 @@ Here’s a Table implementation that uses an array hash with localized strings f
       <B.Td>{{B.data.album}}</B.Td>
       <B.Td>{{B.data.year}}</B.Td>
       <B.Td>
-          <Hds::Dropdown as |dd|>
-            <dd.ToggleIcon
+          <Hds::Dropdown as |D|>
+            <D.ToggleIcon
               @icon="more-horizontal"
               @text="Overflow Options"
               @hasChevron={{false}}
               @size="small"
             />
-            <dd.Interactive @href="#" @text="Create" />
-            <dd.Interactive @href="#" @text="Read" />
-            <dd.Interactive @href="#" @text="Update" />
-            <dd.Separator />
-            <dd.Interactive
+            <D.Interactive @href="#" @text="Create" />
+            <D.Interactive @href="#" @text="Read" />
+            <D.Interactive @href="#" @text="Update" />
+            <D.Separator />
+            <D.Interactive
               @href="#"
               @text='Delete'
               @color='critical'

--- a/website/docs/patterns/table-multi-select/partials/accessibility/accessibility.md
+++ b/website/docs/patterns/table-multi-select/partials/accessibility/accessibility.md
@@ -16,13 +16,13 @@ This is a _representative_ example of how this could be accomplished using HDS c
     <Hds::Text::Body role="status" @tag="p" @size="200" @color="foreground-primary" >
       {{this.selectedCount}} selected out of {{this.totalCount}}
     </Hds::Text::Body>
-    <Hds::Dropdown as |DD|>
-      <DD.ToggleButton @size="small" @text="Actions" @color="secondary" />
-      <DD.Interactive @text="Edit" @icon="edit" />
-      <DD.Interactive @text="Delete" @icon="trash" @color="critical" />
-      <DD.Separator />
-      <DD.Interactive @text="Select all" />
-      <DD.Interactive @text="Reset selection" />
+    <Hds::Dropdown as |D|>
+      <D.ToggleButton @size="small" @text="Actions" @color="secondary" />
+      <D.Interactive @text="Edit" @icon="edit" />
+      <D.Interactive @text="Delete" @icon="trash" @color="critical" />
+      <D.Separator />
+      <D.Interactive @text="Select all" />
+      <D.Interactive @text="Reset selection" />
     </Hds::Dropdown>
   </div>
 </div>


### PR DESCRIPTION
### :pushpin: Summary

Following conversation with @alex-ju in https://github.com/hashicorp/design-system/pull/2233/files/58e3408b27bda17b8140f419e2a7050ba357ae1f#r1678026992 I've opened a distinct PR to update across the website, showcase and integration tests the aliases for:

- `<Hds::Dropdown as |dd|>` → `<Hds::Dropdown as |D|>` → 
- `<Hds::SegmentedGroup as |S|>` → `<Hds::SegmentedGroup as |SG|>` 

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
