### PR TITLE
Add VRT to `DialogPrimitive` components

### DIFF
--- a/showcase/tests/acceptance/percy-test.js
+++ b/showcase/tests/acceptance/percy-test.js
@@ -177,6 +177,9 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/overrides/power-select');
     await percySnapshot('PowerSelect');
 
+    await visit('/utilities/dialog-primitive');
+    await percySnapshot('DialogPrimitive');
+
     await visit('/utilities/dismiss-button');
     await percySnapshot('DismissButton');
 


### PR DESCRIPTION
### :pushpin: Summary

Reviewing #2353 revealed we don't have VRT setup for the `DialogPrimitive`. Some other utility components are also missing VRT (such as `DisclosurePrimitive` and `MenuPrimitive`) but that's because they are setup for manual, functional testing, whereas the `DialogPrimitive` subcomponents are more visual than functional.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
