### PR TITLE
Update Figma release notes

### DIFF
--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -1,5 +1,11 @@
 # [HDS Product - Components](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?type=design&node-id=6790-10926&mode=design&t=Ps0aMGZ6F3z7bAJ4-0)
 
+## September 11th, 2024
+
+`Text Input` - Added support for types `Tel`, `Week` and `Month`.
+
+`Dropdown` - `ListItem` `Interactive` added support for the `Badge` component.
+
 ## August 2nd, 2024
 
 `AppHeader` - Added a new navigation component to contain global and utility navigation elements.

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -4,7 +4,7 @@
 
 `Text Input` - Added support for types `Tel`, `Week` and `Month`.
 
-`Dropdown` - `ListItem` `Interactive` added support for the `Badge` component.
+`Dropdown` - `ListItem Interactive` added support for the `Badge` component.
 
 ## August 2nd, 2024
 


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR will add Figma release notes for the support for `Tel`, `Week` and `Month` for Text Input, and added support for `Badges` in `Dropdown` `ListItem` `Interactive`. This change corresponds with [these consolidated release notes](https://docs.google.com/document/d/1HuoaSibk7Cfn9yXIgWub-KXzQsOSsP_ENamt4sL2Rgw/edit)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
