### PR TITLE
`TextInput`: add support for month, week, tel types

### DIFF
--- a/.changeset/good-pumas-hunt.md
+++ b/.changeset/good-pumas-hunt.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+TextField: add support for `"month"`, `"week"`, and `"tel"` input types

--- a/.changeset/good-pumas-hunt.md
+++ b/.changeset/good-pumas-hunt.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-TextField: add support for `"month"`, `"week"`, and `"tel"` input types
+`TextField`: add support for `"month"`, `"week"`, and `"tel"` input types

--- a/.changeset/good-pumas-hunt.md
+++ b/.changeset/good-pumas-hunt.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`TextField`: add support for `"month"`, `"week"`, and `"tel"` input types
+`Form::TextInput` - added support for `"month"`, `"week"`, and `"tel"` input types

--- a/packages/components/src/components/hds/form/text-input/types.ts
+++ b/packages/components/src/components/hds/form/text-input/types.ts
@@ -12,6 +12,9 @@ export enum HdsFormTextInputTypeValues {
   Time = 'time',
   DateTimeLocal = 'datetime-local',
   Search = 'search',
+  Month = 'month',
+  Week = 'week',
+  Tel = 'tel',
 }
 
 export type HdsFormTextInputTypes = `${HdsFormTextInputTypeValues}`;

--- a/packages/components/src/styles/components/form/text-input.scss
+++ b/packages/components/src/styles/components/form/text-input.scss
@@ -105,7 +105,9 @@
 
   &[type="date"],
   &[type="time"],
-  &[type="datetime-local"] {
+  &[type="datetime-local"],
+  &[type="month"],
+  &[type="week"] {
 
     // browsers set a specific width for these controls, we want to keep it
     width: initial;

--- a/showcase/app/templates/components/form/text-input.hbs
+++ b/showcase/app/templates/components/form/text-input.hbs
@@ -137,6 +137,34 @@
                     @isInvalid={{if (eq variant "invalid") true}}
                   />
                 </SF.Item>
+                <SF.Item>
+                  <Hds::Form::TextInput::Base
+                    aria-label="text input example as {{state}}"
+                    @type="month"
+                    disabled={{if (eq variant "disabled") "disabled"}}
+                    readonly={{if (eq variant "readonly") "readonly"}}
+                    @isInvalid={{if (eq variant "invalid") true}}
+                  />
+                </SF.Item>
+                <SF.Item>
+                  <Hds::Form::TextInput::Base
+                    aria-label="text input example as {{state}}"
+                    @type="week"
+                    disabled={{if (eq variant "disabled") "disabled"}}
+                    readonly={{if (eq variant "readonly") "readonly"}}
+                    @isInvalid={{if (eq variant "invalid") true}}
+                  />
+                </SF.Item>
+                <SF.Item>
+                  <Hds::Form::TextInput::Base
+                    aria-label="text input example as {{state}}"
+                    @type="tel"
+                    @value="1234567890"
+                    disabled={{if (eq variant "disabled") "disabled"}}
+                    readonly={{if (eq variant "readonly") "readonly"}}
+                    @isInvalid={{if (eq variant "invalid") true}}
+                  />
+                </SF.Item>
               </Shw::Flex>
             </SG.Item>
           {{/unless}}

--- a/showcase/tests/integration/components/hds/form/text-input/base-test.js
+++ b/showcase/tests/integration/components/hds/form/text-input/base-test.js
@@ -80,7 +80,7 @@ module('Integration | Component | hds/form/text-input/base', function (hooks) {
 
   test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {
     const errorMessage =
-      '@type for "Hds::Form::TextInput" must be one of the following: text, email, password, url, date, time, datetime-local, search; received: foo';
+      '@type for "Hds::Form::TextInput" must be one of the following: text, email, password, url, date, time, datetime-local, search, month, week, tel; received: foo';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/website/docs/components/form/text-input/partials/code/component-api.md
+++ b/website/docs/components/form/text-input/partials/code/component-api.md
@@ -8,7 +8,7 @@ The Text Input component has two different variants with their own APIs:
 ### Form::TextInput::Base
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" "datetime-local" }} @default="text">
+  <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" "datetime-local" "month" "week" "tel" }} @default="text">
     Sets the native HTML `type` of the `<input>`.
   </C.Property>
   <C.Property @name="value" @type="string|number|date">
@@ -35,7 +35,7 @@ The Text Input component has two different variants with their own APIs:
 ### Form::TextInput::Field
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" "datetime-local" }} @default="text">
+  <C.Property @name="type" @type="enum" @values={{array "text" "email" "password" "url" "search" "date" "time" "datetime-local" "month" "week" "tel" }} @default="text">
     Sets the native HTML `type` of the `<input>`.
   </C.Property>
   <C.Property @name="id" @type="string">

--- a/website/docs/components/form/text-input/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/text-input/partials/guidelines/guidelines.md
@@ -58,6 +58,20 @@ Date and time fields use the native browser functionality for the popovers. Some
   <F.Label>Datetime</F.Label>
 </Hds::Form::TextInput::Field>
 
+<Hds::Form::TextInput::Field @type="month" placeholder="yyyy-mm" as |F|>
+  <F.Label>Month</F.Label>
+</Hds::Form::TextInput::Field>
+
+<Hds::Form::TextInput::Field @type="week" placeholder="yyyy-W00" as |F|>
+  <F.Label>Week</F.Label>
+</Hds::Form::TextInput::Field>
+
+### Telephone
+
+<Hds::Form::TextInput::Field @type="tel" @width="300px" pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}" placeholder="123-456-7890" as |F|>
+  <F.Label>Tel</F.Label>
+</Hds::Form::TextInput::Field>
+
 ## Required and optional
 
 For complex forms, indicate **required** fields. This is the most explicit and transparent method and ensures users don’t have to make assumptions. Read more about best practices for [marking required fields in forms](https://www.nngroup.com/articles/required-fields/).


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add support for the following input types: month, week, tel.

### :hammer_and_wrench: Detailed description

- Updates the input type argument type
- Updates CSS to have month and week input have width='initial'
- Update showcase test error messsage
- Website
  - add new types to prop table
  - add examples of new types to the guidelines

### :camera_flash: Screenshots

**Updated documentation site in Chrome:**
![Screenshot 2024-07-16 at 3 52 18 PM](https://github.com/user-attachments/assets/addc5d62-7a92-4b2d-91ab-2e077517ff74)

**Updated documentation site in Safari:**
![Screenshot 2024-07-16 at 3 45 02 PM](https://github.com/user-attachments/assets/e02f63b5-c297-4286-b62c-f5a39e8db787)

**Added new types to showcase**
![Screenshot 2024-07-16 at 4 49 36 PM](https://github.com/user-attachments/assets/0110ad60-a06f-4139-95c7-1a3961bc6edd)

### :link: External links

Jira ticket: [HDS-3555](https://hashicorp.atlassian.net/browse/HDS-3555)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3555]: https://hashicorp.atlassian.net/browse/HDS-3555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ