### PR TITLE
Add deprecation comments to the type declarations

### DIFF
--- a/packages/components/src/components/hds/dropdown/list-item/interactive.ts
+++ b/packages/components/src/components/hds/dropdown/list-item/interactive.ts
@@ -24,6 +24,9 @@ export interface HdsDropdownListItemInteractiveSignature {
     color?: HdsDropdownListItemInteractiveColors;
     icon?: HdsIconSignature['Args']['name'];
     isLoading?: boolean;
+    /**
+     * @deprecated The `@text` argument for "Hds::Dropdown::ListItem::Interactive" has been deprecated. Please put text in the yielded block. See: https://helios.hashicorp.design/components/dropdown?tab=version%20history#4100
+     */
     text?: string;
     trailingIcon?: HdsIconSignature['Args']['name'];
   };


### PR DESCRIPTION
### :pushpin: Summary

As suggested by @aklkv [in this Slack thread](https://hashicorp.slack.com/archives/C06NMSYDZPA/p1726866221565509) we could communicate these deprecation changes _"also through dev tools (in addition to documentation and deprecation warnings)"_.

After discussion with the HDS Engineering team, we decided this is something we can add to our list of things to do, when deprecating an argument.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a deprecation comment to `@text` argument in `Hds::Dropdown::ListItem::Interactive` component

This is [the only case where this comment can be applied](https://github.com/search?q=repo%3Ahashicorp%2Fdesign-system+%22deprecate%28%22+path%3A%2F%5Epackages%5C%2Fcomponents%5C%2Fsrc%5C%2Fcomponents%5C%2Fhds%5C%2F%2F&type=code). All the other deprecations are entire (sub)components so there's no way to add a comment for the entire component.

I've also updated the documentation in Confluence about [Deprecation of an API feature of a component](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3246130189/Deprecating+a+component+or+one+of+its+APIs#Example---Deprecation-of-an-API-feature-of-a-component)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
