### PR TITLE
update list-item interactive deprecation link

### DIFF
--- a/packages/components/src/components/hds/dropdown/list-item/interactive.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/interactive.ts
@@ -51,7 +51,7 @@ export default class HdsDropdownListItemInteractiveComponent extends Component<H
         {
           id: 'hds.dropdown.list-item.interactive',
           until: '5.0.0',
-          url: 'https://helios.hashicorp.design/components/dropdown?tab=version%20history#deprecated',
+          url: 'https://helios.hashicorp.design/components/dropdown?tab=version%20history#4100',
           for: '@hashicorp/design-system-components',
           since: {
             available: '4.10.0',


### PR DESCRIPTION
### :pushpin: Summary

A small tweak to something I observed which is that linking directly to sub-headings could break in some future instance where a second deprecation is added to this page. Linking to the top-level heading seems ultimately safer and will consistently take folks to the correct place.

Full context in [HDS-3810](https://hashicorp.atlassian.net/browse/HDS-3810) if you're really interested

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
