### PR TITLE
`AppFrame`: Remove withAppHeader argument from SideNav (HDS-3612)

### DIFF
--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -27,7 +27,6 @@ interface HdsSideNavSignature {
     onToggleMinimizedStatus?: (arg: boolean) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onDesktopViewportChange?: (arg: boolean) => void;
-    withAppHeader?: boolean;
   };
   Blocks: {
     header?: [
@@ -144,11 +143,6 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
     }
     if (this.isAnimating) {
       classes.push('hds-side-nav--is-animating');
-    }
-
-    // Add class based on the presence of app-header
-    if (this.args.withAppHeader) {
-      classes.push('hds-side-nav--with-app-header');
     }
 
     return classes.join(' ');

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -239,21 +239,6 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     assert.dom('#test-side-nav-body').doesNotHaveAttribute('inert');
   });
 
-  // HAS_HEADER
-  test('it should not include the `hds-side-nav--with-app-header` class by default', async function (assert) {
-    await render(hbs`<Hds::SideNav id="test-side-nav" />`);
-    assert
-      .dom('#test-side-nav')
-      .doesNotHaveClass('hds-side-nav--with-app-header');
-  });
-
-  test('it should add the `hds-side-nav--with-app-header` class if `withAppHeader` is true', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav @withAppHeader={{true}} id="test-side-nav" />`
-    );
-    assert.dom('#test-side-nav').hasClass('hds-side-nav--with-app-header');
-  });
-
   // CALLBACKS
 
   test('it should call `onToggleMinimizedStatus` function if provided', async function (assert) {

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -31,9 +31,6 @@ This is the full-fledged component (responsive and animated).
   <C.Property @name="isMinimized" @type="boolean" @default="false">
     Controls if the Side Nav is rendered collapsed or expanded when initialized. This allows an application to preserve the collapsed/expanded state across sessions. After the initial render, this argument is altered based on user interactions (collapse/expand the Side Nav or resize the window) and it is not a suitable way of controlling the Side Nav state from outside after render (it’s an internal state).
   </C.Property>
-  <C.Property @name="withAppHeader" @type="boolean" @default="false">
-    Set to `true` when the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) component. Controls the height and position of the Side Nav in relation to the fixed position App Header.
-  </C.Property>
   <C.Property @name="hasA11yRefocus" @type="boolean" @default="true">
     Controls whether a "navigator narrator" and a "skip link" are added to the navigation (provided by the [`ember-a11y-refocus` Ember addon](https://github.com/ember-a11y/ember-a11y-refocus)). It can be programmatically turned off by passing `false`. Warning: if it is set to false, then it will fail Bypass Blocks, [Success Criteria 2.4.1](https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks.html). Since this component appears on every page, the application will not be considered conformant.
     <br><br>

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -399,11 +399,11 @@ Alternatively, if you want to create a custom transition (or respond in a differ
 
 ### Used with App Header
 
-When the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) component, only the `<:body>` slot need be used. The `@withAppHeader` argument should be set to `false` to control the height and position of the Side Nav in relation to the fixed position App Header.
+When the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) component, only the `<:body>` slot need be used.
 
 ```handlebars
 <div class="doc-sidenav-demo">
-  <Hds::SideNav @withAppHeader={{true}}>
+  <Hds::SideNav>
     <:body>
       <Doc::Placeholder @height="500px" @text="&lt;:body /&gt;" @background="#e4e4e4" />
     </:body>


### PR DESCRIPTION
**“Enterprise Nav” phase 1.5 updates**

### :pushpin: Summary

If merged, this PR removes the `withAppHeader` argument from the `SideNav` component along with related documentation & tests.

The `withAppHeader` argument was rendered redundant with refactors made in the `hds-3612-app-frame-updates` branch which this branch points to.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Related PR which this points to: https://github.com/hashicorp/design-system/pull/2299
* Jira ticket: [HDS-3612](https://hashicorp.atlassian.net/browse/HDS-3612)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- ~~[ ] A changelog entry was added via [Changesets]~~ (_Will update in parent branch_)(https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3612]: https://hashicorp.atlassian.net/browse/HDS-3612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ