### PR TITLE
website: duplicated `Breadcrumb` docs example

### DIFF
--- a/website/docs/components/breadcrumb/partials/code/component-api.md
+++ b/website/docs/components/breadcrumb/partials/code/component-api.md
@@ -59,21 +59,3 @@ The Breadcrumb component is composed of three different parts, each with their o
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>
 </Doc::ComponentApi>
-
-#### Width-based truncation
-
-!!! Warning
-
-The text will automatically truncate and be replaced with an ellipsis to fit within the container. Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
-!!!
-
-```handlebars
-<Hds::Breadcrumb @itemsCanWrap={{false}}>
-  <Hds::Breadcrumb::Item @text="Level one with a very long string" @icon="org" />
-  <Hds::Breadcrumb::Item @text="Level two with a very long string" @icon="folder" />
-  <Hds::Breadcrumb::Item @text="Level three with a very long string" />
-  <Hds::Breadcrumb::Item @text="Level four with a very long string" />
-  <Hds::Breadcrumb::Item @text="Level five with a very long string" />
-  <Hds::Breadcrumb::Item @text="Current with a very long string" @current={{true}} />
-</Hds::Breadcrumb>
-```

--- a/website/docs/components/breadcrumb/partials/code/how-to-use.md
+++ b/website/docs/components/breadcrumb/partials/code/how-to-use.md
@@ -67,7 +67,13 @@ It’s possible to hide part of the Breadcrumb tree under a "truncated" item tha
 ```
 #### Width-based truncation
 
-By setting `@itemsCanWrap` to `false`, it is possible to constrain the text to one-line and truncate it if it does not fit the available space. Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
+By setting `@itemsCanWrap` to `false`, it is possible to constrain the text to one-line and truncate it if it does not fit the available space. 
+
+!!! Warning
+
+The text will automatically truncate and be replaced with an ellipsis to fit within the container. Please be aware there are [serious accessibility concerns](/components/copy/snippet?tab=accessibility) with using this feature.
+
+!!!
 
 ```handlebars
 <Hds::Breadcrumb @itemsCanWrap={{false}}>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would move a warning about width based truncation from a duplicate example below the component API to the existing example in the how to use section.

### :camera_flash: Screenshots

**Before there are 2 width based truncation examples**
<img width="779" alt="Screenshot 2024-09-04 at 3 22 34 PM" src="https://github.com/user-attachments/assets/9bf5091a-43e7-44d8-89d8-c9a7a3518d72">

<img width="776" alt="Screenshot 2024-09-04 at 3 18 29 PM" src="https://github.com/user-attachments/assets/7b364fdc-af4b-4180-ad2a-58a0b2e4f0f6">


**After consolidated to one example**
<img width="703" alt="Screenshot 2024-09-04 at 3 21 43 PM" src="https://github.com/user-attachments/assets/d66da5fd-83f5-47b2-b8e8-a070ce157343">

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
