### PR TITLE
`SuperSelect::Multiple` - fix placeholder style and layout

### DIFF
--- a/.changeset/nice-llamas-tap.md
+++ b/.changeset/nice-llamas-tap.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SuperSelect::Multiple` - Fixed placeholder style and layout

--- a/packages/components/src/styles/components/form/super-select.scss
+++ b/packages/components/src/styles/components/form/super-select.scss
@@ -72,8 +72,11 @@ $hds-super-select-item-height: 36px;
       margin-left: 0;
     }
 
-    .ember-power-select-placeholder {
+    .ember-power-select-placeholder {  
       color: var(--token-form-control-base-foreground-placeholder-color);
+      font-size: var(--token-typography-body-200-font-size);
+      font-family: var(--token-typography-body-200-font-family);
+      line-height: var(--token-typography-body-200-line-height);
     }
 
     // `BasicDropdown` uses `aria-disabled` on the trigger, see: https://ember-basic-dropdown.com/docs/disabled
@@ -272,6 +275,7 @@ $hds-super-select-item-height: 36px;
   // Tag List
   .ember-power-select-multiple-options {
     display: flex;
+    flex-grow: 1;
     flex-wrap: wrap;
     gap: 4px;
     min-width: 0;

--- a/showcase/app/templates/components/form/super-select.hbs
+++ b/showcase/app/templates/components/form/super-select.hbs
@@ -521,10 +521,10 @@
 
   <Shw::Text::H2>Form::SuperSelect::Multiple::Base</Shw::Text::H2>
 
-  <Shw::Text::H3>Interaction</Shw::Text::H3>
+  <Shw::Text::H3>Interaction status</Shw::Text::H3>
 
-  <Shw::Flex @direction="row" as |SF|>
-    <SF.Item {{style flex="1"}} @label="Default">
+  <Shw::Grid @columns={{3}} as |SG|>
+    <SG.Item @label="Default">
       <Hds::Form::SuperSelect::Multiple::Base
         @onChange={{this.noop}}
         @options={{@model.OPTIONS}}
@@ -533,9 +533,19 @@
       >
         {{option}}
       </Hds::Form::SuperSelect::Multiple::Base>
-    </SF.Item>
-
-    <SF.Item {{style flex="1"}} @label="Selected">
+    </SG.Item>
+    <SG.Item @label="With placeholder">
+      <Hds::Form::SuperSelect::Multiple::Base
+        @onChange={{fn (mut @model.SELECTED_OPTIONS)}}
+        @options={{@model.OPTIONS}}
+        @placeholder="Placeholder text for multiple selection"
+        @ariaLabel="Label"
+        as |option|
+      >
+        {{option}}
+      </Hds::Form::SuperSelect::Multiple::Base>
+    </SG.Item>
+    <SG.Item @label="Selected">
       <Hds::Form::SuperSelect::Multiple::Base
         @onChange={{fn (mut @model.SELECTED_OPTIONS)}}
         @options={{@model.OPTIONS}}
@@ -545,8 +555,8 @@
       >
         {{option}}
       </Hds::Form::SuperSelect::Multiple::Base>
-    </SF.Item>
-  </Shw::Flex>
+    </SG.Item>
+  </Shw::Grid>
 
   <Shw::Divider @level="2" />
 


### PR DESCRIPTION
### :pushpin: Summary

`SuperSelect::Single` has an HDS-level component for the placeholder, managing the mark-up and the style.

However, the placeholder for `SuperSelect::Multiple` is more complex and doesn't sit at the HDS-level. Hence it requires font style adjustments (only when the search is not enabled) and layout adjustments to fill the parent container (otherwise it will result in trimmed text, as reported by our consumers).

### :camera_flash: Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="367" alt="Screenshot 2024-10-02 at 12 06 52" src="https://github.com/user-attachments/assets/ca4cf048-e796-4069-ad8b-4524c42abd9b">


</td><td>

<img width="370" alt="Screenshot 2024-10-02 at 12 05 45" src="https://github.com/user-attachments/assets/d0d0a284-f449-4be3-b4cf-b61b0b468ed1">

</td></tr>
</table>


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3916](https://hashicorp.atlassian.net/browse/HDS-3916)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3916]: https://hashicorp.atlassian.net/browse/HDS-3916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ