### PR TITLE
Showcase `.gts` - `Shw::Autoscrollable`

### DIFF
--- a/showcase/app/components/shw/autoscrollable/index.gts
+++ b/showcase/app/components/shw/autoscrollable/index.gts
@@ -10,7 +10,7 @@ import { scheduleOnce } from '@ember/runloop';
 import { AutoscrollableDirectionValues } from './types';
 import type { AutoscrollableDirections } from './types';
 
-function centerScrollableArea({
+const centerScrollableArea = ({
   element,
   direction,
   horizontalShift,
@@ -20,7 +20,7 @@ function centerScrollableArea({
   direction: AutoscrollableDirections;
   horizontalShift: number;
   verticalShift: number;
-}) {
+}) => {
   if (
     direction === AutoscrollableDirectionValues.Both ||
     direction === AutoscrollableDirectionValues.X
@@ -35,7 +35,7 @@ function centerScrollableArea({
     element.scrollTop =
       verticalShift + (element.scrollHeight - element.offsetHeight) / 2;
   }
-}
+};
 
 interface ShwAutoscrollableSignature {
   Args: {
@@ -58,4 +58,14 @@ export default class ShwAutoscrollable extends Component<ShwAutoscrollableSignat
       verticalShift: this.args.verticalShift ?? 0,
     });
   });
+
+  <template>
+    <div
+      class="shw-autoscrollable__container"
+      ...attributes
+      {{this.autoscroll}}
+    >
+      {{yield}}
+    </div>
+  </template>
 }

--- a/showcase/app/components/shw/autoscrollable/index.hbs
+++ b/showcase/app/components/shw/autoscrollable/index.hbs
@@ -1,8 +1,0 @@
-{{!
-  Copyright (c) HashiCorp, Inc.
-  SPDX-License-Identifier: MPL-2.0
-}}
-
-<div class="shw-autoscrollable__container" ...attributes {{this.autoscroll}}>
-  {{yield}}
-</div>

--- a/showcase/types/template-registry.ts
+++ b/showcase/types/template-registry.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import ShwAutoscrollable from '../app/components/shw/autoscrollable';
+import ShwAutoscrollable from '../app/components/shw/autoscrollable/index';
 import ShwDivider from '../app/components/shw/divider';
 import ShwFlex from '../app/components/shw/flex';
 import ShwFlexItem from '../app/components/shw/flex/item';


### PR DESCRIPTION
### :hammer_and_wrench: Detailed description

In this PR I have:
- moved the `Shw::Autoscrollable` template code under the unified `.gts` file
- updated the import path in the `template-registry.ts` file to include the `index` file name (as did in previous PR)

Preview: https://hds-showcase-git-showcase-gts-autoscrollable-hashicorp.vercel.app/components/rich-tooltip#collision-detection

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3829

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
