### PR TITLE
Website: add documentation for `tag` and `titleTag` arguments

### DIFF
--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -29,7 +29,9 @@
 @import "pages/foundations/landing";
 @import "pages/foundations/icon";
 @import "pages/components/accordion";
+@import "pages/components/alert";
 @import "pages/components/app-footer";
+@import "pages/components/application-state";
 @import "pages/components/button";
 @import "pages/components/code-block";
 @import "pages/components/copy-snippet";
@@ -49,6 +51,7 @@
 @import "pages/whats-new/changelog";
 @import "pages/patterns/table-multi-select";
 @import "pages/patterns/filter-patterns";
+@import "pages/utilities/dialog-primitive";
 
 // Third-party declarations
 @import "prism-dracula";

--- a/website/app/styles/pages/components/accordion.scss
+++ b/website/app/styles/pages/components/accordion.scss
@@ -21,4 +21,8 @@
     justify-content: space-between;
     margin-bottom: 1rem;
   }
+
+  .doc-accordion-demo-heading {
+    margin-bottom: 1rem;
+  }
 }

--- a/website/app/styles/pages/components/alert.scss
+++ b/website/app/styles/pages/components/alert.scss
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+// COMPONENTS > ALERT
+
+#show-content-components-alert {
+  .doc-alert-demo-heading {
+    margin-bottom: 1rem;
+  }
+}

--- a/website/app/styles/pages/components/application-state.scss
+++ b/website/app/styles/pages/components/application-state.scss
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+// COMPONENTS > APPLICATION-STATE
+
+#show-content-components-application-state {
+  .doc-application-state-demo-heading {
+    margin-bottom: 1rem;
+  }
+}

--- a/website/app/styles/pages/components/code-block.scss
+++ b/website/app/styles/pages/components/code-block.scss
@@ -15,5 +15,13 @@
     border-radius: 3px;
     aspect-ratio: 1/1;
   }
+
+  .doc-code-block-demo-heading {
+    margin-bottom: 1rem;
+
+    h2 {
+      margin-bottom: 0.5rem;
+    }
+  }
 }
 

--- a/website/app/styles/pages/utilities/dialog-primitive.scss
+++ b/website/app/styles/pages/utilities/dialog-primitive.scss
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+// UTILITIES > DIALOG PRIMITIVE
+
+#show-content-utilities-dialog-primitive {
+  .doc-dialog-primitive-grid-layout {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    background: white;
+  }
+
+  .doc-dialog-primitive-flex-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin: 2rem;
+  }
+
+  .doc-dialog-primitive-content-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background-color: var(--token-color-surface-strong);
+    border-radius: 8px;
+  }
+
+  .doc-dialog-primitive-with-border {
+    border-left: 1px solid var(--token-color-border-primary)
+  }
+}

--- a/website/app/styles/pages/utilities/dialog-primitive.scss
+++ b/website/app/styles/pages/utilities/dialog-primitive.scss
@@ -20,14 +20,11 @@
     margin: 2rem;
   }
 
-  .doc-dialog-primitive-content-placeholder {
+  .doc-dialog-primitive-flex-layout {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    background-color: var(--token-color-surface-strong);
-    border-radius: 8px;
+    flex-direction: column;
+    gap: 1rem;
+    margin: 2rem;
   }
 
   .doc-dialog-primitive-with-border {

--- a/website/docs/components/accordion/partials/code/component-api.md
+++ b/website/docs/components/accordion/partials/code/component-api.md
@@ -13,7 +13,7 @@ The `Accordion` component serves as a wrapper to group one or more `Accordion::I
   <C.Property @name="forceState" @type="enum" @values={{array "open" "close" }}>
     Controls the state of all items within a group. Can be used to expand or collapse all items at once.
   </C.Property>
-  <C.Property @name="titleTag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}}>
+  <C.Property @name="titleTag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}} @default="div">
     The HTML tag that wraps the content of each Accordion Item "toggle" block.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/accordion/partials/code/component-api.md
+++ b/website/docs/components/accordion/partials/code/component-api.md
@@ -13,6 +13,9 @@ The `Accordion` component serves as a wrapper to group one or more `Accordion::I
   <C.Property @name="forceState" @type="enum" @values={{array "open" "close" }}>
     Controls the state of all items within a group. Can be used to expand or collapse all items at once.
   </C.Property>
+  <C.Property @name="titleTag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}}>
+    The HTML tag that wraps the content of each Accordion Item "toggle" block.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/components/accordion/partials/code/how-to-use.md
+++ b/website/docs/components/accordion/partials/code/how-to-use.md
@@ -196,6 +196,42 @@ The `ariaLabel` value is applied to the HTML button which controls visibility of
   </Hds::Accordion>
 ```
 
+### titleTag
+
+The `@titleTag` argument changes the HTML element that wraps the title block of each `Accordion::Item`. When organizing the content on a webpage, the heading levels should reflect the structure of the page. For example, if an Accordion is within a subsection of the page below a heading level 2, the value should be `"h3"`.
+
+```handlebars
+  <div class="doc-accordion-demo-heading">
+    <Hds::Text::Display @tag="h2" @size="300">Examination period</Hds::Text::Display>
+  </div>
+  <Hds::Accordion @titleTag="h3" as |A|>
+    <A.Item>
+      <:toggle>Exam experience</:toggle>
+      <:content>
+        All certification exams are taken online with a live proctor, accommodating all locations and time zones. Online proctoring provides the same benefits of a physical test center while being more accessible to exam-takers. The live proctor verifies your identity, walks you through rules and procedures, and watches you take the exam. Learn more ways to prepare for an online proctored exam in our Knowledgebase.
+      </:content>
+    </A.Item>
+    <A.Item>
+      <:toggle>Requirements for attending an exam</:toggle>
+      <:content>
+        Before you register for an exam, review the Exam-taker Handbook to learn the requirements and policies for taking exams. It is your responsibility to know and abide by our program rules to successfully enter your exam appointment, failure to do so may result in forfeiture of appointment fees.        
+      </:content>
+    </A.Item>
+    <A.Item>
+      <:toggle>Your badge and certificate</:toggle>
+      <:content>
+        HashiCorp has partnered with Credly to offer you a digital badge and downloadable certificate upon passing a certification exam. There is no fee for this service and acceptance is up to you. Digital badges can be used in email signatures or digital resumes, and on social media sites such as LinkedIn, Facebook, and Twitter. Badges link back to a real-time verification feature that describes your qualifications.
+      </:content>
+    </A.Item>
+  </Hds::Accordion>
+```
+
+!!! Insight
+
+The default `@titleTag` is `"div"` because the correct value is dependent on the individual page. We strongly encourage consumers to update the `@titleTag` to meet WCAG Success Criterion [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) as the visual experience should match what is presented to the user with assistive technology.
+
+!!!
+
 ### isOpen
 
 Set `isOpen` to `true` on an `Accordion::Item` to display its associated content on page load instead of initially hiding it.

--- a/website/docs/components/alert/partials/code/component-api.md
+++ b/website/docs/components/alert/partials/code/component-api.md
@@ -45,6 +45,9 @@ The `Alert::Title` component, yielded as contextual component.
   <C.Property @name="yield">
     Elements passed as children are yielded as inner content of the "title" block.
   </C.Property>
+  <C.Property @name="tag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}}>
+    The HTML tag that wraps the content of the "title" block.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/components/alert/partials/code/component-api.md
+++ b/website/docs/components/alert/partials/code/component-api.md
@@ -45,7 +45,7 @@ The `Alert::Title` component, yielded as contextual component.
   <C.Property @name="yield">
     Elements passed as children are yielded as inner content of the "title" block.
   </C.Property>
-  <C.Property @name="tag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}}>
+  <C.Property @name="tag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}} @default="div">
     The HTML tag that wraps the content of the "title" block.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/alert/partials/code/how-to-use.md
+++ b/website/docs/components/alert/partials/code/how-to-use.md
@@ -43,6 +43,29 @@ Optionally, you can pass only `title` or only `description`.
 </Hds::Alert>
 ```
 
+### Tag
+
+The `@tag` argument changes the HTML element that wraps the title content of `[A].Title`. When organizing the content on a webpage, the heading levels should reflect the structure of the page. For example, if an Alert appears directly below the main heading of the page, it should be `"h2"`.
+
+```handlebars
+<div class="doc-alert-demo-heading">
+ <Hds::Text::Display @tag="h1" @size="500">Edit credit card</Hds::Text::Display>
+</div>
+<Hds::Alert @type="inline" @color="critical" as |A|>
+  <A.Title @tag="h2">Form submission error</A.Title>
+  <A.Description>Correct the formatting of the following fields to update your user profile:</A.Description>
+  <A.Description>
+    <Hds::Link::Inline @href="#" @color="secondary">Expiration date</Hds::Link::Inline>
+  </A.Description>
+</Hds::Alert>
+```
+
+!!! Insight
+
+The default `@tag` is `"div"` because the correct value is dependent on the individual page. We strongly encourage consumers to update the `@tag` to meet WCAG Success Criterion [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) as the visual experience should match what is presented to the user with assistive technology.
+
+!!!
+
 ### Color
 
 A different color can be applied to the Alert using the `color` argument. This will determine the default icon used in the Alert, unless overwritten.

--- a/website/docs/components/application-state/partials/code/component-api.md
+++ b/website/docs/components/application-state/partials/code/component-api.md
@@ -49,6 +49,9 @@ The `ApplicationState::Header` component, yielded as contextual component.
   <C.Property @name="title" @type="string">
     The text of the title
   </C.Property>
+  <C.Property @name="titleTag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}}>
+    The HTML tag that wraps the title text.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/components/application-state/partials/code/component-api.md
+++ b/website/docs/components/application-state/partials/code/component-api.md
@@ -49,7 +49,7 @@ The `ApplicationState::Header` component, yielded as contextual component.
   <C.Property @name="title" @type="string">
     The text of the title
   </C.Property>
-  <C.Property @name="titleTag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}}>
+  <C.Property @name="titleTag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}} @default="div">
     The HTML tag that wraps the title text.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/application-state/partials/code/how-to-use.md
+++ b/website/docs/components/application-state/partials/code/how-to-use.md
@@ -170,3 +170,29 @@ To indicate that the message is an error state, add `@errorCode` to the `[A].Hea
   </A.Footer>
 </Hds::ApplicationState>
 ```
+
+### titleTag
+
+The `@titleTag` argument changes the HTML element that wraps the `[A].Header` title content. When organizing the content on a webpage, the heading levels should reflect the structure of the page. For example, if an Application State is used as an empty state below the main heading of a page, the value should be `"h2"`. 
+
+```handlebars
+<div class="doc-application-state-demo-heading">
+  <Hds::Text::Display @tag="h1" @size="500">Templates</Hds::Text::Display>
+</div>
+<Hds::ApplicationState as |A|>
+  <A.Header @title="No templates have been created yet" @titleTag="h2" />
+  <A.Body @text="Make a template to easily provision infrastructure for any Waypoint application. Youll need a Terraform co-node module and instructions for your application developers." />
+  <A.Footer as |F|>
+    <F.Button @icon="plus" @text="Create a template" />
+    <F.Button @icon="upload" @text="Import" @color="secondary" />
+    <F.LinkStandalone @icon="docs-link" @text="Learn more" @href="/components/application-state"
+    @iconPosition="trailing" />
+  </A.Footer>
+</Hds::ApplicationState>
+```
+
+!!! Insight
+
+The default `@titleTag` is `"div"` because the correct value is dependent on the individual page. We strongly encourage consumers to update the `@titleTag` to meet WCAG Success Criterion [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) as the visual experience should match what is presented to the user with assistive technology.
+
+!!!

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -47,7 +47,7 @@ The `CodeBlock::Title` component, yielded as contextual component.
   <C.Property @name="yield">
     Accepts complex content, such as logic/conditionals, HTML elements, other Ember components, etc. Content inherits its style. Styling is applied for simple HTML elements, such as `strong`, `em`, `a`, `code/pre`. Consumers will need to style other HTML tags if used as children.
   </C.Property>
-    <C.Property @name="tag" @type="enum" @values={{array "p" "h1" "h2" "h3" "h4" "h5" "h6"}}>
+    <C.Property @name="tag" @type="enum" @values={{array "p" "h1" "h2" "h3" "h4" "h5" "h6"}} @default="p">
     The HTML tag that wraps the content of the "title" block.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -47,6 +47,9 @@ The `CodeBlock::Title` component, yielded as contextual component.
   <C.Property @name="yield">
     Accepts complex content, such as logic/conditionals, HTML elements, other Ember components, etc. Content inherits its style. Styling is applied for simple HTML elements, such as `strong`, `em`, `a`, `code/pre`. Consumers will need to style other HTML tags if used as children.
   </C.Property>
+    <C.Property @name="tag" @type="enum" @values={{array "p" "h1" "h2" "h3" "h4" "h5" "h6"}}>
+    The HTML tag that wraps the content of the "title" block.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/components/code-block/partials/code/how-to-use.md
+++ b/website/docs/components/code-block/partials/code/how-to-use.md
@@ -32,6 +32,38 @@ as |CB|>
 </Hds::CodeBlock>
 ```
 
+### Title tag
+
+The `@tag` argument changes the HTML element that wraps the `[CB].Title` content. When organizing the content on a webpage, the heading levels should reflect the structure of the page. For example, if a CodeBlock is within a subsection of the page below a heading level 2, the value should be `"h3"`. 
+
+```handlebars
+<div class="doc-code-block-demo-heading">
+  <Hds::Text::Display @tag="h2" @size="300">Learn to write functions in JavaScript</Hds::Text::Display>
+  <Hds::Text::Body @tag="p">Functions are a critical part of learning JavaScript. They are reusable chunks of code that can perform tasks like convert an object to an array.</Hds::Text::Body>
+</div>
+<Hds::CodeBlock
+  @language="javascript"
+  @value="function convertObjectToArray (obj) {
+  let arr = Object
+    .keys(obj)
+    .map(key => {return [key, obj[key] ]})
+    .flat()
+    .sort()
+  ;
+  return arr;
+}" as |CB|>
+  <CB.Title @tag="h3">
+    convertObjectToArray.js
+  </CB.Title>
+</Hds::CodeBlock>
+```
+
+!!! Insight
+
+The default `@tag` is `"div"` because the correct value is dependent on the individual page. We strongly encourage consumers to update the `@tag` to meet WCAG Success Criterion [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) as the visual experience should match what is presented to the user with assistive technology.
+
+!!!
+
 ### Language
 
 The `language` argument sets the syntax highlighting used. We only support the following languages: `bash`, `go`, `hcl`, `json`, `log`, `ruby`, `shell-session`, and `yaml`. If you need additional languages <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>

--- a/website/docs/utilities/dialog-primitive/partials/code/component-api.md
+++ b/website/docs/utilities/dialog-primitive/partials/code/component-api.md
@@ -38,7 +38,7 @@ A sub-component used to provide the header content.
    <C.Property @name="onDismiss" @type="function">
     Callback function invoked when the “dismiss” button in the header is clicked by the user.
   </C.Property>
-  <C.Property @name="titleTag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}}>
+  <C.Property @name="titleTag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}} @default="div">
     The HTML tag that wraps the tagline and the content in the "title" block of the header.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/utilities/dialog-primitive/partials/code/component-api.md
+++ b/website/docs/utilities/dialog-primitive/partials/code/component-api.md
@@ -38,6 +38,9 @@ A sub-component used to provide the header content.
    <C.Property @name="onDismiss" @type="function">
     Callback function invoked when the “dismiss” button in the header is clicked by the user.
   </C.Property>
+  <C.Property @name="titleTag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}}>
+    The HTML tag that wraps the tagline and the content in the "title" block of the header.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/utilities/dialog-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/dialog-primitive/partials/code/how-to-use.md
@@ -34,3 +34,51 @@ The `DialogPrimitive` serves as the foundation for dialog derived components lik
   </:footer>
 </Hds::DialogPrimitive::Wrapper>
 ```
+
+### Header titleTag
+
+The `@titleTag` argument changes the HTML element that wraps the `DialogPrimitive::Header` tagline and "title" content. When organizing the content on a webpage, the heading levels should reflect the structure of the page. For example, if the `DialogPrimitive` is used as a Split Window, the value should be `"h2"`. 
+
+```handlebars
+<div class="doc-dialog-primitive-grid-layout">
+  <div class="doc-dialog-primitive-flex-layout">
+    <Hds::Text::Display @tag="h1" @size="500">Page with Split Window</Hds::Text::Display>
+    <div class="doc-dialog-primitive-content-placeholder">
+     <Hds::Text::Body>Main page content </Hds::Text::Body>
+    </div>
+  </div>
+  <Hds::DialogPrimitive::Wrapper class="doc-dialog-primitive-with-border">
+    <:header>
+      <Hds::DialogPrimitive::Header
+        @icon="info"
+        @tagline="Tagline"
+        @titleTag="h2"
+      >
+        Split Window
+      </Hds::DialogPrimitive::Header>
+      <Hds::DialogPrimitive::Description>Description</Hds::DialogPrimitive::Description>
+    </:header>
+    <:body>
+      <Hds::DialogPrimitive::Body>
+        <Hds::Text::Body>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Libero culpa expedita assumenda at nisi minus unde fuga iure suscipit aut qui, odit natus eum voluptates ut molestiae! Perferendis, impedit qui? Lorem ipsum dolor sit amet?
+        </Hds::Text::Body>
+      </Hds::DialogPrimitive::Body>
+    </:body>
+    <:footer>
+      <Hds::DialogPrimitive::Footer>
+        <Hds::ButtonSet>
+          <Hds::Button type="submit" @text="Primary" />
+          <Hds::Button type="button" @text="Secondary" @color="secondary" />
+        </Hds::ButtonSet>
+      </Hds::DialogPrimitive::Footer>
+    </:footer>
+  </Hds::DialogPrimitive::Wrapper>
+</div>
+```
+
+!!! Insight
+
+The default `@titleTag` is `"div"` because the correct value is dependent on the individual page. We strongly encourage consumers to update the `@titleTag` to meet WCAG Success Criterion [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) as the visual experience should match what is presented to the user with assistive technology.
+
+!!!

--- a/website/docs/utilities/dialog-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/dialog-primitive/partials/code/how-to-use.md
@@ -42,10 +42,8 @@ The `@titleTag` argument changes the HTML element that wraps the `DialogPrimitiv
 ```handlebars
 <div class="doc-dialog-primitive-grid-layout">
   <div class="doc-dialog-primitive-flex-layout">
-    <Hds::Text::Display @tag="h1" @size="500">Page with Split Window</Hds::Text::Display>
-    <div class="doc-dialog-primitive-content-placeholder">
-     <Hds::Text::Body>Main page content </Hds::Text::Body>
-    </div>
+    <Hds::Text::Display @tag="h1" @size="500">Page title</Hds::Text::Display>
+    <Doc::Placeholder @text="Main content" @height="100%" @width="100%" @background="#eee" />
   </div>
   <Hds::DialogPrimitive::Wrapper class="doc-dialog-primitive-with-border">
     <:header>
@@ -56,13 +54,10 @@ The `@titleTag` argument changes the HTML element that wraps the `DialogPrimitiv
       >
         Split Window
       </Hds::DialogPrimitive::Header>
-      <Hds::DialogPrimitive::Description>Description</Hds::DialogPrimitive::Description>
     </:header>
     <:body>
       <Hds::DialogPrimitive::Body>
-        <Hds::Text::Body>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Libero culpa expedita assumenda at nisi minus unde fuga iure suscipit aut qui, odit natus eum voluptates ut molestiae! Perferendis, impedit qui? Lorem ipsum dolor sit amet?
-        </Hds::Text::Body>
+       <Doc::Placeholder @text="Split Window content" @height="10rem" @width="100%" @background="#eee" />
       </Hds::DialogPrimitive::Body>
     </:body>
     <:footer>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add content in each of the component's "How to use" section and include the new argument in the "Component API" section.

Changed pages:
* [Accordion](https://hds-website-3w235i59d-hashicorp.vercel.app/components/accordion?tab=code#titletag)
* [Alert](https://hds-website-3w235i59d-hashicorp.vercel.app/components/alert?tab=code#tag)
* [ApplicationState](https://hds-website-3w235i59d-hashicorp.vercel.app/components/application-state?tab=code#titletag)
* [CodeBlock](https://hds-website-3w235i59d-hashicorp.vercel.app/components/code-block?tab=code#title-tag)
* [DialogPrimitive](https://hds-website-3w235i59d-hashicorp.vercel.app/utilities/dialog-primitive?tab=code#header-titletag)

### :link: External links

RFC: https://go.hashi.co/rfc/ds-087
Jira ticket: [HDS-3774](https://hashicorp.atlassian.net/browse/HDS-3774)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3774]: https://hashicorp.atlassian.net/browse/HDS-3774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ