### PR TITLE
Added an extra example in the showcase for modal with an input

### DIFF
--- a/showcase/app/templates/components/modal.hbs
+++ b/showcase/app/templates/components/modal.hbs
@@ -61,7 +61,7 @@
   </Shw::Flex>
 
   <Shw::Flex @direction="column" as |SF|>
-    <SF.Item @label="Critical: another example" class="shw-component-modal-sample-item">
+    <SF.Item @label="Critical with form inside" class="shw-component-modal-sample-item">
       <Hds::Modal open @color="critical" id="modal-example-critical2" as |M|>
         <M.Header @icon="trash">
           Delete App?

--- a/showcase/app/templates/components/modal.hbs
+++ b/showcase/app/templates/components/modal.hbs
@@ -70,7 +70,7 @@
           <p class="hds-typography-body-300 hds-foreground-primary">This action will remove all of the data associated
             with the app "test1." It cannot be reversed.</p>
           <br />
-          <form name="leaving-beta-form">
+          <form name="delete-app-confirmation" aria-label="delete app confirmation">
             <Hds::Form::TextInput::Field @isRequired={{true}} placeholder="DELETE" as |F|>
               <F.Label>Confirm</F.Label>
               <F.HelperText>Type DELETE (all caps) to delete this application.</F.HelperText>

--- a/showcase/app/templates/components/modal.hbs
+++ b/showcase/app/templates/components/modal.hbs
@@ -61,7 +61,7 @@
   </Shw::Flex>
 
   <Shw::Flex @direction="column" as |SF|>
-    <SF.Item @label="Critical" class="shw-component-modal-sample-item">
+    <SF.Item @label="Critical: another example" class="shw-component-modal-sample-item">
       <Hds::Modal open @color="critical" id="modal-example-critical2" as |M|>
         <M.Header @icon="trash">
           Delete App?

--- a/showcase/app/templates/components/modal.hbs
+++ b/showcase/app/templates/components/modal.hbs
@@ -60,6 +60,34 @@
     {{/each}}
   </Shw::Flex>
 
+  <Shw::Flex @direction="column" as |SF|>
+    <SF.Item @label="Critical" class="shw-component-modal-sample-item">
+      <Hds::Modal open @color="critical" id="modal-example-critical2" as |M|>
+        <M.Header @icon="trash">
+          Delete App?
+        </M.Header>
+        <M.Body>
+          <p class="hds-typography-body-300 hds-foreground-primary">This action will remove all of the data associated
+            with the app "test1." It cannot be reversed.</p>
+          <br />
+          <form name="leaving-beta-form">
+            <Hds::Form::TextInput::Field @isRequired={{true}} placeholder="DELETE" as |F|>
+              <F.Label>Confirm</F.Label>
+              <F.HelperText>Type DELETE (all caps) to delete this application.</F.HelperText>
+            </Hds::Form::TextInput::Field>
+          </form>
+        </M.Body>
+        <M.Footer>
+          <Hds::ButtonSet>
+            <Hds::Button type="submit" @text="Confirm Delete" @color="critical" />
+            <Hds::Button type="button" @text="Cancel" @color="secondary" />
+          </Hds::ButtonSet>
+        </M.Footer>
+      </Hds::Modal>
+    </SF.Item>
+
+  </Shw::Flex>
+
   <Shw::Divider />
 
   <Shw::Text::H2>Content</Shw::Text::H2>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds an additional "critical" modal example in the showcase. I've come across this pattern in our apps and I wanted to make sure it was represented in the showcase for easier checking in the future.

Preview: https://hds-showcase-git-melsumner-add-modal-showcase-example-hashicorp.vercel.app/components/modal#color

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
