### PR TITLE
Replace `MenuPrimitive` with `PopoverPrimitive` in `Dropdown` and `Breadcrumb::Truncation`

### DIFF
--- a/.changeset/olive-mugs-travel.md
+++ b/.changeset/olive-mugs-travel.md
@@ -3,3 +3,7 @@
 ---
 
 `Dropdown` - added `@enableCollisionDetection` and `@isOpen` arguments
+
+`Dropdown`, `Breadcrumb::Truncation` - replaced `MenuPrimitive` with `PopoverPrimitive`
+
+`MenuPrimitive` - marked as deprecated and will be removed in the next major version

--- a/.changeset/olive-mugs-travel.md
+++ b/.changeset/olive-mugs-travel.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Dropdown` - added `@enableCollisionDetection` and `@isOpen` arguments

--- a/packages/components/src/components/hds/breadcrumb/truncation.hbs
+++ b/packages/components/src/components/hds/breadcrumb/truncation.hbs
@@ -3,24 +3,25 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 <li class="hds-breadcrumb__item hds-breadcrumb__item--is-truncation" ...attributes>
-  <Hds::MenuPrimitive>
-    <:toggle as |t|>
+  <Hds::PopoverPrimitive @enableClickEvents={{true}} as |PP|>
+    <div {{PP.setupPrimitiveContainer}}>
       <button
         type="button"
         class="hds-breadcrumb__truncation-toggle"
         aria-label={{this.ariaLabel}}
-        aria-expanded={{if t.isOpen "true" "false"}}
-        {{on "click" t.onClickToggle}}
+        aria-expanded={{if PP.isOpen "true" "false"}}
+        {{PP.setupPrimitiveToggle}}
       >
         <FlightIcon @name="more-horizontal" @size="16" @isInlineBlock={{false}} />
       </button>
-    </:toggle>
-    <:content>
-      <div class="hds-breadcrumb__truncation-content">
+      <div
+        class="hds-breadcrumb__truncation-content"
+        {{PP.setupPrimitivePopover anchoredPositionOptions=(hash placement="bottom-start" offsetOptions=4)}}
+      >
         <ol class="hds-breadcrumb__sublist">
           {{yield}}
         </ol>
       </div>
-    </:content>
-  </Hds::MenuPrimitive>
+    </div>
+  </Hds::PopoverPrimitive>
 </li>

--- a/packages/components/src/components/hds/dropdown/index.hbs
+++ b/packages/components/src/components/hds/dropdown/index.hbs
@@ -2,22 +2,26 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<Hds::MenuPrimitive class={{this.classNames}} @onClose={{@onClose}} ...attributes>
-  <:toggle as |t|>
+<Hds::PopoverPrimitive @isOpen={{@isOpen}} @onClose={{@onClose}} @enableClickEvents={{true}} as |PP|>
+  <div class={{this.classNames}} ...attributes {{PP.setupPrimitiveContainer}}>
     {{yield
       (hash
-        ToggleButton=(component "hds/dropdown/toggle/button" isOpen=t.isOpen onClick=t.onClickToggle)
-        ToggleIcon=(component "hds/dropdown/toggle/icon" isOpen=t.isOpen onClick=t.onClickToggle)
+        ToggleButton=(component
+          "hds/dropdown/toggle/button" isOpen=PP.isOpen setupPrimitiveToggle=PP.setupPrimitiveToggle
+        )
+        ToggleIcon=(component "hds/dropdown/toggle/icon" isOpen=PP.isOpen setupPrimitiveToggle=PP.setupPrimitiveToggle)
       )
     }}
-  </:toggle>
-  <:content as |c|>
-    <div class={{this.classNamesContent}} {{style width=@width max-height=@height}}>
+    <div
+      class={{this.classNamesContent}}
+      {{style width=@width max-height=@height}}
+      {{PP.setupPrimitivePopover anchoredPositionOptions=this.anchoredPositionOptions}}
+    >
       {{yield (hash Header=(component "hds/dropdown/header"))}}
       <ul class="hds-dropdown__list" {{did-insert this.didInsertList}}>
         {{yield
           (hash
-            close=c.close
+            close=PP.hidePopover
             Checkbox=(component "hds/dropdown/list-item/checkbox")
             Checkmark=(component "hds/dropdown/list-item/checkmark")
             CopyItem=(component "hds/dropdown/list-item/copy-item")
@@ -30,7 +34,7 @@
           )
         }}
       </ul>
-      {{yield (hash close=c.close Footer=(component "hds/dropdown/footer"))}}
+      {{yield (hash close=PP.hidePopover Footer=(component "hds/dropdown/footer"))}}
     </div>
-  </:content>
-</Hds::MenuPrimitive>
+  </div>
+</Hds::PopoverPrimitive>

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -9,7 +9,7 @@ import { assert } from '@ember/debug';
 
 import {
   // map Dropdown's `listPosition` values to PopoverPrimitive's `placement` values
-  HdsDropdownPositionToPlacementValues, 
+  HdsDropdownPositionToPlacementValues,
   // Dropdown's `listPosition` values
   HdsDropdownPositionValues,
 } from './types.ts';
@@ -129,6 +129,11 @@ export default class HdsDropdownComponent extends Component<HdsDropdownSignature
    */
   get classNamesContent(): string {
     const classes = ['hds-dropdown__content'];
+
+    // add a class based on the @listPosition argument
+    // TODO: we preserved these classes to avoid introducing breaking changes for consumers who rely on these classes for tests, but we aim to remove them in the next major release
+    // context: https://github.com/hashicorp/design-system/pull/2309#discussion_r1706941892
+    classes.push(`hds-dropdown__content--position-${this.listPosition}`);
 
     // add a class based on the @width argument
     if (this.args.width) {

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -41,6 +41,7 @@ export interface HdsDropdownSignature {
     isOpen?: boolean;
     listPosition?: HdsDropdownPositions;
     width?: string;
+    enableCollisionDetection?: FloatingUIOptions['enableCollisionDetection'];
   };
   Blocks: {
     default: [
@@ -85,6 +86,10 @@ export default class HdsDropdownComponent extends Component<HdsDropdownSignature
     return listPosition;
   }
 
+  get enableCollisionDetection(): FloatingUIOptions['enableCollisionDetection'] {
+    return this.args.enableCollisionDetection ?? false;
+  }
+
   get anchoredPositionOptions(): {
     placement: FloatingUIOptions['placement'];
     offsetOptions: FloatingUIOptions['offsetOptions'];
@@ -95,7 +100,7 @@ export default class HdsDropdownComponent extends Component<HdsDropdownSignature
     return {
       placement: HdsDropdownPositionToPlacementValues[this.listPosition],
       offsetOptions: 4,
-      enableCollisionDetection: true,
+      enableCollisionDetection: this.enableCollisionDetection,
     };
   }
 

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -7,7 +7,10 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
-import { HdsDropdownPositionValues } from './types.ts';
+import {
+  HdsDropdownPositionToPlacementValues,
+  HdsDropdownPositionValues,
+} from './types.ts';
 
 import type { ComponentLike } from '@glint/template';
 import type { MenuPrimitiveSignature } from '../menu-primitive';
@@ -26,6 +29,8 @@ import type { HdsDropdownToggleButtonSignature } from './toggle/button';
 import type { HdsDropdownToggleIconSignature } from './toggle/icon';
 import type { HdsDropdownPositions } from './types';
 
+import type { FloatingUIOptions } from '../../../modifiers/hds-anchored-position.ts';
+
 export const DEFAULT_POSITION = HdsDropdownPositionValues.BottomRight;
 export const POSITIONS: string[] = Object.values(HdsDropdownPositionValues);
 
@@ -33,6 +38,7 @@ export interface HdsDropdownSignature {
   Args: MenuPrimitiveSignature['Args'] & {
     height?: string;
     isInline?: boolean;
+    isOpen?: boolean;
     listPosition?: HdsDropdownPositions;
     width?: string;
   };
@@ -79,6 +85,20 @@ export default class HdsDropdownComponent extends Component<HdsDropdownSignature
     return listPosition;
   }
 
+  get anchoredPositionOptions(): {
+    placement: FloatingUIOptions['placement'];
+    offsetOptions: FloatingUIOptions['offsetOptions'];
+    enableCollisionDetection: FloatingUIOptions['enableCollisionDetection'];
+  } {
+    // custom options specific for the `RichTooltip` component
+    // for details see the `hds-anchored-position` modifier
+    return {
+      placement: HdsDropdownPositionToPlacementValues[this.listPosition],
+      offsetOptions: 4,
+      enableCollisionDetection: true,
+    };
+  }
+
   /**
    * Get the class names to apply to the element
    * @method classNames
@@ -102,9 +122,6 @@ export default class HdsDropdownComponent extends Component<HdsDropdownSignature
    */
   get classNamesContent(): string {
     const classes = ['hds-dropdown__content'];
-
-    // add a class based on the @listPosition argument
-    classes.push(`hds-dropdown__content--position-${this.listPosition}`);
 
     // add a class based on the @width argument
     if (this.args.width) {

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -8,7 +8,9 @@ import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
 import {
-  HdsDropdownPositionToPlacementValues,
+  // map Dropdown's `listPosition` values to PopoverPrimitive's `placement` values
+  HdsDropdownPositionToPlacementValues, 
+  // Dropdown's `listPosition` values
   HdsDropdownPositionValues,
 } from './types.ts';
 

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -100,7 +100,7 @@ export default class HdsDropdownComponent extends Component<HdsDropdownSignature
     return {
       placement: HdsDropdownPositionToPlacementValues[this.listPosition],
       offsetOptions: 4,
-      enableCollisionDetection: this.enableCollisionDetection,
+      enableCollisionDetection: this.enableCollisionDetection ? 'flip' : false,
     };
   }
 

--- a/packages/components/src/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/src/components/hds/dropdown/toggle/button.hbs
@@ -8,7 +8,7 @@
   ...attributes
   type="button"
   aria-expanded={{if @isOpen "true" "false"}}
-  {{on "click" this.onClick}}
+  {{@setupPrimitiveToggle}}
 >
   {{#if @icon}}
     <div class="hds-dropdown-toggle-button__icon">

--- a/packages/components/src/components/hds/dropdown/toggle/button.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/button.ts
@@ -18,6 +18,8 @@ import type {
   HdsDropdownToggleButtonSizes,
   HdsDropdownToggleButtonColors,
 } from './types';
+import type { ModifierLike } from '@glint/template';
+import type { SetupPrimitiveToggleModifier } from '../../popover-primitive/index.ts';
 
 export const DEFAULT_SIZE = HdsDropdownToggleButtonSizeValues.Medium;
 export const DEFAULT_COLOR = HdsDropdownToggleButtonColorValues.Primary;
@@ -25,8 +27,6 @@ export const SIZES: string[] = Object.values(HdsDropdownToggleButtonSizeValues);
 export const COLORS: string[] = Object.values(
   HdsDropdownToggleButtonColorValues
 );
-
-const NOOP = (): void => {};
 
 export interface HdsDropdownToggleButtonSignature {
   Args: {
@@ -37,9 +37,9 @@ export interface HdsDropdownToggleButtonSignature {
     icon?: FlightIconSignature['Args']['name'];
     isFullWidth?: boolean;
     isOpen?: boolean;
-    onClick?: (event: MouseEvent) => void;
     size: HdsDropdownToggleButtonSizes;
     text: string;
+    setupPrimitiveToggle?: ModifierLike<SetupPrimitiveToggleModifier>;
   };
   Element: HTMLButtonElement;
 }
@@ -114,23 +114,6 @@ export default class HdsDropdownToggleButtonComponent extends Component<HdsDropd
    */
   get isFullWidth(): boolean {
     return this.args.isFullWidth ?? false;
-  }
-
-  /**
-   * @param onClick
-   * @type {function}
-   * @default () => {}
-   */
-  get onClick(): (event: MouseEvent) => void {
-    const { onClick } = this.args;
-
-    // notice: this is a guard used in case the toggle is used as standalone element (eg. in the showcase)
-    // in reality it's always used inside the Dropdown main component as yielded component, so the onClick handler is always defined
-    if (typeof onClick === 'function') {
-      return onClick;
-    } else {
-      return NOOP;
-    }
   }
 
   /**

--- a/packages/components/src/components/hds/dropdown/toggle/icon.hbs
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.hbs
@@ -7,7 +7,7 @@
   aria-label={{this.text}}
   ...attributes
   aria-expanded={{if @isOpen "true" "false"}}
-  {{on "click" this.onClick}}
+  {{@setupPrimitiveToggle}}
   {{did-update this.onDidUpdateImageSrc @imageSrc}}
   type="button"
 >

--- a/packages/components/src/components/hds/dropdown/toggle/icon.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.ts
@@ -11,11 +11,11 @@ import { HdsDropdownToggleIconSizeValues } from './types.ts';
 
 import type { FlightIconSignature } from '@hashicorp/ember-flight-icons/components/flight-icon';
 import type { HdsDropdownToggleIconSizes } from './types';
+import type { ModifierLike } from '@glint/template';
+import type { SetupPrimitiveToggleModifier } from '../../popover-primitive/index.ts';
 
 export const DEFAULT_SIZE = HdsDropdownToggleIconSizeValues.Medium;
 export const SIZES: string[] = Object.values(HdsDropdownToggleIconSizeValues);
-
-const NOOP = (): void => {};
 
 export interface HdsDropdownToggleIconSignature {
   Args: {
@@ -23,9 +23,9 @@ export interface HdsDropdownToggleIconSignature {
     icon: FlightIconSignature['Args']['name'];
     imageSrc: string;
     isOpen?: boolean;
-    onClick?: (event: MouseEvent) => void;
     size?: HdsDropdownToggleIconSizes;
     text: string;
+    setupPrimitiveToggle?: ModifierLike<SetupPrimitiveToggleModifier>;
   };
   Element: HTMLButtonElement;
 }
@@ -112,23 +112,6 @@ export default class HdsDropdownToggleIconComponent extends Component<HdsDropdow
    */
   get hasChevron(): boolean {
     return this.args.hasChevron ?? true;
-  }
-
-  /**
-   * @param onClick
-   * @type {function}
-   * @default () => {}
-   */
-  get onClick(): (event: MouseEvent) => void {
-    const { onClick } = this.args;
-
-    // notice: this is a guard used in case the toggle is used as standalone element (eg. in the showcase)
-    // in reality it's always used inside the Dropdown main component as yielded component, so the onClick handler is always defined
-    if (typeof onClick === 'function') {
-      return onClick;
-    } else {
-      return NOOP;
-    }
   }
 
   /**

--- a/packages/components/src/components/hds/dropdown/types.ts
+++ b/packages/components/src/components/hds/dropdown/types.ts
@@ -15,6 +15,7 @@ export type HdsDropdownPositions = `${HdsDropdownPositionValues}`;
 
 // map Dropdown's `listPosition` values to PopoverPrimitive's `placement` values for backwards compatibility
 export const HdsDropdownPositionToPlacementValues: Record<
+  // Dropdown's `listPosition` values
   HdsDropdownPositionValues,
   FloatingUIOptions['placement']
 > = {

--- a/packages/components/src/components/hds/dropdown/types.ts
+++ b/packages/components/src/components/hds/dropdown/types.ts
@@ -13,6 +13,7 @@ export enum HdsDropdownPositionValues {
 }
 export type HdsDropdownPositions = `${HdsDropdownPositionValues}`;
 
+// map Dropdown's `listPosition` values to PopoverPrimitive's `placement` values for backwards compatibility
 export const HdsDropdownPositionToPlacementValues: Record<
   HdsDropdownPositionValues,
   FloatingUIOptions['placement']

--- a/packages/components/src/components/hds/dropdown/types.ts
+++ b/packages/components/src/components/hds/dropdown/types.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import type { FloatingUIOptions } from '../../../modifiers/hds-anchored-position.ts';
+
 export enum HdsDropdownPositionValues {
   BottomLeft = 'bottom-left',
   BottomRight = 'bottom-right',
@@ -10,3 +12,13 @@ export enum HdsDropdownPositionValues {
   TopRight = 'top-right',
 }
 export type HdsDropdownPositions = `${HdsDropdownPositionValues}`;
+
+export const HdsDropdownPositionToPlacementValues: Record<
+  HdsDropdownPositionValues,
+  FloatingUIOptions['placement']
+> = {
+  [HdsDropdownPositionValues.BottomLeft]: 'bottom-start',
+  [HdsDropdownPositionValues.BottomRight]: 'bottom-end',
+  [HdsDropdownPositionValues.TopLeft]: 'top-start',
+  [HdsDropdownPositionValues.TopRight]: 'top-end',
+};

--- a/packages/components/src/components/hds/menu-primitive/index.hbs
+++ b/packages/components/src/components/hds/menu-primitive/index.hbs
@@ -2,6 +2,9 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
+{{!
+  THIS COMPONENT IS NOW DEPRECATED
+}}
 {{! template-lint-disable no-invalid-interactive }}
 <div
   class="hds-menu-primitive"

--- a/packages/components/src/components/hds/menu-primitive/index.ts
+++ b/packages/components/src/components/hds/menu-primitive/index.ts
@@ -49,7 +49,7 @@ export default class MenuPrimitiveComponent extends Component<MenuPrimitiveSigna
         url: 'https://helios.hashicorp.design/components/menu-primitive?tab=version%20history#460',
         for: '@hashicorp/design-system-components',
         since: {
-          enabled: '4.8.0',
+          enabled: '4.10.0',
         },
       }
     );

--- a/packages/components/src/components/hds/menu-primitive/index.ts
+++ b/packages/components/src/components/hds/menu-primitive/index.ts
@@ -4,6 +4,7 @@
  */
 
 import Component from '@glimmer/component';
+import { deprecate } from '@ember/debug';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { schedule } from '@ember/runloop';
@@ -35,6 +36,24 @@ export default class MenuPrimitiveComponent extends Component<MenuPrimitiveSigna
   @tracked isOpen: boolean | undefined; // notice: if in the future we need to add a "@isOpen" prop to control the status from outside (eg to have the MenuPrimitive opened on render) just add  "this.args.isOpen" here to initalize the variable
   @tracked toggleRef: HTMLElement | undefined;
   @tracked element!: HTMLElement;
+
+  constructor(owner: unknown, args: MenuPrimitiveSignature['Args']) {
+    super(owner, args);
+
+    deprecate(
+      'The `Hds::MenuPrimitive` component is now deprecated and will be removed in the next major version of `@hashicorp/design-system-components`.',
+      false,
+      {
+        id: 'hds.components.menu-primitive',
+        until: '5.0.0',
+        url: 'https://helios.hashicorp.design/components/menu-primitive?tab=version%20history#460',
+        for: '@hashicorp/design-system-components',
+        since: {
+          enabled: '4.8.0',
+        },
+      }
+    );
+  }
 
   @action
   didInsert(element: HTMLElement): void {

--- a/packages/components/src/styles/components/breadcrumb.scss
+++ b/packages/components/src/styles/components/breadcrumb.scss
@@ -181,15 +181,24 @@ $hds-breadcrumb-item-visual-horizontal-padding: 4px;
 }
 
 .hds-breadcrumb__truncation-content {
-  position: absolute;
-  top: 100%;
-  left: -$hds-breadcrumb-item-visual-horizontal-padding;
-  z-index: 300; // this is the z-index used in Structure for this kind of things, I am reusing the same value
+  position: relative;
   width: max-content;
   max-width: 200px; // by design
-  margin-top: 4px;
   padding: 6px 12px;
   background-color: var(--token-color-surface-primary);
   border-radius: 6px;
   box-shadow: var(--token-surface-high-box-shadow);
+
+  // the "popover" attributes comes with pre-defined styling so we need to override it
+  :where(&[popover]) {
+    width: fit-content;
+    height: fit-content;
+    margin: 0;
+    padding: 0;
+    overflow: visible;
+    color: inherit;
+    background: none;
+    border: none;
+    inset: 0;
+  }
 }

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -188,6 +188,7 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 // GOES INSIDE HDS::MenuPrimitive's :content block
 
 .hds-dropdown__content {
+  position: relative;
   display: flex;
   flex-direction: column;
   width: max-content; // notice: this is important because being in a position absolute means the layout algorithm assigns a width of 0 and this impacts on the flex algorithm of the children (in some cases they don't use the full width)
@@ -196,41 +197,35 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   background-color: var(--token-color-surface-primary);
   border-radius: 6px;
   box-shadow: var(--token-surface-high-box-shadow);
+
+  // the "popover" attributes comes with pre-defined styling so we need to override it
+  :where(&[popover]) {
+    width: fit-content;
+    height: fit-content;
+    margin: 0;
+    padding: 0;
+    overflow: visible;
+    color: inherit;
+    background: none;
+    border: none;
+    inset: 0;
+  }  
+}
+
+.hds-dropdown {
+  .hds-dropdown__content {
+    display: none;
+
+    &[popover]:popover-open {
+      display: flex;
+    }  
+  }
 }
 
 .hds-dropdown__content--fixed-width {
   min-width: initial;
   max-width: initial;
 }
-
-.hds-dropdown__content--position-bottom-right {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  z-index: 2;
-}
-
-.hds-dropdown__content--position-bottom-left {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  z-index: 2;
-}
-
-.hds-dropdown__content--position-top-right {
-  position: absolute;
-  right: 0;
-  bottom: calc(100% + 4px);
-  z-index: 2;
-}
-
-.hds-dropdown__content--position-top-left {
-  position: absolute;
-  bottom: calc(100% + 4px);
-  left: 0;
-  z-index: 2;
-}
-
 
 .hds-dropdown__list {
   flex: 1 1 auto;

--- a/showcase/app/routes/components/dropdown.js
+++ b/showcase/app/routes/components/dropdown.js
@@ -7,6 +7,7 @@ import Route from '@ember/routing/route';
 
 import { COLORS as TOGGLE_BUTTON_COLORS } from '@hashicorp/design-system-components/components/hds/dropdown/toggle/button';
 import { COLORS as ITEM_INTERACTIVE_COLORS } from '@hashicorp/design-system-components/components/hds/dropdown/list-item/interactive';
+import { POSITIONS } from '@hashicorp/design-system-components/components/hds/dropdown/index';
 
 export default class ComponentsDropdownRoute extends Route {
   model() {
@@ -18,6 +19,7 @@ export default class ComponentsDropdownRoute extends Route {
       TOGGLE_STATES,
       ITEM_INTERACTIVE_COLORS,
       ITEM_STATES,
+      POSITIONS,
     };
   }
 }

--- a/showcase/app/styles/showcase-pages/dropdown.scss
+++ b/showcase/app/styles/showcase-pages/dropdown.scss
@@ -13,6 +13,14 @@ body.components-dropdown {
     outline: 1px dashed #d3d3d3;
   }
 
+  .shw-component-dropdown-collision-detection-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 520px;
+    height: 480px;
+  }
+
   .shw-component-dropdown-fixed-height-container {
     min-height: 200px;
   }

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -11,36 +11,19 @@
 
   <Shw::Text::H2>Position</Shw::Text::H2>
 
-  <Shw::Flex as |SF|>
-    <SF.Item @label="Bottom left">
-      <Hds::Dropdown @listPosition="bottom-left" as |D|>
-        <D.ToggleButton @color="secondary" @text="Menu" />
-        <D.Interactive @href="#" @text="Create" />
-        <D.Interactive @href="#" @text="Edit" />
-      </Hds::Dropdown>
-    </SF.Item>
-    <SF.Item @label="Bottom right (default)">
-      <Hds::Dropdown as |D|>
-        <D.ToggleButton @color="secondary" @text="Menu" />
-        <D.Interactive @href="#" @text="Create" />
-        <D.Interactive @href="#" @text="Edit" />
-      </Hds::Dropdown>
-    </SF.Item>
-    <SF.Item @label="Top left">
-      <Hds::Dropdown @listPosition="top-left" as |D|>
-        <D.ToggleButton @color="secondary" @text="Menu" />
-        <D.Interactive @href="#" @text="Create" />
-        <D.Interactive @href="#" @text="Edit" />
-      </Hds::Dropdown>
-    </SF.Item>
-    <SF.Item @label="Top right">
-      <Hds::Dropdown @listPosition="top-right" as |D|>
-        <D.ToggleButton @color="secondary" @text="Menu" />
-        <D.Interactive @href="#" @text="Create" />
-        <D.Interactive @href="#" @text="Edit" />
-      </Hds::Dropdown>
-    </SF.Item>
-  </Shw::Flex>
+  <Shw::Grid @columns={{2}} as |SG|>
+    {{#each @model.POSITIONS as |position|}}
+      <SG.Item {{style padding="5em"}} @label={{capitalize position}}>
+        <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Interactive @href="#" @text="Create" />
+          <D.Interactive @href="#" @text="Edit" />
+        </Hds::Dropdown>
+      </SG.Item>
+    {{/each}}
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H2>Display</Shw::Text::H2>
 
@@ -64,6 +47,31 @@
       </div>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H2>Collision detection</Shw::Text::H2>
+
+  <Shw::Text::Body>Scroll within the boxes to see the collision detection in action</Shw::Text::Body>
+
+  <Shw::Grid @columns={{3}} @gap="2rem" as |SF|>
+    {{#let (array false true) as |detections|}}
+      {{#each detections as |detection|}}
+        <SF.Item @forceMinWidth={{true}} @label={{concat "enableCollisionDetection=" detection}}>
+          <Shw::Autoscrollable @verticalShift={{30}}>
+            <div class="shw-component-dropdown-collision-detection-wrapper">
+              <Hds::Dropdown @isOpen={{true}} @enableCollisionDetection={{detection}} as |D|>
+                <D.ToggleButton @color="secondary" @text="Menu" />
+                <D.Interactive @href="#" @text="Create" />
+                <D.Interactive @href="#" @text="Edit" />
+              </Hds::Dropdown>
+            </div>
+          </Shw::Autoscrollable>
+        </SF.Item>
+      {{/each}}
+    {{/let}}
+    <SF.Item />
+  </Shw::Grid>
 
   <Shw::Divider />
 

--- a/showcase/tests/integration/components/hds/breadcrumb/truncation-test.js
+++ b/showcase/tests/integration/components/hds/breadcrumb/truncation-test.js
@@ -44,7 +44,7 @@ module('Integration | Component | hds/breadcrumb/truncation', function (hooks) {
     );
     assert
       .dom('#test-breadcrumb-truncation .hds-breadcrumb__truncation-content')
-      .doesNotExist();
+      .isNotVisible();
   });
   test('it should yield (and render) the content', async function (assert) {
     await render(

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -12,7 +12,11 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Dropdown id="test-dropdown" />`);
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" />
+      </Hds::Dropdown>
+    `);
     assert.dom('#test-dropdown').hasClass('hds-dropdown');
   });
 
@@ -81,30 +85,6 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
 
   // POSITION
 
-  test('it should render the content aligned on the right by default', async function (assert) {
-    await render(hbs`
-      <Hds::Dropdown id="test-dropdown" as |D|>
-        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <D.Interactive @route="components.dropdown" @text="interactive" />
-      </Hds::Dropdown>
-    `);
-    await click('button#test-toggle-button');
-    assert
-      .dom('#test-dropdown .hds-dropdown__content')
-      .hasClass('hds-dropdown__content--position-bottom-right');
-  });
-  test('it should render the content aligned on the left if the value of @listPosition is "bottom-left"', async function (assert) {
-    await render(hbs`
-      <Hds::Dropdown id="test-dropdown" @listPosition="bottom-left" as |D|>
-        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
-        <D.Interactive @route="components.dropdown" @text="interactive" />
-      </Hds::Dropdown>
-    `);
-    await click('button#test-toggle-button');
-    assert
-      .dom('#test-dropdown .hds-dropdown__content')
-      .hasClass('hds-dropdown__content--position-bottom-left');
-  });
   test('it should render the element as `inline` if the value of @isInline is "true"', async function (assert) {
     await render(hbs`
       <Hds::Dropdown id="test-dropdown" @isInline={{true}} as |D|>
@@ -141,7 +121,7 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     await click('button#test-toggle-button');
     assert.dom('#test-dropdown #test-list-item-interactive').exists();
     await click('#test-list-item-interactive');
-    assert.dom('#test-dropdown #test-list-item-interactive').doesNotExist();
+    assert.dom('#test-dropdown #test-list-item-interactive').isNotVisible();
   });
 
   // ACCESSIBILITY

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -85,6 +85,30 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
 
   // POSITION
 
+  test('it should render the content aligned on the right by default', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Interactive @route="components.dropdown" @text="interactive" />
+      </Hds::Dropdown>
+    `);
+    await click('button#test-toggle-button');
+    assert
+      .dom('#test-dropdown .hds-dropdown__content')
+      .hasClass('hds-dropdown__content--position-bottom-right');
+  });
+  test('it should render the content aligned on the left if the value of @listPosition is "bottom-left"', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" @listPosition="bottom-left" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Interactive @route="components.dropdown" @text="interactive" />
+      </Hds::Dropdown>
+    `);
+    await click('button#test-toggle-button');
+    assert
+      .dom('#test-dropdown .hds-dropdown__content')
+      .hasClass('hds-dropdown__content--position-bottom-left');
+  });
   test('it should render the element as `inline` if the value of @isInline is "true"', async function (assert) {
     await render(hbs`
       <Hds::Dropdown id="test-dropdown" @isInline={{true}} as |D|>

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -9,6 +9,8 @@ related: ['components/segmented-group','patterns/filter-patterns']
 previewImage: assets/illustrations/components/dropdown.jpg
 navigation:
   keywords: ['select', 'menu', 'action menu', 'list']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -28,4 +30,8 @@ navigation:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
 </section>

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -56,15 +56,23 @@ The Dropdown component is composed of different child components each with their
   <C.Property @name="<[D].Footer>" @type="yielded component">
     `Dropdown::Footer` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="listPosition" @type="string" @values={{array "bottom-left" "bottom-right" "top-left" "top-right" }} @default="bottom-right"/>
+  <C.Property @name="listPosition" @type="string" @values={{array "bottom-left" "bottom-right" "top-left" "top-right" }} @default="bottom-right">
+    _Note: If `@enableCollisionDetection` is set, the list will automatically flip position to remain visible when near the edges of the screen regardless of the starting placement._
+  </C.Property>
+  <C.Property @name="isInline" @type="boolean" @default="false" @values={{array "true" "false"}}>
+    If an `@isInline` parameter is provided, then the element will be displayed as `inline-block` (useful to achieve specific layouts like in a container with right alignment). Otherwise, it will have a `block` layout.
+  </C.Property>
+  <C.Property @name="enableCollisionDetection" @type="boolean" @default="false" @values={{array "true" "false"}}>
+     Setting it to `true` will automatically flip the list position to remain visible when near the edges of the viewport.
+  </C.Property>
+  <C.Property @name="isOpen" @type="boolean" @default="false" @values={{array "true" "false"}}>
+    Controls if the list should be rendered initially opened.
+  </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the Dropdown List has a `min-width` of `200px` and a `max-width` of `400px`, so it adapts to the content size. If a `@width` parameter is provided then the list will have a fixed width.
   </C.Property>
   <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
     If a `@height` parameter is provided then the list will have a max-height.
-  </C.Property>
-  <C.Property @name="isInline" @type="boolean" @default="false">
-    If an `@isInline` parameter is provided, then the element will be displayed as `inline-block` (useful to achieve specific layouts like in a container with right alignment). Otherwise, it will have a `block` layout.
   </C.Property>
   <C.Property @name="close" @type="function">
     Function to programmatically close the Dropdown.

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -122,6 +122,22 @@ In contexts where the Dropdown needs to be _inline_, to inherit the alignment fr
 </div>
 ```
 
+### Collision detection
+
+Setting the `@enableCollisionDetection` argument to `true` will automatically adapt the list position relative to the viewport to avoid collisions with the browser window boundaries. This means that when an end-user scrolls the page, or resizes the browser, the position of the list on the page dynamically adapts to these changes.
+
+```handlebars
+<Hds::Dropdown @enableCollisionDetection={{true}} as |D|>
+  <D.ToggleButton @text="Text Toggle" />
+  <D.Interactive @route="components" @text="Item One" />
+  <D.Interactive @route="components" @text="Item Two" />
+  <D.Interactive @route="components" @text="Item Three" />
+  <D.Interactive @text="Item Four (closes on click)" {{on "click" D.close}} />
+  <D.Separator />
+  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+</Hds::Dropdown>
+```
+
 ### List size
 
 You can explicitly control the height or width of a list. Any acceptable value (px, rem, em) can be declared:

--- a/website/docs/components/dropdown/partials/version-history/4.10.0.md
+++ b/website/docs/components/dropdown/partials/version-history/4.10.0.md
@@ -1,0 +1,7 @@
+## 4.10.0
+
+### Updated
+
+Added `@enableCollisionDetection` and `@isOpen` arguments
+
+Replaced the underlying `MenuPrimitive` with `PopoverPrimitive`

--- a/website/docs/components/dropdown/partials/version-history/4.10.0.md
+++ b/website/docs/components/dropdown/partials/version-history/4.10.0.md
@@ -4,4 +4,4 @@
 
 Added `@enableCollisionDetection` and `@isOpen` arguments
 
-Replaced the underlying `MenuPrimitive` with `PopoverPrimitive`
+Replaced the underlying `MenuPrimitive` with [`PopoverPrimitive`](/utilities/popover-primitive)

--- a/website/docs/utilities/menu-primitive/index.md
+++ b/website/docs/utilities/menu-primitive/index.md
@@ -14,3 +14,7 @@ status:
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
 </section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
+</section>

--- a/website/docs/utilities/menu-primitive/index.md
+++ b/website/docs/utilities/menu-primitive/index.md
@@ -6,6 +6,8 @@ related: ['components/breadcrumb', 'components/dropdown', 'utilities/disclosure-
 previewImage: assets/illustrations/utilities/menu-primitive.jpg
 navigation:
   keywords: ['show', 'hide', 'accordion', 'dropdown', 'reveal']
+status:
+  deprecated: 4.10.0
 ---
 
 <section data-tab="Code">

--- a/website/docs/utilities/menu-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/menu-primitive/partials/code/how-to-use.md
@@ -1,6 +1,7 @@
 !!! Warning
 
-This component is intended only for internal Helios use. If you need to use it, please contact the Design Systems Team.
+The `MenuPrimitive` component is deprecated and will be removed in a future major release. We recommend migrating to [PopoverPrimitive](/utilities/popover-primitive).
+
 !!!
 
 ## How to use this component

--- a/website/docs/utilities/menu-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/menu-primitive/partials/code/how-to-use.md
@@ -1,6 +1,6 @@
 !!! Warning
 
-The `MenuPrimitive` component is deprecated and will be removed in a future major release. We recommend migrating to [PopoverPrimitive](/utilities/popover-primitive).
+The `MenuPrimitive` component is deprecated and will be removed in a future major release. We recommend migrating to [`PopoverPrimitive`](/utilities/popover-primitive).
 
 !!!
 

--- a/website/docs/utilities/menu-primitive/partials/version-history/4.10.0.md
+++ b/website/docs/utilities/menu-primitive/partials/version-history/4.10.0.md
@@ -6,4 +6,4 @@ In this version we replaced all `MenuPrimitive` instances with `PopoverPrimitive
 
 #### How to migrate
 
-Consider migrating the existing `MenuPrimitive` instances to [PopoverPrimitive](/utilities/popover-primitive).
+Consider migrating the existing `MenuPrimitive` instances to [`PopoverPrimitive`](/utilities/popover-primitive).

--- a/website/docs/utilities/menu-primitive/partials/version-history/4.10.0.md
+++ b/website/docs/utilities/menu-primitive/partials/version-history/4.10.0.md
@@ -1,0 +1,9 @@
+## 4.10.0
+
+### Deprecated
+
+In this version we replaced all `MenuPrimitive` instances with `PopoverPrimitive`. For this reason we now consider the MenuPrimitive deprecated and we plan to removed in a future major release.
+
+#### How to migrate
+
+Consider migrating the existing `MenuPrimitive` instances to [PopoverPrimitive](/utilities/popover-primitive).


### PR DESCRIPTION
### :pushpin: Summary

This PR replaces the `MenuPrimitive` with `PopoverPrimitive` in `Dropdown` and `Breadcrumb::Truncation` with the main benefits of:
 - aligning the `RichTooltip` and `Dropdown` implementations
 - reducing codebase and abstractions by deprecating the `MenuPrimitive`
 - resolving the current issues we have with the `Dropdown` list positioning on the z-axis (including where placed in a `Modal`, or the `AppHeader`)
 - introducing optional collision detection for the `Dropdown` component

### :hammer_and_wrench: Detailed description

 - Replaced the `MenuPrimitive` with `PopoverPrimitive` in `Dropdown` mapping functionality and preserved the current API
 - Introduced two new optional arguments
   - `@enableCollisionDetection` (default to `false`, to preserve the original behavior; we can switch the default to `true` in the future to benefit more scenarios and align with `RichTooltip`)
   - `@isOpen` (allowing one or multiple dropdowns to be open at render)
 - Replaced the `MenuPrimitive` with `PopoverPrimitive` in `Breadcrumb::Truncation` while preserving the current behavior and API
- Deprecated the `Hds::MenuPrimitive`; after these changes, it is not used anywhere else in our codebase or our consumers' codebases so we want to prevent people from using it

### 👷 Remaining tasks

- [x] test in consumers' codebases
- [x] update `showcase` with new arguments
- [x] update `wesbite` with new arguments

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDSP-3631](https://hashicorp.atlassian.net/browse/HDS-3631)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDSP-96]: https://hashicorp.atlassian.net/browse/HDSP-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ