### PR TITLE
Showcase - Rename `--doc-color` variables to `—shw-color`

### DIFF
--- a/showcase/app/styles/_globals.scss
+++ b/showcase/app/styles/_globals.scss
@@ -17,7 +17,7 @@ body {
   min-height: 100vh;
   margin: 0;
   padding: 0;
-  background: var(--doc-color-white);
+  background: var(--shw-color-white);
 }
 
 .shw-page-header {
@@ -29,7 +29,7 @@ body {
   width: 100%;
   height: 68px;
   padding: 0 24px;
-  color: var(--doc-color-black);
+  color: var(--shw-color-black);
   border-bottom: 1px solid #eaeaea;
 }
 
@@ -98,7 +98,7 @@ body {
   align-items: center;
   width: fit-content;
   padding: 0.5rem 1rem;
-  color: var(--doc-color-black);
+  color: var(--shw-color-black);
   font-size: 0.9rem;
   border: 2px solid transparent;
   border-radius: 5px;
@@ -147,12 +147,12 @@ body {
       padding-left: 5px;
 
       &::marker {
-        color: var(--doc-color-gray-300);
+        color: var(--shw-color-gray-300);
       }
 
       a {
         padding: 4px 6px;
-        color: var(--doc-color-black);
+        color: var(--shw-color-black);
         border-radius: 4px;
 
         &:hover {

--- a/showcase/app/styles/_tokens.scss
+++ b/showcase/app/styles/_tokens.scss
@@ -7,32 +7,32 @@
 
 :root {
   // COLORS
-  --doc-color-white: #fff;
-  --doc-color-gray-600: #f2f2f3;
-  --doc-color-gray-500: #dbdbdc;
-  --doc-color-gray-400: #bfbfc0;
-  --doc-color-gray-300: #727374;
-  --doc-color-gray-200: #343536;
-  --doc-color-gray-100: #1d1e1f;
-  --doc-color-black: #000;
-  --doc-color-link-on-black: #4294ff;
-  --doc-color-link-on-white: #2264d6;
-  --doc-color-feedback-information-100: #0d44cc;
-  --doc-color-feedback-information-200: #1563ff;
-  --doc-color-feedback-information-300: #d0e0ff;
-  --doc-color-feedback-information-400: #eff5ff;
-  --doc-color-feedback-success-100: #007854;
-  --doc-color-feedback-success-200: #00bc7f;
-  --doc-color-feedback-success-300: #c1f1e0;
-  --doc-color-feedback-success-400: #ebfdf7;
-  --doc-color-feedback-warning-100: #975b06;
-  --doc-color-feedback-warning-200: #eaaa32;
-  --doc-color-feedback-warning-300: #f9eacd;
-  --doc-color-feedback-warning-400: #fcf6ea;
-  --doc-color-feedback-critical-100: #ba2226;
-  --doc-color-feedback-critical-200: #f25054;
-  --doc-color-feedback-critical-300: #ffd4d6;
-  --doc-color-feedback-critical-400: #fcf0f2;
+  --shw-color-white: #fff;
+  --shw-color-gray-600: #f2f2f3;
+  --shw-color-gray-500: #dbdbdc;
+  --shw-color-gray-400: #bfbfc0;
+  --shw-color-gray-300: #727374;
+  --shw-color-gray-200: #343536;
+  --shw-color-gray-100: #1d1e1f;
+  --shw-color-black: #000;
+  --shw-color-link-on-black: #4294ff;
+  --shw-color-link-on-white: #2264d6;
+  --shw-color-feedback-information-100: #0d44cc;
+  --shw-color-feedback-information-200: #1563ff;
+  --shw-color-feedback-information-300: #d0e0ff;
+  --shw-color-feedback-information-400: #eff5ff;
+  --shw-color-feedback-success-100: #007854;
+  --shw-color-feedback-success-200: #00bc7f;
+  --shw-color-feedback-success-300: #c1f1e0;
+  --shw-color-feedback-success-400: #ebfdf7;
+  --shw-color-feedback-warning-100: #975b06;
+  --shw-color-feedback-warning-200: #eaaa32;
+  --shw-color-feedback-warning-300: #f9eacd;
+  --shw-color-feedback-warning-400: #fcf6ea;
+  --shw-color-feedback-critical-100: #ba2226;
+  --shw-color-feedback-critical-200: #f25054;
+  --shw-color-feedback-critical-300: #ffd4d6;
+  --shw-color-feedback-critical-400: #fcf0f2;
   // "FLEX/GRID" COMPONENTS
   --shw-layout-gap-base: 1rem;
 }

--- a/showcase/app/styles/_typography.scss
+++ b/showcase/app/styles/_typography.scss
@@ -165,7 +165,7 @@ $show-font-family-mono: ui-monospace, menlo, consolas, monospace;
     padding: 0.15em 0.25em;
     font-weight: normal;
     font-size: 0.95em;
-    background-color: var(--doc-color-gray-600);
+    background-color: var(--shw-color-gray-600);
     border-radius: 0.33em;
   }
 }

--- a/showcase/app/styles/showcase-components/frame.scss
+++ b/showcase/app/styles/showcase-components/frame.scss
@@ -36,14 +36,14 @@ $shw-frame-navigation-bar-height: 48px;
 .shw-frame__open-link {
   width: 16px;
   height: 16px;
-  color: var(--doc-color-gray-300);
+  color: var(--shw-color-gray-300);
 
   &:hover {
-    color: var(--doc-color-gray-200);
+    color: var(--shw-color-gray-200);
   }
 
   &:active {
-    color: var(--doc-color-gray-100);
+    color: var(--shw-color-gray-100);
   }
 }
 

--- a/showcase/tests/integration/components/hds/flight-icon/index-test.js
+++ b/showcase/tests/integration/components/hds/flight-icon/index-test.js
@@ -69,7 +69,7 @@ module('Integration | Component | flight-icon', function (hooks) {
   });
   test('the color property should accept :root variable values', async function (assert) {
     await render(
-      hbs`<FlightIcon @name="alert-circle" @color="var(--doc-color-feedback-critical-100)" />`
+      hbs`<FlightIcon @name="alert-circle" @color="var(--shw-color-feedback-critical-100)" />`
     );
     assert.dom(`svg.flight-icon`).hasStyle({
       fill: 'rgb(186, 34, 38)',


### PR DESCRIPTION
### :pushpin: Summary

Follow-up on top of #2321, this time to rename `--doc-color` variables to `—shw-color` (the `--doc-color` was taken from the color variables of the website).

### :hammer_and_wrench: Detailed description

In this PR I have:
- renamed `--doc-color` variables to `—shw-color`

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
