### PR TITLE
Add missing links to versioned docs

### DIFF
--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -14,6 +14,8 @@
 
 ## 4.7.0
 
+[4.7.0 documentation](https://hds-website-4-7-0.vercel.app/)
+
 **Minor changes**
 
 `FileInput`, `MaskedInput`, `Select`, `TextInput`, `Textarea` - Converted to TypeScript
@@ -88,6 +90,8 @@ Converted form primitives to TypeScript
 - @hashicorp/ember-flight-icons@5.1.3
 
 ## 4.6.0
+
+[4.6.0 documentation](https://hds-website-4-6-0.vercel.app/)
 
 **Minor changes**
 


### PR DESCRIPTION
### :pushpin: Summary

Add missing links to versioned docs on [release notes page](https://hds-website-git-alex-ju-add-missing-version-doc-links-hashicorp.vercel.app/whats-new/release-notes)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
