### PR TITLE
`SegmentedGroup`, `Dropdown` - mark optional args

### DIFF
--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -31,10 +31,10 @@ export const POSITIONS: string[] = Object.values(HdsDropdownPositionValues);
 
 export interface HdsDropdownSignature {
   Args: MenuPrimitiveSignature['Args'] & {
-    height: string;
-    isInline: boolean;
-    listPosition: HdsDropdownPositions;
-    width: string;
+    height?: string;
+    isInline?: boolean;
+    listPosition?: HdsDropdownPositions;
+    width?: string;
   };
   Blocks: {
     default: [

--- a/packages/components/src/components/hds/segmented-group/index.ts
+++ b/packages/components/src/components/hds/segmented-group/index.ts
@@ -11,11 +11,11 @@ interface HdsSegmentedGroupSignature {
   Blocks: {
     default: [
       {
-        Button: ComponentLike<HdsButtonSignature>;
-        Dropdown: ComponentLike<HdsDropdownSignature>;
-        Select: ComponentLike<HdsFormSelectBaseSignature>;
-        TextInput: ComponentLike<HdsFormTextInputBaseSignature>;
-        Generic: ComponentLike<HdsYieldSignature>;
+        Button?: ComponentLike<HdsButtonSignature>;
+        Dropdown?: ComponentLike<HdsDropdownSignature>;
+        Select?: ComponentLike<HdsFormSelectBaseSignature>;
+        TextInput?: ComponentLike<HdsFormTextInputBaseSignature>;
+        Generic?: ComponentLike<HdsYieldSignature>;
       },
     ];
   };


### PR DESCRIPTION
### :pushpin: Summary

Mark optional args as such. We missed them in their conversion PRs, but we haven't released yet so we can patch without changelog entries.

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
