### PR TITLE
`SideNav` - Add documentation for onDesktopViewportChange (HDS-3867)

### DIFF
--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -57,7 +57,10 @@ This is the full-fledged component (responsive and animated).
     Accepts a localized string; the fallback is set to `Open menu` if the menu is closed, and `Close menu` if the menu is open.
   </C.Property>
   <C.Property @name="onToggleMinimizedStatus" @type="function">
-    Callback function invoked when the `SideNav` is collapsed or expanded. The function receives a boolean argument stating if the `SideNav` is minimized on not.
+    Callback function invoked when the `SideNav` is collapsed or expanded. The function receives a boolean argument stating if the `SideNav` is minimized or not.
+  </C.Property>
+  <C.Property @name="onDesktopViewportChange" @type="function">
+    Callback function invoked when the viewport changes. The function receives a boolean argument stating if the `SideNav` is in desktop mode or not.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds documentation to the website for SideNav onDesktopViewportChange.

**Preview:** https://hds-website-git-hds-3867-document-on-desktop-v-aa72eb-hashicorp.vercel.app/components/side-nav?tab=code#side-nav

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?
-->

### :camera_flash: Screenshots

<img width="721" alt="image" src="https://github.com/user-attachments/assets/41280b09-995e-4599-825c-bf957517b066">

### :link: External links

* Jira ticket: [HDS-3867](https://hashicorp.atlassian.net/browse/HDS-3867)

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets]~~(https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3867]: https://hashicorp.atlassian.net/browse/HDS-3867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ