### PR TITLE
Require routing param for controlled pagination

### DIFF
--- a/.changeset/tidy-phones-rest.md
+++ b/.changeset/tidy-phones-rest.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::Pagination::Compact` & `Hds::Pagination::Numbered`
+- Added assertion and more strict typing to ensure that a routing argument (`@model`, `@models`, or `@route`) are present when using `@onPageChange` to control routing.

--- a/packages/components/src/components/hds/pagination/compact/index.ts
+++ b/packages/components/src/components/hds/pagination/compact/index.ts
@@ -48,7 +48,7 @@ interface HdsPaginationCompactArgsControlled extends HdsPaginationCompactArgs {
 
 interface HdsPaginationCompactArgsUncontrolled
   extends HdsPaginationCompactArgs {
-  queryFunction: undefined;
+  queryFunction?: undefined;
 }
 
 interface HdsPaginationCompactSignature {

--- a/packages/components/src/components/hds/pagination/compact/index.ts
+++ b/packages/components/src/components/hds/pagination/compact/index.ts
@@ -22,7 +22,12 @@ type HdsPaginationCompactRoutingQueryProps = HdsPaginationRoutingProps & {
   queryPrev?: HdsInteractiveQuery;
 };
 
-interface HdsPaginationCompactArgs {
+type HdsPaginationQueryFunction = (
+  page: HdsPaginationDirections,
+  pageSize?: number
+) => HdsInteractiveQuery;
+
+interface HdsPaginationCompactArgs extends HdsPaginationRoutingProps {
   ariaLabel?: string;
   showLabels?: boolean;
   isDisabledPrev?: boolean;
@@ -31,16 +36,25 @@ interface HdsPaginationCompactArgs {
   sizeSelectorLabel?: string;
   pageSizes?: number[];
   currentPageSize?: number;
-  queryFunction?: (
-    page: HdsPaginationDirections,
-    pageSize?: number
-  ) => HdsInteractiveQuery;
+  queryFunction?: HdsPaginationQueryFunction;
   onPageChange?: (page: HdsPaginationDirections) => void;
   onPageSizeChange?: (pageSize: number) => void;
 }
 
+interface HdsPaginationCompactArgsControlled extends HdsPaginationCompactArgs {
+  model: string | number;
+  queryFunction: HdsPaginationQueryFunction;
+}
+
+interface HdsPaginationCompactArgsUncontrolled
+  extends HdsPaginationCompactArgs {
+  queryFunction: undefined;
+}
+
 interface HdsPaginationCompactSignature {
-  Args: HdsPaginationCompactArgs & HdsPaginationRoutingProps;
+  Args:
+    | HdsPaginationCompactArgsControlled
+    | HdsPaginationCompactArgsUncontrolled;
   Element: HTMLDivElement;
 }
 
@@ -78,6 +92,10 @@ export default class HdsPaginationCompact extends Component<HdsPaginationCompact
     if (queryFunction === undefined) {
       this.isControlled = false;
     } else {
+      assert(
+        '@model for "Hds::Pagination::Compact" must be provided when using the `@queryFunction` argument',
+        this.args.model !== undefined
+      );
       assert(
         '@queryFunction for "Hds::Pagination::Numbered" must be a function',
         typeof queryFunction === 'function'

--- a/packages/components/src/components/hds/pagination/compact/index.ts
+++ b/packages/components/src/components/hds/pagination/compact/index.ts
@@ -112,13 +112,13 @@ export default class HdsPaginationCompact extends Component<HdsPaginationCompact
       this.isControlled = false;
     } else {
       assert(
-        '`@model`, `@models`, or `@route` for "Hds::Pagination::Compact" must be provided when using the `@queryFunction` argument',
+        '@model, @models, or @route for "Hds::Pagination::Compact" must be provided when using the `@queryFunction` argument',
         this.args.model !== undefined ||
           this.args.models !== undefined ||
           this.args.route !== undefined
       );
       assert(
-        '@queryFunction for "Hds::Pagination::Numbered" must be a function',
+        '@queryFunction for "Hds::Pagination::Compact" must be a function',
         typeof queryFunction === 'function'
       );
       this.isControlled = true;

--- a/packages/components/src/components/hds/pagination/compact/index.ts
+++ b/packages/components/src/components/hds/pagination/compact/index.ts
@@ -41,10 +41,29 @@ interface HdsPaginationCompactArgs extends HdsPaginationRoutingProps {
   onPageSizeChange?: (pageSize: number) => void;
 }
 
-interface HdsPaginationCompactArgsControlled extends HdsPaginationCompactArgs {
-  model: string | number;
+interface HdsPaginationCompactArgsControlledBase
+  extends HdsPaginationCompactArgs {
   queryFunction: HdsPaginationQueryFunction;
 }
+
+interface HdsPaginationCompactArgsControlledWithModel
+  extends HdsPaginationCompactArgsControlledBase {
+  model: string | number;
+}
+
+interface HdsPaginationCompactArgsControlledWithModels
+  extends HdsPaginationCompactArgsControlledBase {
+  models: Array<string | number>;
+}
+interface HdsPaginationCompactArgsControlledWithRoute
+  extends HdsPaginationCompactArgsControlledBase {
+  route: string;
+}
+
+type HdsPaginationCompactArgsControlled =
+  | HdsPaginationCompactArgsControlledWithModel
+  | HdsPaginationCompactArgsControlledWithModels
+  | HdsPaginationCompactArgsControlledWithRoute;
 
 interface HdsPaginationCompactArgsUncontrolled
   extends HdsPaginationCompactArgs {

--- a/packages/components/src/components/hds/pagination/compact/index.ts
+++ b/packages/components/src/components/hds/pagination/compact/index.ts
@@ -112,8 +112,10 @@ export default class HdsPaginationCompact extends Component<HdsPaginationCompact
       this.isControlled = false;
     } else {
       assert(
-        '@model for "Hds::Pagination::Compact" must be provided when using the `@queryFunction` argument',
-        this.args.model !== undefined
+        '`@model`, `@models`, or `@route` for "Hds::Pagination::Compact" must be provided when using the `@queryFunction` argument',
+        this.args.model !== undefined ||
+          this.args.models !== undefined ||
+          this.args.route !== undefined
       );
       assert(
         '@queryFunction for "Hds::Pagination::Numbered" must be a function',

--- a/packages/components/src/components/hds/pagination/numbered/index.ts
+++ b/packages/components/src/components/hds/pagination/numbered/index.ts
@@ -158,6 +158,10 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
       this.isControlled = false;
     } else {
       assert(
+        '@model for "Hds::Pagination::Numbered" must be provided when using the `@queryFunction` argument',
+        this.args.model !== undefined
+      );
+      assert(
         '@queryFunction for "Hds::Pagination::Numbered" must be a function',
         typeof queryFunction === 'function'
       );

--- a/packages/components/src/components/hds/pagination/numbered/index.ts
+++ b/packages/components/src/components/hds/pagination/numbered/index.ts
@@ -60,7 +60,7 @@ interface HdsPaginationNumberedArgsControlled
 
 interface HdsPaginationNumberedArgsUncontrolled
   extends HdsPaginationNumberedArgs {
-  queryFunction: undefined;
+  queryFunction?: undefined;
 }
 
 export interface HdsPaginationNumberedSignature {

--- a/packages/components/src/components/hds/pagination/numbered/index.ts
+++ b/packages/components/src/components/hds/pagination/numbered/index.ts
@@ -32,6 +32,11 @@ type HdsPaginationNumberedRoutingQueryProps = HdsPaginationRoutingProps & {
   >;
 };
 
+type HdsPaginationQueryFunction = (
+  page: number,
+  pageSize: number
+) => HdsInteractiveQuery;
+
 interface HdsPaginationNumberedArgs extends HdsPaginationRoutingProps {
   ariaLabel?: string;
   totalItems: number;
@@ -45,18 +50,36 @@ interface HdsPaginationNumberedArgs extends HdsPaginationRoutingProps {
   sizeSelectorLabel?: string;
   pageSizes?: number[];
   currentPageSize?: number;
-  queryFunction?: (page: number, pageSize: number) => HdsInteractiveQuery;
+  queryFunction?: HdsPaginationQueryFunction;
   onPageChange?: (page: number, pageSize: number) => unknown;
   onPageSizeChange?: (pageSize: number) => unknown;
 }
 
-interface HdsPaginationNumberedArgsControlled
+interface HdsPaginationNumberedArgsControlledBase
   extends HdsPaginationNumberedArgs {
   currentPage: number;
   currentPageSize: number;
-  model: string | number;
-  queryFunction: (page: number, pageSize: number) => HdsInteractiveQuery;
+  queryFunction: HdsPaginationQueryFunction;
 }
+
+interface HdsPaginationNumberedArgsControlledWithModel
+  extends HdsPaginationNumberedArgsControlledBase {
+  model: string | number;
+}
+
+interface HdsPaginationNumberedArgsControlledWithModels
+  extends HdsPaginationNumberedArgsControlledBase {
+  models: Array<string | number>;
+}
+interface HdsPaginationNumberedArgsControlledWithRoute
+  extends HdsPaginationNumberedArgsControlledBase {
+  route: string;
+}
+
+type HdsPaginationNumberedArgsControlled =
+  | HdsPaginationNumberedArgsControlledWithModel
+  | HdsPaginationNumberedArgsControlledWithModels
+  | HdsPaginationNumberedArgsControlledWithRoute;
 
 interface HdsPaginationNumberedArgsUncontrolled
   extends HdsPaginationNumberedArgs {

--- a/packages/components/src/components/hds/pagination/numbered/index.ts
+++ b/packages/components/src/components/hds/pagination/numbered/index.ts
@@ -196,7 +196,7 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
       this.isControlled = false;
     } else {
       assert(
-        '`@model`, `@models`, or `@route` for "Hds::Pagination::Numbered" must be provided when using the `@queryFunction` argument',
+        '@model, @models, or @route for "Hds::Pagination::Numbered" must be provided when using the @queryFunction argument',
         this.args.model !== undefined ||
           this.args.models !== undefined ||
           this.args.route !== undefined

--- a/packages/components/src/components/hds/pagination/numbered/index.ts
+++ b/packages/components/src/components/hds/pagination/numbered/index.ts
@@ -196,8 +196,10 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
       this.isControlled = false;
     } else {
       assert(
-        '@model for "Hds::Pagination::Numbered" must be provided when using the `@queryFunction` argument',
-        this.args.model !== undefined
+        '`@model`, `@models`, or `@route` for "Hds::Pagination::Numbered" must be provided when using the `@queryFunction` argument',
+        this.args.model !== undefined ||
+          this.args.models !== undefined ||
+          this.args.route !== undefined
       );
       assert(
         '@queryFunction for "Hds::Pagination::Numbered" must be a function',

--- a/packages/components/src/components/hds/pagination/numbered/index.ts
+++ b/packages/components/src/components/hds/pagination/numbered/index.ts
@@ -32,7 +32,7 @@ type HdsPaginationNumberedRoutingQueryProps = HdsPaginationRoutingProps & {
   >;
 };
 
-interface HdsPaginationNumberedArgs {
+interface HdsPaginationNumberedArgs extends HdsPaginationRoutingProps {
   ariaLabel?: string;
   totalItems: number;
   showLabels?: boolean;
@@ -50,8 +50,23 @@ interface HdsPaginationNumberedArgs {
   onPageSizeChange?: (pageSize: number) => unknown;
 }
 
+interface HdsPaginationNumberedArgsControlled
+  extends HdsPaginationNumberedArgs {
+  currentPage: number;
+  currentPageSize: number;
+  model: string | number;
+  queryFunction: (page: number, pageSize: number) => HdsInteractiveQuery;
+}
+
+interface HdsPaginationNumberedArgsUncontrolled
+  extends HdsPaginationNumberedArgs {
+  queryFunction: undefined;
+}
+
 export interface HdsPaginationNumberedSignature {
-  Args: HdsPaginationNumberedArgs & HdsPaginationRoutingProps;
+  Args:
+    | HdsPaginationNumberedArgsControlled
+    | HdsPaginationNumberedArgsUncontrolled;
   Element: HTMLDivElement;
 }
 

--- a/showcase/tests/integration/components/hds/pagination/compact-test.js
+++ b/showcase/tests/integration/components/hds/pagination/compact-test.js
@@ -158,7 +158,9 @@ module('Integration | Component | hds/pagination/compact', function (hooks) {
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
-    await render(hbs`<Hds::Pagination::Compact @queryFunction="foo" />`);
+    await render(
+      hbs`<Hds::Pagination::Compact @queryFunction="foo" @model="test" />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });

--- a/showcase/tests/integration/components/hds/pagination/compact-test.js
+++ b/showcase/tests/integration/components/hds/pagination/compact-test.js
@@ -153,12 +153,28 @@ module('Integration | Component | hds/pagination/compact', function (hooks) {
 
   test('it should throw an assertion if @queryFunction is not a function', async function (assert) {
     const errorMessage =
-      '@queryFunction for "Hds::Pagination::Numbered" must be a function';
+      '@queryFunction for "Hds::Pagination::Compact" must be a function';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
     await render(hbs`<Hds::Pagination::Compact @queryFunction="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+
+  test('it should throw an assertion if @queryFunction is provided without a routing argument', async function (assert) {
+    this.set('myQueryFunction', (page) => ({ page }));
+    const errorMessage =
+      '@model, @models, or @route for "Hds::Pagination::Compact" must be provided when using the `@queryFunction` argument';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(
+      hbs`<Hds::Pagination::Compact @queryFunction={{this.myQueryFunction}} />`
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });

--- a/showcase/tests/integration/components/hds/pagination/numbered-test.js
+++ b/showcase/tests/integration/components/hds/pagination/numbered-test.js
@@ -467,4 +467,19 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
       throw new Error(errorMessage);
     });
   });
+  test('it should throw an assertion if @queryFunction is provided without a routing argument', async function (assert) {
+    this.set('myQueryFunction', (page) => ({ page }));
+    const errorMessage =
+      '@model, @models, or @route for "Hds::Pagination::Numbered" must be provided when using the `@queryFunction` argument';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(
+      hbs`<Hds::Pagination::Numbered @queryFunction={{this.myQueryFunction}} />`
+    );
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
 });

--- a/showcase/tests/integration/components/hds/pagination/numbered-test.js
+++ b/showcase/tests/integration/components/hds/pagination/numbered-test.js
@@ -422,7 +422,7 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
     await render(
-      hbs`<Hds::Pagination::Numbered @totalItems={{100}} @queryFunction="foo" />`
+      hbs`<Hds::Pagination::Numbered @totalItems={{100}} @queryFunction="foo" @model="test" />`
     );
     assert.throws(function () {
       throw new Error(errorMessage);
@@ -437,7 +437,7 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
     await render(
-      hbs`<Hds::Pagination::Numbered @totalItems={{100}} @queryFunction={{this.myQueryFunction}} />`
+      hbs`<Hds::Pagination::Numbered @totalItems={{100}} @queryFunction={{this.myQueryFunction}} @model="test" />`
     );
     assert.throws(function () {
       throw new Error(errorMessage);
@@ -470,7 +470,7 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
   test('it should throw an assertion if @queryFunction is provided without a routing argument', async function (assert) {
     this.set('myQueryFunction', (page) => ({ page }));
     const errorMessage =
-      '@model, @models, or @route for "Hds::Pagination::Numbered" must be provided when using the `@queryFunction` argument';
+      '@model, @models, or @route for "Hds::Pagination::Numbered" must be provided when using the @queryFunction argument';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -137,7 +137,7 @@ get demoQueryFunctionNumbered() {
 When the routing parameters are provided, the "navigation controls" are rendered as links and if the user clicks on one of them the page URL is automatically updated. This means that the component’s state is persisted **outside** of the component and so its whole state **must** be "controlled" by the consumer’s code (otherwise there would be conflicting states).
 
 
-!!! Info
+!!! Warning
 
 When a pagination component is controlled externally, as described above, at least one routing argument (`@route`, `@model`, or `@models`) **must** be provided.
 !!!

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -136,6 +136,12 @@ get demoQueryFunctionNumbered() {
 
 When the routing parameters are provided, the "navigation controls" are rendered as links and if the user clicks on one of them the page URL is automatically updated. This means that the component’s state is persisted **outside** of the component and so its whole state **must** be "controlled" by the consumer’s code (otherwise there would be conflicting states).
 
+
+!!! Info
+
+When a pagination component is controlled externally, as described above, at least one routing argument (`@route`, `@model`, or `@models`) **must** be provided.
+!!!
+
 In this case, the component doesn’t update its internal "state" but the value of the state variables (eg. `currentPage/currentPageSize`) is **always** determined by the consumer’s controller code via the component’s arguments (usually, they are directly connected to the query parameters in the URL).
 
 The reason for using a consumer-side function to determine the `query` argument is because it’s dynamic (it depends on the value of the `page` variable) and gives consumers the ability to specify their own query parameters (which will likely differ case by case).


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will require that consumers of our pagination components (
`Hds::Pagination::Compact` & `Hds::Pagination::Numbered`) provide at least 1 routing argument 
(`@model`, `@models`, or `@route`) when routing is controlled externally.

### :hammer_and_wrench: Detailed description

- Added new assertions in component constructors that ensure the above
- Added some discriminated union types to the pagination type definitions that make it more clear when certain arguments are required.

### Questions

- How to we communicate this `required-if` behavior to the user in the docs? Is what we have enough?
- The discriminated union types seem to work in TS not with Glint. (IE, if I try to instantiate a pagination component with `@onPageChange` but omit routing params, I get no TS errors, but if I try to create an object with the same type in the component file, I get the expected errors.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3439](https://hashicorp.atlassian.net/browse/HDS-3439)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3439]: https://hashicorp.atlassian.net/browse/HDS-3439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ