### PR TITLE
`DismissButton`, `RadioCard::Group`, `RichTooltip::Toggle` - Type safety fixes

### DIFF
--- a/.changeset/clean-tigers-promise.md
+++ b/.changeset/clean-tigers-promise.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`DismissButton`, `RadioCard::Group`, `RichTooltip::Toggle` - Type safety fixes

--- a/packages/components/src/components/hds/dismiss-button/index.hbs
+++ b/packages/components/src/components/hds/dismiss-button/index.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/form/field/index.ts
+++ b/packages/components/src/components/hds/form/field/index.ts
@@ -21,6 +21,7 @@ import HdsFormErrorComponent from '../error/index.ts';
 import type { HdsFormFieldLayouts } from './types.ts';
 import type { ComponentLike, WithBoundArgs } from '@glint/template';
 import type { HdsYieldSignature } from '../../yield/index.ts';
+import type { AriaDescribedByComponent } from '../../../../utils/hds-aria-described-by.ts';
 
 export const LAYOUT_TYPES = Object.values(HdsFormFieldLayoutValues);
 
@@ -131,10 +132,10 @@ export default class HdsFormField extends Component<HdsFormFieldSignature> {
 
   @action
   appendDescriptor(element: HTMLElement): void {
-    registerAriaDescriptionElement(this, element);
+    registerAriaDescriptionElement(this as AriaDescribedByComponent, element);
   }
 
   @action removeDescriptor(element: HTMLElement): void {
-    unregisterAriaDescriptionElement(this, element);
+    unregisterAriaDescriptionElement(this as AriaDescribedByComponent, element);
   }
 }

--- a/packages/components/src/components/hds/form/fieldset/index.ts
+++ b/packages/components/src/components/hds/form/fieldset/index.ts
@@ -19,6 +19,7 @@ import HdsFormErrorComponent from '../error/index.ts';
 import type { ComponentLike, WithBoundArgs } from '@glint/template';
 import type { HdsFormFieldsetLayouts } from './types.ts';
 import type { HdsYieldSignature } from '../../yield/index.ts';
+import type { AriaDescribedByComponent } from '../../../../utils/hds-aria-described-by.ts';
 
 export interface HdsFormFieldsetSignature {
   Args: {
@@ -106,10 +107,10 @@ export default class HdsFormFieldset extends Component<HdsFormFieldsetSignature>
 
   @action
   appendDescriptor(element: HTMLElement): void {
-    registerAriaDescriptionElement(this, element);
+    registerAriaDescriptionElement(this as AriaDescribedByComponent, element);
   }
 
   @action removeDescriptor(element: HTMLElement): void {
-    unregisterAriaDescriptionElement(this, element);
+    unregisterAriaDescriptionElement(this as AriaDescribedByComponent, element);
   }
 }

--- a/packages/components/src/components/hds/form/fieldset/index.ts
+++ b/packages/components/src/components/hds/form/fieldset/index.ts
@@ -23,6 +23,7 @@ import type { AriaDescribedByComponent } from '../../../../utils/hds-aria-descri
 
 export interface HdsFormFieldsetSignature {
   Args: {
+    extraAriaDescribedBy?: string;
     isOptional?: boolean;
     isRequired?: boolean;
     layout?: HdsFormFieldsetLayouts;

--- a/packages/components/src/components/hds/form/fieldset/types.ts
+++ b/packages/components/src/components/hds/form/fieldset/types.ts
@@ -5,7 +5,7 @@
 
 export enum HdsFormFieldsetLayoutValues {
   Vertical = 'vertical',
-  Flag = 'flag',
+  Horizontal = 'horizontal',
 }
 
 export type HdsFormFieldsetLayouts = `${HdsFormFieldsetLayoutValues}`;

--- a/packages/components/src/components/hds/form/radio-card/group.hbs
+++ b/packages/components/src/components/hds/form/radio-card/group.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/packages/components/src/components/hds/rich-tooltip/toggle.hbs
+++ b/packages/components/src/components/hds/rich-tooltip/toggle.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
@@ -16,14 +15,18 @@
   {{~#if (has-block)~}}
     {{yield}}
   {{~else~}}
-    {{~#if (and @icon (eq this.iconPosition "leading"))~}}
-      <Hds::Icon class="hds-rich-tooltip__toggle-icon" @name={{@icon}} @isInline={{this.isInline}} />
+    {{~#if @icon~}}
+      {{~#if (eq this.iconPosition "leading")~}}
+        <Hds::Icon class="hds-rich-tooltip__toggle-icon" @name={{@icon}} @isInline={{this.isInline}} />
+      {{~/if~}}
     {{~/if~}}
     {{~#if @text~}}
       <span class="hds-rich-tooltip__toggle-text">{{~@text~}}</span>
     {{~/if~}}
-    {{~#if (and @icon (eq this.iconPosition "trailing"))~}}
-      <Hds::Icon class="hds-rich-tooltip__toggle-icon" @name={{@icon}} @isInline={{this.isInline}} />
+    {{~#if @icon~}}
+      {{~#if (eq this.iconPosition "trailing")~}}
+        <Hds::Icon class="hds-rich-tooltip__toggle-icon" @name={{@icon}} @isInline={{this.isInline}} />
+      {{~/if~}}
     {{~/if~}}
   {{~/if~}}
 </button>

--- a/packages/components/src/utils/hds-aria-described-by.ts
+++ b/packages/components/src/utils/hds-aria-described-by.ts
@@ -44,7 +44,8 @@ const ariaDescriptorMap = new AriaDescriptorMap();
 
 type AriaDescribedByArgs = HdsFormFieldSignature & HdsFormFieldsetSignature;
 
-interface AriaDescribedByComponent extends Component<AriaDescribedByArgs> {
+export interface AriaDescribedByComponent
+  extends Component<AriaDescribedByArgs> {
   __ARIA_DESCRIPTION_IDS__?: string[];
   ariaDescribedBy?: string;
 }

--- a/packages/components/src/utils/hds-aria-described-by.ts
+++ b/packages/components/src/utils/hds-aria-described-by.ts
@@ -42,7 +42,7 @@ class AriaDescriptorMap {
 
 const ariaDescriptorMap = new AriaDescriptorMap();
 
-type AriaDescribedByArgs = HdsFormFieldSignature & HdsFormFieldsetSignature;
+type AriaDescribedByArgs = HdsFormFieldSignature | HdsFormFieldsetSignature;
 
 export interface AriaDescribedByComponent
   extends Component<AriaDescribedByArgs> {


### PR DESCRIPTION
### :pushpin: Summary

As we converted all our components to TypeScript I did a thorough check and discovered a few instances where glint ignore was not removed:
 - `DismissButton`: needed it to be removed
 - `RadioCard::Group`: removing it revealed a complexity where Field and Fieldset share the `layout` argument, but have different values for them (vertical/flag and vertical/horizontal, respectively)
 - `RichTooltip::Toggle`: removing it meant the logic needed small adjustments (open to alternatives/suggestions)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
