### PR TITLE
Website - Add status badge and version history for `ApplicationState`

### DIFF
--- a/website/docs/components/application-state/index.md
+++ b/website/docs/components/application-state/index.md
@@ -16,6 +16,7 @@ status:
   @include "partials/guidelines/overview.md"
   @include "partials/guidelines/guidelines.md"
 </section>
+
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
@@ -27,4 +28,8 @@ status:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.8.0.md"
 </section>

--- a/website/docs/components/application-state/index.md
+++ b/website/docs/components/application-state/index.md
@@ -8,13 +8,14 @@ links:
 previewImage: assets/illustrations/components/application-state.jpg
 navigation:
   keywords: ['empty state', 'error state', 'message']
+status:
+  updated: 4.8.0
 ---
 
 <section data-tab="Guidelines">
   @include "partials/guidelines/overview.md"
   @include "partials/guidelines/guidelines.md"
 </section>
-
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"

--- a/website/docs/components/application-state/partials/version-history/4.8.0.md
+++ b/website/docs/components/application-state/partials/version-history/4.8.0.md
@@ -1,0 +1,18 @@
+## 4.8.0
+
+### Updated
+
+`ApplicationState`
+
+- Added new `@align` argument for aligning content (`left` (default) and `center`)
+- Added new yielded `Media` child component to support illustrations
+- Visual updates related to text colors, spacing and alignment
+
+`ApplicationState::Header`
+
+- The header now supports an optional `@titleTag` argument that can override the default title element (`div`)
+
+`ApplicationState::Footer`
+
+- The footer now yields also `Button` and `Dropdown` components to be used as actions
+- The visual separator has been removed to to modernize the component’s visual look

--- a/website/docs/components/application-state/partials/version-history/4.8.0.md
+++ b/website/docs/components/application-state/partials/version-history/4.8.0.md
@@ -15,4 +15,4 @@
 `ApplicationState::Footer`
 
 - The footer now yields also `Button` and `Dropdown` components to be used as actions
-- The visual separator has been removed to to modernize the component’s visual look
+- The visual separator has been removed to modernize the component’s visual look


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of #2274 and #2269 to add the status badge and the content of the "Version history" tab for the `ApplicationState` component.

### :hammer_and_wrench: Detailed description

In this PR I have:

- added status badge for `ApplicationState`
- added “Version history” tab and content for `ApplicationState`

Previews:

- [ApplicationState](https://hds-website-git-application-state-version-status-hashicorp.vercel.app/components/application-state?tab=version%20history)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
