### PR TITLE
`BadgeCount`, `TooltipButton`: fix types for HCP adoption

### DIFF
--- a/.changeset/three-mugs-kneel.md
+++ b/.changeset/three-mugs-kneel.md
@@ -5,3 +5,5 @@
 `BadgeCount`: updated the type of the `text` argument to allow numbers
 
 `TooltipButton`: made the default value for the `placement` argument `'top'`
+
+`TooltipButton`: made the `extraTippyOptions` argument optional and allowed to be a partial object

--- a/.changeset/three-mugs-kneel.md
+++ b/.changeset/three-mugs-kneel.md
@@ -3,3 +3,5 @@
 ---
 
 `BadgeCount`: updated the type of the `text` argument to allow numbers
+
+`TooltipButton`: made the default value for the `placement` argument `'top'`

--- a/.changeset/three-mugs-kneel.md
+++ b/.changeset/three-mugs-kneel.md
@@ -4,6 +4,6 @@
 
 `BadgeCount`: updated the type of the `text` argument to allow numbers
 
-`TooltipButton`: made the default value for the `placement` argument `'top'`
+`TooltipButton`: made the default value for the `placement` argument `'top'` and fixed the type definition
 
 `TooltipButton`: made the `extraTippyOptions` argument optional and allowed to be a partial object

--- a/.changeset/three-mugs-kneel.md
+++ b/.changeset/three-mugs-kneel.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`BadgeCount`: updated the type of the `text` argument to allow numbers

--- a/packages/components/src/components/hds/badge-count/index.ts
+++ b/packages/components/src/components/hds/badge-count/index.ts
@@ -29,7 +29,7 @@ export interface HdsBadgeCountSignature {
     size?: HdsBadgeCountSizes;
     type?: HdsBadgeCountTypes;
     color?: HdsBadgeCountColors;
-    text: string;
+    text: string | number;
   };
   Element: HTMLDivElement;
 }

--- a/packages/components/src/components/hds/tooltip-button/index.ts
+++ b/packages/components/src/components/hds/tooltip-button/index.ts
@@ -7,7 +7,9 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
 import type { Props as TippyProps } from 'tippy.js';
+
 import { HdsTooltipPlacementValues } from './types.ts';
+import type { HdsTooltipPlacements } from './types.ts';
 
 export const PLACEMENTS: string[] = Object.values(HdsTooltipPlacementValues);
 
@@ -16,7 +18,7 @@ export interface HdsTooltipSignature {
     extraTippyOptions?: Omit<TippyProps, 'placement' | 'offset'>;
     isInline?: boolean;
     offset?: [number, number];
-    placement?: HdsTooltipPlacementValues;
+    placement?: HdsTooltipPlacements;
     text: string;
   };
   Blocks: {

--- a/packages/components/src/components/hds/tooltip-button/index.ts
+++ b/packages/components/src/components/hds/tooltip-button/index.ts
@@ -16,7 +16,7 @@ export interface HdsTooltipSignature {
     extraTippyOptions: Omit<TippyProps, 'placement' | 'offset'>;
     isInline?: boolean;
     offset?: [number, number];
-    placement: HdsTooltipPlacementValues;
+    placement?: HdsTooltipPlacementValues;
     text: string;
   };
   Blocks: {
@@ -43,7 +43,7 @@ export default class HdsTooltip extends Component<HdsTooltipSignature> {
   }
 
   get options(): TippyProps {
-    const { placement } = this.args;
+    const { placement = HdsTooltipPlacementValues.Top } = this.args;
 
     assert(
       '@placement for "Hds::TooltipButton" must have a valid value',

--- a/packages/components/src/components/hds/tooltip-button/index.ts
+++ b/packages/components/src/components/hds/tooltip-button/index.ts
@@ -13,7 +13,7 @@ export const PLACEMENTS: string[] = Object.values(HdsTooltipPlacementValues);
 
 export interface HdsTooltipSignature {
   Args: {
-    extraTippyOptions: Omit<TippyProps, 'placement' | 'offset'>;
+    extraTippyOptions?: Omit<TippyProps, 'placement' | 'offset'>;
     isInline?: boolean;
     offset?: [number, number];
     placement?: HdsTooltipPlacementValues;
@@ -42,8 +42,9 @@ export default class HdsTooltip extends Component<HdsTooltipSignature> {
     return text;
   }
 
-  get options(): TippyProps {
-    const { placement = HdsTooltipPlacementValues.Top } = this.args;
+  get options(): Partial<TippyProps> {
+    const { placement = HdsTooltipPlacementValues.Top, extraTippyOptions } =
+      this.args;
 
     assert(
       '@placement for "Hds::TooltipButton" must have a valid value',
@@ -51,7 +52,7 @@ export default class HdsTooltip extends Component<HdsTooltipSignature> {
     );
 
     return {
-      ...this.args.extraTippyOptions,
+      ...(extraTippyOptions ? extraTippyOptions : {}),
       placement: placement,
       // takes array of 2 numbers (skidding, distance): array(0, 10)
       offset: this.args.offset ? this.args.offset : [0, 10],

--- a/packages/components/src/components/hds/tooltip-button/index.ts
+++ b/packages/components/src/components/hds/tooltip-button/index.ts
@@ -15,7 +15,7 @@ export const PLACEMENTS: string[] = Object.values(HdsTooltipPlacementValues);
 
 export interface HdsTooltipSignature {
   Args: {
-    extraTippyOptions?: Omit<TippyProps, 'placement' | 'offset'>;
+    extraTippyOptions?: Partial<Omit<TippyProps, 'placement' | 'offset'>>;
     isInline?: boolean;
     offset?: [number, number];
     placement?: HdsTooltipPlacements;

--- a/packages/components/src/modifiers/hds-tooltip.ts
+++ b/packages/components/src/modifiers/hds-tooltip.ts
@@ -25,7 +25,7 @@ export interface HdsTooltipModifierSignature {
   Args: {
     Positional: [string];
     Named: {
-      options?: TippyProps;
+      options?: Partial<TippyProps>;
     };
   };
   Element: HTMLElement;

--- a/website/docs/components/badge-count/partials/code/component-api.md
+++ b/website/docs/components/badge-count/partials/code/component-api.md
@@ -4,7 +4,7 @@
   <C.Property @name="type" @type="enum" @values={{array "filled" "inverted" "outlined" }} @default="filled"/>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
   <C.Property @name="color" @type="enum" @values={{array "neutral" "neutral-dark-mode" }} @default="neutral"/>
-  <C.Property @name="text" @type="string" @required={{true}}>
+  <C.Property @name="text" @type="string | number" @required={{true}}>
     Text value that renders in the Badge Count.
   </C.Property>
   <C.Property @name="...attributes">


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR would fix the types for TooltipButton and BadgeCount to unblock HCP from upgrading HDS.

### :hammer_and_wrench: Detailed description

**BadgeCount**
- `text` argument now allows string or number

**TooltipButton**
- `placement` argument is no longer required, has a default value of `'top'`, and the types have been fixed so you don't need to use the `HdsTooltipPlacementValues` enum as a consumer
- `extraTippyOptions` argument is no longer required, accepts partial objects

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3882](https://hashicorp.atlassian.net/browse/HDS-3882)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [X] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3882]: https://hashicorp.atlassian.net/browse/HDS-3882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ