### PR TITLE
`DialogPrimitive` - Fix issue with `box-sizing` inheritance

### DIFF
--- a/.changeset/hot-timers-complain.md
+++ b/.changeset/hot-timers-complain.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`DialogPrimitive` - Fixed issue with `box-sizing` inheritance
+
+`Modal`/`Flyout` - Updated `box-sizing` inheritance via `DialogPrimitive` fix

--- a/packages/components/src/styles/components/dialog-primitive.scss
+++ b/packages/components/src/styles/components/dialog-primitive.scss
@@ -13,17 +13,17 @@ $hds-dialog-primitive-vertical-padding: 16px;
 
 // WRAPPER CONTAINER (<dialog>)
 
-// The special declaration below is used to allow the `<dialog>` to unset
-// all its predefined styles and set them at `Modal/Flyout` level
+// The special declaration below is used to override the `<dialog>` predefined styles
+// Note: some of these style will then be set (again) at `Modal/Flyout` level too
 //
 // Since the `:where()` selector has a specificity of `0` (see https://developer.mozilla.org/en-US/docs/Web/CSS/:where)
 // the styles declared below are applied to the `<dialog>` element, but are overwritten by any other style applied via classname
 //
 
 :where(.hds-dialog-primitive__wrapper) {
-  // -----------
-  all: unset; // removes default dialog & inherited styles. Must be the first style to be applied
-  // -----------
+  // override default `<dialog>` styles
+  position: initial;
+  inset: initial;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -31,6 +31,7 @@ $hds-dialog-primitive-vertical-padding: 16px;
   margin: 0;
   padding: 0;
   background: var(--token-color-surface-primary);
+  border: none;
 }
 
 

--- a/website/docs/components/flyout/index.md
+++ b/website/docs/components/flyout/index.md
@@ -10,7 +10,7 @@ previewImage: assets/illustrations/components/flyout.jpg
 navigation:
   keywords: ['drawer', 'panel', 'side', 'modal']
 status:
-  updated: 4.10.0
+  updated: 4.11.1
 ---
 
 <section data-tab="Guidelines">
@@ -32,6 +32,7 @@ status:
 </section>
 
 <section data-tab="Version history">
+  @include "partials/version-history/4.11.1.md"
   @include "partials/version-history/4.10.0.md"
   @include "partials/version-history/4.7.0.md"
 </section>

--- a/website/docs/components/flyout/partials/version-history/4.11.1.md
+++ b/website/docs/components/flyout/partials/version-history/4.11.1.md
@@ -1,0 +1,5 @@
+## 4.11.1
+
+### Updated
+
+Fixed issue with `box-sizing` inheritance due to a `all: unset` CSS rule applied to the `DialogPrimitive` subcomponent

--- a/website/docs/components/modal/index.md
+++ b/website/docs/components/modal/index.md
@@ -10,7 +10,7 @@ previewImage: assets/illustrations/components/modal.jpg
 navigation:
   keywords: ['flyout', 'popover', 'popup', 'dialog']
 status:
-  updated: 4.10.0
+  updated: 4.11.1
 ---
 
 <section data-tab="Guidelines">
@@ -32,6 +32,7 @@ status:
 </section>
 
 <section data-tab="Version history">
+  @include "partials/version-history/4.11.1.md"
   @include "partials/version-history/4.10.0.md"
   @include "partials/version-history/4.7.0.md"
 </section>

--- a/website/docs/components/modal/partials/version-history/4.11.1.md
+++ b/website/docs/components/modal/partials/version-history/4.11.1.md
@@ -1,0 +1,5 @@
+## 4.11.1
+
+### Updated
+
+Fixed issue with `box-sizing` inheritance due to a `all: unset` CSS rule applied to the `DialogPrimitive` subcomponent

--- a/website/docs/utilities/dialog-primitive/index.md
+++ b/website/docs/utilities/dialog-primitive/index.md
@@ -10,7 +10,7 @@ links:
 navigation:
   keywords: ['modal', 'flyout']
 status:
-  updated: 4.10.0
+  updated: 4.11.1
 ---
 
 <section data-tab="Guidelines">
@@ -32,6 +32,7 @@ status:
 </section>
 
 <section data-tab="Version history">
+  @include "partials/version-history/4.11.1.md"
   @include "partials/version-history/4.10.0.md"
   @include "partials/version-history/4.7.0.md"
 </section>

--- a/website/docs/utilities/dialog-primitive/partials/version-history/4.11.1.md
+++ b/website/docs/utilities/dialog-primitive/partials/version-history/4.11.1.md
@@ -1,0 +1,5 @@
+## 4.11.1
+
+### Updated
+
+Fixed issue with `box-sizing` inheritance due to a `all: unset` CSS rule


### PR DESCRIPTION
### :pushpin: Summary

In https://github.com/hashicorp/design-system/pull/2211 I (specifically @didoo) have introduced a change to the `Modal/Flyout` components, to use a newly created `DialogPrimitive` that could be used as standalone component/primitive as well as sub-component 

Because of this, I decided to reset the default styles applied to the "root" element of the `DialogPrimitive`, which is a `<dialog>` HTML element, using a `all: unset` CSS rule, and then apply the desired styles at `Modal/Flyout` level (while sharing the common styles in the `DialogPrimitive` CSS styles, declaring them just after the `all: unset` reset:

```
:where(.hds-dialog-primitive__wrapper) {
  // -----------
  all: unset; // removes default dialog & inherited styles. Must be the first style to be applied
  // -----------
  display: flex;
  flex-direction: column;
  width: 100%;
  height: 100%;
  margin: 0;
  padding: 0;
  background: var(--token-color-surface-primary);
}
```

The change was described as "non-breaking"m b

Thanks to @aklkv raising the issue [in a Slack thread](https://hashicorp.slack.com/archives/C7KTUHNUS/p1726871393498119), we've come to realize that this actually introduced a regression in the UI of the Modal in some of our components: depending on where the CSS reset for the `box-sizing` property was declared in the order of imports, some of the UI elements assumed a `box-sizing: content-box` property (thanks to the `*, *::before, *::after { box-sizing: inherit; }` rule) and with in some cases the padding applied to them was added to the height, causing them to blow up (see button in the screenshot below):

![image](https://github.com/user-attachments/assets/001f2753-5615-47b8-9c4c-05b2636a2e0a)

We missed this detail, both in implementation as well as in review, because the HDS showcase the reset is declared _after_ the import of the HDS components styles, so the `box-sizing` applied to `<dialog>` is inherited from the `<html>` element, which is set to `border-box` in the reset:

```
@import "@hashicorp/design-system-components";
@import "@hashicorp/design-system-power-select-overrides";

// global declarations

@import "./tokens";
@import "./layout";
@import "./typography";
@import "./globals";  // ← the box-sizing CSS reset is here
```

while in Cloud UI is declared _before_ the import of the CSS 

```
@use "resets";  // ← the box-sizing CSS reset is here
@use "lists";

// Components and helpers provided by the design system
// Notice: the full path is declared in the `hcp/ember-cli-build.js` file, under `sassOptions.includePaths`
@use "helpers/typography.css";
@use "@hashicorp/design-system-components.css";
```

### :hammer_and_wrench: Detailed description

In this PR I have:
- removed `all: unset` declaration from `hds-dialog-primitive__wrapper` and replaced with explicit overrides
- updated version-history and tags in website documentation

_Notice: there was a small visual regression in Percy but only in a mobile viewport and only for a use case, and was likely a fluke._

Preview: https://hds-showcase-git-3869-fix-dialog-primitive-box-sizing-hashicorp.vercel.app/components/modal

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3869

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
