### PR TITLE
Update  `ember-a11y-refocus` to `4.1.3`

### DIFF
--- a/.changeset/heavy-pears-cheer.md
+++ b/.changeset/heavy-pears-cheer.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Update `ember-a11y-refocus` to `4.1.3`

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
     "@hashicorp/ember-flight-icons": "^5.1.3",
     "@hashicorp/flight-icons": "^3.5.0",
     "decorator-transforms": "^1.1.0",
-    "ember-a11y-refocus": "^4.1.0",
+    "ember-a11y-refocus": "^4.1.3",
     "ember-cli-sass": "^11.0.1",
     "ember-composable-helpers": "^5.0.0",
     "ember-element-helper": "^0.8.5",

--- a/website/package.json
+++ b/website/package.json
@@ -57,7 +57,7 @@
     "broccoli-multifilter": "https://github.com/broccolijs/broccoli-multifilter.git#commit=3ae609df0cfb1dae0da04ae041eb75c7115c9838",
     "cspell": "^7.3.8",
     "dotenv": "^16.3.1",
-    "ember-a11y-refocus": "^4.1.0",
+    "ember-a11y-refocus": "^4.1.3",
     "ember-a11y-testing": "^6.1.1",
     "ember-auto-import": "^2.7.3",
     "ember-basic-dropdown": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4124,7 +4124,7 @@ __metadata:
     babel-plugin-ember-template-compilation: "npm:^2.2.4"
     concurrently: "npm:^8.2.2"
     decorator-transforms: "npm:^1.1.0"
-    ember-a11y-refocus: "npm:^4.1.0"
+    ember-a11y-refocus: "npm:^4.1.3"
     ember-basic-dropdown: "npm:^8.1.0"
     ember-cli-sass: "npm:^11.0.1"
     ember-composable-helpers: "npm:^5.0.0"
@@ -12232,13 +12232,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-a11y-refocus@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "ember-a11y-refocus@npm:4.1.0"
+"ember-a11y-refocus@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "ember-a11y-refocus@npm:4.1.3"
   dependencies:
     ember-cli-babel: "npm:^7.26.11"
     ember-cli-htmlbars: "npm:^6.0.1"
-  checksum: 10/16c8df41f42e58ec3fcd5166f3641c4a8cd076c0858b74bf6ce226a44e4a39f275fbdff4ad28dae1978e7a995f4ac4603576dc2940b9cdd18d42153a6c070235
+  checksum: 10/48096bcad40ade3c6373ab9240a87a7ead5e8c1ddd54fc58b93239895a04ec5b7bd2d1f449fe460ec3be70ad5167befd2f11811382758b11ff791e36f0e3dbbe
   languageName: node
   linkType: hard
 
@@ -27878,7 +27878,7 @@ __metadata:
     broccoli-multifilter: "https://github.com/broccolijs/broccoli-multifilter.git#commit=3ae609df0cfb1dae0da04ae041eb75c7115c9838"
     cspell: "npm:^7.3.8"
     dotenv: "npm:^16.3.1"
-    ember-a11y-refocus: "npm:^4.1.0"
+    ember-a11y-refocus: "npm:^4.1.3"
     ember-a11y-testing: "npm:^6.1.1"
     ember-auto-import: "npm:^2.7.3"
     ember-basic-dropdown: "npm:^8.1.0"


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates our version of `ember-a11y-refocus` to the latest version, confirmed to resolve TFC's issues. 


### 👀 Component checklist

- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
