### PR TITLE
Enterprise Nav: `SideNav` & `AppHeader`—Improve scoping for dark theme styling

### DIFF
--- a/.changeset/eight-houses-remain.md
+++ b/.changeset/eight-houses-remain.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav` & `AppHeader` - Fixed issue with inheritance of dark theme to prevent `Button` and `Dropdown` nested within another `Dropdown` from inheriting dark theme styles.

--- a/.changeset/eight-houses-remain.md
+++ b/.changeset/eight-houses-remain.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`SideNav` & `AppHeader` - Fixed issue with inheritance of dark theme to prevent `Button` and `Dropdown` nested within another `Dropdown` from inheriting dark theme styles.
+`SideNav` & `AppHeader` - Fixed styling issue to prevent `Button` and `Dropdown` nested within another `Dropdown` from inheriting dark theme.

--- a/packages/components/src/styles/components/app-header.scss
+++ b/packages/components/src/styles/components/app-header.scss
@@ -112,7 +112,6 @@
   .hds-dropdown-toggle-button,
   .hds-dropdown-toggle-icon {
     // Apply dark theme to child interactive components not within a nested dropdown
-    // NOTE: Testing overrides for ember-basic-dropdown as well although likely not something we want to do
     &:not(.hds-dropdown * *, .ember-basic-dropdown-trigger * *, .ember-basic-dropdown-content * *) {
       @include hds-interactive-dark-theme();
 

--- a/packages/components/src/styles/components/app-header.scss
+++ b/packages/components/src/styles/components/app-header.scss
@@ -107,23 +107,27 @@
     gap: inherit;
   }
 
-  // Apply dark theme to child interactive components
+  // Dropdown & Button color theming overrides
   .hds-button,
   .hds-dropdown-toggle-button,
   .hds-dropdown-toggle-icon {
-    @include hds-interactive-dark-theme();
+    // Apply dark theme to child interactive components not within a nested dropdown
+    // NOTE: Testing overrides for ember-basic-dropdown as well although likely not something we want to do
+    &:not(.hds-dropdown * *, .ember-basic-dropdown-trigger * *, .ember-basic-dropdown-content * *) {
+      @include hds-interactive-dark-theme();
 
-    // disabled state:
-    &:disabled,
-    &[disabled],
-    &.mock-disabled,
-    &:disabled:focus,
-    &[disabled]:focus,
-    &.mock-disabled:focus,
-    &:disabled:hover,
-    &[disabled]:hover,
-    &.mock-disabled:hover {
-      @include hds-interactive-dark-theme-state-disabled();
+      // disabled state:
+      &:disabled,
+      &[disabled],
+      &.mock-disabled,
+      &:disabled:focus,
+      &[disabled]:focus,
+      &.mock-disabled:focus,
+      &:disabled:hover,
+      &[disabled]:hover,
+      &.mock-disabled:hover {
+        @include hds-interactive-dark-theme-state-disabled();
+      }
     }
   }
 }

--- a/packages/components/src/styles/components/side-nav/header.scss
+++ b/packages/components/src/styles/components/side-nav/header.scss
@@ -78,7 +78,6 @@
   .hds-dropdown-toggle-button,
   .hds-dropdown-toggle-icon {
     // Apply dark theme to child interactive components not within a nested dropdown
-    // NOTE: Testing overrides for ember-basic-dropdown as well although likely not something we want to do
     &:not(.hds-dropdown * *, .ember-basic-dropdown-trigger * *, .ember-basic-dropdown-content * *) {
       @include hds-interactive-dark-theme();
 

--- a/packages/components/src/styles/components/side-nav/header.scss
+++ b/packages/components/src/styles/components/side-nav/header.scss
@@ -71,27 +71,29 @@
 }
 
 // Dropdown & Button color theming overrides
-
-// Apply dark theme to child interactive components
 .hds-side-nav__dropdown, // deprecated classname
 .hds-side-nav,
 .hds-side-nav-header {
   .hds-button,
-  .hds-dropdown-toggle-button, 
+  .hds-dropdown-toggle-button,
   .hds-dropdown-toggle-icon {
-    @include hds-interactive-dark-theme();
+    // Apply dark theme to child interactive components not within a nested dropdown
+    // NOTE: Testing overrides for ember-basic-dropdown as well although likely not something we want to do
+    &:not(.hds-dropdown * *, .ember-basic-dropdown-trigger * *, .ember-basic-dropdown-content * *) {
+      @include hds-interactive-dark-theme();
 
-    // disabled state:
-    &:disabled,
-    &[disabled],
-    &.mock-disabled,
-    &:disabled:focus,
-    &[disabled]:focus,
-    &.mock-disabled:focus,
-    &:disabled:hover,
-    &[disabled]:hover,
-    &.mock-disabled:hover {
-      @include hds-interactive-dark-theme-state-disabled();
+      // disabled state:
+      &:disabled,
+      &[disabled],
+      &.mock-disabled,
+      &:disabled:focus,
+      &[disabled]:focus,
+      &.mock-disabled:focus,
+      &:disabled:hover,
+      &[disabled]:hover,
+      &.mock-disabled:hover {
+        @include hds-interactive-dark-theme-state-disabled();
+      }
     }
   }
 }

--- a/showcase/app/templates/components/app-header.hbs
+++ b/showcase/app/templates/components/app-header.hbs
@@ -556,5 +556,35 @@
         <Hds::Dropdown::Toggle::Icon @text="open" @isOpen={{true}} @imageSrc="/assets/images/avatar.png" />
       </div>
     </SG.Item>
+
+    <SG.Item @label="With nested content" {{style padding-bottom="11em"}}>
+      <div class="hds-app-header">
+        <Hds::Dropdown @height="284px" @listPosition="bottom-left" @isOpen={{true}} as |D|>
+          <D.ToggleIcon @icon="help" @text="help menu" />
+          <D.Generic>
+            <Hds::Dropdown as |D|>
+              <D.ToggleButton @text="Menu" />
+              <D.Interactive @href="#" @text="Add" />
+              <D.Interactive @href="#" @text="Add More" />
+              <D.Interactive @href="#" @text="Add Another Thing Too" />
+            </Hds::Dropdown>
+          </D.Generic>
+          <D.Checkbox>access</D.Checkbox>
+          <D.Checkbox>homework</D.Checkbox>
+          <D.Footer @hasDivider={{true}}>
+            <Hds::ButtonSet>
+              <Hds::Button @text="Apply filters" @isFullWidth={{true}} @size="small" />
+              <Hds::Button @text="Cancel" @color="secondary" @size="small" />
+              <Hds::Dropdown as |D|>
+                <D.ToggleButton @text="Menu" />
+                <D.Interactive @href="#" @text="Add" />
+                <D.Interactive @href="#" @text="Add More" />
+                <D.Interactive @href="#" @text="Add Another Thing Too" />
+              </Hds::Dropdown>
+            </Hds::ButtonSet>
+          </D.Footer>
+        </Hds::Dropdown>
+      </div>
+    </SG.Item>
   </Shw::Grid>
 </section>

--- a/showcase/app/templates/components/side-nav.hbs
+++ b/showcase/app/templates/components/side-nav.hbs
@@ -835,6 +835,43 @@
       {{/each}}
     {{/let}}
   </Shw::Flex>
+
+  <Shw::Divider />
+
+  {{! TODO: Reorganize after other SideNav Showcase updates including nested interactive content examples are ready}}
+  <Shw::Text::H2>Nested Dropdown</Shw::Text::H2>
+
+  <Shw::Grid @columns={{4}} as |SG|>
+    <SG.Item @label="With nested content" {{style padding-bottom="11em"}}>
+      <div class="hds-side-nav">
+        <Hds::Dropdown @height="284px" @listPosition="bottom-left" @isOpen={{true}} as |D|>
+          <D.ToggleIcon @icon="help" @text="help menu" />
+          <D.Generic>
+            <Hds::Dropdown as |D|>
+              <D.ToggleButton @text="Menu" />
+              <D.Interactive @href="#" @text="Add" />
+              <D.Interactive @href="#" @text="Add More" />
+              <D.Interactive @href="#" @text="Add Another Thing Too" />
+            </Hds::Dropdown>
+          </D.Generic>
+          <D.Checkbox>access</D.Checkbox>
+          <D.Checkbox>homework</D.Checkbox>
+          <D.Footer @hasDivider={{true}}>
+            <Hds::ButtonSet>
+              <Hds::Button @text="Apply filters" @isFullWidth={{true}} @size="small" />
+              <Hds::Button @text="Cancel" @color="secondary" @size="small" />
+              <Hds::Dropdown as |D|>
+                <D.ToggleButton @text="Menu" />
+                <D.Interactive @href="#" @text="Add" />
+                <D.Interactive @href="#" @text="Add More" />
+                <D.Interactive @href="#" @text="Add Another Thing Too" />
+              </Hds::Dropdown>
+            </Hds::ButtonSet>
+          </D.Footer>
+        </Hds::Dropdown>
+      </div>
+    </SG.Item>
+  </Shw::Grid>
 </section>
 
 <Shw::Divider />


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds additional scoping to dark theme styles for `Button` & `Dropdown` components within the `SideNav` & `AppHeader` so when nested within a Dropdown they will not inherit the dark theme.

### :hammer_and_wrench: Detailed description

**Included changes:**

* Scoped styles to apply dark theme styling to Buttons and Dropdowns within SideNav & AppHeader only when they are not nested within another Dropdown
* Added Showcase examples of Button & Dropdown nested within another Dropdown within SideNav & AppHeader

### :camera_flash: Screenshots

SIDE-NAV NESTED ELEMENTS

<img width="311" alt="image" src="https://github.com/user-attachments/assets/5fad80eb-eca6-4f1b-9edd-b367c915e42a">

APP-HEADER NESTED ELMENTS

<img width="321" alt="image" src="https://github.com/user-attachments/assets/8ff08d16-e286-40f4-aa3a-3e050f5ebdbe">

### :link: External links

* Jira ticket: [HDS-3793](https://hashicorp.atlassian.net/browse/HDS-3793)
* Bug example in Vault: https://github.com/hashicorp/vault/pull/28151

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3793]: https://hashicorp.atlassian.net/browse/HDS-3793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ