### PR TITLE
`BadgeCount`: update the color tokens to be more accurate token for the usage

### DIFF
--- a/.changeset/long-moles-sneeze.md
+++ b/.changeset/long-moles-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`BadgeCount`: update the color tokens to be more accurate token for the usage.

--- a/.changeset/long-moles-sneeze.md
+++ b/.changeset/long-moles-sneeze.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`BadgeCount`: update the color tokens to be more accurate token for the usage.
+`BadgeCount`: updated the color tokens to use palette tokens.

--- a/packages/components/src/styles/components/badge-count.scss
+++ b/packages/components/src/styles/components/badge-count.scss
@@ -71,20 +71,20 @@ $hds-badge-count-size-props: (
 
   &.hds-badge-count--type-inverted {
     color: var(--token-color-foreground-high-contrast);
-    background-color: var(--token-color-foreground-faint);
+    background-color: var(--token-color-palette-neutral-500);
   }
 
   &.hds-badge-count--type-outlined {
     color: var(--token-color-foreground-primary);
     background-color: transparent;
-    border-color: var(--token-color-foreground-faint);
+    border-color: var(--token-color-palette-neutral-500);
   }
 }
 
 .hds-badge-count--color-neutral-dark-mode {
   &.hds-badge-count--type-filled {
     color: var(--token-color-foreground-high-contrast);
-    background-color: var(--token-color-foreground-faint);
+    background-color: var(--token-color-palette-neutral-500);
   }
 
   &.hds-badge-count--type-inverted {
@@ -95,6 +95,6 @@ $hds-badge-count-size-props: (
   &.hds-badge-count--type-outlined {
     color: var(--token-color-foreground-high-contrast);
     background-color: transparent;
-    border-color: var(--token-color-palette-neutral-100);
+    border-color: var(--token-color-palette-neutral-50);
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would change the usage of foreground colors in the `BadgeCount` component as background and border colors to just the palette colors.

### :camera_flash: Screenshots

![Screenshot 2024-09-05 at 12 43 58 PM](https://github.com/user-attachments/assets/83892852-800a-4285-8789-67395477ecf1)
![Screenshot 2024-09-05 at 12 44 12 PM](https://github.com/user-attachments/assets/256c211d-38cc-4157-aee0-e86296c068ad)

### :link: External links

Jira ticket: [HDS-3817](https://hashicorp.atlassian.net/browse/HDS-3817)
Figma file: https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/%5BWIP%5D-HDS-Components-v2.0?node-id=205-564&t=16lLFxX1rGve3Zqp-1

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3817]: https://hashicorp.atlassian.net/browse/HDS-3817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ