### PR TITLE
fix(components): remove `Component` in the backing class names

### DIFF
--- a/packages/components/src/components.ts
+++ b/packages/components/src/components.ts
@@ -82,17 +82,17 @@ import HdsLinkInline from './components/hds/link/inline.ts';
 import HdsLinkStandalone from './components/hds/link/standalone.ts';
 import HdsMenuPrimitive from './components/hds/menu-primitive/index.ts';
 import HdsModal from './components/hds/modal/index.ts';
-import HdsModalBodyComponent from './components/hds/modal/body.ts';
+import HdsModalBody from './components/hds/modal/body.ts';
 import HdsModalFooter from './components/hds/modal/footer.ts';
 import HdsModalHeader from './components/hds/modal/header.ts';
 import HdsPageHeader from './components/hds/page-header/index.ts';
-import HdsPaginationCompactComponent from './components/hds/pagination/compact/index.ts';
-import HdsPaginationControlInfoComponent from './components/hds/pagination/info/index.ts';
-import HdsPaginationControlArrowComponent from './components/hds/pagination/nav/arrow.ts';
-import HdsPaginationControlEllipsisComponent from './components/hds/pagination/nav/ellipsis.ts';
-import HdsPaginationControlNumberComponent from './components/hds/pagination/nav/number.ts';
-import HdsPaginationNumberedComponent from './components/hds/pagination/numbered/index.ts';
-import HdsPaginationSizeSelectorComponent from './components/hds/pagination/size-selector/index.ts';
+import HdsPaginationCompact from './components/hds/pagination/compact/index.ts';
+import HdsPaginationControlInfo from './components/hds/pagination/info/index.ts';
+import HdsPaginationControlArrow from './components/hds/pagination/nav/arrow.ts';
+import HdsPaginationControlEllipsis from './components/hds/pagination/nav/ellipsis.ts';
+import HdsPaginationControlNumber from './components/hds/pagination/nav/number.ts';
+import HdsPaginationNumbered from './components/hds/pagination/numbered/index.ts';
+import HdsPaginationSizeSelector from './components/hds/pagination/size-selector/index.ts';
 import HdsPopoverPrimitive from './components/hds/popover-primitive/index.ts';
 import HdsReveal from './components/hds/reveal/index.ts';
 import HdsRichTooltip from './components/hds/rich-tooltip/index.ts';
@@ -204,17 +204,17 @@ export {
   HdsLinkStandalone,
   HdsMenuPrimitive,
   HdsModal,
-  HdsModalBodyComponent,
+  HdsModalBody,
   HdsModalFooter,
   HdsModalHeader,
   HdsPageHeader,
-  HdsPaginationCompactComponent,
-  HdsPaginationControlInfoComponent,
-  HdsPaginationControlArrowComponent,
-  HdsPaginationControlEllipsisComponent,
-  HdsPaginationControlNumberComponent,
-  HdsPaginationNumberedComponent,
-  HdsPaginationSizeSelectorComponent,
+  HdsPaginationCompact,
+  HdsPaginationControlInfo,
+  HdsPaginationControlArrow,
+  HdsPaginationControlEllipsis,
+  HdsPaginationControlNumber,
+  HdsPaginationNumbered,
+  HdsPaginationSizeSelector,
   HdsPopoverPrimitive,
   HdsReveal,
   HdsRichTooltip,

--- a/packages/components/src/components/hds/accordion/index.ts
+++ b/packages/components/src/components/hds/accordion/index.ts
@@ -35,7 +35,7 @@ interface HdsAccordionSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsAccordionComponent extends Component<HdsAccordionSignature> {
+export default class HdsAccordion extends Component<HdsAccordionSignature> {
   /**
    * Sets the size for the component
    *

--- a/packages/components/src/components/hds/accordion/item/button.ts
+++ b/packages/components/src/components/hds/accordion/item/button.ts
@@ -21,7 +21,7 @@ interface HdsAccordionItemButtonSignature {
   Element: HTMLButtonElement;
 }
 
-export default class HdsAccordionItemButtonComponent extends Component<HdsAccordionItemButtonSignature> {
+export default class HdsAccordionItemButton extends Component<HdsAccordionItemButtonSignature> {
   @action
   onClick(event: MouseEvent): void {
     if (this.args.onClickToggle) {

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -56,7 +56,7 @@ export interface HdsAccordionItemSignature {
   Element: HTMLElement;
 }
 
-export default class HdsAccordionItemComponent extends Component<HdsAccordionItemSignature> {
+export default class HdsAccordionItem extends Component<HdsAccordionItemSignature> {
   /**
    * Generates a unique ID for the Content
    *

--- a/packages/components/src/components/hds/alert/description.ts
+++ b/packages/components/src/components/hds/alert/description.ts
@@ -12,7 +12,7 @@ export interface HdsAlertDescriptionSignature {
   Element: HTMLDivElement;
 }
 
-const HdsAlertDescriptionComponent =
+const HdsAlertDescription =
   TemplateOnlyComponent<HdsAlertDescriptionSignature>();
 
-export default HdsAlertDescriptionComponent;
+export default HdsAlertDescription;

--- a/packages/components/src/components/hds/alert/index.ts
+++ b/packages/components/src/components/hds/alert/index.ts
@@ -61,7 +61,7 @@ export interface HdsAlertSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsAlertComponent extends Component<HdsAlertSignature> {
+export default class HdsAlert extends Component<HdsAlertSignature> {
   @tracked role = 'alert';
   @tracked ariaLabelledBy?: string;
 

--- a/packages/components/src/components/hds/alert/title.ts
+++ b/packages/components/src/components/hds/alert/title.ts
@@ -16,10 +16,8 @@ export interface HdsAlertTitleSignature {
   Element: HTMLDivElement;
 }
 
-class HdsAlertTitleComponent extends Component<HdsAlertTitleSignature> {
+export default class HdsAlertTitle extends Component<HdsAlertTitleSignature> {
   get componentTag(): HdsAlertTitleTags {
     return this.args.tag ?? HdsAlertTitleTagValues.Div;
   }
 }
-
-export default HdsAlertTitleComponent;

--- a/packages/components/src/components/hds/app-footer/copyright.ts
+++ b/packages/components/src/components/hds/app-footer/copyright.ts
@@ -12,7 +12,7 @@ export interface HdsAppFooterCopyrightSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsAppFooterCopyrightComponent extends Component<HdsAppFooterCopyrightSignature> {
+export default class HdsAppFooterCopyright extends Component<HdsAppFooterCopyrightSignature> {
   /**
    * @param year
    * @type {string}

--- a/packages/components/src/components/hds/app-footer/index.ts
+++ b/packages/components/src/components/hds/app-footer/index.ts
@@ -34,7 +34,7 @@ export interface HdsAppFooterSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsAppFooterComponent extends Component<HdsAppFooterSignature> {
+export default class HdsAppFooter extends Component<HdsAppFooterSignature> {
   /**
    * @param ariaLabel
    * @type {string}

--- a/packages/components/src/components/hds/app-footer/item.ts
+++ b/packages/components/src/components/hds/app-footer/item.ts
@@ -12,4 +12,4 @@ export interface HdsAppFooterItemSignature {
   Element: HTMLLIElement;
 }
 
-export default class HdsAppFooterItemComponent extends Component<HdsAppFooterItemSignature> {}
+export default class HdsAppFooterItem extends Component<HdsAppFooterItemSignature> {}

--- a/packages/components/src/components/hds/app-footer/legal-links.ts
+++ b/packages/components/src/components/hds/app-footer/legal-links.ts
@@ -17,7 +17,7 @@ export interface HdsAppFooterLegalLinksSignature {
   Element: HTMLUListElement;
 }
 
-export default class HdsAppFooterLegalLinksComponent extends Component<HdsAppFooterLegalLinksSignature> {
+export default class HdsAppFooterLegalLinks extends Component<HdsAppFooterLegalLinksSignature> {
   /**
    * @param ariaLabel
    * @type {string}

--- a/packages/components/src/components/hds/app-footer/link.ts
+++ b/packages/components/src/components/hds/app-footer/link.ts
@@ -22,4 +22,4 @@ export interface HdsAppFooterLinkSignature {
   Element: HdsLinkInlineSignature['Element'];
 }
 
-export default class HdsAppFooterLinkComponent extends Component<HdsAppFooterLinkSignature> {}
+export default class HdsAppFooterLink extends Component<HdsAppFooterLinkSignature> {}

--- a/packages/components/src/components/hds/app-footer/status-link.ts
+++ b/packages/components/src/components/hds/app-footer/status-link.ts
@@ -27,7 +27,7 @@ export interface HdsAppFooterStatusLinkSignature {
   Element: HdsAppFooterLinkSignature['Element'];
 }
 
-export default class HdsAppFooterStatusLinkComponent extends Component<HdsAppFooterStatusLinkSignature> {
+export default class HdsAppFooterStatusLink extends Component<HdsAppFooterStatusLinkSignature> {
   constructor(owner: unknown, args: HdsInteractiveSignature['Args']) {
     super(owner, args);
 

--- a/packages/components/src/components/hds/app-frame/index.ts
+++ b/packages/components/src/components/hds/app-frame/index.ts
@@ -32,7 +32,7 @@ export interface HdsAppFrameSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsAppFrameComponent extends Component<HdsAppFrameSignature> {
+export default class HdsAppFrame extends Component<HdsAppFrameSignature> {
   // Indicates if the "header" container should be displayed
   get hasHeader(): boolean {
     return this.args.hasHeader ?? true;

--- a/packages/components/src/components/hds/app-frame/parts/footer.ts
+++ b/packages/components/src/components/hds/app-frame/parts/footer.ts
@@ -12,4 +12,4 @@ export interface HdsAppFrameFooterSignature {
   Element: HTMLElement;
 }
 
-export default class HdsAppFrameFooterComponent extends Component<HdsAppFrameFooterSignature> {}
+export default class HdsAppFrameFooter extends Component<HdsAppFrameFooterSignature> {}

--- a/packages/components/src/components/hds/app-frame/parts/header.ts
+++ b/packages/components/src/components/hds/app-frame/parts/header.ts
@@ -12,4 +12,4 @@ export interface HdsAppFrameHeaderSignature {
   Element: HTMLElement;
 }
 
-export default class HdsAppFrameHeaderComponent extends Component<HdsAppFrameHeaderSignature> {}
+export default class HdsAppFrameHeader extends Component<HdsAppFrameHeaderSignature> {}

--- a/packages/components/src/components/hds/app-frame/parts/main.ts
+++ b/packages/components/src/components/hds/app-frame/parts/main.ts
@@ -12,4 +12,4 @@ export interface HdsAppFrameMainSignature {
   Element: HTMLElement;
 }
 
-export default class HdsAppFrameMainComponent extends Component<HdsAppFrameMainSignature> {}
+export default class HdsAppFrameMain extends Component<HdsAppFrameMainSignature> {}

--- a/packages/components/src/components/hds/app-frame/parts/modals.ts
+++ b/packages/components/src/components/hds/app-frame/parts/modals.ts
@@ -12,4 +12,4 @@ export interface HdsAppFrameModalsSignature {
   Element: HTMLElement;
 }
 
-export default class HdsAppFrameModalsComponent extends Component<HdsAppFrameModalsSignature> {}
+export default class HdsAppFrameModals extends Component<HdsAppFrameModalsSignature> {}

--- a/packages/components/src/components/hds/app-frame/parts/sidebar.ts
+++ b/packages/components/src/components/hds/app-frame/parts/sidebar.ts
@@ -12,4 +12,4 @@ export interface HdsAppFrameSidebarSignature {
   Element: HTMLElement;
 }
 
-export default class HdsAppFrameSidebarComponent extends Component<HdsAppFrameSidebarSignature> {}
+export default class HdsAppFrameSidebar extends Component<HdsAppFrameSidebarSignature> {}

--- a/packages/components/src/components/hds/app-header/home-link.ts
+++ b/packages/components/src/components/hds/app-header/home-link.ts
@@ -18,7 +18,7 @@ export interface HdsAppHeaderHomeLinkSignature {
   Element: HdsInteractiveSignature['Element'];
 }
 
-export default class HdsAppHeaderHomeLinkComponent extends Component<HdsAppHeaderHomeLinkSignature> {
+export default class HdsAppHeaderHomeLink extends Component<HdsAppHeaderHomeLinkSignature> {
   get ariaLabel(): string {
     const { ariaLabel } = this.args;
 

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -27,7 +27,7 @@ export interface HdsAppHeaderSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsAppHeaderComponent extends Component<HdsAppHeaderSignature> {
+export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
   @tracked isOpen = false;
   @tracked isDesktop = true;
   @tracked hasOverflowContent = false;

--- a/packages/components/src/components/hds/app-header/menu-button.ts
+++ b/packages/components/src/components/hds/app-header/menu-button.ts
@@ -17,7 +17,7 @@ export interface HdsAppHeaderMenuButtonSignature {
   Element: HdsButtonSignature['Element'];
 }
 
-export default class HdsAppHeaderMenuButtonComponent extends Component<HdsAppHeaderMenuButtonSignature> {
+export default class HdsAppHeaderMenuButton extends Component<HdsAppHeaderMenuButtonSignature> {
   get icon(): 'x' | 'menu' {
     return this.args.isOpen ? 'x' : 'menu';
   }

--- a/packages/components/src/components/hds/application-state/body.ts
+++ b/packages/components/src/components/hds/application-state/body.ts
@@ -15,7 +15,7 @@ export interface HdsApplicationStateBodySignature {
   Element: HTMLDivElement;
 }
 
-const HdsApplicationStateBodyComponent =
+const HdsApplicationStateBody =
   TemplateOnlyComponent<HdsApplicationStateBodySignature>();
 
-export default HdsApplicationStateBodyComponent;
+export default HdsApplicationStateBody;

--- a/packages/components/src/components/hds/application-state/footer.ts
+++ b/packages/components/src/components/hds/application-state/footer.ts
@@ -25,7 +25,7 @@ export interface HdsApplicationStateFooterSignature {
   Element: HTMLDivElement;
 }
 
-const HdsApplicationStateFooterComponent =
+const HdsApplicationStateFooter =
   TemplateOnlyComponent<HdsApplicationStateFooterSignature>();
 
-export default HdsApplicationStateFooterComponent;
+export default HdsApplicationStateFooter;

--- a/packages/components/src/components/hds/application-state/header.ts
+++ b/packages/components/src/components/hds/application-state/header.ts
@@ -18,7 +18,7 @@ export interface HdsApplicationStateHeaderSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsApplicationStateHeaderComponent extends Component<HdsApplicationStateHeaderSignature> {
+export default class HdsApplicationStateHeader extends Component<HdsApplicationStateHeaderSignature> {
   get titleTag(): HdsApplicationStateTitleTags {
     return this.args.titleTag ?? HdsApplicationStateTitleTagValues.Div;
   }

--- a/packages/components/src/components/hds/application-state/index.ts
+++ b/packages/components/src/components/hds/application-state/index.ts
@@ -32,7 +32,7 @@ export interface HdsApplicationStateSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsApplicationStateComponent extends Component<HdsApplicationStateSignature> {
+export default class HdsApplicationState extends Component<HdsApplicationStateSignature> {
   get align(): HdsApplicationStateAligns {
     const validAlignValues: HdsApplicationStateAligns[] = Object.values(
       HdsApplicationStateAlignValues

--- a/packages/components/src/components/hds/application-state/media.ts
+++ b/packages/components/src/components/hds/application-state/media.ts
@@ -12,7 +12,7 @@ export interface HdsApplicationStateMediaSignature {
   Element: HTMLDivElement;
 }
 
-const HdsApplicationStateMediaComponent =
+const HdsApplicationStateMedia =
   TemplateOnlyComponent<HdsApplicationStateMediaSignature>();
 
-export default HdsApplicationStateMediaComponent;
+export default HdsApplicationStateMedia;

--- a/packages/components/src/components/hds/badge-count/index.ts
+++ b/packages/components/src/components/hds/badge-count/index.ts
@@ -34,7 +34,7 @@ export interface HdsBadgeCountSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsBadgeCountComponent extends Component<HdsBadgeCountSignature> {
+export default class HdsBadgeCount extends Component<HdsBadgeCountSignature> {
   /**
    * Sets the size for the component
    * Accepted sizes: small, medium, large

--- a/packages/components/src/components/hds/badge/index.ts
+++ b/packages/components/src/components/hds/badge/index.ts
@@ -34,7 +34,7 @@ export interface HdsBadgeSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsBadgeComponent extends Component<HdsBadgeSignature> {
+export default class HdsBadge extends Component<HdsBadgeSignature> {
   /**
    * Sets the size for the component
    * Accepted values: small, medium, large

--- a/packages/components/src/components/hds/breadcrumb/index.ts
+++ b/packages/components/src/components/hds/breadcrumb/index.ts
@@ -19,7 +19,7 @@ export interface HdsBreadcrumbSignature {
 
 const NOOP = () => {};
 
-export default class HdsBreadcrumbComponent extends Component<HdsBreadcrumbSignature> {
+export default class HdsBreadcrumb extends Component<HdsBreadcrumbSignature> {
   /**
    * @param onDidInsert
    * @type {function}

--- a/packages/components/src/components/hds/breadcrumb/item.ts
+++ b/packages/components/src/components/hds/breadcrumb/item.ts
@@ -26,7 +26,7 @@ export interface HdsBreadcrumbItemSignature {
   Element: HTMLLIElement;
 }
 
-export default class HdsBreadcrumbItemComponent extends Component<HdsBreadcrumbItemSignature> {
+export default class HdsBreadcrumbItem extends Component<HdsBreadcrumbItemSignature> {
   /**
    * @param maxWidth
    * @type {string}

--- a/packages/components/src/components/hds/breadcrumb/truncation.ts
+++ b/packages/components/src/components/hds/breadcrumb/truncation.ts
@@ -15,7 +15,7 @@ export interface HdsBreadcrumbTruncationSignature {
   Element: HTMLLIElement;
 }
 
-export default class HdsBreadcrumbTruncationComponent extends Component<HdsBreadcrumbTruncationSignature> {
+export default class HdsBreadcrumbTruncation extends Component<HdsBreadcrumbTruncationSignature> {
   /**
    * @param ariaLabel
    * @type {string}

--- a/packages/components/src/components/hds/button-set/index.ts
+++ b/packages/components/src/components/hds/button-set/index.ts
@@ -8,6 +8,6 @@ interface HdsButtonSetSignature {
   Blocks: { default: [] };
   Element: HTMLDivElement;
 }
-const HdsButtonSetComponent = TemplateOnlyComponent<HdsButtonSetSignature>();
+const HdsButtonSet = TemplateOnlyComponent<HdsButtonSetSignature>();
 
-export default HdsButtonSetComponent;
+export default HdsButtonSet;

--- a/packages/components/src/components/hds/button/index.ts
+++ b/packages/components/src/components/hds/button/index.ts
@@ -33,7 +33,7 @@ export interface HdsButtonSignature {
   Element: HdsInteractiveSignature['Element'];
 }
 
-export default class HdsButtonComponent extends Component<HdsButtonSignature> {
+export default class HdsButton extends Component<HdsButtonSignature> {
   /**
    * @param text
    * @type {string}

--- a/packages/components/src/components/hds/card/container.ts
+++ b/packages/components/src/components/hds/card/container.ts
@@ -42,7 +42,7 @@ export interface HdsCardContainerSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsCardContainerComponent extends Component<HdsCardContainerSignature> {
+export default class HdsCardContainer extends Component<HdsCardContainerSignature> {
   /**
    * Sets the "elevation" level for the component
    * Accepted values: base, mid, high

--- a/packages/components/src/components/hds/code-block/copy-button.ts
+++ b/packages/components/src/components/hds/code-block/copy-button.ts
@@ -16,7 +16,7 @@ export interface HdsCodeBlockCopyButtonSignature {
   Element: HdsCopyButtonSignature['Element'];
 }
 
-const HdsCodeBlockCopyButtonComponent =
+const HdsCodeBlockCopyButton =
   templateOnlyComponent<HdsCodeBlockCopyButtonSignature>();
 
-export default HdsCodeBlockCopyButtonComponent;
+export default HdsCodeBlockCopyButton;

--- a/packages/components/src/components/hds/code-block/description.ts
+++ b/packages/components/src/components/hds/code-block/description.ts
@@ -13,7 +13,7 @@ export interface HdsCodeBlockDescriptionSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-const HdsCodeBlockDescriptionComponent =
+const HdsCodeBlockDescription =
   templateOnlyComponent<HdsCodeBlockDescriptionSignature>();
 
-export default HdsCodeBlockDescriptionComponent;
+export default HdsCodeBlockDescription;

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -63,7 +63,7 @@ export interface HdsCodeBlockSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsCodeBlockComponent extends Component<HdsCodeBlockSignature> {
+export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   @tracked prismCode: SafeString = htmlSafe('');
 
   /**

--- a/packages/components/src/components/hds/code-block/title.ts
+++ b/packages/components/src/components/hds/code-block/title.ts
@@ -17,10 +17,8 @@ export interface HdsCodeBlockTitleSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-class HdsCodeBlockTitleComponent extends Component<HdsCodeBlockTitleSignature> {
+export default class HdsCodeBlockTitle extends Component<HdsCodeBlockTitleSignature> {
   get componentTag(): HdsCodeBlockTitleTags {
     return this.args.tag ?? HdsCodeBlockTitleTagValues.P;
   }
 }
-
-export default HdsCodeBlockTitleComponent;

--- a/packages/components/src/components/hds/copy/button/index.ts
+++ b/packages/components/src/components/hds/copy/button/index.ts
@@ -31,7 +31,7 @@ export interface HdsCopyButtonSignature {
   Element: HdsButtonSignature['Element'];
 }
 
-export default class HdsCopyButtonComponent extends Component<HdsCopyButtonSignature> {
+export default class HdsCopyButton extends Component<HdsCopyButtonSignature> {
   @tracked status = DEFAULT_STATUS;
   @tracked timer: ReturnType<typeof setTimeout> | undefined;
 

--- a/packages/components/src/components/hds/copy/snippet/index.ts
+++ b/packages/components/src/components/hds/copy/snippet/index.ts
@@ -32,7 +32,7 @@ export interface HdsCopySnippetSignature {
   Element: HTMLButtonElement;
 }
 
-export default class HdsCopySnippetComponent extends Component<HdsCopySnippetSignature> {
+export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
   @tracked status = DEFAULT_STATUS;
   @tracked timer: ReturnType<typeof setTimeout> | undefined;
 

--- a/packages/components/src/components/hds/dialog-primitive/body.ts
+++ b/packages/components/src/components/hds/dialog-primitive/body.ts
@@ -15,7 +15,7 @@ export interface HdsDialogPrimitiveBodySignature {
   Element: HTMLDivElement;
 }
 
-const HdsDialogPrimitiveBodyComponent =
+const HdsDialogPrimitiveBody =
   templateOnlyComponent<HdsDialogPrimitiveBodySignature>();
 
-export default HdsDialogPrimitiveBodyComponent;
+export default HdsDialogPrimitiveBody;

--- a/packages/components/src/components/hds/dialog-primitive/description.ts
+++ b/packages/components/src/components/hds/dialog-primitive/description.ts
@@ -15,7 +15,7 @@ export interface HdsDialogPrimitiveDescriptionSignature {
   Element: HTMLDivElement;
 }
 
-const HdsDialogPrimitiveDescriptionComponent =
+const HdsDialogPrimitiveDescription =
   templateOnlyComponent<HdsDialogPrimitiveDescriptionSignature>();
 
-export default HdsDialogPrimitiveDescriptionComponent;
+export default HdsDialogPrimitiveDescription;

--- a/packages/components/src/components/hds/dialog-primitive/footer.ts
+++ b/packages/components/src/components/hds/dialog-primitive/footer.ts
@@ -22,7 +22,7 @@ export interface HdsDialogPrimitiveFooterSignature {
   Element: HTMLDivElement;
 }
 
-const HdsDialogPrimitiveFooterComponent =
+const HdsDialogPrimitiveFooter =
   templateOnlyComponent<HdsDialogPrimitiveFooterSignature>();
 
-export default HdsDialogPrimitiveFooterComponent;
+export default HdsDialogPrimitiveFooter;

--- a/packages/components/src/components/hds/dialog-primitive/header.ts
+++ b/packages/components/src/components/hds/dialog-primitive/header.ts
@@ -26,7 +26,7 @@ export interface HdsDialogPrimitiveHeaderSignature {
 
 const NOOP = (): void => {};
 
-export default class HdsDialogPrimitiveHeaderComponent extends Component<HdsDialogPrimitiveHeaderSignature> {
+export default class HdsDialogPrimitiveHeader extends Component<HdsDialogPrimitiveHeaderSignature> {
   get titleTag(): HdsDialogPrimitiveHeaderTitleTags {
     return this.args.titleTag ?? HdsDialogPrimitiveHeaderTitleTagValues.Div;
   }

--- a/packages/components/src/components/hds/dialog-primitive/overlay.ts
+++ b/packages/components/src/components/hds/dialog-primitive/overlay.ts
@@ -12,7 +12,7 @@ export interface HdsDialogPrimitiveOverlaySignature {
   Element: HTMLDivElement;
 }
 
-const HdsDialogPrimitiveOverlayComponent =
+const HdsDialogPrimitiveOverlay =
   templateOnlyComponent<HdsDialogPrimitiveOverlaySignature>();
 
-export default HdsDialogPrimitiveOverlayComponent;
+export default HdsDialogPrimitiveOverlay;

--- a/packages/components/src/components/hds/dialog-primitive/wrapper.ts
+++ b/packages/components/src/components/hds/dialog-primitive/wrapper.ts
@@ -14,7 +14,7 @@ export interface HdsDialogPrimitiveWrapperSignature {
   Element: HTMLDialogElement;
 }
 
-const HdsDialogPrimitiveWrapperComponent =
+const HdsDialogPrimitiveWrapper =
   templateOnlyComponent<HdsDialogPrimitiveWrapperSignature>();
 
-export default HdsDialogPrimitiveWrapperComponent;
+export default HdsDialogPrimitiveWrapper;

--- a/packages/components/src/components/hds/disclosure-primitive/index.ts
+++ b/packages/components/src/components/hds/disclosure-primitive/index.ts
@@ -34,7 +34,7 @@ export interface HdsDisclosurePrimitiveSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsDisclosurePrimitiveComponent extends Component<HdsDisclosurePrimitiveSignature> {
+export default class HdsDisclosurePrimitive extends Component<HdsDisclosurePrimitiveSignature> {
   @tracked _isOpen = false;
   @tracked _isControlled = this.args.isOpen !== undefined;
 

--- a/packages/components/src/components/hds/dismiss-button/index.ts
+++ b/packages/components/src/components/hds/dismiss-button/index.ts
@@ -12,7 +12,7 @@ export interface HdsDismissButtonSignature {
   Element: HTMLButtonElement;
 }
 
-export default class HdsDismissButtonComponent extends Component<HdsDismissButtonSignature> {
+export default class HdsDismissButton extends Component<HdsDismissButtonSignature> {
   /**
    * @param ariaLabel
    * @type {string}

--- a/packages/components/src/components/hds/dropdown/footer.ts
+++ b/packages/components/src/components/hds/dropdown/footer.ts
@@ -15,7 +15,6 @@ export interface HdsDropdownFooterSignature {
   Element: HTMLDivElement;
 }
 
-const HdsDropdownFooterComponent =
-  templateOnlyComponent<HdsDropdownFooterSignature>();
+const HdsDropdownFooter = templateOnlyComponent<HdsDropdownFooterSignature>();
 
-export default HdsDropdownFooterComponent;
+export default HdsDropdownFooter;

--- a/packages/components/src/components/hds/dropdown/header.ts
+++ b/packages/components/src/components/hds/dropdown/header.ts
@@ -15,7 +15,6 @@ export interface HdsDropdownHeaderSignature {
   Element: HTMLDivElement;
 }
 
-const HdsDropdownHeaderComponent =
-  templateOnlyComponent<HdsDropdownHeaderSignature>();
+const HdsDropdownHeader = templateOnlyComponent<HdsDropdownHeaderSignature>();
 
-export default HdsDropdownHeaderComponent;
+export default HdsDropdownHeader;

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -68,7 +68,7 @@ export interface HdsDropdownSignature {
   Element: MenuPrimitiveSignature['Element'];
 }
 
-export default class HdsDropdownComponent extends Component<HdsDropdownSignature> {
+export default class HdsDropdown extends Component<HdsDropdownSignature> {
   /**
    * @param listPosition
    * @type {string}

--- a/packages/components/src/components/hds/dropdown/list-item/checkbox.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/checkbox.ts
@@ -19,7 +19,7 @@ export interface HdsDropdownListItemCheckboxSignature {
   Element: HdsFormCheckboxBaseSignature['Element'];
 }
 
-export default class HdsDropdownListItemCheckboxComponent extends Component<HdsDropdownListItemCheckboxSignature> {
+export default class HdsDropdownListItemCheckbox extends Component<HdsDropdownListItemCheckboxSignature> {
   /**
    * Determines the unique ID to assign to the checkbox control
    */

--- a/packages/components/src/components/hds/dropdown/list-item/checkmark.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/checkmark.ts
@@ -19,7 +19,7 @@ export interface HdsDropdownListItemCheckmarkSignature {
   Element: HdsInteractiveSignature['Element'];
 }
 
-export default class HdsDropdownListItemCheckmarkComponent extends Component<HdsDropdownListItemCheckmarkSignature> {
+export default class HdsDropdownListItemCheckmark extends Component<HdsDropdownListItemCheckmarkSignature> {
   /**
    * Get the class names to apply to the component.
    * @method classNames

--- a/packages/components/src/components/hds/dropdown/list-item/copy-item.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/copy-item.ts
@@ -16,7 +16,7 @@ export interface HdsDropdownListItemCopyItemSignature {
   Element: HTMLLIElement;
 }
 
-export default class HdsDropdownListItemCopyItemComponent extends Component<HdsDropdownListItemCopyItemSignature> {
+export default class HdsDropdownListItemCopyItem extends Component<HdsDropdownListItemCopyItemSignature> {
   /**
    * @param text
    * @type {string}

--- a/packages/components/src/components/hds/dropdown/list-item/description.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/description.ts
@@ -14,7 +14,7 @@ export interface HdsDropdownListItemDescriptionSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-export default class HdsDropdownListItemDescriptionComponent extends Component<HdsDropdownListItemDescriptionSignature> {
+export default class HdsDropdownListItemDescription extends Component<HdsDropdownListItemDescriptionSignature> {
   /**
    * @param text
    * @type {string}

--- a/packages/components/src/components/hds/dropdown/list-item/generic.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/generic.ts
@@ -12,7 +12,7 @@ export interface HdsDropdownListItemGenericSignature {
   Element: HTMLLIElement;
 }
 
-const HdsDropdownListItemGenericComponent =
+const HdsDropdownListItemGeneric =
   templateOnlyComponent<HdsDropdownListItemGenericSignature>();
 
-export default HdsDropdownListItemGenericComponent;
+export default HdsDropdownListItemGeneric;

--- a/packages/components/src/components/hds/dropdown/list-item/interactive.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/interactive.ts
@@ -37,7 +37,7 @@ export interface HdsDropdownListItemInteractiveSignature {
   Element: HTMLDivElement | HdsInteractiveSignature['Element'];
 }
 
-export default class HdsDropdownListItemInteractiveComponent extends Component<HdsDropdownListItemInteractiveSignature> {
+export default class HdsDropdownListItemInteractive extends Component<HdsDropdownListItemInteractiveSignature> {
   constructor(
     owner: unknown,
     args: HdsDropdownListItemInteractiveSignature['Args']

--- a/packages/components/src/components/hds/dropdown/list-item/radio.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/radio.ts
@@ -19,7 +19,7 @@ export interface HdsDropdownListItemRadioSignature {
   Element: HdsFormRadioBaseSignature['Element'];
 }
 
-export default class HdsDropdownListItemRadioComponent extends Component<HdsDropdownListItemRadioSignature> {
+export default class HdsDropdownListItemRadio extends Component<HdsDropdownListItemRadioSignature> {
   /**
    * Determines the unique ID to assign to the radio control
    */

--- a/packages/components/src/components/hds/dropdown/list-item/separator.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/separator.ts
@@ -9,7 +9,7 @@ export interface HdsDropdownListItemSeparatorSignature {
   Element: HTMLLIElement;
 }
 
-const HdsDropdownListItemSeparatorComponent =
+const HdsDropdownListItemSeparator =
   templateOnlyComponent<HdsDropdownListItemSeparatorSignature>();
 
-export default HdsDropdownListItemSeparatorComponent;
+export default HdsDropdownListItemSeparator;

--- a/packages/components/src/components/hds/dropdown/list-item/title.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/title.ts
@@ -14,7 +14,7 @@ export interface HdsDropdownListItemTitleSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-export default class HdsDropdownListItemTitleComponent extends Component<HdsDropdownListItemTitleSignature> {
+export default class HdsDropdownListItemTitle extends Component<HdsDropdownListItemTitleSignature> {
   /**
    * @param text
    * @type {string}

--- a/packages/components/src/components/hds/dropdown/toggle/button.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/button.ts
@@ -44,7 +44,7 @@ export interface HdsDropdownToggleButtonSignature {
   Element: HTMLButtonElement;
 }
 
-export default class HdsDropdownToggleButtonComponent extends Component<HdsDropdownToggleButtonSignature> {
+export default class HdsDropdownToggleButton extends Component<HdsDropdownToggleButtonSignature> {
   /**
    * Generates a unique ID for the button
    *

--- a/packages/components/src/components/hds/dropdown/toggle/chevron.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/chevron.ts
@@ -7,7 +7,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface HdsDropdownToggleChevronSignature {}
 
-const HdsDropdownToggleChevronComponent =
+const HdsDropdownToggleChevron =
   templateOnlyComponent<HdsDropdownToggleChevronSignature>();
 
-export default HdsDropdownToggleChevronComponent;
+export default HdsDropdownToggleChevron;

--- a/packages/components/src/components/hds/dropdown/toggle/icon.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.ts
@@ -30,7 +30,7 @@ export interface HdsDropdownToggleIconSignature {
   Element: HTMLButtonElement;
 }
 
-export default class HdsDropdownToggleIconComponent extends Component<HdsDropdownToggleIconSignature> {
+export default class HdsDropdownToggleIcon extends Component<HdsDropdownToggleIconSignature> {
   @tracked hasImage = true;
 
   constructor(owner: unknown, args: HdsDropdownToggleIconSignature['Args']) {

--- a/packages/components/src/components/hds/flyout/body.ts
+++ b/packages/components/src/components/hds/flyout/body.ts
@@ -13,7 +13,7 @@ export interface HdsFlyoutBodySignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsFlyoutBodyComponent extends Component<HdsFlyoutBodySignature> {
+export default class HdsFlyoutBody extends Component<HdsFlyoutBodySignature> {
   constructor(owner: unknown) {
     super(owner, {});
 

--- a/packages/components/src/components/hds/flyout/description.ts
+++ b/packages/components/src/components/hds/flyout/description.ts
@@ -14,7 +14,7 @@ interface HdsFlyoutDescriptionSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-export default class HdsFlyoutDescriptionComponent extends Component<HdsFlyoutDescriptionSignature> {
+export default class HdsFlyoutDescription extends Component<HdsFlyoutDescriptionSignature> {
   constructor(owner: unknown) {
     super(owner, {});
 

--- a/packages/components/src/components/hds/flyout/footer.ts
+++ b/packages/components/src/components/hds/flyout/footer.ts
@@ -16,7 +16,7 @@ interface HdsFlyoutFooterSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsFlyoutFooterComponent extends Component<HdsFlyoutFooterSignature> {
+export default class HdsFlyoutFooter extends Component<HdsFlyoutFooterSignature> {
   constructor(owner: unknown, args: HdsFlyoutFooterSignature['Args']) {
     super(owner, args);
 

--- a/packages/components/src/components/hds/flyout/header.ts
+++ b/packages/components/src/components/hds/flyout/header.ts
@@ -20,7 +20,7 @@ export interface HdsFlyoutHeaderSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsFlyoutHeaderComponent extends Component<HdsFlyoutHeaderSignature> {
+export default class HdsFlyoutHeader extends Component<HdsFlyoutHeaderSignature> {
   constructor(owner: unknown, args: HdsFlyoutHeaderSignature['Args']) {
     super(owner, args);
 

--- a/packages/components/src/components/hds/flyout/index.ts
+++ b/packages/components/src/components/hds/flyout/index.ts
@@ -25,7 +25,7 @@ export const DEFAULT_SIZE = HdsFlyoutSizesValues.Medium;
 export const DEFAULT_HAS_OVERLAY = true;
 export const SIZES: string[] = Object.values(HdsFlyoutSizesValues);
 
-export interface HdsFlyoutIndexSignature {
+export interface HdsFlyoutSignature {
   Args: {
     isDismissDisabled?: boolean;
     size?: HdsFlyoutSizes;
@@ -57,7 +57,7 @@ export interface HdsFlyoutIndexSignature {
   Element: HTMLDialogElement;
 }
 
-export default class HdsFlyoutIndex extends Component<HdsFlyoutIndexSignature> {
+export default class HdsFlyout extends Component<HdsFlyoutSignature> {
   @tracked isOpen = false;
   element!: HTMLDialogElement;
   body!: HTMLElement;

--- a/packages/components/src/components/hds/flyout/index.ts
+++ b/packages/components/src/components/hds/flyout/index.ts
@@ -57,7 +57,7 @@ export interface HdsFlyoutIndexSignature {
   Element: HTMLDialogElement;
 }
 
-export default class HdsFlyoutIndexComponent extends Component<HdsFlyoutIndexSignature> {
+export default class HdsFlyoutIndex extends Component<HdsFlyoutIndexSignature> {
   @tracked isOpen = false;
   element!: HTMLDialogElement;
   body!: HTMLElement;

--- a/packages/components/src/components/hds/form/character-count/index.ts
+++ b/packages/components/src/components/hds/form/character-count/index.ts
@@ -33,7 +33,7 @@ interface HdsFormCharacterCountSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-export default class HdsFormCharacterCountComponent extends Component<HdsFormCharacterCountSignature> {
+export default class HdsFormCharacterCount extends Component<HdsFormCharacterCountSignature> {
   // The current number of characters in @value
   get currentLength(): number {
     const { value } = this.args;

--- a/packages/components/src/components/hds/form/checkbox/base.ts
+++ b/packages/components/src/components/hds/form/checkbox/base.ts
@@ -12,7 +12,7 @@ export interface HdsFormCheckboxBaseSignature {
   Element: HTMLInputElement;
 }
 
-const HdsFormCheckboxBaseComponent =
+const HdsFormCheckboxBase =
   templateOnlyComponent<HdsFormCheckboxBaseSignature>();
 
-export default HdsFormCheckboxBaseComponent;
+export default HdsFormCheckboxBase;

--- a/packages/components/src/components/hds/form/checkbox/field.ts
+++ b/packages/components/src/components/hds/form/checkbox/field.ts
@@ -27,7 +27,7 @@ export interface HdsFormCheckboxFieldSignature {
   Element: HdsFormFieldSignature['Element'];
 }
 
-const HdsFormCheckboxFieldComponent =
+const HdsFormCheckboxField =
   templateOnlyComponent<HdsFormCheckboxFieldSignature>();
 
-export default HdsFormCheckboxFieldComponent;
+export default HdsFormCheckboxField;

--- a/packages/components/src/components/hds/form/checkbox/group.ts
+++ b/packages/components/src/components/hds/form/checkbox/group.ts
@@ -28,7 +28,7 @@ interface HdsFormCheckboxGroupSignature {
   Element: HdsFormFieldsetSignature['Element'];
 }
 
-const HdsFormCheckboxGroupComponent =
+const HdsFormCheckboxGroup =
   templateOnlyComponent<HdsFormCheckboxGroupSignature>();
 
-export default HdsFormCheckboxGroupComponent;
+export default HdsFormCheckboxGroup;

--- a/packages/components/src/components/hds/form/error/index.ts
+++ b/packages/components/src/components/hds/form/error/index.ts
@@ -30,7 +30,7 @@ export interface HdsFormErrorSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsFormErrorComponent extends Component<HdsFormErrorSignature> {
+export default class HdsFormError extends Component<HdsFormErrorSignature> {
   /**
    * Determines the unique ID to assign to the element
    * @method id

--- a/packages/components/src/components/hds/form/error/message.ts
+++ b/packages/components/src/components/hds/form/error/message.ts
@@ -14,7 +14,7 @@ export interface HdsFormErrorMessageSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-const HdsFormErrorMessageComponent =
+const HdsFormErrorMessage =
   templateOnlyComponent<HdsFormErrorMessageSignature>();
 
-export default HdsFormErrorMessageComponent;
+export default HdsFormErrorMessage;

--- a/packages/components/src/components/hds/form/field/index.ts
+++ b/packages/components/src/components/hds/form/field/index.ts
@@ -61,9 +61,9 @@ export interface HdsFormFieldSignature {
   Element: HTMLElement;
 }
 
-// @ts-expect-error: decorator function return type 'ClassOf<AriaDescribedByComponent>' is not assignable to 'typeof HdsFormFieldComponent'
+// @ts-expect-error: decorator function return type 'ClassOf<AriaDescribedBy>' is not assignable to 'typeof HdsFormField'
 @ariaDescribedBy
-class HdsFormFieldComponent extends Component<HdsFormFieldSignature> {
+export default class HdsFormField extends Component<HdsFormFieldSignature> {
   /**
    * Sets the layout of the field
    *
@@ -138,5 +138,3 @@ class HdsFormFieldComponent extends Component<HdsFormFieldSignature> {
     unregisterAriaDescriptionElement(this, element);
   }
 }
-
-export default HdsFormFieldComponent;

--- a/packages/components/src/components/hds/form/fieldset/index.ts
+++ b/packages/components/src/components/hds/form/fieldset/index.ts
@@ -52,7 +52,7 @@ export interface HdsFormFieldsetSignature {
 
 // @ts-expect-error: decorator function return type 'ClassOf<AriaDescribedByComponent>' is not assignable to 'typeof HdsFormFieldComponent'
 @ariaDescribedBy
-class HdsFormFieldsetComponent extends Component<HdsFormFieldsetSignature> {
+export default class HdsFormFieldset extends Component<HdsFormFieldsetSignature> {
   /**
    * Sets the layout of the group
    *
@@ -113,5 +113,3 @@ class HdsFormFieldsetComponent extends Component<HdsFormFieldsetSignature> {
     unregisterAriaDescriptionElement(this, element);
   }
 }
-
-export default HdsFormFieldsetComponent;

--- a/packages/components/src/components/hds/form/file-input/base.ts
+++ b/packages/components/src/components/hds/form/file-input/base.ts
@@ -9,7 +9,7 @@ interface HdsFormFileInputBaseSignature {
   Element: HTMLInputElement;
 }
 
-const HdsFormFileInputBaseComponent =
+const HdsFormFileInputBase =
   templateOnlyComponent<HdsFormFileInputBaseSignature>();
 
-export default HdsFormFileInputBaseComponent;
+export default HdsFormFileInputBase;

--- a/packages/components/src/components/hds/form/file-input/field.ts
+++ b/packages/components/src/components/hds/form/file-input/field.ts
@@ -24,7 +24,7 @@ interface HdsFormFileInputFieldSignature {
   Element: HdsFormFieldSignature['Element'];
 }
 
-const HdsFormFileInputFieldComponent =
+const HdsFormFileInputField =
   templateOnlyComponent<HdsFormFileInputFieldSignature>();
 
-export default HdsFormFileInputFieldComponent;
+export default HdsFormFileInputField;

--- a/packages/components/src/components/hds/form/helper-text/index.ts
+++ b/packages/components/src/components/hds/form/helper-text/index.ts
@@ -23,7 +23,7 @@ export interface HdsFormHelperTextSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-export default class HdsFormHelperTextComponent extends Component<HdsFormHelperTextSignature> {
+export default class HdsFormHelperText extends Component<HdsFormHelperTextSignature> {
   /**
    * Determines the unique ID to assign to the element
    * @method id

--- a/packages/components/src/components/hds/form/indicator/index.ts
+++ b/packages/components/src/components/hds/form/indicator/index.ts
@@ -15,7 +15,7 @@ export interface HdsFormIndicatorSignature {
   Element: HdsTextBodySignature['Element'] | HdsBadgeSignature['Element'];
 }
 
-export default class HdsFormIndicatorComponent extends Component<HdsFormIndicatorSignature> {
+export default class HdsFormIndicator extends Component<HdsFormIndicatorSignature> {
   /**
    * Get the class names to apply to the component.
    * @method classNames

--- a/packages/components/src/components/hds/form/label/index.ts
+++ b/packages/components/src/components/hds/form/label/index.ts
@@ -21,7 +21,7 @@ export interface HdsFormLabelSignature {
   Element: HTMLLabelElement;
 }
 
-export default class HdsFormLabelComponent extends Component<HdsFormLabelSignature> {
+export default class HdsFormLabel extends Component<HdsFormLabelSignature> {
   /**
    * Determines the unique ID to assign to the element
    * @method id

--- a/packages/components/src/components/hds/form/legend/index.ts
+++ b/packages/components/src/components/hds/form/legend/index.ts
@@ -19,7 +19,7 @@ export interface HdsFormLegendSignature {
   Element: HTMLLegendElement;
 }
 
-export default class HdsFormLegendComponent extends Component<HdsFormLegendSignature> {
+export default class HdsFormLegend extends Component<HdsFormLegendSignature> {
   /**
    * Get the class names to apply to the component.
    * @method classNames

--- a/packages/components/src/components/hds/form/masked-input/base.ts
+++ b/packages/components/src/components/hds/form/masked-input/base.ts
@@ -27,7 +27,7 @@ export interface HdsFormMaskedInputBaseSignature {
   Element: HTMLElement;
 }
 
-export default class HdsFormMaskedInputBaseComponent extends Component<HdsFormMaskedInputBaseSignature> {
+export default class HdsFormMaskedInputBase extends Component<HdsFormMaskedInputBaseSignature> {
   @tracked isContentMasked = this.args.isContentMasked ?? true;
 
   @action

--- a/packages/components/src/components/hds/form/masked-input/field.ts
+++ b/packages/components/src/components/hds/form/masked-input/field.ts
@@ -31,7 +31,7 @@ interface HdsFormMaskedInputFieldSignature {
   Element: HdsFormFieldSignature['Element'];
 }
 
-const HdsFormMaskedInputFieldComponent =
+const HdsFormMaskedInputField =
   templateOnlyComponent<HdsFormMaskedInputFieldSignature>();
 
-export default HdsFormMaskedInputFieldComponent;
+export default HdsFormMaskedInputField;

--- a/packages/components/src/components/hds/form/radio-card/description.ts
+++ b/packages/components/src/components/hds/form/radio-card/description.ts
@@ -13,7 +13,7 @@ export interface HdsFormRadioCardDescriptionSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-const HdsFormRadioCardDescriptionComponent =
+const HdsFormRadioCardDescription =
   templateOnlyComponent<HdsFormRadioCardDescriptionSignature>();
 
-export default HdsFormRadioCardDescriptionComponent;
+export default HdsFormRadioCardDescription;

--- a/packages/components/src/components/hds/form/radio-card/group.ts
+++ b/packages/components/src/components/hds/form/radio-card/group.ts
@@ -34,7 +34,7 @@ interface HdsFormRadioCardGroupSignature {
   Element: HdsFormFieldsetSignature['Element'];
 }
 
-const HdsFormRadioCardGroupComponent =
+const HdsFormRadioCardGroup =
   templateOnlyComponent<HdsFormRadioCardGroupSignature>();
 
-export default HdsFormRadioCardGroupComponent;
+export default HdsFormRadioCardGroup;

--- a/packages/components/src/components/hds/form/radio-card/index.ts
+++ b/packages/components/src/components/hds/form/radio-card/index.ts
@@ -57,7 +57,7 @@ export interface HdsFormRadioCardSignature {
   Element: HdsFormRadioBaseSignature['Element'];
 }
 
-export default class HdsFormRadioCardComponent extends Component<HdsFormRadioCardSignature> {
+export default class HdsFormRadioCard extends Component<HdsFormRadioCardSignature> {
   /**
    * Sets the position of the control
    * Accepted values: buttom, left

--- a/packages/components/src/components/hds/form/radio-card/label.ts
+++ b/packages/components/src/components/hds/form/radio-card/label.ts
@@ -13,7 +13,7 @@ export interface HdsFormRadioCardLabelSignature {
   Element: HdsTextDisplaySignature['Element'];
 }
 
-const HdsFormRadioCardLabelComponent =
+const HdsFormRadioCardLabel =
   templateOnlyComponent<HdsFormRadioCardLabelSignature>();
 
-export default HdsFormRadioCardLabelComponent;
+export default HdsFormRadioCardLabel;

--- a/packages/components/src/components/hds/form/radio/base.ts
+++ b/packages/components/src/components/hds/form/radio/base.ts
@@ -12,7 +12,6 @@ export interface HdsFormRadioBaseSignature {
   Element: HTMLInputElement;
 }
 
-const HdsFormRadioBaseComponent =
-  templateOnlyComponent<HdsFormRadioBaseSignature>();
+const HdsFormRadioBase = templateOnlyComponent<HdsFormRadioBaseSignature>();
 
-export default HdsFormRadioBaseComponent;
+export default HdsFormRadioBase;

--- a/packages/components/src/components/hds/form/radio/field.ts
+++ b/packages/components/src/components/hds/form/radio/field.ts
@@ -27,7 +27,6 @@ export interface HdsFormRadioFieldSignature {
   Element: HdsFormFieldSignature['Element'];
 }
 
-const HdsFormRadioFieldComponent =
-  templateOnlyComponent<HdsFormRadioFieldSignature>();
+const HdsFormRadioField = templateOnlyComponent<HdsFormRadioFieldSignature>();
 
-export default HdsFormRadioFieldComponent;
+export default HdsFormRadioField;

--- a/packages/components/src/components/hds/form/radio/group.ts
+++ b/packages/components/src/components/hds/form/radio/group.ts
@@ -28,7 +28,6 @@ interface HdsFormRadioGroupSignature {
   Element: HdsFormFieldsetSignature['Element'];
 }
 
-const HdsFormRadioGroupComponent =
-  templateOnlyComponent<HdsFormRadioGroupSignature>();
+const HdsFormRadioGroup = templateOnlyComponent<HdsFormRadioGroupSignature>();
 
-export default HdsFormRadioGroupComponent;
+export default HdsFormRadioGroup;

--- a/packages/components/src/components/hds/form/select/base.ts
+++ b/packages/components/src/components/hds/form/select/base.ts
@@ -22,7 +22,7 @@ export interface HdsFormSelectBaseSignature {
   Element: HTMLSelectElement;
 }
 
-export default class HdsFormSelectBaseComponent extends Component<HdsFormSelectBaseSignature> {
+export default class HdsFormSelectBase extends Component<HdsFormSelectBaseSignature> {
   /**
    * Get the class names to apply to the component.
    * @method classNames

--- a/packages/components/src/components/hds/form/select/field.ts
+++ b/packages/components/src/components/hds/form/select/field.ts
@@ -28,7 +28,6 @@ interface HdsFormSelectFieldSignature {
   Element: HdsFormFieldSignature['Element'];
 }
 
-const HdsFormSelectFieldComponent =
-  templateOnlyComponent<HdsFormSelectFieldSignature>();
+const HdsFormSelectField = templateOnlyComponent<HdsFormSelectFieldSignature>();
 
-export default HdsFormSelectFieldComponent;
+export default HdsFormSelectField;

--- a/packages/components/src/components/hds/form/super-select/after-options.ts
+++ b/packages/components/src/components/hds/form/super-select/after-options.ts
@@ -13,7 +13,7 @@ interface HdsFormSuperSelectAfterOptionsSignature {
   };
 }
 
-const HdsFormSuperSelectAfterOptionsComponent =
+const HdsFormSuperSelectAfterOptions =
   templateOnlyComponent<HdsFormSuperSelectAfterOptionsSignature>();
 
-export default HdsFormSuperSelectAfterOptionsComponent;
+export default HdsFormSuperSelectAfterOptions;

--- a/packages/components/src/components/hds/form/super-select/multiple/base.ts
+++ b/packages/components/src/components/hds/form/super-select/multiple/base.ts
@@ -36,7 +36,7 @@ export interface HdsFormSuperSelectMultipleBaseSignature {
   Element: PowerSelectSignature['Element'];
 }
 
-export default class HdsFormSuperSelectMultipleBaseComponent extends Component<HdsFormSuperSelectMultipleBaseSignature> {
+export default class HdsFormSuperSelectMultipleBase extends Component<HdsFormSuperSelectMultipleBaseSignature> {
   @tracked powerSelectAPI?: PowerSelect;
   @tracked showOnlySelected = false;
   @tracked showNoSelectedMessage = false;

--- a/packages/components/src/components/hds/form/super-select/multiple/field.ts
+++ b/packages/components/src/components/hds/form/super-select/multiple/field.ts
@@ -18,7 +18,7 @@ interface HdsFormSuperSelectMultipleFieldSignature {
   Element: HdsFormFieldSignature['Element'];
 }
 
-export default class HdsFormSuperSelectMultipleFieldComponent extends Component<HdsFormSuperSelectMultipleFieldSignature> {
+export default class HdsFormSuperSelectMultipleField extends Component<HdsFormSuperSelectMultipleFieldSignature> {
   get idPrefix(): string {
     return ID_PREFIX;
   }

--- a/packages/components/src/components/hds/form/super-select/option-group.ts
+++ b/packages/components/src/components/hds/form/super-select/option-group.ts
@@ -17,7 +17,7 @@ interface HdsFormSuperSelectOptionGroupSignature {
   };
 }
 
-export default class HdsFormSuperSelectOptionGroupComponent extends Component<HdsFormSuperSelectOptionGroupSignature> {
+export default class HdsFormSuperSelectOptionGroup extends Component<HdsFormSuperSelectOptionGroupSignature> {
   /**
    * Generates a unique ID for the group title
    * @return {string}

--- a/packages/components/src/components/hds/form/super-select/placeholder.ts
+++ b/packages/components/src/components/hds/form/super-select/placeholder.ts
@@ -6,7 +6,7 @@ interface HdsFormSuperSelectPlaceholderSignature {
   };
 }
 
-const HdsFormSuperSelectPlaceholderComponent =
+const HdsFormSuperSelectPlaceholder =
   templateOnlyComponent<HdsFormSuperSelectPlaceholderSignature>();
 
-export default HdsFormSuperSelectPlaceholderComponent;
+export default HdsFormSuperSelectPlaceholder;

--- a/packages/components/src/components/hds/form/super-select/single/base.ts
+++ b/packages/components/src/components/hds/form/super-select/single/base.ts
@@ -36,7 +36,7 @@ export interface HdsFormSuperSelectSingleBaseSignature {
   Element: PowerSelectSignature['Element'];
 }
 
-export default class HdsFormSuperSelectSingleBaseComponent extends Component<HdsFormSuperSelectSingleBaseSignature> {
+export default class HdsFormSuperSelectSingleBase extends Component<HdsFormSuperSelectSingleBaseSignature> {
   @tracked powerSelectAPI?: PowerSelect;
 
   get horizontalPosition(): HdsFormSuperSelectHorizontalPositions {

--- a/packages/components/src/components/hds/form/super-select/single/field.ts
+++ b/packages/components/src/components/hds/form/super-select/single/field.ts
@@ -18,7 +18,7 @@ interface HdsFormSuperSelectSingleFieldSignature {
   Element: HdsFormFieldSignature['Element'];
 }
 
-export default class HdsFormSuperSelectSingleFieldComponent extends Component<HdsFormSuperSelectSingleFieldSignature> {
+export default class HdsFormSuperSelectSingleField extends Component<HdsFormSuperSelectSingleFieldSignature> {
   get idPrefix(): string {
     return ID_PREFIX;
   }

--- a/packages/components/src/components/hds/form/text-input/base.ts
+++ b/packages/components/src/components/hds/form/text-input/base.ts
@@ -26,7 +26,7 @@ export interface HdsFormTextInputBaseSignature {
   Element: HTMLInputElement;
 }
 
-export default class HdsFormTextInputBaseComponent extends Component<HdsFormTextInputBaseSignature> {
+export default class HdsFormTextInputBase extends Component<HdsFormTextInputBaseSignature> {
   /**
    * Sets the type of input
    *

--- a/packages/components/src/components/hds/form/text-input/field.ts
+++ b/packages/components/src/components/hds/form/text-input/field.ts
@@ -38,7 +38,7 @@ interface HdsFormTextInputFieldSignature {
   Element: HdsFormFieldSignature['Element'];
 }
 
-export default class HdsFormTextInputFieldComponent extends Component<HdsFormTextInputFieldSignature> {
+export default class HdsFormTextInputField extends Component<HdsFormTextInputFieldSignature> {
   @tracked isPasswordMasked = true;
   @tracked hasVisibilityToggle = this.args.hasVisibilityToggle ?? true;
   @tracked type = this.args.type ?? 'text';

--- a/packages/components/src/components/hds/form/textarea/base.ts
+++ b/packages/components/src/components/hds/form/textarea/base.ts
@@ -15,7 +15,7 @@ export interface HdsFormTextareaBaseSignature {
   Element: HTMLElement;
 }
 
-export default class HdsFormTextareaBaseComponent extends Component<HdsFormTextareaBaseSignature> {
+export default class HdsFormTextareaBase extends Component<HdsFormTextareaBaseSignature> {
   /**
    * Get the class names to apply to the component.
    * @method classNames

--- a/packages/components/src/components/hds/form/textarea/field.ts
+++ b/packages/components/src/components/hds/form/textarea/field.ts
@@ -32,7 +32,7 @@ interface HdsFormTextareaFieldSignature {
   Element: HdsFormFieldSignature['Element'];
 }
 
-const HdsFormTextareaFieldComponent =
+const HdsFormTextareaField =
   templateOnlyComponent<HdsFormTextareaFieldSignature>();
 
-export default HdsFormTextareaFieldComponent;
+export default HdsFormTextareaField;

--- a/packages/components/src/components/hds/form/toggle/base.ts
+++ b/packages/components/src/components/hds/form/toggle/base.ts
@@ -12,7 +12,6 @@ interface HdsFormToggleBaseSignature {
   Element: HTMLInputElement;
 }
 
-const HdsFormToggleBaseComponent =
-  templateOnlyComponent<HdsFormToggleBaseSignature>();
+const HdsFormToggleBase = templateOnlyComponent<HdsFormToggleBaseSignature>();
 
-export default HdsFormToggleBaseComponent;
+export default HdsFormToggleBase;

--- a/packages/components/src/components/hds/form/toggle/field.ts
+++ b/packages/components/src/components/hds/form/toggle/field.ts
@@ -26,7 +26,6 @@ export interface HdsFormToggleFieldSignature {
   Element: HdsFormFieldSignature['Element'];
 }
 
-const HdsFormToggleFieldComponent =
-  templateOnlyComponent<HdsFormToggleFieldSignature>();
+const HdsFormToggleField = templateOnlyComponent<HdsFormToggleFieldSignature>();
 
-export default HdsFormToggleFieldComponent;
+export default HdsFormToggleField;

--- a/packages/components/src/components/hds/form/toggle/group.ts
+++ b/packages/components/src/components/hds/form/toggle/group.ts
@@ -28,7 +28,6 @@ interface HdsFormToggleGroupSignature {
   Element: HdsFormFieldsetSignature['Element'];
 }
 
-const HdsFormToggleGroupComponent =
-  templateOnlyComponent<HdsFormToggleGroupSignature>();
+const HdsFormToggleGroup = templateOnlyComponent<HdsFormToggleGroupSignature>();
 
-export default HdsFormToggleGroupComponent;
+export default HdsFormToggleGroup;

--- a/packages/components/src/components/hds/form/visibility-toggle/index.ts
+++ b/packages/components/src/components/hds/form/visibility-toggle/index.ts
@@ -14,7 +14,7 @@ export interface HdsFormVisibilityToggleSignature {
   Element: HTMLButtonElement;
 }
 
-const HdsFormVisibilityToggleComponent =
+const HdsFormVisibilityToggle =
   templateOnlyComponent<HdsFormVisibilityToggleSignature>();
 
-export default HdsFormVisibilityToggleComponent;
+export default HdsFormVisibilityToggle;

--- a/packages/components/src/components/hds/icon-tile/index.ts
+++ b/packages/components/src/components/hds/icon-tile/index.ts
@@ -40,7 +40,7 @@ export interface HdsIconTileSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsIconTileComponent extends Component<HdsIconTileSignature> {
+export default class HdsIconTile extends Component<HdsIconTileSignature> {
   get size(): HdsIconTileSizes {
     const { size = DEFAULT_SIZE } = this.args;
 

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -24,7 +24,7 @@ export interface HdsInteractiveSignature {
   Element: HTMLAnchorElement | HTMLButtonElement;
 }
 
-export default class HdsInteractiveComponent extends Component<HdsInteractiveSignature> {
+export default class HdsInteractive extends Component<HdsInteractiveSignature> {
   /**
    * Determines if a @href value is "external" (it adds target="_blank" rel="noopener noreferrer")
    *

--- a/packages/components/src/components/hds/link/inline.ts
+++ b/packages/components/src/components/hds/link/inline.ts
@@ -28,7 +28,7 @@ export interface HdsLinkInlineSignature {
   Element: HdsInteractiveSignature['Element'];
 }
 
-export default class HdsLinkInlineComponent extends Component<HdsLinkInlineSignature> {
+export default class HdsLinkInline extends Component<HdsLinkInlineSignature> {
   constructor(owner: unknown, args: HdsLinkInlineSignature['Args']) {
     super(owner, args);
     if (!(this.args.href || this.args.route)) {

--- a/packages/components/src/components/hds/link/standalone.ts
+++ b/packages/components/src/components/hds/link/standalone.ts
@@ -37,7 +37,7 @@ export const ICONPOSITIONS: string[] = Object.values(HdsLinkIconPositionValues);
 export const COLORS: string[] = Object.values(HdsLinkColorValues);
 export const SIZES: string[] = Object.values(HdsLinkStandaloneSizeValues);
 
-export default class HdsLinkStandaloneComponent extends Component<HdsLinkStandaloneSignature> {
+export default class HdsLinkStandalone extends Component<HdsLinkStandaloneSignature> {
   constructor(owner: unknown, args: HdsLinkStandaloneSignature['Args']) {
     super(owner, args);
     if (!(this.args.href || this.args.route)) {

--- a/packages/components/src/components/hds/menu-primitive/index.ts
+++ b/packages/components/src/components/hds/menu-primitive/index.ts
@@ -32,7 +32,7 @@ export interface MenuPrimitiveSignature {
   Element: HTMLDivElement;
 }
 
-export default class MenuPrimitiveComponent extends Component<MenuPrimitiveSignature> {
+export default class MenuPrimitive extends Component<MenuPrimitiveSignature> {
   @tracked isOpen: boolean | undefined; // notice: if in the future we need to add a "@isOpen" prop to control the status from outside (eg to have the MenuPrimitive opened on render) just add  "this.args.isOpen" here to initalize the variable
   @tracked toggleRef: HTMLElement | undefined;
   @tracked element!: HTMLElement;

--- a/packages/components/src/components/hds/modal/body.ts
+++ b/packages/components/src/components/hds/modal/body.ts
@@ -13,7 +13,7 @@ export interface HdsModalBodySignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsModalBodyComponent extends Component<HdsModalBodySignature> {
+export default class HdsModalBody extends Component<HdsModalBodySignature> {
   constructor(owner: unknown) {
     super(owner, {});
 

--- a/packages/components/src/components/hds/modal/footer.ts
+++ b/packages/components/src/components/hds/modal/footer.ts
@@ -16,7 +16,7 @@ export interface HdsModalFooterSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsModalFooterComponent extends Component<HdsModalFooterSignature> {
+export default class HdsModalFooter extends Component<HdsModalFooterSignature> {
   constructor(owner: unknown, args: HdsModalFooterSignature['Args']) {
     super(owner, args);
 

--- a/packages/components/src/components/hds/modal/header.ts
+++ b/packages/components/src/components/hds/modal/header.ts
@@ -20,7 +20,7 @@ export interface HdsModalHeaderSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsModalHeaderComponent extends Component<HdsModalHeaderSignature> {
+export default class HdsModalHeader extends Component<HdsModalHeaderSignature> {
   constructor(owner: unknown, args: HdsModalHeaderSignature['Args']) {
     super(owner, args);
 

--- a/packages/components/src/components/hds/modal/index.ts
+++ b/packages/components/src/components/hds/modal/index.ts
@@ -26,7 +26,7 @@ export const DEFAULT_COLOR = HdsModalColorValues.Neutral;
 export const SIZES: string[] = Object.values(HdsModalSizeValues);
 export const COLORS: string[] = Object.values(HdsModalColorValues);
 
-export interface HdsModalIndexSignature {
+export interface HdsModalSignature {
   Args: {
     isDismissDisabled?: boolean;
     size?: HdsModalSizes;
@@ -55,7 +55,7 @@ export interface HdsModalIndexSignature {
   Element: HTMLDialogElement;
 }
 
-export default class HdsModalIndex extends Component<HdsModalIndexSignature> {
+export default class HdsModal extends Component<HdsModalSignature> {
   @tracked isOpen = false;
   @tracked isDismissDisabled = this.args.isDismissDisabled ?? false;
   element!: HTMLDialogElement;

--- a/packages/components/src/components/hds/modal/index.ts
+++ b/packages/components/src/components/hds/modal/index.ts
@@ -55,7 +55,7 @@ export interface HdsModalIndexSignature {
   Element: HTMLDialogElement;
 }
 
-export default class HdsModalIndexComponent extends Component<HdsModalIndexSignature> {
+export default class HdsModalIndex extends Component<HdsModalIndexSignature> {
   @tracked isOpen = false;
   @tracked isDismissDisabled = this.args.isDismissDisabled ?? false;
   element!: HTMLDialogElement;

--- a/packages/components/src/components/hds/page-header/actions.ts
+++ b/packages/components/src/components/hds/page-header/actions.ts
@@ -12,7 +12,7 @@ export interface HdsPageHeaderActionsSignature {
   Element: HTMLDivElement;
 }
 
-const HdsPageHeaderActionsComponent =
+const HdsPageHeaderActions =
   TemplateOnlyComponent<HdsPageHeaderActionsSignature>();
 
-export default HdsPageHeaderActionsComponent;
+export default HdsPageHeaderActions;

--- a/packages/components/src/components/hds/page-header/badges.ts
+++ b/packages/components/src/components/hds/page-header/badges.ts
@@ -12,7 +12,7 @@ export interface HdsPageHeaderBadgesSignature {
   Element: HTMLDivElement;
 }
 
-const HdsPageHeaderBadgesComponent =
+const HdsPageHeaderBadges =
   TemplateOnlyComponent<HdsPageHeaderBadgesSignature>();
 
-export default HdsPageHeaderBadgesComponent;
+export default HdsPageHeaderBadges;

--- a/packages/components/src/components/hds/page-header/description.ts
+++ b/packages/components/src/components/hds/page-header/description.ts
@@ -14,7 +14,7 @@ export interface HdsPageHeaderDescriptionSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-const HdsPageHeaderDescriptionComponent =
+const HdsPageHeaderDescription =
   TemplateOnlyComponent<HdsPageHeaderDescriptionSignature>();
 
-export default HdsPageHeaderDescriptionComponent;
+export default HdsPageHeaderDescription;

--- a/packages/components/src/components/hds/page-header/index.ts
+++ b/packages/components/src/components/hds/page-header/index.ts
@@ -31,6 +31,6 @@ interface HdsPageHeaderSignature {
   Element: HTMLElement;
 }
 
-const HdsPageHeaderComponent = TemplateOnlyComponent<HdsPageHeaderSignature>();
+const HdsPageHeader = TemplateOnlyComponent<HdsPageHeaderSignature>();
 
-export default HdsPageHeaderComponent;
+export default HdsPageHeader;

--- a/packages/components/src/components/hds/page-header/subtitle.ts
+++ b/packages/components/src/components/hds/page-header/subtitle.ts
@@ -14,7 +14,7 @@ export interface HdsPageHeaderSubtitleSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-const HdsPageHeaderSubtitleComponent =
+const HdsPageHeaderSubtitle =
   TemplateOnlyComponent<HdsPageHeaderSubtitleSignature>();
 
-export default HdsPageHeaderSubtitleComponent;
+export default HdsPageHeaderSubtitle;

--- a/packages/components/src/components/hds/page-header/title.ts
+++ b/packages/components/src/components/hds/page-header/title.ts
@@ -14,7 +14,6 @@ export interface HdsPageHeaderTitleSignature {
   Element: HdsTextDisplaySignature['Element'];
 }
 
-const HdsPageHeaderTitleComponent =
-  TemplateOnlyComponent<HdsPageHeaderTitleSignature>();
+const HdsPageHeaderTitle = TemplateOnlyComponent<HdsPageHeaderTitleSignature>();
 
-export default HdsPageHeaderTitleComponent;
+export default HdsPageHeaderTitle;

--- a/packages/components/src/components/hds/pagination/compact/index.ts
+++ b/packages/components/src/components/hds/pagination/compact/index.ts
@@ -47,7 +47,7 @@ interface HdsPaginationCompactSignature {
 // for context about the decision to use these values, see:
 // https://hashicorp.slack.com/archives/C03A0N1QK8S/p1673546329082759
 export const DEFAULT_PAGE_SIZES = [10, 30, 50];
-export default class HdsPaginationCompactComponent extends Component<HdsPaginationCompactSignature> {
+export default class HdsPaginationCompact extends Component<HdsPaginationCompactSignature> {
   // This private variable is used to differentiate between
   // "uncontrolled" component (where the state is handled internally) and
   // "controlled" component (where the state is handled externally, by the consumer's code).

--- a/packages/components/src/components/hds/pagination/info/index.ts
+++ b/packages/components/src/components/hds/pagination/info/index.ts
@@ -16,7 +16,7 @@ interface HdsPaginationInfoSignature {
   Element: HdsTextBodySignature['Element'];
 }
 
-export default class HdsPaginationInfoComponent extends Component<HdsPaginationInfoSignature> {
+export default class HdsPaginationInfo extends Component<HdsPaginationInfoSignature> {
   get showTotalItems(): boolean {
     return this.args.showTotalItems ?? true;
   }

--- a/packages/components/src/components/hds/pagination/nav/arrow.ts
+++ b/packages/components/src/components/hds/pagination/nav/arrow.ts
@@ -42,7 +42,7 @@ export const DIRECTIONS: HdsPaginationDirections[] = [
   HdsPaginationDirectionValues.Next,
 ];
 
-export default class HdsPaginationControlArrowComponent extends Component<HdsPaginationControlArrowSignature> {
+export default class HdsPaginationControlArrow extends Component<HdsPaginationControlArrowSignature> {
   get content(): HdsPaginationControlArrowContent {
     const { direction } = this.args;
 

--- a/packages/components/src/components/hds/pagination/nav/ellipsis.ts
+++ b/packages/components/src/components/hds/pagination/nav/ellipsis.ts
@@ -8,7 +8,7 @@ export interface HdsApplicationPaginationNavEllipsisSignature {
   Element: HTMLDivElement;
 }
 
-const HdsApplicationPaginationNavEllipsisComponent =
+const HdsApplicationPaginationNavEllipsis =
   TemplateOnlyComponent<HdsApplicationPaginationNavEllipsisSignature>();
 
-export default HdsApplicationPaginationNavEllipsisComponent;
+export default HdsApplicationPaginationNavEllipsis;

--- a/packages/components/src/components/hds/pagination/nav/number.ts
+++ b/packages/components/src/components/hds/pagination/nav/number.ts
@@ -19,7 +19,7 @@ interface HdsPaginationNavNumberSignature {
   Element: HdsInteractiveSignature['Element'];
 }
 
-export default class HdsPaginationControlNumberComponent extends Component<HdsPaginationNavNumberSignature> {
+export default class HdsPaginationControlNumber extends Component<HdsPaginationNavNumberSignature> {
   get page(): number {
     const { page } = this.args;
 

--- a/packages/components/src/components/hds/pagination/numbered/index.ts
+++ b/packages/components/src/components/hds/pagination/numbered/index.ts
@@ -120,7 +120,7 @@ export const elliptize = ({
 
   return result;
 };
-export default class HdsPaginationNumberedComponent extends Component<HdsPaginationNumberedSignature> {
+export default class HdsPaginationNumbered extends Component<HdsPaginationNumberedSignature> {
   // These two private variables are used to differentiate between
   // "uncontrolled" component (where the state is handled internally) and
   // "controlled" component (where the state is handled externally, by the consumer's code).

--- a/packages/components/src/components/hds/pagination/size-selector/index.ts
+++ b/packages/components/src/components/hds/pagination/size-selector/index.ts
@@ -20,7 +20,7 @@ interface HdsPaginationSizeSelectorSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsPaginationSizeSelectorComponent extends Component<HdsPaginationSizeSelectorSignature> {
+export default class HdsPaginationSizeSelector extends Component<HdsPaginationSizeSelectorSignature> {
   SizeSelectorId = 'pagination-size-selector-' + guidFor(this);
 
   get pageSizes(): number[] {

--- a/packages/components/src/components/hds/popover-primitive/index.ts
+++ b/packages/components/src/components/hds/popover-primitive/index.ts
@@ -58,7 +58,7 @@ export interface SetupPrimitivePopoverModifier {
   };
 }
 
-export default class HdsPopoverPrimitiveComponent extends Component<HdsPopoverPrimitiveSignature> {
+export default class HdsPopoverPrimitive extends Component<HdsPopoverPrimitiveSignature> {
   @tracked isOpen = this.args.isOpen ?? false;
   @tracked isClosing = false;
   containerElement?: HTMLElement;

--- a/packages/components/src/components/hds/reveal/index.ts
+++ b/packages/components/src/components/hds/reveal/index.ts
@@ -22,7 +22,7 @@ interface HdsRevealSignature {
   Element: HdsDisclosurePrimitiveSignature['Element'];
 }
 
-export default class HdsRevealComponent extends Component<HdsRevealSignature> {
+export default class HdsReveal extends Component<HdsRevealSignature> {
   /**
    * Generates a unique ID for the Content
    *

--- a/packages/components/src/components/hds/reveal/toggle/button.ts
+++ b/packages/components/src/components/hds/reveal/toggle/button.ts
@@ -15,7 +15,7 @@ export interface HdsRevealToggleButtonSignature {
   Element: HdsButtonSignature['Element'];
 }
 
-export default class HdsRevealToggleButtonComponent extends Component<HdsRevealToggleButtonSignature> {
+export default class HdsRevealToggleButton extends Component<HdsRevealToggleButtonSignature> {
   /**
    * Get the class names to apply to the component.
    * @method ToggleButton#classNames

--- a/packages/components/src/components/hds/rich-tooltip/bubble.ts
+++ b/packages/components/src/components/hds/rich-tooltip/bubble.ts
@@ -32,7 +32,7 @@ export interface HdsRichTooltipBubbleSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsRichTooltipBubbleComponent extends Component<HdsRichTooltipBubbleSignature> {
+export default class HdsRichTooltipBubble extends Component<HdsRichTooltipBubbleSignature> {
   /**
    * @param placement
    * @type {string}

--- a/packages/components/src/components/hds/rich-tooltip/index.ts
+++ b/packages/components/src/components/hds/rich-tooltip/index.ts
@@ -31,7 +31,7 @@ interface HdsRichTooltipSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsRichTooltipComponent extends Component<HdsRichTooltipSignature> {
+export default class HdsRichTooltip extends Component<HdsRichTooltipSignature> {
   elementId: string = getElementId(this);
   arrowId: string = `arrow-${this.elementId}`;
   popoverId: string = `popover-${this.elementId}`;

--- a/packages/components/src/components/hds/rich-tooltip/toggle.ts
+++ b/packages/components/src/components/hds/rich-tooltip/toggle.ts
@@ -42,7 +42,7 @@ export interface HdsRichTooltipToggleSignature {
   Element: HTMLButtonElement;
 }
 
-export default class HdsRichTooltipToggleComponent extends Component<HdsRichTooltipToggleSignature> {
+export default class HdsRichTooltipToggle extends Component<HdsRichTooltipToggleSignature> {
   /**
    * @param isInline
    * @type {boolean}

--- a/packages/components/src/components/hds/segmented-group/index.ts
+++ b/packages/components/src/components/hds/segmented-group/index.ts
@@ -27,7 +27,6 @@ interface HdsSegmentedGroupSignature {
   Element: HTMLDivElement;
 }
 
-const HdsSegmentedGroupComponent =
-  TemplateOnlyComponent<HdsSegmentedGroupSignature>();
+const HdsSegmentedGroup = TemplateOnlyComponent<HdsSegmentedGroupSignature>();
 
-export default HdsSegmentedGroupComponent;
+export default HdsSegmentedGroup;

--- a/packages/components/src/components/hds/separator/index.ts
+++ b/packages/components/src/components/hds/separator/index.ts
@@ -19,7 +19,7 @@ interface HdsSeparatorSignature {
   Element: HTMLElement;
 }
 
-export default class HdsSeparatorComponent extends Component<HdsSeparatorSignature> {
+export default class HdsSeparator extends Component<HdsSeparatorSignature> {
   /**
    * Sets the margin for the separator
    * Accepted values: 24, 0

--- a/packages/components/src/components/hds/side-nav/base.ts
+++ b/packages/components/src/components/hds/side-nav/base.ts
@@ -19,7 +19,6 @@ export interface HdsSideNavBaseSignature {
   Element: HTMLDivElement;
 }
 
-const HdsSideNavBaseComponent =
-  TemplateOnlyComponent<HdsSideNavBaseSignature>();
+const HdsSideNavBase = TemplateOnlyComponent<HdsSideNavBaseSignature>();
 
-export default HdsSideNavBaseComponent;
+export default HdsSideNavBase;

--- a/packages/components/src/components/hds/side-nav/header/home-link.ts
+++ b/packages/components/src/components/hds/side-nav/header/home-link.ts
@@ -18,7 +18,7 @@ interface HdsSideNavHeaderHomeLinkSignature {
   Element: HdsInteractiveSignature['Element'];
 }
 
-export default class HdsSideNavHeaderHomeLinkComponent extends Component<HdsSideNavHeaderHomeLinkSignature> {
+export default class HdsSideNavHeaderHomeLink extends Component<HdsSideNavHeaderHomeLinkSignature> {
   /**
    * @param ariaLabel
    * @type {string}

--- a/packages/components/src/components/hds/side-nav/header/icon-button.ts
+++ b/packages/components/src/components/hds/side-nav/header/icon-button.ts
@@ -17,7 +17,7 @@ interface HdsSideNavHeaderIconButtonSignature {
   Element: HdsInteractiveSignature['Element'];
 }
 
-export default class HdsSideNavHeaderIconButtonComponent extends Component<HdsSideNavHeaderIconButtonSignature> {
+export default class HdsSideNavHeaderIconButton extends Component<HdsSideNavHeaderIconButtonSignature> {
   /**
    * @param ariaLabel
    * @type {string}

--- a/packages/components/src/components/hds/side-nav/header/index.ts
+++ b/packages/components/src/components/hds/side-nav/header/index.ts
@@ -13,7 +13,6 @@ interface HdsSideNavHeaderSignature {
   Element: HTMLDivElement;
 }
 
-const HdsSideNavHeaderComponent =
-  TemplateOnlyComponent<HdsSideNavHeaderSignature>();
+const HdsSideNavHeader = TemplateOnlyComponent<HdsSideNavHeaderSignature>();
 
-export default HdsSideNavHeaderComponent;
+export default HdsSideNavHeader;

--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -51,7 +51,7 @@ interface HdsSideNavSignature {
   Element: HdsSideNavBaseSignature['Element'];
 }
 
-export default class HdsSideNavComponent extends Component<HdsSideNavSignature> {
+export default class HdsSideNav extends Component<HdsSideNavSignature> {
   @tracked isResponsive = this.args.isResponsive ?? true; // controls if the component reacts to viewport changes
   @tracked isMinimized = this.args.isMinimized ?? false; // sets the default state on 'desktop' viewports
   @tracked isCollapsible = this.args.isCollapsible ?? false; // controls if users can collapse the sidenav on 'desktop' viewports

--- a/packages/components/src/components/hds/side-nav/list/back-link.ts
+++ b/packages/components/src/components/hds/side-nav/list/back-link.ts
@@ -14,7 +14,7 @@ export interface HdsSideNavListBackLinkSignature {
   Element: HdsInteractiveSignature['Element'];
 }
 
-const HdsSideNavListBackLinkComponent =
+const HdsSideNavListBackLink =
   TemplateOnlyComponent<HdsSideNavListBackLinkSignature>();
 
-export default HdsSideNavListBackLinkComponent;
+export default HdsSideNavListBackLink;

--- a/packages/components/src/components/hds/side-nav/list/index.ts
+++ b/packages/components/src/components/hds/side-nav/list/index.ts
@@ -28,7 +28,6 @@ export interface HdsSideNavListSignature {
   Element: HTMLElement;
 }
 
-const HdsSideNavListComponent =
-  TemplateOnlyComponent<HdsSideNavListSignature>();
+const HdsSideNavList = TemplateOnlyComponent<HdsSideNavListSignature>();
 
-export default HdsSideNavListComponent;
+export default HdsSideNavList;

--- a/packages/components/src/components/hds/side-nav/list/item.ts
+++ b/packages/components/src/components/hds/side-nav/list/item.ts
@@ -12,7 +12,6 @@ export interface HdsSideNavListItemSignature {
   Element: HTMLLIElement;
 }
 
-const HdsSideNavListItemComponent =
-  TemplateOnlyComponent<HdsSideNavListItemSignature>();
+const HdsSideNavListItem = TemplateOnlyComponent<HdsSideNavListItemSignature>();
 
-export default HdsSideNavListItemComponent;
+export default HdsSideNavListItem;

--- a/packages/components/src/components/hds/side-nav/list/link.ts
+++ b/packages/components/src/components/hds/side-nav/list/link.ts
@@ -23,7 +23,6 @@ export interface HdsSideNavListLinkSignature {
   Element: HdsInteractiveSignature['Element'];
 }
 
-const HdsSideNavListLinkComponent =
-  TemplateOnlyComponent<HdsSideNavListLinkSignature>();
+const HdsSideNavListLink = TemplateOnlyComponent<HdsSideNavListLinkSignature>();
 
-export default HdsSideNavListLinkComponent;
+export default HdsSideNavListLink;

--- a/packages/components/src/components/hds/side-nav/list/title.ts
+++ b/packages/components/src/components/hds/side-nav/list/title.ts
@@ -12,7 +12,7 @@ export interface HdsSideNavListTitleSignature {
   Element: HTMLDivElement;
 }
 
-const HdsSideNavListTitleComponent =
+const HdsSideNavListTitle =
   TemplateOnlyComponent<HdsSideNavListTitleSignature>();
 
-export default HdsSideNavListTitleComponent;
+export default HdsSideNavListTitle;

--- a/packages/components/src/components/hds/side-nav/portal/index.ts
+++ b/packages/components/src/components/hds/side-nav/portal/index.ts
@@ -29,4 +29,4 @@ export interface HdsSideNavPortalSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsSideNavPortalComponent extends Component<HdsSideNavPortalSignature> {}
+export default class HdsSideNavPortal extends Component<HdsSideNavPortalSignature> {}

--- a/packages/components/src/components/hds/side-nav/portal/target.ts
+++ b/packages/components/src/components/hds/side-nav/portal/target.ts
@@ -34,7 +34,7 @@ interface HdsSideNavPortalTargetSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsSideNavPortalTargetComponent extends Component<HdsSideNavPortalTargetSignature> {
+export default class HdsSideNavPortalTarget extends Component<HdsSideNavPortalTargetSignature> {
   @service router!: Services['router'];
 
   @tracked numSubnavs = 0;
@@ -50,7 +50,7 @@ export default class HdsSideNavPortalTargetComponent extends Component<HdsSideNa
 
   get prefersReducedMotion(): boolean {
     return (
-      HdsSideNavPortalTargetComponent.prefersReducedMotionOverride ||
+      HdsSideNavPortalTarget.prefersReducedMotionOverride ||
       (this.prefersReducedMotionMQ && this.prefersReducedMotionMQ.matches)
     );
   }

--- a/packages/components/src/components/hds/side-nav/toggle-button.ts
+++ b/packages/components/src/components/hds/side-nav/toggle-button.ts
@@ -14,7 +14,7 @@ interface HdsSideNavToggleButtonSignature {
   Element: HTMLButtonElement;
 }
 
-const HdsSideNavToggleButtonComponent =
+const HdsSideNavToggleButton =
   TemplateOnlyComponent<HdsSideNavToggleButtonSignature>();
 
-export default HdsSideNavToggleButtonComponent;
+export default HdsSideNavToggleButton;

--- a/packages/components/src/components/hds/stepper/step/indicator.ts
+++ b/packages/components/src/components/hds/stepper/step/indicator.ts
@@ -21,7 +21,7 @@ interface HdsStepperStepIndicatorSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsStepperStepIndicatorComponent extends Component<HdsStepperStepIndicatorSignature> {
+export default class HdsStepperStepIndicator extends Component<HdsStepperStepIndicatorSignature> {
   /**
    * @param status
    * @type {string}

--- a/packages/components/src/components/hds/stepper/task/indicator.ts
+++ b/packages/components/src/components/hds/stepper/task/indicator.ts
@@ -26,7 +26,7 @@ interface HdsStepperTaskIndicatorSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsStepperTaskIndicatorComponent extends Component<HdsStepperTaskIndicatorSignature> {
+export default class HdsStepperTaskIndicator extends Component<HdsStepperTaskIndicatorSignature> {
   /**
    * @param status
    * @type {string}

--- a/packages/components/src/components/hds/table/index.ts
+++ b/packages/components/src/components/hds/table/index.ts
@@ -84,7 +84,7 @@ export interface HdsTableArgs {
   Element: HTMLTableElement;
 }
 
-export default class HdsTableIndex extends Component<HdsTableArgs> {
+export default class HdsTable extends Component<HdsTableArgs> {
   @tracked sortBy = this.args.sortBy;
   @tracked sortOrder = this.args.sortOrder || HdsTableThSortOrderValues.Asc;
   @tracked selectAllCheckbox?: HdsFormCheckboxBaseSignature['Element'] =

--- a/packages/components/src/components/hds/table/index.ts
+++ b/packages/components/src/components/hds/table/index.ts
@@ -84,7 +84,7 @@ export interface HdsTableArgs {
   Element: HTMLTableElement;
 }
 
-export default class HdsTableIndexComponent extends Component<HdsTableArgs> {
+export default class HdsTableIndex extends Component<HdsTableArgs> {
   @tracked sortBy = this.args.sortBy;
   @tracked sortOrder = this.args.sortOrder || HdsTableThSortOrderValues.Asc;
   @tracked selectAllCheckbox?: HdsFormCheckboxBaseSignature['Element'] =

--- a/packages/components/src/components/hds/table/td.ts
+++ b/packages/components/src/components/hds/table/td.ts
@@ -23,7 +23,7 @@ export interface HdsTableTdArgs {
   };
   Element: HTMLTableCellElement;
 }
-export default class HdsTableTdComponent extends Component<HdsTableTdArgs> {
+export default class HdsTableTd extends Component<HdsTableTdArgs> {
   /**
    * @param align
    * @type {string}

--- a/packages/components/src/components/hds/table/th-button-sort.ts
+++ b/packages/components/src/components/hds/table/th-button-sort.ts
@@ -26,7 +26,7 @@ export interface HdsTableThButtonSortArgs {
 
 const NOOP = () => {};
 
-export default class HdsTableThButtonSortComponent extends Component<HdsTableThButtonSortArgs> {
+export default class HdsTableThButtonSort extends Component<HdsTableThButtonSortArgs> {
   /**
    * Generates a unique ID for the (hidden) "label prefix/suffix" <span> elements
    *

--- a/packages/components/src/components/hds/table/th-button-tooltip.ts
+++ b/packages/components/src/components/hds/table/th-button-tooltip.ts
@@ -15,7 +15,7 @@ export interface HdsTableThButtonTooltipArgs {
   Element: HTMLButtonElement;
 }
 
-export default class HdsTableThButtonTooltipComponent extends Component<HdsTableThButtonTooltipArgs> {
+export default class HdsTableThButtonTooltip extends Component<HdsTableThButtonTooltipArgs> {
   /**
    * Generates a unique ID for the (hidden) "label prefix" <span> element
    *

--- a/packages/components/src/components/hds/table/th-selectable.ts
+++ b/packages/components/src/components/hds/table/th-selectable.ts
@@ -30,7 +30,7 @@ export interface HdsTableThSelectableArgs {
   Element: HdsTableThArgs['Element'];
 }
 
-export default class HdsTableThSelectableComponent extends Component<HdsTableThSelectableArgs> {
+export default class HdsTableThSelectable extends Component<HdsTableThSelectableArgs> {
   @tracked isSelected = this.args.isSelected;
 
   /**

--- a/packages/components/src/components/hds/table/th-sort.ts
+++ b/packages/components/src/components/hds/table/th-sort.ts
@@ -37,7 +37,7 @@ export interface HdsTableThSortArgs {
   Element: HTMLDivElement;
 }
 
-export default class HdsTableThSortComponent extends Component<HdsTableThSortArgs> {
+export default class HdsTableThSort extends Component<HdsTableThSortArgs> {
   /**
    * Generates a unique ID for the <span> element ("label")
    *

--- a/packages/components/src/components/hds/table/th.ts
+++ b/packages/components/src/components/hds/table/th.ts
@@ -29,7 +29,7 @@ export interface HdsTableThArgs {
   Element: HTMLTableCellElement;
 }
 
-export default class HdsTableThComponent extends Component<HdsTableThArgs> {
+export default class HdsTableTh extends Component<HdsTableThArgs> {
   /**
    * Generates a unique ID for the <span> element ("label")
    *

--- a/packages/components/src/components/hds/table/tr.ts
+++ b/packages/components/src/components/hds/table/tr.ts
@@ -44,7 +44,7 @@ export interface SelectableHdsTableTrArgs extends BaseHdsTableTrArgs {
 // Union type to combine both possible states
 export type HdsTableTrArgs = BaseHdsTableTrArgs | SelectableHdsTableTrArgs;
 
-export default class HdsTableTrComponent extends Component<HdsTableTrArgs> {
+export default class HdsTableTr extends Component<HdsTableTrArgs> {
   /**
    * @param selectionKey
    * @type {string}

--- a/packages/components/src/components/hds/tabs/index.ts
+++ b/packages/components/src/components/hds/tabs/index.ts
@@ -34,7 +34,7 @@ interface HdsTabsSignature {
   Element: HTMLDivElement;
 }
 
-export default class HdsTabsComponent extends Component<HdsTabsSignature> {
+export default class HdsTabs extends Component<HdsTabsSignature> {
   @tracked tabNodes: HTMLButtonElement[] = [];
   @tracked tabIds: HdsTabsTabIds = [];
   @tracked panelNodes: HTMLElement[] = [];

--- a/packages/components/src/components/hds/tabs/panel.ts
+++ b/packages/components/src/components/hds/tabs/panel.ts
@@ -27,7 +27,7 @@ export interface HdsTabsPanelSignature {
   Element: HTMLElement;
 }
 
-export default class HdsTabsPanelComponent extends Component<HdsTabsPanelSignature> {
+export default class HdsTabsPanel extends Component<HdsTabsPanelSignature> {
   /**
    * Generate a unique ID for the Panel
    * @return {string}

--- a/packages/components/src/components/hds/tabs/tab.ts
+++ b/packages/components/src/components/hds/tabs/tab.ts
@@ -28,7 +28,7 @@ export interface HdsTabsTabSignature {
   Element: HTMLLIElement;
 }
 
-export default class HdsTabsTabComponent extends Component<HdsTabsTabSignature> {
+export default class HdsTabsTab extends Component<HdsTabsTabSignature> {
   /**
    * Generate a unique ID for the Tab
    * @return {string}

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -24,7 +24,7 @@ interface HdsTagSignature {
   Element: HTMLSpanElement;
 }
 
-export default class HdsTagComponent extends Component<HdsTagSignature> {
+export default class HdsTag extends Component<HdsTagSignature> {
   /**
    * @param onDismiss
    * @type {function}

--- a/packages/components/src/components/hds/text/body.ts
+++ b/packages/components/src/components/hds/text/body.ts
@@ -76,7 +76,7 @@ export interface HdsTextBodySignature {
   };
 }
 
-export default class HdsTextBodyComponent extends Component<HdsTextBodySignature> {
+export default class HdsTextBody extends Component<HdsTextBodySignature> {
   /**
    * Sets the "size" for the text
    * Accepted values: see AVAILABLE_SIZES

--- a/packages/components/src/components/hds/text/code.ts
+++ b/packages/components/src/components/hds/text/code.ts
@@ -70,7 +70,7 @@ export interface HdsTextCodeSignature {
   };
 }
 
-export default class HdsTextCodeComponent extends Component<HdsTextCodeSignature> {
+export default class HdsTextCode extends Component<HdsTextCodeSignature> {
   /**
    * Sets the "size" for the text
    * Accepted values: see AVAILABLE_SIZES

--- a/packages/components/src/components/hds/text/display.ts
+++ b/packages/components/src/components/hds/text/display.ts
@@ -76,7 +76,7 @@ export interface HdsTextDisplaySignature {
   };
 }
 
-export default class HdsTextDisplayComponent extends Component<HdsTextDisplaySignature> {
+export default class HdsTextDisplay extends Component<HdsTextDisplaySignature> {
   /**
    * Sets the "size" for the text
    * Accepted values: see AVAILABLE_SIZES

--- a/packages/components/src/components/hds/text/index.ts
+++ b/packages/components/src/components/hds/text/index.ts
@@ -36,7 +36,7 @@ export interface HdsTextSignature {
   };
 }
 
-export default class HdsTextComponent extends Component<HdsTextSignature> {
+export default class HdsText extends Component<HdsTextSignature> {
   /**
    * Get a tag to render based on the `@tag` argument passed or the value of `this.size` (via mapping)
    *

--- a/packages/components/src/components/hds/toast/index.ts
+++ b/packages/components/src/components/hds/toast/index.ts
@@ -10,6 +10,6 @@ export interface HdsToastSignature extends Omit<HdsAlertSignature, 'Args'> {
   Args: Omit<HdsAlertSignature['Args'], 'type'>;
 }
 
-const HdsToastComponent = TemplateOnlyComponent<HdsToastSignature>();
+const HdsToast = TemplateOnlyComponent<HdsToastSignature>();
 
-export default HdsToastComponent;
+export default HdsToast;

--- a/packages/components/src/components/hds/tooltip-button/index.ts
+++ b/packages/components/src/components/hds/tooltip-button/index.ts
@@ -25,7 +25,7 @@ export interface HdsTooltipSignature {
   Element: HTMLButtonElement;
 }
 
-export default class HdsTooltipIndex extends Component<HdsTooltipSignature> {
+export default class HdsTooltip extends Component<HdsTooltipSignature> {
   /**
    * @param text
    * @type {string}

--- a/packages/components/src/components/hds/tooltip-button/index.ts
+++ b/packages/components/src/components/hds/tooltip-button/index.ts
@@ -25,7 +25,7 @@ export interface HdsTooltipSignature {
   Element: HTMLButtonElement;
 }
 
-export default class HdsTooltipIndexComponent extends Component<HdsTooltipSignature> {
+export default class HdsTooltipIndex extends Component<HdsTooltipSignature> {
   /**
    * @param text
    * @type {string}

--- a/packages/components/src/components/hds/yield/index.ts
+++ b/packages/components/src/components/hds/yield/index.ts
@@ -11,6 +11,6 @@ export interface HdsYieldSignature {
   };
 }
 
-const HdsYieldComponent = TemplateOnlyComponent<HdsYieldSignature>();
+const HdsYield = TemplateOnlyComponent<HdsYieldSignature>();
 
-export default HdsYieldComponent;
+export default HdsYield;

--- a/wiki/TypeScript-Migration.md
+++ b/wiki/TypeScript-Migration.md
@@ -21,7 +21,7 @@ The following steps are recommended for migrating components to TypeScript.
       interface HdsBadgeSignature {
         // signature
       }
-      const HdsBadgeComponent = TemplateOnlyComponent<HdsBadgeSignature>();
+      const HdsBadge = TemplateOnlyComponent<HdsBadgeSignature>();
       export default HdsBadgeComponent;
 
 5. Add types and use them in the signature


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

Following [this](https://hashicorp.slack.com/archives/C06NMSYDZPA/p1724963825147589) conversation it would be beneficial to align backing class names to that component name is and drop all `Component` sufix from the name so that in the moder `gts/gjs` components consumers can expect identical name comparatively to `hds` usage

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
