### PR TITLE
Website - Fix font weight for headings in Safari

### DIFF
--- a/website/app/styles/typography/mixins.scss
+++ b/website/app/styles/typography/mixins.scss
@@ -13,6 +13,7 @@
 @mixin doc-font-family($family) {
   @if ($family == "hashicorp-sans") {
     font-family: hashicorp-sans-variable, Geneva, Tahoma, Helvetica, Verdana, sans-serif;
+    font-synthesis: none; // Safari makes this variable font too bold, compared to Chrome, and this fixes the issue
   } @else if ($family == "sans") {
     font-family: metro-web, Metro, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   } @else if ($family == "mono") {
@@ -29,7 +30,7 @@
 
 @mixin doc-font-style-h1($responsive: true) {
   @include doc-font-family("hashicorp-sans");
-  font-weight: 700;
+  font-weight: 600;
 
   @if $responsive {
     @include breakpoint.small () {
@@ -56,7 +57,7 @@
 
 @mixin doc-font-style-h2($responsive: true) {
   @include doc-font-family("hashicorp-sans");
-  font-weight: 700;
+  font-weight: 600;
 
   @if $responsive {
     @include breakpoint.small () {
@@ -83,7 +84,7 @@
 
 @mixin doc-font-style-h3($responsive: true) {
   @include doc-font-family("hashicorp-sans");
-  font-weight: 700;
+  font-weight: 600;
 
   @if $responsive {
     @include breakpoint.small () {
@@ -110,7 +111,7 @@
 
 @mixin doc-font-style-h4($responsive: true) {
   @include doc-font-family("hashicorp-sans");
-  font-weight: 700;
+  font-weight: 600;
   font-size: 1.125rem; // 18px
   line-height: 1.556; // 28px
 }
@@ -119,7 +120,7 @@
 
 @mixin doc-font-style-h5 {
   @include doc-font-family("hashicorp-sans");
-  font-weight: 700;
+  font-weight: 600;
   font-size: 1rem; // 16px
   line-height: 1.5; // 24px
 }
@@ -128,7 +129,7 @@
 
 @mixin doc-font-style-h6 {
   @include doc-font-family("hashicorp-sans");
-  font-weight: 700;
+  font-weight: 600;
   font-size: 0.938rem; // 15px
   line-height: 1.333; // 20px
 }


### PR DESCRIPTION
### :pushpin: Summary

Two issues in one are leading Safari to over-render the boldness of the headings on the website.

First, when we recently updated the headings font in #2065, to match the new marketing/brand guidelines, we updated the `font-family` (using the `Hashicorp Sans Variable` variable font) but left the `font-weight` values the same (`700`).

But actually the max value of the `weight` axis for this font is `600`:
<img width="502" alt="screenshot_3945" src="https://github.com/user-attachments/assets/37f1b931-db6a-4169-aebc-e7ceda799a8e">

Second, for "reasons", Safari is too eager to apply a bold weight to this variable font, and renders the text very bold (see before/after below). @shleewhite raised the issue in [this thread](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1721146018467379).

![Screenshot 2024-07-16 at 12 03 49 PM](https://github.com/user-attachments/assets/710554f8-5ce6-4c58-9136-e135b68b859e)

This PR fixes the problem in Safari, by setting the correct weight but also adding `font-synthesis: none;` to prevent this super-bold effect.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated CSS for headings using `Hashicorp Sans Variable` font to fix font weight in Safari

 👉👉 👉 **Preview**: https://hds-website-git-website-fix-font-weight-headings-hashicorp.vercel.app/testing/components/typography

### :camera_flash: Screenshots

| Safari / Before | Safari / After |
| ------- | ------- | 
| <img width="702" alt="screenshot_3950" src="https://github.com/user-attachments/assets/e1d71586-d5fe-4354-bfb7-6735202e5248"> | <img width="676" alt="screenshot_3951" src="https://github.com/user-attachments/assets/375d9749-3826-4b0d-9a5b-ab601dc53080"> |

| Crome / Before | Chrome / After |
| ------- | ------- | 
| <img width="564" alt="screenshot_3949" src="https://github.com/user-attachments/assets/5c177890-157b-4fb8-91bf-32b09a3e74f8"> | <img width="563" alt="screenshot_3948" src="https://github.com/user-attachments/assets/30907972-8c68-4b1b-b2e2-2577d77c5de6"> | 

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
