### PR TITLE
`FlightIcon` => `Hds::Icon` Migration - `showcase`

### DIFF
--- a/showcase/app/components/shw/frame/index.hbs
+++ b/showcase/app/components/shw/frame/index.hbs
@@ -10,7 +10,7 @@
   <div class="shw-frame__browser">
     <div class="shw-frame__browser-navigation">
       <a class="shw-frame__open-link" href={{this.src}} target="_blank" rel="noopener noreferrer">
-        <FlightIcon @name="external-link" @isInlineBlock={{false}} @stretched={{true}} />
+        <Hds::Icon @name="external-link" @stretched={{true}} />
         <span class="sr-only">open the frame in a new window</span>
       </a>
     </div>

--- a/showcase/app/templates/application.hbs
+++ b/showcase/app/templates/application.hbs
@@ -16,10 +16,7 @@
   </header>
 
   <aside class="shw-page-aside">
-    <LinkTo class="shw-back-to-components-list" @route="index"><FlightIcon
-        @name="arrow-left"
-        @isInlineBlock={{false}}
-      />
+    <LinkTo class="shw-back-to-components-list" @route="index"><Hds::Icon @name="arrow-left" />
       Component list</LinkTo>
   </aside>
 

--- a/showcase/app/templates/components/application-state.hbs
+++ b/showcase/app/templates/components/application-state.hbs
@@ -368,7 +368,7 @@
       <SF.Item @label="With icon / {{align}} aligned">
         <Hds::ApplicationState @align={{align}} as |A|>
           <A.Media>
-            <FlightIcon @name="channel" @size="24" @isInlineBlock={{false}} />
+            <Hds::Icon @name="channel" @size="24" />
           </A.Media>
           <A.Header @title="Empty state title" />
           <A.Body

--- a/showcase/app/templates/components/rich-tooltip.hbs
+++ b/showcase/app/templates/components/rich-tooltip.hbs
@@ -599,7 +599,7 @@
                   Lorem ipsum dolor
                 {{/if}}
                 {{#if (eq toggle "icon")}}
-                  <FlightIcon @name="org" @isInlineBlock={{false}} />
+                  <Hds::Icon @name="org" />
                 {{/if}}
                 {{#if (eq toggle "badge")}}
                   <Hds::Badge @text="Lorem ipsum" @color="neutral" @icon="hexagon" type="outlined" />
@@ -866,7 +866,7 @@
             </B.Td>
             <B.Td>
               <div class="shw-component-rich-tooltip-demo-table-cell-content-flex">
-                <FlightIcon @name={{B.data.cluster-icon}} />
+                <Hds::Icon @name={{B.data.cluster-icon}} />
                 <div>
                   <Hds::RichTooltip as |RT|>
                     <RT.Toggle @text={{B.data.cluster-partition}} />

--- a/showcase/app/templates/components/table.hbs
+++ b/showcase/app/templates/components/table.hbs
@@ -949,7 +949,7 @@
         <B.Td><Hds::Link::Inline @href="#showcase">{{B.data.artist}}</Hds::Link::Inline></B.Td>
         <B.Td>
           <div class="shw-component-table-cell-content-div">
-            <FlightIcon @name={{B.data.icon}} />
+            <Hds::Icon @name={{B.data.icon}} />
             {{B.data.album}}
           </div>
         </B.Td>
@@ -1543,15 +1543,15 @@
           </B.Tr>
           <B.Tr>
             <B.Th>Icon</B.Th>
-            <B.Td @align="left"><FlightIcon @name="film" /></B.Td>
-            <B.Td @align="center"><FlightIcon @name="film" /></B.Td>
-            <B.Td @align="right"><FlightIcon @name="film" /></B.Td>
+            <B.Td @align="left"><Hds::Icon @name="film" /></B.Td>
+            <B.Td @align="center"><Hds::Icon @name="film" /></B.Td>
+            <B.Td @align="right"><Hds::Icon @name="film" /></B.Td>
           </B.Tr>
           <B.Tr>
             <B.Th>Icon + Inline text</B.Th>
-            <B.Td @align="left"><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
-            <B.Td @align="center"><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
-            <B.Td @align="right"><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td @align="left"><Hds::Icon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td @align="center"><Hds::Icon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td @align="right"><Hds::Icon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
           </B.Tr>
           <B.Tr>
             <B.Th>Badge</B.Th>
@@ -1640,11 +1640,11 @@
           <B.Tr @selectionKey="row">
             <B.Th>Top (default)<Shw::Placeholder @height="50" /></B.Th>
             <B.Td>Text is top aligned</B.Td>
-            <B.Td><FlightIcon @name="film" /></B.Td>
-            <B.Td><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td><Hds::Icon @name="film" /></B.Td>
+            <B.Td><Hds::Icon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
             <B.Td>
               <div {{style display="flex" gap="8px" align-items="center"}}>
-                <FlightIcon @name="film" />
+                <Hds::Icon @name="film" />
                 <span>Text in a <code>&lt;span&gt;</code></span>
               </div>
             </B.Td>
@@ -1682,11 +1682,11 @@
           <B.Tr @selectionKey="row">
             <B.Th><Shw::Placeholder @height="25" />Middle<Shw::Placeholder @height="25" /></B.Th>
             <B.Td>Text is middle aligned</B.Td>
-            <B.Td><FlightIcon @name="film" /></B.Td>
-            <B.Td><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td><Hds::Icon @name="film" /></B.Td>
+            <B.Td><Hds::Icon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
             <B.Td>
               <div {{style display="flex" gap="8px" align-items="center"}}>
-                <FlightIcon @name="film" />
+                <Hds::Icon @name="film" />
                 <span>Text in a <code>&lt;span&gt;</code></span>
               </div>
             </B.Td>
@@ -1724,11 +1724,11 @@
           <B.Tr @selectionKey="row">
             <B.Th><Shw::Placeholder @height="25" />Baseline<Shw::Placeholder @height="25" /></B.Th>
             <B.Td>Text is middle aligned</B.Td>
-            <B.Td><FlightIcon @name="film" /></B.Td>
-            <B.Td><FlightIcon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
+            <B.Td><Hds::Icon @name="film" /></B.Td>
+            <B.Td><Hds::Icon @name="film" /> <span>Text in a <code>&lt;span&gt;</code></span></B.Td>
             <B.Td>
               <div {{style display="flex" gap="8px" align-items="center"}}>
-                <FlightIcon @name="film" />
+                <Hds::Icon @name="film" />
                 <span>Text in a <code>&lt;span&gt;</code></span>
               </div>
             </B.Td>

--- a/showcase/app/templates/components/tooltip.hbs
+++ b/showcase/app/templates/components/tooltip.hbs
@@ -16,7 +16,7 @@
   <Shw::Flex as |SF|>
     <SF.Item @label="With a FlightIcon as content">
       <Hds::TooltipButton @text="Here is more information" aria-label="Information">
-        <FlightIcon @name="info" />
+        <Hds::Icon @name="info" />
       </Hds::TooltipButton>
     </SF.Item>
 
@@ -48,16 +48,12 @@
   <Shw::Text::H4>Used next to text</Shw::Text::H4>
   <p>
     <span class="hds-typography-display-300">Lorem ipsum dolor sit amet consectetur</span>
-    <Hds::TooltipButton @text="Here is more info" aria-label="Information"><FlightIcon
-        @name="info"
-      /></Hds::TooltipButton>
+    <Hds::TooltipButton @text="Here is more info" aria-label="Information"><Hds::Icon @name="info" /></Hds::TooltipButton>
   </p>
 
   <p class="hds-typography-body-300">
     Lorem ipsum dolor sit amet consectetur
-    <Hds::TooltipButton aria-label="more information" @text="Here is more info"><FlightIcon
-        @name="info"
-      /></Hds::TooltipButton>
+    <Hds::TooltipButton aria-label="more information" @text="Here is more info"><Hds::Icon @name="info" /></Hds::TooltipButton>
     adipisicing elit. Doloremque blanditiis sapiente iste beatae voluptates voluptatum.
   </p>
 
@@ -73,22 +69,16 @@
         <T.Panel>
           <p class="hds-typography-body-300">
             Content 1
-            <Hds::TooltipButton @text="Here is more info" aria-label="Information"><FlightIcon
-                @name="info"
-              /></Hds::TooltipButton>
+            <Hds::TooltipButton @text="Here is more info" aria-label="Information"><Hds::Icon @name="info" /></Hds::TooltipButton>
           </p>
         </T.Panel>
         <T.Panel><p class="hds-typography-body-300">
             Content 2
-            <Hds::TooltipButton @text="Here is more info" aria-label="Information"><FlightIcon
-                @name="info"
-              /></Hds::TooltipButton>
+            <Hds::TooltipButton @text="Here is more info" aria-label="Information"><Hds::Icon @name="info" /></Hds::TooltipButton>
           </p></T.Panel>
         <T.Panel><p class="hds-typography-body-300">
             Content 3
-            <Hds::TooltipButton @text="Here is more info" aria-label="Information"><FlightIcon
-                @name="info"
-              /></Hds::TooltipButton>
+            <Hds::TooltipButton @text="Here is more info" aria-label="Information"><Hds::Icon @name="info" /></Hds::TooltipButton>
           </p></T.Panel>
       </Hds::Tabs>
     </SF.Item>
@@ -97,9 +87,7 @@
         <A.Title>Warning</A.Title>
         <A.Description>
           Caution is advised.
-          <Hds::TooltipButton @text="Be careful with this" aria-label="Information"><FlightIcon
-              @name="info"
-            /></Hds::TooltipButton>
+          <Hds::TooltipButton @text="Be careful with this" aria-label="Information"><Hds::Icon @name="info" /></Hds::TooltipButton>
         </A.Description>
       </Hds::Alert>
     </SF.Item>
@@ -114,7 +102,7 @@
       <p class="hds-typography-body-300">
         Lorem ipsum dolor sit amet consectetur
         <Hds::TooltipButton @text="Here is more info" @isInline={{false}} aria-label="Information">
-          <FlightIcon @name="info" />
+          <Hds::Icon @name="info" />
         </Hds::TooltipButton>
         adipisicing elit. Doloremque blanditiis sapiente iste beatae voluptates voluptatum.
       </p>
@@ -185,7 +173,7 @@
           aria-label="tooltip button example"
           @text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
         >
-          <FlightIcon @name="info" />
+          <Hds::Icon @name="info" />
         </Hds::TooltipButton>
       </div>
     </SF.Item>
@@ -262,11 +250,9 @@
             mock-state-value={{state}}
             @extraTippyOptions={{hash showOnCreate=true}}
             aria-label="Information"
-          ><FlightIcon @name="info" /></Hds::TooltipButton>
+          ><Hds::Icon @name="info" /></Hds::TooltipButton>
         {{else}}
-          <Hds::TooltipButton @text="More info" aria-label="Information" mock-state-value={{state}}><FlightIcon
-              @name="info"
-            /></Hds::TooltipButton>
+          <Hds::TooltipButton @text="More info" aria-label="Information" mock-state-value={{state}}><Hds::Icon @name="info" /></Hds::TooltipButton>
         {{/if}}
       </SF.Item>
     {{/each}}
@@ -343,7 +329,7 @@
   @text="<b>Hello</b> <em>there</em>!"
   aria-label="Information"
 >
-  <FlightIcon @name="info" />
+  <Hds::Icon @name="info" />
 </Hds::TooltipButton>
 
 <Shw::Divider />

--- a/showcase/app/templates/components/tooltip.hbs
+++ b/showcase/app/templates/components/tooltip.hbs
@@ -14,7 +14,7 @@
 
   <Shw::Text::H4>On its own</Shw::Text::H4>
   <Shw::Flex as |SF|>
-    <SF.Item @label="With a FlightIcon as content">
+    <SF.Item @label="With Icon as content">
       <Hds::TooltipButton @text="Here is more information" aria-label="Information">
         <Hds::Icon @name="info" />
       </Hds::TooltipButton>
@@ -48,12 +48,16 @@
   <Shw::Text::H4>Used next to text</Shw::Text::H4>
   <p>
     <span class="hds-typography-display-300">Lorem ipsum dolor sit amet consectetur</span>
-    <Hds::TooltipButton @text="Here is more info" aria-label="Information"><Hds::Icon @name="info" /></Hds::TooltipButton>
+    <Hds::TooltipButton @text="Here is more info" aria-label="Information">
+      <Hds::Icon @name="info" />
+    </Hds::TooltipButton>
   </p>
 
   <p class="hds-typography-body-300">
     Lorem ipsum dolor sit amet consectetur
-    <Hds::TooltipButton aria-label="more information" @text="Here is more info"><Hds::Icon @name="info" /></Hds::TooltipButton>
+    <Hds::TooltipButton aria-label="more information" @text="Here is more info">
+      <Hds::Icon @name="info" />
+    </Hds::TooltipButton>
     adipisicing elit. Doloremque blanditiis sapiente iste beatae voluptates voluptatum.
   </p>
 
@@ -69,17 +73,24 @@
         <T.Panel>
           <p class="hds-typography-body-300">
             Content 1
-            <Hds::TooltipButton @text="Here is more info" aria-label="Information"><Hds::Icon @name="info" /></Hds::TooltipButton>
+            <Hds::TooltipButton @text="Here is more info" aria-label="Information">
+              <Hds::Icon @name="info" />
+            </Hds::TooltipButton>
           </p>
         </T.Panel>
         <T.Panel><p class="hds-typography-body-300">
             Content 2
-            <Hds::TooltipButton @text="Here is more info" aria-label="Information"><Hds::Icon @name="info" /></Hds::TooltipButton>
+            <Hds::TooltipButton @text="Here is more info" aria-label="Information">
+              <Hds::Icon @name="info" />
+            </Hds::TooltipButton>
           </p></T.Panel>
         <T.Panel><p class="hds-typography-body-300">
             Content 3
-            <Hds::TooltipButton @text="Here is more info" aria-label="Information"><Hds::Icon @name="info" /></Hds::TooltipButton>
-          </p></T.Panel>
+            <Hds::TooltipButton @text="Here is more info" aria-label="Information">
+              <Hds::Icon @name="info" />
+            </Hds::TooltipButton>
+          </p>
+        </T.Panel>
       </Hds::Tabs>
     </SF.Item>
     <SF.Item @label="Used within an alert">
@@ -87,7 +98,9 @@
         <A.Title>Warning</A.Title>
         <A.Description>
           Caution is advised.
-          <Hds::TooltipButton @text="Be careful with this" aria-label="Information"><Hds::Icon @name="info" /></Hds::TooltipButton>
+          <Hds::TooltipButton @text="Be careful with this" aria-label="Information">
+            <Hds::Icon @name="info" />
+          </Hds::TooltipButton>
         </A.Description>
       </Hds::Alert>
     </SF.Item>
@@ -252,7 +265,9 @@
             aria-label="Information"
           ><Hds::Icon @name="info" /></Hds::TooltipButton>
         {{else}}
-          <Hds::TooltipButton @text="More info" aria-label="Information" mock-state-value={{state}}><Hds::Icon @name="info" /></Hds::TooltipButton>
+          <Hds::TooltipButton @text="More info" aria-label="Information" mock-state-value={{state}}>
+            <Hds::Icon @name="info" />
+          </Hds::TooltipButton>
         {{/if}}
       </SF.Item>
     {{/each}}

--- a/showcase/app/templates/foundations/icon.hbs
+++ b/showcase/app/templates/foundations/icon.hbs
@@ -15,10 +15,10 @@
 
   <Shw::Flex as |SF|>
     <SF.Item @label="16px (default)">
-      <FlightIcon @name="bug" />
+      <Hds::Icon @name="bug" />
     </SF.Item>
     <SF.Item @label="24px">
-      <FlightIcon @name="bug" @size="24" />
+      <Hds::Icon @name="bug" @size="24" />
     </SF.Item>
   </Shw::Flex>
 
@@ -27,12 +27,12 @@
   <Shw::Flex as |SF|>
     <SF.Item @label="12px (stretched)">
       <div {{style width="12px" height="12px"}}>
-        <FlightIcon @name="bug" @size="16" @stretched={{true}} />
+        <Hds::Icon @name="bug" @size="16" @stretched={{true}} />
       </div>
     </SF.Item>
     <SF.Item @label="32px (stretched)">
       <div {{style width="32px" height="32px"}}>
-        <FlightIcon @name="bug" @size="24" @stretched={{true}} />
+        <Hds::Icon @name="bug" @size="24" @stretched={{true}} />
       </div>
     </SF.Item>
   </Shw::Flex>
@@ -44,16 +44,16 @@
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item as |SFI|>
       <SFI.Label>Unspecified color (<code>currentColor</code>)</SFI.Label>
-      <FlightIcon @name="bookmark" />
+      <Hds::Icon @name="bookmark" />
     </SF.Item>
     <SF.Item as |SFI|>
       <SFI.Label>Custom red color, specified via <code>@color</code> argument</SFI.Label>
-      <FlightIcon @name="folder-fill" @color="red" />
+      <Hds::Icon @name="folder-fill" @color="red" />
     </SF.Item>
     <SF.Item as |SFI|>
       <SFI.Label>Unspecified color (<code>currentColor</code>) + parent with custom blue color (to check inheritance)</SFI.Label>
       <a {{style color="blue"}} href="#">
-        <FlightIcon @name="external-link" />
+        <Hds::Icon @name="external-link" />
       </a>
     </SF.Item>
     <SF.Item as |SFI|>
@@ -64,7 +64,7 @@
         green color declared (to check overrides not working)</SFI.Label>
       {{! template-lint-disable no-inline-styles }}
       <div style="color:green !important">
-        <FlightIcon @name="heart-fill" @color="orange" />
+        <Hds::Icon @name="heart-fill" @color="orange" />
       </div>
       {{! template-lint-enable no-inline-styles }}
     </SF.Item>
@@ -80,29 +80,29 @@
 
       <Shw::Flex class="shw-foundation-outline-icons" as |SF|>
         <SF.Item @label="single icon">
-          <FlightIcon @name="bookmark" @isInlineBlock={{isInline}} />
+          <Hds::Icon @name="bookmark" @isInline={{isInline}} />
         </SF.Item>
         <SF.Item @label="multiple icons">
-          <FlightIcon @name="alert-circle-fill" @isInlineBlock={{isInline}} />
-          <FlightIcon @name="alert-diamond-fill" @isInlineBlock={{isInline}} />
-          <FlightIcon @name="alert-triangle-fill" @isInlineBlock={{isInline}} />
+          <Hds::Icon @name="alert-circle-fill" @isInline={{isInline}} />
+          <Hds::Icon @name="alert-diamond-fill" @isInline={{isInline}} />
+          <Hds::Icon @name="alert-triangle-fill" @isInline={{isInline}} />
         </SF.Item>
       </Shw::Flex>
 
       <Shw::Flex class="shw-foundation-outline-icons" @gap="4rem" as |SG|>
         <SG.Item @label="icon + inline text">
-          <FlightIcon @name="bookmark" @isInlineBlock={{isInline}} />
+          <Hds::Icon @name="bookmark" @isInline={{isInline}} />
           <span class="hds-typography-body-200">Lorem ipsum dolor</span>
         </SG.Item>
         <SG.Item @label="icon + inline text (inside flexbox)">
           <div class="shw-foundation-icon-container-flex">
-            <FlightIcon @name="bookmark" @isInlineBlock={{isInline}} />
+            <Hds::Icon @name="bookmark" @isInline={{isInline}} />
             <span class="hds-typography-body-200">Lorem ipsum dolor</span>
           </div>
         </SG.Item>
         <SG.Item @label="icon + inline text (inside grid)">
           <div class="shw-foundation-icon-container-grid">
-            <FlightIcon @name="bookmark" @isInlineBlock={{isInline}} />
+            <Hds::Icon @name="bookmark" @isInline={{isInline}} />
             <span class="hds-typography-body-200">Lorem ipsum dolor</span>
           </div>
         </SG.Item>
@@ -111,20 +111,20 @@
       <Shw::Flex class="shw-foundation-outline-icons" @gap="4rem" as |SF|>
         <SF.Item @label="icons interleaved with inline text">
           <span class="hds-typography-body-200">Lorem ipsum dolor</span>
-          <FlightIcon @name="bookmark" @isInlineBlock={{isInline}} />
+          <Hds::Icon @name="bookmark" @isInline={{isInline}} />
           <span class="hds-typography-body-200">Sit amet consectetur</span>
-          <FlightIcon @name="alert-circle-fill" @isInlineBlock={{isInline}} />
-          <FlightIcon @name="alert-diamond-fill" @isInlineBlock={{isInline}} />
-          <FlightIcon @name="alert-triangle-fill" @isInlineBlock={{isInline}} />
+          <Hds::Icon @name="alert-circle-fill" @isInline={{isInline}} />
+          <Hds::Icon @name="alert-diamond-fill" @isInline={{isInline}} />
+          <Hds::Icon @name="alert-triangle-fill" @isInline={{isInline}} />
           <span class="hds-typography-body-200">Adipisicing elit</span>
         </SF.Item>
         <SF.Item @label="icons interleaved with block text">
           <p class="hds-typography-body-200">Lorem ipsum dolor</p>
-          <FlightIcon @name="bookmark" @isInlineBlock={{isInline}} />
+          <Hds::Icon @name="bookmark" @isInline={{isInline}} />
           <p class="hds-typography-body-200">Sit amet consectetur</p>
-          <FlightIcon @name="alert-circle-fill" @isInlineBlock={{isInline}} />
-          <FlightIcon @name="alert-diamond-fill" @isInlineBlock={{isInline}} />
-          <FlightIcon @name="alert-triangle-fill" @isInlineBlock={{isInline}} />
+          <Hds::Icon @name="alert-circle-fill" @isInline={{isInline}} />
+          <Hds::Icon @name="alert-diamond-fill" @isInline={{isInline}} />
+          <Hds::Icon @name="alert-triangle-fill" @isInline={{isInline}} />
           <p class="hds-typography-body-200">Adipisicing elit</p>
         </SF.Item>
       </Shw::Flex>

--- a/showcase/app/templates/utilities/disclosure-primitive.hbs
+++ b/showcase/app/templates/utilities/disclosure-primitive.hbs
@@ -18,7 +18,7 @@
           <:toggle as |t|>
             <button type="button" {{on "click" t.onClickToggle}}>
               Click me
-              <FlightIcon @name={{if t.isOpen "chevron-up" "chevron-down"}} />
+              <Hds::Icon @name={{if t.isOpen "chevron-up" "chevron-down"}} />
             </button>
           </:toggle>
           <:content>
@@ -150,7 +150,7 @@
           <:toggle as |t|>
             <button type="button" {{on "click" t.onClickToggle}}>
               Click me
-              <FlightIcon @name={{if t.isOpen "chevron-up" "chevron-down"}} />
+              <Hds::Icon @name={{if t.isOpen "chevron-up" "chevron-down"}} />
             </button>
           </:toggle>
           <:content>

--- a/showcase/app/templates/utilities/menu-primitive.hbs
+++ b/showcase/app/templates/utilities/menu-primitive.hbs
@@ -18,7 +18,7 @@
           <:toggle as |t|>
             <button type="button" {{on "click" t.onClickToggle}}>
               Click me
-              <FlightIcon @name={{if t.isOpen "chevron-up" "chevron-down"}} />
+              <Hds::Icon @name={{if t.isOpen "chevron-up" "chevron-down"}} />
             </button>
           </:toggle>
           <:content>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates instances of `FlightIcon` within `showcase` to use the `Hds::Icon` component.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3707](https://hashicorp.atlassian.net/browse/HDS-3707)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3707]: https://hashicorp.atlassian.net/browse/HDS-3707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ