### PR TITLE
Remove glint nocheck from remaining templates and fix revealed type issues

### DIFF
--- a/.changeset/funny-papayas-act.md
+++ b/.changeset/funny-papayas-act.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Dropdown`, `RadioCard`, `SuperSelect`, `Stepper`, `Table` - Fixed optional arguments in signatures

--- a/packages/components/src/components/hds/application-state/footer.ts
+++ b/packages/components/src/components/hds/application-state/footer.ts
@@ -7,7 +7,7 @@ import TemplateOnlyComponent from '@ember/component/template-only';
 import type { ComponentLike } from '@glint/template';
 import type { HdsLinkStandaloneSignature } from '../link/standalone';
 import type { HdsButtonSignature } from '../button';
-import type { HdsDropdownSignature } from 'src/components/hds/dropdown';
+import type { HdsDropdownSignature } from '../dropdown';
 
 export interface HdsApplicationStateFooterSignature {
   Args: {

--- a/packages/components/src/components/hds/dropdown/footer.ts
+++ b/packages/components/src/components/hds/dropdown/footer.ts
@@ -7,7 +7,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 export interface HdsDropdownFooterSignature {
   Args: {
-    hasDivider: boolean;
+    hasDivider?: boolean;
   };
   Blocks: {
     default: [];

--- a/packages/components/src/components/hds/dropdown/header.ts
+++ b/packages/components/src/components/hds/dropdown/header.ts
@@ -7,7 +7,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 export interface HdsDropdownHeaderSignature {
   Args: {
-    hasDivider: boolean;
+    hasDivider?: boolean;
   };
   Blocks: {
     default: [];

--- a/packages/components/src/components/hds/dropdown/list-item/interactive.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/interactive.ts
@@ -21,10 +21,10 @@ export const COLORS: string[] = Object.values(
 
 export interface HdsDropdownListItemInteractiveSignature {
   Args: HdsInteractiveSignature['Args'] & {
-    color: HdsDropdownListItemInteractiveColors;
+    color?: HdsDropdownListItemInteractiveColors;
     icon?: HdsIconSignature['Args']['name'];
     isLoading?: boolean;
-    text: string;
+    text?: string;
     trailingIcon?: HdsIconSignature['Args']['name'];
   };
   Blocks: {

--- a/packages/components/src/components/hds/dropdown/toggle/button.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/button.ts
@@ -32,12 +32,12 @@ export interface HdsDropdownToggleButtonSignature {
   Args: {
     badge?: HdsBadgeSignature['Args']['text'];
     badgeIcon?: HdsBadgeSignature['Args']['icon'];
-    color: HdsDropdownToggleButtonColors;
+    color?: HdsDropdownToggleButtonColors;
     count?: HdsBadgeCountSignature['Args']['text'];
     icon?: HdsIconSignature['Args']['name'];
     isFullWidth?: boolean;
     isOpen?: boolean;
-    size: HdsDropdownToggleButtonSizes;
+    size?: HdsDropdownToggleButtonSizes;
     text: string;
     setupPrimitiveToggle?: ModifierLike<SetupPrimitiveToggleModifier>;
   };

--- a/packages/components/src/components/hds/dropdown/toggle/icon.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.ts
@@ -20,8 +20,8 @@ export const SIZES: string[] = Object.values(HdsDropdownToggleIconSizeValues);
 export interface HdsDropdownToggleIconSignature {
   Args: {
     hasChevron?: boolean;
-    icon: HdsIconSignature['Args']['name'];
-    imageSrc: string;
+    icon?: HdsIconSignature['Args']['name'];
+    imageSrc?: string;
     isOpen?: boolean;
     size?: HdsDropdownToggleIconSizes;
     text: string;

--- a/packages/components/src/components/hds/form/radio-card/group.ts
+++ b/packages/components/src/components/hds/form/radio-card/group.ts
@@ -17,8 +17,8 @@ import type {
 
 interface HdsFormRadioCardGroupSignature {
   Args: HdsFormFieldsetSignature['Args'] & {
-    controlPosition: HdsFormRadioCardControlPositions;
-    alignment: HdsFormRadioCardAlignments;
+    controlPosition?: HdsFormRadioCardControlPositions;
+    alignment?: HdsFormRadioCardAlignments;
     name?: string;
   };
   Blocks: {

--- a/packages/components/src/components/hds/form/radio-card/index.ts
+++ b/packages/components/src/components/hds/form/radio-card/index.ts
@@ -34,14 +34,14 @@ export const ALIGNMENTS: string[] = Object.values(
 
 export interface HdsFormRadioCardSignature {
   Args: {
-    name: string;
-    value: string;
-    checked: boolean;
-    disabled: boolean;
-    controlPosition: HdsFormRadioCardControlPositions;
-    alignment: HdsFormRadioCardAlignments;
-    maxWidth: string;
-    extraAriaDescribedBy: string;
+    name?: string;
+    value?: string;
+    checked?: boolean;
+    disabled?: boolean;
+    controlPosition?: HdsFormRadioCardControlPositions;
+    alignment?: HdsFormRadioCardAlignments;
+    maxWidth?: string;
+    extraAriaDescribedBy?: string;
   };
   Blocks: {
     default: [

--- a/packages/components/src/components/hds/form/super-select/multiple/field.ts
+++ b/packages/components/src/components/hds/form/super-select/multiple/field.ts
@@ -6,14 +6,30 @@
 import Component from '@glimmer/component';
 import { ID_PREFIX } from '../../label/index.ts';
 
+import type { ComponentLike } from '@glint/template';
+import type { HdsFormErrorSignature } from '../../error/index.ts';
 import type { HdsFormFieldSignature } from '../../field/index.ts';
+import type { HdsFormHelperTextSignature } from '../../helper-text/index.ts';
+import type { HdsFormLabelSignature } from '../../label';
 import type { HdsFormSuperSelectMultipleBaseSignature } from './base.ts';
+import type { Select as PowerSelect } from 'ember-power-select/components/power-select';
+import type { HdsYieldSignature } from 'src/components/hds/yield/index.ts';
 
 interface HdsFormSuperSelectMultipleFieldSignature {
   Args: HdsFormSuperSelectMultipleBaseSignature['Args'] &
     HdsFormFieldSignature['Args'];
   Blocks: {
-    default: [unknown];
+    default: [
+      {
+        Label?: ComponentLike<HdsFormLabelSignature>;
+        HelperText?: ComponentLike<HdsFormHelperTextSignature>;
+        Error?: ComponentLike<HdsFormErrorSignature>;
+        Options?: ComponentLike<HdsYieldSignature>;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        options?: any;
+        select?: PowerSelect;
+      },
+    ];
   };
   Element: HdsFormFieldSignature['Element'];
 }

--- a/packages/components/src/components/hds/form/super-select/multiple/field.ts
+++ b/packages/components/src/components/hds/form/super-select/multiple/field.ts
@@ -13,7 +13,7 @@ import type { HdsFormHelperTextSignature } from '../../helper-text/index.ts';
 import type { HdsFormLabelSignature } from '../../label';
 import type { HdsFormSuperSelectMultipleBaseSignature } from './base.ts';
 import type { Select as PowerSelect } from 'ember-power-select/components/power-select';
-import type { HdsYieldSignature } from 'src/components/hds/yield/index.ts';
+import type { HdsYieldSignature } from '../../../yield/index.ts';
 
 interface HdsFormSuperSelectMultipleFieldSignature {
   Args: HdsFormSuperSelectMultipleBaseSignature['Args'] &

--- a/packages/components/src/components/hds/form/super-select/multiple/field.ts
+++ b/packages/components/src/components/hds/form/super-select/multiple/field.ts
@@ -25,8 +25,7 @@ interface HdsFormSuperSelectMultipleFieldSignature {
         HelperText?: ComponentLike<HdsFormHelperTextSignature>;
         Error?: ComponentLike<HdsFormErrorSignature>;
         Options?: ComponentLike<HdsYieldSignature>;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        options?: any;
+        options?: unknown;
         select?: PowerSelect;
       },
     ];

--- a/packages/components/src/components/hds/form/super-select/single/field.ts
+++ b/packages/components/src/components/hds/form/super-select/single/field.ts
@@ -13,7 +13,7 @@ import type { HdsFormHelperTextSignature } from '../../helper-text/index.ts';
 import type { HdsFormLabelSignature } from '../../label';
 import type { HdsFormSuperSelectSingleBaseSignature } from './base.ts';
 import type { Select as PowerSelect } from 'ember-power-select/components/power-select';
-import type { HdsYieldSignature } from 'src/components/hds/yield/index.ts';
+import type { HdsYieldSignature } from '../../../yield/index.ts';
 
 interface HdsFormSuperSelectSingleFieldSignature {
   Args: HdsFormSuperSelectSingleBaseSignature['Args'] &

--- a/packages/components/src/components/hds/form/super-select/single/field.ts
+++ b/packages/components/src/components/hds/form/super-select/single/field.ts
@@ -25,8 +25,7 @@ interface HdsFormSuperSelectSingleFieldSignature {
         HelperText?: ComponentLike<HdsFormHelperTextSignature>;
         Error?: ComponentLike<HdsFormErrorSignature>;
         Options?: ComponentLike<HdsYieldSignature>;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        options?: any;
+        options?: unknown;
         select?: PowerSelect;
       },
     ];

--- a/packages/components/src/components/hds/form/super-select/single/field.ts
+++ b/packages/components/src/components/hds/form/super-select/single/field.ts
@@ -6,14 +6,30 @@
 import Component from '@glimmer/component';
 import { ID_PREFIX } from '../../label/index.ts';
 
+import type { ComponentLike } from '@glint/template';
+import type { HdsFormErrorSignature } from '../../error/index.ts';
 import type { HdsFormFieldSignature } from '../../field/index.ts';
+import type { HdsFormHelperTextSignature } from '../../helper-text/index.ts';
+import type { HdsFormLabelSignature } from '../../label';
 import type { HdsFormSuperSelectSingleBaseSignature } from './base.ts';
+import type { Select as PowerSelect } from 'ember-power-select/components/power-select';
+import type { HdsYieldSignature } from 'src/components/hds/yield/index.ts';
 
 interface HdsFormSuperSelectSingleFieldSignature {
   Args: HdsFormSuperSelectSingleBaseSignature['Args'] &
     HdsFormFieldSignature['Args'];
   Blocks: {
-    default: [unknown];
+    default: [
+      {
+        Label?: ComponentLike<HdsFormLabelSignature>;
+        HelperText?: ComponentLike<HdsFormHelperTextSignature>;
+        Error?: ComponentLike<HdsFormErrorSignature>;
+        Options?: ComponentLike<HdsYieldSignature>;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        options?: any;
+        select?: PowerSelect;
+      },
+    ];
   };
   Element: HdsFormFieldSignature['Element'];
 }

--- a/packages/components/src/components/hds/stepper/step/indicator.ts
+++ b/packages/components/src/components/hds/stepper/step/indicator.ts
@@ -14,9 +14,9 @@ export const STATUSES: string[] = Object.values(HdsStepperStatusesValues);
 
 interface HdsStepperStepIndicatorSignature {
   Args: {
-    status: HdsStepperStatuses;
+    status?: HdsStepperStatuses;
     isInteractive?: boolean;
-    text: string;
+    text?: string;
   };
   Element: HTMLDivElement;
 }

--- a/packages/components/src/components/hds/stepper/task/indicator.ts
+++ b/packages/components/src/components/hds/stepper/task/indicator.ts
@@ -20,7 +20,7 @@ export const MAPPING_STATUS_TO_ICONS = HdsStepperStatusToIconsValues;
 
 interface HdsStepperTaskIndicatorSignature {
   Args: {
-    status: HdsStepperStatuses;
+    status?: HdsStepperStatuses;
     isInteractive?: boolean;
   };
   Element: HTMLDivElement;

--- a/packages/components/src/components/hds/table/index.ts
+++ b/packages/components/src/components/hds/table/index.ts
@@ -64,19 +64,19 @@ export interface HdsTableArgs {
   Blocks: {
     head?: [
       {
-        Tr: ComponentLike<HdsTableTrArgs>;
-        Th: ComponentLike<HdsTableThArgs>;
-        ThSort: ComponentLike<HdsTableThSortArgs>;
+        Tr?: ComponentLike<HdsTableTrArgs>;
+        Th?: ComponentLike<HdsTableThArgs>;
+        ThSort?: ComponentLike<HdsTableThSortArgs>;
         sortBy?: string;
         sortOrder?: HdsTableThSortOrder;
-        setSortBy: (column: string) => void;
+        setSortBy?: (column: string) => void;
       },
     ];
     body?: [
       {
-        Td: ComponentLike<HdsTableTdArgs>;
-        Tr: ComponentLike<HdsTableTrArgs>;
-        Th: ComponentLike<HdsTableThArgs>;
+        Td?: ComponentLike<HdsTableTdArgs>;
+        Tr?: ComponentLike<HdsTableTrArgs>;
+        Th?: ComponentLike<HdsTableThArgs>;
         data?: Record<string, unknown>;
         sortBy?: string;
         sortOrder?: HdsTableThSortOrder;

--- a/showcase/app/templates/components/breadcrumb.hbs
+++ b/showcase/app/templates/components/breadcrumb.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/showcase/app/templates/components/form/super-select/mock-components/generic-content.hbs
+++ b/showcase/app/templates/components/form/super-select/mock-components/generic-content.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/showcase/app/templates/components/form/super-select/mock-components/selected-component-multiple.hbs
+++ b/showcase/app/templates/components/form/super-select/mock-components/selected-component-multiple.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
@@ -6,5 +5,6 @@
 
 {{! This is not an HDS component, but a supporting file for `form/super-select.hbs` which requires a component to be passed in for the showcase }}
 <span>
+  {{! @glint-expect-error - option is known to be an object in this mock component }}
   {{@option.size}}
 </span>

--- a/showcase/app/templates/components/form/super-select/mock-components/selected-component-single.hbs
+++ b/showcase/app/templates/components/form/super-select/mock-components/selected-component-single.hbs
@@ -1,8 +1,8 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
 
 {{! This is not an HDS component, but a supporting file for `form/super-select.hbs` which requires a component to be passed in for the showcase }}
+{{! @glint-expect-error - option is known to be an object in this mock component }}
 <Hds::Text::Body @tag="span" @size="200">{{@option.size}}</Hds::Text::Body>

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
@@ -256,6 +256,7 @@
 
   <Frame.Footer>
     <Hds::AppFooter as |AF|>
+      {{! @glint-expect-error - TODO: investigate why this line fails }}
       <AF.LegalLinks />
     </Hds::AppFooter>
   </Frame.Footer>

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
@@ -3,7 +3,6 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{! @glint-nocheck: not typesafe yet }}
 {{page-title "AppFrame Component - Frameless"}}
 
 <Hds::AppFrame as |Frame|>
@@ -73,7 +72,7 @@
           <SNL.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
           <SNL.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
           <SNL.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
-          <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
+          <SNL.Link @href="#" @isHrefExternal={{true}} @icon="guide" @text="Documentation" />
         </Hds::SideNav::List>
       </:body>
     </Hds::SideNav>

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
@@ -252,6 +252,7 @@
 
   <Frame.Footer>
     <Hds::AppFooter as |AF|>
+      {{! @glint-expect-error - TODO: investigate why this line fails }}
       <AF.LegalLinks />
     </Hds::AppFooter>
   </Frame.Footer>

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
@@ -3,12 +3,11 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{! @glint-nocheck: not typesafe yet }}
 {{page-title "AppFrame Component - Frameless"}}
 
 <Hds::AppFrame @hasHeader={{false}} as |Frame|>
   <Frame.Sidebar>
-    <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{true}} @isCollapsible={{true}} @hasHeader={{false}}>
+    <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{true}} @isCollapsible={{true}}>
       <:header>
         <Hds::SideNav::Header>
           <:logo>
@@ -57,7 +56,7 @@
           <SNL.Link @text="Access control (IAM)" @icon="users" @href="#" @hasSubItems={{true}} />
           <SNL.Link @text="Billing" @icon="credit-card" @href="#" @hasSubItems={{true}} />
           <SNL.Link @text="Settings" @icon="settings" @href="#" @hasSubItems={{true}} />
-          <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="Documentation" />
+          <SNL.Link @href="#" @isHrefExternal={{true}} @icon="guide" @text="Documentation" />
         </Hds::SideNav::List>
       </:body>
       <:footer>

--- a/showcase/app/templates/utilities/dialog-primitive.hbs
+++ b/showcase/app/templates/utilities/dialog-primitive.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
@@ -172,21 +171,21 @@
     </SF.Item>
     <SF.Item @label="with icon">
       <div class="hds-dialog-primitive__wrapper-header">
-        <Hds::DialogPrimitive::Header @icon="info" @onDismiss={{this.onDismiss}}>
+        <Hds::DialogPrimitive::Header @icon="info">
           Title
         </Hds::DialogPrimitive::Header>
       </div>
     </SF.Item>
     <SF.Item @label="with tagline">
       <div class="hds-dialog-primitive__wrapper-header">
-        <Hds::DialogPrimitive::Header @tagline="Tagline" @onDismiss={{this.onDismiss}}>
+        <Hds::DialogPrimitive::Header @tagline="Tagline">
           Title
         </Hds::DialogPrimitive::Header>
       </div>
     </SF.Item>
     <SF.Item @label="with tagline and icon">
       <div class="hds-dialog-primitive__wrapper-header">
-        <Hds::DialogPrimitive::Header @icon="info" @tagline="Tagline" @onDismiss={{this.onDismiss}}>
+        <Hds::DialogPrimitive::Header @icon="info" @tagline="Tagline">
           Title
         </Hds::DialogPrimitive::Header>
       </div>
@@ -204,14 +203,14 @@
     </SF.Item>
     <SF.Item @label="as H1">
       <div class="hds-dialog-primitive__wrapper-header">
-        <Hds::DialogPrimitive::Header @tagline="Tagline" @tag="h1" @onDismiss={{this.onDismiss}}>
+        <Hds::DialogPrimitive::Header @tagline="Tagline" @titleTag="h1">
           Title
         </Hds::DialogPrimitive::Header>
       </div>
     </SF.Item>
     <SF.Item @label="as H2">
       <div class="hds-dialog-primitive__wrapper-header">
-        <Hds::DialogPrimitive::Header @tagline="Tagline" @tag="h2" @onDismiss={{this.onDismiss}}>
+        <Hds::DialogPrimitive::Header @tagline="Tagline" @titleTag="h2">
           Title
         </Hds::DialogPrimitive::Header>
       </div>

--- a/showcase/app/templates/utilities/disclosure-primitive.hbs
+++ b/showcase/app/templates/utilities/disclosure-primitive.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/showcase/app/templates/utilities/menu-primitive.hbs
+++ b/showcase/app/templates/utilities/menu-primitive.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0

--- a/website/docs/components/app-header/partials/code/component-api.md
+++ b/website/docs/components/app-header/partials/code/component-api.md
@@ -47,7 +47,7 @@
 The `AppHeader::HomeLink` component uses the generic `Hds::Interactive` component. For more details about this utility component, please refer to [its documentation page](/utilities/interactive).
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="icon" @type="string">
+  <C.Property @name="icon" @type="string" @required={{true}}>
     Used to show an icon. Any [icon](/icons/library) name is accepted. [See guidance on which icon to use depending on the product](/components/app-header#home-link).
   </C.Property>
   <C.Property @name="color" @type="string">

--- a/website/docs/components/badge-count/partials/code/component-api.md
+++ b/website/docs/components/badge-count/partials/code/component-api.md
@@ -4,7 +4,7 @@
   <C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
   <C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" }} @default="neutral"/>
-  <C.Property @name="text" @type="string">
+  <C.Property @name="text" @type="string" @required={{true}}>
     Text value that renders in the Badge Count.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/components/badge/partials/code/component-api.md
+++ b/website/docs/components/badge/partials/code/component-api.md
@@ -4,7 +4,7 @@
   <C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
   <C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" "highlight" "critical" "success" "warning" }} @default="neutral"/>
-  <C.Property @name="text" @type="string | number">
+  <C.Property @name="text" @type="string | number" @required={{true}}>
     The text of the Badge or value of the screen-reader only element if `isIconOnly` is set to `true`. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="icon" @type="string">

--- a/website/docs/components/breadcrumb/partials/code/component-api.md
+++ b/website/docs/components/breadcrumb/partials/code/component-api.md
@@ -26,7 +26,7 @@ The Breadcrumb component is composed of three different parts, each with their o
 ### Breadcrumb::Item
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="text" @type="string">
+  <C.Property @name="text" @type="string" @required={{true}}>
     The text displayed within the item.
   </C.Property>
   <C.Property @name="icon" @type="string">

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -11,7 +11,7 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
   <C.Property @name="<[CB].Description>" @type="yielded component">
     `ContentBlock::Description` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="value" @type="string">
+  <C.Property @name="value" @type="string" @required={{true}}>
     The text/code content for the `CodeBlock`. The component encodes this argument before displaying it.
   </C.Property>
   <C.Property @name="language" @type="string" @values={{array "bash" "go" "hcl" "json" "log" "ruby" "shell-session" "yaml"}}>

--- a/website/docs/components/tag/partials/code/component-api.md
+++ b/website/docs/components/tag/partials/code/component-api.md
@@ -6,7 +6,7 @@
   <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary">
     Sets the color of a link when `@route` or `@href` are set.
   </C.Property>
-  <C.Property @name="text" @type="string">
+  <C.Property @name="text" @type="string" @required={{true}}>
     The text of the Tag; or link text when the `@route` or `@href` are set. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="ariaLabel" @type="string">


### PR DESCRIPTION
### :pushpin: Summary

This PR will help [unblock HCP from upgrading to the latest HDS](https://hashicorp.slack.com/archives/C06NMSYDZPA/p1726276284759049) (tested this branch in `cloud-ui` locally)

### 🛠️ Detailed description

- Removed `@glint-nocheck` from a series of templates in `showcase` (these would've been ideally removed at conversion) and fixed a few type issues this change reveals
 - Fixed optional arguments in component signatures and mark `@icon` as required in `AppHeader::HomeLink` (we seem to have quite a bit of misalignment between what we mark as required in our docs and what's required via TypeScript, so I tried aligning the two, preventing many potential blockers in adoption where our signatures were stricter than needed)
 - Fixed absolute paths to signatures (we have a few instances where because of absolute paths, some files were not resolved by the ember CLI at build time)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3847](https://hashicorp.atlassian.net/browse/HDS-3847)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3847]: https://hashicorp.atlassian.net/browse/HDS-3847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ