### PR TITLE
Showcase - Cleanup of the `<Shw::Label>` instances

### DIFF
--- a/showcase/app/templates/components/badge.hbs
+++ b/showcase/app/templates/components/badge.hbs
@@ -80,8 +80,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <div class="shw-component-badge-group" {{style display=display}}>
             <Hds::Badge @text="Only text" /><Hds::Badge @icon="activity" @text="Text + icon" /><Hds::Badge
               @icon="activity"

--- a/showcase/app/templates/components/button.hbs
+++ b/showcase/app/templates/components/button.hbs
@@ -12,21 +12,21 @@
   <Shw::Text::H2>Generated element</Shw::Text::H2>
 
   <Shw::Flex as |SF|>
-    <SF.Item class="shw-component-button-generated">
-      <Shw::Label>Default ⇒ <code>&lt;button&gt;</code></Shw::Label>
+    <SF.Item class="shw-component-button-generated" as |SFI|>
+      <SFI.Label>Default ⇒ <code>&lt;button&gt;</code></SFI.Label>
       <Hds::Button @icon="plus" @text="Lorem ipsum" @color="primary" />
       <Hds::Button @icon="plus" @text="Lorem ipsum" @color="primary" disabled />
     </SF.Item>
-    <SF.Item class="shw-component-button-generated">
-      <Shw::Label>With <code>@href</code> ⇒ <code>&lt;a&gt;</code></Shw::Label>
+    <SF.Item class="shw-component-button-generated" as |SFI|>
+      <SFI.Label>With <code>@href</code> ⇒ <code>&lt;a&gt;</code></SFI.Label>
       <Hds::Button @icon="plus" @text="Lorem ipsum" @color="primary" @href="#" />
     </SF.Item>
-    <SF.Item class="shw-component-button-generated">
-      <Shw::Label>With<code>@route</code>
+    <SF.Item class="shw-component-button-generated" as |SFI|>
+      <SFI.Label>With<code>@route</code>
         ⇒
         <code>&lt;LinkTo&gt;</code>
         ⇒
-        <code>&lt;a&gt;</code></Shw::Label>
+        <code>&lt;a&gt;</code></SFI.Label>
       <Hds::Button @icon="plus" @text="Lorem ipsum" @color="primary" @route="index" />
     </SF.Item>
   </Shw::Flex>
@@ -142,8 +142,8 @@
   <Shw::Text::H2>Containers</Shw::Text::H2>
 
   <Shw::Grid @columns={{4}} as |SG|>
-    <SG.Item @forceMinWidth={{true}}>
-      <Shw::Label>Parent with <code>display: inline-block</code></Shw::Label>
+    <SG.Item @forceMinWidth={{true}} as |SGI|>
+      <SGI.Label>Parent with <code>display: inline-block</code></SGI.Label>
       <div {{style display="inline-block"}}>
         <Hds::Button @icon="plus" @iconPosition="leading" @text="Lorem ipsum" />
       </div>
@@ -152,8 +152,8 @@
         <Hds::Button @icon="plus" @text="This is a very long text that should go on multiple lines" />
       </div>
     </SG.Item>
-    <SG.Item @forceMinWidth={{true}}>
-      <Shw::Label>Parent with <code>display: inline-flex</code></Shw::Label>
+    <SG.Item @forceMinWidth={{true}} as |SGI|>
+      <SGI.Label>Parent with <code>display: inline-flex</code></SGI.Label>
       <div {{style display="inline-flex"}}>
         <Hds::Button @icon="plus" @iconPosition="leading" @text="Lorem ipsum" />
       </div>
@@ -162,8 +162,8 @@
         <Hds::Button @icon="plus" @text="This is a very long text that should go on multiple lines" />
       </div>
     </SG.Item>
-    <SG.Item @forceMinWidth={{true}}>
-      <Shw::Label>Parent with <code>flex-grow: 0</code></Shw::Label>
+    <SG.Item @forceMinWidth={{true}} as |SGI|>
+      <SGI.Label>Parent with <code>flex-grow: 0</code></SGI.Label>
       <div {{style display="flex"}}>
         <div {{style flex-grow="0"}}>
           <Hds::Button @icon="plus" @iconPosition="leading" @text="Lorem ipsum" />
@@ -176,8 +176,8 @@
         </div>
       </div>
     </SG.Item>
-    <SG.Item @forceMinWidth={{true}}>
-      <Shw::Label>Parent with <code>max-width: fit-content</code></Shw::Label>
+    <SG.Item @forceMinWidth={{true}} as |SGI|>
+      <SGI.Label>Parent with <code>max-width: fit-content</code></SGI.Label>
       <div {{style max-width="fit-content"}}>
         <Hds::Button @icon="plus" @iconPosition="leading" @text="Lorem ipsum" />
       </div>

--- a/showcase/app/templates/components/code-block.hbs
+++ b/showcase/app/templates/components/code-block.hbs
@@ -26,8 +26,7 @@ console.log(`I am ${codeLang} code`);"
   <Shw::Text::Body>New lines handling</Shw::Text::Body>
 
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
-    <SG.Item @forceMinWidth={{true}} as |SGI|>
-      <SGI.Label>new lines in Handlebars</SGI.Label>
+    <SG.Item @label="new lines in Handlebars" @forceMinWidth={{true}}>
       <Hds::CodeBlock
         @language="javascript"
         @value="let codeLang='JavaScript';
@@ -540,8 +539,7 @@ end'
   <Shw::Text::H2>Demo</Shw::Text::H2>
 
   <Shw::Flex @direction="column" @gap="2rem" as |SF|>
-    <SF.Item>
-      <Shw::Label>Within Tabs</Shw::Label>
+    <SF.Item @label="Within Tabs">
       <Hds::Tabs {{style width="400px"}} as |T|>
         <T.Tab>JavaScript</T.Tab>
         <T.Tab>Go</T.Tab>
@@ -574,8 +572,7 @@ func main() {
       </Hds::Tabs>
 
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Within a Dropdown</Shw::Label>
+    <SF.Item @label="Within a Dropdown">
       <Hds::Dropdown @listPosition="bottom-left" as |dd|>
         <dd.ToggleButton @text="Open menu" />
         <dd.Generic>
@@ -592,8 +589,7 @@ func main() {
         </dd.Generic>
       </Hds::Dropdown>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Within a Modal</Shw::Label>
+    <SF.Item @label="Within a Modal">
       <Hds::Button @color="secondary" @text="Open modal" {{on "click" this.activateModal}} />
 
       {{! template-lint-disable no-autofocus-attribute }}

--- a/showcase/app/templates/components/copy/button.hbs
+++ b/showcase/app/templates/components/copy/button.hbs
@@ -149,8 +149,7 @@
   <Shw::Text::H4>Target types</Shw::Text::H4>
 
   <Shw::Flex @columns={{3}} @gap="2rem" as |SF|>
-    <SF.Item>
-      <Shw::Label>Target as a CSS selector (`string`)</Shw::Label>
+    <SF.Item @label="Target as a CSS selector (`string`)">
       <div class="shw-component-copy-button-flex-container">
         <p class="shw-text-body" id="test-target-string">Lorem ipsum dolor</p>
         <Hds::Copy::Button
@@ -160,8 +159,7 @@
         />
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Target as a DOM element (`Node`)</Shw::Label>
+    <SF.Item @label="Target as a DOM element (`Node`)">
       <div class="shw-component-copy-button-flex-container">
         <p class="shw-text-body" id="test-target-node-element">Lorem ipsum dolor</p>
         <Hds::Copy::Button
@@ -176,15 +174,13 @@
   <Shw::Text::H4>HDS components</Shw::Text::H4>
 
   <Shw::Grid @columns={{3}} @gap="2rem" as |SG|>
-    <SG.Item class="shw-component-copy-button-input-component">
-      <Shw::Label>Input component</Shw::Label>
+    <SG.Item @label="Input component" class="shw-component-copy-button-input-component">
       <Hds::Form::TextInput::Field @value="036140285924" @name="test-input" @id="test-input" as |F|>
         <F.Label>Input Label</F.Label>
       </Hds::Form::TextInput::Field>
       <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input" />
     </SG.Item>
-    <SG.Item class="shw-component-copy-button-input-component">
-      <Shw::Label>Input component (readonly)</Shw::Label>
+    <SG.Item @label="Input component (readonly)" class="shw-component-copy-button-input-component">
       <Hds::Form::TextInput::Field
         readonly
         @value="036140285924-readonly"
@@ -196,8 +192,7 @@
       </Hds::Form::TextInput::Field>
       <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input-readonly" />
     </SG.Item>
-    <SG.Item class="shw-component-copy-button-input-component">
-      <Shw::Label>Input component (disabled)</Shw::Label>
+    <SG.Item @label="Input component (disabled)" class="shw-component-copy-button-input-component">
       <Hds::Form::TextInput::Field
         disabled
         @value="036140285924-disabled"
@@ -209,8 +204,7 @@
       </Hds::Form::TextInput::Field>
       <Hds::Copy::Button @text="Copy the input value" @targetToCopy="#test-input-disabled" />
     </SG.Item>
-    <SG.Item>
-      <Shw::Label>Textarea component</Shw::Label>
+    <SG.Item @label="Textarea component">
       <div class="shw-component-copy-button-flex-container">
         <Hds::Form::Textarea::Base
           @value="This is a normal
@@ -222,8 +216,7 @@ that should be copied"
         <Hds::Copy::Button @isIconOnly={{true}} @text="Copy the textarea value" @targetToCopy="#test-textarea" />
       </div>
     </SG.Item>
-    <SG.Item>
-      <Shw::Label>Textarea component (readonly)</Shw::Label>
+    <SG.Item @label="Textarea component (readonly)">
       <div class="shw-component-copy-button-flex-container">
         <Hds::Form::Textarea::Base
           readonly
@@ -240,8 +233,7 @@ that should be copied"
         />
       </div>
     </SG.Item>
-    <SG.Item>
-      <Shw::Label>Textarea component (disabled)</Shw::Label>
+    <SG.Item @label="Textarea component (disabled)">
       <div class="shw-component-copy-button-flex-container">
         <Hds::Form::Textarea::Base
           disabled
@@ -258,8 +250,7 @@ that should be copied"
         />
       </div>
     </SG.Item>
-    <SG.Item>
-      <Shw::Label>Select component</Shw::Label>
+    <SG.Item @label="Select component">
       <div class="shw-component-copy-button-flex-container">
         <Hds::Form::Select::Base @name="test-select" id="test-select" as |C|>
           <C.Options>
@@ -271,8 +262,7 @@ that should be copied"
         <Hds::Copy::Button @isIconOnly={{true}} @text="Copy the textarea value" @targetToCopy="#test-select" />
       </div>
     </SG.Item>
-    <SG.Item>
-      <Shw::Label>Select component (disabled)</Shw::Label>
+    <SG.Item @label="Select component (disabled)">
       <div class="shw-component-copy-button-flex-container">
         <Hds::Form::Select::Base disabled @name="test-select-disabled" id="test-select-disabled" as |C|>
           <C.Options>
@@ -287,8 +277,7 @@ that should be copied"
   </Shw::Grid>
 
   <Shw::Grid @columns={{3}} @gap="2rem" as |SG|>
-    <SG.Item>
-      <Shw::Label>Within a Dropdown</Shw::Label>
+    <SG.Item @label="Within a Dropdown">
       <Hds::Dropdown @listPosition="bottom-left" as |dd|>
         <dd.ToggleButton @text="Open menu" />
         <dd.Generic>
@@ -342,8 +331,7 @@ that should be copied"
         </dd.Generic>
       </Hds::Dropdown>
     </SG.Item>
-    <SG.Item>
-      <Shw::Label>Within a Modal</Shw::Label>
+    <SG.Item @label="Within a Modal">
       <Hds::Button @color="secondary" @text="Open modal" {{on "click" this.activateModal}} />
 
       {{! template-lint-disable no-autofocus-attribute }}
@@ -415,8 +403,7 @@ that should be copied"
   <Shw::Text::H4>HTML blocks</Shw::Text::H4>
 
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
-    <SG.Item>
-      <Shw::Label>Structured content</Shw::Label>
+    <SG.Item @label="Structured content">
       <Hds::Copy::Button @text="Copy the content below" @targetToCopy="#test-structured-content" />
       <ul class="shw-component-copy-structured-content" id="test-structured-content">
         <li class="shw-text-body">
@@ -435,8 +422,7 @@ that should be copied"
         </li>
       </ul>
     </SG.Item>
-    <SG.Item>
-      <Shw::Label>With hidden content</Shw::Label>
+    <SG.Item @label="With hidden content">
       <Hds::Copy::Button @text="Copy the content below" @targetToCopy="#test-hidden-content" />
       <p class="shw-text-body" id="test-hidden-content">This paragraph contains some
         <strong class="shw-component-copy-button-display-none">not</strong>
@@ -447,15 +433,13 @@ that should be copied"
   </Shw::Grid>
 
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
-    <SG.Item>
-      <Shw::Label>Code block</Shw::Label>
+    <SG.Item @label="Code block">
       <Hds::Copy::Button @text="Copy the code block" @targetToCopy="#test-code-block" />
       {{!-- prettier-ignore --}}
       <pre class="shw-component-copy-button-code-block"><code id="test-code-block">&lt;h1&gt;A page header example&lt;/h1&gt;
 &lt;p&gt;Some paragraph text also&lt;/p&gt;</code></pre>
     </SG.Item>
-    <SG.Item>
-      <Shw::Label>Code block with 'contenteditable'</Shw::Label>
+    <SG.Item @label="Code block with 'contenteditable'">
       <Hds::Copy::Button @text="Edit and copy the code block" @targetToCopy="#test-code-block-editable" />
       {{!-- prettier-ignore --}}
       <pre class="shw-component-copy-button-code-block"><code id="test-code-block-editable" contenteditable="true">&lt;h1&gt;A page header example&lt;/h1&gt;
@@ -466,8 +450,7 @@ that should be copied"
   <Shw::Text::H4>HTML input elements</Shw::Text::H4>
 
   <Shw::Flex @gap="2rem" as |SF|>
-    <SF.Item>
-      <Shw::Label>Text input</Shw::Label>
+    <SF.Item @label="Text input">
       <div class="shw-component-copy-button-flex-container">
         <input type="text" name="test-generic-input-text" id="test-generic-input-text" value="Lorem ipsum dolor" />
         <Hds::Copy::Button
@@ -477,8 +460,7 @@ that should be copied"
         />
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Password input</Shw::Label>
+    <SF.Item @label="Password input">
       <div class="shw-component-copy-button-flex-container">
         <input
           type="password"
@@ -493,8 +475,7 @@ that should be copied"
         />
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Number input</Shw::Label>
+    <SF.Item @label="Number input">
       <div class="shw-component-copy-button-flex-container">
         <input type="number" name="test-generic-input-number" id="test-generic-input-number" value="123456" />
         <Hds::Copy::Button
@@ -504,8 +485,7 @@ that should be copied"
         />
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>URL input</Shw::Label>
+    <SF.Item @label="URL input">
       <div class="shw-component-copy-button-flex-container">
         <input type="url" name="test-generic-input-url" id="test-generic-input-url" value="https://www.hello.com" />
         <Hds::Copy::Button
@@ -515,8 +495,7 @@ that should be copied"
         />
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Email input</Shw::Label>
+    <SF.Item @label="Email input">
       <div class="shw-component-copy-button-flex-container">
         <input type="email" name="test-generic-input-email" id="test-generic-input-email" value="info@hello.com" />
         <Hds::Copy::Button
@@ -526,8 +505,7 @@ that should be copied"
         />
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Date input</Shw::Label>
+    <SF.Item @label="Date input">
       <div class="shw-component-copy-button-flex-container">
         <input type="date" name="test-generic-input-date" id="test-generic-input-date" value="2018-07-22" />
         <Hds::Copy::Button
@@ -537,8 +515,7 @@ that should be copied"
         />
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Time input</Shw::Label>
+    <SF.Item @label="Time input">
       <div class="shw-component-copy-button-flex-container">
         <input type="time" name="test-generic-input-time" id="test-generic-input-time" value="23:59" />
         <Hds::Copy::Button
@@ -548,8 +525,7 @@ that should be copied"
         />
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Range input</Shw::Label>
+    <SF.Item @label="Range input">
       <div class="shw-component-copy-button-flex-container">
         <input type="range" name="test-generic-input-range" id="test-generic-input-range" min="0" max="10" value="6" />
         <Hds::Copy::Button
@@ -559,8 +535,7 @@ that should be copied"
         />
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Color input</Shw::Label>
+    <SF.Item @label="Color input">
       <div class="shw-component-copy-button-flex-container">
         <input type="color" name="test-generic-input-color" id="test-generic-input-color" value="#e66465" />
         <Hds::Copy::Button
@@ -572,8 +547,7 @@ that should be copied"
     </SF.Item>
   </Shw::Flex>
   <Shw::Flex @gap="2rem" as |SF|>
-    <SF.Item>
-      <Shw::Label>Textarea</Shw::Label>
+    <SF.Item @label="Textarea">
       <div class="shw-component-copy-button-flex-container">
         <textarea name="test-generic-textarea" id="test-generic-textarea" rows="3">Lorem ipsum dolor</textarea>
         <Hds::Copy::Button
@@ -583,8 +557,7 @@ that should be copied"
         />
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>Select</Shw::Label>
+    <SF.Item @label="Select">
       <div class="shw-component-copy-button-flex-container">
         <select name="test-generic-select" id="test-generic-select">
           <option>Lorem ipsum dolor</option>

--- a/showcase/app/templates/components/copy/snippet.hbs
+++ b/showcase/app/templates/components/copy/snippet.hbs
@@ -12,18 +12,15 @@
   <Shw::Text::H2>Content</Shw::Text::H2>
 
   <Shw::Flex as |SF|>
-    <SF.Item>
-      <Shw::Label>With short text</Shw::Label>
+    <SF.Item @label="With short text">
       <Hds::Copy::Snippet @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r" />
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>With long text (multi-line / default)</Shw::Label>
+    <SF.Item @label="With long text (multi-line / default)">
       <Shw::Outliner {{style width="300px"}}>
         <Hds::Copy::Snippet @textToCopy="With some really long text that should wrap and be multi-line" />
       </Shw::Outliner>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>With long text (truncated)</Shw::Label>
+    <SF.Item @label="With long text (truncated)">
       <Shw::Outliner {{style width="300px"}}>
         <Hds::Copy::Snippet
           @textToCopy="With some really long text that should be truncated because `isTruncated` is set to `true`"
@@ -34,8 +31,7 @@
   </Shw::Flex>
 
   <Shw::Flex as |SF|>
-    <SF.Item>
-      <Shw::Label>With number to copy</Shw::Label>
+    <SF.Item @label="With number to copy">
       {{! context: https://github.com/hashicorp/design-system/pull/1564 }}
       <Hds::Copy::Snippet @textToCopy={{123456789}} />
     </SF.Item>
@@ -43,14 +39,12 @@
 
   <Shw::Text::H2>Full width</Shw::Text::H2>
   <Shw::Flex as |SF|>
-    <SF.Item>
-      <Shw::Label>With short text</Shw::Label>
+    <SF.Item @label="With short text">
       <Shw::Outliner {{style width="500px"}}>
         <Hds::Copy::Snippet @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r" @isFullWidth={{true}} />
       </Shw::Outliner>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>With long text</Shw::Label>
+    <SF.Item @label="With long text">
       <Shw::Outliner {{style width="500px"}}>
         <Hds::Copy::Snippet
           @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r and some other text that should not matter because the element with is set to full width and hopefully people will not do this but in case they do we want to make sure that we still have the designed layout"
@@ -113,8 +107,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item @forceMinWidth={{true}}>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item @forceMinWidth={{true}} as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <div {{style display=display overflow="hidden"}}>
             <Hds::Copy::Snippet @textToCopy="With short text" />
           </div>

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -426,8 +426,8 @@
   <Shw::Text::H4>Generated element</Shw::Text::H4>
 
   <Shw::Flex as |SF|>
-    <SF.Item>
-      <Shw::Label>Default ⇒ <code>&lt;button&gt;</code></Shw::Label>
+    <SF.Item as |SFI|>
+      <SFI.Label>Default ⇒ <code>&lt;button&gt;</code></SFI.Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           <Hds::Dropdown::ListItem::Interactive>
@@ -436,11 +436,11 @@
         </ul>
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>With
+    <SF.Item as |SFI|>
+      <SFI.Label>With
         <code>@href</code>
         ⇒
-        <code>&lt;a&gt;</code></Shw::Label>
+        <code>&lt;a&gt;</code></SFI.Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           <Hds::Dropdown::ListItem::Interactive @href="/">
@@ -449,13 +449,13 @@
         </ul>
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>With
+    <SF.Item as |SFI|>
+      <SFI.Label>With
         <code>@route</code>
         ⇒
         <code>&lt;LinkTo&gt;</code>
         ⇒
-        <code>&lt;a&gt;</code></Shw::Label>
+        <code>&lt;a&gt;</code></SFI.Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           <Hds::Dropdown::ListItem::Interactive @route="components.dropdown">

--- a/showcase/app/templates/components/form/base-elements.hbs
+++ b/showcase/app/templates/components/form/base-elements.hbs
@@ -21,8 +21,8 @@
     <SF.Item @label="With optional indicator">
       <Hds::Form::Label @isOptional={{true}}>This is the label</Hds::Form::Label>
     </SF.Item>
-    <SF.Item as |SF|>
-      <SF.Label>With structured content (eg. a <code>flex</code> layout and a <code>&lt;Badge&gt;</code>)</SF.Label>
+    <SF.Item as |SFI|>
+      <SFI.Label>With structured content (eg. a <code>flex</code> layout and a <code>&lt;Badge&gt;</code>)</SFI.Label>
       <Hds::Form::Label>
         <div class="shw-component-form-base-elements-container-with-badge">
           This is the label
@@ -30,11 +30,11 @@
         </div>
       </Hds::Form::Label>
     </SF.Item>
-    <SF.Item>
-      <SF.Label>With structured content (eg. a
+    <SF.Item as |SFI|>
+      <SFI.Label>With structured content (eg. a
         <code>flex</code>
         layout and a
-        <code>&lt;Badge&gt;</code>) and required indicator</SF.Label>
+        <code>&lt;Badge&gt;</code>) and required indicator</SFI.Label>
       <Hds::Form::Label @isRequired={{true}}>
         <div class="shw-component-form-base-elements-container-with-badge">
           This is the label
@@ -42,11 +42,11 @@
         </div>
       </Hds::Form::Label>
     </SF.Item>
-    <SF.Item>
-      <SF.Label>With structured content (eg. a
+    <SF.Item as |SFI|>
+      <SFI.Label>With structured content (eg. a
         <code>flex</code>
         layout and a
-        <code>&lt;Badge&gt;</code>) and optional indicator</SF.Label>
+        <code>&lt;Badge&gt;</code>) and optional indicator</SFI.Label>
       <Hds::Form::Label @isOptional={{true}}>
         <Shw::Outliner class="shw-component-form-base-elements-container-with-badge">
           This is the label
@@ -94,13 +94,13 @@
     <SF.Item @label="With simple text">
       <Hds::Form::HelperText>This is the helper text, usually used jointly with the label.</Hds::Form::HelperText>
     </SF.Item>
-    <SF.Item as |SF|>
-      <SF.Label>With <code>&lt;Link::Inline&gt;</code></SF.Label>
+    <SF.Item as |SFI|>
+      <SFI.Label>With <code>&lt;Link::Inline&gt;</code></SFI.Label>
       <Hds::Form::HelperText>This is a helper text
         <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></Hds::Form::HelperText>
     </SF.Item>
-    <SF.Item as |SF|>
-      <SF.Label>With <code>&lt;Link::Inline&gt;</code> and <code>secondary</code> color</SF.Label>
+    <SF.Item as |SFI|>
+      <SFI.Label>With <code>&lt;Link::Inline&gt;</code> and <code>secondary</code> color</SFI.Label>
       <Hds::Form::HelperText>This is a helper text
         <Hds::Link::Inline @route="index" @color="secondary">with a secondary link</Hds::Link::Inline></Hds::Form::HelperText>
     </SF.Item>
@@ -410,13 +410,13 @@
     <SF.Item @label="With simple text">
       <Hds::Form::Legend>This is a simple legend</Hds::Form::Legend>
     </SF.Item>
-    <SF.Item as |SF|>
-      <SF.Label>With <code>&lt;Link::Inline&gt;</code></SF.Label>
+    <SF.Item as |SFI|>
+      <SFI.Label>With <code>&lt;Link::Inline&gt;</code></SFI.Label>
       <Hds::Form::Legend>This is a legend
         <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></Hds::Form::Legend>
     </SF.Item>
-    <SF.Item as |SF|>
-      <SF.Label>With <code>&lt;Link::Inline&gt;</code> and <code>secondary</code> color</SF.Label>
+    <SF.Item as |SFI|>
+      <SFI.Label>With <code>&lt;Link::Inline&gt;</code> and <code>secondary</code> color</SFI.Label>
       <Hds::Form::Legend>This is a legend
         <Hds::Link::Inline @route="index" @color="secondary">with a secondary link</Hds::Link::Inline></Hds::Form::Legend>
     </SF.Item>
@@ -426,24 +426,24 @@
     <SF.Item @label="With optional indicator">
       <Hds::Form::Legend @isOptional={{true}}>This is a simple legend</Hds::Form::Legend>
     </SF.Item>
-    <SF.Item as |SF|>
-      <SF.Label>With structured content (eg. a
+    <SF.Item as |SFI|>
+      <SFI.Label>With structured content (eg. a
         <code>flex</code>
         layout and a
         <code>&lt;Badge&gt;</code>)
-      </SF.Label>
+      </SFI.Label>
       <Hds::Form::Legend>
         <div class="shw-component-form-base-elements-container-with-badge">This is the legend
           <Hds::Badge @size="small" @text="Some badge" @color="highlight" />
         </div>
       </Hds::Form::Legend>
     </SF.Item>
-    <SF.Item as |SF|>
-      <SF.Label>With structured content (eg. a
+    <SF.Item as |SFI|>
+      <SFI.Label>With structured content (eg. a
         <code>flex</code>
         layout and a
         <code>&lt;Badge&gt;</code>) and required indicator
-      </SF.Label>
+      </SFI.Label>
       <div class="shw-component-form-base-elements-container-with-badge">
         <Hds::Form::Legend @isRequired={{true}}>
           This is the legend
@@ -451,12 +451,12 @@
         </Hds::Form::Legend>
       </div>
     </SF.Item>
-    <SF.Item as |SF|>
-      <SF.Label>With structured content (eg. a
+    <SF.Item as |SFI|>
+      <SFI.Label>With structured content (eg. a
         <code>flex</code>
         layout and a
         <code>&lt;Badge&gt;</code>) and optional indicator
-      </SF.Label>
+      </SFI.Label>
       <div class="shw-component-form-base-elements-container-with-badge">
         <Hds::Form::Legend @isOptional={{true}}>
           This is the legend
@@ -643,8 +643,8 @@
         <Shw::Grid @columns={{3}} as |SG|>
           {{#let (array "block" "flex" "grid") as |displays|}}
             {{#each displays as |display|}}
-              <SG.Item>
-                <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+              <SG.Item as |SGI|>
+                <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
                 <div {{style display=display}}>
                   <Hds::Form::Field @layout={{layout}} @isRequired={{true}} as |F|>
                     <F.Label>This is the label</F.Label>
@@ -733,8 +733,8 @@
         <Shw::Grid @columns={{3}} as |SG|>
           {{#let (array "block" "flex" "grid") as |displays|}}
             {{#each displays as |display|}}
-              <SG.Item>
-                <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+              <SG.Item as |SGI|>
+                <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
                 <div {{style display=display}}>
                   <Hds::Form::Fieldset @layout={{layout}} @isRequired={{true}} as |F|>
                     <F.Legend>This is the legend</F.Legend>

--- a/showcase/app/templates/components/form/masked-input.hbs
+++ b/showcase/app/templates/components/form/masked-input.hbs
@@ -427,8 +427,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <Shw::Flex as |SF|>
             <SF.Item @grow={{true}} {{style display=display}}>
               <Hds::Form::MaskedInput::Field @value="Default width" as |F|>
@@ -457,8 +457,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <Shw::Flex as |SF|>
             <SF.Item @grow={{true}} {{style display=display}}>
               <Hds::Form::MaskedInput::Field @isMultiline={{true}} @value="Default width" as |F|>

--- a/showcase/app/templates/components/form/select.hbs
+++ b/showcase/app/templates/components/form/select.hbs
@@ -81,8 +81,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <Shw::Flex as |SF|>
             <SF.Item {{style display=display}}>
               <Hds::Form::Select::Base aria-label="{{display}} select example" as |C|>
@@ -201,8 +201,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <div {{style display=display}}>
             <Hds::Form::Select::Field @isInvalid={{true}} as |F|>
               <F.Label>This is the label</F.Label>

--- a/showcase/app/templates/components/form/text-input.hbs
+++ b/showcase/app/templates/components/form/text-input.hbs
@@ -195,8 +195,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <Shw::Flex @direction="column" as |SF|>
             <SF.Item {{style display=display}}>
               <Hds::Form::TextInput::Base @value="Default width" aria-label="text input example as {{display}}" />
@@ -356,8 +356,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <Shw::Flex as |SF|>
             <SF.Item @grow={{true}} {{style display=display}}>
               <Hds::Form::TextInput::Field @value="Default width" as |F|>

--- a/showcase/app/templates/components/form/textarea.hbs
+++ b/showcase/app/templates/components/form/textarea.hbs
@@ -106,8 +106,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <Shw::Flex as |SF|>
             <SF.Item @grow={{true}} {{style display=display}}>
               <Hds::Form::Textarea::Base aria-label="textarea example as {{display}}" @value="Default width" />
@@ -251,8 +251,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <Shw::Flex as |SF|>
             <SF.Item @grow={{true}} {{style display=display}}>
               <Hds::Form::Textarea::Field @value="Default width" @isInvalid={{true}} as |F|>

--- a/showcase/app/templates/components/link/inline.hbs
+++ b/showcase/app/templates/components/link/inline.hbs
@@ -12,22 +12,22 @@
   <Shw::Text::H2>Generated element</Shw::Text::H2>
 
   <Shw::Flex as |SF|>
-    <SF.Item>
-      <Shw::Label>With
+    <SF.Item as |SFI|>
+      <SFI.Label>With
         <code>@href</code>
         ⇒
-        <code>&lt;a&gt;</code></Shw::Label>
+        <code>&lt;a&gt;</code></SFI.Label>
       <div class="hds-typography-body-300">
         <Hds::Link::Inline @color="primary" @href="#">Lorem ipsum dolor</Hds::Link::Inline>
       </div>
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>With
+    <SF.Item as |SFI|>
+      <SFI.Label>With
         <code>@route</code>
         ⇒
         <code>&lt;LinkTo&gt;</code>
         ⇒
-        <code>&lt;a&gt;</code></Shw::Label>
+        <code>&lt;a&gt;</code></SFI.Label>
       <div class="hds-typography-body-300">
         <Hds::Link::Inline @color="primary" @route="index">Lorem ipsum dolor</Hds::Link::Inline>
       </div>

--- a/showcase/app/templates/components/link/standalone.hbs
+++ b/showcase/app/templates/components/link/standalone.hbs
@@ -12,20 +12,20 @@
   <Shw::Text::H2>Generated element</Shw::Text::H2>
 
   <Shw::Flex as |SF|>
-    <SF.Item>
-      <Shw::Label>With
+    <SF.Item as |SFI|>
+      <SFI.Label>With
         <code>@href</code>
         ⇒
-        <code>&lt;a&gt;</code></Shw::Label>
+        <code>&lt;a&gt;</code></SFI.Label>
       <Hds::Link::Standalone @icon="plus" @text="Lorem ipsum dolor" @color="primary" @href="#" />
     </SF.Item>
-    <SF.Item>
-      <Shw::Label>With
+    <SF.Item as |SFI|>
+      <SFI.Label>With
         <code>@route</code>
         ⇒
         <code>&lt;LinkTo&gt;</code>
         ⇒
-        <code>&lt;a&gt;</code></Shw::Label>
+        <code>&lt;a&gt;</code></SFI.Label>
       <Hds::Link::Standalone @icon="plus" @text="Lorem ipsum dolor" @color="primary" @route="index" />
     </SF.Item>
   </Shw::Flex>

--- a/showcase/app/templates/components/rich-tooltip.hbs
+++ b/showcase/app/templates/components/rich-tooltip.hbs
@@ -123,8 +123,7 @@
   <Shw::Text::H2>Interactions</Shw::Text::H2>
 
   <Shw::Flex @gap="8rem" as |SF|>
-    <SF.Item as |SFI|>
-      <SFI.Label>"Soft" (hover/focus)</SFI.Label>
+    <SF.Item @label="'Soft' (hover/focus)">
       <Hds::RichTooltip as |RT|>
         <RT.Toggle @text="Lorem ipsum dolor" @icon="info" @size="medium" />
         <RT.Bubble>
@@ -132,8 +131,7 @@
         </RT.Bubble>
       </Hds::RichTooltip>
     </SF.Item>
-    <SF.Item as |SFI|>
-      <SFI.Label>"Click"</SFI.Label>
+    <SF.Item @label="'Click'">
       <Hds::RichTooltip @enableClickEvents={{true}} as |RT|>
         <RT.Toggle @text="Lorem ipsum dolor" @icon="info" @size="medium" />
         <RT.Bubble>

--- a/showcase/app/templates/components/tag.hbs
+++ b/showcase/app/templates/components/tag.hbs
@@ -105,8 +105,8 @@
   <Shw::Grid @columns={{3}} as |SG|>
     {{#let (array "block" "flex" "grid") as |displays|}}
       {{#each displays as |display|}}
-        <SG.Item>
-          <Shw::Label>Parent with <code>display: {{display}}</code></Shw::Label>
+        <SG.Item as |SGI|>
+          <SGI.Label>Parent with <code>display: {{display}}</code></SGI.Label>
           <div class="shw-component-tag-group" {{style display=display flex-wrap="wrap"}}>
             <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
             <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />


### PR DESCRIPTION
### :pushpin: Summary

While writing the documentation for the showcase, I notice that there were a lot of instances of `<Shw::Label>` that could be replaced with the existing helpers provided by the `<Shw::Flex>` and `<Shw::Grid>` components:

- the `@label` argument, for simple text strings
- the yielded `Label` component, for structured content (that contains HTML tags or special characters)

The two failed test in Percy are actually OK:
- forms/base-element is failing because a couple of labels were not rendering (it was a bug) and now they do
- richtooltip is failing because I've replaced double quotes with single in a couple of labels

### :hammer_and_wrench: Detailed description

In this PR I have:
- reviewed all the instances of `<Shw::Label>` in the showcase page

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
