### PR TITLE
Website - Add status and version history to recently updated components

### DIFF
--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -9,6 +9,8 @@ related: ['components/badge-count','components/tag']
 previewImage: assets/illustrations/components/badge.jpg
 navigation:
   keywords: ['chip', 'pill', 'tag', 'label']
+status:
+  updated: 4.7.0
 ---
 
 <section data-tab="Guidelines">
@@ -27,4 +29,8 @@ navigation:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.7.0.md"
 </section>

--- a/website/docs/components/badge/partials/version-history/4.7.0.md
+++ b/website/docs/components/badge/partials/version-history/4.7.0.md
@@ -1,0 +1,5 @@
+## 4.7.0
+
+### Updated
+
+Updated `@text` argument type to include numbers.

--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -9,6 +9,8 @@ related: ['components/form/select', 'components/form/textarea', 'components/form
 previewImage: assets/illustrations/components/form/text-input.jpg
 navigation:
   keywords: ['text field', 'search', 'form']
+status:
+  updated: 4.7.0
 ---
 
 <section data-tab="Guidelines">
@@ -28,4 +30,8 @@ navigation:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.7.0.md"
 </section>

--- a/website/docs/components/form/text-input/partials/version-history/4.7.0.md
+++ b/website/docs/components/form/text-input/partials/version-history/4.7.0.md
@@ -1,0 +1,5 @@
+## 4.7.0
+
+### Updated
+
+Added support for `month`, `week`, and `tel` input types


### PR DESCRIPTION
### :pushpin: Summary

Small PR to add status ("updated") and version history for `Form::TextInput` (#2198) and `Badge` (#2270)

👉 👉 👉 Previews:
- [Badge](https://hds-website-git-website-add-missing-histories-hashicorp.vercel.app/components/badge)
- [Form::TextInput](https://hds-website-git-website-add-missing-histories-hashicorp.vercel.app/components/form/text-input)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
