### PR TITLE
`Dropdown`: added `isOpen` state to dropdown content

### DIFF
--- a/.changeset/chilled-cups-divide.md
+++ b/.changeset/chilled-cups-divide.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`Dropdown`: add `isOpen` state to the Dropdown content
+`Dropdown`: added `isOpen` state to the Dropdown content

--- a/.changeset/chilled-cups-divide.md
+++ b/.changeset/chilled-cups-divide.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Dropdown`: add `isOpen` state to the Dropdown content

--- a/packages/components/src/components/hds/dropdown/index.hbs
+++ b/packages/components/src/components/hds/dropdown/index.hbs
@@ -22,6 +22,7 @@
         {{yield
           (hash
             close=PP.hidePopover
+            isOpen=PP.isOpen
             Checkbox=(component "hds/dropdown/list-item/checkbox")
             Checkmark=(component "hds/dropdown/list-item/checkmark")
             CopyItem=(component "hds/dropdown/list-item/copy-item")
@@ -34,7 +35,7 @@
           )
         }}
       </ul>
-      {{yield (hash close=PP.hidePopover Footer=(component "hds/dropdown/footer"))}}
+      {{yield (hash close=PP.hidePopover isOpen=PP.isOpen Footer=(component "hds/dropdown/footer"))}}
     </div>
   </div>
 </Hds::PopoverPrimitive>

--- a/packages/components/src/components/hds/dropdown/index.hbs
+++ b/packages/components/src/components/hds/dropdown/index.hbs
@@ -35,7 +35,7 @@
           )
         }}
       </ul>
-      {{yield (hash close=PP.hidePopover isOpen=PP.isOpen Footer=(component "hds/dropdown/footer"))}}
+      {{yield (hash close=PP.hidePopover Footer=(component "hds/dropdown/footer"))}}
     </div>
   </div>
 </Hds::PopoverPrimitive>

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -62,6 +62,7 @@ export interface HdsDropdownSignature {
         ToggleButton?: ComponentLike<HdsDropdownToggleButtonSignature>;
         ToggleIcon?: ComponentLike<HdsDropdownToggleIconSignature>;
         close?: () => void;
+        isOpen?: boolean;
       },
     ];
   };

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -1539,6 +1539,21 @@
         </Hds::Dropdown>
       </div>
     </SG.Item>
+    <SG.Item @label="Using component isOpen state">
+      <div class="shw-component-dropdown-fixed-height-container">
+        <Hds::Dropdown @listPosition="bottom-left" @width="200px" as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          {{#if D.isOpen}}
+            <D.Interactive @href="#">
+              Lorem ipsum dolor sit amet
+            </D.Interactive>
+            <D.Interactive @href="#">
+              Consectetur adipisicing elit
+            </D.Interactive>
+          {{/if}}
+        </Hds::Dropdown>
+      </div>
+    </SG.Item>
   </Shw::Grid>
 
 </section>

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -148,6 +148,23 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown #test-list-item-interactive').isNotVisible();
   });
 
+  // YIELDED STATE
+
+  test('it should yield the isOpen state to the block', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        {{#if D.isOpen}}
+          <D.Interactive @text="interactive" id="test-list-item-interactive" />
+        {{/if}}
+      </Hds::Dropdown>
+    `);
+
+    assert.dom('#test-dropdown #test-list-item-interactive').doesNotExist();
+    await click('button#test-toggle-button');
+    assert.dom('#test-dropdown #test-list-item-interactive').exists();
+  });
+
   // ACCESSIBILITY
 
   test('it should render a list of items without a role if no selectable items are passed in', async function (assert) {

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -56,12 +56,12 @@ The Dropdown component is composed of different child components each with their
   <C.Property @name="<[D].Footer>" @type="yielded component">
     `Dropdown::Footer` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[D].close>" @type="function">
+  <C.Property @name="[D].close" @type="function">
     Function to programmatically close the Dropdown yielded to the content.
     <br/><br/>
     If this function is invoked using an `\{{on "click"}}` modifier applied to the `ListItem::Interactive` element, there is a quirky behavior of the Ember `<LinkTo>` component which requires a workaround to have the events executed in the right order (this happens only if it has a `@route` argument). Read more about the issue and a possible solution [in this GitHub comment](https://github.com/hashicorp/design-system/pull/399#issuecomment-1171186772).
   </C.Property>
-  <C.Property @name="<[D].isOpen>" @type="boolean" @default="false" @values={{array "true" "false"}}>
+  <C.Property @name="[D].isOpen" @type="boolean" @default="false" @values={{array "true" "false"}}>
     The state of the Dropdown yielded to the content.
   </C.Property>
   <C.Property @name="listPosition" @type="string" @values={{array "bottom-left" "bottom-right" "top-left" "top-right" }} @default="bottom-right">

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -56,6 +56,14 @@ The Dropdown component is composed of different child components each with their
   <C.Property @name="<[D].Footer>" @type="yielded component">
     `Dropdown::Footer` yielded as contextual component (see below).
   </C.Property>
+  <C.Property @name="<[D].close>" @type="function">
+    Function to programmatically close the Dropdown yielded to the content.
+    <br/><br/>
+    If this function is invoked using an `\{{on "click"}}` modifier applied to the `ListItem::Interactive` element, there is a quirky behavior of the Ember `<LinkTo>` component which requires a workaround to have the events executed in the right order (this happens only if it has a `@route` argument). Read more about the issue and a possible solution [in this GitHub comment](https://github.com/hashicorp/design-system/pull/399#issuecomment-1171186772).
+  </C.Property>
+  <C.Property @name="<[D].isOpen>" @type="boolean" @default="false" @values={{array "true" "false"}}>
+    The state of the Dropdown yielded to the content.
+  </C.Property>
   <C.Property @name="listPosition" @type="string" @values={{array "bottom-left" "bottom-right" "top-left" "top-right" }} @default="bottom-right">
     _Note: If `@enableCollisionDetection` is set, the list will automatically flip position to remain visible when near the edges of the screen regardless of the starting placement._
   </C.Property>
@@ -73,11 +81,6 @@ The Dropdown component is composed of different child components each with their
   </C.Property>
   <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
     If a `@height` parameter is provided then the list will have a max-height.
-  </C.Property>
-  <C.Property @name="close" @type="function">
-    Function to programmatically close the Dropdown.
-    <br/><br/>
-    If this function is invoked using an `\{{on "click"}}` modifier applied to the `ListItem::Interactive` element, there is a quirky behavior of the Ember `<LinkTo>` component which requires a workaround to have the events executed in the right order (this happens only if it has a `@route` argument). Read more about the issue and a possible solution [in this GitHub comment](https://github.com/hashicorp/design-system/pull/399#issuecomment-1171186772).
   </C.Property>
   <C.Property @name="onClose" @type="function">
     Callback function invoked when the Dropdown is closed, if provided.

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -138,6 +138,24 @@ Setting the `@enableCollisionDetection` argument to `true` will automatically ad
 </Hds::Dropdown>
 ```
 
+### Conditionally render content
+
+By default, the content of the Dropdown is rendered into the browser even when the Dropdown is closed. To change this behavior, use the yielded `[D].isOpen` state to conditionally render the content when the Dropdown is open.
+
+```handlebars
+<Hds::Dropdown @enableCollisionDetection={{true}} as |D|>
+  <D.ToggleButton @text="Text Toggle" />
+  {{#if D.isOpen}}
+    <D.Interactive @route="components" @text="Item One" />
+    <D.Interactive @route="components" @text="Item Two" />
+    <D.Interactive @route="components" @text="Item Three" />
+    <D.Interactive @text="Item Four (closes on click)" {{on "click" D.close}} />
+    <D.Separator />
+    <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+  {{/if}}
+</Hds::Dropdown>
+```
+
 ### List size
 
 You can explicitly control the height or width of a list. Any acceptable value (px, rem, em) can be declared:


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would expose the `isOpen` state to the yielded content. This would allow implementations like:
```hbs
<Hds::Dropdown @listPosition="bottom-left" @width="200px" as |D|>
  <D.ToggleButton @color="secondary" @text="Menu" />
  {{#if D.isOpen}}
    <D.Interactive @href="#">
      Lorem ipsum dolor sit amet
    </D.Interactive>
    <D.Interactive @href="#">
      Consectetur adipisicing elit
    </D.Interactive>
  {{/if}}
</Hds::Dropdown>
```

### :hammer_and_wrench: Detailed description

* adds `isOpen` to the yielded content
* adds a test that the `isOpen` state works correctly
* adds a showcase example using it
* update website docs to make yielded close and isOpen more clear

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3871](https://hashicorp.atlassian.net/browse/HDS-3871)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3871]: https://hashicorp.atlassian.net/browse/HDS-3871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ