### PR TITLE
add explicit dotenv dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
-    "@changesets/get-github-info": "^0.5.2"
+    "@changesets/get-github-info": "^0.5.2",
+    "dotenv": "^16.3.1"
   },
   "scripts": {
     "release-packages": "yarn changeset publish",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4192,6 +4192,7 @@ __metadata:
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@changesets/get-github-info": "npm:^0.5.2"
+    dotenv: "npm:^16.3.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### :pushpin: Summary

We added a [reference to dotenv](https://github.com/hashicorp/design-system/blob/64a0cc615e5b2e55506f762b573e5c6e2b5a82f1/.changeset/changelog-hds.cjs.js#L13) but are relying on it existing from dependencies in other parts of the monorepo. This makes it more explicit.

```bash
⋊> ~/c/w/design-system on main ◦ npx depcheck                                                                                                                   
Missing dependencies
* dotenv: ./.changeset/changelog-hds.cjs.js
 ```

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
