### PR TITLE
`CodeBlock` - fix line numbers always shown when `highlightLines` is set

### DIFF
--- a/.changeset/rich-lemons-think.md
+++ b/.changeset/rich-lemons-think.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`CodeBlock` - Decoupled the display of line numbers from `highlightLines`

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -192,7 +192,7 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
     }
 
     // Note: Prism.js is using the specific class name "line-numbers" to determine implementation of line numbers in the UI
-    if (this.hasLineNumbers || this.args.highlightLines) {
+    if (this.hasLineNumbers) {
       classes.push('line-numbers');
     }
 

--- a/showcase/app/templates/components/code-block.hbs
+++ b/showcase/app/templates/components/code-block.hbs
@@ -311,9 +311,10 @@ function assertObjectsEqual (actual, expected, testName) {
   <Shw::Text::H3>Highlight lines</Shw::Text::H3>
 
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
-    <SG.Item @label="Highlight lines 2 & 4" @forceMinWidth={{true}}>
+    <SG.Item @label="Highlight lines 2 & 4, hasLineNumbers=false" @forceMinWidth={{true}}>
       <Hds::CodeBlock
         @language="javascript"
+        @hasLineNumbers={{false}}
         @highlightLines="2, 4"
         @value="import Application from '@ember/application';
 import Resolver from 'ember-resolver';


### PR DESCRIPTION
### :pushpin: Summary

Uncouple `hasLineNumbers` from `highlightLines`.

### :hammer_and_wrench: Detailed description

With this change, if `@hasLineNumbers={{false}}` we highlight the lines without automatically showing the numbers.

[Preview in `showcase`](https://hds-showcase-git-alex-ju-fix-code-block-highli-496ddf-hashicorp.vercel.app/components/code-block#highlight-lines)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3348](https://hashicorp.atlassian.net/browse/HDS-3348)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3348]: https://hashicorp.atlassian.net/browse/HDS-3348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ