### PR TITLE
Showcase - Added examples of `Modal` using the `SuperSelect`

### DIFF
--- a/showcase/app/controllers/components/modal.js
+++ b/showcase/app/controllers/components/modal.js
@@ -15,6 +15,7 @@ export default class ModalController extends Controller {
   @tracked dropdownModalActive = false;
   @tracked superselectModalActive1 = false;
   @tracked superselectModalActive2 = false;
+  @tracked superselectModalActive3 = false;
 
   @action
   activateModal(modal) {

--- a/showcase/app/controllers/components/modal.js
+++ b/showcase/app/controllers/components/modal.js
@@ -13,6 +13,8 @@ export default class ModalController extends Controller {
   @tracked formModalActive = false;
   @tracked tabsModalActive = false;
   @tracked dropdownModalActive = false;
+  @tracked superselectModalActive1 = false;
+  @tracked superselectModalActive2 = false;
 
   @action
   activateModal(modal) {

--- a/showcase/app/routes/components/modal.js
+++ b/showcase/app/routes/components/modal.js
@@ -12,9 +12,18 @@ import {
 
 export default class ComponentsModalRoute extends Route {
   model() {
+    const SUPERSELECT_OPTIONS1 = ['Option 1', 'Option 2', 'Option 3'];
+    const SUPERSELECT_SELECTED_OPTION1 = SUPERSELECT_OPTIONS1[0];
+    const SUPERSELECT_OPTIONS2 = ['Option 1', 'Option 2', 'Option 3'];
+    const SUPERSELECT_SELECTED_OPTION2 = SUPERSELECT_OPTIONS2[0];
+
     return {
       COLORS,
       SIZES,
+      SUPERSELECT_OPTIONS1,
+      SUPERSELECT_SELECTED_OPTION1,
+      SUPERSELECT_OPTIONS2,
+      SUPERSELECT_SELECTED_OPTION2,
     };
   }
 }

--- a/showcase/app/routes/components/modal.js
+++ b/showcase/app/routes/components/modal.js
@@ -16,6 +16,8 @@ export default class ComponentsModalRoute extends Route {
     const SUPERSELECT_SELECTED_OPTION1 = SUPERSELECT_OPTIONS1[0];
     const SUPERSELECT_OPTIONS2 = ['Option 1', 'Option 2', 'Option 3'];
     const SUPERSELECT_SELECTED_OPTION2 = SUPERSELECT_OPTIONS2[0];
+    const SUPERSELECT_OPTIONS3 = ['Option 1', 'Option 2', 'Option 3'];
+    const SUPERSELECT_SELECTED_OPTION3 = SUPERSELECT_OPTIONS2[0];
 
     return {
       COLORS,
@@ -24,6 +26,8 @@ export default class ComponentsModalRoute extends Route {
       SUPERSELECT_SELECTED_OPTION1,
       SUPERSELECT_OPTIONS2,
       SUPERSELECT_SELECTED_OPTION2,
+      SUPERSELECT_OPTIONS3,
+      SUPERSELECT_SELECTED_OPTION3,
     };
   }
 }

--- a/showcase/app/styles/showcase-pages/modal.scss
+++ b/showcase/app/styles/showcase-pages/modal.scss
@@ -25,4 +25,11 @@ body.components-modal {
       margin-bottom: 20px;
     }
   }
+
+  // this is a hacky way to fix the issue with the SuperSelect used in the Modal
+  .shw-component-modal-with-super-select-fix-overflow {
+    .hds-dialog-primitive__wrapper-body {
+      overflow: unset;
+    }
+  }
 }

--- a/showcase/app/templates/components/modal.hbs
+++ b/showcase/app/templates/components/modal.hbs
@@ -276,6 +276,9 @@
     </Hds::Modal>
   {{/if}}
 
+  <br />
+  <br />
+
   <button type="button" {{on "click" (fn this.activateModal "formModalActive")}}>Open form modal</button>
 
   {{! template-lint-disable no-autofocus-attribute }}
@@ -335,6 +338,9 @@
     </Hds::Modal>
   {{/if}}
 
+  <br />
+  <br />
+
   <button type="button" {{on "click" (fn this.activateModal "dropdownModalActive")}}>Open dropdown modal</button>
 
   {{#if this.dropdownModalActive}}
@@ -354,6 +360,68 @@
           <dd.Interactive @href="#" @text="Ipsum" />
           <dd.Interactive @href="#" @text="Dolor" />
         </Hds::Dropdown>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
+
+  <button type="button" {{on "click" (fn this.activateModal "superselectModalActive1")}}>Open super-select modal (base)</button>
+
+  {{#if this.superselectModalActive1}}
+    <Hds::Modal id="superselect-modal1" @onClose={{fn this.deactivateModal "superselectModalActive1"}} as |M|>
+      <M.Header>
+        Modal title
+      </M.Header>
+      <M.Body>
+        <p class="hds-typography-body-200 hds-foreground-primary" {{style margin-bottom="12px"}}>Lorem ipsum dolor sit
+          amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        <p class="hds-typography-body-200 hds-foreground-primary" {{style margin-bottom="12px"}}>Ut enim ad minim
+          veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+          dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+        <Hds::Form::SuperSelect::Single::Base
+          @onChange={{fn (mut @model.SUPERSELECT_SELECTED_OPTION1)}}
+          @options={{@model.SUPERSELECT_OPTIONS1}}
+          @selected={{@model.SUPERSELECT_SELECTED_OPTION1}}
+          @verticalPosition="below"
+          @ariaLabel="Label"
+          as |option|
+        >
+          {{option}}
+        </Hds::Form::SuperSelect::Single::Base>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
+
+  <button type="button" {{on "click" (fn this.activateModal "superselectModalActive2")}}>Open super-select modal (with search)</button>
+
+  {{#if this.superselectModalActive2}}
+    <Hds::Modal id="superselect-modal2" @onClose={{fn this.deactivateModal "superselectModalActive2"}} as |M|>
+      <M.Header>
+        Modal title
+      </M.Header>
+      <M.Body>
+        <p class="hds-typography-body-200 hds-foreground-primary" {{style margin-bottom="12px"}}>Lorem ipsum dolor sit
+          amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        <p class="hds-typography-body-200 hds-foreground-primary" {{style margin-bottom="12px"}}>Ut enim ad minim
+          veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+          dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+        <Hds::Form::SuperSelect::Single::Base
+          @onChange={{fn (mut @model.SUPERSELECT_SELECTED_OPTION2)}}
+          @options={{@model.SUPERSELECT_OPTIONS2}}
+          @selected={{@model.SUPERSELECT_SELECTED_OPTION2}}
+          @searchEnabled={{true}}
+          @initiallyOpened={{true}}
+          @verticalPosition="below"
+          @ariaLabel="Label"
+          as |option|
+        >
+          {{option}}
+        </Hds::Form::SuperSelect::Single::Base>
       </M.Body>
       <M.Footer as |F|>
         <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />

--- a/showcase/app/templates/components/modal.hbs
+++ b/showcase/app/templates/components/modal.hbs
@@ -397,7 +397,8 @@
     </Hds::Modal>
   {{/if}}
 
-  <button type="button" {{on "click" (fn this.activateModal "superselectModalActive2")}}>Open super-select modal (with search)</button>
+  <button type="button" {{on "click" (fn this.activateModal "superselectModalActive2")}}>Open super-select modal (with
+    search) [bug]</button>
 
   {{#if this.superselectModalActive2}}
     <Hds::Modal id="superselect-modal2" @onClose={{fn this.deactivateModal "superselectModalActive2"}} as |M|>
@@ -414,6 +415,44 @@
           @onChange={{fn (mut @model.SUPERSELECT_SELECTED_OPTION2)}}
           @options={{@model.SUPERSELECT_OPTIONS2}}
           @selected={{@model.SUPERSELECT_SELECTED_OPTION2}}
+          @searchEnabled={{true}}
+          @initiallyOpened={{true}}
+          @verticalPosition="below"
+          @ariaLabel="Label"
+          as |option|
+        >
+          {{option}}
+        </Hds::Form::SuperSelect::Single::Base>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
+
+  <button type="button" {{on "click" (fn this.activateModal "superselectModalActive3")}}>Open super-select modal (with
+    search) [fix]</button>
+
+  {{#if this.superselectModalActive3}}
+    <Hds::Modal
+      id="superselect-modal3"
+      class="shw-component-modal-with-super-select-fix-overflow"
+      @onClose={{fn this.deactivateModal "superselectModalActive2"}}
+      as |M|
+    >
+      <M.Header>
+        Modal title
+      </M.Header>
+      <M.Body>
+        <p class="hds-typography-body-200 hds-foreground-primary" {{style margin-bottom="12px"}}>Lorem ipsum dolor sit
+          amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        <p class="hds-typography-body-200 hds-foreground-primary" {{style margin-bottom="12px"}}>Ut enim ad minim
+          veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+          dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+        <Hds::Form::SuperSelect::Single::Base
+          @onChange={{fn (mut @model.SUPERSELECT_SELECTED_OPTION3)}}
+          @options={{@model.SUPERSELECT_OPTIONS3}}
+          @selected={{@model.SUPERSELECT_SELECTED_OPTION3}}
           @searchEnabled={{true}}
           @initiallyOpened={{true}}
           @verticalPosition="below"


### PR DESCRIPTION
### :pushpin: Summary

This PR adds a few examples to the showcase page of the `Modal` to help investigate the bug reported in this Slack thread: https://hashicorp.slack.com/archives/C7KTUHNUS/p1726765830642429

In this way I was able to reproduce the strange behaviour when the SuperSelect is used inside a Modal (but it happens **only** with the search enabled 🤔) and compare it [with the "fix/hack" used in TFC](https://github.com/hashicorp/atlas/blob/817a29991cbaca963c705b0247022d3371c894d2/frontend/atlas/app/styles/components/_modals.scss#L69C1-L74C2).

### :hammer_and_wrench: Detailed description

In this PR I have:
- added three examples using the `SuperSelect` to the `Modal` showcase page
- SuperSelect basic
- SuperSelect with "search" (bugged)
- SuperSelect with "search" ("fixed")

👉 👉 👉 **Preview**: https://hds-showcase-git-showcase-modal-superselect-hashicorp.vercel.app/components/modal#demo

### :camera_flash: Screenshots

https://github.com/user-attachments/assets/404a80d1-1e4a-4c32-aa14-cd3b6205afe1

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
