### PR TITLE
fix: template-registry import for `shwText` component

### DIFF
--- a/showcase/types/template-registry.ts
+++ b/showcase/types/template-registry.ts
@@ -14,7 +14,7 @@ import ShwLabel from '../app/components/shw/label';
 import ShwLogoDesignSystem from '../app/components/shw/logo/design-system';
 import ShwOutliner from '../app/components/shw/outliner';
 import ShwPlaceholder from '../app/components/shw/placeholder/index';
-import ShwText from '../app/components/shw/text';
+import ShwText from '../app/components/shw/text/index';
 import ShwTextBody from '../app/components/shw/text/body';
 import ShwTextH1 from '../app/components/shw/text/h1';
 import ShwTextH2 from '../app/components/shw/text/h2';


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the shwText import in the template registry file.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
