### PR TITLE
Website - Add status badges and version history for `AppHeader` and `SideNav`

### DIFF
--- a/website/docs/components/app-header/index.md
+++ b/website/docs/components/app-header/index.md
@@ -17,6 +17,7 @@ status:
   @include "partials/guidelines/overview.md"
   @include "partials/guidelines/guidelines.md"
 </section>
+
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
@@ -28,4 +29,8 @@ status:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.8.0.md"
 </section>

--- a/website/docs/components/app-header/index.md
+++ b/website/docs/components/app-header/index.md
@@ -9,13 +9,14 @@ related: ['components/side-nav', 'components/app-footer', 'layouts/app-frame']
 previewImage: assets/illustrations/components/app-header.jpg
 navigation:
   keywords: ['navigation', 'header', 'navbar', 'menubar', 'topbar']
+status:
+  added: 4.8.0
 ---
 
 <section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
   @include "partials/guidelines/guidelines.md"
 </section>
-
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"

--- a/website/docs/components/app-header/partials/version-history/4.8.0.md
+++ b/website/docs/components/app-header/partials/version-history/4.8.0.md
@@ -1,0 +1,11 @@
+## 4.8.0
+
+### Added
+
+Added the `AppHeader` component and its sub-components, to be used in conjunction with the `AppFrame` and the `Sidenav` components.
+
+Also added the following design tokens:
+
+- `--token-app-header-height`
+- `--token-app-header-home-link-size`
+- `--token-app-header-logo-size`

--- a/website/docs/components/side-nav/index.md
+++ b/website/docs/components/side-nav/index.md
@@ -31,3 +31,8 @@ status:
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.8.0.md"
+</section>
+

--- a/website/docs/components/side-nav/index.md
+++ b/website/docs/components/side-nav/index.md
@@ -10,6 +10,8 @@ previewImage: assets/illustrations/components/side-nav.jpg
 navigation:
   hidden: false
   keywords: ['navigation', 'side navigation', 'sidenav', 'sidebar']
+status:
+  updated: 4.8.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/side-nav/partials/version-history/4.8.0.md
+++ b/website/docs/components/side-nav/partials/version-history/4.8.0.md
@@ -1,0 +1,5 @@
+## 4.8.0
+
+### Updated
+
+Added new `withAppHeader` option to control the height of the Side Nav when there is also an [App Header](/components/app-header) in the application.


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of #2161 and #2239 to add the status badges and the content of the "Version history" tab for the `AppHeader` and `SideNav` components.

### :hammer_and_wrench: Detailed description

In this PR I have:

- added status badges for `AppHeader` and `SideNav`
- added “Version history” tabs and content for `AppHeader` and `SideNav`
- removed status badges for `4.7.0` updates

Previews:

- [AppHeader](https://hds-website-git-appheader-version-history-hashicorp.vercel.app/components/app-header)
- [SideNav](https://hds-website-git-appheader-version-history-hashicorp.vercel.app/components/side-nav)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
