### PR TITLE
Inert synchronization issue

### DIFF
--- a/.changeset/tricky-trains-ring.md
+++ b/.changeset/tricky-trains-ring.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Hds::SideNav` - Fixes a couple bugs where SideNav would remain inert when no longer minimized (or would not be inert when minimized)

--- a/.changeset/tricky-trains-ring.md
+++ b/.changeset/tricky-trains-ring.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Hds::SideNav` - Fixes a couple bugs where SideNav would remain inert when no longer minimized (or would not be inert when minimized)
+`Hds::SideNav` - Fixed a couple of bugs where SideNav would remain inert when no longer minimized (or would not be inert when minimized)

--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -141,6 +141,16 @@ export default class HdsSideNav extends Component<HdsSideNavSignature> {
     return classes.join(' ');
   }
 
+  synchronizeInert(): void {
+    this.containersToHide?.forEach((element): void => {
+      if (this.isMinimized) {
+        element.setAttribute('inert', '');
+      } else {
+        element.removeAttribute('inert');
+      }
+    });
+  }
+
   @action
   escapePress(event: KeyboardEvent): void {
     if (event.key === 'Escape' && !this.isMinimized && !this.isDesktop) {
@@ -152,13 +162,7 @@ export default class HdsSideNav extends Component<HdsSideNavSignature> {
   toggleMinimizedStatus(): void {
     this.isMinimized = !this.isMinimized;
 
-    this.containersToHide.forEach((element): void => {
-      if (this.isMinimized) {
-        element.setAttribute('inert', '');
-      } else {
-        element.removeAttribute('inert');
-      }
-    });
+    this.synchronizeInert();
 
     const { onToggleMinimizedStatus } = this.args;
 
@@ -194,13 +198,7 @@ export default class HdsSideNav extends Component<HdsSideNavSignature> {
     // automatically minimize on narrow viewports (when not in desktop mode)
     this.isMinimized = !this.isDesktop;
 
-    this.containersToHide?.forEach((element): void => {
-      if (this.isMinimized) {
-        element.setAttribute('inert', '');
-      } else {
-        element.removeAttribute('inert');
-      }
-    });
+    this.synchronizeInert();
 
     const { onDesktopViewportChange } = this.args;
 

--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -155,6 +155,7 @@ export default class HdsSideNav extends Component<HdsSideNavSignature> {
   escapePress(event: KeyboardEvent): void {
     if (event.key === 'Escape' && !this.isMinimized && !this.isDesktop) {
       this.isMinimized = true;
+      this.synchronizeInert();
     }
   }
 

--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -194,6 +194,14 @@ export default class HdsSideNav extends Component<HdsSideNavSignature> {
     // automatically minimize on narrow viewports (when not in desktop mode)
     this.isMinimized = !this.isDesktop;
 
+    this.containersToHide?.forEach((element): void => {
+      if (this.isMinimized) {
+        element.setAttribute('inert', '');
+      } else {
+        element.removeAttribute('inert');
+      }
+    });
+
     const { onDesktopViewportChange } = this.args;
 
     if (typeof onDesktopViewportChange === 'function') {

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -187,7 +187,18 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
   test('it collapses when the ESC key is pressed on narrow viewports', async function (assert) {
     await render(hbs`
       <style>:root {--hds-app-desktop-breakpoint: 10088px}</style>
-      <Hds::SideNav id="test-side-nav" />
+      <Hds::SideNav id="test-side-nav">
+        <:header as |H|>
+          <span id="test-side-nav-header" data-test-minimized={{H.isMinimized}} />
+        </:header>
+        <:body as |B|>
+          <span id="test-side-nav-body" data-test-minimized={{B.isMinimized}} />
+          <span class="hds-side-nav-hide-when-minimized" />
+        </:body>
+        <:footer as |F|>
+          <span id="test-side-nav-footer" data-test-minimized={{F.isMinimized}} />
+        </:footer>
+      </Hds::SideNav>
     `);
     assert.dom('#test-side-nav').hasClass('hds-side-nav--is-minimized');
     await click('.hds-side-nav__toggle-button');
@@ -195,6 +206,7 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
 
     await triggerKeyEvent('#test-side-nav', 'keydown', 'Escape');
     assert.dom('#test-side-nav').hasClass('hds-side-nav--is-minimized');
+    assert.dom('.hds-side-nav-hide-when-minimized').hasAttribute('inert');
   });
 
   // COLLAPSIBLE

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -9,15 +9,41 @@ import {
   render,
   click,
   resetOnerror,
+  settled,
   triggerKeyEvent,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
+class MockEventTarget extends EventTarget {}
+
 module('Integration | Component | hds/side-nav/index', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.afterEach(() => {
+  hooks.beforeEach(function () {
+    // Mock window.matchMedia to control media query events
+    let mockMedia = new MockEventTarget();
+    mockMedia.matches = true;
+
+    this.__matchMedia = window.matchMedia;
+
+    this.mockMedia = () => {
+      window.matchMedia = () => mockMedia;
+    };
+
+    this.changeBrowserSize = async (isDesktop) => {
+      mockMedia.matches = isDesktop;
+      mockMedia.dispatchEvent(
+        new MediaQueryListEvent('change', {
+          matches: isDesktop,
+        })
+      );
+      await settled();
+    };
+  });
+
+  hooks.afterEach(function () {
     resetOnerror();
+    window.matchMedia = this.__matchMedia;
   });
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
@@ -236,6 +262,86 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
     assert.dom('#test-side-nav-footer').hasAttribute('data-test-minimized');
     assert.dom('.hds-side-nav-hide-when-minimized').hasAttribute('inert');
     assert.dom('#test-side-nav-body').doesNotHaveAttribute('inert');
+  });
+
+  test('when the viewport changes from desktop to mobile, it automatically collapses and becomes inert', async function (assert) {
+    this.mockMedia();
+
+    let calls = [];
+    this.setProperties({
+      onDesktopViewportChange: (...args) => calls.push(args),
+    });
+
+    await render(hbs`
+      <Hds::SideNav @isCollapsible={{true}} @onDesktopViewportChange={{this.onDesktopViewportChange}}>
+        <:header as |H|>
+          <span id="test-side-nav-header" data-test-minimized={{H.isMinimized}} />
+        </:header>
+        <:body as |B|>
+          <span id="test-side-nav-body" data-test-minimized={{B.isMinimized}} />
+          <span class="hds-side-nav-hide-when-minimized" />
+        </:body>
+        <:footer as |F|>
+          <span id="test-side-nav-footer" data-test-minimized={{F.isMinimized}} />
+        </:footer>
+      </Hds::SideNav>
+    `);
+
+    assert.strictEqual(calls.length, 1, 'called with initial viewport');
+
+    await this.changeBrowserSize(false);
+    assert.deepEqual(
+      calls[1],
+      [false],
+      'resizing to mobile triggers a false event'
+    );
+
+    assert.dom('.hds-side-nav-hide-when-minimized').hasAttribute('inert');
+  });
+
+  test('when collapsed and the viewport changes from mobile to desktop, it automatically expands and is no longer inert', async function (assert) {
+    this.mockMedia();
+
+    let calls = [];
+    this.setProperties({
+      onDesktopViewportChange: (...args) => calls.push(args),
+    });
+
+    await render(hbs`
+      <Hds::SideNav @isCollapsible={{true}} @onDesktopViewportChange={{this.onDesktopViewportChange}}>
+        <:header as |H|>
+          <span id="test-side-nav-header" data-test-minimized={{H.isMinimized}} />
+        </:header>
+        <:body as |B|>
+          <span id="test-side-nav-body" data-test-minimized={{B.isMinimized}} />
+          <span class="hds-side-nav-hide-when-minimized" />
+        </:body>
+        <:footer as |F|>
+          <span id="test-side-nav-footer" data-test-minimized={{F.isMinimized}} />
+        </:footer>
+      </Hds::SideNav>
+    `);
+
+    await click('.hds-side-nav__toggle-button');
+    assert.dom('.hds-side-nav-hide-when-minimized').hasAttribute('inert');
+
+    await this.changeBrowserSize(false);
+    assert.deepEqual(
+      calls[1],
+      [false],
+      'resizing to mobile triggers a false event'
+    );
+    assert.dom('.hds-side-nav-hide-when-minimized').hasAttribute('inert');
+
+    await this.changeBrowserSize(true);
+    assert.deepEqual(
+      calls[2],
+      [true],
+      'resizing to desktop triggers a true event'
+    );
+    assert
+      .dom('.hds-side-nav-hide-when-minimized')
+      .doesNotHaveAttribute('inert');
   });
 
   // CALLBACKS


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR will fix two bugs related to the inert state of `Hds::SideNav` when the viewport changes sizes.

### :hammer_and_wrench: Detailed description

Right now we toggle the `inert` state of certain elements when the menu is manually minimized or expanded. However, there are two other ways the menu can be minimized/expanded:

1. Via mobile/desktop breakpoint: If the menu is open and the viewport shrinks, the nav minimized and the inert attributes are not applied. Similarly, if the nav is mimized and the viewport expands, the inert attributes remain.
2. Via ESC when in mobile mode: If the menu is open while the viewport is mobile, the menu shrinks, but the inert attributes are not applied.

This is simple enough to test today in production:

1. Go to the HCP Portal or to HCP Terraform
2. Starting from a desktop viewport:
    1. Toggle the menu closed
    2. Shrink the viewport to mobile
    3. Expand the viewport back to desktop
4. Observe that the nav automatically expanded, but it is not interactive

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
