### PR TITLE
Accessible Headings: Add tag arguments to components

### DIFF
--- a/.changeset/gentle-cows-remain.md
+++ b/.changeset/gentle-cows-remain.md
@@ -2,12 +2,12 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`Accordion`: Add `@titleTag` argument
+`Accordion`: Added `@titleTag` argument
 
-`Alert`: Add `@tag` argument to `[A].Title`
+`Alert`: Added `@tag` argument to `[A].Title`
 
-`ApplicationState`: Update the `@titleTag` argument to only accept `"div" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"`
+`ApplicationState`: Updated the `@titleTag` argument to only accept `"div" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"`
 
-`CodeBlock`: Add `@tag` argument to `[CB].Title`
+`CodeBlock`: Added `@tag` argument to `[CB].Title`
 
-`DialogPrimitive`: Add `@titleTag` argument to `DialogPrimitive::Header`
+`DialogPrimitive`: Added `@titleTag` argument to `DialogPrimitive::Header`

--- a/.changeset/gentle-cows-remain.md
+++ b/.changeset/gentle-cows-remain.md
@@ -1,0 +1,13 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Accordion`: Add `@titleTag` argument
+
+`Alert`: Add `@tag` argument to `[A].Title`
+
+`ApplicationState`: Update the `@titleTag` argument to only accept `"div" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"`
+
+`CodeBlock`: Add `@tag` argument to `[CB].Title`
+
+`DialogPrimitive`: Add `@titleTag` argument to `DialogPrimitive::Header`

--- a/packages/components/src/components/hds/accordion/index.hbs
+++ b/packages/components/src/components/hds/accordion/index.hbs
@@ -4,5 +4,9 @@
 }}
 
 <div class={{this.classNames}} ...attributes>
-  {{yield (hash Item=(component "hds/accordion/item" size=this.size type=this.type forceState=@forceState))}}
+  {{yield
+    (hash
+      Item=(component "hds/accordion/item" titleTag=this.titleTag size=this.size type=this.type forceState=@forceState)
+    )
+  }}
 </div>

--- a/packages/components/src/components/hds/accordion/index.ts
+++ b/packages/components/src/components/hds/accordion/index.ts
@@ -56,11 +56,6 @@ export default class HdsAccordionComponent extends Component<HdsAccordionSignatu
     return size;
   }
 
-  /**
-   * @param titleTag
-   * @type {HdsAccordionItemTitleTags}
-   * @default 'div'
-   */
   get titleTag(): HdsAccordionItemTitleTags {
     return this.args.titleTag ?? HdsAccordionItemTitleTagValues.Div;
   }

--- a/packages/components/src/components/hds/accordion/index.ts
+++ b/packages/components/src/components/hds/accordion/index.ts
@@ -14,6 +14,7 @@ import type {
   HdsAccordionForceStates,
   HdsAccordionSizes,
   HdsAccordionTypes,
+  HdsAccordionItemTags,
 } from './types.ts';
 
 interface HdsAccordionSignature {
@@ -21,6 +22,7 @@ interface HdsAccordionSignature {
     size?: HdsAccordionSizes;
     type?: HdsAccordionTypes;
     forceState?: HdsAccordionForceStates;
+    titleTag?: HdsAccordionItemTags;
   };
   Blocks: {
     default: [
@@ -51,6 +53,15 @@ export default class HdsAccordionComponent extends Component<HdsAccordionSignatu
     );
 
     return size;
+  }
+
+  /**
+   * @param titleTag
+   * @type {HdsAccordionItemTags}
+   * @default 'div'
+   */
+  get titleTag(): HdsAccordionItemTags {
+    return this.args.titleTag ?? 'div';
   }
 
   /**

--- a/packages/components/src/components/hds/accordion/index.ts
+++ b/packages/components/src/components/hds/accordion/index.ts
@@ -9,12 +9,13 @@ import { assert } from '@ember/debug';
 import { SIZES, DEFAULT_SIZE, TYPES, DEFAULT_TYPE } from './item/index.ts';
 
 import type { ComponentLike } from '@glint/template';
+import { HdsAccordionItemTitleTagValues } from './types.ts';
 import type { HdsAccordionItemSignature } from './item/index.ts';
 import type {
   HdsAccordionForceStates,
   HdsAccordionSizes,
   HdsAccordionTypes,
-  HdsAccordionItemTags,
+  HdsAccordionItemTitleTags,
 } from './types.ts';
 
 interface HdsAccordionSignature {
@@ -22,7 +23,7 @@ interface HdsAccordionSignature {
     size?: HdsAccordionSizes;
     type?: HdsAccordionTypes;
     forceState?: HdsAccordionForceStates;
-    titleTag?: HdsAccordionItemTags;
+    titleTag?: HdsAccordionItemTitleTags;
   };
   Blocks: {
     default: [
@@ -57,11 +58,11 @@ export default class HdsAccordionComponent extends Component<HdsAccordionSignatu
 
   /**
    * @param titleTag
-   * @type {HdsAccordionItemTags}
+   * @type {HdsAccordionItemTitleTags}
    * @default 'div'
    */
-  get titleTag(): HdsAccordionItemTags {
-    return this.args.titleTag ?? 'div';
+  get titleTag(): HdsAccordionItemTitleTags {
+    return this.args.titleTag ?? HdsAccordionItemTitleTagValues.Div;
   }
 
   /**

--- a/packages/components/src/components/hds/accordion/item/index.hbs
+++ b/packages/components/src/components/hds/accordion/item/index.hbs
@@ -21,7 +21,7 @@
       />
 
       <Hds::Text::Body
-        @tag="div"
+        @tag={{this.titleTag}}
         @size={{this.toggleTextSize}}
         @weight="semibold"
         @color="strong"

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -132,11 +132,6 @@ export default class HdsAccordionItemComponent extends Component<HdsAccordionIte
     return type;
   }
 
-  /**
-   * @param titleTag
-   * @type {HdsAccordionItemTitleTags}
-   * @default 'div'
-   */
   get titleTag(): HdsAccordionItemTitleTags {
     return this.args.titleTag ?? HdsAccordionItemTitleTagValues.Div;
   }

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -12,6 +12,7 @@ import type {
   HdsAccordionForceStates,
   HdsAccordionSizes,
   HdsAccordionTypes,
+  HdsAccordionItemTags,
 } from '../types.ts';
 
 export const SIZES: string[] = Object.values(HdsAccordionSizeValues);
@@ -29,14 +30,15 @@ const TEXT_SIZE_MAP = {
 export interface HdsAccordionItemSignature {
   Args: {
     ariaLabel?: string;
+    containsInteractive?: boolean;
+    forceState?: HdsAccordionForceStates;
     isOpen?: boolean;
     isStatic?: boolean;
-    containsInteractive?: boolean;
-    size?: HdsAccordionSizes;
-    type?: HdsAccordionTypes;
-    forceState?: HdsAccordionForceStates;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onClickToggle?: (event: MouseEvent, ...args: any[]) => void;
+    size?: HdsAccordionSizes;
+    titleTag?: HdsAccordionItemTags;
+    type?: HdsAccordionTypes;
   };
   Blocks: {
     toggle?: [];
@@ -124,6 +126,15 @@ export default class HdsAccordionItemComponent extends Component<HdsAccordionIte
     );
 
     return type;
+  }
+
+  /**
+   * @param titleTag
+   * @type {HdsAccordionItemTags}
+   * @default 'div'
+   */
+  get titleTag(): HdsAccordionItemTags {
+    return this.args.titleTag ?? 'div';
   }
 
   /**

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -7,12 +7,16 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
 
-import { HdsAccordionSizeValues, HdsAccordionTypeValues } from '../types.ts';
+import {
+  HdsAccordionSizeValues,
+  HdsAccordionTypeValues,
+  HdsAccordionItemTitleTagValues,
+} from '../types.ts';
 import type {
   HdsAccordionForceStates,
   HdsAccordionSizes,
   HdsAccordionTypes,
-  HdsAccordionItemTags,
+  HdsAccordionItemTitleTags,
 } from '../types.ts';
 
 export const SIZES: string[] = Object.values(HdsAccordionSizeValues);
@@ -37,7 +41,7 @@ export interface HdsAccordionItemSignature {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onClickToggle?: (event: MouseEvent, ...args: any[]) => void;
     size?: HdsAccordionSizes;
-    titleTag?: HdsAccordionItemTags;
+    titleTag?: HdsAccordionItemTitleTags;
     type?: HdsAccordionTypes;
   };
   Blocks: {
@@ -130,11 +134,11 @@ export default class HdsAccordionItemComponent extends Component<HdsAccordionIte
 
   /**
    * @param titleTag
-   * @type {HdsAccordionItemTags}
+   * @type {HdsAccordionItemTitleTags}
    * @default 'div'
    */
-  get titleTag(): HdsAccordionItemTags {
-    return this.args.titleTag ?? 'div';
+  get titleTag(): HdsAccordionItemTitleTags {
+    return this.args.titleTag ?? HdsAccordionItemTitleTagValues.Div;
   }
 
   /**

--- a/packages/components/src/components/hds/accordion/types.ts
+++ b/packages/components/src/components/hds/accordion/types.ts
@@ -22,7 +22,7 @@ export enum HdsAccordionForceStateValues {
 }
 export type HdsAccordionForceStates = `${HdsAccordionForceStateValues}`;
 
-export enum HdsAccordionItemTagValues {
+export enum HdsAccordionItemTitleTagValues {
   Div = 'div',
   H1 = 'h1',
   H2 = 'h2',
@@ -32,4 +32,4 @@ export enum HdsAccordionItemTagValues {
   H6 = 'h6',
 }
 
-export type HdsAccordionItemTags = `${HdsAccordionItemTagValues}`;
+export type HdsAccordionItemTitleTags = `${HdsAccordionItemTitleTagValues}`;

--- a/packages/components/src/components/hds/accordion/types.ts
+++ b/packages/components/src/components/hds/accordion/types.ts
@@ -21,3 +21,15 @@ export enum HdsAccordionForceStateValues {
   Close = 'close',
 }
 export type HdsAccordionForceStates = `${HdsAccordionForceStateValues}`;
+
+export enum HdsAccordionItemTagValues {
+  Div = 'div',
+  H1 = 'h1',
+  H2 = 'h2',
+  H3 = 'h3',
+  H4 = 'h4',
+  H5 = 'h5',
+  H6 = 'h6',
+}
+
+export type HdsAccordionItemTags = `${HdsAccordionItemTagValues}`;

--- a/packages/components/src/components/hds/alert/title.hbs
+++ b/packages/components/src/components/hds/alert/title.hbs
@@ -2,4 +2,8 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class="hds-alert__title hds-font-weight-semibold" ...attributes>{{yield}}</div>
+{{! IMPORTANT: we removed any extra newlines before/after the `let` to reduce the issues with unexpected whitespaces (see https://github.com/hashicorp/design-system/pull/1652) }}
+{{#let (element this.componentTag) as |Tag|}}<Tag
+    class="hds-alert__title hds-typography-body-200 hds-font-weight-semibold"
+    ...attributes
+  >{{yield}}</Tag>{{/let}}

--- a/packages/components/src/components/hds/alert/title.ts
+++ b/packages/components/src/components/hds/alert/title.ts
@@ -4,10 +4,11 @@
  */
 
 import Component from '@glimmer/component';
-import type { HdsAlertTags } from './types';
+import { HdsAlertTitleTagValues } from './types.ts';
+import type { HdsAlertTitleTags } from './types';
 export interface HdsAlertTitleSignature {
   Args: {
-    tag?: HdsAlertTags;
+    tag?: HdsAlertTitleTags;
   };
   Blocks: {
     default: [];
@@ -16,8 +17,8 @@ export interface HdsAlertTitleSignature {
 }
 
 class HdsAlertTitleComponent extends Component<HdsAlertTitleSignature> {
-  get componentTag(): HdsAlertTags {
-    return this.args.tag ?? 'div';
+  get componentTag(): HdsAlertTitleTags {
+    return this.args.tag ?? HdsAlertTitleTagValues.Div;
   }
 }
 

--- a/packages/components/src/components/hds/alert/title.ts
+++ b/packages/components/src/components/hds/alert/title.ts
@@ -3,15 +3,22 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import TemplateOnlyComponent from '@ember/component/template-only';
-
+import Component from '@glimmer/component';
+import type { HdsAlertTags } from './types';
 export interface HdsAlertTitleSignature {
+  Args: {
+    tag?: HdsAlertTags;
+  };
   Blocks: {
     default: [];
   };
   Element: HTMLDivElement;
 }
 
-const HdsAlertTitleComponent = TemplateOnlyComponent<HdsAlertTitleSignature>();
+class HdsAlertTitleComponent extends Component<HdsAlertTitleSignature> {
+  get componentTag(): HdsAlertTags {
+    return this.args.tag ?? 'div';
+  }
+}
 
 export default HdsAlertTitleComponent;

--- a/packages/components/src/components/hds/alert/types.ts
+++ b/packages/components/src/components/hds/alert/types.ts
@@ -18,3 +18,15 @@ export enum HdsAlertColorValues {
   Critical = 'critical',
 }
 export type HdsAlertColors = `${HdsAlertColorValues}`;
+
+export enum HdsAlertTagValues {
+  Div = 'div',
+  H1 = 'h1',
+  H2 = 'h2',
+  H3 = 'h3',
+  H4 = 'h4',
+  H5 = 'h5',
+  H6 = 'h6',
+}
+
+export type HdsAlertTags = `${HdsAlertTagValues}`;

--- a/packages/components/src/components/hds/alert/types.ts
+++ b/packages/components/src/components/hds/alert/types.ts
@@ -19,7 +19,7 @@ export enum HdsAlertColorValues {
 }
 export type HdsAlertColors = `${HdsAlertColorValues}`;
 
-export enum HdsAlertTagValues {
+export enum HdsAlertTitleTagValues {
   Div = 'div',
   H1 = 'h1',
   H2 = 'h2',
@@ -29,4 +29,4 @@ export enum HdsAlertTagValues {
   H6 = 'h6',
 }
 
-export type HdsAlertTags = `${HdsAlertTagValues}`;
+export type HdsAlertTitleTags = `${HdsAlertTitleTagValues}`;

--- a/packages/components/src/components/hds/application-state/header.ts
+++ b/packages/components/src/components/hds/application-state/header.ts
@@ -4,6 +4,7 @@
  */
 
 import Component from '@glimmer/component';
+import { HdsApplicationStateTitleTagValues } from './types.ts';
 
 import type { HdsIconSignature } from '../icon';
 import type { HdsApplicationStateTitleTags } from './types';
@@ -19,6 +20,6 @@ export interface HdsApplicationStateHeaderSignature {
 
 export default class HdsApplicationStateHeaderComponent extends Component<HdsApplicationStateHeaderSignature> {
   get titleTag(): HdsApplicationStateTitleTags {
-    return this.args.titleTag ?? 'div';
+    return this.args.titleTag ?? HdsApplicationStateTitleTagValues.Div;
   }
 }

--- a/packages/components/src/components/hds/application-state/header.ts
+++ b/packages/components/src/components/hds/application-state/header.ts
@@ -6,11 +6,11 @@
 import Component from '@glimmer/component';
 
 import type { HdsIconSignature } from '../icon';
-import type { HdsTextDisplaySignature } from '../text/display';
+import type { HdsApplicationStateTitleTags } from './types';
 export interface HdsApplicationStateHeaderSignature {
   Args: {
     title?: string;
-    titleTag?: HdsTextDisplaySignature['Args']['tag'];
+    titleTag?: HdsApplicationStateTitleTags;
     errorCode?: string;
     icon?: HdsIconSignature['Args']['name'];
   };
@@ -18,7 +18,7 @@ export interface HdsApplicationStateHeaderSignature {
 }
 
 export default class HdsApplicationStateHeaderComponent extends Component<HdsApplicationStateHeaderSignature> {
-  get titleTag() {
+  get titleTag(): HdsApplicationStateTitleTags {
     return this.args.titleTag ?? 'div';
   }
 }

--- a/packages/components/src/components/hds/application-state/types.ts
+++ b/packages/components/src/components/hds/application-state/types.ts
@@ -19,9 +19,4 @@ export enum HdsApplicationStateTitleTagValues {
   H6 = 'h6',
 }
 
-<<<<<<< HEAD
 export type HdsApplicationStateTitleTags = `${HdsApplicationStateTitleTagValues}`;
-=======
-export type HdsApplicationStateTitleTags =
-  `${HdsApplicationStateTitleTagValues}`;
->>>>>>> 32f391db3 (fix: implement feedback)

--- a/packages/components/src/components/hds/application-state/types.ts
+++ b/packages/components/src/components/hds/application-state/types.ts
@@ -19,4 +19,5 @@ export enum HdsApplicationStateTitleTagValues {
   H6 = 'h6',
 }
 
-export type HdsApplicationStateTitleTags = `${HdsApplicationStateTitleTagValues}`;
+export type HdsApplicationStateTitleTags =
+  `${HdsApplicationStateTitleTagValues}`;

--- a/packages/components/src/components/hds/application-state/types.ts
+++ b/packages/components/src/components/hds/application-state/types.ts
@@ -8,3 +8,15 @@ export enum HdsApplicationStateAlignValues {
   Center = 'center',
 }
 export type HdsApplicationStateAligns = `${HdsApplicationStateAlignValues}`;
+
+export enum HdsApplicationStateTitleTagValues {
+  Div = 'div',
+  H1 = 'h1',
+  H2 = 'h2',
+  H3 = 'h3',
+  H4 = 'h4',
+  H5 = 'h5',
+  H6 = 'h6',
+}
+
+export type HdsApplicationStateTitleTags = `${HdsApplicationStateTitleTagValues}`;

--- a/packages/components/src/components/hds/application-state/types.ts
+++ b/packages/components/src/components/hds/application-state/types.ts
@@ -19,4 +19,9 @@ export enum HdsApplicationStateTitleTagValues {
   H6 = 'h6',
 }
 
+<<<<<<< HEAD
 export type HdsApplicationStateTitleTags = `${HdsApplicationStateTitleTagValues}`;
+=======
+export type HdsApplicationStateTitleTags =
+  `${HdsApplicationStateTitleTagValues}`;
+>>>>>>> 32f391db3 (fix: implement feedback)

--- a/packages/components/src/components/hds/code-block/title.hbs
+++ b/packages/components/src/components/hds/code-block/title.hbs
@@ -3,6 +3,6 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<Hds::Text::Body @size="200" @tag="p" @weight="semibold" class="hds-code-block__title" ...attributes>
+<Hds::Text::Body @size="200" @tag={{this.componentTag}} @weight="semibold" class="hds-code-block__title" ...attributes>
   {{yield}}
 </Hds::Text::Body>

--- a/packages/components/src/components/hds/code-block/title.ts
+++ b/packages/components/src/components/hds/code-block/title.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 import Component from '@glimmer/component';
+import { HdsCodeBlockTitleTagValues } from './types.ts';
 import type { HdsCodeBlockTitleTags } from './types';
 import type { HdsTextBodySignature } from '../text/body';
 
@@ -18,7 +19,7 @@ export interface HdsCodeBlockTitleSignature {
 
 class HdsCodeBlockTitleComponent extends Component<HdsCodeBlockTitleSignature> {
   get componentTag(): HdsCodeBlockTitleTags {
-    return this.args.tag ?? 'p';
+    return this.args.tag ?? HdsCodeBlockTitleTagValues.P;
   }
 }
 

--- a/packages/components/src/components/hds/code-block/title.ts
+++ b/packages/components/src/components/hds/code-block/title.ts
@@ -2,18 +2,24 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-import templateOnlyComponent from '@ember/component/template-only';
+import Component from '@glimmer/component';
+import type { HdsCodeBlockTitleTags } from './types';
 import type { HdsTextBodySignature } from '../text/body';
 
 export interface HdsCodeBlockTitleSignature {
+  Args: {
+    tag?: HdsCodeBlockTitleTags;
+  };
   Blocks: {
     default: [];
   };
   Element: HdsTextBodySignature['Element'];
 }
 
-const HdsCodeBlockTitleComponent =
-  templateOnlyComponent<HdsCodeBlockTitleSignature>();
+class HdsCodeBlockTitleComponent extends Component<HdsCodeBlockTitleSignature> {
+  get componentTag(): HdsCodeBlockTitleTags {
+    return this.args.tag ?? 'p';
+  }
+}
 
 export default HdsCodeBlockTitleComponent;

--- a/packages/components/src/components/hds/code-block/types.ts
+++ b/packages/components/src/components/hds/code-block/types.ts
@@ -15,3 +15,15 @@ export enum HdsCodeBlockLanguageValues {
 }
 
 export type HdsCodeBlockLanguages = `${HdsCodeBlockLanguageValues}`;
+
+export enum HdsCodeBlockTitleTagValues {
+  P = 'p',
+  H1 = 'h1',
+  H2 = 'h2',
+  H3 = 'h3',
+  H4 = 'h4',
+  H5 = 'h5',
+  H6 = 'h6',
+}
+
+export type HdsCodeBlockTitleTags = `${HdsCodeBlockTitleTagValues}`;

--- a/packages/components/src/components/hds/dialog-primitive/header.hbs
+++ b/packages/components/src/components/hds/dialog-primitive/header.hbs
@@ -14,24 +14,26 @@
     />
   {{/if}}
 
-  <div
-    class="hds-dialog-primitive__title {{if @contextualClassPrefix (concat @contextualClassPrefix '__title')}}"
-    id={{@id}}
-  >
-    {{#if @tagline}}
-      <Hds::Text::Body
-        class="hds-dialog-primitive__tagline {{if @contextualClassPrefix (concat @contextualClassPrefix '__tagline')}}"
-        @tag="div"
-        @size="100"
-      >
-        {{@tagline}}
-      </Hds::Text::Body>
-    {{/if}}
+  {{#let (element this.titleTag) as |Tag|}}<Tag
+      class="hds-dialog-primitive__title {{if @contextualClassPrefix (concat @contextualClassPrefix '__title')}}"
+      id={{@id}}
+    >
+      {{#if @tagline}}
+        <Hds::Text::Body
+          class="hds-dialog-primitive__tagline
+            {{if @contextualClassPrefix (concat @contextualClassPrefix '__tagline')}}"
+          @tag="div"
+          @size="100"
+        >
+          {{@tagline}}
+        </Hds::Text::Body>
+      {{/if}}
 
-    <Hds::Text::Display @tag="div" @size="300" @weight="semibold">
-      {{yield}}
-    </Hds::Text::Display>
-  </div>
+      <Hds::Text::Display @tag="div" @size="300" @weight="semibold">
+        {{yield}}
+      </Hds::Text::Display>
+    </Tag>
+  {{/let}}
 
   <Hds::DismissButton
     class="hds-dialog-primitive__dismiss {{if @contextualClassPrefix (concat @contextualClassPrefix '__dismiss')}}"

--- a/packages/components/src/components/hds/dialog-primitive/header.ts
+++ b/packages/components/src/components/hds/dialog-primitive/header.ts
@@ -27,11 +27,6 @@ export interface HdsDialogPrimitiveHeaderSignature {
 const NOOP = (): void => {};
 
 export default class HdsDialogPrimitiveHeaderComponent extends Component<HdsDialogPrimitiveHeaderSignature> {
-  /**
-   * @param titleTag
-   * @type {HdsDialogPrimitiveHeaderTags}
-   * @default 'div'
-   */
   get titleTag(): HdsDialogPrimitiveHeaderTitleTags {
     return this.args.titleTag ?? HdsDialogPrimitiveHeaderTitleTagValues.Div;
   }

--- a/packages/components/src/components/hds/dialog-primitive/header.ts
+++ b/packages/components/src/components/hds/dialog-primitive/header.ts
@@ -6,6 +6,7 @@
 import Component from '@glimmer/component';
 import type { HdsIconSignature } from '../icon';
 import type { HdsDialogPrimitiveHeaderTitleTags } from './types';
+import { HdsDialogPrimitiveHeaderTitleTagValues } from './types.ts';
 
 export interface HdsDialogPrimitiveHeaderSignature {
   Args: {
@@ -32,7 +33,7 @@ export default class HdsDialogPrimitiveHeaderComponent extends Component<HdsDial
    * @default 'div'
    */
   get titleTag(): HdsDialogPrimitiveHeaderTitleTags {
-    return this.args.titleTag ?? 'div';
+    return this.args.titleTag ?? HdsDialogPrimitiveHeaderTitleTagValues.Div;
   }
 
   /**

--- a/packages/components/src/components/hds/dialog-primitive/header.ts
+++ b/packages/components/src/components/hds/dialog-primitive/header.ts
@@ -5,15 +5,17 @@
 
 import Component from '@glimmer/component';
 import type { HdsIconSignature } from '../icon';
+import type { HdsDialogPrimitiveHeaderTitleTags } from './types';
 
 export interface HdsDialogPrimitiveHeaderSignature {
   Args: {
     contextualClassPrefix?: string;
     id?: string;
-    tagline?: string;
     icon?: HdsIconSignature['Args']['name'];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onDismiss?: (event: MouseEvent, ...args: any[]) => void;
+    titleTag?: HdsDialogPrimitiveHeaderTitleTags;
+    tagline?: string;
   };
   Blocks: {
     default: [];
@@ -24,6 +26,15 @@ export interface HdsDialogPrimitiveHeaderSignature {
 const NOOP = (): void => {};
 
 export default class HdsDialogPrimitiveHeaderComponent extends Component<HdsDialogPrimitiveHeaderSignature> {
+  /**
+   * @param titleTag
+   * @type {HdsDialogPrimitiveHeaderTags}
+   * @default 'div'
+   */
+  get titleTag(): HdsDialogPrimitiveHeaderTitleTags {
+    return this.args.titleTag ?? 'div';
+  }
+
   /**
    * @param onDismiss
    * @type {function}

--- a/packages/components/src/components/hds/dialog-primitive/types.ts
+++ b/packages/components/src/components/hds/dialog-primitive/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export enum HdsDialogPrimitiveHeaderTitleTagValues {
+  P = 'div',
+  H1 = 'h1',
+  H2 = 'h2',
+  H3 = 'h3',
+  H4 = 'h4',
+  H5 = 'h5',
+  H6 = 'h6',
+}
+
+export type HdsDialogPrimitiveHeaderTitleTags =
+  `${HdsDialogPrimitiveHeaderTitleTagValues}`;

--- a/packages/components/src/components/hds/dialog-primitive/types.ts
+++ b/packages/components/src/components/hds/dialog-primitive/types.ts
@@ -4,7 +4,7 @@
  */
 
 export enum HdsDialogPrimitiveHeaderTitleTagValues {
-  P = 'div',
+  Div = 'div',
   H1 = 'h1',
   H2 = 'h2',
   H3 = 'h3',

--- a/packages/components/src/styles/components/dialog-primitive.scss
+++ b/packages/components/src/styles/components/dialog-primitive.scss
@@ -10,6 +10,7 @@
 $hds-dialog-primitive-horizontal-padding: 24px;
 $hds-dialog-primitive-vertical-padding: 16px;
 
+
 // WRAPPER CONTAINER (<dialog>)
 
 // The special declaration below is used to allow the `<dialog>` to unset
@@ -32,6 +33,7 @@ $hds-dialog-primitive-vertical-padding: 16px;
   background: var(--token-color-surface-primary);
 }
 
+
 // Note: this wraps both .hds-dialog-primitive__header & .hds-dialog-primitive__description
 .hds-dialog-primitive__wrapper-header {
   flex: none;
@@ -41,7 +43,7 @@ $hds-dialog-primitive-vertical-padding: 16px;
   border-top-right-radius: inherit;
 
   // because of the way in which Ember generates whitespace, we need to use this complicated selector to hide the container when it's "empty" (no children)
-  &:not(:has(> *)) {
+  &:not(:has( > *)) {
     display: none;
   }
 }
@@ -62,10 +64,11 @@ $hds-dialog-primitive-vertical-padding: 16px;
   border-bottom-left-radius: inherit;
 
   // because of the way in which Ember generates whitespace, we need to use this complicated selector to hide the container when it's "empty" (no children)
-  &:not(:has(> *)) {
+  &:not(:has( > *)) {
     display: none;
   }
 }
+
 
 // HEADER
 
@@ -73,11 +76,8 @@ $hds-dialog-primitive-vertical-padding: 16px;
   display: flex;
   gap: 16px;
   align-items: flex-start;
-  padding: $hds-dialog-primitive-vertical-padding
-    $hds-dialog-primitive-horizontal-padding;
-  color: var(
-    --token-color-foreground-strong
-  ); // default color (applied to both the title and the icon)
+  padding: $hds-dialog-primitive-vertical-padding $hds-dialog-primitive-horizontal-padding;
+  color: var(--token-color-foreground-strong); // default color (applied to both the title and the icon)
   border-top-left-radius: inherit;
   border-top-right-radius: inherit;
 }
@@ -101,13 +101,14 @@ $hds-dialog-primitive-vertical-padding: 16px;
   align-self: flex-start;
 }
 
+
 // DESCRIPTION
 // (currently used only in Flyout, not in Modal)
 
 .hds-dialog-primitive__description {
-  padding: 0 $hds-dialog-primitive-horizontal-padding
-    $hds-dialog-primitive-vertical-padding;
+  padding: 0 $hds-dialog-primitive-horizontal-padding $hds-dialog-primitive-vertical-padding;
 }
+
 
 // BODY
 
@@ -115,11 +116,11 @@ $hds-dialog-primitive-vertical-padding: 16px;
   padding: $hds-dialog-primitive-horizontal-padding;
 }
 
+
 // FOOTER
 
 .hds-dialog-primitive__footer {
-  padding: $hds-dialog-primitive-vertical-padding
-    $hds-dialog-primitive-horizontal-padding;
+  padding: $hds-dialog-primitive-vertical-padding $hds-dialog-primitive-horizontal-padding;
   background: var(--token-color-surface-faint);
   border-bottom-right-radius: inherit;
   border-bottom-left-radius: inherit;

--- a/packages/components/src/styles/components/dialog-primitive.scss
+++ b/packages/components/src/styles/components/dialog-primitive.scss
@@ -10,7 +10,6 @@
 $hds-dialog-primitive-horizontal-padding: 24px;
 $hds-dialog-primitive-vertical-padding: 16px;
 
-
 // WRAPPER CONTAINER (<dialog>)
 
 // The special declaration below is used to allow the `<dialog>` to unset
@@ -33,7 +32,6 @@ $hds-dialog-primitive-vertical-padding: 16px;
   background: var(--token-color-surface-primary);
 }
 
-
 // Note: this wraps both .hds-dialog-primitive__header & .hds-dialog-primitive__description
 .hds-dialog-primitive__wrapper-header {
   flex: none;
@@ -43,7 +41,7 @@ $hds-dialog-primitive-vertical-padding: 16px;
   border-top-right-radius: inherit;
 
   // because of the way in which Ember generates whitespace, we need to use this complicated selector to hide the container when it's "empty" (no children)
-  &:not(:has( > *)) {
+  &:not(:has(> *)) {
     display: none;
   }
 }
@@ -64,11 +62,10 @@ $hds-dialog-primitive-vertical-padding: 16px;
   border-bottom-left-radius: inherit;
 
   // because of the way in which Ember generates whitespace, we need to use this complicated selector to hide the container when it's "empty" (no children)
-  &:not(:has( > *)) {
+  &:not(:has(> *)) {
     display: none;
   }
 }
-
 
 // HEADER
 
@@ -76,8 +73,11 @@ $hds-dialog-primitive-vertical-padding: 16px;
   display: flex;
   gap: 16px;
   align-items: flex-start;
-  padding: $hds-dialog-primitive-vertical-padding $hds-dialog-primitive-horizontal-padding;
-  color: var(--token-color-foreground-strong); // default color (applied to both the title and the icon)
+  padding: $hds-dialog-primitive-vertical-padding
+    $hds-dialog-primitive-horizontal-padding;
+  color: var(
+    --token-color-foreground-strong
+  ); // default color (applied to both the title and the icon)
   border-top-left-radius: inherit;
   border-top-right-radius: inherit;
 }
@@ -89,6 +89,7 @@ $hds-dialog-primitive-vertical-padding: 16px;
 
 .hds-dialog-primitive__title {
   flex-grow: 1;
+  margin: 0;
 }
 
 .hds-dialog-primitive__tagline {
@@ -100,14 +101,13 @@ $hds-dialog-primitive-vertical-padding: 16px;
   align-self: flex-start;
 }
 
-
 // DESCRIPTION
 // (currently used only in Flyout, not in Modal)
 
 .hds-dialog-primitive__description {
-  padding: 0 $hds-dialog-primitive-horizontal-padding $hds-dialog-primitive-vertical-padding;
+  padding: 0 $hds-dialog-primitive-horizontal-padding
+    $hds-dialog-primitive-vertical-padding;
 }
-
 
 // BODY
 
@@ -115,11 +115,11 @@ $hds-dialog-primitive-vertical-padding: 16px;
   padding: $hds-dialog-primitive-horizontal-padding;
 }
 
-
 // FOOTER
 
 .hds-dialog-primitive__footer {
-  padding: $hds-dialog-primitive-vertical-padding $hds-dialog-primitive-horizontal-padding;
+  padding: $hds-dialog-primitive-vertical-padding
+    $hds-dialog-primitive-horizontal-padding;
   background: var(--token-color-surface-faint);
   border-bottom-right-radius: inherit;
   border-bottom-left-radius: inherit;

--- a/showcase/app/templates/components/accordion.hbs
+++ b/showcase/app/templates/components/accordion.hbs
@@ -409,6 +409,27 @@
 
   <Shw::Divider @level={{2}} />
 
+  <Shw::Text::H3>Custom title tag</Shw::Text::H3>
+
+  <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
+    {{#each @model.TYPES as |type|}}
+      <SG.Item @label="With a custom title tag">
+        <Hds::Accordion @type={{type}} @titleTag="h2" as |A|>
+          <A.Item>
+            <:toggle>
+              Item one
+            </:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+        </Hds::Accordion>
+      </SG.Item>
+    {{/each}}
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Edge cases</Shw::Text::H3>
 
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>

--- a/showcase/app/templates/components/alert.hbs
+++ b/showcase/app/templates/components/alert.hbs
@@ -244,4 +244,27 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Text::H2>With a custom title tag</Shw::Text::H2>
+
+  <Shw::Grid @columns={{2}} as |SG|>
+    <SG.Item>
+      <Hds::Alert @type="inline" @color="neutral" as |A|>
+        <A.Title @tag="h1">Lorem ipsum dolor</A.Title>
+        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
+      </Hds::Alert>
+    </SG.Item>
+    <SG.Item>
+      <Hds::Alert @type="page" @color="neutral" as |A|>
+        <A.Title @tag="h2">Lorem ipsum dolor</A.Title>
+        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
+      </Hds::Alert>
+    </SG.Item>
+    <SG.Item>
+      <Hds::Alert @type="compact" @color="neutral" as |A|>
+        <A.Title @tag="h3">Without the dismiss button (default)</A.Title>
+        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
+      </Hds::Alert>
+    </SG.Item>
+  </Shw::Grid>
+
 </section>

--- a/showcase/app/templates/components/alert.hbs
+++ b/showcase/app/templates/components/alert.hbs
@@ -176,6 +176,29 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Text::H3>With a custom title tag</Shw::Text::H3>
+
+  <Shw::Grid @columns={{2}} as |SG|>
+    <SG.Item>
+      <Hds::Alert @type="inline" @color="neutral" as |A|>
+        <A.Title @tag="h1">Lorem ipsum dolor</A.Title>
+        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
+      </Hds::Alert>
+    </SG.Item>
+    <SG.Item>
+      <Hds::Alert @type="page" @color="neutral" as |A|>
+        <A.Title @tag="h2">Lorem ipsum dolor</A.Title>
+        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
+      </Hds::Alert>
+    </SG.Item>
+    <SG.Item>
+      <Hds::Alert @type="compact" @color="neutral" as |A|>
+        <A.Title @tag="h3">Without the dismiss button (default)</A.Title>
+        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
+      </Hds::Alert>
+    </SG.Item>
+  </Shw::Grid>
+
   <Shw::Text::H2>Actions</Shw::Text::H2>
 
   <Shw::Grid @columns={{2}} as |SG|>
@@ -240,29 +263,6 @@
     <SG.Item>
       <Hds::Alert @type="inline" @color="neutral" @onDismiss={{this.noop}} as |A|>
         <A.Description>With the dismiss button and no title</A.Description>
-      </Hds::Alert>
-    </SG.Item>
-  </Shw::Grid>
-
-  <Shw::Text::H2>With a custom title tag</Shw::Text::H2>
-
-  <Shw::Grid @columns={{2}} as |SG|>
-    <SG.Item>
-      <Hds::Alert @type="inline" @color="neutral" as |A|>
-        <A.Title @tag="h1">Lorem ipsum dolor</A.Title>
-        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
-      </Hds::Alert>
-    </SG.Item>
-    <SG.Item>
-      <Hds::Alert @type="page" @color="neutral" as |A|>
-        <A.Title @tag="h2">Lorem ipsum dolor</A.Title>
-        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
-      </Hds::Alert>
-    </SG.Item>
-    <SG.Item>
-      <Hds::Alert @type="compact" @color="neutral" as |A|>
-        <A.Title @tag="h3">Without the dismiss button (default)</A.Title>
-        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
       </Hds::Alert>
     </SG.Item>
   </Shw::Grid>

--- a/showcase/app/templates/components/code-block.hbs
+++ b/showcase/app/templates/components/code-block.hbs
@@ -62,7 +62,6 @@ console.log(`I am ${codeLang} code`);"
         <CB.Title>Title</CB.Title>
       </Hds::CodeBlock>
     </SG.Item>
-
     <SG.Item @label="description">
       <Hds::CodeBlock @value="console.log('I am JavaScript code');" @language="javascript" as |CB|>
         <CB.Description>Description</CB.Description>
@@ -80,6 +79,11 @@ console.log(`I am ${codeLang} code`);"
           or even
           <code>code</code>.
         </CB.Description>
+      </Hds::CodeBlock>
+    </SG.Item>
+    <SG.Item @label="custom title tag">
+      <Hds::CodeBlock @value="console.log('I am JavaScript code');" @language="javascript" as |CB|>
+        <CB.Title @tag="h2">Title</CB.Title>
       </Hds::CodeBlock>
     </SG.Item>
   </Shw::Grid>

--- a/showcase/app/templates/utilities/dialog-primitive.hbs
+++ b/showcase/app/templates/utilities/dialog-primitive.hbs
@@ -202,6 +202,20 @@
         </Hds::DialogPrimitive::Header>
       </div>
     </SF.Item>
+    <SF.Item @label="as H1">
+      <div class="hds-dialog-primitive__wrapper-header">
+        <Hds::DialogPrimitive::Header @tagline="Tagline" @tag="h1" @onDismiss={{this.onDismiss}}>
+          Title
+        </Hds::DialogPrimitive::Header>
+      </div>
+    </SF.Item>
+    <SF.Item @label="as H2">
+      <div class="hds-dialog-primitive__wrapper-header">
+        <Hds::DialogPrimitive::Header @tagline="Tagline" @tag="h2" @onDismiss={{this.onDismiss}}>
+          Title
+        </Hds::DialogPrimitive::Header>
+      </div>
+    </SF.Item>
   </Shw::Flex>
 
   <Shw::Divider />

--- a/showcase/tests/integration/components/hds/accordion/index-test.js
+++ b/showcase/tests/integration/components/hds/accordion/index-test.js
@@ -48,6 +48,30 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
     assert.dom('#test-em').exists().hasText('Content one');
   });
 
+  test('it renders a div when the @titleTag argument is not provided', async function (assert) {
+    await render(hbs`
+      <Hds::Accordion as |A|>
+        <A.Item>
+          <:toggle>Item one</:toggle>
+          <:content>Content one</:content>
+        </A.Item>
+      </Hds::Accordion>
+    `);
+    assert.dom('.hds-accordion-item__toggle-content').hasTagName('div');
+  });
+
+  test('it renders the custom title tag when the @titleTag argument is provided', async function (assert) {
+    await render(hbs`
+      <Hds::Accordion @titleTag='h2' as |A|>
+        <A.Item>
+          <:toggle>Item one</:toggle>
+          <:content>Content one</:content>
+        </A.Item>
+      </Hds::Accordion>
+    `);
+    assert.dom('.hds-accordion-item__toggle-content').hasTagName('h2');
+  });
+
   // SIZE
 
   test('it should render the medium size as the default if no @size is declared', async function (assert) {

--- a/showcase/tests/integration/components/hds/alert/index-test.js
+++ b/showcase/tests/integration/components/hds/alert/index-test.js
@@ -80,17 +80,17 @@ module('Integration | Component | hds/alert/index', function (hooks) {
     assert.dom('.hds-alert__description code').exists().hasText('code');
     assert.dom('.hds-alert__description a').exists().hasText('link');
   });
-  test('it should render a div when the @titleTag argument is not provided', async function (assert) {
+  test('it should render a div when the @tag argument is not provided', async function (assert) {
     await render(hbs`
       <Hds::Alert @type="inline" as |A|>
         <A.Title>This is the title</A.Title>
       </Hds::Alert>`);
     assert.dom('.hds-alert__title').hasTagName('div');
   });
-  test('it should render the custom title tag when the @titleTag argument is provided', async function (assert) {
+  test('it should render the custom title tag when the @tag argument is provided', async function (assert) {
     await render(hbs`
-      <Hds::Alert @type="inline" @titleTag="h2" as |A|>
-        <A.Title>This is the title</A.Title>
+      <Hds::Alert @type="inline" as |A|>
+        <A.Title @tag="h2">This is the title</A.Title>
       </Hds::Alert>`);
     assert.dom('.hds-alert__title').hasTagName('h2');
   });

--- a/showcase/tests/integration/components/hds/alert/index-test.js
+++ b/showcase/tests/integration/components/hds/alert/index-test.js
@@ -80,6 +80,20 @@ module('Integration | Component | hds/alert/index', function (hooks) {
     assert.dom('.hds-alert__description code').exists().hasText('code');
     assert.dom('.hds-alert__description a').exists().hasText('link');
   });
+  test('it should render a div when the @titleTag argument is not provided', async function (assert) {
+    await render(hbs`
+      <Hds::Alert @type="inline" as |A|>
+        <A.Title>This is the title</A.Title>
+      </Hds::Alert>`);
+    assert.dom('.hds-alert__title').hasTagName('div');
+  });
+  test('it should render the custom title tag when the @titleTag argument is provided', async function (assert) {
+    await render(hbs`
+      <Hds::Alert @type="inline" @titleTag="h2" as |A|>
+        <A.Title>This is the title</A.Title>
+      </Hds::Alert>`);
+    assert.dom('.hds-alert__title').hasTagName('h2');
+  });
 
   // ACTIONS
 

--- a/showcase/tests/integration/components/hds/code-block/index-test.js
+++ b/showcase/tests/integration/components/hds/code-block/index-test.js
@@ -68,6 +68,24 @@ module('Integration | Component | hds/code-block/index', function (hooks) {
     assert.dom('.hds-code-block__description').hasText('Description');
   });
 
+  test('it renders the title as a p when the @tag argument is not provided', async function (assert) {
+    await render(hbs`
+      <Hds::CodeBlock @value="console.log('Hello world');" id="test-code-block" as |CB|>
+        <CB.Title>Title</CB.Title>
+      </Hds::CodeBlock>
+    `);
+    assert.dom('.hds-code-block__title').hasTagName('p');
+  });
+
+  test('it renders the title as the custom title tag when the @tag argument is provided', async function (assert) {
+    await render(hbs`
+      <Hds::CodeBlock @value="console.log('Hello world');" id="test-code-block" as |CB|>
+        <CB.Title @tag='h2'>Title</CB.Title>
+      </Hds::CodeBlock>
+    `);
+    assert.dom('.hds-code-block__title').hasTagName('h2');
+  });
+
   // OPTIONS
 
   // isStandalone

--- a/showcase/tests/integration/components/hds/dialog-primitive/header-test.js
+++ b/showcase/tests/integration/components/hds/dialog-primitive/header-test.js
@@ -57,6 +57,24 @@ module(
       assert.dom('.hds-dialog-primitive__tagline').hasText('Tagline');
     });
 
+    test('it renders the title as a div when the @titleTag argument is not provided', async function (assert) {
+      await render(hbs`
+        <Hds::DialogPrimitive::Header @icon="info" @tagline="Tagline">
+          Title
+        </Hds::DialogPrimitive::Header>
+      `);
+      assert.dom('.hds-dialog-primitive__title').hasTagName('div');
+    });
+
+    test('it renders the title as a custom title tag when the @titleTag argument is provided', async function (assert) {
+      await render(hbs`
+        <Hds::DialogPrimitive::Header @icon="info" @tagline="Tagline" @titleTag='h1'>
+          Title
+        </Hds::DialogPrimitive::Header>
+      `);
+      assert.dom('.hds-dialog-primitive__title').hasTagName('h1');
+    });
+
     // CONTEXTUAL CLASSES
 
     test('it adds contextual classes to different DOM nodes using the `@contextualClassPrefix`', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add a `tag` or `titleTag` argument to the following components:
* Accordion
* Alert
* ApplicationState
* CodeBlock
* DialogPrimitive

**Note for reviewers:** It is probably easiest to review this PR by commit because each component was done in a separate commit.

### :hammer_and_wrench: Detailed description

The new argument accepts: "div" or "p", depending on which the component currently uses, and `"h1" | "h2" | "h3" | "h4" | "h5" | "h6"`

**Accordion**
* Add titleTag argument

**Alert**
* Add tag argument to Alert Title

**ApplicationState**
* Update the titleTag argument to only allow: `"div" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"`

**CodeBlock**
* Add tag argument to CodeBlock Header

**DialogPrimitive**
* add titleTag argument to DialogPrimitive Header
* update styles so changing the tag doesn't add margin

Also updates the showcase so there are examples of customized tags.

### :camera_flash: Screenshots

**The rendered HTML for Accordion when you pass `titleTag`**
![Screenshot 2024-08-21 at 4 08 21 PM](https://github.com/user-attachments/assets/b5ec57a7-b199-4e0d-b6ed-53f0f240a708)

### :link: External links

RFC: https://go.hashi.co/rfc/ds-087
Jira ticket: [HDS-3772](https://hashicorp.atlassian.net/browse/HDS-3772)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3772]: https://hashicorp.atlassian.net/browse/HDS-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ