### PR TITLE
Fix default registry in `showcase`

### DIFF
--- a/showcase/types/global.d.ts
+++ b/showcase/types/global.d.ts
@@ -4,25 +4,21 @@
  */
 import '@glint/environment-ember-loose';
 
-import type PageTitle from 'ember-page-title/template-registry';
+import type EmberStyleModifierRegistry from 'ember-style-modifier/template-registry';
 import type EmberTruthRegistry from 'ember-truth-helpers/template-registry';
+import type FlightIconsRegistry from '@hashicorp/ember-flight-icons/template-registry';
+import type HdsComponentsRegistry from '@hashicorp/design-system-components/template-registry';
+import type PageTitle from 'ember-page-title/template-registry';
 import type RenderModifiersRegistry from '@ember/render-modifiers/template-registry';
 import type ShowcaseTemplateRegistry from './template-registry';
-import type HdsComponentsRegistry from '@hashicorp/design-system-components/template-registry';
-import type FlightIconsRegistry from '@hashicorp/ember-flight-icons/template-registry';
-import type EmberStyleModifier from 'ember-style-modifier';
-
-export default interface EmberStyleModifierRegistry {
-  style: typeof EmberStyleModifier;
-}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry
     extends EmberStyleModifierRegistry,
       EmberTruthRegistry,
-      HdsComponentsRegistry,
-      RenderModifiersRegistry,
       FlightIconsRegistry,
+      HdsComponentsRegistry,
       PageTitle,
+      RenderModifiersRegistry,
       ShowcaseTemplateRegistry {}
 }


### PR DESCRIPTION
### :pushpin: Summary

Remove the first 'default' registry causing false positives both in VSCode and in CI – `EmberStyleModifierRegistry` is already present and covers the `style` modifier. Reordered them alphabetically to be able to compare imports with extends.

- [ ] fix issues highlighted by this change

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
