### PR TITLE
Remove web component scraping examples that blow up the website

### DIFF
--- a/website/docs/testing/markdown/scraping-playground.md
+++ b/website/docs/testing/markdown/scraping-playground.md
@@ -88,20 +88,6 @@ Lorem ipsum
 
 ----------------
 
-# Web Components
-
-<custom-tag class="div-class">
-  <p><span class="span-class">Hello</span> world</p>
-</custom-tag>
-
-<another-custom-tag />
-
-<CustomTag class="customtag-class">
-  <p><span class="span-class">Hello</span> world</p>
-</CustomTag>
-
-----------------
-
 # DOC Components
 
 <Doc::Content::HdsPrinciples />


### PR DESCRIPTION
_Super low priority, but I noticed these errors in our build log and spent 5 minutes investigating. I'm not sure if there's value in trying to keep these examples around or digging into the root cause more, but if not removing them seems pragmatic if for not other reason than to clean up our build logs._ 

### :pushpin: Summary

Removes example code that prevents this page from rendering

### :hammer_and_wrench: Detailed description

I'm not sure why, but Ember does not like trying to process this content. It blows up in Prember and also doesn't work in the [real website either](https://hds-website-hashicorp.vercel.app/testing/markdown/scraping-playground).

```bash
 building... [prember > Builder Cleanup]Error [SyntaxError]: Closing tag </p> did not match last open tag <custom-tag> (on line 93): 

|
|  </p>
|

(error occurred in 'an unknown module' @ line 94 : column 2)
    at generateSyntaxError (/var/folders/n5/ym98p8l9545bjw7v76pb9bmw0000gn/T/broccoli-625022RCoX1bVd7tX/out-418-broccoli_merge_trees/assets/@glimmer/syntax.js:1656:1)
    at TokenizerEventHandlers.validateEndTag (/var/folders/n5/ym98p8l9545bjw7v76pb9bmw0000gn/T/broccoli-625022RCoX1bVd7tX/out-418-broccoli_merge_trees/assets/@glimmer/syntax.js:4080:1)
...
 much more after this
```