### PR TITLE
`SideNav`: remove `Ember.testing` because it will be deprecated

### DIFF
--- a/.changeset/brave-feet-melt.md
+++ b/.changeset/brave-feet-melt.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav`: remove usage of `Ember.testing` because it is deprecated.

--- a/packages/components/src/components/hds/side-nav/portal/target.ts
+++ b/packages/components/src/components/hds/side-nav/portal/target.ts
@@ -41,11 +41,7 @@ export default class HdsSideNavPortalTarget extends Component<HdsSideNavPortalTa
   @tracked lastPanelEl: Element | undefined;
 
   static get prefersReducedMotionOverride(): boolean {
-    if (macroCondition(isTesting())) {
-      return true;
-    }
-
-    return false;
+    return macroCondition(isTesting()) ? true : false;
   }
 
   prefersReducedMotionMQ = window.matchMedia(

--- a/packages/components/src/components/hds/side-nav/portal/target.ts
+++ b/packages/components/src/components/hds/side-nav/portal/target.ts
@@ -41,7 +41,11 @@ export default class HdsSideNavPortalTarget extends Component<HdsSideNavPortalTa
   @tracked lastPanelEl: Element | undefined;
 
   static get prefersReducedMotionOverride(): boolean {
-    return macroCondition(isTesting());
+    if (macroCondition(isTesting())) {
+      return true;
+    }
+
+    return false;
   }
 
   prefersReducedMotionMQ = window.matchMedia(

--- a/packages/components/src/components/hds/side-nav/portal/target.ts
+++ b/packages/components/src/components/hds/side-nav/portal/target.ts
@@ -8,7 +8,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
-import Ember from 'ember';
+import { macroCondition, isTesting } from '@embroider/macros';
 
 import type { HdsSideNavPortalSignature } from './index';
 
@@ -41,7 +41,7 @@ export default class HdsSideNavPortalTarget extends Component<HdsSideNavPortalTa
   @tracked lastPanelEl: Element | undefined;
 
   static get prefersReducedMotionOverride(): boolean {
-    return Ember.testing;
+    return macroCondition(isTesting());
   }
 
   prefersReducedMotionMQ = window.matchMedia(


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would remove usage of `Ember.testing` because it will be deprecated and replace it with [the suggested replacement](https://github.com/emberjs/rfcs/blob/3e032300e02f1222a0d1a0788b3e1936fc33a143/text/1003-deprecation-import-ember-from-ember.md?plain=1#L207).

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3813](https://hashicorp.atlassian.net/browse/HDS-3813)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3813]: https://hashicorp.atlassian.net/browse/HDS-3813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ