### PR TITLE
Update changelog entry for v4.6.0

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 <div class="doc-whats-new-changelog-separator"></div>
 
-`Accordion` - added `@size`, `@type`, and `@isStatic` arguments
+`Accordion` - added `@size`, `@type`, and `@isStatic` arguments. While previously equivalent to `large` the default `Accordion` size is now `medium`; use `@size="large"` to maintain the original appearance.
 
 <small class="doc-whats-new-changelog-metadata">[#2156](https://github.com/hashicorp/design-system/pull/2156)</small>
 

--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -47,7 +47,7 @@
 
 <div class="doc-whats-new-changelog-separator"></div>
 
-`Accordion` - added `@size`, `@type`, and `@isStatic` arguments
+`Accordion` - added `@size`, `@type`, and `@isStatic` arguments. While previously equivalent to `large` the default `Accordion` size is now `medium`; use `@size="large"` to maintain the original appearance.
 
 <small class="doc-whats-new-changelog-metadata">[#2156](https://github.com/hashicorp/design-system/pull/2156)</small>
 


### PR DESCRIPTION
### :pushpin: Summary

Update changelog entry to highlight the difference in style for `Accordion` introduced with 4.6.0.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3564](https://hashicorp.atlassian.net/browse/HDS-3564)

***
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3564]: https://hashicorp.atlassian.net/browse/HDS-3564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ