### PR TITLE
`SideNav`: Add default value for a11yRefocusSkipTo

### DIFF
--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -6,7 +6,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { assert } from '@ember/debug';
 import { registerDestructor } from '@ember/destroyable';
 
 import type { HdsSideNavBaseSignature } from './base';
@@ -61,6 +60,7 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
   desktopMQ: MediaQueryList;
   containersToHide!: NodeListOf<Element>;
   hasA11yRefocus = this.args.hasA11yRefocus ?? true;
+  a11yRefocusSkipTo = this.args.a11yRefocusSkipTo ?? 'main';
 
   desktopMQVal = getComputedStyle(document.documentElement).getPropertyValue(
     '--hds-app-desktop-breakpoint'
@@ -73,13 +73,6 @@ export default class HdsSideNavComponent extends Component<HdsSideNavSignature> 
     registerDestructor(this, (): void => {
       this.removeEventListeners();
     });
-
-    if (this.args.hasA11yRefocus) {
-      assert(
-        '@a11yRefocusSkipTo for NavigatorNarrator (a11y-refocus) in "Hds::SideNav" must have a valid value',
-        this.args.a11yRefocusSkipTo !== undefined
-      );
-    }
   }
 
   addEventListeners(): void {

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -9,7 +9,6 @@ import {
   render,
   click,
   resetOnerror,
-  setupOnerror,
   triggerKeyEvent,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -52,9 +51,7 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
   // A11Y
 
   test('it renders the `a11y-refocus` elements by default', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav @hasA11yRefocus={{true}} @a11yRefocusSkipTo="foo" />`
-    );
+    await render(hbs`<Hds::SideNav @a11yRefocusSkipTo="foo" />`);
     assert.dom('#ember-a11y-refocus-nav-message').exists();
     assert.dom('#ember-a11y-refocus-skip-link').exists();
   });
@@ -62,7 +59,6 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
   test('it renders the `a11y-refocus` elements with the right properties provided as arguments', async function (assert) {
     await render(hbs`
       <Hds::SideNav
-        @hasA11yRefocus={{true}}
         @a11yRefocusSkipTo="test-skip-to"
         @a11yRefocusSkipText="test-skip-text"
         @a11yRefocusNavigationText="test-navigation-text"
@@ -264,20 +260,5 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     );
     await click('.hds-side-nav__toggle-button');
     assert.ok(toggled);
-  });
-
-  // ASSERTIONS
-
-  test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {
-    const errorMessage =
-      '@a11yRefocusSkipTo for NavigatorNarrator (a11y-refocus) in "Hds::SideNav" must have a valid value';
-    assert.expect(2);
-    setupOnerror(function (error) {
-      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
-    });
-    await render(hbs`<Hds::SideNav @hasA11yRefocus={{true}} />`);
-    assert.throws(function () {
-      throw new Error(errorMessage);
-    });
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a default value of "#main" to `a11yRefocusSkipTo` and removes an assertion which wasn't working and is no longer needed with the change. It also fixes associated tests.

It will be merged back into the `hds-3613-app-header-updates` branch. The changset will be added in that branch following approval and merge of this PR.

<!-- 
### :hammer_and_wrench: Detailed description

If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots

Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Parent branch PR: https://github.com/hashicorp/design-system/pull/2306

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets] _- will add in parent branch_  
(https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
