### PR TITLE
`IconTile`: fix the `@color` argument type

### DIFF
--- a/.changeset/famous-dragons-march.md
+++ b/.changeset/famous-dragons-march.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`IconTile`: fixed color type signature
+`IconTile`: fixed `@color` argument type signature

--- a/.changeset/famous-dragons-march.md
+++ b/.changeset/famous-dragons-march.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`IconTile`: fixed color type signature

--- a/packages/components/src/components/hds/icon-tile/types.ts
+++ b/packages/components/src/components/hds/icon-tile/types.ts
@@ -31,6 +31,4 @@ export enum HdsIconTileColorNeutral {
   Neutral = 'neutral',
 }
 
-export type HdsIconTileColors =
-  | HdsIconTileProductValues
-  | HdsIconTileColorNeutral;
+export type HdsIconTileColors = HdsIconTileProducts | HdsIconTileColorNeutral;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the `@color` argument type so you don't need to use the enums as a consumer.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3890](https://hashicorp.atlassian.net/browse/HDS-3890)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3890]: https://hashicorp.atlassian.net/browse/HDS-3890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ