### PR TITLE
Badge: update @text arg to allow numbers

### DIFF
--- a/.changeset/proud-bugs-tickle.md
+++ b/.changeset/proud-bugs-tickle.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Badge`: updated `@text` argument type to include numbers.

--- a/packages/components/src/components/hds/badge/index.ts
+++ b/packages/components/src/components/hds/badge/index.ts
@@ -103,7 +103,7 @@ export default class HdsBadgeComponent extends Component<HdsBadgeSignature> {
    * @type {string}
    * @description The text of the badge. If `isIconOnly` is set to `true`, the text will be visually hidden but still available to assistive technology. If no text value is defined, an error will be thrown.
    */
-  get text(): string {
+  get text(): string | number {
     const { text } = this.args;
 
     assert(

--- a/packages/components/src/components/hds/badge/index.ts
+++ b/packages/components/src/components/hds/badge/index.ts
@@ -27,7 +27,7 @@ export interface HdsBadgeSignature {
     size?: HdsBadgeSizes;
     type?: HdsBadgeTypes;
     color?: HdsBadgeColors;
-    text: string;
+    text: string | number;
     icon?: FlightIconSignature['Args']['name'];
     isIconOnly?: boolean;
   };

--- a/website/docs/components/badge/partials/code/component-api.md
+++ b/website/docs/components/badge/partials/code/component-api.md
@@ -1,19 +1,19 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
-<C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
-<C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
-<C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" "highlight" "critical" "success" "warning" }} @default="neutral"/>
-<C.Property @name="text" @type="string | number">
-The text of the Badge or value of the screen-reader only element if `isIconOnly` is set to `true`. If no text value is defined an error will be thrown.
-</C.Property>
-<C.Property @name="icon" @type="string">
-Use this parameter to show an icon. Any [icon](/icons/library) name is acceptable.
-</C.Property>
-<C.Property @name="isIconOnly" @type="boolean" @default="false">
-This indicates if the button will only contain an icon. An internal check is in place to ensure that accessible text is still applied to the component.
-</C.Property>
-<C.Property @name="...attributes">
-This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
-</C.Property>
+  <C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
+  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" "highlight" "critical" "success" "warning" }} @default="neutral"/>
+  <C.Property @name="text" @type="string | number">
+    The text of the Badge or value of the screen-reader only element if `isIconOnly` is set to `true`. If no text value is defined an error will be thrown.
+  </C.Property>
+  <C.Property @name="icon" @type="string">
+    Use this parameter to show an icon. Any [icon](/icons/library) name is acceptable.
+  </C.Property>
+  <C.Property @name="isIconOnly" @type="boolean" @default="false">
+    This indicates if the button will only contain an icon. An internal check is in place to ensure that accessible text is still applied to the component.
+  </C.Property>
+  <C.Property @name="...attributes">
+    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+  </C.Property>
 </Doc::ComponentApi>

--- a/website/docs/components/badge/partials/code/component-api.md
+++ b/website/docs/components/badge/partials/code/component-api.md
@@ -1,19 +1,19 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
-  <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
-  <C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" "highlight" "critical" "success" "warning" }} @default="neutral"/>
-  <C.Property @name="text" @type="string">
-    The text of the Badge or value of the screen-reader only element if `isIconOnly` is set to `true`. If no text value is defined an error will be thrown.
-  </C.Property>
-  <C.Property @name="icon" @type="string">
-    Use this parameter to show an icon. Any [icon](/icons/library) name is acceptable.
-  </C.Property>
-  <C.Property @name="isIconOnly" @type="boolean" @default="false">
-    This indicates if the button will only contain an icon. An internal check is in place to ensure that accessible text is still applied to the component.
-  </C.Property>
-  <C.Property @name="...attributes">
-    This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
-  </C.Property>
+<C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
+<C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
+<C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" "highlight" "critical" "success" "warning" }} @default="neutral"/>
+<C.Property @name="text" @type="string | number">
+The text of the Badge or value of the screen-reader only element if `isIconOnly` is set to `true`. If no text value is defined an error will be thrown.
+</C.Property>
+<C.Property @name="icon" @type="string">
+Use this parameter to show an icon. Any [icon](/icons/library) name is acceptable.
+</C.Property>
+<C.Property @name="isIconOnly" @type="boolean" @default="false">
+This indicates if the button will only contain an icon. An internal check is in place to ensure that accessible text is still applied to the component.
+</C.Property>
+<C.Property @name="...attributes">
+This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
+</C.Property>
 </Doc::ComponentApi>


### PR DESCRIPTION
### :pushpin: Summary

If merged, people will be able to pass `numbers` for the `@text` argument on the Badge component

### :hammer_and_wrench: Detailed description

* updates the badge component signature to include number
* update the website documentation to match the new type
![Screenshot 2024-07-23 at 3 56 46 PM](https://github.com/user-attachments/assets/f0cb9ef5-b5c1-42b0-bc26-60991d666cf1)

### :link: External links

Jira ticket: [HDS-3567](https://hashicorp.atlassian.net/browse/HDS-3567)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3567]: https://hashicorp.atlassian.net/browse/HDS-3567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ