### PR TITLE
Website - Include support for “added” status for the components

### DIFF
--- a/website/app/components/doc/cards/card.hbs
+++ b/website/app/components/doc/cards/card.hbs
@@ -13,6 +13,8 @@
           <Doc::Badge class="doc-cards-card__badge" @type="warning-inverted" @size="medium">Deprecated</Doc::Badge>
         {{else if @status.updated}}
           <Doc::Badge class="doc-cards-card__badge" @type="neutral-inverted" @size="medium">Updated</Doc::Badge>
+        {{else if @status.added}}
+          <Doc::Badge class="doc-cards-card__badge" @type="information-inverted" @size="medium">Added</Doc::Badge>
         {{/if}}
         <p class="doc-cards-card_description">{{@caption}}</p>
       </div>
@@ -27,6 +29,8 @@
           <Doc::Badge class="doc-cards-card__badge" @type="warning-inverted" @size="medium">Deprecated</Doc::Badge>
         {{else if @status.updated}}
           <Doc::Badge class="doc-cards-card__badge" @type="neutral-inverted" @size="medium">Updated</Doc::Badge>
+        {{else if @status.added}}
+          <Doc::Badge class="doc-cards-card__badge" @type="information-inverted" @size="medium">Added</Doc::Badge>
         {{/if}}
         <p class="doc-cards-card_description">{{@caption}}</p>
       </div>

--- a/website/app/components/doc/table-of-contents/index.hbs
+++ b/website/app/components/doc/table-of-contents/index.hbs
@@ -24,6 +24,8 @@
               <Doc::Badge @type="warning-inverted" @size="medium">Deprecated</Doc::Badge>
             {{else if item.pageAttributes.status.updated}}
               <Doc::Badge @type="neutral-inverted" @size="medium">Updated</Doc::Badge>
+            {{else if item.pageAttributes.status.added}}
+              <Doc::Badge @type="information-inverted" @size="medium">Added</Doc::Badge>
             {{/if}}
           {{/if}}
         </LinkTo>

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -98,6 +98,10 @@ export default class ShowController extends Controller {
         type = 'neutral';
         label = 'Updated';
         version = this.model.frontmatter?.status?.updated;
+      } else if (this.model.frontmatter?.status?.added) {
+        type = 'information';
+        label = 'Added';
+        version = this.model.frontmatter?.status?.added;
       }
       if (version.match(/^\d+\.\d+\.\d+$/)) {
         label += ` in v${version}`;

--- a/wiki/Website-Doc-folder.md
+++ b/wiki/Website-Doc-folder.md
@@ -152,8 +152,8 @@ The "frontmatter" attributes that we support are the following:
     An optional full path to an image used when listing the page as "card" (eg. in landing pages). The path refers to the `dist` folder generated at build time, so is relative to the content of the `/website/public` folder.
 *   `status`
     An optional status of the component (that will be reflected in the pages with specific badges next to the component card or name)
-        * `deprecated` - the version number in which the component has been deprecated (in the format `x.y.z`)
-        * `updated` - the version number in which the component has been updated (in the format `x.y.z`) - notice: this can be removed after some time, when the changes are not anymore recent enough to justify the extra information
+    * `added` | `updated` | `deprecated` - the version number in which the component has been added, updated or deprecated (in the format `x.y.z`)
+    Notice: it should be removed after some time, when the changes are not anymore recent enough to justify the extra information
 
 Only the `title` attribute is technically required, all the others are optional (even though some of them like `description` and `caption` are necessary for component pages).
 


### PR DESCRIPTION
### :pushpin: Summary

In https://github.com/hashicorp/design-system/pull/2216 we didn't consider the case of **new** components 🤦‍♂️

### :hammer_and_wrench: Detailed description

In this PR I have:
- included support for the “added” status for the components (using the `information` badge color)

You can see a preview of how it would look like here: https://hds-website-git-dialog-primitive-non-breaking-58ad01-hashicorp.vercel.app/utilities/dialog-primitive

### :camera_flash: Screenshots

![image](https://github.com/user-attachments/assets/dfa01947-4cd8-4414-8c7a-87ddea32b0ee)

![image](https://github.com/user-attachments/assets/2ef07f08-5f9b-4e38-aefa-776e5e9610c5)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
