### PR TITLE
Fix `Stepper::indicator::Task` colors

### DIFF
--- a/.changeset/silent-dolls-unite.md
+++ b/.changeset/silent-dolls-unite.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Stepper::Indicator::Task`: Updated palette tokens to use semantic tokens.

--- a/packages/components/src/styles/components/stepper/task-indicator.scss
+++ b/packages/components/src/styles/components/stepper/task-indicator.scss
@@ -7,31 +7,36 @@
 // STEPPER > INDICATOR > TASK
 //
 
-$hds-stepper-indicator-task-statuses: ( "incomplete", "progress", "processing", "complete" );
+$hds-stepper-indicator-task-statuses: (
+  "incomplete",
+  "progress",
+  "processing",
+  "complete"
+);
 $hds-stepper-indicator-task-size: 16px;
 
 // Determine states and corresponding styles
 $hds-stepper-indicator-task-status-props: (
   "incomplete": (
     "color-default": var(--token-color-palette-neutral-300),
-    "color-hover": var(--token-color-palette-blue-300),
-    "color-active": var(--token-color-palette-blue-400),
+    "color-hover": var(--token-color-foreground-action-hover),
+    "color-active": var(--token-color-foreground-action-active),
   ),
   "progress": (
-    "color-default": var(--token-color-palette-blue-200),
-    "color-hover": var(--token-color-palette-blue-300),
-    "color-active": var(--token-color-palette-blue-400),
+    "color-default": var(--token-color-foreground-action),
+    "color-hover": var(--token-color-foreground-action-hover),
+    "color-active": var(--token-color-foreground-action-active),
   ),
   "processing": (
-    "color-default": var(--token-color-palette-blue-200),
-    "color-hover": var(--token-color-palette-blue-300),
-    "color-active": var(--token-color-palette-blue-400),
+    "color-default": var(--token-color-foreground-action),
+    "color-hover": var(--token-color-foreground-action-hover),
+    "color-active": var(--token-color-foreground-action-active),
   ),
   "complete": (
-    "color-default": var(--token-color-palette-green-200),
+    "color-default": var(--token-color-foreground-success),
     "color-hover": var(--token-color-palette-green-300),
     "color-active": var(--token-color-palette-green-400),
-  )
+  ),
 );
 
 // Base styling for indicator::task
@@ -56,18 +61,29 @@ $hds-stepper-indicator-task-status-props: (
   @each $status in $hds-stepper-indicator-task-statuses {
     // For each status set the icon color based on the $hds-stepper-indicator-task-status-props
     &.hds-stepper-indicator-task--status-#{$status} {
-      color: map-get($hds-stepper-indicator-task-status-props, $status, "color-default");
+      color: map-get(
+        $hds-stepper-indicator-task-status-props,
+        $status,
+        "color-default"
+      );
 
       &:hover,
       &.mock-hover {
-        color: map-get($hds-stepper-indicator-task-status-props, $status, "color-hover");
+        color: map-get(
+          $hds-stepper-indicator-task-status-props,
+          $status,
+          "color-hover"
+        );
       }
 
       &:active,
       &.mock-active {
-        color: map-get($hds-stepper-indicator-task-status-props, $status, "color-active");
+        color: map-get(
+          $hds-stepper-indicator-task-status-props,
+          $status,
+          "color-active"
+        );
       }
     }
   }
 }
-


### PR DESCRIPTION
### :pushpin: Summary

This PR updates the `Stepper::Indicator::Task` to use colors from the semantic palette instead of the core palette. This results in no visual change and was uncovered as a small improvement that could be made during the Figma v2.0 project.

~~_I've marked this as a draft for now as there is still some discussion around some other updates that could be made to the Stepper Indicator to match the button (and vice versa)._~~

On second thought, I think it makes sense to determine these updates incrementally, the color questions with regards to the `Stepper::Indicator::Step` require more discussion and potentially a more holistic solution.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3815](https://hashicorp.atlassian.net/browse/HDS-3815)
Figma file: [Stepper Indicator](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/%5BWIP%5D-HDS-Components-v2.0?node-id=11677-26453&t=ofasSy7VIwHndY03-1)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3815]: https://hashicorp.atlassian.net/browse/HDS-3815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ