### PR TITLE
`Badge`: update the color tokens to be more accurate token for the usage

### DIFF
--- a/.changeset/popular-shoes-tease.md
+++ b/.changeset/popular-shoes-tease.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Badge`: update the color tokens to use palette tokens.

--- a/packages/components/src/styles/components/badge.scss
+++ b/packages/components/src/styles/components/badge.scss
@@ -11,6 +11,24 @@ $hds-badge-types: ( "flat","inverted","outlined" );
 $hds-badge-colors-accents: ( "highlight", "success", "warning", "critical" );
 $hds-badge-sizes: ( "small", "medium", "large" );
 $hds-badge-border-width: 1px;
+$hds-badge-colors-props: (
+  "highlight": (
+    "inverted-background-color":  var(--token-color-palette-purple-200),
+    "outlined-border-color": var(--token-color-palette-purple-200),
+  ),
+  "success": (
+    "inverted-background-color":  var(--token-color-palette-green-200),
+    "outlined-border-color": var(--token-color-palette-green-200),
+  ),
+  "warning": (
+    "inverted-background-color":  var(--token-color-palette-amber-200),
+    "outlined-border-color": var(--token-color-palette-amber-200),
+  ),
+  "critical": (
+    "inverted-background-color":  var(--token-color-palette-red-200),
+    "outlined-border-color": var(--token-color-palette-red-200),
+  ),
+);
 
 
 .hds-badge {
@@ -96,20 +114,20 @@ $hds-badge-size-props: (
 
   &.hds-badge--type-inverted {
     color: var(--token-color-foreground-high-contrast);
-    background-color: var(--token-color-foreground-faint);
+    background-color: var(--token-color-palette-neutral-500);
   }
 
   &.hds-badge--type-outlined {
     color: var(--token-color-foreground-primary);
     background-color: transparent;
-    border-color: var(--token-color-foreground-faint);
+    border-color: var(--token-color-palette-neutral-500);
   }
 }
 
 .hds-badge--color-neutral-dark-mode {
   &.hds-badge--type-filled {
     color: var(--token-color-foreground-high-contrast);
-    background-color: var(--token-color-foreground-faint);
+    background-color: var(--token-color-palette-neutral-500);
   }
 
   &.hds-badge--type-inverted {
@@ -120,7 +138,7 @@ $hds-badge-size-props: (
   &.hds-badge--type-outlined {
     color: var(--token-color-foreground-high-contrast);
     background-color: transparent;
-    border-color: var(--token-color-palette-neutral-100);
+    border-color: var(--token-color-palette-neutral-50);
   }
 }
 
@@ -133,13 +151,13 @@ $hds-badge-size-props: (
 
     &.hds-badge--type-inverted {
       color: var(--token-color-foreground-high-contrast);
-      background-color: var(--token-color-foreground-#{$color});
+      background-color: map-get($hds-badge-colors-props, $color, "inverted-background-color");
     }
 
     &.hds-badge--type-outlined {
       color: var(--token-color-foreground-#{$color});
       background-color: transparent;
-      border-color: currentColor;
+      border-color: map-get($hds-badge-colors-props, $color, "outlined-border-color");
     }
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would change the usage of foreground colors in the Badge component as background and border colors to just the palette colors.

### :camera_flash: Screenshots

![Screenshot 2024-09-05 at 1 15 55 PM](https://github.com/user-attachments/assets/a6f665ac-ab35-406c-a9dd-100ade68595a)
![Screenshot 2024-09-05 at 1 16 16 PM](https://github.com/user-attachments/assets/f4c57b55-82c9-4b5f-b653-ada022e26fe4)

### :link: External links

Jira ticket: [HDS-3814](https://hashicorp.atlassian.net/browse/HDS-3814)
Figma file: https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/%5BWIP%5D-HDS-Components-v2.0?node-id=2-8&t=H85BsHoufgLKUuEk-1

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3814]: https://hashicorp.atlassian.net/browse/HDS-3814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ