### PR TITLE
chore: remove ember-keyboard dependency

### DIFF
--- a/.changeset/sharp-phones-wait.md
+++ b/.changeset/sharp-phones-wait.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Removed `ember-keyboard` dependency

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,7 +49,6 @@
     "ember-element-helper": "^0.8.5",
     "ember-focus-trap": "^1.1.0",
     "ember-get-config": "^2.1.1",
-    "ember-keyboard": "^8.2.1",
     "ember-modifier": "^4.1.0",
     "ember-power-select": "^8.2.0",
     "ember-stargate": "^0.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4293,7 +4293,6 @@ __metadata:
     ember-element-helper: "npm:^0.8.5"
     ember-focus-trap: "npm:^1.1.0"
     ember-get-config: "npm:^2.1.1"
-    ember-keyboard: "npm:^8.2.1"
     ember-modifier: "npm:^4.1.0"
     ember-power-select: "npm:^8.2.0"
     ember-stargate: "npm:^0.4.3"
@@ -13194,7 +13193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-destroyable-polyfill@npm:^2.0.1, ember-destroyable-polyfill@npm:^2.0.2, ember-destroyable-polyfill@npm:^2.0.3":
+"ember-destroyable-polyfill@npm:^2.0.1, ember-destroyable-polyfill@npm:^2.0.2":
   version: 2.0.3
   resolution: "ember-destroyable-polyfill@npm:2.0.3"
   dependencies:
@@ -13316,23 +13315,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-keyboard@npm:^8.2.1":
-  version: 8.2.1
-  resolution: "ember-keyboard@npm:8.2.1"
-  dependencies:
-    "@embroider/addon-shim": "npm:^1.8.4"
-    ember-destroyable-polyfill: "npm:^2.0.3"
-    ember-modifier: "npm:^2.1.2 || ^3.1.0 || ^4.0.0"
-    ember-modifier-manager-polyfill: "npm:^1.2.0"
-  peerDependencies:
-    "@ember/test-helpers": ^2.6.0 || ^3.0.0
-  peerDependenciesMeta:
-    "@ember/test-helpers":
-      optional: true
-  checksum: 10/1c9e62a44a6ee95e52276865d63c35e2bf294720f903bc3214508e9641d8dc37860a6ee582b332b5570bb124dc4d80ff210752cf66b91c7cff35ce279117e444
-  languageName: node
-  linkType: hard
-
 "ember-lifeline@npm:^7.0.0":
   version: 7.0.0
   resolution: "ember-lifeline@npm:7.0.0"
@@ -13391,7 +13373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-modifier@npm:^2.1.2 || ^3.1.0 || ^4.0.0, ember-modifier@npm:^3.2.7 || ^4.0.0, ember-modifier@npm:^3.2.7 || ^4.1.0, ember-modifier@npm:^4.1.0":
+"ember-modifier@npm:^3.2.7 || ^4.0.0, ember-modifier@npm:^3.2.7 || ^4.1.0, ember-modifier@npm:^4.1.0":
   version: 4.1.0
   resolution: "ember-modifier@npm:4.1.0"
   dependencies:


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would remove the dependency on ember-keyboard. It seems like this was a relic dependency from [the CTA component](https://github.com/hashicorp/design-system/commit/01d4b033bfa2a35968208da5abcec2fa22fefd8a), but it has not been used in a long time.

I looked into using It for the dataGrid spike, but there is not a strong reason to use it over the native addEventListener plus it isn't typesafe yet.

- [X] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
