### PR TITLE
Convert Breadcrumb to TypeScript

### DIFF
--- a/.changeset/olive-eagles-add.md
+++ b/.changeset/olive-eagles-add.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Breadcrumb` - Converted component to TypeScript

--- a/packages/components/src/components.ts
+++ b/packages/components/src/components.ts
@@ -11,6 +11,9 @@ import HdsAppFrame from './components/hds/app-frame/index.ts';
 import HdsApplicationState from './components/hds/application-state/index.ts';
 import HdsBadge from './components/hds/badge/index.ts';
 import HdsBadgeCount from './components/hds/badge-count/index.ts';
+import HdsBreadcrumb from './components/hds/breadcrumb/index.ts';
+import HdsBreadcrumbItem from './components/hds/breadcrumb/item.ts';
+import HdsBreadcrumbTruncation from './components/hds/breadcrumb/truncation.ts';
 import HdsButton from './components/hds/button/index.ts';
 import HdsButtonSet from './components/hds/button-set/index.ts';
 import HdsCard from './components/hds/card/container.ts';
@@ -101,6 +104,9 @@ export {
   HdsApplicationState,
   HdsBadge,
   HdsBadgeCount,
+  HdsBreadcrumb,
+  HdsBreadcrumbItem,
+  HdsBreadcrumbTruncation,
   HdsButton,
   HdsButtonSet,
   HdsCard,

--- a/packages/components/src/components/hds/breadcrumb/index.hbs
+++ b/packages/components/src/components/hds/breadcrumb/index.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/breadcrumb/index.ts
+++ b/packages/components/src/components/hds/breadcrumb/index.ts
@@ -25,7 +25,7 @@ export default class HdsBreadcrumbComponent extends Component<HdsBreadcrumbSigna
    * @type {function}
    * @default () => {}
    */
-  get didInsert() {
+  get didInsert(): () => void {
     const { didInsert } = this.args;
 
     if (typeof didInsert === 'function') {
@@ -40,7 +40,7 @@ export default class HdsBreadcrumbComponent extends Component<HdsBreadcrumbSigna
    * @type {boolean}
    * @default true
    */
-  get itemsCanWrap() {
+  get itemsCanWrap(): boolean {
     return this.args.itemsCanWrap ?? true;
   }
 
@@ -49,7 +49,7 @@ export default class HdsBreadcrumbComponent extends Component<HdsBreadcrumbSigna
    * @type {string}
    * @default 'breadcrumbs'
    */
-  get ariaLabel() {
+  get ariaLabel(): string {
     return this.args.ariaLabel ?? 'breadcrumbs';
   }
 
@@ -58,7 +58,7 @@ export default class HdsBreadcrumbComponent extends Component<HdsBreadcrumbSigna
    * @method Breadcrumb#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-breadcrumb'];
 
     // add a class based on the @itemsCanWrap argument

--- a/packages/components/src/components/hds/breadcrumb/index.ts
+++ b/packages/components/src/components/hds/breadcrumb/index.ts
@@ -5,16 +5,28 @@
 
 import Component from '@glimmer/component';
 
+export interface HdsBreadcrumbSignature {
+  Args: {
+    ariaLabel?: string;
+    itemsCanWrap?: boolean;
+    didInsert?: () => void;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: HTMLElement;
+}
+
 const NOOP = () => {};
 
-export default class HdsBreadcrumbComponent extends Component {
+export default class HdsBreadcrumbComponent extends Component<HdsBreadcrumbSignature> {
   /**
    * @param onDidInsert
    * @type {function}
    * @default () => {}
    */
   get didInsert() {
-    let { didInsert } = this.args;
+    const { didInsert } = this.args;
 
     if (typeof didInsert === 'function') {
       return didInsert;
@@ -47,7 +59,7 @@ export default class HdsBreadcrumbComponent extends Component {
    * @return {string} The "class" attribute to apply to the component.
    */
   get classNames() {
-    let classes = ['hds-breadcrumb'];
+    const classes = ['hds-breadcrumb'];
 
     // add a class based on the @itemsCanWrap argument
     if (this.itemsCanWrap) {

--- a/packages/components/src/components/hds/breadcrumb/item.hbs
+++ b/packages/components/src/components/hds/breadcrumb/item.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/breadcrumb/item.ts
+++ b/packages/components/src/components/hds/breadcrumb/item.ts
@@ -6,6 +6,7 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { assert } from '@ember/debug';
+import type { SafeString } from '@ember/template/-private/handlebars';
 import type { FlightIconSignature } from '@hashicorp/ember-flight-icons/components/flight-icon';
 
 export interface HdsBreadcrumbItemSignature {
@@ -32,7 +33,7 @@ export default class HdsBreadcrumbItemComponent extends Component<HdsBreadcrumbI
    * @default undefined
    * @description A parameter that can be applied to an "item" to limit its max-width
    */
-  get maxWidth() {
+  get maxWidth(): string | undefined {
     const { maxWidth } = this.args;
 
     if (maxWidth) {
@@ -52,7 +53,7 @@ export default class HdsBreadcrumbItemComponent extends Component<HdsBreadcrumbI
    * @method BreadcrumbItem#itemStyle
    * @return {string} The "style" attribute to apply to the item.
    */
-  get itemStyle() {
+  get itemStyle(): SafeString | undefined {
     if (this.maxWidth) {
       return htmlSafe(`max-width: ${this.maxWidth}`);
     } else {
@@ -65,7 +66,7 @@ export default class HdsBreadcrumbItemComponent extends Component<HdsBreadcrumbI
    * @method BreadcrumbItem#classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-breadcrumb__item'];
 
     return classes.join(' ');

--- a/packages/components/src/components/hds/breadcrumb/item.ts
+++ b/packages/components/src/components/hds/breadcrumb/item.ts
@@ -6,8 +6,26 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { assert } from '@ember/debug';
+import type { FlightIconSignature } from '@hashicorp/ember-flight-icons/components/flight-icon';
 
-export default class HdsBreadcrumbItemComponent extends Component {
+export interface HdsBreadcrumbItemSignature {
+  Args: {
+    current?: boolean;
+    maxWidth?: string;
+    text: string;
+    isRouteExternal?: boolean;
+    icon?: FlightIconSignature['Args']['name'];
+    route?: string;
+    models?: Array<string | number>;
+    model?: string | number;
+    query?: Record<string, string>;
+    'current-when'?: string;
+    replace?: boolean;
+  };
+  Element: HTMLLIElement;
+}
+
+export default class HdsBreadcrumbItemComponent extends Component<HdsBreadcrumbItemSignature> {
   /**
    * @param maxWidth
    * @type {string}
@@ -15,7 +33,7 @@ export default class HdsBreadcrumbItemComponent extends Component {
    * @description A parameter that can be applied to an "item" to limit its max-width
    */
   get maxWidth() {
-    let { maxWidth } = this.args;
+    const { maxWidth } = this.args;
 
     if (maxWidth) {
       assert(
@@ -48,7 +66,7 @@ export default class HdsBreadcrumbItemComponent extends Component {
    * @return {string} The "class" attribute to apply to the component.
    */
   get classNames() {
-    let classes = ['hds-breadcrumb__item'];
+    const classes = ['hds-breadcrumb__item'];
 
     return classes.join(' ');
   }

--- a/packages/components/src/components/hds/breadcrumb/truncation.hbs
+++ b/packages/components/src/components/hds/breadcrumb/truncation.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/breadcrumb/truncation.ts
+++ b/packages/components/src/components/hds/breadcrumb/truncation.ts
@@ -21,7 +21,7 @@ export default class HdsBreadcrumbTruncationComponent extends Component<HdsBread
    * @type {string}
    * @default 'show more'
    */
-  get ariaLabel() {
+  get ariaLabel(): string {
     return this.args.ariaLabel ?? 'show more';
   }
 }

--- a/packages/components/src/components/hds/breadcrumb/truncation.ts
+++ b/packages/components/src/components/hds/breadcrumb/truncation.ts
@@ -5,7 +5,17 @@
 
 import Component from '@glimmer/component';
 
-export default class HdsBreadcrumbTruncationComponent extends Component {
+export interface HdsBreadcrumbTruncationSignature {
+  Args: {
+    ariaLabel?: string;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: HTMLLIElement;
+}
+
+export default class HdsBreadcrumbTruncationComponent extends Component<HdsBreadcrumbTruncationSignature> {
   /**
    * @param ariaLabel
    * @type {string}

--- a/packages/components/src/components/hds/menu-primitive/index.ts
+++ b/packages/components/src/components/hds/menu-primitive/index.ts
@@ -17,7 +17,7 @@ export interface MenuPrimitiveSignature {
     toggle?: [
       {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        onClickToggle?: (event: MouseEvent, ...args: any[]) => void;
+        onClickToggle: (event: MouseEvent, ...args: any[]) => void;
         isOpen?: boolean;
       },
     ];

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -21,6 +21,9 @@ import type HdsAppFooterLinkComponent from './components/hds/app-footer/link';
 import type HdsAppFooterStatusLinkComponent from './components/hds/app-footer/status-link';
 import type HdsBadgeComponent from './components/hds/badge';
 import type HdsBadgeCountComponent from './components/hds/badge-count';
+import type HdsBreadcrumbComponent from './components/hds/breadcrumb/index.ts';
+import type HdsBreadcrumbItemComponent from './components/hds/breadcrumb/item';
+import type HdsBreadcrumbTruncationComponent from './components/hds/breadcrumb/truncation.ts';
 import type HdsButtonComponent from './components/hds/button';
 import type HdsButtonSetComponent from './components/hds/button-set';
 import type HdsAppFrameComponent from './components/hds/app-frame';
@@ -247,6 +250,16 @@ export default interface HdsComponentsRegistry {
   // BadgeCount
   'Hds::BadgeCount': typeof HdsBadgeCountComponent;
   'hds/badge-count': typeof HdsBadgeCountComponent;
+
+  // Breadcrumb
+  'Hds::Breadcrumb': typeof HdsBreadcrumbComponent;
+  'hds/breadcrumb': typeof HdsBreadcrumbComponent;
+
+  'Hds::Breadcrumb::Item': typeof HdsBreadcrumbItemComponent;
+  'hds/breadcrumb/item': typeof HdsBreadcrumbItemComponent;
+
+  'Hds::Breadcrumb::Truncation': typeof HdsBreadcrumbTruncationComponent;
+  'hds/breadcrumb/truncation': typeof HdsBreadcrumbTruncationComponent;
 
   // Button
   'Hds::Button': typeof HdsButtonComponent;


### PR DESCRIPTION
### :pushpin: Summary

Converted breadcrumb to typescript.

### :hammer_and_wrench: Detailed description

### :link: External links

Jira ticket: [HDS-2685](https://hashicorp.atlassian.net/browse/HDS-2685)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2685]: https://hashicorp.atlassian.net/browse/HDS-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ