### PR TITLE
fix: ignore heading order rule on modal/flyout docs pages

### DIFF
--- a/website/tests/acceptance/components/flyout-test.js
+++ b/website/tests/acceptance/components/flyout-test.js
@@ -19,7 +19,13 @@ module('Acceptance | components/flyout', function (hooks) {
   test('Components/flyout page passes automated a11y checks', async function (assert) {
     await visit('/components/flyout');
 
-    await a11yAudit();
+    await a11yAudit({
+      rules: {
+        'heading-order': {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true, 'a11y automation audit passed');
   });

--- a/website/tests/acceptance/components/modal-test.js
+++ b/website/tests/acceptance/components/modal-test.js
@@ -19,7 +19,13 @@ module('Acceptance | components/modal', function (hooks) {
 
   test('components/modal passes a11y automated checks', async function (assert) {
     await visit('/components/modal');
-    await a11yAudit();
+    await a11yAudit({
+      rules: {
+        'heading-order': {
+          enabled: false,
+        },
+      },
+    });
     assert.ok(true, 'a11y automation audit passed');
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR should fix the failing website tests on the modal and flyout pages introduced in this PR: https://github.com/hashicorp/design-system/pull/2358

To fix the failing tests, instead of changing the components - we decided to turn off [the heading-order](https://dequeuniversity.com/rules/axe/4.8/heading-order?application=axeAPI)  rule because it is better for the component to be correct in product than have correct heading structure on the docs site.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
