### PR TITLE
Align page title and main headings to blueprint format

### DIFF
--- a/showcase/app/templates/application.hbs
+++ b/showcase/app/templates/application.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "HDS Design System"}}
+{{page-title "HDS Showcase"}}
 
 {{#if this.isFrameless}}
   {{outlet}}

--- a/showcase/app/templates/components/alert.hbs
+++ b/showcase/app/templates/components/alert.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "Alert component"}}
+{{page-title "Alert Component"}}
 
 <Shw::Text::H1>Alert</Shw::Text::H1>
 

--- a/showcase/app/templates/components/application-state.hbs
+++ b/showcase/app/templates/components/application-state.hbs
@@ -3,9 +3,9 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "Application State Component"}}
+{{page-title "ApplicationState Component"}}
 
-<Shw::Text::H1>Application State</Shw::Text::H1>
+<Shw::Text::H1>ApplicationState</Shw::Text::H1>
 
 <section data-test-percy>
   <Shw::Flex @direction="column" as |SF|>

--- a/showcase/app/templates/components/badge-count.hbs
+++ b/showcase/app/templates/components/badge-count.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "BadgeCount component"}}
+{{page-title "BadgeCount Component"}}
 
 <Shw::Text::H1>BadgeCount</Shw::Text::H1>
 

--- a/showcase/app/templates/components/badge.hbs
+++ b/showcase/app/templates/components/badge.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "Badge component"}}
+{{page-title "Badge Component"}}
 
 <Shw::Text::H1>Badge</Shw::Text::H1>
 

--- a/showcase/app/templates/components/breadcrumb.hbs
+++ b/showcase/app/templates/components/breadcrumb.hbs
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "Breadcrumb"}}
+{{page-title "Breadcrumb Component"}}
 
 <Shw::Text::H1>Breadcrumb</Shw::Text::H1>
 

--- a/showcase/app/templates/components/button.hbs
+++ b/showcase/app/templates/components/button.hbs
@@ -3,9 +3,9 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "Button component"}}
+{{page-title "Button Component"}}
 
-<Shw::Text::H1>Button component</Shw::Text::H1>
+<Shw::Text::H1>Button</Shw::Text::H1>
 
 <section data-test-percy>
 

--- a/showcase/app/templates/components/card.hbs
+++ b/showcase/app/templates/components/card.hbs
@@ -3,9 +3,9 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "Card component"}}
+{{page-title "Card Component"}}
 
-<Shw::Text::H1>Card container</Shw::Text::H1>
+<Shw::Text::H1>Card</Shw::Text::H1>
 
 <section data-test-percy>
 

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -5,7 +5,7 @@
 
 {{page-title "Dropdown Component"}}
 
-<Shw::Text::H1>Dropdown Component</Shw::Text::H1>
+<Shw::Text::H1>Dropdown</Shw::Text::H1>
 
 <section data-test-percy>
 

--- a/showcase/app/templates/components/icon-tile.hbs
+++ b/showcase/app/templates/components/icon-tile.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "IconTile"}}
+{{page-title "IconTile Component"}}
 
 <Shw::Text::H1>IconTile</Shw::Text::H1>
 

--- a/showcase/app/templates/components/stepper.hbs
+++ b/showcase/app/templates/components/stepper.hbs
@@ -5,7 +5,7 @@
 
 {{page-title "Stepper Indicator Component"}}
 
-<Shw::Text::H1>Stepper Indicator Component</Shw::Text::H1>
+<Shw::Text::H1>Stepper Indicator</Shw::Text::H1>
 
 <section data-test-percy>
 

--- a/showcase/app/templates/components/tag.hbs
+++ b/showcase/app/templates/components/tag.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "Tag component"}}
+{{page-title "Tag Component"}}
 
 <Shw::Text::H1>Tag</Shw::Text::H1>
 

--- a/showcase/app/templates/components/text.hbs
+++ b/showcase/app/templates/components/text.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "Text component"}}
+{{page-title "Text Component"}}
 
 <Shw::Text::H1>Text</Shw::Text::H1>
 

--- a/showcase/app/templates/components/toast.hbs
+++ b/showcase/app/templates/components/toast.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "Toast component"}}
+{{page-title "Toast Component"}}
 
 <Shw::Text::H1>Toast</Shw::Text::H1>
 

--- a/showcase/app/templates/utilities/dialog-primitive.hbs
+++ b/showcase/app/templates/utilities/dialog-primitive.hbs
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "DialogPrimitive Components"}}
+{{page-title "DialogPrimitive Component"}}
 
 <Shw::Text::H1>DialogPrimitive</Shw::Text::H1>
 

--- a/showcase/app/templates/utilities/disclosure-primitive.hbs
+++ b/showcase/app/templates/utilities/disclosure-primitive.hbs
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "DisclosurePrimitive"}}
+{{page-title "DisclosurePrimitive Component"}}
 
 <Shw::Text::H1>DisclosurePrimitive</Shw::Text::H1>
 

--- a/showcase/app/templates/utilities/interactive.hbs
+++ b/showcase/app/templates/utilities/interactive.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "Interactive"}}
+{{page-title "Interactive Component"}}
 
 <Shw::Text::H1>Interactive</Shw::Text::H1>
 

--- a/showcase/app/templates/utilities/menu-primitive.hbs
+++ b/showcase/app/templates/utilities/menu-primitive.hbs
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "MenuPrimitive"}}
+{{page-title "MenuPrimitive Component"}}
 
 <Shw::Text::H1>MenuPrimitive</Shw::Text::H1>
 

--- a/showcase/app/templates/utilities/popover-primitive.hbs
+++ b/showcase/app/templates/utilities/popover-primitive.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title "PopoverPrimitive"}}
+{{page-title "PopoverPrimitive Component"}}
 
 <Shw::Text::H1>PopoverPrimitive</Shw::Text::H1>
 


### PR DESCRIPTION
### :pushpin: Summary

Align page title and main headings in `showcase` to match [blueprint format](https://github.com/hashicorp/design-system/blob/main/showcase/blueprints/hds-component-test/files/app/templates/components/__name__.hbs)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
