### PR TITLE
Update Vagrant primary gradient tokens

### DIFF
--- a/.changeset/many-lies-leave.md
+++ b/.changeset/many-lies-leave.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/design-system-tokens': patch
+---
+
+Updated design tokens for Vagrant primary gradient to match Figma.

--- a/packages/tokens/dist/cloud-email/helpers/color.css
+++ b/packages/tokens/dist/cloud-email/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-border-primary { border: 1px solid #656a7633; }

--- a/packages/tokens/dist/cloud-email/helpers/elevation.css
+++ b/packages/tokens/dist/cloud-email/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-elevation-high { box-shadow: 0px 2px 3px 0px #656a7626, 0px 16px 16px -10px #656a7633); }

--- a/packages/tokens/dist/cloud-email/helpers/focus-ring.css
+++ b/packages/tokens/dist/cloud-email/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff; }

--- a/packages/tokens/dist/cloud-email/helpers/typography.css
+++ b/packages/tokens/dist/cloud-email/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-font-family-sans-display { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; }

--- a/packages/tokens/dist/cloud-email/tokens.scss
+++ b/packages/tokens/dist/cloud-email/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 24 Jul 2024 00:26:23 GMT
+// Generated on Tue, 27 Aug 2024 16:41:13 GMT
 
 $token-color-palette-blue-500: #1c345f;
 $token-color-palette-blue-400: #0046d1;
@@ -137,8 +137,8 @@ $token-color-vagrant-brand: #1868f2;
 $token-color-vagrant-foreground: #1c61d8;
 $token-color-vagrant-surface: #d6ebff;
 $token-color-vagrant-border: #c7dbfc;
-$token-color-vagrant-gradient-primary-start: #c7dbfc;
-$token-color-vagrant-gradient-primary-stop: #7dadff;
+$token-color-vagrant-gradient-primary-start: #639cff;
+$token-color-vagrant-gradient-primary-stop: #2e71e5;
 $token-color-vagrant-gradient-faint-start: #f4faff; // this is the 'vagrant-50' value at 25% opacity on white
 $token-color-vagrant-gradient-faint-stop: #d6ebff;
 $token-color-vault-radar-brand: #ffcf25;

--- a/packages/tokens/dist/devdot/css/helpers/color.css
+++ b/packages/tokens/dist/devdot/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/devdot/css/helpers/elevation.css
+++ b/packages/tokens/dist/devdot/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-elevation-high { box-shadow: var(--token-elevation-high-box-shadow); }

--- a/packages/tokens/dist/devdot/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/devdot/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/devdot/css/helpers/typography.css
+++ b/packages/tokens/dist/devdot/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/devdot/css/tokens.css
+++ b/packages/tokens/dist/devdot/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 :root {
@@ -141,8 +141,8 @@
   --token-color-vagrant-foreground: #1c61d8;
   --token-color-vagrant-surface: #d6ebff;
   --token-color-vagrant-border: #c7dbfc;
-  --token-color-vagrant-gradient-primary-start: #c7dbfc;
-  --token-color-vagrant-gradient-primary-stop: #7dadff;
+  --token-color-vagrant-gradient-primary-start: #639cff;
+  --token-color-vagrant-gradient-primary-stop: #2e71e5;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
   --token-color-vault-radar-brand: #ffcf25;

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -2945,11 +2945,11 @@
     ]
   },
   {
-    "value": "#c7dbfc",
+    "value": "#639cff",
     "type": "color",
     "group": "branding",
     "original": {
-      "value": "{color.palette.vagrant-100.value}",
+      "value": "{color.palette.vagrant-300.value}",
       "type": "color",
       "group": "branding"
     },
@@ -2970,11 +2970,11 @@
     ]
   },
   {
-    "value": "#7dadff",
+    "value": "#2e71e5",
     "type": "color",
     "group": "branding",
     "original": {
-      "value": "{color.palette.vagrant-200.value}",
+      "value": "{color.palette.vagrant-400.value}",
       "type": "color",
       "group": "branding"
     },

--- a/packages/tokens/dist/marketing/css/helpers/color.css
+++ b/packages/tokens/dist/marketing/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/marketing/css/helpers/elevation.css
+++ b/packages/tokens/dist/marketing/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-elevation-high { box-shadow: var(--token-elevation-high-box-shadow); }

--- a/packages/tokens/dist/marketing/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/marketing/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/marketing/css/helpers/typography.css
+++ b/packages/tokens/dist/marketing/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/marketing/css/tokens.css
+++ b/packages/tokens/dist/marketing/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 :root {
@@ -139,8 +139,8 @@
   --token-color-vagrant-foreground: #1c61d8;
   --token-color-vagrant-surface: #d6ebff;
   --token-color-vagrant-border: #c7dbfc;
-  --token-color-vagrant-gradient-primary-start: #c7dbfc;
-  --token-color-vagrant-gradient-primary-stop: #7dadff;
+  --token-color-vagrant-gradient-primary-start: #639cff;
+  --token-color-vagrant-gradient-primary-stop: #2e71e5;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
   --token-color-vault-radar-brand: #ffcf25;

--- a/packages/tokens/dist/marketing/tokens.json
+++ b/packages/tokens/dist/marketing/tokens.json
@@ -3279,13 +3279,13 @@
       "gradient": {
         "primary": {
           "start": {
-            "value": "#c7dbfc",
+            "value": "#639cff",
             "type": "color",
             "group": "branding",
             "filePath": "src/products/shared/color/semantic-product-vagrant.json",
             "isSource": true,
             "original": {
-              "value": "{color.palette.vagrant-100.value}",
+              "value": "{color.palette.vagrant-300.value}",
               "type": "color",
               "group": "branding"
             },
@@ -3306,13 +3306,13 @@
             ]
           },
           "stop": {
-            "value": "#7dadff",
+            "value": "#2e71e5",
             "type": "color",
             "group": "branding",
             "filePath": "src/products/shared/color/semantic-product-vagrant.json",
             "isSource": true,
             "original": {
-              "value": "{color.palette.vagrant-200.value}",
+              "value": "{color.palette.vagrant-400.value}",
               "type": "color",
               "group": "branding"
             },

--- a/packages/tokens/dist/products/css/helpers/color.css
+++ b/packages/tokens/dist/products/css/helpers/color.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-border-primary { border: 1px solid var(--token-color-border-primary); }

--- a/packages/tokens/dist/products/css/helpers/elevation.css
+++ b/packages/tokens/dist/products/css/helpers/elevation.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-elevation-high { box-shadow: var(--token-elevation-high-box-shadow); }

--- a/packages/tokens/dist/products/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/products/css/helpers/focus-ring.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-focus-ring-action-box-shadow { box-shadow: var(--token-focus-ring-action-box-shadow); }

--- a/packages/tokens/dist/products/css/helpers/typography.css
+++ b/packages/tokens/dist/products/css/helpers/typography.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 .hds-font-family-sans-display { font-family: var(--token-typography-font-stack-display); }

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jul 2024 00:26:23 GMT
+ * Generated on Tue, 27 Aug 2024 16:41:13 GMT
  */
 
 :root {
@@ -139,8 +139,8 @@
   --token-color-vagrant-foreground: #1c61d8;
   --token-color-vagrant-surface: #d6ebff;
   --token-color-vagrant-border: #c7dbfc;
-  --token-color-vagrant-gradient-primary-start: #c7dbfc;
-  --token-color-vagrant-gradient-primary-stop: #7dadff;
+  --token-color-vagrant-gradient-primary-start: #639cff;
+  --token-color-vagrant-gradient-primary-stop: #2e71e5;
   --token-color-vagrant-gradient-faint-start: #f4faff; /* this is the 'vagrant-50' value at 25% opacity on white */
   --token-color-vagrant-gradient-faint-stop: #d6ebff;
   --token-color-vault-radar-brand: #ffcf25;

--- a/packages/tokens/src/products/shared/color/semantic-product-vagrant.json
+++ b/packages/tokens/src/products/shared/color/semantic-product-vagrant.json
@@ -24,12 +24,12 @@
             "gradient": {
                 "primary": {
                     "start": {
-                        "value": "{color.palette.vagrant-100.value}",
+                        "value": "{color.palette.vagrant-300.value}",
                         "type": "color",
                         "group": "branding"
                     },
                     "stop": {
-                        "value": "{color.palette.vagrant-200.value}",
+                        "value": "{color.palette.vagrant-400.value}",
                         "type": "color",
                         "group": "branding"
                     }


### PR DESCRIPTION
### :pushpin: Summary

In the Figma v2.0 library work a discrepancy was uncovered between design and code.

### :hammer_and_wrench: Detailed description

- In code/`style-dictionary` the Vagrant primary gradient stops aliased `Vagrant / 100` and `Vagrant / 200`
- In Figma the gradient "aliases" (not technical an alias) `Vagrant / 300` and `Vagrant / 400`.

Double checking in [HDS Global Foundations](https://www.figma.com/design/rR2zONuQi54Hqeq1RAVt48/HDS-Global-Foundations?m=auto&node-id=0-1&t=6C2j7PSymXWWEUab-1) the implementation seems incorrect.

### :camera_flash: Screenshots

Before
<img width="854" alt="Screenshot 2024-08-27 at 9 48 11 AM" src="https://github.com/user-attachments/assets/a5b6be7f-10de-4c1b-8fad-f6c7b4d55cbc">

After
<img width="853" alt="Screenshot 2024-08-27 at 9 47 53 AM" src="https://github.com/user-attachments/assets/dd919e28-ee66-4d94-84fa-d9f574967a1c">

***

### 👀 Component checklist

- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
