### PR TITLE
`Accordion`: make toggle button names unique

### DIFF
--- a/.changeset/khaki-bats-admire.md
+++ b/.changeset/khaki-bats-admire.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Accordion`: changed the default name of the `Accordion` item toggles. Now, they are labelled by the content in the `Accordion` title.

--- a/packages/components/src/components/hds/accordion/item/button.hbs
+++ b/packages/components/src/components/hds/accordion/item/button.hbs
@@ -10,6 +10,7 @@
   aria-controls={{@contentId}}
   aria-expanded={{if @isOpen "true" "false"}}
   aria-label={{@ariaLabel}}
+  aria-labelledby={{@ariaLabelledBy}}
   ...attributes
 >
   <Hds::Icon @name="chevron-down" @size={{if (eq @size "large") "24" "16"}} />

--- a/packages/components/src/components/hds/accordion/item/button.ts
+++ b/packages/components/src/components/hds/accordion/item/button.ts
@@ -11,12 +11,14 @@ import type { HdsAccordionSizes } from '../types.ts';
 interface HdsAccordionItemButtonSignature {
   Args: {
     ariaLabel?: string;
+    ariaLabelledBy?: string;
     contentId?: string;
     isOpen?: boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onClickToggle?: (event: MouseEvent, ...args: any[]) => void;
     parentContainsInteractive?: boolean;
     size?: HdsAccordionSizes;
+    id?: string;
   };
   Element: HTMLButtonElement;
 }

--- a/packages/components/src/components/hds/accordion/item/index.hbs
+++ b/packages/components/src/components/hds/accordion/item/index.hbs
@@ -15,7 +15,8 @@
         @isOpen={{t.isOpen}}
         @onClickToggle={{t.onClickToggle}}
         @contentId={{this.contentId}}
-        @ariaLabel={{this.ariaLabel}}
+        @ariaLabel={{@ariaLabel}}
+        @ariaLabelledBy={{this.ariaLabelledBy}}
         @size={{this.size}}
         @parentContainsInteractive={{this.containsInteractive}}
       />
@@ -25,6 +26,7 @@
         @size={{this.toggleTextSize}}
         @weight="semibold"
         @color="strong"
+        id={{this.titleId}}
         class="hds-accordion-item__toggle-content"
       >
         {{yield to="toggle"}}

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -63,14 +63,13 @@ export default class HdsAccordionItem extends Component<HdsAccordionItemSignatur
    * @param contentId
    */
   contentId = 'content-' + guidFor(this);
+  titleId = 'title-' + guidFor(this);
 
-  /**
-   * @param ariaLabel
-   * @type {string}
-   * @default 'Toggle display'
-   */
-  get ariaLabel(): string {
-    return this.args.ariaLabel ?? 'Toggle display';
+  get ariaLabelledBy(): string | undefined {
+    if (!this.args.ariaLabel) {
+      return this.titleId;
+    }
+    return undefined;
   }
 
   /**

--- a/showcase/tests/integration/components/hds/accordion/index-test.js
+++ b/showcase/tests/integration/components/hds/accordion/index-test.js
@@ -213,6 +213,55 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
     );
   });
 
+  test('the AccordionItem toggle has an aria-labelledby attribute set to the id of the toggle text by default', async function (assert) {
+    await render(
+      hbs`
+        <Hds::Accordion as |A|>
+          <A.Item>
+            <:toggle>Item one</:toggle>
+            <:content>Additional content</:content>
+          </A.Item>
+        </Hds::Accordion>
+      `
+    );
+
+    assert.dom('.hds-accordion-item__button').hasAttribute('aria-labelledby');
+
+    assert
+      .dom('.hds-accordion-item__button')
+      .doesNotHaveAttribute('aria-label');
+
+    assert.strictEqual(
+      this.element
+        .querySelector('.hds-accordion-item__toggle-content')
+        .getAttribute('id'),
+      this.element
+        .querySelector('.hds-accordion-item__button')
+        .getAttribute('aria-labelledby')
+    );
+  });
+
+  test('the AccordionItem toggle has an aria-label attribute when the argument is passed', async function (assert) {
+    await render(
+      hbs`
+        <Hds::Accordion as |A|>
+          <A.Item @ariaLabel="Custom toggle label">
+            <:toggle>Item one</:toggle>
+            <:content>Additional content</:content>
+          </A.Item>
+        </Hds::Accordion>
+      `
+    );
+
+    assert
+      .dom('.hds-accordion-item__button')
+      .hasAttribute('aria-label', 'Custom toggle label');
+
+    assert
+      .dom('.hds-accordion-item__button')
+      .doesNotHaveAttribute('aria-labelledby');
+  });
+
   // OPTIONS
 
   // isOpen


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the accordion toggle to make the button names unique.

### :hammer_and_wrench: Detailed description

To make `aria-label` not required on each item but still create unique labels for the toggle buttons, I decided to use `aria-labelledby`. `aria-labelledby` is set to the id of the wrapper around the toggle block and I removed the `aria-label` default value. This makes it so the accessible name is just the title of the accordion. 

If the developer passes an `aria-label` to the accordion item, `aria-labelledby` isn't set.

**NOTE:**

I used to have a different implementation where I also included a visually hidden piece of text that said "Expand" so the button name would be "Expand {title}", but after discussing with @MelSumner we decided that wasn't even necessary because the fact that it shows/hide content is implied by `aria-expanded`. When you navigate to the button with VoiceOver it says "{title}, collapsed, button" and then when you press the button it says "expanded". this makes including the word "expand" in the button name redundnant.

### :camera_flash: Screenshots

**DOM after changes:**
![](https://github.com/user-attachments/assets/9f768b7f-eae4-44a7-b4a1-d999a7c949ca)

### :link: External links
Jira ticket: [HDS-3809](https://hashicorp.atlassian.net/browse/HDS-3809)
***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://github.com/hashicorp/design-system/blob/main/wiki/Website-Changelog.md#templates-for-npm-packages))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3809]: https://hashicorp.atlassian.net/browse/HDS-3809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ