### PR TITLE
`Interactive` - align types with `LinkTo`

### DIFF
--- a/.changeset/forty-hounds-nail.md
+++ b/.changeset/forty-hounds-nail.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Interactive` - aligned types with `LinkTo`

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -12,10 +12,10 @@ export interface HdsInteractiveSignature {
     isHrefExternal?: boolean;
     isRouteExternal?: boolean;
     route?: string;
-    models?: Array<string | number>;
-    model?: string | number;
-    query?: Record<string, string>;
-    'current-when'?: string;
+    models?: unknown[];
+    model?: unknown;
+    query?: Record<string, unknown>;
+    'current-when'?: string | boolean;
     replace?: boolean;
   };
   Blocks: {

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -11,6 +11,8 @@ export interface HdsInteractiveSignature {
     href?: string;
     isHrefExternal?: boolean;
     isRouteExternal?: boolean;
+    // the arguments and types below are mirroring the ones in LinkTo https://github.com/typed-ember/glint/blob/main/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts#L9
+    // because they're not exported we're unable to import them directly from glint
     route?: string;
     models?: unknown[];
     model?: unknown;


### PR DESCRIPTION
### :pushpin: Summary

We can't import the [LinkTo type](https://github.com/typed-ember/glint/blob/main/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts#L9) from glint so we manually align the two.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3891](https://hashicorp.atlassian.net/browse/HDS-3891)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3891]: https://hashicorp.atlassian.net/browse/HDS-3891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ