### PR TITLE
`AppSideNav` - Follow-on improvements for headers & aria (HDS-3897)

### DIFF
--- a/packages/components/src/components/hds/app-side-nav/base.hbs
+++ b/packages/components/src/components/hds/app-side-nav/base.hbs
@@ -4,6 +4,8 @@
 }}
 {{! IMPORTANT: we need to add "squishies" here (~) because otherwise the whitespace added by Ember causes the empty element to still have visible padding - See https://handlebarsjs.com/guide/expressions.html#whitespace-control }}
 <div class="hds-app-side-nav" ...attributes>
+  <h2 class="sr-only">Local navigation</h2>
+
   <div class="hds-app-side-nav__wrapper">
     {{yield to="root"}}
     <div class="hds-app-side-nav__wrapper-header">

--- a/packages/components/src/components/hds/app-side-nav/base.hbs
+++ b/packages/components/src/components/hds/app-side-nav/base.hbs
@@ -4,7 +4,7 @@
 }}
 {{! IMPORTANT: we need to add "squishies" here (~) because otherwise the whitespace added by Ember causes the empty element to still have visible padding - See https://handlebarsjs.com/guide/expressions.html#whitespace-control }}
 <div class="hds-app-side-nav" ...attributes>
-  <h2 class="sr-only">Local navigation</h2>
+  <h2 class="sr-only" id="hds-app-side-nav-header">Application local navigation</h2>
 
   <div class="hds-app-side-nav__wrapper">
     {{yield to="root"}}

--- a/packages/components/src/components/hds/app-side-nav/index.hbs
+++ b/packages/components/src/components/hds/app-side-nav/index.hbs
@@ -19,7 +19,7 @@
       <div class="hds-app-side-nav__overlay" {{on "click" this.toggleMinimizedStatus}} />
       {{! template-lint-enable no-invalid-interactive}}
       <Hds::AppSideNav::ToggleButton
-        aria-label="App navigation"
+        aria-labelledby="hds-app-side-nav-header"
         aria-expanded={{if this.isMinimized "false" "true"}}
         @icon={{if this.isMinimized "chevrons-right" "chevrons-left"}}
         {{on "click" this.toggleMinimizedStatus}}

--- a/packages/components/src/components/hds/app-side-nav/index.hbs
+++ b/packages/components/src/components/hds/app-side-nav/index.hbs
@@ -19,7 +19,8 @@
       <div class="hds-app-side-nav__overlay" {{on "click" this.toggleMinimizedStatus}} />
       {{! template-lint-enable no-invalid-interactive}}
       <Hds::AppSideNav::ToggleButton
-        aria-label={{this.toggleButtonAriaLabel}}
+        aria-label="App navigation"
+        aria-expanded={{if this.isMinimized "false" "true"}}
         @icon={{if this.isMinimized "chevrons-right" "chevrons-left"}}
         {{on "click" this.toggleMinimizedStatus}}
       />

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -15,7 +15,6 @@ interface HdsAppSideNavSignature {
     isResponsive?: boolean;
     isCollapsible?: boolean;
     isMinimized?: boolean;
-    toggleButtonAriaLabel?: string;
     onToggleMinimizedStatus?: (arg: boolean) => void;
     onDesktopViewportChange?: (arg: boolean) => void;
   };
@@ -93,13 +92,6 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
 
   get showToggleButton(): boolean {
     return (this.isResponsive && !this.isDesktop) || this.isCollapsible;
-  }
-
-  get toggleButtonAriaLabel(): string {
-    if (this.isMinimized) {
-      return this.args.toggleButtonAriaLabel ?? 'Open menu';
-    }
-    return this.args.toggleButtonAriaLabel ?? 'Close menu';
   }
 
   get classNames(): string {

--- a/packages/components/src/components/hds/app-side-nav/list/index.hbs
+++ b/packages/components/src/components/hds/app-side-nav/list/index.hbs
@@ -5,12 +5,12 @@
 
 <nav class="hds-app-side-nav__list-wrapper" aria-labelledby="hds-app-side-nav-header" ...attributes>
   {{yield (hash ExtraBefore=(component "hds/yield"))}}
-  <ul class="hds-app-side-nav__list" role="list">
+  <ul class="hds-app-side-nav__list" role="list" aria-labelledby={{this.titleIds}}>
     {{yield
       (hash
         Item=(component "hds/app-side-nav/list/item")
         BackLink=(component "hds/app-side-nav/list/back-link")
-        Title=(component "hds/app-side-nav/list/title")
+        Title=(component "hds/app-side-nav/list/title" didInsertTitle=this.didInsertTitle)
         Link=(component "hds/app-side-nav/list/link")
       )
     }}

--- a/packages/components/src/components/hds/app-side-nav/list/index.hbs
+++ b/packages/components/src/components/hds/app-side-nav/list/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<nav class="hds-app-side-nav__list-wrapper" ...attributes>
+<nav class="hds-app-side-nav__list-wrapper" aria-labelledby="hds-app-side-nav-header" ...attributes>
   {{yield (hash ExtraBefore=(component "hds/yield"))}}
   <ul class="hds-app-side-nav__list" role="list">
     {{yield

--- a/packages/components/src/components/hds/app-side-nav/list/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/list/index.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import TemplateOnlyComponent from '@ember/component/template-only';
-
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import type { ComponentLike } from '@glint/template';
 import type { HdsYieldSignature } from '../../yield';
 import type { HdsAppSideNavListItemSignature } from './item';
@@ -28,6 +29,15 @@ export interface HdsAppSideNavListSignature {
   Element: HTMLElement;
 }
 
-const HdsAppSideNavList = TemplateOnlyComponent<HdsAppSideNavListSignature>();
+export default class HdsAppSideNavList extends Component<HdsAppSideNavListSignature> {
+  @tracked _titleIds: string[] = [];
 
-export default HdsAppSideNavList;
+  get titleIds(): string {
+    return this._titleIds.join(' ');
+  }
+
+  @action
+  didInsertTitle(titleId: string): void {
+    this._titleIds = [...this._titleIds, titleId];
+  }
+}

--- a/packages/components/src/components/hds/app-side-nav/list/title.hbs
+++ b/packages/components/src/components/hds/app-side-nav/list/title.hbs
@@ -4,8 +4,8 @@
 }}
 
 <Hds::AppSideNav::List::Item>
-  <div
+  <h3
     class="hds-app-side-nav__list-title hds-typography-body-100 hds-font-weight-semibold"
     ...attributes
-  >{{~yield~}}</div>
+  >{{~yield~}}</h3>
 </Hds::AppSideNav::List::Item>

--- a/packages/components/src/components/hds/app-side-nav/list/title.hbs
+++ b/packages/components/src/components/hds/app-side-nav/list/title.hbs
@@ -4,10 +4,10 @@
 }}
 
 <Hds::AppSideNav::List::Item>
-  <h3
+  <div
     class="hds-app-side-nav__list-title hds-typography-body-100 hds-font-weight-semibold"
     id={{this.titleId}}
     {{did-insert this.didInsertTitle}}
     ...attributes
-  >{{~yield~}}</h3>
+  >{{~yield~}}</div>
 </Hds::AppSideNav::List::Item>

--- a/packages/components/src/components/hds/app-side-nav/list/title.hbs
+++ b/packages/components/src/components/hds/app-side-nav/list/title.hbs
@@ -6,6 +6,8 @@
 <Hds::AppSideNav::List::Item>
   <h3
     class="hds-app-side-nav__list-title hds-typography-body-100 hds-font-weight-semibold"
+    id={{this.titleId}}
+    {{did-insert this.didInsertTitle}}
     ...attributes
   >{{~yield~}}</h3>
 </Hds::AppSideNav::List::Item>

--- a/packages/components/src/components/hds/app-side-nav/list/title.ts
+++ b/packages/components/src/components/hds/app-side-nav/list/title.ts
@@ -3,16 +3,30 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import TemplateOnlyComponent from '@ember/component/template-only';
+import { guidFor } from '@ember/object/internals';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
 
 export interface HdsAppSideNavListTitleSignature {
+  Args: {
+    didInsertTitle: (titleId: string) => void;
+  };
   Blocks: {
     default: [];
   };
   Element: HTMLDivElement;
 }
 
-const HdsAppSideNavListTitle =
-  TemplateOnlyComponent<HdsAppSideNavListTitleSignature>();
+export default class HdsAppSideNavListTitle extends Component<HdsAppSideNavListTitleSignature> {
+  /*  Generate a unique ID for each Title */
+  titleId = 'title-' + guidFor(this);
 
-export default HdsAppSideNavListTitle;
+  @action
+  didInsertTitle(element: HTMLElement): void {
+    const { didInsertTitle } = this.args;
+
+    if (typeof didInsertTitle === 'function') {
+      didInsertTitle(element.id);
+    }
+  }
+}

--- a/showcase/tests/acceptance/components/hds/app-side-nav-test.js
+++ b/showcase/tests/acceptance/components/hds/app-side-nav-test.js
@@ -21,6 +21,10 @@ module('Acceptance | Component | hds/app-side-nav', function (hooks) {
           enabled: false,
           selectors: [['.shw-placeholder']],
         },
+        'landmark-unique': {
+          enabled: false,
+          selectors: [['.hds-app-side-nav__list-wrapper']],
+        },
       },
     };
 

--- a/showcase/tests/integration/components/hds/app-side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/index-test.js
@@ -222,7 +222,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       .hasClass('hds-app-side-nav--is-not-minimized');
     assert
       .dom('.hds-app-side-nav__toggle-button')
-      .hasAttribute('aria-label', 'Close menu');
+      .hasAttribute('aria-expanded', 'true');
     assert
       .dom('.hds-app-side-nav__toggle-button .hds-icon')
       .hasClass('hds-icon-chevrons-left');
@@ -245,7 +245,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');
     assert
       .dom('.hds-app-side-nav__toggle-button')
-      .hasAttribute('aria-label', 'Open menu');
+      .hasAttribute('aria-expanded', 'false');
     assert
       .dom('.hds-app-side-nav__toggle-button .hds-icon')
       .hasClass('hds-icon-chevrons-right');


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will make improvements to the `AppSideNav` component related to `List::Title` headers and the `ToggleButton` aria properties. 

(It will merge into the component branch, not directly into the main branch.)

### :hammer_and_wrench: Detailed description

**Implemented changes:**

* Change `List::Title` to h3 & add visually hidden h2 to AppSideNav - [Reference comment](https://github.com/hashicorp/design-system/pull/2384#discussion_r1764009486)
* Improve ariaLabel for `ToggleButton` state & use aria-expanded - [Reference comment](https://github.com/hashicorp/design-system/pull/2384#discussion_r1764017267)

<!--
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-3897](https://hashicorp.atlassian.net/browse/HDS-3897)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- ~~[ ] A changelog entry was added via [Changesets]~~(https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3897]: https://hashicorp.atlassian.net/browse/HDS-3897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ