### PR TITLE
add explicit ember-get-config depedency

### DIFF
--- a/.changeset/small-peaches-complain.md
+++ b/.changeset/small-peaches-complain.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Add explicit `ember-get-config` dependency for use in the icon sprite initializer

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,6 +47,7 @@
     "ember-composable-helpers": "^5.0.0",
     "ember-element-helper": "^0.8.5",
     "ember-focus-trap": "^1.1.0",
+    "ember-get-config": "^2.1.1",
     "ember-keyboard": "^8.2.1",
     "ember-modifier": "^4.1.0",
     "ember-power-select": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4130,6 +4130,7 @@ __metadata:
     ember-concurrency: "npm:^4.0.2"
     ember-element-helper: "npm:^0.8.5"
     ember-focus-trap: "npm:^1.1.0"
+    ember-get-config: "npm:^2.1.1"
     ember-keyboard: "npm:^8.2.1"
     ember-modifier: "npm:^4.1.0"
     ember-power-select: "npm:^8.2.0"


### PR DESCRIPTION
### :pushpin: Summary

Adds an explicit reference to a dependency used in the icon initializer

### :hammer_and_wrench: Detailed description

Running the website I noticed this warning

```bash
[js] (!) Unresolved dependencies
[js] https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency
[js] ember-get-config (imported by "src/instance-initializers/load-sprite.ts")
```

https://github.com/hashicorp/design-system/pull/2198 added this logic to the components package without explicitly referencing the `ember-get-config` dependency that is used [here](https://github.com/hashicorp/design-system/blob/bc16ff4d6a3721e23517467344d3e585e069c34f/packages/components/src/instance-initializers/load-sprite.ts#L6). Similar to https://github.com/hashicorp/design-system/pull/2169, we need to explicitly depend on it to avoid issues (even though I would imagine it's always going to exist somewhere in the dependency tree anyhow).


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
