### PR TITLE
`CodeBlock` - Expose ability to set custom line number start

### DIFF
--- a/.changeset/spicy-grapes-happen.md
+++ b/.changeset/spicy-grapes-happen.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`CodeBlock` - Added `lineNumberStart` option to set custom starting number for line numbering`

--- a/packages/components/src/components/hds/code-block/index.hbs
+++ b/packages/components/src/components/hds/code-block/index.hbs
@@ -14,6 +14,7 @@
       class="hds-code-block__code"
       {{style maxHeight=@maxHeight}}
       data-line={{@highlightLines}}
+      data-start={{@lineNumberStart}}
       id={{this.preCodeId}}
       tabindex="0"
     ><code {{did-insert this.setPrismCode}} {{did-update this.setPrismCode this.code @language}}>

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -47,6 +47,7 @@ export interface HdsCodeBlockSignature {
     hasLineNumbers?: boolean;
     hasLineWrapping?: boolean;
     highlightLines?: string;
+    lineNumberStart?: number;
     isStandalone?: boolean;
     language?: HdsCodeBlockLanguages;
     maxHeight?: string;

--- a/showcase/app/templates/components/code-block.hbs
+++ b/showcase/app/templates/components/code-block.hbs
@@ -49,6 +49,36 @@ console.log(`I am ${codeLang} code`);"
         @value="let codeLang='JavaScript';\nconsole.log(`I am ${codeLang} code`);"
       />
     </SG.Item>
+    <SG.Item @forceMinWidth={{true}} as |SGI|>
+      <SGI.Label>Line numbering start changed to "5"
+      </SGI.Label>
+      {{! template-lint-disable no-whitespace-for-layout }}
+      <Hds::CodeBlock
+        @language="javascript"
+        @maxHeight="105px"
+        @lineNumberStart={{5}}
+        @value="function convertObjectToArray (obj) {
+  let arr = Object
+    .keys(obj) // return object's keys as an array
+    .map(key => {return [key, obj[key] ]}) // map a function on each array item
+    .flat()
+    .sort()
+  ;
+  return arr;
+}
+function assertObjectsEqual (actual, expected, testName) {
+  let actualStr = JSON.stringify( convertObjectToArray(actual) );
+  let expectedStr = JSON.stringify( convertObjectToArray(expected) );
+  console.log(`ACTUAL: ${actualStr}  EXPECTED: ${expectedStr}`);
+  if (actualStr === expectedStr) {
+    console.log('passed');
+  } else {
+    console.log(`FAILED [${testName}] Expected ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);
+  }
+}"
+      />
+      {{! template-lint-enable no-whitespace-for-layout }}
+    </SG.Item>
   </Shw::Grid>
 
   <Shw::Divider @level="2" />

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -26,6 +26,9 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
   <C.Property @name="hasLineNumbers" @type="boolean" @default="true">
     Used to control display of line numbers. Note that due to technical limitations, if the `@value` changes dynamically the line numbers will fail to update.
   </C.Property>
+  <C.Property @name="lineNumberStart" @type="number" @default="1">
+    Used to set a custom starting number for line numbering.
+  </C.Property>
   <C.Property @name="hasLineWrapping" @type="boolean" @default="false">
     Used to control line wrapping for lines of code. If `true`, lines of code will wrap to fit the available space. Otherwise, horizontal scrolling is enabled if lines overflow the available space.
   </C.Property>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add the ability to set a custom line numbering starting number to the `CodeBlock` component.

* Showcase preview: https://hds-showcase-git-code-block-add-line-number-st-0fda5f-hashicorp.vercel.app/components/code-block#content
* API docs preview: https://hds-website-git-code-block-add-line-number-sta-677e12-hashicorp.vercel.app/components/code-block?tab=code#codeblock

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Follow on from [Slack conversation thread related to CodeBlock line numbering](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1727802991563809)

<!-- Issues, RFC, etc.
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]
 -->

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
