### PR TITLE
`CodeBlock`: convert component to TypeScript

### DIFF
--- a/.changeset/quick-socks-look.md
+++ b/.changeset/quick-socks-look.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Code Block`: Converted component to TypeScript

--- a/.changeset/quick-socks-look.md
+++ b/.changeset/quick-socks-look.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`Code Block`: Converted component to TypeScript
+`CodeBlock`: Converted component to TypeScript

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,6 +77,7 @@
     "@types/ember-qunit": "^6.1.1",
     "@types/ember-resolver": "^9.0.0",
     "@types/ember__destroyable": "^4.0.5",
+    "@types/prismjs": "^1.26.4",
     "@types/qunit": "^2.19.10",
     "@types/rsvp": "^4.0.9",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/packages/components/src/components.ts
+++ b/packages/components/src/components.ts
@@ -21,6 +21,10 @@ import HdsBreadcrumbTruncation from './components/hds/breadcrumb/truncation.ts';
 import HdsButton from './components/hds/button/index.ts';
 import HdsButtonSet from './components/hds/button-set/index.ts';
 import HdsCard from './components/hds/card/container.ts';
+import HdsCodeBlock from './components/hds/code-block/index.ts';
+import HdsCodeBlockCopyButton from './components/hds/code-block/copy-button.ts';
+import HdsCodeBlockDescription from './components/hds/code-block/description.ts';
+import HdsCodeBlockTitle from './components/hds/code-block/title.ts';
 import HdsCopyButton from './components/hds/copy/button/index.ts';
 import HdsCopySnippet from './components/hds/copy/snippet/index.ts';
 import HdsDialogPrimitiveBody from './components/hds/dialog-primitive/body.ts';
@@ -118,6 +122,10 @@ export {
   HdsButton,
   HdsButtonSet,
   HdsCard,
+  HdsCodeBlock,
+  HdsCodeBlockCopyButton,
+  HdsCodeBlockDescription,
+  HdsCodeBlockTitle,
   HdsCopyButton,
   HdsCopySnippet,
   HdsDialogPrimitiveBody,

--- a/packages/components/src/components/hds/code-block/copy-button.hbs
+++ b/packages/components/src/components/hds/code-block/copy-button.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/code-block/copy-button.ts
+++ b/packages/components/src/components/hds/code-block/copy-button.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import templateOnlyComponent from '@ember/component/template-only';
+import type { HdsCopyButtonSignature } from '../copy/button';
+
+export interface HdsCodeBlockCopyButtonSignature {
+  Args: {
+    targetToCopy?: HdsCopyButtonSignature['Args']['targetToCopy'];
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: HdsCopyButtonSignature['Element'];
+}
+
+const HdsCodeBlockCopyButtonComponent =
+  templateOnlyComponent<HdsCodeBlockCopyButtonSignature>();
+
+export default HdsCodeBlockCopyButtonComponent;

--- a/packages/components/src/components/hds/code-block/description.hbs
+++ b/packages/components/src/components/hds/code-block/description.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/code-block/description.ts
+++ b/packages/components/src/components/hds/code-block/description.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import templateOnlyComponent from '@ember/component/template-only';
+import type { HdsTextBodySignature } from '../text/body';
+
+export interface HdsCodeBlockDescriptionSignature {
+  Blocks: {
+    default: [];
+  };
+  Element: HdsTextBodySignature['Element'];
+}
+
+const HdsCodeBlockDescriptionComponent =
+  templateOnlyComponent<HdsCodeBlockDescriptionSignature>();
+
+export default HdsCodeBlockDescriptionComponent;

--- a/packages/components/src/components/hds/code-block/index.hbs
+++ b/packages/components/src/components/hds/code-block/index.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -13,6 +13,12 @@ import { guidFor } from '@ember/object/internals';
 
 import Prism from 'prismjs';
 
+import type { SafeString } from '@ember/template/-private/handlebars';
+import type { ComponentLike } from '@glint/template';
+
+import type { HdsCodeBlockTitleSignature } from './title';
+import type { HdsCodeBlockDescriptionSignature } from './description';
+
 import 'prismjs/plugins/line-numbers/prism-line-numbers';
 import 'prismjs/plugins/line-highlight/prism-line-highlight';
 
@@ -31,8 +37,40 @@ import 'prismjs/components/prism-yaml';
 import 'prismjs/components/prism-markup-templating';
 import 'prismjs/components/prism-handlebars';
 
-export default class HdsCodeBlockIndexComponent extends Component {
-  @tracked prismCode = '';
+type Language =
+  | 'bash'
+  | 'go'
+  | 'hcl'
+  | 'json'
+  | 'log'
+  | 'ruby'
+  | 'shell-session'
+  | 'yaml';
+
+export interface HdsCodeBlockIndexSignature {
+  Args: {
+    hasCopyButton?: boolean;
+    hasLineNumbers?: boolean;
+    hasLineWrapping?: boolean;
+    highlightLines?: string;
+    isStandalone?: boolean;
+    language?: Language;
+    maxHeight?: string;
+    value: string;
+  };
+  Blocks: {
+    default: [
+      {
+        Title?: ComponentLike<HdsCodeBlockTitleSignature>;
+        Description?: ComponentLike<HdsCodeBlockDescriptionSignature>;
+      },
+    ];
+  };
+  Element: HTMLDivElement;
+}
+
+export default class HdsCodeBlockIndexComponent extends Component<HdsCodeBlockIndexSignature> {
+  @tracked prismCode: SafeString = htmlSafe('');
 
   /**
    * Generates a unique ID for the code content
@@ -46,7 +84,7 @@ export default class HdsCodeBlockIndexComponent extends Component {
    * @type {string}
    * @description code text content for the CodeBlock
    */
-  get code() {
+  get code(): string {
     const code = this.args.value;
 
     assert(
@@ -54,8 +92,8 @@ export default class HdsCodeBlockIndexComponent extends Component {
       code !== undefined
     );
 
-    if (Prism?.plugins?.NormalizeWhitespace) {
-      return Prism.plugins.NormalizeWhitespace.normalize(code);
+    if (Prism?.plugins?.['NormalizeWhitespace']) {
+      return Prism.plugins['NormalizeWhitespace'].normalize(code);
     }
 
     return code;
@@ -67,7 +105,7 @@ export default class HdsCodeBlockIndexComponent extends Component {
    * @default undefined
    * @description name of coding language used within CodeBlock for syntax highlighting
    */
-  get language() {
+  get language(): Language | undefined {
     return this.args.language ?? undefined;
   }
 
@@ -77,7 +115,7 @@ export default class HdsCodeBlockIndexComponent extends Component {
    * @default true
    * @description Displays line numbers if true
    */
-  get hasLineNumbers() {
+  get hasLineNumbers(): boolean {
     return this.args.hasLineNumbers ?? true;
   }
 
@@ -87,7 +125,7 @@ export default class HdsCodeBlockIndexComponent extends Component {
    * @default true
    * @description Make CodeBlock container corners appear rounded
    */
-  get isStandalone() {
+  get isStandalone(): boolean {
     return this.args.isStandalone ?? true;
   }
 
@@ -97,22 +135,24 @@ export default class HdsCodeBlockIndexComponent extends Component {
    * @default false
    * @description Make text content wrap on multiple lines
    */
-  get hasLineWrapping() {
+  get hasLineWrapping(): boolean {
     return this.args.hasLineWrapping ?? false;
   }
 
   @action
-  setPrismCode(element) {
+  setPrismCode(element: HTMLElement): void {
     const code = this.code;
     const language = this.language;
-    const grammar = Prism.languages[language];
+    const grammar = language ? Prism.languages[language] : undefined;
 
     if (code) {
       next(() => {
         if (language && grammar) {
           this.prismCode = htmlSafe(Prism.highlight(code, grammar, language));
         } else {
-          this.prismCode = htmlSafe(Prism.util.encode(code));
+          // const test = Prism.util.encode(code);
+          // console.log('test', test.toString());
+          this.prismCode = htmlSafe(Prism.util.encode(code).toString());
         }
 
         // Force prism-line-numbers plugin initialization, required for Prism.highlight usage
@@ -140,10 +180,10 @@ export default class HdsCodeBlockIndexComponent extends Component {
    * @method classNames
    * @return {string} The "class" attribute to apply to the component.
    */
-  get classNames() {
+  get classNames(): string {
     // Currently there is only one theme so the class name is hard-coded.
     // In the future, additional themes such as a "light" theme could be added.
-    let classes = ['hds-code-block', 'hds-code-block--theme-dark'];
+    const classes = ['hds-code-block', 'hds-code-block--theme-dark'];
 
     if (this.language) {
       classes.push(`language-${this.language}`);

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -150,8 +150,6 @@ export default class HdsCodeBlockIndexComponent extends Component<HdsCodeBlockIn
         if (language && grammar) {
           this.prismCode = htmlSafe(Prism.highlight(code, grammar, language));
         } else {
-          // const test = Prism.util.encode(code);
-          // console.log('test', test.toString());
           this.prismCode = htmlSafe(Prism.util.encode(code).toString());
         }
 

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -18,6 +18,8 @@ import type { ComponentLike } from '@glint/template';
 
 import type { HdsCodeBlockTitleSignature } from './title';
 import type { HdsCodeBlockDescriptionSignature } from './description';
+import { HdsCodeBlockLanguageValues } from './types.ts';
+import type { HdsCodeBlockLanguages } from './types.ts';
 
 import 'prismjs/plugins/line-numbers/prism-line-numbers';
 import 'prismjs/plugins/line-highlight/prism-line-highlight';
@@ -37,24 +39,16 @@ import 'prismjs/components/prism-yaml';
 import 'prismjs/components/prism-markup-templating';
 import 'prismjs/components/prism-handlebars';
 
-type Language =
-  | 'bash'
-  | 'go'
-  | 'hcl'
-  | 'json'
-  | 'log'
-  | 'ruby'
-  | 'shell-session'
-  | 'yaml';
+export const LANGUAGES: string[] = Object.values(HdsCodeBlockLanguageValues);
 
-export interface HdsCodeBlockIndexSignature {
+export interface HdsCodeBlockSignature {
   Args: {
     hasCopyButton?: boolean;
     hasLineNumbers?: boolean;
     hasLineWrapping?: boolean;
     highlightLines?: string;
     isStandalone?: boolean;
-    language?: Language;
+    language?: HdsCodeBlockLanguages;
     maxHeight?: string;
     value: string;
   };
@@ -69,7 +63,7 @@ export interface HdsCodeBlockIndexSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsCodeBlockIndexComponent extends Component<HdsCodeBlockIndexSignature> {
+export default class HdsCodeBlockComponent extends Component<HdsCodeBlockSignature> {
   @tracked prismCode: SafeString = htmlSafe('');
 
   /**
@@ -105,7 +99,7 @@ export default class HdsCodeBlockIndexComponent extends Component<HdsCodeBlockIn
    * @default undefined
    * @description name of coding language used within CodeBlock for syntax highlighting
    */
-  get language(): Language | undefined {
+  get language(): HdsCodeBlockLanguages | undefined {
     return this.args.language ?? undefined;
   }
 

--- a/packages/components/src/components/hds/code-block/title.hbs
+++ b/packages/components/src/components/hds/code-block/title.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/code-block/title.ts
+++ b/packages/components/src/components/hds/code-block/title.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import templateOnlyComponent from '@ember/component/template-only';
+import type { HdsTextBodySignature } from '../text/body';
+
+export interface HdsCodeBlockTitleSignature {
+  Blocks: {
+    default: [];
+  };
+  Element: HdsTextBodySignature['Element'];
+}
+
+const HdsCodeBlockTitleComponent =
+  templateOnlyComponent<HdsCodeBlockTitleSignature>();
+
+export default HdsCodeBlockTitleComponent;

--- a/packages/components/src/components/hds/code-block/types.ts
+++ b/packages/components/src/components/hds/code-block/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export enum HdsCodeBlockLanguageValues {
+  Bash = 'bash',
+  Go = 'go',
+  Hcl = 'hcl',
+  Json = 'json',
+  Log = 'log',
+  Ruby = 'ruby',
+  ShellSession = 'shell-session',
+  Yaml = 'yaml',
+}
+
+export type HdsCodeBlockLanguages = `${HdsCodeBlockLanguageValues}`;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -38,6 +38,10 @@ import type HdsApplicationStateFooterComponent from './components/hds/applicatio
 import type HdsApplicationStateHeaderComponent from './components/hds/application-state/header';
 import type HdsApplicationStateMediaComponent from './components/hds/application-state/media';
 import type HdsCardContainerComponent from './components/hds/card/container.ts';
+import type HdsCodeBlockComponent from './components/hds/code-block';
+import type HdsCodeBlockCopyButtonComponent from './components/hds/code-block/copy-button';
+import type HdsCodeBlockDescriptionComponent from './components/hds/code-block/description';
+import type HdsCodeBlockTitleComponent from './components/hds/code-block/title';
 import type HdsCopyButtonComponent from './components/hds/copy/button/index';
 import type HdsCopySnippetComponent from './components/hds/copy/snippet';
 import type HdsDisclosurePrimitiveComponent from './components/hds/disclosure-primitive';
@@ -276,6 +280,19 @@ export default interface HdsComponentsRegistry {
   // Card
   'Hds::Card': typeof HdsCardContainerComponent;
   'hds/card': typeof HdsCardContainerComponent;
+
+  // Code Block
+  'Hds::CodeBlock': typeof HdsCodeBlockComponent;
+  'hds/code-block': typeof HdsCodeBlockComponent;
+
+  'Hds::CodeBlock::CopyButton': typeof HdsCodeBlockCopyButtonComponent;
+  'hds/code-block/copy-button': typeof HdsCodeBlockCopyButtonComponent;
+
+  'Hds::CodeBlock::Description': typeof HdsCodeBlockDescriptionComponent;
+  'hds/code-block/description': typeof HdsCodeBlockDescriptionComponent;
+
+  'Hds::CodeBlock::Title': typeof HdsCodeBlockTitleComponent;
+  'hds/code-block/title': typeof HdsCodeBlockTitleComponent;
 
   // Copy Button
   'Hds::Copy::Button': typeof HdsCopyButtonComponent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4116,6 +4116,7 @@ __metadata:
     "@types/ember-qunit": "npm:^6.1.1"
     "@types/ember-resolver": "npm:^9.0.0"
     "@types/ember__destroyable": "npm:^4.0.5"
+    "@types/prismjs": "npm:^1.26.4"
     "@types/qunit": "npm:^2.19.10"
     "@types/rsvp": "npm:^4.0.9"
     "@typescript-eslint/eslint-plugin": "npm:^6.21.0"
@@ -6128,6 +6129,13 @@ __metadata:
   version: 4.0.2
   resolution: "@types/parse-json@npm:4.0.2"
   checksum: 10/5bf62eec37c332ad10059252fc0dab7e7da730764869c980b0714777ad3d065e490627be9f40fc52f238ffa3ac4199b19de4127196910576c2fe34dd47c7a470
+  languageName: node
+  linkType: hard
+
+"@types/prismjs@npm:^1.26.4":
+  version: 1.26.4
+  resolution: "@types/prismjs@npm:1.26.4"
+  checksum: 10/fcf7072c56835bfdc9bd9c06acd733440c5198b9fba33c5de09cd7bfe9e6663604120c5d602ffbeb806cdc06447fb711d84fc89c9039b8cc95078702a15e7ff1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will convert the Code Block component to TypeScript

### :hammer_and_wrench: Detailed description

Only other thing is that I added `@types/prismjs` as a dev dependency.

### :link: External links

Jira ticket: [HDS-3550](https://hashicorp.atlassian.net/browse/HDS-3550)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3550]: https://hashicorp.atlassian.net/browse/HDS-3550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ