### PR TITLE
Cleanup color tokens

### DIFF
--- a/.changeset/friendly-balloons-fetch.md
+++ b/.changeset/friendly-balloons-fetch.md
@@ -1,0 +1,8 @@
+---
+'@hashicorp/design-system-components': patch
+---
+
+`CopyButton` - Updated icon colors to match interactive states of the component.
+
+`Stepper` - Updated to use semantic token over palette token in
+`Stepper::Indicator::Step`.

--- a/.changeset/friendly-balloons-fetch.md
+++ b/.changeset/friendly-balloons-fetch.md
@@ -4,5 +4,8 @@
 
 `CopyButton` - Updated icon colors to match interactive states of the component.
 
+`CopySnippet` - Prevent the color from adhering to interactive states when
+status is `success` or `error`.
+
 `Stepper` - Updated to use semantic token over palette token in
 `Stepper::Indicator::Step`.

--- a/packages/components/src/styles/components/copy/button.scss
+++ b/packages/components/src/styles/components/copy/button.scss
@@ -16,6 +16,20 @@
     color: var(--token-color-foreground-action);
   }
 
+  &:hover,
+  &.mock-hover {
+    .hds-button__icon {
+      color: var(--token-color-foreground-action-hover);
+    }
+  }
+
+  &:active,
+  &.mock-active {
+    .hds-button__icon {
+      color: var(--token-color-foreground-action-active);
+    }
+  }
+
   &.hds-copy-button--status-success {
     .hds-button__icon {
       color: var(--token-color-foreground-success);
@@ -28,4 +42,3 @@
     }
   }
 }
-

--- a/packages/components/src/styles/components/copy/snippet.scss
+++ b/packages/components/src/styles/components/copy/snippet.scss
@@ -58,10 +58,10 @@
     background-color: var(--token-color-surface-interactive);
     border-color: var(--token-color-border-strong);
 
-    // Change the color of the icon in hover state, except if the component has a status of success or error
     .hds-copy-snippet__icon:not(
-        .hds-copy-snippet--status-success .hds-copy-snippet__icon
-      ):not(.hds-copy-snippet--status-error .hds-copy-snippet__icon) {
+        .hds-copy-snippet--status-success .hds-copy-snippet__icon,
+        .hds-copy-snippet--status-error .hds-copy-snippet__icon
+      ) {
       color: var(--token-color-foreground-action-hover);
     }
   }
@@ -73,8 +73,9 @@
 
     // Change the color of the icon in active status, except if the component has a status of success or error
     .hds-copy-snippet__icon:not(
-        .hds-copy-snippet--status-success .hds-copy-snippet__icon
-      ):not(.hds-copy-snippet--status-error .hds-copy-snippet__icon) {
+        .hds-copy-snippet--status-success .hds-copy-snippet__icon,
+        .hds-copy-snippet--status-error .hds-copy-snippet__icon
+      ) {
       color: var(--token-color-foreground-action-active);
     }
   }

--- a/packages/components/src/styles/components/copy/snippet.scss
+++ b/packages/components/src/styles/components/copy/snippet.scss
@@ -49,31 +49,33 @@
   color: var(--token-color-foreground-primary);
   background-color: transparent;
 
+  .hds-copy-snippet__icon {
+    color: var(--token-color-foreground-action);
+  }
+
   &:hover,
   &.mock-hover {
     background-color: var(--token-color-surface-interactive);
     border-color: var(--token-color-border-strong);
+
+    // Change the color of the icon in hover state, except if the component has a status of success or error
+    .hds-copy-snippet__icon:not(
+        .hds-copy-snippet--status-success .hds-copy-snippet__icon
+      ):not(.hds-copy-snippet--status-error .hds-copy-snippet__icon) {
+      color: var(--token-color-foreground-action-hover);
+    }
   }
 
   &:active,
   &.mock-active {
     background-color: var(--token-color-surface-interactive-active);
     border-color: var(--token-color-border-strong);
-  }
 
-  .hds-copy-snippet__icon {
-    color: var(--token-color-foreground-action);
-
-    &:hover {
-      color: var(--token-color-foreground-action-hover);
-    }
-
-    &:active {
+    // Change the color of the icon in active status, except if the component has a status of success or error
+    .hds-copy-snippet__icon:not(
+        .hds-copy-snippet--status-success .hds-copy-snippet__icon
+      ):not(.hds-copy-snippet--status-error .hds-copy-snippet__icon) {
       color: var(--token-color-foreground-action-active);
-    }
-
-    &:focus {
-      color: var(--token-color-foreground-action);
     }
   }
 }

--- a/packages/components/src/styles/components/copy/snippet.scss
+++ b/packages/components/src/styles/components/copy/snippet.scss
@@ -8,6 +8,24 @@
 //
 @use "../../mixins/focus-ring" as *;
 
+@mixin hds-copy-snippet-success-error() {
+  &.hds-copy-snippet--status-success {
+    background-color: var(--token-color-surface-interactive);
+
+    .hds-copy-snippet__icon {
+      color: var(--token-color-foreground-success);
+    }
+  }
+
+  &.hds-copy-snippet--status-error {
+    background-color: var(--token-color-surface-interactive);
+
+    .hds-copy-snippet__icon {
+      color: var(--token-color-foreground-critical);
+    }
+  }
+}
+
 .hds-copy-snippet {
   @include hds-focus-ring-with-pseudo-element();
 
@@ -40,9 +58,7 @@
     border-color: var(--token-color-border-strong);
   }
 
-  &:focus {
-    background-color: transparent;
-  }
+  @include hds-copy-snippet-success-error();
 }
 
 .hds-copy-snippet--color-secondary {
@@ -58,10 +74,7 @@
     background-color: var(--token-color-surface-interactive);
     border-color: var(--token-color-border-strong);
 
-    .hds-copy-snippet__icon:not(
-        .hds-copy-snippet--status-success .hds-copy-snippet__icon,
-        .hds-copy-snippet--status-error .hds-copy-snippet__icon
-      ) {
+    .hds-copy-snippet__icon {
       color: var(--token-color-foreground-action-hover);
     }
   }
@@ -71,14 +84,12 @@
     background-color: var(--token-color-surface-interactive-active);
     border-color: var(--token-color-border-strong);
 
-    // Change the color of the icon in active status, except if the component has a status of success or error
-    .hds-copy-snippet__icon:not(
-        .hds-copy-snippet--status-success .hds-copy-snippet__icon,
-        .hds-copy-snippet--status-error .hds-copy-snippet__icon
-      ) {
+    .hds-copy-snippet__icon {
       color: var(--token-color-foreground-action-active);
     }
   }
+
+  @include hds-copy-snippet-success-error();
 }
 
 .hds-copy-snippet--status-success {

--- a/packages/components/src/styles/components/stepper/step-indicator.scss
+++ b/packages/components/src/styles/components/stepper/step-indicator.scss
@@ -7,7 +7,12 @@
 // STEPPER > INDICATOR > STEP
 //
 
-$hds-stepper-indicator-step-statuses: ( "incomplete", "progress", "processing", "complete" );
+$hds-stepper-indicator-step-statuses: (
+  "incomplete",
+  "progress",
+  "processing",
+  "complete"
+);
 $hds-stepper-indicator-step-size: 24px;
 
 // Base stepper indicator styling
@@ -72,19 +77,31 @@ $hds-stepper-indicator-step-non-interactive-props: (
     "text-color": var(--token-color-foreground-high-contrast),
     "fill-color": var(--token-color-foreground-strong),
     "stroke-color": var(--token-color-foreground-strong),
-  )
+  ),
 );
 
 @each $status in $hds-stepper-indicator-step-statuses {
   // For each status of the non-interactive variant, set the text color, svg fill, and svg stroke colors based on $non-interactive-props
   .hds-stepper-indicator-step--status-#{$status} {
     .hds-stepper-indicator-step__status {
-      color: map-get($hds-stepper-indicator-step-non-interactive-props, $status, "text-color");
+      color: map-get(
+        $hds-stepper-indicator-step-non-interactive-props,
+        $status,
+        "text-color"
+      );
     }
 
     .hds-stepper-indicator-step__svg-hexagon path {
-      fill: map-get($hds-stepper-indicator-step-non-interactive-props, $status, "fill-color");
-      stroke: map-get($hds-stepper-indicator-step-non-interactive-props, $status, "stroke-color");
+      fill: map-get(
+        $hds-stepper-indicator-step-non-interactive-props,
+        $status,
+        "fill-color"
+      );
+      stroke: map-get(
+        $hds-stepper-indicator-step-non-interactive-props,
+        $status,
+        "stroke-color"
+      );
     }
   }
 }
@@ -120,7 +137,7 @@ $hds-stepper-indicator-step-status-props: (
   ),
   "complete": (
     "text-color-default": var(--token-color-palette-blue-200),
-    "fill-color-default": var(--token-color-palette-blue-50),
+    "fill-color-default": var(--token-color-surface-action),
     "stroke-color-default": var(--token-color-palette-blue-300),
     "text-color-hover": var(--token-color-palette-blue-300),
     "fill-color-hover": var(--token-color-palette-blue-100),
@@ -128,7 +145,7 @@ $hds-stepper-indicator-step-status-props: (
     "text-color-active": var(--token-color-palette-blue-400),
     "fill-color-active": var(--token-color-palette-blue-100),
     "stroke-color-active": var(--token-color-palette-blue-400),
-  )
+  ),
 );
 
 .hds-stepper-indicator-step--is-interactive {
@@ -138,24 +155,48 @@ $hds-stepper-indicator-step-status-props: (
     // For each status set the text, svg fill, and svg stroke color based on $hds-stepper-indicator-step-status-props
     &.hds-stepper-indicator-step--status-#{$status} {
       .hds-stepper-indicator-step__status {
-        color: map-get($hds-stepper-indicator-step-status-props, $status, "text-color-default");
+        color: map-get(
+          $hds-stepper-indicator-step-status-props,
+          $status,
+          "text-color-default"
+        );
       }
 
       .hds-stepper-indicator-step__svg-hexagon path {
-        fill: map-get($hds-stepper-indicator-step-status-props, $status, "fill-color-default");
-        stroke: map-get($hds-stepper-indicator-step-status-props, $status, "stroke-color-default");
+        fill: map-get(
+          $hds-stepper-indicator-step-status-props,
+          $status,
+          "fill-color-default"
+        );
+        stroke: map-get(
+          $hds-stepper-indicator-step-status-props,
+          $status,
+          "stroke-color-default"
+        );
       }
 
       &:hover,
       &.mock-hover {
         .hds-stepper-indicator-step__status {
-          color: map-get($hds-stepper-indicator-step-status-props, $status, "text-color-hover");
+          color: map-get(
+            $hds-stepper-indicator-step-status-props,
+            $status,
+            "text-color-hover"
+          );
         }
 
         .hds-stepper-indicator-step__svg-hexagon {
           path {
-            fill: map-get($hds-stepper-indicator-step-status-props, $status, "fill-color-hover");
-            stroke: map-get($hds-stepper-indicator-step-status-props, $status, "stroke-color-hover");
+            fill: map-get(
+              $hds-stepper-indicator-step-status-props,
+              $status,
+              "fill-color-hover"
+            );
+            stroke: map-get(
+              $hds-stepper-indicator-step-status-props,
+              $status,
+              "stroke-color-hover"
+            );
           }
         }
       }
@@ -163,13 +204,25 @@ $hds-stepper-indicator-step-status-props: (
       &:active,
       &.mock-active {
         .hds-stepper-indicator-step__status {
-          color: map-get($hds-stepper-indicator-step-status-props, $status, "text-color-active");
+          color: map-get(
+            $hds-stepper-indicator-step-status-props,
+            $status,
+            "text-color-active"
+          );
         }
 
         .hds-stepper-indicator-step__svg-hexagon {
           path {
-            fill: map-get($hds-stepper-indicator-step-status-props, $status, "fill-color-active");
-            stroke: map-get($hds-stepper-indicator-step-status-props, $status, "stroke-color-active");
+            fill: map-get(
+              $hds-stepper-indicator-step-status-props,
+              $status,
+              "fill-color-active"
+            );
+            stroke: map-get(
+              $hds-stepper-indicator-step-status-props,
+              $status,
+              "stroke-color-active"
+            );
           }
         }
       }


### PR DESCRIPTION
### :pushpin: Summary

As discovered in the Figma v2.0 Library project:

- Updates the icon colors in the `Copy::Button` to match Figma and the interactive states of the component
- Updates the `Stepper::Indicator::Step` to use a surface token instead of a palette token.
- Fixes a bug in the `secondary` `Copy::Snippet` where the icon had it's own interactive state, now preventing the color of the icon from changing with the component status = `success` or `error`. This matches the experience for the `primary` variant.

### :camera_flash: Screenshots

No visual change in the Stepper, but there is a visual change in the CopyButton:

**Before**
<img width="690" alt="Screenshot 2024-09-13 at 12 21 08 PM" src="https://github.com/user-attachments/assets/0886697b-94e5-4dba-8a34-54126ae75f11">


**After**
<img width="703" alt="Screenshot 2024-09-13 at 12 20 23 PM" src="https://github.com/user-attachments/assets/85c6c11d-7341-4440-80d5-616ede7b7544">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3845](https://hashicorp.atlassian.net/browse/HDS-3845), [HDS-3845](https://hashicorp.atlassian.net/browse/HDS-3845)
Figma file: [CopyButton](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/%5BWIP%5D-HDS-Components-v2.0?node-id=39372-123324&t=rq4Nnx1RFT1CKnGV-1)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3845]: https://hashicorp.atlassian.net/browse/HDS-3845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ