### PR TITLE
Set changeset to ignore `@hashicorp/ember-flight-icons`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,5 +12,5 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "updateInternalDependents": "always"
   },
-  "ignore": []
+  "ignore": ["@hashicorp/ember-flight-icons", "showcase", "website"]
 }


### PR DESCRIPTION
### :pushpin: Summary

Set changeset to ignore `@hashicorp/ember-flight-icons` to prevent a new version from being published for this deprecated package.

> [!WARNING]  
> This PR must get in before #2416 to avoid having to undo the results. The related changelog entry in #2416 should to be removed right before merging it.



### :hammer_and_wrench: Detailed description

Because `showcase` still uses `@hashicorp/ember-flight-icons` via workspace we need to ignore it as well (otherwise changeset will complain); since we're at it, we also remove `website`, keeping only the active packages as options in the CLI.

### :link: External links

<!-- Issues, RFC, etc. -->
Context: [HDS eng sync](https://docs.google.com/document/d/1twnk39hZ7p8oZYrld_FYsdiuUb6yn_weA46KnhF4nu4/edit#bookmark=id.cwywdkqsdnm2)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
