### PR TITLE
“Enterprise Nav”: Misc follow ons (HDS-3693)

### DIFF
--- a/.changeset/four-zoos-promise.md
+++ b/.changeset/four-zoos-promise.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AppHeader` - Fixed issue with mobile menu to prevent tabbing to hidden content and hiding it from assistive technology when closed.

--- a/packages/components/src/components/hds/app-header/index.hbs
+++ b/packages/components/src/components/hds/app-header/index.hbs
@@ -29,7 +29,7 @@
   <div
     class="hds-app-header__actions"
     id={{this.menuContentId}}
-    aria-hidden="{{(and (not this.isDesktop) (not this.isOpen))}}"
+    aria-hidden={{(and (not this.isDesktop) (not this.isOpen) "true")}}
   >
     <div class="hds-app-header__global-actions">
       {{yield to="globalActions"}}

--- a/packages/components/src/components/hds/app-header/index.hbs
+++ b/packages/components/src/components/hds/app-header/index.hbs
@@ -25,12 +25,7 @@
     />
   {{/if}}
 
-  {{! if it's not desktop view and the menu is not open, we want to hide the actions from assistive tech }}
-  <div
-    class="hds-app-header__actions"
-    id={{this.menuContentId}}
-    aria-hidden={{(and (not this.isDesktop) (not this.isOpen) "true")}}
-  >
+  <div class="hds-app-header__actions" id={{this.menuContentId}}>
     <div class="hds-app-header__global-actions">
       {{yield to="globalActions"}}
     </div>

--- a/packages/components/src/components/hds/app-header/index.hbs
+++ b/packages/components/src/components/hds/app-header/index.hbs
@@ -3,7 +3,12 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<div class={{this.classNames}} ...attributes>
+<div
+  class={{this.classNames}}
+  {{! @glint-expect-error - https://github.com/josemarluedke/ember-focus-trap/issues/86 }}
+  {{focus-trap isActive=this.shouldTrapFocus}}
+  ...attributes
+>
   {{#if (and this.hasA11yRefocus (not this.isOpen))}}
     {{! @glint-expect-error - `ember-a11y-refocus` doesn't expose types yet }}
     <NavigationNarrator

--- a/packages/components/src/components/hds/app-header/index.hbs
+++ b/packages/components/src/components/hds/app-header/index.hbs
@@ -25,7 +25,12 @@
     />
   {{/if}}
 
-  <div class="hds-app-header__actions" id={{this.menuContentId}}>
+  {{! if it's not desktop view and the menu is not open, we want to hide the actions from assistive tech }}
+  <div
+    class="hds-app-header__actions"
+    id={{this.menuContentId}}
+    aria-hidden="{{(and (not this.isDesktop) (not this.isOpen))}}"
+  >
     <div class="hds-app-header__global-actions">
       {{yield to="globalActions"}}
     </div>

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -80,6 +80,11 @@ export default class HdsAppHeaderComponent extends Component<HdsAppHeaderSignatu
     );
   }
 
+  // In mobile view when the menu is open, trap focus within the AppHeader
+  get shouldTrapFocus(): boolean {
+    return !this.isDesktop && this.isOpen;
+  }
+
   // Get the class names to apply to the component.
   get classNames(): string {
     const classes = ['hds-app-header'];
@@ -115,5 +120,11 @@ export default class HdsAppHeaderComponent extends Component<HdsAppHeaderSignatu
   @action
   updateDesktopVariable(event: MediaQueryListEvent): void {
     this.isDesktop = event.matches;
+
+    // Close the menu when switching to desktop view
+    // (prevents menu from being open when resizing which causes Skip button to not render)
+    if (this.isDesktop) {
+      this.isOpen = false;
+    }
   }
 }

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -88,12 +88,13 @@ export default class HdsAppHeaderComponent extends Component<HdsAppHeaderSignatu
       classes.push('hds-app-header--is-desktop');
     } else {
       classes.push('hds-app-header--is-mobile');
-    }
 
-    if (this.isOpen) {
-      classes.push('hds-app-header--menu-is-open');
-    } else {
-      classes.push('hds-app-header--menu-is-closed');
+      // open and closed menu states are only relevant on mobile
+      if (this.isOpen) {
+        classes.push('hds-app-header--menu-is-open');
+      } else {
+        classes.push('hds-app-header--menu-is-closed');
+      }
     }
 
     return classes.join(' ');

--- a/packages/components/src/styles/components/app-header.scss
+++ b/packages/components/src/styles/components/app-header.scss
@@ -76,9 +76,7 @@
 
     &.hds-app-header--menu-is-closed {
       .hds-app-header__actions {
-        height: 0;
-        padding-top: 0;
-        padding-bottom: 0;
+        display: none;
       }
     }
 

--- a/showcase/app/templates/components/app-header.hbs
+++ b/showcase/app/templates/components/app-header.hbs
@@ -44,7 +44,7 @@
           <Hds::AppHeader::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp home menu" @href="#" />
         </:logo>
         <:globalActions>
-          <Hds::Dropdown as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleButton @text="Choose an organization" @icon="org" />
             <dd.Checkmark>
               organizationName
@@ -53,7 +53,7 @@
         </:globalActions>
 
         <:utilityActions>
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
             <dd.Interactive @text="Documentation" @href="#" />
@@ -65,7 +65,7 @@
             <dd.Interactive @text="Give feedback" @href="#" />
           </Hds::Dropdown>
 
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
@@ -81,7 +81,7 @@
           <Hds::AppHeader::HomeLink @icon="terraform" @ariaLabel="Terraform home menu" @href="#" />
         </:logo>
         <:globalActions>
-          <Hds::Dropdown as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleButton @text="Choose an organization" @icon="org" />
             <dd.Checkmark>
               organizationName
@@ -92,7 +92,7 @@
         <:utilityActions>
           <Hds::Button @color="secondary" @icon="search" @isIconOnly={{true}} @text="Search" />
 
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
             <dd.Interactive @text="Documentation" @href="#" />
@@ -104,7 +104,7 @@
             <dd.Interactive @text="Give feedback" @href="#" />
           </Hds::Dropdown>
 
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
@@ -120,7 +120,7 @@
           <Hds::AppHeader::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp home menu" @href="#" />
         </:logo>
         <:globalActions>
-          <Hds::Dropdown as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleButton @text="Choose an organization" @icon="org" />
             <dd.Checkmark>
               organizationName
@@ -129,7 +129,7 @@
         </:globalActions>
 
         <:utilityActions>
-          <Hds::Dropdown as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleButton @text="Europe" @icon="globe" />
             <dd.Checkmark>
               Americas
@@ -138,7 +138,7 @@
 
           <Hds::Button @icon="search" @isIconOnly={{true}} @text="Search" />
 
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
             <dd.Interactive @text="Documentation" @href="#" />
@@ -150,7 +150,7 @@
             <dd.Interactive @text="Give feedback" @href="#" />
           </Hds::Dropdown>
 
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
@@ -172,7 +172,7 @@
           <Hds::AppHeader::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp home menu" @href="#" />
         </:logo>
         <:globalActions>
-          <Hds::Dropdown as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleButton @text="Long-Organization-Name-Long-Organization" @icon="org" />
             <dd.Checkmark>
               organizationName
@@ -181,7 +181,7 @@
         </:globalActions>
         <:utilityActions>
           <Hds::Button @color="secondary" @icon="search" @isIconOnly={{true}} @text="Search" />
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
             <dd.Interactive @text="Documentation" @href="#" />
@@ -192,7 +192,7 @@
             <dd.Interactive @text="Create support ticket" @href="#" />
             <dd.Interactive @text="Give feedback" @href="#" />
           </Hds::Dropdown>
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
@@ -208,7 +208,7 @@
           <Hds::AppHeader::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp home menu" @href="#" />
         </:logo>
         <:globalActions>
-          <Hds::Dropdown as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleButton @text="WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW" @icon="org" />
             <dd.Checkmark>
               organizationName
@@ -217,7 +217,7 @@
         </:globalActions>
         <:utilityActions>
           <Hds::Button @color="secondary" @icon="search" @isIconOnly={{true}} @text="Search" />
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
             <dd.Interactive @text="Documentation" @href="#" />
@@ -228,7 +228,7 @@
             <dd.Interactive @text="Create support ticket" @href="#" />
             <dd.Interactive @text="Give feedback" @href="#" />
           </Hds::Dropdown>
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
@@ -250,7 +250,7 @@
           <Hds::AppHeader::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp home menu" @href="#" />
         </:logo>
         <:globalActions>
-          <Hds::Dropdown as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleButton @text="Choose an organization" @icon="org" />
             <dd.Checkmark>
               organizationName
@@ -259,7 +259,7 @@
         </:globalActions>
 
         <:utilityActions>
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
             <dd.Interactive @text="Documentation" @href="#" />
@@ -271,7 +271,7 @@
             <dd.Interactive @text="Give feedback" @href="#" />
           </Hds::Dropdown>
 
-          <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />

--- a/showcase/app/templates/components/side-nav.hbs
+++ b/showcase/app/templates/components/side-nav.hbs
@@ -124,7 +124,7 @@
                     <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
                   </:logo>
                   <:actions>
-                    <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+                    <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
                       <dd.ToggleIcon @icon="help" @text="help menu" />
                       <dd.Title @text="Help & Support" />
                       <dd.Interactive @text="Documentation" @href="#" />
@@ -135,7 +135,7 @@
                       <dd.Interactive @text="Create support ticket" @href="#" />
                       <dd.Interactive @text="Give feedback" @href="#" />
                     </Hds::Dropdown>
-                    <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+                    <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
                       <dd.ToggleIcon @icon="user" @text="user menu" />
                       <dd.Title @text="Signed In" />
                       <dd.Description @text="email@domain.com" />
@@ -188,7 +188,7 @@
                   </:logo>
                   <:actions>
                     <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
-                    <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+                    <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
                       <dd.ToggleIcon @icon="help" @text="help menu" />
                       <dd.Title @text="Help & Support" />
                       <dd.Interactive @text="Documentation" @href="#" />
@@ -199,7 +199,7 @@
                       <dd.Interactive @text="Create support ticket" @href="#" />
                       <dd.Interactive @text="Give feedback" @href="#" />
                     </Hds::Dropdown>
-                    <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+                    <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
                       <dd.ToggleIcon @icon="user" @text="user menu" />
                       <dd.Title @text="Signed In" />
                       <dd.Description @text="email@domain.com" />
@@ -336,7 +336,7 @@
             <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
           </:logo>
           <:actions>
-            <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+            <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
               <dd.ToggleIcon @icon="help" @text="help menu" />
               <dd.Title @text="Help & Support" />
               <dd.Interactive @text="Documentation" @href="#" />
@@ -347,7 +347,7 @@
               <dd.Interactive @text="Create support ticket" @href="#" />
               <dd.Interactive @text="Give feedback" @href="#" />
             </Hds::Dropdown>
-            <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+            <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
               <dd.ToggleIcon @icon="user" @text="user menu" />
               <dd.Title @text="Signed In" />
               <dd.Description @text="email@domain.com" />
@@ -365,7 +365,7 @@
           </:logo>
           <:actions>
             <Hds::SideNav::Header::IconButton @icon="terminal-screen" @ariaLabel="Terminal" />
-            <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+            <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
               <dd.ToggleButton @text="Help" />
               <dd.Title @text="Help & Support" />
               <dd.Interactive @text="Documentation" @href="#" />

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
@@ -13,7 +13,7 @@
         <Hds::AppHeader::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp home menu" @href="#" />
       </:logo>
       <:globalActions>
-        <Hds::Dropdown as |dd|>
+        <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
           <dd.ToggleButton @text="WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW" @icon="org" />
           <dd.Checkmark>
             organizationName
@@ -21,7 +21,7 @@
         </Hds::Dropdown>
       </:globalActions>
       <:utilityActions>
-        <Hds::Dropdown as |dd|>
+        <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
           <dd.ToggleButton @text="Europe" @icon="globe" />
           <dd.Checkmark>
             Americas
@@ -29,7 +29,7 @@
         </Hds::Dropdown>
 
         <Hds::Button @icon="search" @isIconOnly={{true}} @text="Search" />
-        <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+        <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
           <dd.ToggleIcon @icon="help" @text="help menu" />
           <dd.Title @text="Help & Support" />
           <dd.Interactive @text="Documentation" @href="#" />
@@ -40,7 +40,7 @@
           <dd.Interactive @text="Create support ticket" @href="#" />
           <dd.Interactive @text="Give feedback" @href="#" />
         </Hds::Dropdown>
-        <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+        <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
           <dd.ToggleIcon @icon="user" @text="user menu" />
           <dd.Title @text="Signed In" />
           <dd.Description @text="email@domain.com" />

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
@@ -22,7 +22,7 @@
           </:logo>
           <:actions>
             <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
-            <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+            <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
               <dd.ToggleIcon @icon="help" @text="help menu" />
               <dd.Title @text="Help & Support" />
               <dd.Interactive @text="Documentation" @href="#" />
@@ -33,7 +33,7 @@
               <dd.Interactive @text="Create support ticket" @href="#" />
               <dd.Interactive @text="Give feedback" @href="#" />
             </Hds::Dropdown>
-            <Hds::Dropdown @listPosition="bottom-left" as |dd|>
+            <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
               <dd.ToggleIcon @icon="user" @text="user menu" />
               <dd.Title @text="Signed In" />
               <dd.Description @text="email@domain.com" />
@@ -67,7 +67,11 @@
         </Hds::SideNav::List>
       </:body>
       <:footer>
-        <Hds::Dropdown class="hds-side-nav-hide-when-minimized shw-layout-app-frame-full-width-elem" as |dd|>
+        <Hds::Dropdown
+          class="hds-side-nav-hide-when-minimized shw-layout-app-frame-full-width-elem"
+          @enableCollisionDetection={{true}}
+          as |dd|
+        >
           <dd.ToggleButton @text="Choose an organization" @icon="org" />
           <dd.Checkmark>
             organizationName

--- a/showcase/tests/integration/components/hds/app-header/index-test.js
+++ b/showcase/tests/integration/components/hds/app-header/index-test.js
@@ -78,7 +78,6 @@ module('Integration | Component | hds/app-header/index', function (hooks) {
       <Hds::AppHeader id="test-app-header" />
     `);
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-closed');
-    assert.dom('.hds-app-header__actions').hasAttribute('aria-hidden', 'true');
   });
 
   test(`the actions show/hide when the menu button is pressed on narrow viewports`, async function (assert) {
@@ -90,11 +89,9 @@ module('Integration | Component | hds/app-header/index', function (hooks) {
 
     await click('.hds-app-header__menu-button');
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-open');
-    assert.dom('.hds-app-header__actions').doesNotHaveAttribute('aria-hidden');
 
     await click('.hds-app-header__menu-button');
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-closed');
-    assert.dom('.hds-app-header__actions').hasAttribute('aria-hidden', 'true');
   });
 
   // OPTIONS

--- a/showcase/tests/integration/components/hds/app-header/index-test.js
+++ b/showcase/tests/integration/components/hds/app-header/index-test.js
@@ -78,6 +78,7 @@ module('Integration | Component | hds/app-header/index', function (hooks) {
       <Hds::AppHeader id="test-app-header" />
     `);
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-closed');
+    assert.dom('.hds-app-header__actions').hasAttribute('aria-hidden', 'true');
   });
 
   test(`the actions show/hide when the menu button is pressed on narrow viewports`, async function (assert) {
@@ -89,9 +90,11 @@ module('Integration | Component | hds/app-header/index', function (hooks) {
 
     await click('.hds-app-header__menu-button');
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-open');
+    assert.dom('.hds-app-header__actions').doesNotHaveAttribute('aria-hidden');
 
     await click('.hds-app-header__menu-button');
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-closed');
+    assert.dom('.hds-app-header__actions').hasAttribute('aria-hidden', 'true');
   });
 
   // OPTIONS

--- a/website/docs/components/app-header/partials/code/how-to-use.md
+++ b/website/docs/components/app-header/partials/code/how-to-use.md
@@ -44,6 +44,12 @@ probably need to be set to `true` (or omitted to rely on defaults)
 
 ### Content
 
+!!! Info
+
+When adding Dropdown components within the App Header, be sure to set `enableCollisionDetection` to `true` for each Dropdown.
+
+!!!
+
 #### HomeLink
 
 The `Hds::AppHeader::HomeLink` child component should be yielded within the `<:logo>` block. It provides consistent branding and navigates the user to the “home” or main dashboard page.
@@ -126,7 +132,7 @@ probably need to be set to `true` (or omitted to rely on defaults)
   </:logo>
   
   <:globalActions>
-    <Hds::Dropdown as |dd|>
+    <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
       <dd.ToggleButton @text="Choose an organization" @icon="org" />
       <dd.Checkmark>
         organizationName
@@ -160,7 +166,7 @@ probably need to be set to `true` (or omitted to rely on defaults)
   </:logo>
   
   <:globalActions>
-    <Hds::Dropdown as |dd|>
+    <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
       <dd.ToggleButton @text="Choose an organization" @icon="org" />
       <dd.Checkmark>
         organizationName
@@ -169,7 +175,7 @@ probably need to be set to `true` (or omitted to rely on defaults)
   </:globalActions>
 
   <:utilityActions>
-    <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+    <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
       <dd.ToggleIcon @icon="help" @text="help menu" />
       <dd.Title @text="Help & Support" />
       <dd.Interactive @text="Documentation" @href="#" />
@@ -181,7 +187,7 @@ probably need to be set to `true` (or omitted to rely on defaults)
       <dd.Interactive @text="Give feedback" @href="#" />
     </Hds::Dropdown>
 
-    <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+    <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
       <dd.ToggleIcon @icon="user" @text="user menu" />
       <dd.Title @text="Signed In" />
       <dd.Description @text="email@domain.com" />

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -93,7 +93,7 @@ This is the basic component (layout only).
     A named block where the main product logo linked to your app’s home page will be rendered. The `SideNav::HomeLink` component should be added here.
   </C.Property>
   <C.Property @name="<:actions>" @type="named block">
-    A named block where the header “action” components will be rendered. Typically `Dropdown` components and/or `SideNav::IconButton` components will be added here. Special Side Nav coordinated styling can be applied to dropdowns by adding the `hds-side-nav__dropdown` class name.
+    A named block where the header “action” components will be rendered. Typically `Dropdown` components and/or `SideNav::IconButton` components will be added here.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -141,7 +141,7 @@ Here is an example of some possible actions:
         </:logo>
         <:actions>
           <Hds::SideNav::Header::IconButton @icon="search" @ariaLabel="Search" />
-          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="settings menu" />
             <dd.Title @text="Help & Support" />
             <dd.Interactive @text="Documentation" @href="#" />
@@ -152,7 +152,7 @@ Here is an example of some possible actions:
             <dd.Interactive @text="Create support ticket" @href="#" />
             <dd.Interactive @text="Give feedback" @href="#" />
           </Hds::Dropdown>
-          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
@@ -168,7 +168,7 @@ Here is an example of some possible actions:
 
 The `Hds::SideNav::Header::IconButton` is a specialized sub-component that can be used to add a button (or link) as "action" with a visual style specific to the Side Nav. It requires a value for the `@icon` and `@ariaLabel` arguments. The IconButton is built on top of the [`Hds::Interactive` component](/utilities/interactive), so it accepts all its routing arguments (eg. `@href`, `@route`, `@query`, `@model(s)`, etc.).
 
-The dropdown elements instead (in this case) are using the standard [`Hds::Dropdown` component](/components/dropdown). An extra `hds-side-nav__dropdown` class needs to be applied to it, so that the "toggle" button takes the visual style of the other interactive elements in the Side Nav.
+The dropdown elements instead (in this case) are using the standard [`Hds::Dropdown` component](/components/dropdown). We recommend setting `enableCollisionDetection` to `true` for each Dropdown component used within the Side Nav.
 
 You can also add custom elements to the `<:actions>` block, if these two don't cover your specific needs, but in this case you will have to take care of their styling so that they blend in with the rest of the Side Nav elements.
 
@@ -280,7 +280,7 @@ but in your app they will probably need to be set to `true` (or omitted to rely 
           <Hds::SideNav::Header::HomeLink @icon="hashicorp" @ariaLabel="HashiCorp" @href="#" />
         </:logo>
         <:actions>
-          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
             <dd.Interactive @text="Documentation" @href="#" />
@@ -291,7 +291,7 @@ but in your app they will probably need to be set to `true` (or omitted to rely 
             <dd.Interactive @text="Create support ticket" @href="#" />
             <dd.Interactive @text="Give feedback" @href="#" />
           </Hds::Dropdown>
-          <Hds::Dropdown class="hds-side-nav__dropdown" @listPosition="bottom-left" as |dd|>
+          <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds misc updates related to “Enterprise Nav” associated components.

**Previews:**

* [AppFrame showcase](https://hds-showcase-git-hds-3693-enterprise-nav-follow-ons-hashicorp.vercel.app/layouts/app-frame)
* [Framed example](https://hds-showcase-git-hds-3693-enterprise-nav-follow-ons-hashicorp.vercel.app/layouts/app-frame/frameless/demo-full-app-frame-with-app-header)
* [AppHeader code Web docs](https://hds-website-git-hds-3693-enterprise-nav-follow-ons-hashicorp.vercel.app/components/app-header?tab=code#content)
* [SideNav code Web docs](https://hds-website-git-hds-3693-enterprise-nav-follow-ons-hashicorp.vercel.app/components/side-nav?tab=code)

### :hammer_and_wrench: Detailed description

**Included changes:**

- AppHeader component:
  - Prevented tabbing to non-visible interactive items in closed mobile menu.
  - Hid content in closed mobile menu from assistive tech.
- Showcase:
  - Updated AppHeader & SideNav examples to remove listPosition from nested Dropdowns and instead set enableCollision to true.
- Web docs:
  - Updated AppHeader & SideNav examples to remove listPosition from nested Dropdowns and instead set enableCollision to true.
  - Removed unneeded classname from SideNav nested Dropdown examples.
  - Added text advising consumers to set enableCollision to true for Dropdowns in AppHeader & SideNav.

<!-- 
### :camera_flash: Screenshots

Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

Jira ticket: [HDS-3693](https://hashicorp.atlassian.net/browse/HDS-3693)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets] (https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3693]: https://hashicorp.atlassian.net/browse/HDS-3693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ