### PR TITLE
Website: Change out the "updated" badges and add 4.10.0 version history

### DIFF
--- a/website/docs/components/accordion/index.md
+++ b/website/docs/components/accordion/index.md
@@ -10,6 +10,8 @@ previewImage: assets/illustrations/components/accordion.jpg
 navigation:
   hidden: false
   keywords: ['toggle', 'disclosure', 'details', 'reveal', 'list', 'summary', 'expand', 'collapse']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -29,4 +31,8 @@ navigation:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
 </section>

--- a/website/docs/components/accordion/partials/version-history/4.10.0.md
+++ b/website/docs/components/accordion/partials/version-history/4.10.0.md
@@ -1,0 +1,8 @@
+## 4.10.0
+
+### Updated
+
+`Accoridon`
+
+- Added `@titleTag` argument
+- Changed the default name of the `Accordion` item toggles. Now, they are labelled by the content in the `Accordion` title.

--- a/website/docs/components/alert/index.md
+++ b/website/docs/components/alert/index.md
@@ -9,6 +9,8 @@ related: ['components/modal', 'components/toast']
 previewImage: assets/illustrations/components/alert.jpg
 navigation:
   keywords: ['alert', 'toast', 'notification', 'banner', 'message']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -33,3 +35,6 @@ navigation:
   @include "partials/accessibility/accessibility.md"
 </section>
 
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
+</section>

--- a/website/docs/components/alert/partials/version-history/4.10.0.md
+++ b/website/docs/components/alert/partials/version-history/4.10.0.md
@@ -1,0 +1,7 @@
+## 4.10.0
+
+### Updated
+
+`Alert::Title`
+
+- Added `@tag` argument

--- a/website/docs/components/app-header/index.md
+++ b/website/docs/components/app-header/index.md
@@ -9,8 +9,6 @@ related: ['components/side-nav', 'components/app-footer', 'layouts/app-frame']
 previewImage: assets/illustrations/components/app-header.jpg
 navigation:
   keywords: ['navigation', 'header', 'navbar', 'menubar', 'topbar']
-status:
-  added: 4.8.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/app-header/index.md
+++ b/website/docs/components/app-header/index.md
@@ -9,6 +9,8 @@ related: ['components/side-nav', 'components/app-footer', 'layouts/app-frame']
 previewImage: assets/illustrations/components/app-header.jpg
 navigation:
   keywords: ['navigation', 'header', 'navbar', 'menubar', 'topbar']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -30,5 +32,6 @@ navigation:
 </section>
 
 <section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
   @include "partials/version-history/4.8.0.md"
 </section>

--- a/website/docs/components/app-header/partials/version-history/4.10.0.md
+++ b/website/docs/components/app-header/partials/version-history/4.10.0.md
@@ -1,0 +1,10 @@
+## 4.10.0
+
+### Updated
+
+- Changed default value of `a11yRefocusSkipTo` from "#main" to "#hds-main"
+- Hid the closed menu content in mobile view using CSS instead of conditionally rendering/not rendering the menu content.
+- Added `NavigationNarrator` with associated arguments to provide a "skip link".
+- Styled inoperable actions as disabled (which occurs when the `SideNav` is expanded in mobile view)
+- Fixed styling issue to prevent `Button` and `Dropdown` nested within another `Dropdown` from inheriting dark theme.
+- Fixed issue with mobile menu to prevent tabbing to hidden content and hiding it from assistive technology when closed.

--- a/website/docs/components/application-state/index.md
+++ b/website/docs/components/application-state/index.md
@@ -8,6 +8,8 @@ links:
 previewImage: assets/illustrations/components/application-state.jpg
 navigation:
   keywords: ['empty state', 'error state', 'message']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -29,5 +31,6 @@ navigation:
 </section>
 
 <section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
   @include "partials/version-history/4.8.0.md"
 </section>

--- a/website/docs/components/application-state/index.md
+++ b/website/docs/components/application-state/index.md
@@ -8,8 +8,6 @@ links:
 previewImage: assets/illustrations/components/application-state.jpg
 navigation:
   keywords: ['empty state', 'error state', 'message']
-status:
-  updated: 4.8.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/application-state/partials/version-history/4.10.0.md
+++ b/website/docs/components/application-state/partials/version-history/4.10.0.md
@@ -1,0 +1,5 @@
+## 4.10.0
+
+### Updated
+
+Updated the type of the `@titleTag` argument to only accept `"div" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"`. If using another value, update the argument to the appropriate heading level. For example, if an Application State is used as an empty state below the main heading of a page, the value should be `"h2"`. 

--- a/website/docs/components/badge/index.md
+++ b/website/docs/components/badge/index.md
@@ -9,8 +9,6 @@ related: ['components/badge-count','components/tag']
 previewImage: assets/illustrations/components/badge.jpg
 navigation:
   keywords: ['chip', 'pill', 'tag', 'label']
-status:
-  updated: 4.7.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/breadcrumb/index.md
+++ b/website/docs/components/breadcrumb/index.md
@@ -9,6 +9,8 @@ related: ['components/side-nav', 'components/tabs']
 previewImage: assets/illustrations/components/breadcrumb.jpg
 navigation:
   keywords: ['navigation', 'crumb', 'path']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -28,4 +30,8 @@ navigation:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
 </section>

--- a/website/docs/components/breadcrumb/partials/version-history/4.10.0.md
+++ b/website/docs/components/breadcrumb/partials/version-history/4.10.0.md
@@ -1,0 +1,8 @@
+## 4.10.0
+
+### Updated
+
+`Breadcrumb::Truncation`
+
+- Replaced the underlying `MenuPrimitive` with [`PopoverPrimitive`](/utilities/popover-primitive)
+- Fixed the background hover color for `Breadcrumb::Truncation`

--- a/website/docs/components/card/index.md
+++ b/website/docs/components/card/index.md
@@ -8,6 +8,8 @@ links:
 previewImage: assets/illustrations/components/card.jpg
 navigation:
   keywords: ['tile', 'container', 'box']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -21,4 +23,8 @@ navigation:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
 </section>

--- a/website/docs/components/card/partials/version-history/4.10.0.md
+++ b/website/docs/components/card/partials/version-history/4.10.0.md
@@ -1,0 +1,7 @@
+## 4.10.0
+
+### Updated
+
+`Card::Container`
+
+Fixed the `HdsCard` type reexport to reflect correct component name `HdsCardContainer`. If you are importing `HdsCard` types, update it to `HdsCardContainer`.

--- a/website/docs/components/code-block/index.md
+++ b/website/docs/components/code-block/index.md
@@ -9,6 +9,8 @@ related: ['components/copy/snippet', 'components/copy/button']
 previewImage: assets/illustrations/components/code-block.jpg
 navigation:
   keywords: ['code', 'snippet', 'copy', 'text', 'editor', 'language', 'example', 'syntax', 'highlight']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -28,4 +30,8 @@ navigation:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
 </section>

--- a/website/docs/components/code-block/partials/version-history/4.10.0.md
+++ b/website/docs/components/code-block/partials/version-history/4.10.0.md
@@ -1,0 +1,7 @@
+## 4.10.0
+
+### Updated
+
+`CodeBlock::Title`
+
+-  Added `@tag` argument

--- a/website/docs/components/flyout/index.md
+++ b/website/docs/components/flyout/index.md
@@ -9,6 +9,8 @@ related: ['components/reveal','components/modal','components/accordion', 'utilit
 previewImage: assets/illustrations/components/flyout.jpg
 navigation:
   keywords: ['drawer', 'panel', 'side', 'modal']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -30,5 +32,6 @@ navigation:
 </section>
 
 <section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
   @include "partials/version-history/4.7.0.md"
 </section>

--- a/website/docs/components/flyout/index.md
+++ b/website/docs/components/flyout/index.md
@@ -9,8 +9,6 @@ related: ['components/reveal','components/modal','components/accordion', 'utilit
 previewImage: assets/illustrations/components/flyout.jpg
 navigation:
   keywords: ['drawer', 'panel', 'side', 'modal']
-status:
-  updated: 4.7.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/flyout/partials/version-history/4.10.0.md
+++ b/website/docs/components/flyout/partials/version-history/4.10.0.md
@@ -1,0 +1,7 @@
+## 4.10.0
+
+### Updated
+
+`Flyout.Header`
+
+Changed the HTML element wrapping the tagline and title from a `<div>` to a `<h1>`. If you have a heading HTML tag inside the header yield block, either remove it or change it to a `<span>`.

--- a/website/docs/components/form/super-select/index.md
+++ b/website/docs/components/form/super-select/index.md
@@ -31,3 +31,7 @@ status:
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
+</section>

--- a/website/docs/components/form/super-select/index.md
+++ b/website/docs/components/form/super-select/index.md
@@ -9,6 +9,8 @@ related: ['components/form/select', 'components/dropdown']
 previewImage: assets/illustrations/components/form/super-select.jpg
 navigation:
   keywords: ['dropdown', 'powerselect']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/form/super-select/partials/version-history/4.10.0.md
+++ b/website/docs/components/form/super-select/partials/version-history/4.10.0.md
@@ -1,0 +1,5 @@
+## 4.10.0
+
+### Updated
+
+Converted the component to TypeScript.

--- a/website/docs/components/form/text-input/index.md
+++ b/website/docs/components/form/text-input/index.md
@@ -9,8 +9,6 @@ related: ['components/form/select', 'components/form/textarea', 'components/form
 previewImage: assets/illustrations/components/form/text-input.jpg
 navigation:
   keywords: ['text field', 'search', 'form']
-status:
-  updated: 4.7.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -9,8 +9,6 @@ related: ['components/alert','components/flyout','components/accordion','compone
 previewImage: assets/illustrations/components/modal.jpg
 navigation:
   keywords: ['flyout', 'popover', 'popup', 'dialog']
-status:
-  updated: 4.7.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -9,6 +9,8 @@ related: ['components/alert','components/flyout','components/accordion','compone
 previewImage: assets/illustrations/components/modal.jpg
 navigation:
   keywords: ['flyout', 'popover', 'popup', 'dialog']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -30,5 +32,6 @@ navigation:
 </section>
 
 <section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
   @include "partials/version-history/4.7.0.md"
 </section>

--- a/website/docs/components/modal/partials/version-history/4.10.0.md
+++ b/website/docs/components/modal/partials/version-history/4.10.0.md
@@ -1,0 +1,7 @@
+## 4.10.0
+
+### Updated
+
+`Modal.Header`
+
+Changed the HTML element wrapping the tagline and title from a `<div>` to a `<h1>`. If you have a heading HTML tag inside the header yield block, either remove it or change it to a `<span>`.

--- a/website/docs/components/pagination/index.md
+++ b/website/docs/components/pagination/index.md
@@ -7,6 +7,8 @@ links:
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/pagination
 related: ['components/table','patterns/filter-patterns', 'patterns/table-multi-select']
 previewImage: assets/illustrations/components/pagination.jpg
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -27,3 +29,8 @@ previewImage: assets/illustrations/components/pagination.jpg
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
+</section>
+

--- a/website/docs/components/pagination/partials/version-history/4.10.0.md
+++ b/website/docs/components/pagination/partials/version-history/4.10.0.md
@@ -1,0 +1,5 @@
+## 4.10.0
+
+### Updated
+
+Converted component to Typescript

--- a/website/docs/components/side-nav/index.md
+++ b/website/docs/components/side-nav/index.md
@@ -10,6 +10,8 @@ previewImage: assets/illustrations/components/side-nav.jpg
 navigation:
   hidden: false
   keywords: ['navigation', 'side navigation', 'sidenav', 'sidebar']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/side-nav/index.md
+++ b/website/docs/components/side-nav/index.md
@@ -10,8 +10,6 @@ previewImage: assets/illustrations/components/side-nav.jpg
 navigation:
   hidden: false
   keywords: ['navigation', 'side navigation', 'sidenav', 'sidebar']
-status:
-  updated: 4.8.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/components/side-nav/partials/version-history/4.10.0.md
+++ b/website/docs/components/side-nav/partials/version-history/4.10.0.md
@@ -1,5 +1,18 @@
 ## 4.10.0
 
+### Updated
+
+`SideNav`
+
+- Added a default value of "#hds-main" for `a11yRefocusSkipTo`
+- Fixed styling issue to prevent `Button` and `Dropdown` nested within another `Dropdown` from inheriting dark theme.
+
 ### Deprecated
 
-`Hds::SideNav::Header::IconButton` - Deprecated the component. Use the [`Hds::Button` component](/components/button) with isIconOnly set to true as a replacement.
+`SideNav`
+
+Deprecated the `withAppHeader` argument as it is no longer needed. If you are using this argument, simply remove it.
+
+`SideNav::Header::IconButton` 
+
+Deprecated the component. Use the [`Hds::Button` component](/components/button) with isIconOnly set to true as a replacement.

--- a/website/docs/components/table/index.md
+++ b/website/docs/components/table/index.md
@@ -9,6 +9,8 @@ related: ['components/pagination','patterns/filter-patterns','patterns/table-mul
 previewImage: assets/illustrations/components/table.jpg
 navigation:
   keywords: ['data table', 'data grid', 'datagrid', 'grid', 'list']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -36,4 +38,8 @@ navigation:
 
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
 </section>

--- a/website/docs/components/table/partials/version-history/4.10.0.md
+++ b/website/docs/components/table/partials/version-history/4.10.0.md
@@ -1,0 +1,5 @@
+## 4.10.0
+
+### Updated
+
+Converted component and sub-components to TypeScript.

--- a/website/docs/layouts/app-frame/index.md
+++ b/website/docs/layouts/app-frame/index.md
@@ -7,9 +7,15 @@ links:
 previewImage: assets/illustrations/layouts/app-frame.jpg
 navigation:
   keywords: ['layout', 'application', 'frame', 'header', 'sidebar', 'sidenav', 'footer', 'modal']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Code">
   @include "partials/code/how-to-use.md"
   @include "partials/code/component-api.md"
+</section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
 </section>

--- a/website/docs/layouts/app-frame/partials/version-history/4.10.0.md
+++ b/website/docs/layouts/app-frame/partials/version-history/4.10.0.md
@@ -1,0 +1,11 @@
+## 4.10.0
+
+### Updated
+
+`AppFrame`
+- Modified sticky/fixed position to turn off when viewport height is under 480px in height
+- Refactored styles to make `AppFrame` responsible for sticky/fixed layout of `SideNav` and `AppHeader`
+
+`AppFrame::Main`
+
+- Added `id` with default value of "hds-main" which the `SideNav` and `AppHeader` `a11yRefocusSkipTo` arguments point to.

--- a/website/docs/utilities/dialog-primitive/index.md
+++ b/website/docs/utilities/dialog-primitive/index.md
@@ -9,6 +9,8 @@ links:
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/dialog-primitive
 navigation:
   keywords: ['modal', 'flyout']
+status:
+  updated: 4.10.0
 ---
 
 <section data-tab="Guidelines">
@@ -30,5 +32,6 @@ navigation:
 </section>
 
 <section data-tab="Version history">
+  @include "partials/version-history/4.10.0.md"
   @include "partials/version-history/4.7.0.md"
 </section>

--- a/website/docs/utilities/dialog-primitive/index.md
+++ b/website/docs/utilities/dialog-primitive/index.md
@@ -9,8 +9,6 @@ links:
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/addon/components/hds/dialog-primitive
 navigation:
   keywords: ['modal', 'flyout']
-status:
-  added: 4.7.0
 ---
 
 <section data-tab="Guidelines">

--- a/website/docs/utilities/dialog-primitive/partials/version-history/4.10.0.md
+++ b/website/docs/utilities/dialog-primitive/partials/version-history/4.10.0.md
@@ -1,0 +1,6 @@
+## 4.10.0
+
+### Updated
+
+`DialogPrimitive::Header`
+- Added the `@titleTag` argument

--- a/website/tests/acceptance/component-query-test.js
+++ b/website/tests/acceptance/component-query-test.js
@@ -21,7 +21,12 @@ module('Acceptance | Component Tabs', function (hooks) {
       .hasClass('doc-page-tabs__tab--is-current');
 
     // Sidebar should show this component as the active "link"
-    assert.dom('.doc-table-of-contents__link.active').hasText('Alert');
+
+    const activeLink = document.getElementsByClassName(
+      'doc-table-of-contents__link active'
+    );
+
+    assert.ok(activeLink[0].textContent.includes('Alert'));
     assert.dom('.doc-table-of-contents__link.active').exists({ count: 1 });
 
     await click('#tab-code');
@@ -33,7 +38,7 @@ module('Acceptance | Component Tabs', function (hooks) {
     assert.strictEqual(currentURL(), '/components/alert?tab=code');
 
     // Sidebar should show this component as the active "link"
-    assert.dom('.doc-table-of-contents__link.active').hasText('Alert');
+    assert.ok(activeLink[0].textContent.includes('Alert'));
     assert.dom('.doc-table-of-contents__link.active').exists({ count: 1 });
   });
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would:
* clear out the updated status metadata from before 4.9.0
* add updated status metadata for components changed in 4.10.0
* add version history to components changed in 4.10.0
* update the component tabs acceptance tests to not fail if the "Alert" link in the sidebar has an "updated" tag.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
