### PR TITLE
`AppSideNav` - overlay scrolling bug fix (HDS-3914)

### DIFF
--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -136,6 +136,18 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
     });
   }
 
+  lockBodyScroll(): void {
+    document.body.style.top = `-${window.scrollY}px`;
+    document.body.style.position = 'fixed';
+  }
+
+  unlockBodyScroll(): void {
+    const verticalScrollPosition = document.body.style.top;
+    document.body.style.position = '';
+    document.body.style.top = '';
+    window.scrollTo(0, parseInt(verticalScrollPosition || '0') * -1);
+  }
+
   @action
   escapePress(event: KeyboardEvent): void {
     if (event.key === 'Escape' && !this.isMinimized && !this.isDesktop) {
@@ -147,13 +159,18 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   @action
   toggleMinimizedStatus(): void {
     this.isMinimized = !this.isMinimized;
-
     this.synchronizeInert();
 
     const { onToggleMinimizedStatus } = this.args;
 
     if (typeof onToggleMinimizedStatus === 'function') {
       onToggleMinimizedStatus(this.isMinimized);
+    }
+
+    if (this.isMinimized) {
+      this.unlockBodyScroll();
+    } else {
+      this.lockBodyScroll();
     }
   }
 

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -140,9 +140,6 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
 
   lockBodyScroll(): void {
     if (this.body) {
-      // Store the initial `overflow` value of `<body>` so we can reset to it
-      this.bodyInitialOverflowValue =
-        this.body.style.getPropertyValue('overflow');
       // Prevent page from scrolling when the dialog is open
       this.body.style.setProperty('overflow', 'hidden');
     }
@@ -194,6 +191,9 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
       '.hds-app-side-nav-hide-when-minimized'
     );
     this.body = document.body;
+    // Store the initial `overflow` value of `<body>` so we can reset to it
+    this.bodyInitialOverflowValue =
+      this.body.style.getPropertyValue('overflow');
   }
 
   @action

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -48,6 +48,8 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   @tracked isCollapsible = this.args.isCollapsible ?? false; // controls if users can collapse the sidenav on 'desktop' viewports
   @tracked isAnimating = false;
   @tracked isDesktop = true;
+  body!: HTMLElement;
+  bodyInitialOverflowValue = '';
   desktopMQ: MediaQueryList;
   containersToHide!: NodeListOf<Element>;
 
@@ -137,15 +139,27 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   }
 
   lockBodyScroll(): void {
-    document.body.style.top = `-${window.scrollY}px`;
-    document.body.style.position = 'fixed';
+    if (this.body) {
+      // Store the initial `overflow` value of `<body>` so we can reset to it
+      this.bodyInitialOverflowValue =
+        this.body.style.getPropertyValue('overflow');
+      // Prevent page from scrolling when the dialog is open
+      this.body.style.setProperty('overflow', 'hidden');
+    }
   }
 
   unlockBodyScroll(): void {
-    const verticalScrollPosition = document.body.style.top;
-    document.body.style.position = '';
-    document.body.style.top = '';
-    window.scrollTo(0, parseInt(verticalScrollPosition || '0') * -1);
+    // Reset page `overflow` property
+    if (this.body) {
+      this.body.style.removeProperty('overflow');
+      if (this.bodyInitialOverflowValue === '') {
+        if (this.body.style.length === 0) {
+          this.body.removeAttribute('style');
+        }
+      } else {
+        this.body.style.setProperty('overflow', this.bodyInitialOverflowValue);
+      }
+    }
   }
 
   @action
@@ -179,6 +193,7 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
     this.containersToHide = element.querySelectorAll(
       '.hds-app-side-nav-hide-when-minimized'
     );
+    this.body = document.body;
   }
 
   @action


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes an issue with the body content scrolling when the `AppSideNav` is expanded as an overlay in mobile view. The fix prevents the body content from scrolling while maintaining the previous scroll position.

(It will merge into the component branch, not directly into the main branch.)

**Preview of fix in action:** https://hds-showcase-git-hds-3914-app-side-nav-overlay-d5df13-hashicorp.vercel.app/layouts/app-frame/frameless/demo-full-app-frame-with-app-header-and-app-side-nav

**To test:**

1. Narrow browser window until you are in "mobile" view
2. With the AppSideNav still minimizing scroll the main content a noticeable amount
3. Use the Toggle Button to expand the AppSideNav
4. Attempt to scroll within the main content under the gray screen overlay.

**Expected:** The main content should not react when you try to scroll. The previous scroll position should be maintained instead of jumping back to the top of the main content.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-3914](https://hashicorp.atlassian.net/browse/HDS-3914)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3914]: https://hashicorp.atlassian.net/browse/HDS-3914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ