### PR TITLE
fix: remove the word component from hds component blueprint

### DIFF
--- a/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.ts
+++ b/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.ts
@@ -17,7 +17,7 @@ export interface Hds<%= classifiedModuleName %>Signature {
 }
 // More info on types and signatures: https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3245932580/Using+Typescript
 
-export default class Hds<%= classifiedModuleName %>Component extends Component<Hds<%= classifiedModuleName %>Signature> {
+export default class Hds<%= classifiedModuleName %> extends Component<Hds<%= classifiedModuleName %>Signature> {
   // UNCOMMENT THIS IF YOU NEED A CONSTRUCTOR
   // constructor() {
   //   super(...arguments);


### PR DESCRIPTION
### :pushpin: Summary

If merged, the component blueprint will no longer make the default export `Hds{ComponentName}Component`, it will be `Hds{ComponentName}`.

### :link: External links

Jira ticket: [HDS-3812](https://hashicorp.atlassian.net/browse/HDS-3812)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
