### PR TITLE
Update `SuperSelect` selected list item style

### DIFF
--- a/.changeset/new-days-enjoy.md
+++ b/.changeset/new-days-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SuperSelect` - Update the the default state of selected list items to `Foreground / Primary` to match other list items and the `Dropdown`.

--- a/packages/components/src/styles/components/form/super-select.scss
+++ b/packages/components/src/styles/components/form/super-select.scss
@@ -360,13 +360,23 @@ $hds-super-select-item-height: 36px;
     background-repeat: no-repeat;
     background-position: 15px 10px;
     background-size: var(--token-form-select-background-image-size) var(--token-form-select-background-image-size);
-
+    
     // checked
     &[aria-selected="true"]:not([aria-disabled="true"]) {
-      color: var(--token-color-foreground-action);
+      color: var(--token-color-foreground-primary);
 
       // checkmark icon:
       background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M14.78 4.28a.75.75 0 00-1.06-1.06l-7.97 7.97-3.47-3.47a.75.75 0 00-1.06 1.06l4 4a.75.75 0 001.06 0l8.5-8.5z' fill='%231060ff'/%3E%3C/svg%3E");
+
+      &:hover,
+      &.mock-hover {
+        color: var(--token-color-foreground-action-hover);
+      }
+
+      &:active,
+      &.mock-active {
+        color: var(--token-color-foreground-action-active);
+      }
     }
 
     &[aria-current="true"],


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR updates the default/resting state of selected list items in the `SuperSelect` to `Foreground / Primary` to match other list items and the `Dropdown` component.

### :camera_flash: Screenshots

**Before:**
<img width="584" alt="Screenshot 2024-10-03 at 10 27 57 AM" src="https://github.com/user-attachments/assets/886c655e-645b-4def-b3e8-0fe0550d80df">

**After:**

<img width="596" alt="Screenshot 2024-10-03 at 10 27 24 AM" src="https://github.com/user-attachments/assets/8a0bfbb7-6f15-4eaf-8d45-ef1da1025fce">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3942](https://hashicorp.atlassian.net/browse/HDS-3942)
Figma file: [Figma v2.0 Libraries | SuperSelect](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/%5BWIP%5D-HDS-Components-v2.0?node-id=66693-46041&t=x7kyNHcw8AknH9xw-1)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3942]: https://hashicorp.atlassian.net/browse/HDS-3942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ