### PR TITLE
`Breadcrumb`: fix background-color for `Breadcrumb::Truncation`

### DIFF
--- a/.changeset/fuzzy-buses-mate.md
+++ b/.changeset/fuzzy-buses-mate.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Breadrcumb`: fix background hover color for `Breadcrumb::Truncation`

--- a/packages/components/src/styles/components/breadcrumb.scss
+++ b/packages/components/src/styles/components/breadcrumb.scss
@@ -160,7 +160,8 @@ $hds-breadcrumb-item-visual-horizontal-padding: 4px;
   &:hover,
   &.mock-hover {
     color: var(--token-color-foreground-faint);
-    border-color: var(--token-color-border-strong);
+    background-color: var(--token-color-surface-interactive);
+    border-color: var(--token-color-border-strong)
   }
 
   // we apply the focus directly to the element, without using a pseudo-element


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would change the background color of `Breadcrumb::Truncation` from `transparent` to `var(--token-color-surface-interactive)`.

### :camera_flash: Screenshots

<img width="809" alt="Screenshot 2024-09-06 at 1 41 10 PM" src="https://github.com/user-attachments/assets/e819dfcb-eb2b-4106-8c21-347f4d4ebf70">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3816](https://hashicorp.atlassian.net/browse/HDS-3816)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3816]: https://hashicorp.atlassian.net/browse/HDS-3816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ