### PR TITLE
`SideNav` & `AppFrame` - Fix a11yRefocusSkipTo bugs (HDS-3672)

### DIFF
--- a/.changeset/famous-garlics-fetch.md
+++ b/.changeset/famous-garlics-fetch.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`SideNav` - Added a default value of "#hds-main" for `a11yRefocusSkipTo`

--- a/packages/components/src/components/hds/app-frame/parts/main.hbs
+++ b/packages/components/src/components/hds/app-frame/parts/main.hbs
@@ -2,6 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<main class="hds-app-frame__main" id="main" ...attributes>
+<main class="hds-app-frame__main" id="hds-main" ...attributes>
   {{yield}}
 </main>

--- a/packages/components/src/components/hds/app-frame/parts/main.hbs
+++ b/packages/components/src/components/hds/app-frame/parts/main.hbs
@@ -2,6 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<main class="hds-app-frame__main" ...attributes>
+<main class="hds-app-frame__main" id="main" ...attributes>
   {{yield}}
 </main>

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -33,7 +33,7 @@ export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
   @tracked hasOverflowContent = false;
   desktopMQ: MediaQueryList;
   hasA11yRefocus = this.args.hasA11yRefocus ?? true;
-  a11yRefocusSkipTo = '#' + (this.args.a11yRefocusSkipTo ?? 'main');
+  a11yRefocusSkipTo = '#' + (this.args.a11yRefocusSkipTo ?? 'hds-main');
 
   // Generates a unique ID for the Menu Content
   menuContentId = 'hds-menu-content-' + guidFor(this);

--- a/packages/components/src/components/hds/side-nav/index.hbs
+++ b/packages/components/src/components/hds/side-nav/index.hbs
@@ -18,7 +18,7 @@
       {{! @glint-expect-error - `ember-a11y-refocus` doesn't expose types yet }}
       <NavigationNarrator
         @routeChangeValidator={{@a11yRefocusRouteChangeValidator}}
-        @skipTo="#{{@a11yRefocusSkipTo}}"
+        @skipTo={{this.a11yRefocusSkipTo}}
         @skipText={{@a11yRefocusSkipText}}
         @navigationText={{@a11yRefocusNavigationText}}
         @excludeAllQueryParams={{@a11yRefocusExcludeAllQueryParams}}

--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -6,7 +6,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { assert } from '@ember/debug';
 import { registerDestructor } from '@ember/destroyable';
 
 import type { HdsSideNavBaseSignature } from './base';
@@ -60,6 +59,7 @@ export default class HdsSideNav extends Component<HdsSideNavSignature> {
   desktopMQ: MediaQueryList;
   containersToHide!: NodeListOf<Element>;
   hasA11yRefocus = this.args.hasA11yRefocus ?? true;
+  a11yRefocusSkipTo = '#' + (this.args.a11yRefocusSkipTo ?? 'main');
 
   desktopMQVal = getComputedStyle(document.documentElement).getPropertyValue(
     '--hds-app-desktop-breakpoint'
@@ -72,13 +72,6 @@ export default class HdsSideNav extends Component<HdsSideNavSignature> {
     registerDestructor(this, (): void => {
       this.removeEventListeners();
     });
-
-    if (this.args.hasA11yRefocus) {
-      assert(
-        '@a11yRefocusSkipTo for NavigatorNarrator (a11y-refocus) in "Hds::SideNav" must have a valid value',
-        this.args.a11yRefocusSkipTo !== undefined
-      );
-    }
   }
 
   addEventListeners(): void {

--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -59,7 +59,7 @@ export default class HdsSideNav extends Component<HdsSideNavSignature> {
   desktopMQ: MediaQueryList;
   containersToHide!: NodeListOf<Element>;
   hasA11yRefocus = this.args.hasA11yRefocus ?? true;
-  a11yRefocusSkipTo = '#' + (this.args.a11yRefocusSkipTo ?? 'main');
+  a11yRefocusSkipTo = '#' + (this.args.a11yRefocusSkipTo ?? 'hds-main');
 
   desktopMQVal = getComputedStyle(document.documentElement).getPropertyValue(
     '--hds-app-desktop-breakpoint'

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
@@ -79,7 +79,7 @@
     </Hds::SideNav>
   </Frame.Sidebar>
 
-  <Frame.Main id="main">
+  <Frame.Main>
     <div class="shw-layout-app-frame__main-content-padding">
       <Hds::PageHeader as |PH|>
         <PH.Title>Page title</PH.Title>

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
@@ -81,7 +81,7 @@
     </Hds::SideNav>
   </Frame.Sidebar>
 
-  <Frame.Main id="main">
+  <Frame.Main>
     <div class="shw-layout-app-frame__main-content-padding">
       <Hds::PageHeader as |PH|>
         <PH.Title>Page title</PH.Title>

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
@@ -8,13 +8,7 @@
 
 <Hds::AppFrame @hasHeader={{false}} as |Frame|>
   <Frame.Sidebar>
-    <Hds::SideNav
-      @isResponsive={{true}}
-      @a11yRefocusSkipTo="main"
-      @hasA11yRefocus={{true}}
-      @isCollapsible={{true}}
-      @hasHeader={{false}}
-    >
+    <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{true}} @isCollapsible={{true}} @hasHeader={{false}}>
       <:header>
         <Hds::SideNav::Header>
           <:logo>

--- a/showcase/tests/integration/components/hds/app-frame/index-test.js
+++ b/showcase/tests/integration/components/hds/app-frame/index-test.js
@@ -41,9 +41,13 @@ module('Integration | Component | hds/app-frame/index', function (hooks) {
 
     assert.dom('#test-app-frame[data-test-app-frame]').exists();
 
+    // Header
+
     assert.dom('#test-app-frame-header[data-test-app-frame-header]').exists();
     assert.dom('header.hds-app-frame__header').exists();
     assert.dom('header.hds-app-frame__header').includesText('header container');
+
+    // Sidebar
 
     assert.dom('#test-app-frame-sidebar[data-test-app-frame-sidebar]').exists();
     assert.dom('aside.hds-app-frame__sidebar').exists();
@@ -51,13 +55,19 @@ module('Integration | Component | hds/app-frame/index', function (hooks) {
       .dom('aside.hds-app-frame__sidebar')
       .includesText('sidebar container');
 
+    // Main
+
     assert.dom('#test-app-frame-main[data-test-app-frame-main]').exists();
     assert.dom('main.hds-app-frame__main').exists();
     assert.dom('main.hds-app-frame__main').includesText('main container');
 
+    // Footer
+
     assert.dom('#test-app-frame-footer[data-test-app-frame-footer]').exists();
     assert.dom('footer.hds-app-frame__footer').exists();
     assert.dom('footer.hds-app-frame__footer').includesText('footer container');
+
+    // Modals
 
     assert.dom('#test-app-frame-modals[data-test-app-frame-modals]').exists();
     assert.dom('div.hds-app-frame__modals').exists();
@@ -108,5 +118,24 @@ module('Integration | Component | hds/app-frame/index', function (hooks) {
         </Hds::AppFrame>
     `);
     assert.dom('#test-app-frame-modals').doesNotExist();
+  });
+
+  // Main id
+  test('it should have a default id of "hds-main" on the main container', async function (assert) {
+    await render(hbs`
+        <Hds::AppFrame as |Frame|>
+          <Frame.Main />
+        </Hds::AppFrame>
+    `);
+    assert.dom('main#hds-main').exists();
+  });
+
+  test('it should allow a custom id for the main container to be passed in', async function (assert) {
+    await render(hbs`
+        <Hds::AppFrame as |Frame|>
+          <Frame.Main id="test-main" />
+        </Hds::AppFrame>
+    `);
+    assert.dom('main#test-main').exists();
   });
 });

--- a/showcase/tests/integration/components/hds/app-header/index-test.js
+++ b/showcase/tests/integration/components/hds/app-header/index-test.js
@@ -157,13 +157,13 @@ module('Integration | Component | hds/app-header/index', function (hooks) {
 
   // A11Y Refocus
 
-  test('it renders the `a11y-refocus` elements by default with a default skip link href value of "#main', async function (assert) {
+  test('it renders the `a11y-refocus` elements by default with a default skip link href value of "#hds-main', async function (assert) {
     await render(hbs`<Hds::AppHeader />`);
     assert.dom('#ember-a11y-refocus-nav-message').exists();
     assert
       .dom('#ember-a11y-refocus-skip-link')
       .exists()
-      .hasAttribute('href', '#main');
+      .hasAttribute('href', '#hds-main');
   });
 
   test('it renders the `a11y-refocus` elements with the right properties provided as arguments', async function (assert) {

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -50,13 +50,13 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
 
   // A11Y
 
-  test('it renders the `a11y-refocus` elements by default with a default skip link href value of "#main', async function (assert) {
+  test('it renders the `a11y-refocus` elements by default with a default skip link href value of "#hds-main', async function (assert) {
     await render(hbs`<Hds::SideNav />`);
     assert.dom('#ember-a11y-refocus-nav-message').exists();
     assert
       .dom('#ember-a11y-refocus-skip-link')
       .exists()
-      .hasAttribute('href', '#main');
+      .hasAttribute('href', '#hds-main');
   });
 
   test('it renders the `a11y-refocus` elements with the right properties provided as arguments', async function (assert) {

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -9,7 +9,6 @@ import {
   render,
   click,
   resetOnerror,
-  setupOnerror,
   triggerKeyEvent,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -51,12 +50,13 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
 
   // A11Y
 
-  test('it renders the `a11y-refocus` elements by default', async function (assert) {
-    await render(
-      hbs`<Hds::SideNav @hasA11yRefocus={{true}} @a11yRefocusSkipTo="foo" />`
-    );
+  test('it renders the `a11y-refocus` elements by default with a default skip link href value of "#main', async function (assert) {
+    await render(hbs`<Hds::SideNav />`);
     assert.dom('#ember-a11y-refocus-nav-message').exists();
-    assert.dom('#ember-a11y-refocus-skip-link').exists();
+    assert
+      .dom('#ember-a11y-refocus-skip-link')
+      .exists()
+      .hasAttribute('href', '#main');
   });
 
   test('it renders the `a11y-refocus` elements with the right properties provided as arguments', async function (assert) {
@@ -249,20 +249,5 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     );
     await click('.hds-side-nav__toggle-button');
     assert.ok(toggled);
-  });
-
-  // ASSERTIONS
-
-  test('it should throw an assertion if an incorrect value for @type is provided', async function (assert) {
-    const errorMessage =
-      '@a11yRefocusSkipTo for NavigatorNarrator (a11y-refocus) in "Hds::SideNav" must have a valid value';
-    assert.expect(2);
-    setupOnerror(function (error) {
-      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
-    });
-    await render(hbs`<Hds::SideNav @hasA11yRefocus={{true}} />`);
-    assert.throws(function () {
-      throw new Error(errorMessage);
-    });
   });
 });

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -62,7 +62,6 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
   test('it renders the `a11y-refocus` elements with the right properties provided as arguments', async function (assert) {
     await render(hbs`
       <Hds::SideNav
-        @hasA11yRefocus={{true}}
         @a11yRefocusSkipTo="test-skip-to"
         @a11yRefocusSkipText="test-skip-text"
         @a11yRefocusNavigationText="test-navigation-text"

--- a/website/docs/components/app-header/partials/code/component-api.md
+++ b/website/docs/components/app-header/partials/code/component-api.md
@@ -20,7 +20,7 @@
     <br><br>
     <em>For details about the addon behaviour and functionality, refer to the [official documentation](https://github.com/ember-a11y/ember-a11y-refocus#readme).</em>
     <Doc::ComponentApi as |C|>
-      <C.Property @name="a11yRefocusSkipTo" @type="string" @default='"#main"'>
+      <C.Property @name="a11yRefocusSkipTo" @type="string" @default='"#hds-main"'>
         Pass-through property for the `skipTo` argument - The element ID that should receive focus on skip. The default value matches the default id value on the [`AppFrame::Main` component](/layouts/app-frame#afmain).
       </C.Property>
       <C.Property @name="a11yRefocusSkipText" @type="string">

--- a/website/docs/components/app-header/partials/code/component-api.md
+++ b/website/docs/components/app-header/partials/code/component-api.md
@@ -20,8 +20,8 @@
     <br><br>
     <em>For details about the addon behaviour and functionality, refer to the [official documentation](https://github.com/ember-a11y/ember-a11y-refocus#readme).</em>
     <Doc::ComponentApi as |C|>
-      <C.Property @name="a11yRefocusSkipTo" @type="string">
-        Pass-through property for the `skipTo` argument - The element ID that should receive focus on skip.
+      <C.Property @name="a11yRefocusSkipTo" @type="string" @default='"#main"'>
+        Pass-through property for the `skipTo` argument - The element ID that should receive focus on skip. The default value matches the default id value on the [`AppFrame::Main` component](/layouts/app-frame#afmain).
       </C.Property>
       <C.Property @name="a11yRefocusSkipText" @type="string">
         Pass-through property for the `skipText` argument - The text passed in the skip link; defaults to "Skip to main content".

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -36,8 +36,8 @@ This is the full-fledged component (responsive and animated).
     <br><br>
     <em>For details about the addon behaviour and functionality, refer to the [official documentation](https://github.com/ember-a11y/ember-a11y-refocus#readme).</em>
     <Doc::ComponentApi as |C|>
-      <C.Property @name="a11yRefocusSkipTo" @type="string">
-        Pass-through property for the `skipTo` argument - The element ID that should receive focus on skip.
+      <C.Property @name="a11yRefocusSkipTo" @type="string" @default='"#main"'>
+        Pass-through property for the `skipTo` argument - The element ID that should receive focus on skip. The default value matches the default id value on the [`AppFrame::Main` component](/layouts/app-frame#afmain).
       </C.Property>
       <C.Property @name="a11yRefocusSkipText" @type="string">
         Pass-through property for the `skipText` argument - The text passed in the skip link; defaults to "Skip to main content".

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -36,7 +36,7 @@ This is the full-fledged component (responsive and animated).
     <br><br>
     <em>For details about the addon behaviour and functionality, refer to the [official documentation](https://github.com/ember-a11y/ember-a11y-refocus#readme).</em>
     <Doc::ComponentApi as |C|>
-      <C.Property @name="a11yRefocusSkipTo" @type="string" @default='"#main"'>
+      <C.Property @name="a11yRefocusSkipTo" @type="string" @default='"#hds-main"'>
         Pass-through property for the `skipTo` argument - The element ID that should receive focus on skip. The default value matches the default id value on the [`AppFrame::Main` component](/layouts/app-frame#afmain).
       </C.Property>
       <C.Property @name="a11yRefocusSkipText" @type="string">

--- a/website/docs/layouts/app-frame/partials/code/component-api.md
+++ b/website/docs/layouts/app-frame/partials/code/component-api.md
@@ -77,6 +77,9 @@ To be used as container for the application's main page content.
   <C.Property @name="yield">
     Elements passed as children are yielded as inner content of a `<main>` HTML element.
   </C.Property>
+  <C.Property @name="id" @default='"main"'>
+    A default id value is set which serves as the target of the skip link included in the `AppHeader` and standalone `SideNav` components. This id can be overridden if needed but be sure to update the `a11yRefocusSkipTo` argument of the [`AppHeader`](/components/app-header?tab=code#appheader) or [`SideNav`](/components/side-nav?tab=code#side-nav) to match.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/layouts/app-frame/partials/code/how-to-use.md
+++ b/website/docs/layouts/app-frame/partials/code/how-to-use.md
@@ -6,7 +6,7 @@ The `AppFrame` is a pure layout component that can be used to build the top-leve
 
 The `AppFrame::Main` child component includes a default id with the value “hds-main” on the HTML `main` element it renders. This serves as a target for the `hasA11yRefocus` feature skip links which are build into the [`AppHeader`](/components/app-header?tab=code#appheader) and the old standalone [`SideNav`](http://localhost:4203/components/app-header?tab=code#appheader) components.
 
-Note: The `AppSideNav` component, which is meant to only be used together with the `AppHeader` and not as standalone navigation, does not include a skip link.
+Note: The upcoming `AppSideNav` component, which is meant to only be used together with the `AppHeader` and not as standalone navigation, does not include a skip link.
 
 ### Basic use
 

--- a/website/docs/layouts/app-frame/partials/code/how-to-use.md
+++ b/website/docs/layouts/app-frame/partials/code/how-to-use.md
@@ -4,7 +4,7 @@ The `AppFrame` is a pure layout component that can be used to build the top-leve
 
 ### “Main” container
 
-The `AppFrame::Main` child component includes a default `id` with the value `hds-main` on the HTML `<main>` element it renders. This serves as a target for the `hasA11yRefocus` feature skip links which are built into the [`AppHeader`](/components/app-header?tab=code#appheader) and the standalone [`SideNav`](/components/app-header?tab=code#appheader) components.
+The `AppFrame::Main` child component includes a default `id` with the value `hds-main` on the HTML `<main>` element it renders. This serves as a target for the `hasA11yRefocus` feature skip links which are built into the [`AppHeader`](/components/app-header?tab=code#appheader) and the standalone [`SideNav`](/components/side-nav?tab=code#side-nav) components.
 
 Note: The upcoming `AppSideNav` component, which is meant to only be used together with the `AppHeader` and not as standalone navigation, does not include a skip link.
 

--- a/website/docs/layouts/app-frame/partials/code/how-to-use.md
+++ b/website/docs/layouts/app-frame/partials/code/how-to-use.md
@@ -1,6 +1,12 @@
 ## How to use this component
 
-The `AppFrame` is a pure layout component that can be used to build the top-level “frame“ of an application. The frame’s child containers (“header”, “sidebar“, “main”, “footer“) are agnostic of the content, and don’t have intrinsic sizes (apart from the ones that are required to make it work as top-level application frame).
+The `AppFrame` is a pure layout component that can be used to build the top-level “frame” of an application. The frame’s child containers (“header”, “sidebar”, “main”, “footer”) are agnostic of the content, and don’t have intrinsic sizes (apart from the ones that are required to make it work as top-level application frame).
+
+### “Main” container
+
+The `AppFrame::Main` child component includes a default id with the value “hds-main” on the HTML `main` element it renders. This serves as a target for the `hasA11yRefocus` feature skip links which are build into the [`AppHeader`](/components/app-header?tab=code#appheader) and the old standalone [`SideNav`](http://localhost:4203/components/app-header?tab=code#appheader) components.
+
+Note: The `AppSideNav` component, which is meant to only be used together with the `AppHeader` and not as standalone navigation, does not include a skip link.
 
 ### Basic use
 
@@ -31,7 +37,7 @@ The most basic invocation of an application “frame” looks like this:
 
 ### Optional containers
 
-Depending on the UI implementation of the product where the component is used, it's possible to omit certain containers simply by not yielding them. For example, this would be the “frame” of an application that doesn't have an “header”:
+Depending on the UI implementation of the product where the component is used, it's possible to omit certain containers simply by not yielding them. For example, this would be the “frame” of an application that doesn't have a “header”:
 
 ```handlebars
 <div class="doc-app-frame-mock-viewport">

--- a/website/docs/layouts/app-frame/partials/code/how-to-use.md
+++ b/website/docs/layouts/app-frame/partials/code/how-to-use.md
@@ -1,6 +1,6 @@
 ## How to use this component
 
-The `AppFrame` is a pure layout component that can be used to build the top-level “frame“ of an application. The frame's child containers (“header”, “sidebar“, “footer“, etc.) are agnostic of the content, and don‘t have intrinsic sizes (apart from the ones that are required to make it work as top-level application frame).
+The `AppFrame` is a pure layout component that can be used to build the top-level “frame“ of an application. The frame’s child containers (“header”, “sidebar“, “main”, “footer“) are agnostic of the content, and don’t have intrinsic sizes (apart from the ones that are required to make it work as top-level application frame).
 
 ### Basic use
 
@@ -49,7 +49,7 @@ Depending on the UI implementation of the product where the component is used, i
 </div>
 ```
 
-#### Programmatic control of the containers‘ rendering
+#### Programmatic control of the containers’ rendering
 
 Using the [exposed API of the component](#component-api), it's possible to programmatically control the rendering of some of the containers. An example of programmatic control of the rendering of the sidebar could be this:
 

--- a/website/docs/layouts/app-frame/partials/code/how-to-use.md
+++ b/website/docs/layouts/app-frame/partials/code/how-to-use.md
@@ -4,7 +4,7 @@ The `AppFrame` is a pure layout component that can be used to build the top-leve
 
 ### “Main” container
 
-The `AppFrame::Main` child component includes a default id with the value “hds-main” on the HTML `main` element it renders. This serves as a target for the `hasA11yRefocus` feature skip links which are build into the [`AppHeader`](/components/app-header?tab=code#appheader) and the old standalone [`SideNav`](http://localhost:4203/components/app-header?tab=code#appheader) components.
+The `AppFrame::Main` child component includes a default `id` with the value `hds-main` on the HTML `<main>` element it renders. This serves as a target for the `hasA11yRefocus` feature skip links which are built into the [`AppHeader`](/components/app-header?tab=code#appheader) and the standalone [`SideNav`](/components/app-header?tab=code#appheader) components.
 
 Note: The upcoming `AppSideNav` component, which is meant to only be used together with the `AppHeader` and not as standalone navigation, does not include a skip link.
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes bugs with the SideNav a11yRefocusSkipTo and adds a default id to the AppFrame for it to point to.

**Previews:**

* [AppHeader `a11yRefocusSkipTo` docs](https://hds-website-git-hds-3672-a11y-refocus-bug-hashicorp.vercel.app/components/app-header?tab=code#component-api)
* [SideNav `a11yRefocusSkipTo` docs](https://hds-website-git-hds-3672-a11y-refocus-bug-hashicorp.vercel.app/components/side-nav?tab=code#side-nav)
* [AppFrame::Main `id` docs](https://hds-website-git-hds-3672-a11y-refocus-bug-hashicorp.vercel.app/layouts/app-frame#afmain)

### :hammer_and_wrench: Detailed description

**Details of changes:**

* SideNav: 
  - Add a default value of "#hds-main" for `a11yRefocusSkipTo`
  - Removes assertion for `a11yRefocusSkipTo` which is no longer needed
  - Updates related integration tests
* AppHeader:
  - Change default value of `a11yRefocusSkipTo` from "#main" to "#hds-main"
* AppFrame:
  - Add id with value of "hds-main" to AppFrame::Main which is overridable by consumers
  - Remove ids from framed AppFrame Showcase examples as they are no longer needed
* Web docs:
  - Updated `SideNav` API docs to include default value of `a11yRefocusSkipTo`.
  - Updated `AppHeader` API docs to include default value of `a11yRefocusSkipTo`.
  - Documented default id value added to `AppFrame::Main`

<!-- 
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

Jira ticket: [HDS-3672](https://hashicorp.atlassian.net/browse/HDS-3672)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3672]: https://hashicorp.atlassian.net/browse/HDS-3672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ