### PR TITLE
Showcase - Use "action" color variables

### DIFF
--- a/showcase/app/styles/_globals.scss
+++ b/showcase/app/styles/_globals.scss
@@ -104,29 +104,29 @@ body {
   border-radius: 5px;
 
   &:hover {
-    background-color: aliceblue;
-    border-color: blue;
+    background-color: var(--shw-color-action-active-background);
+    border-color: var(--shw-color-action-active-border);
     border-style: dashed;
   }
 
   &:focus {
     text-decoration: underline;
-    border-color: blue;
+    border-color: var(--shw-color-action-active-border);
   }
 
   &:focus-visible {
-    outline-color: blue;
+    outline-color: var(--shw-color-action-active-border);
     outline-offset: 4px;
   }
 
   &:active {
     text-decoration: underline;
-    background-color: aliceblue;
-    border-color: blue;
+    background-color: var(--shw-color-action-active-background);
+    border-color: var(--shw-color-action-active-border);
   }
 
   .flight-icon {
-    color: blue;
+    color: var(--shw-color-action-active-foreground);
   }
 }
 
@@ -156,8 +156,8 @@ body {
         border-radius: 4px;
 
         &:hover {
-          background-color: aliceblue;
-          outline: 2px dashed blue;
+          background-color: var(--shw-color-action-active-background);
+          outline: 2px dashed var(--shw-color-action-active-border);
         }
       }
 
@@ -213,8 +213,8 @@ body {
 
   &:focus-visible {
     &::after {
-      background-color: aliceblue;
-      border: 2px dashed blue;
+      background-color: var(--shw-color-action-active-background);
+      border: 2px dashed var(--shw-color-action-active-border);
       border-radius: 5px;
       opacity: 1;
     }

--- a/showcase/app/styles/_tokens.scss
+++ b/showcase/app/styles/_tokens.scss
@@ -33,6 +33,9 @@
   --shw-color-feedback-critical-200: #f25054;
   --shw-color-feedback-critical-300: #ffd4d6;
   --shw-color-feedback-critical-400: #fcf0f2;
+  --shw-color-action-active-foreground: #00f; // HTML "blue"
+  --shw-color-action-active-border: #00f; // HTML "blue"
+  --shw-color-action-active-background: #f0f8ff; // HTML "aliceblue"
   // "FLEX/GRID" COMPONENTS
   --shw-layout-gap-base: 1rem;
 }


### PR DESCRIPTION
### :pushpin: Summary

This PR simply replace some HTML color names with CSS color variables, so they can be shared (and changed is needed in the HDS+ showcase, to differentiate them).

### :hammer_and_wrench: Detailed description

In this PR I have:
- replaced HTML color names with shared CSS variables

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
