### PR TITLE
Update the `Getting started for Engineers` documentation to include marketing and email "targets"

### DIFF
--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -239,8 +239,14 @@ Import design tokens as CSS variables by adding one of the following lines to th
 // for product applications (Ember apps)
 @import "@hashicorp/design-system-tokens/dist/products/css/tokens.css";
 
+// for Cloud UI email templating
+@import "@hashicorp/design-system-tokens/dist/cloud-email/tokens.css";
+
 // for HashiCorp developer platform
 @import "~@hashicorp/design-system-tokens/dist/devdot/css/tokens.css";
+
+// for HashiCorp web/marketing websites
+@import '@hashicorp/design-system-tokens/dist/marketing/css/tokens.css';
 ```
 
 ### Import styles as CSS helper classes
@@ -254,11 +260,23 @@ Import CSS helper classes by adding any of the following lines to the main Sass 
 @import "@hashicorp/design-system-tokens/dist/products/css/helpers/typography.css";
 @import "@hashicorp/design-system-tokens/dist/products/css/helpers/focus-ring.css";
 
+// for Cloud UI email templating
+@import "@hashicorp/design-system-tokens/dist/cloud-email/helpers/colors.css";
+@import "@hashicorp/design-system-tokens/dist/cloud-email/helpers/elevation.css";
+@import "@hashicorp/design-system-tokens/dist/cloud-email/helpers/typography.css";
+@import "@hashicorp/design-system-tokens/dist/cloud-email/helpers/focus-ring.css";
+
 // for HashiCorp developer platform
 @import "~@hashicorp/design-system-tokens/dist/devdot/css/helpers/colors.css";
 @import "~@hashicorp/design-system-tokens/dist/devdot/css/helpers/elevation.css";
 @import "~@hashicorp/design-system-tokens/dist/devdot/css/helpers/typography.css";
 @import "~@hashicorp/design-system-tokens/dist/devdot/css/helpers/focus-ring.css";
+
+// for HashiCorp web/marketing websites
+@import "@hashicorp/design-system-tokens/dist/marketing/css/helpers/color.css";
+@import "@hashicorp/design-system-tokens/dist/marketing/css/helpers/elevation.css";
+@import "@hashicorp/design-system-tokens/dist/marketing/css/helpers/focus-ring.css";
+@import "@hashicorp/design-system-tokens/dist/marketing/css/helpers/typography.css";
 ```
 
 For more examples and guidelines read [the tokens documentation](/foundations/tokens).


### PR DESCRIPTION
### :pushpin: Summary

Small PR to address this comment/suggestion: https://github.com/hashicorp/design-system/pull/1965#pullrequestreview-1931373775

### :hammer_and_wrench: Detailed description

In this PR I have:
- added entries for “Cloud UI email templating” and “HashiCorp web/marketing websites” to the explanation of how to consume the HDS design tokens in the “Getting started for engineers” documentation page

**Preview**: https://hds-website-git-update-getting-started-for-engineers-hashicorp.vercel.app/getting-started/for-engineers#tokens

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3201

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
