### PR TITLE
Fix `RadioCard` styles and interactive states

### DIFF
--- a/.changeset/quiet-ducks-develop.md
+++ b/.changeset/quiet-ducks-develop.md
@@ -1,0 +1,9 @@
+---
+'@hashicorp/design-system-components': patch
+---
+
+`RadioCard`
+
+- Fixed selected border colors to match Figma and interactive states.
+- Updated icon, label, and description colors to use `disabled-foreground` when
+  the `RadioCard` is disabled.

--- a/packages/components/src/styles/components/form/radio-card.scss
+++ b/packages/components/src/styles/components/form/radio-card.scss
@@ -96,7 +96,7 @@
     }
 
     .hds-form-radio-card__content {
-      opacity: 0.6;
+      opacity: 0.5;
     }
   }
 }

--- a/packages/components/src/styles/components/form/radio-card.scss
+++ b/packages/components/src/styles/components/form/radio-card.scss
@@ -79,10 +79,10 @@
 
   &--disabled,
   &.mock-disabled {
+    color: var(--token-form-control-disabled-foreground-color);
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
     box-shadow: none;
-    color: var(--token-form-control-disabled-foreground-color);
     cursor: not-allowed;
 
     .hds-form-radio-card__label,

--- a/packages/components/src/styles/components/form/radio-card.scss
+++ b/packages/components/src/styles/components/form/radio-card.scss
@@ -98,7 +98,7 @@
     /* Set the opacity of nested components to make them appear disabled */
     .hds-badge,
     .hds-icon {
-      opacity: 50%;
+      opacity: 0.5;
     }
   }
 }

--- a/packages/components/src/styles/components/form/radio-card.scss
+++ b/packages/components/src/styles/components/form/radio-card.scss
@@ -95,10 +95,8 @@
       border-color: var(--token-color-border-primary);
     }
 
-    /* Set the opacity of nested components to make them appear disabled */
-    .hds-badge,
-    .hds-icon {
-      opacity: 0.5;
+    .hds-form-radio-card__content {
+      opacity: 0.6;
     }
   }
 }

--- a/packages/components/src/styles/components/form/radio-card.scss
+++ b/packages/components/src/styles/components/form/radio-card.scss
@@ -7,7 +7,6 @@
 // FORM > RADIO-CARD
 //
 
-
 // RadioCard Group
 
 .hds-form-group--radio-cards {
@@ -38,7 +37,8 @@
   display: flex;
   flex-direction: column;
   background-color: var(--token-color-surface-primary);
-  border: var(--token-form-radiocard-border-width) solid var(--token-color-border-primary);
+  border: var(--token-form-radiocard-border-width) solid
+    var(--token-color-border-primary);
   border-radius: var(--token-form-radiocard-border-radius);
   box-shadow: var(--token-elevation-mid-box-shadow);
   cursor: pointer;
@@ -64,11 +64,16 @@
 
   &--checked,
   &.mock-checked {
-    border-color: var(--token-color-focus-action-internal);
+    border-color: var(--token-color-palette-blue-300);
 
     .hds-form-radio-card__control-wrapper {
       background-color: var(--token-color-surface-action);
       border-color: var(--token-color-border-action);
+    }
+
+    &:hover,
+    &.mock-hover {
+      border-color: var(--token-color-palette-blue-400);
     }
   }
 
@@ -77,7 +82,13 @@
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
     box-shadow: none;
+    color: var(--token-form-control-disabled-foreground-color);
     cursor: not-allowed;
+
+    .hds-form-radio-card__label,
+    .hds-form-radio-card__description {
+      color: var(--token-form-control-disabled-foreground-color);
+    }
 
     .hds-form-radio-card__control-wrapper {
       background-color: var(--token-color-surface-interactive-disabled);

--- a/packages/components/src/styles/components/form/radio-card.scss
+++ b/packages/components/src/styles/components/form/radio-card.scss
@@ -79,16 +79,10 @@
 
   &--disabled,
   &.mock-disabled {
-    color: var(--token-form-control-disabled-foreground-color);
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
     box-shadow: none;
     cursor: not-allowed;
-
-    .hds-form-radio-card__label,
-    .hds-form-radio-card__description {
-      color: var(--token-form-control-disabled-foreground-color);
-    }
 
     .hds-form-radio-card__control-wrapper {
       background-color: var(--token-color-surface-interactive-disabled);

--- a/packages/components/src/styles/components/form/radio-card.scss
+++ b/packages/components/src/styles/components/form/radio-card.scss
@@ -94,6 +94,12 @@
       background-color: var(--token-color-surface-interactive-disabled);
       border-color: var(--token-color-border-primary);
     }
+
+    /* Set the opacity of nested components to make them appear disabled */
+    .hds-badge,
+    .hds-icon {
+      opacity: 50%;
+    }
   }
 }
 

--- a/showcase/app/templates/components/form/radio-card.hbs
+++ b/showcase/app/templates/components/form/radio-card.hbs
@@ -17,18 +17,28 @@
     {{#each @model.STATES as |state|}}
       <SG.Item @label={{capitalize state}} mock-state-value={{state}} mock-state-selector="label">
         <Hds::Form::RadioCard @disabled={{eq state "disabled"}} as |R|>
-          <R.Icon @name="hexagon" />
+          <R.Icon @name="aws-color" />
           <R.Label>Label</R.Label>
           <R.Description>Description</R.Description>
+          <R.Badge @text="Badge" @color="highlight" />
+          <R.Generic>
+            <Hds::Text::Body @color="strong">Strong text in a generic.</Hds::Text::Body>
+            <Hds::Tag @text="Tag in a generic" />
+          </R.Generic>
         </Hds::Form::RadioCard>
       </SG.Item>
     {{/each}}
     {{#each @model.STATES as |state|}}
       <SG.Item @label="{{capitalize state}} selected" mock-state-value={{state}} mock-state-selector="label">
         <Hds::Form::RadioCard @checked={{true}} @disabled={{eq state "disabled"}} as |R|>
-          <R.Icon @name="hexagon" />
+          <R.Icon @name="aws-color" />
           <R.Label>Label</R.Label>
           <R.Description>Description</R.Description>
+          <R.Badge @text="Badge" @color="highlight" />
+          <R.Generic>
+            <Hds::Text::Body @color="strong">Strong text in a generic.</Hds::Text::Body>
+            <Hds::Tag @text="Tag in a generic" />
+          </R.Generic>
         </Hds::Form::RadioCard>
       </SG.Item>
     {{/each}}

--- a/showcase/app/templates/components/form/radio-card.hbs
+++ b/showcase/app/templates/components/form/radio-card.hbs
@@ -17,6 +17,7 @@
     {{#each @model.STATES as |state|}}
       <SG.Item @label={{capitalize state}} mock-state-value={{state}} mock-state-selector="label">
         <Hds::Form::RadioCard @disabled={{eq state "disabled"}} as |R|>
+          <R.Icon @name="hexagon" />
           <R.Label>Label</R.Label>
           <R.Description>Description</R.Description>
         </Hds::Form::RadioCard>
@@ -25,6 +26,7 @@
     {{#each @model.STATES as |state|}}
       <SG.Item @label="{{capitalize state}} selected" mock-state-value={{state}} mock-state-selector="label">
         <Hds::Form::RadioCard @checked={{true}} @disabled={{eq state "disabled"}} as |R|>
+          <R.Icon @name="hexagon" />
           <R.Label>Label</R.Label>
           <R.Description>Description</R.Description>
         </Hds::Form::RadioCard>

--- a/showcase/app/templates/components/form/radio-card.hbs
+++ b/showcase/app/templates/components/form/radio-card.hbs
@@ -17,28 +17,16 @@
     {{#each @model.STATES as |state|}}
       <SG.Item @label={{capitalize state}} mock-state-value={{state}} mock-state-selector="label">
         <Hds::Form::RadioCard @disabled={{eq state "disabled"}} as |R|>
-          <R.Icon @name="aws-color" />
           <R.Label>Label</R.Label>
           <R.Description>Description</R.Description>
-          <R.Badge @text="Badge" @color="highlight" />
-          <R.Generic>
-            <Hds::Text::Body @color="strong">Strong text in a generic.</Hds::Text::Body>
-            <Hds::Tag @text="Tag in a generic" />
-          </R.Generic>
         </Hds::Form::RadioCard>
       </SG.Item>
     {{/each}}
     {{#each @model.STATES as |state|}}
       <SG.Item @label="{{capitalize state}} selected" mock-state-value={{state}} mock-state-selector="label">
         <Hds::Form::RadioCard @checked={{true}} @disabled={{eq state "disabled"}} as |R|>
-          <R.Icon @name="aws-color" />
           <R.Label>Label</R.Label>
           <R.Description>Description</R.Description>
-          <R.Badge @text="Badge" @color="highlight" />
-          <R.Generic>
-            <Hds::Text::Body @color="strong">Strong text in a generic.</Hds::Text::Body>
-            <Hds::Tag @text="Tag in a generic" />
-          </R.Generic>
         </Hds::Form::RadioCard>
       </SG.Item>
     {{/each}}


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes the tokens applied to the `RadioCard` in it's selected state and updates the color of text elements within a disabled `RadioCard`.

### :hammer_and_wrench: Detailed description

Previously the `RadioCard` was using `focus-action-internal` for the `border-color` when a `RadioCard` was selected. Not only is this the incorrect token, but it differs from Figma and the interactive states of the component. This change updates the border color for a selected `RadioCard` to:

- `blue-300` for resting/default state
- `blue-400` for hover state

Additionally, we are proposing in design to change the tokens for text elements (namely the icon, `description`, and `label` within the `RadioCard`) to use `form-control-disabled-foreground-color` to semantically match the rest of the tokens applied when the component is disabled.

### :camera_flash: Screenshots

**Before**
<img width="1137" alt="Screenshot 2024-09-23 at 1 24 32 PM" src="https://github.com/user-attachments/assets/9eeb4059-0bfc-46ae-bb8b-64573800cdf8">

**After**
<img width="1161" alt="Screenshot 2024-09-23 at 1 24 06 PM" src="https://github.com/user-attachments/assets/a7861e20-b925-4c19-afb9-445c98ac3303">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3868](https://hashicorp.atlassian.net/browse/HDS-3868)
Figma file: [Update RadioCard disabled colors](https://www.figma.com/design/noyY6dUMDYjmySpHcMjhkN/branch/3ctSmHIlVaRYqa8E6OaIaG/HDS-Components?m=auto&node-id=16838-51020&t=JkKW71GXhXPqXkeX-1)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3868]: https://hashicorp.atlassian.net/browse/HDS-3868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ