### PR TITLE
Update Figma release notes

### DIFF
--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -14,6 +14,10 @@ Notable visual changes in the `ApplicationState`:
 - The title text will be reduced from Display 400 to Display 300 to better fit within the page hierarchy.
 - The icon and title have been changed from `foreground/faint` to `foreground/strong`. The body text has changed from `foreground/faint` to `foreground/primary`. These changes better align with our color standards established with other components.
 
+### Breaking change
+
+The changes in the footer of the `ApplicationState` to support a Dropdown, Button, and Standalone Link results in a breaking change. To avoid overwriting in-progress design work, we recommend taking screenshots of legacy instances of the Application state prior to updating your library.
+
 `Enterprise Navigation` - multiple enhancements to navigation components including:
 
 - Added a new `AppHeader` component to contain global and utility navigation elements.

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -8,7 +8,7 @@
 
 `Application Template` - Added a template component that provides a consistent starting point for the UI chrome.
 
-`SideNav` - **Deprecated** the legacy navigation component. It will be removed from the library once adoption of the `AppHeader` is complete.
+`SideNav` - **Deprecated** the legacy navigation component. It will be removed from the library once adoption of the `AppHeader` and `AppSideNav` is complete.
 
 ### Breaking changes
 
@@ -18,12 +18,10 @@
 - Added an `alignment` property which can be set at the root level to `left` or `center`.
 - The footer now supports up to three actions at once. The actions are now organized in accordance with our [Button Organization](/patterns/button-organization) pattern.
 - Updated several visual styles including:
-  - Removing the divider
-  - Reducing the title from `Display/400/Bold` to `Display/300/Bold`
-  - Changing the icon and the title color from `Foreground/Faint` to `Foreground/Strong`
-  - Changing the body text color from `Foreground/Faint` to `Foreground/Primary`
-
-### Breaking change
+    - Removing the divider
+    - Reducing the title from `Display/400/Bold` to `Display/300/Bold`
+    - Changing the icon and the title color from `Foreground/Faint` to `Foreground/Strong`
+    - Changing the body text color from `Foreground/Faint` to `Foreground/Primary`
 
 _Adding support for three actions within the `ApplicationState` results in a breaking change to the previous actions. Before updating the library, we recommend annotating the text and icon name (with a comment or otherwise) in files that are in progress or still being referenced by engineering._
 

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -1,5 +1,26 @@
 # [HDS Product - Components](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=6790-10926&mode=design&t=Ps0aMGZ6F3z7bAJ4-0)
 
+## August 2nd, 2024
+
+`ApplicationState` - multiple enhancements to the `ApplicationState` including:
+
+- Added support for a media slot, which when enabled, will be added above the title, allowing yielded illustrations to occupy that space.
+- Added an `alignment` property which can be set at the root level to `left` or `center`. This adjusts the component’s text, footer actions, and media alignment.
+- The footer now supports up to three actions at once, modeled after the Button Set. Previously the actions were justified (one all the way left and one all the way right). Supported actions now include Dropdown, Button, and Standalone Link. Previously Standalone Link was the only supported option.
+
+Notable visual changes in the `ApplicationState`:
+
+- The divider has been removed to modernize the component and align with our visual standards.
+- The title text will be reduced from Display 400 to Display 300 to better fit within the page hierarchy.
+- The icon and title have been changed from `foreground/faint` to `foreground/strong`. The body text has changed from `foreground/faint` to `foreground/primary`. These changes better align with our color standards established with other components.
+
+`Enterprise Navigation` - multiple enhancements to navigation components including:
+
+- Added a new `AppHeader` component to contain global and utility navigation elements.
+- Added a new `AppSideNav` component which shares features and functionality with the legacy `SideNav`
+  - The legacy `SideNav` is marked as **deprecated** and will be removed from the library once adoption of the `AppHeader` is complete.
+- Add a new `Application Template` which provides a consistent starting point for the UI chrome with HDS navigation components (`AppHeader`, `AppSideNav`, and `AppFooter`).
+
 ## February 27th, 2024
 
 ### Breaking changes

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -2,28 +2,30 @@
 
 ## August 2nd, 2024
 
-`ApplicationState` - multiple enhancements to the `ApplicationState` including:
+`AppHeader` - Added a new navigation component to contain global and utility navigation elements.
 
-- Added support for a media slot, which when enabled, will be added above the title, allowing yielded illustrations to occupy that space.
-- Added an `alignment` property which can be set at the root level to `left` or `center`. This adjusts the component’s text, footer actions, and media alignment.
-- The footer now supports up to three actions at once, modeled after the Button Set. Previously, the actions were justified (one all the way left and one all the way right). The three actions are now organized in accordance with our [Button Organization](/patterns/button-organization) pattern with `primary` and `secondary` grouped on the left, and `tertiary` on the right. Supported actions now include Dropdown, Button, and Standalone Link. Previously Standalone Link was the only supported option.
+`AppSideNav` - Added a new component that shares features and functionality with the legacy `SideNav`.
 
-Notable visual changes in the `ApplicationState`:
+`Application Template` - Added a template component that provides a consistent starting point for the UI chrome.
 
-- The divider has been removed to modernize the component and align with our visual standards.
-- The title text has been reduced from Display 400 to Display 300 to better fit within the page hierarchy.
-- The icon and title have been changed from `foreground/faint` to `foreground/strong`. The body text has changed from `foreground/faint` to `foreground/primary`. These changes better align with our color standards established with other components.
+`SideNav` - **Deprecated** the legacy navigation component. It will be removed from the library once adoption of the `AppHeader` is complete.
+
+### Breaking changes
+
+`ApplicationState` - multiple enhancements including:
+
+- Added support for a media slot above the title.
+- Added an `alignment` property which can be set at the root level to `left` or `center`.
+- The footer now supports up to three actions at once. The actions are now organized in accordance with our [Button Organization](/patterns/button-organization) pattern.
+- Updated several visual styles including:
+  - Removing the divider
+  - Reducing the title from `Display/400/Bold` to `Display/300/Bold`
+  - Changing the icon and the title color from `Foreground/Faint` to `Foreground/Strong`
+  - Changing the body text color from `Foreground/Faint` to `Foreground/Primary`
 
 ### Breaking change
 
-The changes in the footer of the `ApplicationState` to support a Dropdown, Button, and Standalone Link results in a breaking change. To avoid overwriting in-progress design work, we recommend taking screenshots of legacy instances of the Application state prior to updating your library.
-
-`Enterprise Navigation` - multiple enhancements to navigation components including:
-
-- Added a new `AppHeader` component to contain global and utility navigation elements.
-- Added a new `AppSideNav` component which shares features and functionality with the legacy `SideNav`
-  - The legacy `SideNav` is marked as **deprecated** and will be removed from the library once adoption of the `AppHeader` is complete.
-- Add a new `Application Template` which provides a consistent starting point for the UI chrome with HDS navigation components (`AppHeader`, `AppSideNav`, and `AppFooter`).
+_Adding support for three actions within the `ApplicationState` results in a breaking change to the previous actions. Before updating the library, we recommend annotating the text and icon name (with a comment or otherwise) in files that are in progress or still being referenced by engineering._
 
 ## February 27th, 2024
 

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -6,12 +6,12 @@
 
 - Added support for a media slot, which when enabled, will be added above the title, allowing yielded illustrations to occupy that space.
 - Added an `alignment` property which can be set at the root level to `left` or `center`. This adjusts the component’s text, footer actions, and media alignment.
-- The footer now supports up to three actions at once, modeled after the Button Set. Previously the actions were justified (one all the way left and one all the way right). Supported actions now include Dropdown, Button, and Standalone Link. Previously Standalone Link was the only supported option.
+- The footer now supports up to three actions at once, modeled after the Button Set. Previously, the actions were justified (one all the way left and one all the way right). The three actions are now organized in accordance with our [Button Organization](/patterns/button-organization) pattern with `primary` and `secondary` grouped on the left, and `tertiary` on the right. Supported actions now include Dropdown, Button, and Standalone Link. Previously Standalone Link was the only supported option.
 
 Notable visual changes in the `ApplicationState`:
 
 - The divider has been removed to modernize the component and align with our visual standards.
-- The title text will be reduced from Display 400 to Display 300 to better fit within the page hierarchy.
+- The title text has been reduced from Display 400 to Display 300 to better fit within the page hierarchy.
 - The icon and title have been changed from `foreground/faint` to `foreground/strong`. The body text has changed from `foreground/faint` to `foreground/primary`. These changes better align with our color standards established with other components.
 
 ### Breaking change

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -69,6 +69,8 @@ Add explicit `ember-get-config` dependency for use in the icon sprite initialize
 
 ## 4.7.0
 
+[4.7.0 documentation](https://hds-website-4-7-0.vercel.app/)
+
 ### Minor Changes
 
 `FileInput`, `MaskedInput`, `Select`, `TextInput`, `Textarea` - Converted to TypeScript
@@ -143,6 +145,8 @@ Converted form primitives to TypeScript
 - @hashicorp/ember-flight-icons@5.1.3
 
 ## 4.6.0
+
+[4.6.0 documentation](https://hds-website-4-6-0.vercel.app/)
 
 ### Minor Changes
 

--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -14,6 +14,8 @@
 
 ## 4.8.0
 
+[4.8.0 documentation](https://hds-website-4-8-0.vercel.app/)
+
 **Minor changes**
 
 `AppHeader` - Added new component.
@@ -78,6 +80,8 @@ Add explicit `ember-get-config` dependency for use in the icon sprite initialize
 - @hashicorp/design-system-tokens@2.2.0
 
 ## 4.7.0
+
+[4.7.0 documentation](https://hds-website-4-7-0.vercel.app/)
 
 **Minor changes**
 
@@ -153,6 +157,8 @@ Converted form primitives to TypeScript
 - @hashicorp/ember-flight-icons@5.1.3
 
 ## 4.6.0
+
+[4.6.0 documentation](https://hds-website-4-6-0.vercel.app/)
 
 **Minor changes**
 

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -20,7 +20,7 @@
 
 `Application Template` - Added a template component that provides a consistent starting point for the UI chrome.
 
-`SideNav` - **Deprecated** the legacy navigation component. It will be removed from the library once adoption of the `AppHeader` is complete.
+`SideNav` - **Deprecated** the legacy navigation component. It will be removed from the library once adoption of the `AppHeader` and `AppSideNav` is complete.
 
 #### Breaking changes
 
@@ -30,12 +30,10 @@
 - Added an `alignment` property which can be set at the root level to `left` or `center`.
 - The footer now supports up to three actions at once. The actions are now organized in accordance with our [Button Organization](/patterns/button-organization) pattern.
 - Updated several visual styles including:
-  - Removing the divider
-  - Reducing the title from `Display/400/Bold` to `Display/300/Bold`
-  - Changing the icon and the title color from `Foreground/Faint` to `Foreground/Strong`
-  - Changing the body text color from `Foreground/Faint` to `Foreground/Primary`
-
-#### Breaking change
+    - Removing the divider
+    - Reducing the title from `Display/400/Bold` to `Display/300/Bold`
+    - Changing the icon and the title color from `Foreground/Faint` to `Foreground/Strong`
+    - Changing the body text color from `Foreground/Faint` to `Foreground/Primary`
 
 _Adding support for three actions within the `ApplicationState` results in a breaking change to the previous actions. Before updating the library, we recommend annotating the text and icon name (with a comment or otherwise) in files that are in progress or still being referenced by engineering._
 

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -14,28 +14,30 @@
 
 ### August 2nd, 2024
 
-`ApplicationState` - multiple enhancements to the `ApplicationState` including:
+`AppHeader` - Added a new navigation component to contain global and utility navigation elements.
 
-- Added support for a media slot, which when enabled, will be added above the title, allowing yielded illustrations to occupy that space.
-- Added an `alignment` property which can be set at the root level to `left` or `center`. This adjusts the component’s text, footer actions, and media alignment.
-- The footer now supports up to three actions at once, modeled after the Button Set. Previously, the actions were justified (one all the way left and one all the way right). The three actions are now organized in accordance with our [Button Organization](/patterns/button-organization) pattern with `primary` and `secondary` grouped on the left, and `tertiary` on the right. Supported actions now include Dropdown, Button, and Standalone Link. Previously Standalone Link was the only supported option.
+`AppSideNav` - Added a new component that shares features and functionality with the legacy `SideNav`.
 
-Notable visual changes in the `ApplicationState`:
+`Application Template` - Added a template component that provides a consistent starting point for the UI chrome.
 
-- The divider has been removed to modernize the component and align with our visual standards.
-- The title text has been reduced from Display 400 to Display 300 to better fit within the page hierarchy.
-- The icon and title have been changed from `foreground/faint` to `foreground/strong`. The body text has changed from `foreground/faint` to `foreground/primary`. These changes better align with our color standards established with other components.
+`SideNav` - **Deprecated** the legacy navigation component. It will be removed from the library once adoption of the `AppHeader` is complete.
+
+#### Breaking changes
+
+`ApplicationState` - multiple enhancements including:
+
+- Added support for a media slot above the title.
+- Added an `alignment` property which can be set at the root level to `left` or `center`.
+- The footer now supports up to three actions at once. The actions are now organized in accordance with our [Button Organization](/patterns/button-organization) pattern.
+- Updated several visual styles including:
+  - Removing the divider
+  - Reducing the title from `Display/400/Bold` to `Display/300/Bold`
+  - Changing the icon and the title color from `Foreground/Faint` to `Foreground/Strong`
+  - Changing the body text color from `Foreground/Faint` to `Foreground/Primary`
 
 #### Breaking change
 
-The changes in the footer of the `ApplicationState` to support a Dropdown, Button, and Standalone Link results in a breaking change. To avoid overwriting in-progress design work, we recommend taking screenshots of legacy instances of the Application state prior to updating your library.
-
-`Enterprise Navigation` - multiple enhancements to navigation components including:
-
-- Added a new `AppHeader` component to contain global and utility navigation elements.
-- Added a new `AppSideNav` component which shares features and functionality with the legacy `SideNav`
-  - The legacy `SideNav` is marked as **deprecated** and will be removed from the library once adoption of the `AppHeader` is complete.
-- Add a new `Application Template` which provides a consistent starting point for the UI chrome with HDS navigation components (`AppHeader`, `AppSideNav`, and `AppFooter`).
+_Adding support for three actions within the `ApplicationState` results in a breaking change to the previous actions. Before updating the library, we recommend annotating the text and icon name (with a comment or otherwise) in files that are in progress or still being referenced by engineering._
 
 ### February 27th, 2024
 

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -12,6 +12,27 @@
 </p>
 
 
+### August 2nd, 2024
+
+`ApplicationState` - multiple enhancements to the `ApplicationState` including:
+
+- Added support for a media slot, which when enabled, will be added above the title, allowing yielded illustrations to occupy that space.
+- Added an `alignment` property which can be set at the root level to `left` or `center`. This adjusts the component’s text, footer actions, and media alignment.
+- The footer now supports up to three actions at once, modeled after the Button Set. Previously the actions were justified (one all the way left and one all the way right). Supported actions now include Dropdown, Button, and Standalone Link. Previously Standalone Link was the only supported option.
+
+Notable visual changes in the `ApplicationState`:
+
+- The divider has been removed to modernize the component and align with our visual standards.
+- The title text will be reduced from Display 400 to Display 300 to better fit within the page hierarchy.
+- The icon and title have been changed from `foreground/faint` to `foreground/strong`. The body text has changed from `foreground/faint` to `foreground/primary`. These changes better align with our color standards established with other components.
+
+`Enterprise Navigation` - multiple enhancements to navigation components including:
+
+- Added a new `AppHeader` component to contain global and utility navigation elements.
+- Added a new `AppSideNav` component which shares features and functionality with the legacy `SideNav`
+  - The legacy `SideNav` is marked as **deprecated** and will be removed from the library once adoption of the `AppHeader` is complete.
+- Add a new `Application Template` which provides a consistent starting point for the UI chrome with HDS navigation components (`AppHeader`, `AppSideNav`, and `AppFooter`).
+
 ### February 27th, 2024
 
 #### Breaking changes
@@ -64,10 +85,6 @@ Added new components:
 
 - `Accordion`
 - `MaskedInput`
-
-### July 12th, 2023
-
-Added a “Form Primitives” page to house the `Fieldset` component.
 
 
 ---

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -18,13 +18,17 @@
 
 - Added support for a media slot, which when enabled, will be added above the title, allowing yielded illustrations to occupy that space.
 - Added an `alignment` property which can be set at the root level to `left` or `center`. This adjusts the component’s text, footer actions, and media alignment.
-- The footer now supports up to three actions at once, modeled after the Button Set. Previously the actions were justified (one all the way left and one all the way right). Supported actions now include Dropdown, Button, and Standalone Link. Previously Standalone Link was the only supported option.
+- The footer now supports up to three actions at once, modeled after the Button Set. Previously, the actions were justified (one all the way left and one all the way right). The three actions are now organized in accordance with our [Button Organization](/patterns/button-organization) pattern with `primary` and `secondary` grouped on the left, and `tertiary` on the right. Supported actions now include Dropdown, Button, and Standalone Link. Previously Standalone Link was the only supported option.
 
 Notable visual changes in the `ApplicationState`:
 
 - The divider has been removed to modernize the component and align with our visual standards.
-- The title text will be reduced from Display 400 to Display 300 to better fit within the page hierarchy.
+- The title text has been reduced from Display 400 to Display 300 to better fit within the page hierarchy.
 - The icon and title have been changed from `foreground/faint` to `foreground/strong`. The body text has changed from `foreground/faint` to `foreground/primary`. These changes better align with our color standards established with other components.
+
+#### Breaking change
+
+The changes in the footer of the `ApplicationState` to support a Dropdown, Button, and Standalone Link results in a breaking change. To avoid overwriting in-progress design work, we recommend taking screenshots of legacy instances of the Application state prior to updating your library.
 
 `Enterprise Navigation` - multiple enhancements to navigation components including:
 


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR will add Figma release notes for the `ApplicationState` and additions/updates in the Enterprise navigation project (`AppHeader`, `AppSideNav`, `SideNav [Deprecated]`, and Application Template). This change corresponds with [these consolidated release notes](https://docs.google.com/document/d/1qaRUTkwYp9iQwrDf67bJOwKTxIJ6DtLjjolyUJ3hBv4/edit)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
