### PR TITLE
Update checkmark `ListItem` styling

### DIFF
--- a/.changeset/odd-poets-complain.md
+++ b/.changeset/odd-poets-complain.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Dropdown` - Update the color of the text and icons in the selected state checkmark list item to match the styling of the others.
+`Dropdown` - Update the color of the text and icons in the selected state checkmark list item to match the styling of the ListItems (`Radio` and `Checkbox`).

--- a/.changeset/odd-poets-complain.md
+++ b/.changeset/odd-poets-complain.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Dropdown` - Update the color of the text and icons in the selected state checkmark list item to match the styling of the others.

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -518,12 +518,8 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 // HDS::DROPDOWN::LIST-ITEM::CHECKMARK
 
 .hds-dropdown-list-item--variant-checkmark-selected {
-  .hds-dropdown-list-item__interactive {
-    color: var(--token-color-foreground-primary);
-
-    .hds-dropdown-list-item__checkmark {
-      color: var(--token-color-foreground-action);
-    }
+  .hds-dropdown-list-item__checkmark {
+    color: var(--token-color-foreground-action);
   }
 }
 

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -48,7 +48,13 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
     cursor: pointer;
   }
 
-  @include hds-focus-ring-with-pseudo-element($top: -1px, $right: -1px, $bottom: -1px, $left: -1px, $radius: $hds-dropdown-toggle-border-radius);
+  @include hds-focus-ring-with-pseudo-element(
+    $top: -1px,
+    $right: -1px,
+    $bottom: -1px,
+    $left: -1px,
+    $radius: $hds-dropdown-toggle-border-radius
+  );
 
   &:active,
   &.mock-active {
@@ -209,7 +215,7 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
     background: none;
     border: none;
     inset: 0;
-  }  
+  }
 }
 
 .hds-dropdown {
@@ -218,7 +224,7 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 
     &[popover]:popover-open {
       display: flex;
-    }  
+    }
   }
 }
 
@@ -286,7 +292,6 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   width: 100%;
   padding: 10px 16px 12px;
 }
-
 
 // HDS::DROPDOWN::LIST-ITEM::DESCRIPTION
 
@@ -446,7 +451,9 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
     --current-color-active: var(--token-color-foreground-action-active);
 
     &::after {
-      --current-focus-ring-box-shadow: var(--token-focus-ring-action-box-shadow);
+      --current-focus-ring-box-shadow: var(
+        --token-focus-ring-action-box-shadow
+      );
     }
   }
 }
@@ -463,7 +470,9 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 
     &::after {
       --current-background-color: var(--token-color-surface-critical);
-      --current-focus-ring-box-shadow: var(--token-focus-ring-critical-box-shadow);
+      --current-focus-ring-box-shadow: var(
+        --token-focus-ring-critical-box-shadow
+      );
     }
   }
 }
@@ -510,7 +519,11 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 
 .hds-dropdown-list-item--variant-checkmark-selected {
   .hds-dropdown-list-item__interactive {
-    color: var(--token-color-foreground-action);
+    color: var(--token-color-foreground-primary);
+
+    .hds-dropdown-list-item__checkmark {
+      color: var(--token-color-foreground-action);
+    }
   }
 }
 
@@ -530,7 +543,6 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   color: var(--token-color-foreground-disabled);
   cursor: not-allowed;
 }
-
 
 // HDS::DROPDOWN::LIST-ITEM::CHECKBOX & HDS::DROPDOWN::LIST-ITEM::RADIO
 


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR will update the styling of the selected state checkmark `ListItem` in the `Dropdown` to match the other variants.

### :hammer_and_wrench: Detailed description

Currently, the selected state of the checkmark `ListItem` styles the icon, label, and checkmark with `Foreground / Action`, which differs from the selected state of the other `ListItem`'s where the icon and label persist the usage of `Foreground / Primary`.

However, because the checkmark variant is slightly different in interaction, I have left the hover and active states unchanged, only the resting/default state of the selected checkmark has been updated.

![image](https://github.com/user-attachments/assets/c7827dfb-3c93-4594-abcd-787cdba68e5a)


### :camera_flash: Screenshots

**Before**
<img width="1134" alt="Screenshot 2024-09-27 at 4 02 25 PM" src="https://github.com/user-attachments/assets/9821a3e6-70e5-4f22-910e-654b158d3be0">


**After**
<img width="1107" alt="Screenshot 2024-09-27 at 4 00 54 PM" src="https://github.com/user-attachments/assets/73c59e37-6903-4554-9ebe-b34b74efa9b3">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3895](https://hashicorp.atlassian.net/browse/HDS-3895)
Figma file: [Figma v2.0 Library | Dropdown](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/%5BWIP%5D-HDS-Components-v2.0?node-id=66540-30899&t=f4Ce9l2SHLEZN8EU-1)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3895]: https://hashicorp.atlassian.net/browse/HDS-3895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ