### PR TITLE
Remove ember-flight-icons as trigger for component CI

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files.sh "packages/components" "packages/ember-flight-icons" "packages/flight-icons/catalog.json" "showcase" ".github/workflows/ci-components.yml"
+        run: ./.github/scripts/filter_changed_files.sh "packages/components" "packages/flight-icons/catalog.json" "showcase" ".github/workflows/ci-components.yml"
 
   test:
     name: "Tests"


### PR DESCRIPTION
### :pushpin: Summary

Since we no longer rely on ember-flight-icons directly in the components package it's no longer necessary to use it as a trigger for running the component tests/percy