### PR TITLE
feat(components): simplify reexport and add type reexport example

### DIFF
--- a/.changeset/fifty-kiwis-impress.md
+++ b/.changeset/fifty-kiwis-impress.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+- simplify components reexports and add types reexports
+- update `HdsCard` reexport to reflect correct component name `HdsCardContainer`

--- a/packages/components/src/components.ts
+++ b/packages/components/src/components.ts
@@ -11,18 +11,28 @@
 
 // Accordion
 export { default as HdsAccordion } from './components/hds/accordion/index.ts';
+export { default as HdsAccordionItem } from './components/hds/accordion/item/index.ts';
 export * from './components/hds/accordion/types.ts';
 
 // Alert
 export { default as HdsAlert } from './components/hds/alert/index.ts';
+export { default as HdsAlertDescription } from './components/hds/alert/description.ts';
+export { default as HdsAlertTitle } from './components/hds/alert/title.ts';
 export * from './components/hds/alert/types.ts';
 
 // AppFooter
 export { default as HdsAppFooter } from './components/hds/app-footer/index.ts';
+export { default as HdsAppFooterCopyright } from './components/hds/app-footer/copyright.ts';
+export { default as HdsAppFooterItem } from './components/hds/app-footer/item.ts';
+export { default as HdsAppFooterLegalLinks } from './components/hds/app-footer/legal-links.ts';
+export { default as HdsAppFooterLink } from './components/hds/app-footer/link.ts';
+export { default as HdsAppFooterStatusLink } from './components/hds/app-footer/status-link.ts';
 export * from './components/hds/app-footer/types.ts';
 
 // AppHeader
 export { default as HdsAppHeader } from './components/hds/app-header/index.ts';
+export { default as HdsAppHeaderHomeLink } from './components/hds/app-header/home-link.ts';
+export { default as HdsAppHeaderMenuButton } from './components/hds/app-header/menu-button.ts';
 
 // ApplicationState
 export { default as HdsApplicationState } from './components/hds/application-state/index.ts';
@@ -52,7 +62,7 @@ export { default as HdsButton } from './components/hds/button/index.ts';
 export { default as HdsButtonSet } from './components/hds/button-set/index.ts';
 
 // Card
-export { default as HdsCard } from './components/hds/card/container.ts';
+export { default as HdsCardContainer } from './components/hds/card/container.ts';
 export * from './components/hds/card/types.ts';
 
 // CodeBlock
@@ -72,6 +82,19 @@ export * from './components/hds/copy/snippet/types.ts';
 
 // Dropdown
 export { default as HdsDropdown } from './components/hds/dropdown/index.ts';
+export { default as HdsDropdownFooter } from './components/hds/dropdown/footer.ts';
+export { default as HdsDropdownHeader } from './components/hds/dropdown/header.ts';
+export { default as HdsDropdownListItemCheckbox } from './components/hds/dropdown/list-item/checkbox.ts';
+export { default as HdsDropdownListItemCheckmark } from './components/hds/dropdown/list-item/checkmark.ts';
+export { default as HdsDropdownListItemCopyItem } from './components/hds/dropdown/list-item/copy-item.ts';
+export { default as HdsDropdownListItemDescription } from './components/hds/dropdown/list-item/description.ts';
+export { default as HdsDropdownListItemGeneric } from './components/hds/dropdown/list-item/generic.ts';
+export { default as HdsDropdownListItemInteractive } from './components/hds/dropdown/list-item/interactive.ts';
+export { default as HdsDropdownListItemRadio } from './components/hds/dropdown/list-item/radio.ts';
+export { default as HdsDropdownListItemSeparator } from './components/hds/dropdown/list-item/separator.ts';
+export { default as HdsDropdownListItemTitle } from './components/hds/dropdown/list-item/title.ts';
+export { default as HdsDropdownToggleButton } from './components/hds/dropdown/toggle/button.ts';
+export { default as HdsDropdownToggleIcon } from './components/hds/dropdown/toggle/icon.ts';
 export * from './components/hds/dropdown/list-item/types.ts';
 export * from './components/hds/dropdown/toggle/types.ts';
 export * from './components/hds/dropdown/types.ts';
@@ -80,51 +103,72 @@ export * from './components/hds/dropdown/types.ts';
 export { default as HdsFlyout } from './components/hds/flyout/index.ts';
 export * from './components/hds/flyout/types.ts';
 
-export { default as HdsFlyoutBody } from './components/hds/flyout/body.ts';
-export { default as HdsFlyoutDescription } from './components/hds/flyout/description.ts';
-export { default as HdsFlyoutFooter } from './components/hds/flyout/footer.ts';
-export { default as HdsFlyoutHeader } from './components/hds/flyout/header.ts';
-
-// Form
+// Form > Base elements
 export { default as HdsFormCharacterCount } from './components/hds/form/character-count/index.ts';
-export { default as HdsFormCheckboxBase } from './components/hds/form/checkbox/base.ts';
-export { default as HdsFormCheckboxField } from './components/hds/form/checkbox/field.ts';
-export { default as HdsFormCheckboxGroup } from './components/hds/form/checkbox/group.ts';
 export { default as HdsFormError } from './components/hds/form/error/index.ts';
+export { default as HdsFormErrorMessage } from './components/hds/form/error/message.ts';
 export { default as HdsFormField } from './components/hds/form/field/index.ts';
-export * from './components/hds/form/field/types.ts';
 export { default as HdsFormFieldset } from './components/hds/form/fieldset/index.ts';
-export * from './components/hds/form/fieldset/types.ts';
-export { default as HdsFormFileInputBase } from './components/hds/form/file-input/base.ts';
-export { default as HdsFormFileInputField } from './components/hds/form/file-input/field.ts';
 export { default as HdsFormHelperText } from './components/hds/form/helper-text/index.ts';
 export { default as HdsFormIndicator } from './components/hds/form/indicator/index.ts';
 export { default as HdsFormLabel } from './components/hds/form/label/index.ts';
 export { default as HdsFormLegend } from './components/hds/form/legend/index.ts';
+export { default as HdsFormVisibilityToggle } from './components/hds/form/visibility-toggle/index.ts';
+export * from './components/hds/form/field/types.ts';
+export * from './components/hds/form/fieldset/types.ts';
+
+// Form > Checkbox
+export { default as HdsFormCheckboxBase } from './components/hds/form/checkbox/base.ts';
+export { default as HdsFormCheckboxField } from './components/hds/form/checkbox/field.ts';
+export { default as HdsFormCheckboxGroup } from './components/hds/form/checkbox/group.ts';
+
+// Form > FileInput
+export { default as HdsFormFileInputBase } from './components/hds/form/file-input/base.ts';
+export { default as HdsFormFileInputField } from './components/hds/form/file-input/field.ts';
+
+// Form > MaskedInput
 export { default as HdsFormMaskedInputBase } from './components/hds/form/masked-input/base.ts';
 export { default as HdsFormMaskedInputField } from './components/hds/form/masked-input/field.ts';
+
+// Form > Radio
 export { default as HdsFormRadioBase } from './components/hds/form/radio/base.ts';
-export { default as HdsFormRadioCard } from './components/hds/form/radio-card/index.ts';
-export * from './components/hds/form/radio-card/types.ts';
-export { default as HdsFormRadioCardGroup } from './components/hds/form/radio-card/group.ts';
 export { default as HdsFormRadioField } from './components/hds/form/radio/field.ts';
 export { default as HdsFormRadioGroup } from './components/hds/form/radio/group.ts';
+
+// Form > RadioCard
+export { default as HdsFormRadioCard } from './components/hds/form/radio-card/index.ts';
+export { default as HdsFormRadioCardGroup } from './components/hds/form/radio-card/group.ts';
+export { default as HdsFormRadioCardDescription } from './components/hds/form/radio-card/description.ts';
+export { default as HdsFormRadioCardLabel } from './components/hds/form/radio-card/label.ts';
+export * from './components/hds/form/radio-card/types.ts';
+
+// Form > Select
 export { default as HdsFormSelectBase } from './components/hds/form/select/base.ts';
 export { default as HdsFormSelectField } from './components/hds/form/select/field.ts';
+
+// Form > SuperSelect
 export { default as HdsFormSuperSelectSingleBase } from './components/hds/form/super-select/single/base.ts';
 export { default as HdsFormSuperSelectSingleField } from './components/hds/form/super-select/single/field.ts';
 export { default as HdsFormSuperSelectMultipleBase } from './components/hds/form/super-select/multiple/base.ts';
 export { default as HdsFormSuperSelectMultipleField } from './components/hds/form/super-select/multiple/field.ts';
+export { default as HdsFormSuperSelectAfterOptions } from './components/hds/form/super-select/after-options.ts';
+export { default as HdsFormSuperSelectOptionGroup } from './components/hds/form/super-select/option-group.ts';
+export { default as HdsFormSuperSelectPlaceholder } from './components/hds/form/super-select/placeholder.ts';
 export * from './components/hds/form/super-select/types.ts';
+
+// Form > Textarea
 export { default as HdsFormTextareaBase } from './components/hds/form/textarea/base.ts';
 export { default as HdsFormTextareaField } from './components/hds/form/textarea/field.ts';
+
+// Form > TextInput
 export { default as HdsFormTextInputBase } from './components/hds/form/text-input/base.ts';
 export { default as HdsFormTextInputField } from './components/hds/form/text-input/field.ts';
 export * from './components/hds/form/text-input/types.ts';
+
+// Form > Toggle
 export { default as HdsFormToggleBase } from './components/hds/form/toggle/base.ts';
 export { default as HdsFormToggleField } from './components/hds/form/toggle/field.ts';
 export { default as HdsFormToggleGroup } from './components/hds/form/toggle/group.ts';
-export { default as HdsFormVisibilityToggle } from './components/hds/form/visibility-toggle/index.ts';
 
 // Icon
 export { default as HdsIcon } from './components/hds/icon/index.ts';
@@ -141,29 +185,34 @@ export * from './components/hds/link/types.ts';
 
 // Modal
 export { default as HdsModal } from './components/hds/modal/index.ts';
-export { default as HdsModalBody } from './components/hds/modal/body.ts';
-export { default as HdsModalFooter } from './components/hds/modal/footer.ts';
-export { default as HdsModalHeader } from './components/hds/modal/header.ts';
 export * from './components/hds/modal/types.ts';
 
 // PageHeader
 export { default as HdsPageHeader } from './components/hds/page-header/index.ts';
+export { default as HdsPageHeaderActions } from './components/hds/page-header/actions.ts';
+export { default as HdsPageHeaderBadges } from './components/hds/page-header/badges.ts';
+export { default as HdsPageHeaderDescription } from './components/hds/page-header/description.ts';
+export { default as HdsPageHeaderSubtitle } from './components/hds/page-header/subtitle.ts';
+export { default as HdsPageHeaderTitle } from './components/hds/page-header/title.ts';
 
 // Pagination
 export { default as HdsPaginationCompact } from './components/hds/pagination/compact/index.ts';
-export { default as HdsPaginationControlInfo } from './components/hds/pagination/info/index.ts';
-export { default as HdsPaginationControlArrow } from './components/hds/pagination/nav/arrow.ts';
-export { default as HdsPaginationControlEllipsis } from './components/hds/pagination/nav/ellipsis.ts';
-export { default as HdsPaginationControlNumber } from './components/hds/pagination/nav/number.ts';
+export { default as HdsPaginationInfo } from './components/hds/pagination/info/index.ts';
+export { default as HdsPaginationNavArrow } from './components/hds/pagination/nav/arrow.ts';
+export { default as HdsPaginationNavEllipsis } from './components/hds/pagination/nav/ellipsis.ts';
+export { default as HdsPaginationNavNumber } from './components/hds/pagination/nav/number.ts';
 export { default as HdsPaginationNumbered } from './components/hds/pagination/numbered/index.ts';
 export { default as HdsPaginationSizeSelector } from './components/hds/pagination/size-selector/index.ts';
 export * from './components/hds/pagination/types.ts';
 
 // Reveal
 export { default as HdsReveal } from './components/hds/reveal/index.ts';
+export { default as HdsRevealToggleButton } from './components/hds/reveal/toggle/button.ts';
 
 // RichTooltip
 export { default as HdsRichTooltip } from './components/hds/rich-tooltip/index.ts';
+export { default as HdsRichTooltipBubble } from './components/hds/rich-tooltip/bubble.ts';
+export { default as HdsRichTooltipToggle } from './components/hds/rich-tooltip/toggle.ts';
 export * from './components/hds/rich-tooltip/types.ts';
 
 // SegmentedGroup
@@ -179,9 +228,14 @@ export { default as HdsSideNavBase } from './components/hds/side-nav/base.ts';
 export { default as HdsSideNavHeader } from './components/hds/side-nav/header/index.ts';
 export { default as HdsSideNavHeaderHomeLink } from './components/hds/side-nav/header/home-link.ts';
 export { default as HdsSideNavHeaderIconButton } from './components/hds/side-nav/header/icon-button.ts';
-export { default as HdsSideNavPortalTarget } from './components/hds/side-nav/portal/target.ts';
-export { default as HdsSideNavPortal } from './components/hds/side-nav/portal/index.ts';
 export { default as HdsSideNavList } from './components/hds/side-nav/list/index.ts';
+export { default as HdsSideNavListBackLink } from './components/hds/side-nav/list/back-link.ts';
+export { default as HdsSideNavListItem } from './components/hds/side-nav/list/item.ts';
+export { default as HdsSideNavListLink } from './components/hds/side-nav/list/link.ts';
+export { default as HdsSideNavListTitle } from './components/hds/side-nav/list/title.ts';
+export { default as HdsSideNavPortal } from './components/hds/side-nav/portal/index.ts';
+export { default as HdsSideNavPortalTarget } from './components/hds/side-nav/portal/target.ts';
+export { default as HdsSideNavToggleButton } from './components/hds/side-nav/toggle-button.ts';
 
 // Stepper
 export { default as HdsStepperStepIndicator } from './components/hds/stepper/step/indicator.ts';
@@ -194,13 +248,15 @@ export { default as HdsTableTd } from './components/hds/table/td.ts';
 export { default as HdsTableTh } from './components/hds/table/th.ts';
 export { default as HdsTableThButtonSort } from './components/hds/table/th-button-sort.ts';
 export { default as HdsTableThButtonTooltip } from './components/hds/table/th-button-tooltip.ts';
-export { default as HdsTableThSort } from './components/hds/table/th-sort.ts';
 export { default as HdsTableThSelectable } from './components/hds/table/th-selectable.ts';
+export { default as HdsTableThSort } from './components/hds/table/th-sort.ts';
 export { default as HdsTableTr } from './components/hds/table/tr.ts';
 export * from './components/hds/table/types.ts';
 
 // Tabs
 export { default as HdsTabs } from './components/hds/tabs/index.ts';
+export { default as HdsTabsPanel } from './components/hds/tabs/panel.ts';
+export { default as HdsTabsTab } from './components/hds/tabs/tab.ts';
 export * from './components/hds/tabs/types.ts';
 
 // Tag
@@ -227,6 +283,11 @@ export * from './components/hds/tooltip-button/types.ts';
 
 // AppFrame
 export { default as HdsAppFrame } from './components/hds/app-frame/index.ts';
+export { default as HdsAppFrameFooter } from './components/hds/app-frame/parts/footer.ts';
+export { default as HdsAppFrameHeader } from './components/hds/app-frame/parts/header.ts';
+export { default as HdsAppFrameMain } from './components/hds/app-frame/parts/main.ts';
+export { default as HdsAppFrameModals } from './components/hds/app-frame/parts/modals.ts';
+export { default as HdsAppFrameSidebar } from './components/hds/app-frame/parts/sidebar.ts';
 
 // -----------------------------------------------------------
 // ### UTILITIES

--- a/packages/components/src/components.ts
+++ b/packages/components/src/components.ts
@@ -3,247 +3,243 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// This file is use to expose public components
-import HdsAccordion from './components/hds/accordion/index.ts';
-import HdsAlert from './components/hds/alert/index.ts';
-import HdsAppFooter from './components/hds/app-footer/index.ts';
-import HdsAppFrame from './components/hds/app-frame/index.ts';
-import HdsApplicationState from './components/hds/application-state/index.ts';
-import HdsApplicationStateBody from './components/hds/application-state/body.ts';
-import HdsApplicationStateFooter from './components/hds/application-state/footer.ts';
-import HdsApplicationStateHeader from './components/hds/application-state/header.ts';
-import HdsApplicationStateMedia from './components/hds/application-state/media.ts';
-import HdsBadge from './components/hds/badge/index.ts';
-import HdsBadgeCount from './components/hds/badge-count/index.ts';
-import HdsBreadcrumb from './components/hds/breadcrumb/index.ts';
-import HdsBreadcrumbItem from './components/hds/breadcrumb/item.ts';
-import HdsBreadcrumbTruncation from './components/hds/breadcrumb/truncation.ts';
-import HdsButton from './components/hds/button/index.ts';
-import HdsButtonSet from './components/hds/button-set/index.ts';
-import HdsCard from './components/hds/card/container.ts';
-import HdsCodeBlock from './components/hds/code-block/index.ts';
-import HdsCodeBlockCopyButton from './components/hds/code-block/copy-button.ts';
-import HdsCodeBlockDescription from './components/hds/code-block/description.ts';
-import HdsCodeBlockTitle from './components/hds/code-block/title.ts';
-import HdsCopyButton from './components/hds/copy/button/index.ts';
-import HdsCopySnippet from './components/hds/copy/snippet/index.ts';
-import HdsDialogPrimitiveBody from './components/hds/dialog-primitive/body.ts';
-import HdsDialogPrimitiveDescription from './components/hds/dialog-primitive/description.ts';
-import HdsDialogPrimitiveFooter from './components/hds/dialog-primitive/footer.ts';
-import HdsDialogPrimitiveHeader from './components/hds/dialog-primitive/header.ts';
-import HdsDialogPrimitiveOverlay from './components/hds/dialog-primitive/overlay.ts';
-import HdsDialogPrimitiveWrapper from './components/hds/dialog-primitive/wrapper.ts';
-import HdsDisclosurePrimitive from './components/hds/disclosure-primitive/index.ts';
-import HdsDismissButton from './components/hds/dismiss-button/index.ts';
-import HdsDropdown from './components/hds/dropdown/index.ts';
-import HdsFlyout from './components/hds/flyout/index.ts';
-import HdsFlyoutBody from './components/hds/flyout/body.ts';
-import HdsFlyoutDescription from './components/hds/flyout/description.ts';
-import HdsFlyoutFooter from './components/hds/flyout/footer.ts';
-import HdsFlyoutHeader from './components/hds/flyout/header.ts';
-import HdsFormCharacterCount from './components/hds/form/character-count/index.ts';
-import HdsFormCheckboxBase from './components/hds/form/checkbox/base.ts';
-import HdsFormCheckboxField from './components/hds/form/checkbox/field.ts';
-import HdsFormCheckboxGroup from './components/hds/form/checkbox/group.ts';
-import HdsFormError from './components/hds/form/error/index.ts';
-import HdsFormField from './components/hds/form/field/index.ts';
-import HdsFormFieldset from './components/hds/form/fieldset/index.ts';
-import HdsFormFileInputBase from './components/hds/form/file-input/base.ts';
-import HdsFormFileInputField from './components/hds/form/file-input/field.ts';
-import HdsFormHelperText from './components/hds/form/helper-text/index.ts';
-import HdsFormIndicator from './components/hds/form/indicator/index.ts';
-import HdsFormLabel from './components/hds/form/label/index.ts';
-import HdsFormLegend from './components/hds/form/legend/index.ts';
-import HdsFormMaskedInputBase from './components/hds/form/masked-input/base.ts';
-import HdsFormMaskedInputField from './components/hds/form/masked-input/field.ts';
-import HdsFormRadioBase from './components/hds/form/radio/base.ts';
-import HdsFormRadioCard from './components/hds/form/radio-card/index.ts';
-import HdsFormRadioCardGroup from './components/hds/form/radio-card/group.ts';
-import HdsFormRadioField from './components/hds/form/radio/field.ts';
-import HdsFormRadioGroup from './components/hds/form/radio/group.ts';
-import HdsFormSelectBase from './components/hds/form/select/base.ts';
-import HdsFormSelectField from './components/hds/form/select/field.ts';
-import HdsFormSuperSelectSingleBase from './components/hds/form/super-select/single/base.ts';
-import HdsFormSuperSelectSingleField from './components/hds/form/super-select/single/field.ts';
-import HdsFormSuperSelectMultipleBase from './components/hds/form/super-select/multiple/base.ts';
-import HdsFormSuperSelectMultipleField from './components/hds/form/super-select/multiple/field.ts';
-import HdsFormTextareaBase from './components/hds/form/textarea/base.ts';
-import HdsFormTextareaField from './components/hds/form/textarea/field.ts';
-import HdsFormTextInputBase from './components/hds/form/text-input/base.ts';
-import HdsFormTextInputField from './components/hds/form/text-input/field.ts';
-import HdsFormToggleBase from './components/hds/form/toggle/base.ts';
-import HdsFormToggleField from './components/hds/form/toggle/field.ts';
-import HdsFormToggleGroup from './components/hds/form/toggle/group.ts';
-import HdsFormVisibilityToggle from './components/hds/form/visibility-toggle/index.ts';
-import HdsIcon from './components/hds/icon/index.ts';
-import HdsIconTile from './components/hds/icon-tile/index.ts';
-import HdsInteractive from './components/hds/interactive/index.ts';
-import HdsLinkInline from './components/hds/link/inline.ts';
-import HdsLinkStandalone from './components/hds/link/standalone.ts';
-import HdsMenuPrimitive from './components/hds/menu-primitive/index.ts';
-import HdsModal from './components/hds/modal/index.ts';
-import HdsModalBody from './components/hds/modal/body.ts';
-import HdsModalFooter from './components/hds/modal/footer.ts';
-import HdsModalHeader from './components/hds/modal/header.ts';
-import HdsPageHeader from './components/hds/page-header/index.ts';
-import HdsPaginationCompact from './components/hds/pagination/compact/index.ts';
-import HdsPaginationControlInfo from './components/hds/pagination/info/index.ts';
-import HdsPaginationControlArrow from './components/hds/pagination/nav/arrow.ts';
-import HdsPaginationControlEllipsis from './components/hds/pagination/nav/ellipsis.ts';
-import HdsPaginationControlNumber from './components/hds/pagination/nav/number.ts';
-import HdsPaginationNumbered from './components/hds/pagination/numbered/index.ts';
-import HdsPaginationSizeSelector from './components/hds/pagination/size-selector/index.ts';
-import HdsPopoverPrimitive from './components/hds/popover-primitive/index.ts';
-import HdsReveal from './components/hds/reveal/index.ts';
-import HdsRichTooltip from './components/hds/rich-tooltip/index.ts';
-import HdsSegmentedGroup from './components/hds/segmented-group/index.ts';
-import HdsSeparator from './components/hds/separator/index.ts';
-import HdsSideNav from './components/hds/side-nav/index.ts';
-import HdsSideNavBase from './components/hds/side-nav/base.ts';
-import HdsSideNavHeader from './components/hds/side-nav/header/index.ts';
-import HdsSideNavHeaderHomeLink from './components/hds/side-nav/header/home-link.ts';
-import HdsSideNavHeaderIconButton from './components/hds/side-nav/header/icon-button.ts';
-import HdsSideNavPortalTarget from './components/hds/side-nav/portal/target.ts';
-import HdsSideNavPortal from './components/hds/side-nav/portal/index.ts';
-import HdsSideNavList from './components/hds/side-nav/list/index.ts';
-import HdsStepperStepIndicator from './components/hds/stepper/step/indicator.ts';
-import HdsStepperTaskIndicator from './components/hds/stepper/task/indicator.ts';
-import HdsTable from './components/hds/table/index.ts';
-import HdsTableTd from './components/hds/table/td.ts';
-import HdsTableTh from './components/hds/table/th.ts';
-import HdsTableThButtonSort from './components/hds/table/th-button-sort.ts';
-import HdsTableThButtonTooltip from './components/hds/table/th-button-tooltip.ts';
-import HdsTableThSort from './components/hds/table/th-sort.ts';
-import HdsTableThSelectable from './components/hds/table/th-selectable.ts';
-import HdsTableTr from './components/hds/table/tr.ts';
-import HdsTabs from './components/hds/tabs/index.ts';
-import HdsTag from './components/hds/tag/index.ts';
-import HdsText from './components/hds/text/index.ts';
-import HdsTextBody from './components/hds/text/body.ts';
-import HdsTextCode from './components/hds/text/code.ts';
-import HdsTextDisplay from './components/hds/text/display.ts';
-import HdsToast from './components/hds/toast/index.ts';
-import HdsTooltipButton from './components/hds/tooltip-button/index.ts';
+// This file is use to expose public components and it's types (enums only) to the consumers of this package.
 
-export {
-  HdsAccordion,
-  HdsAlert,
-  HdsAppFooter,
-  HdsAppFrame,
-  HdsApplicationState,
-  HdsApplicationStateBody,
-  HdsApplicationStateFooter,
-  HdsApplicationStateHeader,
-  HdsApplicationStateMedia,
-  HdsBadge,
-  HdsBadgeCount,
-  HdsBreadcrumb,
-  HdsBreadcrumbItem,
-  HdsBreadcrumbTruncation,
-  HdsButton,
-  HdsButtonSet,
-  HdsCard,
-  HdsCodeBlock,
-  HdsCodeBlockCopyButton,
-  HdsCodeBlockDescription,
-  HdsCodeBlockTitle,
-  HdsCopyButton,
-  HdsCopySnippet,
-  HdsDialogPrimitiveBody,
-  HdsDialogPrimitiveDescription,
-  HdsDialogPrimitiveFooter,
-  HdsDialogPrimitiveHeader,
-  HdsDialogPrimitiveOverlay,
-  HdsDialogPrimitiveWrapper,
-  HdsDisclosurePrimitive,
-  HdsDismissButton,
-  HdsDropdown,
-  HdsFlyout,
-  HdsFlyoutBody,
-  HdsFlyoutDescription,
-  HdsFlyoutFooter,
-  HdsFlyoutHeader,
-  HdsFormCharacterCount,
-  HdsFormCheckboxBase,
-  HdsFormCheckboxField,
-  HdsFormCheckboxGroup,
-  HdsFormError,
-  HdsFormField,
-  HdsFormFieldset,
-  HdsFormFileInputBase,
-  HdsFormFileInputField,
-  HdsFormHelperText,
-  HdsFormIndicator,
-  HdsFormLabel,
-  HdsFormLegend,
-  HdsFormMaskedInputBase,
-  HdsFormMaskedInputField,
-  HdsFormRadioBase,
-  HdsFormRadioCard,
-  HdsFormRadioCardGroup,
-  HdsFormRadioField,
-  HdsFormRadioGroup,
-  HdsFormSelectBase,
-  HdsFormSelectField,
-  HdsFormSuperSelectSingleBase,
-  HdsFormSuperSelectSingleField,
-  HdsFormSuperSelectMultipleBase,
-  HdsFormSuperSelectMultipleField,
-  HdsFormTextareaBase,
-  HdsFormTextareaField,
-  HdsFormTextInputBase,
-  HdsFormTextInputField,
-  HdsFormToggleBase,
-  HdsFormToggleField,
-  HdsFormToggleGroup,
-  HdsFormVisibilityToggle,
-  HdsIcon,
-  HdsIconTile,
-  HdsInteractive,
-  HdsLinkInline,
-  HdsLinkStandalone,
-  HdsMenuPrimitive,
-  HdsModal,
-  HdsModalBody,
-  HdsModalFooter,
-  HdsModalHeader,
-  HdsPageHeader,
-  HdsPaginationCompact,
-  HdsPaginationControlInfo,
-  HdsPaginationControlArrow,
-  HdsPaginationControlEllipsis,
-  HdsPaginationControlNumber,
-  HdsPaginationNumbered,
-  HdsPaginationSizeSelector,
-  HdsPopoverPrimitive,
-  HdsReveal,
-  HdsRichTooltip,
-  HdsSegmentedGroup,
-  HdsSeparator,
-  HdsSideNav,
-  HdsSideNavBase,
-  HdsSideNavHeader,
-  HdsSideNavHeaderHomeLink,
-  HdsSideNavHeaderIconButton,
-  HdsSideNavPortalTarget,
-  HdsSideNavPortal,
-  HdsSideNavList,
-  HdsStepperStepIndicator,
-  HdsStepperTaskIndicator,
-  HdsTable,
-  HdsTableTd,
-  HdsTableThButtonSort,
-  HdsTableTh,
-  HdsTableThButtonTooltip,
-  HdsTableThSort,
-  HdsTableThSelectable,
-  HdsTableTr,
-  HdsTabs,
-  HdsTag,
-  HdsText,
-  HdsTextBody,
-  HdsTextCode,
-  HdsTextDisplay,
-  HdsToast,
-  HdsTooltipButton,
-};
+// Accordion
+export { default as HdsAccordion } from './components/hds/accordion/index.ts';
+export * from './components/hds/accordion/types.ts';
+
+// Alert
+export { default as HdsAlert } from './components/hds/alert/index.ts';
+export * from './components/hds/alert/types.ts';
+
+// App Footer
+export { default as HdsAppFooter } from './components/hds/app-footer/index.ts';
+export * from './components/hds/app-footer/types.ts';
+
+// App Frame
+export { default as HdsAppFrame } from './components/hds/app-frame/index.ts';
+
+// App Header
+export { default as HdsAppHeader } from './components/hds/app-header/index.ts';
+
+// Application State
+export { default as HdsApplicationState } from './components/hds/application-state/index.ts';
+export { default as HdsApplicationStateBody } from './components/hds/application-state/body.ts';
+export { default as HdsApplicationStateFooter } from './components/hds/application-state/footer.ts';
+export { default as HdsApplicationStateHeader } from './components/hds/application-state/header.ts';
+export { default as HdsApplicationStateMedia } from './components/hds/application-state/media.ts';
+export * from './components/hds/application-state/types.ts';
+
+// Badge
+export { default as HdsBadge } from './components/hds/badge/index.ts';
+export * from './components/hds/badge/types.ts';
+
+// Badge Count
+export { default as HdsBadgeCount } from './components/hds/badge-count/index.ts';
+export * from './components/hds/badge-count/types.ts';
+
+// Breadcrumb
+export { default as HdsBreadcrumb } from './components/hds/breadcrumb/index.ts';
+export { default as HdsBreadcrumbItem } from './components/hds/breadcrumb/item.ts';
+export { default as HdsBreadcrumbTruncation } from './components/hds/breadcrumb/truncation.ts';
+
+// Button
+export { default as HdsButton } from './components/hds/button/index.ts';
+
+// Button Set
+export { default as HdsButtonSet } from './components/hds/button-set/index.ts';
+
+// Card
+export { default as HdsCard } from './components/hds/card/container.ts';
+export * from './components/hds/card/types.ts';
+
+// Code Block
+export { default as HdsCodeBlock } from './components/hds/code-block/index.ts';
+export { default as HdsCodeBlockCopyButton } from './components/hds/code-block/copy-button.ts';
+export { default as HdsCodeBlockDescription } from './components/hds/code-block/description.ts';
+export { default as HdsCodeBlockTitle } from './components/hds/code-block/title.ts';
+export * from './components/hds/code-block/types.ts';
+
+// Copy Button
+export { default as HdsCopyButton } from './components/hds/copy/button/index.ts';
+export * from './components/hds/copy/button/types.ts';
+
+// Copy Snippet
+export { default as HdsCopySnippet } from './components/hds/copy/snippet/index.ts';
+export * from './components/hds/copy/snippet/types.ts';
+
+// Dialog
+export { default as HdsDialogPrimitiveBody } from './components/hds/dialog-primitive/body.ts';
+export { default as HdsDialogPrimitiveDescription } from './components/hds/dialog-primitive/description.ts';
+export { default as HdsDialogPrimitiveFooter } from './components/hds/dialog-primitive/footer.ts';
+export { default as HdsDialogPrimitiveHeader } from './components/hds/dialog-primitive/header.ts';
+export { default as HdsDialogPrimitiveOverlay } from './components/hds/dialog-primitive/overlay.ts';
+export { default as HdsDialogPrimitiveWrapper } from './components/hds/dialog-primitive/wrapper.ts';
+export * from './components/hds/dialog-primitive/types.ts';
+
+// Disclosure
+export { default as HdsDisclosurePrimitive } from './components/hds/disclosure-primitive/index.ts';
+
+// Dismiss Button
+export { default as HdsDismissButton } from './components/hds/dismiss-button/index.ts';
+
+// Dropdown
+export { default as HdsDropdown } from './components/hds/dropdown/index.ts';
+export * from './components/hds/dropdown/list-item/types.ts';
+export * from './components/hds/dropdown/toggle/types.ts';
+export * from './components/hds/dropdown/types.ts';
+
+// Flyout
+export { default as HdsFlyout } from './components/hds/flyout/index.ts';
+export * from './components/hds/flyout/types.ts';
+
+export { default as HdsFlyoutBody } from './components/hds/flyout/body.ts';
+export { default as HdsFlyoutDescription } from './components/hds/flyout/description.ts';
+export { default as HdsFlyoutFooter } from './components/hds/flyout/footer.ts';
+export { default as HdsFlyoutHeader } from './components/hds/flyout/header.ts';
+
+// Form
+export { default as HdsFormCharacterCount } from './components/hds/form/character-count/index.ts';
+export { default as HdsFormCheckboxBase } from './components/hds/form/checkbox/base.ts';
+export { default as HdsFormCheckboxField } from './components/hds/form/checkbox/field.ts';
+export { default as HdsFormCheckboxGroup } from './components/hds/form/checkbox/group.ts';
+export { default as HdsFormError } from './components/hds/form/error/index.ts';
+export { default as HdsFormField } from './components/hds/form/field/index.ts';
+export * from './components/hds/form/field/types.ts';
+export { default as HdsFormFieldset } from './components/hds/form/fieldset/index.ts';
+export * from './components/hds/form/fieldset/types.ts';
+export { default as HdsFormFileInputBase } from './components/hds/form/file-input/base.ts';
+export { default as HdsFormFileInputField } from './components/hds/form/file-input/field.ts';
+export { default as HdsFormHelperText } from './components/hds/form/helper-text/index.ts';
+export { default as HdsFormIndicator } from './components/hds/form/indicator/index.ts';
+export { default as HdsFormLabel } from './components/hds/form/label/index.ts';
+export { default as HdsFormLegend } from './components/hds/form/legend/index.ts';
+export { default as HdsFormMaskedInputBase } from './components/hds/form/masked-input/base.ts';
+export { default as HdsFormMaskedInputField } from './components/hds/form/masked-input/field.ts';
+export { default as HdsFormRadioBase } from './components/hds/form/radio/base.ts';
+export { default as HdsFormRadioCard } from './components/hds/form/radio-card/index.ts';
+export * from './components/hds/form/radio-card/types.ts';
+export { default as HdsFormRadioCardGroup } from './components/hds/form/radio-card/group.ts';
+export { default as HdsFormRadioField } from './components/hds/form/radio/field.ts';
+export { default as HdsFormRadioGroup } from './components/hds/form/radio/group.ts';
+export { default as HdsFormSelectBase } from './components/hds/form/select/base.ts';
+export { default as HdsFormSelectField } from './components/hds/form/select/field.ts';
+export { default as HdsFormSuperSelectSingleBase } from './components/hds/form/super-select/single/base.ts';
+export { default as HdsFormSuperSelectSingleField } from './components/hds/form/super-select/single/field.ts';
+export { default as HdsFormSuperSelectMultipleBase } from './components/hds/form/super-select/multiple/base.ts';
+export { default as HdsFormSuperSelectMultipleField } from './components/hds/form/super-select/multiple/field.ts';
+export * from './components/hds/form/super-select/types.ts';
+export { default as HdsFormTextareaBase } from './components/hds/form/textarea/base.ts';
+export { default as HdsFormTextareaField } from './components/hds/form/textarea/field.ts';
+export { default as HdsFormTextInputBase } from './components/hds/form/text-input/base.ts';
+export { default as HdsFormTextInputField } from './components/hds/form/text-input/field.ts';
+export * from './components/hds/form/text-input/types.ts';
+export { default as HdsFormToggleBase } from './components/hds/form/toggle/base.ts';
+export { default as HdsFormToggleField } from './components/hds/form/toggle/field.ts';
+export { default as HdsFormToggleGroup } from './components/hds/form/toggle/group.ts';
+export { default as HdsFormVisibilityToggle } from './components/hds/form/visibility-toggle/index.ts';
+
+// Icon
+export { default as HdsIcon } from './components/hds/icon/index.ts';
+export * from './components/hds/icon/types.ts';
+
+// Icon Tile
+export { default as HdsIconTile } from './components/hds/icon-tile/index.ts';
+export * from './components/hds/icon-tile/types.ts';
+
+// Interactive
+export { default as HdsInteractive } from './components/hds/interactive/index.ts';
+
+//Link
+export { default as HdsLinkInline } from './components/hds/link/inline.ts';
+export { default as HdsLinkStandalone } from './components/hds/link/standalone.ts';
+export * from './components/hds/link/types.ts';
+
+// Menu Primitive
+export { default as HdsMenuPrimitive } from './components/hds/menu-primitive/index.ts';
+
+// Modal
+export { default as HdsModal } from './components/hds/modal/index.ts';
+export { default as HdsModalBody } from './components/hds/modal/body.ts';
+export { default as HdsModalFooter } from './components/hds/modal/footer.ts';
+export { default as HdsModalHeader } from './components/hds/modal/header.ts';
+export * from './components/hds/modal/types.ts';
+
+// Page Header
+export { default as HdsPageHeader } from './components/hds/page-header/index.ts';
+
+// Pagination
+export { default as HdsPaginationCompact } from './components/hds/pagination/compact/index.ts';
+export { default as HdsPaginationControlInfo } from './components/hds/pagination/info/index.ts';
+export { default as HdsPaginationControlArrow } from './components/hds/pagination/nav/arrow.ts';
+export { default as HdsPaginationControlEllipsis } from './components/hds/pagination/nav/ellipsis.ts';
+export { default as HdsPaginationControlNumber } from './components/hds/pagination/nav/number.ts';
+export { default as HdsPaginationNumbered } from './components/hds/pagination/numbered/index.ts';
+export { default as HdsPaginationSizeSelector } from './components/hds/pagination/size-selector/index.ts';
+export * from './components/hds/pagination/types.ts';
+
+// Popover
+export { default as HdsPopoverPrimitive } from './components/hds/popover-primitive/index.ts';
+
+// Reveal
+export { default as HdsReveal } from './components/hds/reveal/index.ts';
+
+// Rich Tooltip
+export { default as HdsRichTooltip } from './components/hds/rich-tooltip/index.ts';
+export * from './components/hds/rich-tooltip/types.ts';
+
+// Segmented Group
+export { default as HdsSegmentedGroup } from './components/hds/segmented-group/index.ts';
+
+// Separator
+export { default as HdsSeparator } from './components/hds/separator/index.ts';
+export * from './components/hds/separator/types.ts';
+
+// Side Nav
+export { default as HdsSideNav } from './components/hds/side-nav/index.ts';
+export { default as HdsSideNavBase } from './components/hds/side-nav/base.ts';
+export { default as HdsSideNavHeader } from './components/hds/side-nav/header/index.ts';
+export { default as HdsSideNavHeaderHomeLink } from './components/hds/side-nav/header/home-link.ts';
+export { default as HdsSideNavHeaderIconButton } from './components/hds/side-nav/header/icon-button.ts';
+export { default as HdsSideNavPortalTarget } from './components/hds/side-nav/portal/target.ts';
+export { default as HdsSideNavPortal } from './components/hds/side-nav/portal/index.ts';
+export { default as HdsSideNavList } from './components/hds/side-nav/list/index.ts';
+
+// Stepper
+export { default as HdsStepperStepIndicator } from './components/hds/stepper/step/indicator.ts';
+export { default as HdsStepperTaskIndicator } from './components/hds/stepper/task/indicator.ts';
+export * from './components/hds/stepper/types.ts';
+
+// Table
+export { default as HdsTable } from './components/hds/table/index.ts';
+export { default as HdsTableTd } from './components/hds/table/td.ts';
+export { default as HdsTableTh } from './components/hds/table/th.ts';
+export { default as HdsTableThButtonSort } from './components/hds/table/th-button-sort.ts';
+export { default as HdsTableThButtonTooltip } from './components/hds/table/th-button-tooltip.ts';
+export { default as HdsTableThSort } from './components/hds/table/th-sort.ts';
+export { default as HdsTableThSelectable } from './components/hds/table/th-selectable.ts';
+export { default as HdsTableTr } from './components/hds/table/tr.ts';
+export * from './components/hds/table/types.ts';
+
+// Tabs
+export { default as HdsTabs } from './components/hds/tabs/index.ts';
+export * from './components/hds/tabs/types.ts';
+
+// Tag
+export { default as HdsTag } from './components/hds/tag/index.ts';
+export * from './components/hds/tag/types.ts';
+
+// Text
+export { default as HdsText } from './components/hds/text/index.ts';
+export { default as HdsTextBody } from './components/hds/text/body.ts';
+export { default as HdsTextCode } from './components/hds/text/code.ts';
+export { default as HdsTextDisplay } from './components/hds/text/display.ts';
+export * from './components/hds/text/types.ts';
+
+// Toast
+export { default as HdsToast } from './components/hds/toast/index.ts';
+
+// Tooltip Button
+export { default as HdsTooltipButton } from './components/hds/tooltip-button/index.ts';
+export * from './components/hds/tooltip-button/types.ts';

--- a/packages/components/src/components.ts
+++ b/packages/components/src/components.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// This file is use to expose public components and it's types (enums only) to the consumers of this package.
+// This file is use to expose public components/subcomponents and their types to the consumers of this package.
+
+// -----------------------------------------------------------
+// ### COMPONENTS
+// -----------------------------------------------------------
 
 // Accordion
 export { default as HdsAccordion } from './components/hds/accordion/index.ts';
@@ -13,17 +17,14 @@ export * from './components/hds/accordion/types.ts';
 export { default as HdsAlert } from './components/hds/alert/index.ts';
 export * from './components/hds/alert/types.ts';
 
-// App Footer
+// AppFooter
 export { default as HdsAppFooter } from './components/hds/app-footer/index.ts';
 export * from './components/hds/app-footer/types.ts';
 
-// App Frame
-export { default as HdsAppFrame } from './components/hds/app-frame/index.ts';
-
-// App Header
+// AppHeader
 export { default as HdsAppHeader } from './components/hds/app-header/index.ts';
 
-// Application State
+// ApplicationState
 export { default as HdsApplicationState } from './components/hds/application-state/index.ts';
 export { default as HdsApplicationStateBody } from './components/hds/application-state/body.ts';
 export { default as HdsApplicationStateFooter } from './components/hds/application-state/footer.ts';
@@ -35,7 +36,7 @@ export * from './components/hds/application-state/types.ts';
 export { default as HdsBadge } from './components/hds/badge/index.ts';
 export * from './components/hds/badge/types.ts';
 
-// Badge Count
+// BadgeCount
 export { default as HdsBadgeCount } from './components/hds/badge-count/index.ts';
 export * from './components/hds/badge-count/types.ts';
 
@@ -47,42 +48,27 @@ export { default as HdsBreadcrumbTruncation } from './components/hds/breadcrumb/
 // Button
 export { default as HdsButton } from './components/hds/button/index.ts';
 
-// Button Set
+// ButtonSet
 export { default as HdsButtonSet } from './components/hds/button-set/index.ts';
 
 // Card
 export { default as HdsCard } from './components/hds/card/container.ts';
 export * from './components/hds/card/types.ts';
 
-// Code Block
+// CodeBlock
 export { default as HdsCodeBlock } from './components/hds/code-block/index.ts';
 export { default as HdsCodeBlockCopyButton } from './components/hds/code-block/copy-button.ts';
 export { default as HdsCodeBlockDescription } from './components/hds/code-block/description.ts';
 export { default as HdsCodeBlockTitle } from './components/hds/code-block/title.ts';
 export * from './components/hds/code-block/types.ts';
 
-// Copy Button
+// CopyButton
 export { default as HdsCopyButton } from './components/hds/copy/button/index.ts';
 export * from './components/hds/copy/button/types.ts';
 
-// Copy Snippet
+// CopySnippet
 export { default as HdsCopySnippet } from './components/hds/copy/snippet/index.ts';
 export * from './components/hds/copy/snippet/types.ts';
-
-// Dialog
-export { default as HdsDialogPrimitiveBody } from './components/hds/dialog-primitive/body.ts';
-export { default as HdsDialogPrimitiveDescription } from './components/hds/dialog-primitive/description.ts';
-export { default as HdsDialogPrimitiveFooter } from './components/hds/dialog-primitive/footer.ts';
-export { default as HdsDialogPrimitiveHeader } from './components/hds/dialog-primitive/header.ts';
-export { default as HdsDialogPrimitiveOverlay } from './components/hds/dialog-primitive/overlay.ts';
-export { default as HdsDialogPrimitiveWrapper } from './components/hds/dialog-primitive/wrapper.ts';
-export * from './components/hds/dialog-primitive/types.ts';
-
-// Disclosure
-export { default as HdsDisclosurePrimitive } from './components/hds/disclosure-primitive/index.ts';
-
-// Dismiss Button
-export { default as HdsDismissButton } from './components/hds/dismiss-button/index.ts';
 
 // Dropdown
 export { default as HdsDropdown } from './components/hds/dropdown/index.ts';
@@ -144,20 +130,14 @@ export { default as HdsFormVisibilityToggle } from './components/hds/form/visibi
 export { default as HdsIcon } from './components/hds/icon/index.ts';
 export * from './components/hds/icon/types.ts';
 
-// Icon Tile
+// IconTile
 export { default as HdsIconTile } from './components/hds/icon-tile/index.ts';
 export * from './components/hds/icon-tile/types.ts';
 
-// Interactive
-export { default as HdsInteractive } from './components/hds/interactive/index.ts';
-
-//Link
+// Link
 export { default as HdsLinkInline } from './components/hds/link/inline.ts';
 export { default as HdsLinkStandalone } from './components/hds/link/standalone.ts';
 export * from './components/hds/link/types.ts';
-
-// Menu Primitive
-export { default as HdsMenuPrimitive } from './components/hds/menu-primitive/index.ts';
 
 // Modal
 export { default as HdsModal } from './components/hds/modal/index.ts';
@@ -166,7 +146,7 @@ export { default as HdsModalFooter } from './components/hds/modal/footer.ts';
 export { default as HdsModalHeader } from './components/hds/modal/header.ts';
 export * from './components/hds/modal/types.ts';
 
-// Page Header
+// PageHeader
 export { default as HdsPageHeader } from './components/hds/page-header/index.ts';
 
 // Pagination
@@ -179,24 +159,21 @@ export { default as HdsPaginationNumbered } from './components/hds/pagination/nu
 export { default as HdsPaginationSizeSelector } from './components/hds/pagination/size-selector/index.ts';
 export * from './components/hds/pagination/types.ts';
 
-// Popover
-export { default as HdsPopoverPrimitive } from './components/hds/popover-primitive/index.ts';
-
 // Reveal
 export { default as HdsReveal } from './components/hds/reveal/index.ts';
 
-// Rich Tooltip
+// RichTooltip
 export { default as HdsRichTooltip } from './components/hds/rich-tooltip/index.ts';
 export * from './components/hds/rich-tooltip/types.ts';
 
-// Segmented Group
+// SegmentedGroup
 export { default as HdsSegmentedGroup } from './components/hds/segmented-group/index.ts';
 
 // Separator
 export { default as HdsSeparator } from './components/hds/separator/index.ts';
 export * from './components/hds/separator/types.ts';
 
-// Side Nav
+// SideNav
 export { default as HdsSideNav } from './components/hds/side-nav/index.ts';
 export { default as HdsSideNavBase } from './components/hds/side-nav/base.ts';
 export { default as HdsSideNavHeader } from './components/hds/side-nav/header/index.ts';
@@ -240,6 +217,41 @@ export * from './components/hds/text/types.ts';
 // Toast
 export { default as HdsToast } from './components/hds/toast/index.ts';
 
-// Tooltip Button
+// TooltipButton
 export { default as HdsTooltipButton } from './components/hds/tooltip-button/index.ts';
 export * from './components/hds/tooltip-button/types.ts';
+
+// -----------------------------------------------------------
+// ### LAYOUTS
+// -----------------------------------------------------------
+
+// AppFrame
+export { default as HdsAppFrame } from './components/hds/app-frame/index.ts';
+
+// -----------------------------------------------------------
+// ### UTILITIES
+// -----------------------------------------------------------
+
+// DialogPrimitive
+export { default as HdsDialogPrimitiveBody } from './components/hds/dialog-primitive/body.ts';
+export { default as HdsDialogPrimitiveDescription } from './components/hds/dialog-primitive/description.ts';
+export { default as HdsDialogPrimitiveFooter } from './components/hds/dialog-primitive/footer.ts';
+export { default as HdsDialogPrimitiveHeader } from './components/hds/dialog-primitive/header.ts';
+export { default as HdsDialogPrimitiveOverlay } from './components/hds/dialog-primitive/overlay.ts';
+export { default as HdsDialogPrimitiveWrapper } from './components/hds/dialog-primitive/wrapper.ts';
+export * from './components/hds/dialog-primitive/types.ts';
+
+// DisclosurePrimitive
+export { default as HdsDisclosurePrimitive } from './components/hds/disclosure-primitive/index.ts';
+
+// DismissButton
+export { default as HdsDismissButton } from './components/hds/dismiss-button/index.ts';
+
+// Interactive
+export { default as HdsInteractive } from './components/hds/interactive/index.ts';
+
+// MenuPrimitive
+export { default as HdsMenuPrimitive } from './components/hds/menu-primitive/index.ts';
+
+// PopoverPrimitive
+export { default as HdsPopoverPrimitive } from './components/hds/popover-primitive/index.ts';


### PR DESCRIPTION
### :pushpin: Summary

* simplify reexport for components (might need to split and clean up some non top level reexports as intentions of this files is to only export top level components, non top level component will never be imported directly)
* type reexport (enum specifically)

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

Reference: https://hashicorp.slack.com/archives/C06NMSYDZPA/p1722372651081339

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
