### PR TITLE
Add back `@deprecated` arg to `Property` component

### DIFF
--- a/website/app/components/doc/component-api/property.hbs
+++ b/website/app/components/doc/component-api/property.hbs
@@ -13,6 +13,9 @@
       {{#if @required}}
         <Doc::Badge @type="critical-inverted">Required</Doc::Badge>
       {{/if}}
+      {{#if @deprecated}}
+        <Doc::Badge @type="warning">Deprecated</Doc::Badge>
+      {{/if}}
     </div>
   {{/if}}
   {{#if (or @values @valueNote)}}


### PR DESCRIPTION
### :pushpin: Summary

Originally introduced in #2215 it got wiped out accidentally in #2233

***
