### PR TITLE
Website - Fix disappearing "back" button in `index` pages

### DIFF
--- a/showcase/app/controllers/application.js
+++ b/showcase/app/controllers/application.js
@@ -18,6 +18,7 @@ export default class ApplicationController extends Controller {
   }
 
   routeDidChange() {
+    // it's a "framless" page (we infer it from the URL for simplicity)
     this.isFrameless = this.router?.currentURL?.includes('frameless');
   }
 }

--- a/showcase/app/styles/_layout.scss
+++ b/showcase/app/styles/_layout.scss
@@ -41,7 +41,8 @@
 
 // PAGE-SPECIFIC OVERRIDES
 
-body.index {
+// this is the homepage
+body:has(.shw-landing-lists) {
   .shw-page-aside {
     display: none;
   }


### PR DESCRIPTION
### :pushpin: Summary

In #2259 I've converted a normal page to a "folder" route but in doing so it has become an "index", hitting a CSS selector that was meant only for the homepage.

Context: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1721854575430409

### :hammer_and_wrench: Detailed description

In this PR I have:
- fixed the issue with the CSS selector for the homepage

### :camera_flash: Screenshots

After the fix:
![image](https://github.com/user-attachments/assets/3dee71d9-589d-4319-899c-38f1b5a6e36f)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
