### PR TITLE
fix: move keyboard focus when click scroll to top button

### DIFF
--- a/website/app/components/doc/page/stage.hbs
+++ b/website/app/components/doc/page/stage.hbs
@@ -3,6 +3,6 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<main class="doc-page-stage" ...attributes id="main" tabindex="-1">
+<main class="doc-page-stage" ...attributes id="main" aria-labelledby="doc-page-cover__title">
   {{yield}}
 </main>

--- a/website/app/components/doc/page/stage.hbs
+++ b/website/app/components/doc/page/stage.hbs
@@ -3,6 +3,6 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<main class="doc-page-stage" ...attributes id="main">
+<main class="doc-page-stage" ...attributes id="main" tabindex="-1">
   {{yield}}
 </main>

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -8,7 +8,6 @@
   aria-label="Scroll back to top"
   class="doc-scroll-to-top {{if this.isVisible 'doc-scroll-to-top--is-visible'}}"
   tabindex={{if this.isVisible 0 -1}}
-  {{on "click" this.scrollToTop}}
   {{doc-track-event eventName="Navigation - Scroll to Top"}}
 >
   <FlightIcon @name="arrow-up" @color="white" @size="24" @isInlineBlock={{false}} />

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -6,8 +6,8 @@
 <a
   href="#main"
   aria-label="Scroll back to top"
-  class="doc-scroll-to-top {{if this.isLinkVisible 'doc-scroll-to-top--is-visible'}}"
-  tabindex={{if this.isLinkVisible 0 -1}}
+  class="doc-scroll-to-top {{if this.isVisible 'doc-scroll-to-top--is-visible'}}"
+  tabindex={{if this.isVisible 0 -1}}
   {{on "click" this.scrollToTop}}
   {{doc-track-event eventName="Navigation - Scroll to Top"}}
 >

--- a/website/app/components/doc/scroll-to-top/index.hbs
+++ b/website/app/components/doc/scroll-to-top/index.hbs
@@ -3,13 +3,13 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<button
+<a
+  href="#main"
   aria-label="Scroll back to top"
-  class="doc-scroll-to-top {{if this.isButtonVisible 'doc-scroll-to-top--is-visible'}}"
-  type="button"
-  tabindex={{if this.isButtonVisible 0 -1}}
+  class="doc-scroll-to-top {{if this.isLinkVisible 'doc-scroll-to-top--is-visible'}}"
+  tabindex={{if this.isLinkVisible 0 -1}}
   {{on "click" this.scrollToTop}}
   {{doc-track-event eventName="Navigation - Scroll to Top"}}
 >
   <FlightIcon @name="arrow-up" @color="white" @size="24" @isInlineBlock={{false}} />
-</button>
+</a>

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -10,7 +10,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class DocScrollToTopComponent extends Component {
   @service fastboot;
-  @tracked isButtonVisible = false;
+  @tracked isLinkVisible = false;
 
   constructor() {
     super(...arguments);
@@ -29,22 +29,11 @@ export default class DocScrollToTopComponent extends Component {
   @action
   scrollToTop() {
     window.scrollTo({ top: 0, behavior: 'smooth' });
-    const main = document.getElementsByTagName('main');
-    if (main) {
-      const focusable = main[0].querySelectorAll(
-        'button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
-      const filteredFocusable = Array.from(focusable).filter(
-        (el) => !el.classList.contains('doc-scroll-to-top')
-      );
-      if (filteredFocusable.length > 0) filteredFocusable[0].focus();
-      else main[0].focus();
-    }
   }
 
   @action
   checkScroll() {
-    this.isButtonVisible = window.scrollY > 200;
+    this.isLinkVisible = window.scrollY > 200;
   }
 
   @action

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -29,6 +29,13 @@ export default class DocScrollToTopComponent extends Component {
   @action
   scrollToTop() {
     window.scrollTo({ top: 0, behavior: 'smooth' });
+    const main = document.getElementById('main');
+    if (main) {
+      const focusable = main.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length > 0) focusable[0].focus();
+    }
   }
 
   @action

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -27,11 +27,6 @@ export default class DocScrollToTopComponent extends Component {
   }
 
   @action
-  scrollToTop() {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  }
-
-  @action
   checkScroll() {
     this.isVisible = window.scrollY > 200;
   }

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -32,9 +32,13 @@ export default class DocScrollToTopComponent extends Component {
     const main = document.getElementsByTagName('main');
     if (main) {
       const focusable = main[0].querySelectorAll(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        'button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
       );
-      if (focusable.length > 0) focusable[0].focus();
+      const filteredFocusable = Array.from(focusable).filter(
+        (el) => !el.classList.contains('doc-scroll-to-top')
+      );
+      if (filteredFocusable.length > 0) filteredFocusable[0].focus();
+      else main[0].focus();
     }
   }
 

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -29,9 +29,9 @@ export default class DocScrollToTopComponent extends Component {
   @action
   scrollToTop() {
     window.scrollTo({ top: 0, behavior: 'smooth' });
-    const main = document.getElementById('main');
+    const main = document.getElementsByTagName('main');
     if (main) {
-      const focusable = main.querySelectorAll(
+      const focusable = main[0].querySelectorAll(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
       );
       if (focusable.length > 0) focusable[0].focus();

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -10,7 +10,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class DocScrollToTopComponent extends Component {
   @service fastboot;
-  @tracked isLinkVisible = false;
+  @tracked isVisible = false;
 
   constructor() {
     super(...arguments);
@@ -33,7 +33,7 @@ export default class DocScrollToTopComponent extends Component {
 
   @action
   checkScroll() {
-    this.isLinkVisible = window.scrollY > 200;
+    this.isVisible = window.scrollY > 200;
   }
 
   @action

--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -65,6 +65,7 @@ html {
   height: 100%;
   margin: 0;
   padding: 0;
+  scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would make it so when a user clicks the scroll back to top on the website, their keyboard focus moves to the `<main/>` element.

### 🛠️ Detailed description

I ended up changing the implementation from a button to an anchor. I initially made it where the button searched the DOM for all the interactive elements and focus the first one, but this had a few downsides:
* for some pages, when the first interactive element isn't close to the top, the scroll wouldn't go all the way up
* if there are no interactive elements, I tried programmatically focusing the main element but screen readers wouldn't consistently move the screen reader cursor
* overall, the approach seemed over complicated - especially when the skip to main content link works well and announces correctly.

Other changes: 
* set `aria-labelledby` for the `<main />` element on all pages except the home page to id of the h1

### :link: External links

Jira ticket: [HDS-3596](https://hashicorp.atlassian.net/browse/HDS-3596)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3596]: https://hashicorp.atlassian.net/browse/HDS-3596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ