### PR TITLE
`Hds::Dropdown::ListItem::Interactive` docs updates

### DIFF
--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -16,8 +16,12 @@
       <SG.Item {{style padding="5em"}} @label={{capitalize position}}>
         <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
           <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#" @text="Create" />
-          <D.Interactive @href="#" @text="Edit" />
+          <D.Interactive @href="#">
+            Create
+          </D.Interactive>
+          <D.Interactive @href="#">
+            Edit
+          </D.Interactive>
         </Hds::Dropdown>
       </SG.Item>
     {{/each}}
@@ -32,8 +36,12 @@
       <div class="shw-component-dropdown-display-sample">
         <Hds::Dropdown @listPosition="bottom-left" as |D|>
           <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#" @text="Create" />
-          <D.Interactive @href="#" @text="Edit" />
+          <D.Interactive @href="#">
+            Create
+          </D.Interactive>
+          <D.Interactive @href="#">
+            Edit
+          </D.Interactive>
         </Hds::Dropdown>
       </div>
     </SF.Item>
@@ -41,8 +49,12 @@
       <div class="shw-component-dropdown-display-sample">
         <Hds::Dropdown @listPosition="bottom-left" @isInline={{true}} as |D|>
           <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#" @text="Create" />
-          <D.Interactive @href="#" @text="Edit" />
+          <D.Interactive @href="#">
+            Create
+          </D.Interactive>
+          <D.Interactive @href="#">
+            Edit
+          </D.Interactive>
         </Hds::Dropdown>
       </div>
     </SF.Item>
@@ -62,8 +74,12 @@
             <div class="shw-component-dropdown-collision-detection-wrapper">
               <Hds::Dropdown @isOpen={{true}} @enableCollisionDetection={{detection}} as |D|>
                 <D.ToggleButton @color="secondary" @text="Menu" />
-                <D.Interactive @href="#" @text="Create" />
-                <D.Interactive @href="#" @text="Edit" />
+                <D.Interactive @href="#">
+                  Create
+                </D.Interactive>
+                <D.Interactive @href="#">
+                  Edit
+                </D.Interactive>
               </Hds::Dropdown>
             </div>
           </Shw::Autoscrollable>
@@ -369,7 +385,9 @@
           <Hds::Dropdown::ListItem::Title @text="A simple title" />
           <Hds::Dropdown::ListItem::Description @text="A description." />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive @route="index" @text="Item" />
+          <Hds::Dropdown::ListItem::Interactive @route="index">
+            Item
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
@@ -383,10 +401,9 @@
             @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
           />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive
-            @route="index"
-            @text="A longer item that could span multiple lines if the characters surpass a certain length"
-          />
+          <Hds::Dropdown::ListItem::Interactive @route="index">
+            A longer item that could span multiple lines if the characters surpass a certain length
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
@@ -401,10 +418,9 @@
             @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
           />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive
-            @route="index"
-            @text="A longer item that could span multiple lines if the characters surpass a certain length"
-          />
+          <Hds::Dropdown::ListItem::Interactive @route="index">
+            A longer item that could span multiple lines if the characters surpass a certain length
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}
@@ -422,7 +438,9 @@
       <Shw::Label>Default ⇒ <code>&lt;button&gt;</code></Shw::Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @text="Lorem ipsum dolor" />
+          <Hds::Dropdown::ListItem::Interactive>
+            Lorem ipsum dolor
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
@@ -433,7 +451,9 @@
         <code>&lt;a&gt;</code></Shw::Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @href="/" @text="Lorem ipsum dolor" />
+          <Hds::Dropdown::ListItem::Interactive @href="/">
+            Lorem ipsum dolor
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
@@ -446,7 +466,9 @@
         <code>&lt;a&gt;</code></Shw::Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @route="components.dropdown" @text="Lorem ipsum dolor" />
+          <Hds::Dropdown::ListItem::Interactive @route="components.dropdown">
+            Lorem ipsum dolor
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
@@ -458,32 +480,94 @@
     <SF.Item @label="No icon (default)">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @text="Basic" />
+          <Hds::Dropdown::ListItem::Interactive>
+            Basic
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
     <SF.Item @label="Leading icon">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @icon="settings" @text="Settings" />
+          <Hds::Dropdown::ListItem::Interactive @icon="settings">
+            Settings
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
     <SF.Item @label="Trailing icon">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @trailingIcon="external-link" @text="Documentation" />
+          <Hds::Dropdown::ListItem::Interactive @trailingIcon="external-link">
+            Documentation
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
     <SF.Item @label="Leading + Trailing icons">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive
-            @icon="terraform-color"
-            @trailingIcon="external-link"
-            @text="Terraform"
-          />
+          <Hds::Dropdown::ListItem::Interactive @icon="terraform-color" @trailingIcon="external-link">
+            Terraform
+          </Hds::Dropdown::ListItem::Interactive>
+        </ul>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Text::H4>Badge</Shw::Text::H4>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="No icon (default)">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive as |I|>
+            With badge
+            <I.Badge @text="Badge" />
+          </Hds::Dropdown::ListItem::Interactive>
+        </ul>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Leading icon">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @icon="settings" as |I|>
+            With leading icon
+            <I.Badge @text="Badge" />
+          </Hds::Dropdown::ListItem::Interactive>
+        </ul>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Trailing icon">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @trailingIcon="external-link" as |I|>
+            With trailing icon
+            <I.Badge @text="Badge" />
+          </Hds::Dropdown::ListItem::Interactive>
+        </ul>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Leading + Trailing icon">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @icon="settings" @trailingIcon="external-link" as |I|>
+            With leading + trailing icons
+            <I.Badge @text="Badge" />
+          </Hds::Dropdown::ListItem::Interactive>
+        </ul>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="With long content that might push the badge down">
+      <div class="hds-dropdown__content">
+        <ul class="hds-dropdown__list">
+          <Hds::Dropdown::ListItem::Interactive @icon="settings" @trailingIcon="settings" as |I|>
+            Lorem ipsum dolor sit amet, consectetur adipisici tempor incidunt ut labore et dolore
+            <I.Badge @text="Badge" />
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
@@ -495,14 +579,18 @@
     <SF.Item @label="Action (default)">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @icon="settings" @text="Lorem ipsum dolor" @color="action" />
+          <Hds::Dropdown::ListItem::Interactive @icon="settings" @color="action">
+            Lorem ipsum dolor
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
     <SF.Item @label="Critical">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @icon="trash" @text="Lorem ipsum dolor" @color="critical" />
+          <Hds::Dropdown::ListItem::Interactive @icon="trash" @color="critical">
+            Lorem ipsum dolor
+          </Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
@@ -518,10 +606,14 @@
             <div class="hds-dropdown__content">
               <ul class="hds-dropdown__list">
                 {{#each @model.ITEM_STATES as |state|}}
-                  <Hds::Dropdown::ListItem::Interactive @text={{state}} @color={{color}} mock-state-value={{state}} />
+                  <Hds::Dropdown::ListItem::Interactive @color={{color}} mock-state-value={{state}}>
+                    {{state}}
+                  </Hds::Dropdown::ListItem::Interactive>
                 {{/each}}
                 <Hds::Dropdown::ListItem::Separator />
-                <Hds::Dropdown::ListItem::Interactive @text="loading" @color={{color}} @isLoading={{true}} />
+                <Hds::Dropdown::ListItem::Interactive @color={{color}} @isLoading={{true}}>
+                  Loading
+                </Hds::Dropdown::ListItem::Interactive>
               </ul>
             </div>
           </SF.Item>
@@ -531,18 +623,21 @@
                 {{#each @model.ITEM_STATES as |state|}}
                   <Hds::Dropdown::ListItem::Interactive
                     @icon={{if (eq color "critical") "trash" "settings"}}
-                    @text="{{state}} with icon"
                     @color={{color}}
                     mock-state-value={{state}}
-                  />
+                  >
+                    {{state}}
+                    with icon
+                  </Hds::Dropdown::ListItem::Interactive>
                 {{/each}}
                 <Hds::Dropdown::ListItem::Separator />
                 <Hds::Dropdown::ListItem::Interactive
                   @icon={{if (eq color "critical") "trash" "settings"}}
-                  @text="loading with icon"
                   @color={{color}}
                   @isLoading={{true}}
-                />
+                >
+                  loading with icon
+                </Hds::Dropdown::ListItem::Interactive>
               </ul>
             </div>
           </SF.Item>
@@ -552,10 +647,12 @@
                 {{#each @model.ITEM_STATES as |state|}}
                   <Hds::Dropdown::ListItem::Interactive
                     @icon={{if (eq color "critical") "trash" "settings"}}
-                    @text="{{state}} with a longer text string that may wrap since max-width is defined on the container"
                     @color={{color}}
                     mock-state-value={{state}}
-                  />
+                  >
+                    {{state}}
+                    with a longer text string that may wrap since max-width is defined on the container
+                  </Hds::Dropdown::ListItem::Interactive>
                 {{/each}}
               </ul>
             </div>
@@ -1428,8 +1525,12 @@
       <div class="shw-component-dropdown-fixed-height-container">
         <Hds::Dropdown @listPosition="bottom-left" @width="200px" as |D|>
           <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#" @text="Lorem ipsum dolor sit amet" />
-          <D.Interactive @href="#" @text="Consectetur adipisicing elit" />
+          <D.Interactive @href="#">
+            Lorem ipsum dolor sit amet
+          </D.Interactive>
+          <D.Interactive @href="#">
+            Consectetur adipisicing elit
+          </D.Interactive>
         </Hds::Dropdown>
       </div>
     </SG.Item>

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -16,12 +16,8 @@
       <SG.Item {{style padding="5em"}} @label={{capitalize position}}>
         <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
           <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">
-            Create
-          </D.Interactive>
-          <D.Interactive @href="#">
-            Edit
-          </D.Interactive>
+          <D.Interactive @href="#" @text="Create" />
+          <D.Interactive @href="#" @text="Edit" />
         </Hds::Dropdown>
       </SG.Item>
     {{/each}}
@@ -36,12 +32,8 @@
       <div class="shw-component-dropdown-display-sample">
         <Hds::Dropdown @listPosition="bottom-left" as |D|>
           <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">
-            Create
-          </D.Interactive>
-          <D.Interactive @href="#">
-            Edit
-          </D.Interactive>
+          <D.Interactive @href="#" @text="Create" />
+          <D.Interactive @href="#" @text="Edit" />
         </Hds::Dropdown>
       </div>
     </SF.Item>
@@ -49,12 +41,8 @@
       <div class="shw-component-dropdown-display-sample">
         <Hds::Dropdown @listPosition="bottom-left" @isInline={{true}} as |D|>
           <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">
-            Create
-          </D.Interactive>
-          <D.Interactive @href="#">
-            Edit
-          </D.Interactive>
+          <D.Interactive @href="#" @text="Create" />
+          <D.Interactive @href="#" @text="Edit" />
         </Hds::Dropdown>
       </div>
     </SF.Item>
@@ -74,12 +62,8 @@
             <div class="shw-component-dropdown-collision-detection-wrapper">
               <Hds::Dropdown @isOpen={{true}} @enableCollisionDetection={{detection}} as |D|>
                 <D.ToggleButton @color="secondary" @text="Menu" />
-                <D.Interactive @href="#">
-                  Create
-                </D.Interactive>
-                <D.Interactive @href="#">
-                  Edit
-                </D.Interactive>
+                <D.Interactive @href="#" @text="Create" />
+                <D.Interactive @href="#" @text="Edit" />
               </Hds::Dropdown>
             </div>
           </Shw::Autoscrollable>
@@ -385,9 +369,7 @@
           <Hds::Dropdown::ListItem::Title @text="A simple title" />
           <Hds::Dropdown::ListItem::Description @text="A description." />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive @route="index">
-            Item
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="index" @text="Item" />
         </ul>
       </div>
     </SF.Item>
@@ -401,9 +383,10 @@
             @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
           />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive @route="index">
-            A longer item that could span multiple lines if the characters surpass a certain length
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive
+            @route="index"
+            @text="A longer item that could span multiple lines if the characters surpass a certain length"
+          />
         </ul>
       </div>
     </SF.Item>
@@ -418,9 +401,10 @@
             @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
           />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive @route="index">
-            A longer item that could span multiple lines if the characters surpass a certain length
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive
+            @route="index"
+            @text="A longer item that could span multiple lines if the characters surpass a certain length"
+          />
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}
@@ -438,9 +422,7 @@
       <Shw::Label>Default ⇒ <code>&lt;button&gt;</code></Shw::Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive>
-            Lorem ipsum dolor
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @text="Lorem ipsum dolor" />
         </ul>
       </div>
     </SF.Item>
@@ -451,9 +433,7 @@
         <code>&lt;a&gt;</code></Shw::Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @href="/">
-            Lorem ipsum dolor
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @href="/" @text="Lorem ipsum dolor" />
         </ul>
       </div>
     </SF.Item>
@@ -466,9 +446,7 @@
         <code>&lt;a&gt;</code></Shw::Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @route="components.dropdown">
-            Lorem ipsum dolor
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components.dropdown" @text="Lorem ipsum dolor" />
         </ul>
       </div>
     </SF.Item>
@@ -480,94 +458,32 @@
     <SF.Item @label="No icon (default)">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive>
-            Basic
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @text="Basic" />
         </ul>
       </div>
     </SF.Item>
     <SF.Item @label="Leading icon">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @icon="settings">
-            Settings
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @icon="settings" @text="Settings" />
         </ul>
       </div>
     </SF.Item>
     <SF.Item @label="Trailing icon">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @trailingIcon="external-link">
-            Documentation
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @trailingIcon="external-link" @text="Documentation" />
         </ul>
       </div>
     </SF.Item>
     <SF.Item @label="Leading + Trailing icons">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @icon="terraform-color" @trailingIcon="external-link">
-            Terraform
-          </Hds::Dropdown::ListItem::Interactive>
-        </ul>
-      </div>
-    </SF.Item>
-  </Shw::Flex>
-
-  <Shw::Text::H4>Badge</Shw::Text::H4>
-
-  <Shw::Flex as |SF|>
-    <SF.Item @label="No icon (default)">
-      <div class="hds-dropdown__content">
-        <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive as |I|>
-            With badge
-            <I.Badge @text="Badge" />
-          </Hds::Dropdown::ListItem::Interactive>
-        </ul>
-      </div>
-    </SF.Item>
-    <SF.Item @label="Leading icon">
-      <div class="hds-dropdown__content">
-        <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @icon="settings" as |I|>
-            With leading icon
-            <I.Badge @text="Badge" />
-          </Hds::Dropdown::ListItem::Interactive>
-        </ul>
-      </div>
-    </SF.Item>
-    <SF.Item @label="Trailing icon">
-      <div class="hds-dropdown__content">
-        <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @trailingIcon="external-link" as |I|>
-            With trailing icon
-            <I.Badge @text="Badge" />
-          </Hds::Dropdown::ListItem::Interactive>
-        </ul>
-      </div>
-    </SF.Item>
-    <SF.Item @label="Leading + Trailing icon">
-      <div class="hds-dropdown__content">
-        <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @icon="settings" @trailingIcon="external-link" as |I|>
-            With leading + trailing icons
-            <I.Badge @text="Badge" />
-          </Hds::Dropdown::ListItem::Interactive>
-        </ul>
-      </div>
-    </SF.Item>
-  </Shw::Flex>
-
-  <Shw::Flex as |SF|>
-    <SF.Item @label="With long content that might push the badge down">
-      <div class="hds-dropdown__content">
-        <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @icon="settings" @trailingIcon="settings" as |I|>
-            Lorem ipsum dolor sit amet, consectetur adipisici tempor incidunt ut labore et dolore
-            <I.Badge @text="Badge" />
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive
+            @icon="terraform-color"
+            @trailingIcon="external-link"
+            @text="Terraform"
+          />
         </ul>
       </div>
     </SF.Item>
@@ -579,18 +495,14 @@
     <SF.Item @label="Action (default)">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @icon="settings" @color="action">
-            Lorem ipsum dolor
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @icon="settings" @text="Lorem ipsum dolor" @color="action" />
         </ul>
       </div>
     </SF.Item>
     <SF.Item @label="Critical">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @icon="trash" @color="critical">
-            Lorem ipsum dolor
-          </Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @icon="trash" @text="Lorem ipsum dolor" @color="critical" />
         </ul>
       </div>
     </SF.Item>
@@ -606,14 +518,10 @@
             <div class="hds-dropdown__content">
               <ul class="hds-dropdown__list">
                 {{#each @model.ITEM_STATES as |state|}}
-                  <Hds::Dropdown::ListItem::Interactive @color={{color}} mock-state-value={{state}}>
-                    {{state}}
-                  </Hds::Dropdown::ListItem::Interactive>
+                  <Hds::Dropdown::ListItem::Interactive @text={{state}} @color={{color}} mock-state-value={{state}} />
                 {{/each}}
                 <Hds::Dropdown::ListItem::Separator />
-                <Hds::Dropdown::ListItem::Interactive @color={{color}} @isLoading={{true}}>
-                  Loading
-                </Hds::Dropdown::ListItem::Interactive>
+                <Hds::Dropdown::ListItem::Interactive @text="loading" @color={{color}} @isLoading={{true}} />
               </ul>
             </div>
           </SF.Item>
@@ -623,21 +531,18 @@
                 {{#each @model.ITEM_STATES as |state|}}
                   <Hds::Dropdown::ListItem::Interactive
                     @icon={{if (eq color "critical") "trash" "settings"}}
+                    @text="{{state}} with icon"
                     @color={{color}}
                     mock-state-value={{state}}
-                  >
-                    {{state}}
-                    with icon
-                  </Hds::Dropdown::ListItem::Interactive>
+                  />
                 {{/each}}
                 <Hds::Dropdown::ListItem::Separator />
                 <Hds::Dropdown::ListItem::Interactive
                   @icon={{if (eq color "critical") "trash" "settings"}}
+                  @text="loading with icon"
                   @color={{color}}
                   @isLoading={{true}}
-                >
-                  loading with icon
-                </Hds::Dropdown::ListItem::Interactive>
+                />
               </ul>
             </div>
           </SF.Item>
@@ -647,12 +552,10 @@
                 {{#each @model.ITEM_STATES as |state|}}
                   <Hds::Dropdown::ListItem::Interactive
                     @icon={{if (eq color "critical") "trash" "settings"}}
+                    @text="{{state}} with a longer text string that may wrap since max-width is defined on the container"
                     @color={{color}}
                     mock-state-value={{state}}
-                  >
-                    {{state}}
-                    with a longer text string that may wrap since max-width is defined on the container
-                  </Hds::Dropdown::ListItem::Interactive>
+                  />
                 {{/each}}
               </ul>
             </div>
@@ -1525,12 +1428,8 @@
       <div class="shw-component-dropdown-fixed-height-container">
         <Hds::Dropdown @listPosition="bottom-left" @width="200px" as |D|>
           <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">
-            Lorem ipsum dolor sit amet
-          </D.Interactive>
-          <D.Interactive @href="#">
-            Consectetur adipisicing elit
-          </D.Interactive>
+          <D.Interactive @href="#" @text="Lorem ipsum dolor sit amet" />
+          <D.Interactive @href="#" @text="Consectetur adipisicing elit" />
         </Hds::Dropdown>
       </div>
     </SG.Item>

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -195,8 +195,14 @@ The `Dropdown::ListItem::Interactive` component, yielded as contextual component
 It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API, please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="text" @required={{true}} @type="string">
-    Text to be used in the item. If no text value is defined, an error will be thrown.
+  <C.Property @name="yield">
+    Elements passed as children are yielded as inner content of `interactive` block.
+  </C.Property>
+  <C.Property @name="<[I].Badge>" @type="yielded component">
+    The `Badge` component, yielded as contextual component inside `interactive` blocks of the `Dropdown`. It exposes the same API as the [`Badge` component](/components/badge).
+  </C.Property>
+  <C.Property @name="text" @required={{true}} @deprecated={{true}} @type="string">
+    Text to be used in the item. If no text value is defined and no content is yielded, an error will be thrown.
   </C.Property>
   <C.Property @name="color" @type="enum" @values={{array "action" "critical" }} @default="action">
     Color applied to the text and (optional) icons.

--- a/website/docs/components/dropdown/partials/version-history/4.10.0.md
+++ b/website/docs/components/dropdown/partials/version-history/4.10.0.md
@@ -2,6 +2,16 @@
 
 ### Updated
 
+The component now yields the `Hds::Badge` component as a contextual component.
+
 Added `@enableCollisionDetection` and `@isOpen` arguments
 
 Replaced the underlying `MenuPrimitive` with [`PopoverPrimitive`](/utilities/popover-primitive)
+
+### Deprecated
+
+Deprecated the `@text` argument. Users are instructed to put text in the yielded block instead.
+
+#### How to migrate
+
+You can automate this migration using the codemod `v4/dropdown-list-item-interactive` (see [readme file](https://github.com/hashicorp/design-system/tree/main/packages/codemods/transforms/v4/dropdown-list-item-interactive)).


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates documentation for the `Hds::Dropdown::ListItem::Interactive` to include new attributes and the deprecation of `@text`

### :camera_flash: Screenshots

![Screenshot 2024-08-19 at 4 12 32 PM](https://github.com/user-attachments/assets/f720843d-eb46-401d-a6ca-8069b5e0d8c8)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3694](https://hashicorp.atlassian.net/browse/HDS-3694)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3694]: https://hashicorp.atlassian.net/browse/HDS-3694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ