### PR TITLE
Showcase - Updated the “main” content available width from `1024px` to `1088px`

### DIFF
--- a/showcase/app/styles/_layout.scss
+++ b/showcase/app/styles/_layout.scss
@@ -5,7 +5,7 @@
 
 :root {
   --aside-width: calc(200px + 1 * 2rem);
-  --main-width: calc(1024px + 2 * 2rem);
+  --main-width: calc(1088px + 2 * 2rem);;
   --content-width: calc(var(--aside-width) + var(--main-width));
 }
 

--- a/showcase/app/styles/_layout.scss
+++ b/showcase/app/styles/_layout.scss
@@ -5,7 +5,7 @@
 
 :root {
   --aside-width: calc(200px + 1 * 2rem);
-  --main-width: calc(1088px + 2 * 2rem);;
+  --main-width: calc(1088px + 2 * 2rem);
   --content-width: calc(var(--aside-width) + var(--main-width));
 }
 


### PR DESCRIPTION
### :pushpin: Summary

Since some components have breaking points of `1088px`, if we use a `Shw::Frame` in the showcase page for those components, it's not possible (unless opened as "frameless" page) to see their full behaviour. 

Context: https://github.com/hashicorp/design-system/pull/2299/files#r1696105906

This PR changes the value of the `--main-width` CSS variable for the showcase, to see the impact in terms of visual regression (~~probably every page will break now~~ Percy takes screenshots at a fixed with of `1280px` (and `375px`) so there is no visual difference at that viewport width) and if we're OK with it promote this code change to production.

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
