### PR TITLE
fix: icon for month/week input types

### DIFF
--- a/packages/components/src/styles/components/form/text-input.scss
+++ b/packages/components/src/styles/components/form/text-input.scss
@@ -128,7 +128,9 @@
   // we override the default icon with the Flight corresponding one
   // notice: the original in Chrome has two assets, one for light and one for dark mode, and uses a special syntax, but apparently it doesn't work if used in a stylesheet
   &[type="date"],
-  &[type="datetime-local"] {
+  &[type="datetime-local"],
+  &[type="month"],
+  &[type="week"] {
     &::-webkit-calendar-picker-indicator {
       background-image: var(--token-form-text-input-background-image-data-url-date);
       background-position: center center;


### PR DESCRIPTION
### :pushpin: Summary

If merged, the icons in the input type="week/month" will match the ones for date and datetime local.

### :camera_flash: Screenshots
Current icons:
![image](https://github.com/user-attachments/assets/f65b58ad-877e-4b4a-a053-a2da53c2ca90)

Now the icons in the month and week inputs match the ones for date and datetime local.
![Screenshot 2024-07-17 at 1 22 27 PM](https://github.com/user-attachments/assets/bf26f9a1-6f38-4d25-beec-045d58f1af93)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3560](https://hashicorp.atlassian.net/browse/HDS-3560)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3560]: https://hashicorp.atlassian.net/browse/HDS-3560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ