### PR TITLE
removed `ember-unique-id-helper-polyfill` dependency from showcase

### DIFF
--- a/showcase/package.json
+++ b/showcase/package.json
@@ -87,7 +87,6 @@
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "ember-truth-helpers": "^3.1.1",
     "ember-try": "^3.0.0",
-    "ember-unique-id-helper-polyfill": "^1.2.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-ember": "^11.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13709,17 +13709,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-unique-id-helper-polyfill@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "ember-unique-id-helper-polyfill@npm:1.2.2"
-  dependencies:
-    broccoli-funnel: "npm:^3.0.8"
-    ember-cli-babel: "npm:^7.26.10"
-    ember-cli-version-checker: "npm:^5.1.2"
-  checksum: 10/bfb208e469e1d7b5570a5070d897ab8a8a4b3211c6555d92d86f74a7e7c8b1f0817b93e6007b645bd2b7b13b3e072dd20e43c42695385b72b670a985c2ac9f4c
-  languageName: node
-  linkType: hard
-
 "emittery@npm:^0.13.1":
   version: 0.13.1
   resolution: "emittery@npm:0.13.1"
@@ -24644,7 +24633,6 @@ __metadata:
     ember-template-lint-plugin-prettier: "npm:^5.0.0"
     ember-truth-helpers: "npm:^3.1.1"
     ember-try: "npm:^3.0.0"
-    ember-unique-id-helper-polyfill: "npm:^1.2.2"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-ember: "npm:^11.12.0"


### PR DESCRIPTION
### :pushpin: Summary

While running the showcase, I noticed this message in the CLI console:

<img width="535" alt="screenshot_4142" src="https://github.com/user-attachments/assets/0abb9cc8-292e-4d04-8d05-b91257921788">


This PR removes the dependency `ember-unique-id-helper-polyfill` from the Showcase.

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
