### PR TITLE
`DialogPrimitive`: add a guard so the yielded `close` function is always defined

### DIFF
--- a/.changeset/tricky-forks-lay.md
+++ b/.changeset/tricky-forks-lay.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`DialogPrimitive`: added a guard so the yielded close function is always defined'

--- a/packages/components/src/components/hds/dialog-primitive/footer.hbs
+++ b/packages/components/src/components/hds/dialog-primitive/footer.hbs
@@ -3,5 +3,5 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 <div class="hds-dialog-primitive__footer {{@contextualClass}}" ...attributes>
-  {{yield (hash close=@onDismiss)}}
+  {{yield (hash close=this.onDismiss)}}
 </div>

--- a/packages/components/src/components/hds/dialog-primitive/footer.ts
+++ b/packages/components/src/components/hds/dialog-primitive/footer.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import templateOnlyComponent from '@ember/component/template-only';
+import Component from '@glimmer/component';
 
 export interface HdsDialogPrimitiveFooterSignature {
   Args: {
@@ -15,14 +15,26 @@ export interface HdsDialogPrimitiveFooterSignature {
     default: [
       {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        close?: (event: MouseEvent, ...args: any[]) => void;
+        close: (event: MouseEvent, ...args: any[]) => void;
       },
     ];
   };
   Element: HTMLDivElement;
 }
 
-const HdsDialogPrimitiveFooter =
-  templateOnlyComponent<HdsDialogPrimitiveFooterSignature>();
+const NOOP = (): void => {};
 
-export default HdsDialogPrimitiveFooter;
+export default class HdsDialogPrimitiveFooter extends Component<HdsDialogPrimitiveFooterSignature> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get onDismiss(): (event: MouseEvent, ...args: any[]) => void {
+    const { onDismiss } = this.args;
+
+    // notice: this is to make sure the function is always defined when consumers add `{{on 'click' F.close}}` to a button in the DialogFooter.
+    // in reality it's always used inside the main components as a yielded component, so the onDismiss handler is always defined
+    if (typeof onDismiss === 'function') {
+      return onDismiss;
+    } else {
+      return NOOP;
+    }
+  }
+}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would create a `onDismiss` getter in the DialogPrimitive so the close function that is yielded to the Footer is always defined.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3889](https://hashicorp.atlassian.net/browse/HDS-3889)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [X] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3889]: https://hashicorp.atlassian.net/browse/HDS-3889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ