### PR TITLE
fix(components): add `instance-initializers` to appReexports

### DIFF
--- a/.changeset/warm-needles-boil.md
+++ b/.changeset/warm-needles-boil.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fixed issue with icon sprite not initiated

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -290,6 +290,7 @@
       "./components/hds/yield/index.js": "./dist/_app_/components/hds/yield/index.js",
       "./helpers/hds-link-to-models.js": "./dist/_app_/helpers/hds-link-to-models.js",
       "./helpers/hds-link-to-query.js": "./dist/_app_/helpers/hds-link-to-query.js",
+      "./instance-initializers/load-sprite.js": "./dist/_app_/instance-initializers/load-sprite.js",
       "./modifiers/hds-anchored-position.js": "./dist/_app_/modifiers/hds-anchored-position.js",
       "./modifiers/hds-clipboard.js": "./dist/_app_/modifiers/hds-clipboard.js",
       "./modifiers/hds-register-event.js": "./dist/_app_/modifiers/hds-register-event.js",

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -31,6 +31,7 @@ const plugins = [
     'components/**/!(*types).js',
     'helpers/**/*.js',
     'modifiers/**/*.js',
+    'instance-initializers/**/*.js',
   ]),
 
   // Follow the V2 Addon rules about dependencies. Your code can import from


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

We need to add `instance-initializers` otherwise it will not be registered by consuming app there may be side effects if consumer uses `ember-flight-icons` still

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
