### PR TITLE
`Modal`, `Flyout`: make title an H1

### DIFF
--- a/.changeset/old-pots-argue.md
+++ b/.changeset/old-pots-argue.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Flyout`: Changed the HTML element wrapping the tagline and title from a `<div>` to a `<h1>`
+
+`Modal`: Changed the HTML element wrapping the tagline and title from a `<div>` to a `<h1>`

--- a/packages/components/src/components/hds/flyout/index.hbs
+++ b/packages/components/src/components/hds/flyout/index.hbs
@@ -15,7 +15,11 @@
     {{yield
       (hash
         Header=(component
-          "hds/dialog-primitive/header" id=this.id onDismiss=this.onDismiss contextualClassPrefix="hds-flyout"
+          "hds/dialog-primitive/header"
+          id=this.id
+          onDismiss=this.onDismiss
+          contextualClassPrefix="hds-flyout"
+          titleTag="h1"
         )
         Description=(component "hds/dialog-primitive/description" contextualClass="hds-flyout__description")
       )

--- a/packages/components/src/components/hds/modal/index.hbs
+++ b/packages/components/src/components/hds/modal/index.hbs
@@ -15,7 +15,11 @@
     {{yield
       (hash
         Header=(component
-          "hds/dialog-primitive/header" id=this.id onDismiss=this.onDismiss contextualClassPrefix="hds-modal"
+          "hds/dialog-primitive/header"
+          id=this.id
+          onDismiss=this.onDismiss
+          contextualClassPrefix="hds-modal"
+          titleTag="h1"
         )
       )
     }}

--- a/showcase/app/templates/components/flyout.hbs
+++ b/showcase/app/templates/components/flyout.hbs
@@ -74,7 +74,7 @@
 
   <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H3>Body</Shw::Text::H3>
+  <Shw::Text::H3 @tag="h2">Body</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="With basic style" class="shw-component-flyout-sample-item">
@@ -108,7 +108,7 @@
 
   <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H3>Footer</Shw::Text::H3>
+  <Shw::Text::H3 @tag="h2">Footer</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="One action" class="shw-component-flyout-sample-item">

--- a/showcase/tests/integration/components/hds/flyout/index-test.js
+++ b/showcase/tests/integration/components/hds/flyout/index-test.js
@@ -113,6 +113,15 @@ module('Integration | Component | hds/flyout/index', function (hooks) {
     assert.dom('.hds-flyout__tagline').doesNotExist();
   });
 
+  test('it renders the title as an h1', async function (assert) {
+    await render(
+      hbs`<Hds::Flyout id="test-flyout" as |F|>
+            <F.Header @icon="info" @tagline="Tagline">Title</F.Header>
+          </Hds::Flyout>`
+    );
+    assert.dom('.hds-flyout__title').hasTagName('h1');
+  });
+
   // DISMISS
 
   test('it should always render the "dismiss" button', async function (assert) {

--- a/showcase/tests/integration/components/hds/modal/index-test.js
+++ b/showcase/tests/integration/components/hds/modal/index-test.js
@@ -100,6 +100,15 @@ module('Integration | Component | hds/modal/index', function (hooks) {
     assert.dom('.hds-modal__tagline').hasText('Tagline');
   });
 
+  test('it renders the title as an h1', async function (assert) {
+    await render(
+      hbs`<Hds::Modal id="test-modal" as |M|>
+            <M.Header @icon="info" @tagline="Tagline">Title</M.Header>
+          </Hds::Modal>`
+    );
+    assert.dom('.hds-modal__title').hasTagName('h1');
+  });
+
   // DISMISS
 
   test('it should always render the "dismiss" button', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would change the HTML element wrapping the Modal and Flyout tagline + title in the heading to an H1 (the previous element was a div).

### :hammer_and_wrench: Detailed description

* update the Modal and Flyout title to be H1s
* add tests to ensure the correct tag is rendered
* update the Flyout showcase page heading structure so it doesn't jump from H1 to H3 (this causes an automated a11y test failure)

### :camera_flash: Screenshots

**New Modal markup:**
<img width="966" alt="Screenshot 2024-08-22 at 12 10 24 PM" src="https://github.com/user-attachments/assets/9fb768a0-5ba1-4c1f-bbbe-9b651c898dba">

### :link: External links

RFC: https://go.hashi.co/rfc/ds-087
Jira ticket: [HDS-3773](https://hashicorp.atlassian.net/browse/HDS-3773)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3773]: https://hashicorp.atlassian.net/browse/HDS-3773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ