### PR TITLE
Update `Accordion::Item` border radius

### DIFF
--- a/.changeset/sharp-wombats-beg.md
+++ b/.changeset/sharp-wombats-beg.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Accordion` - Update the border radius of the Accordion::Item small variant.

--- a/packages/components/src/styles/components/accordion.scss
+++ b/packages/components/src/styles/components/accordion.scss
@@ -40,6 +40,7 @@
   --hds-accordion-item-content-padding-left: 12px;
   --hds-accordion-item-gap: 8px;
   --hds-accordion-item-icon-size: 16px;
+  --hds-accordion-item-border-radius: 3px;
 }
 
 .hds-accordion-item--size-medium {
@@ -51,6 +52,7 @@
   --hds-accordion-item-content-padding-left: 12px;
   --hds-accordion-item-gap: 12px;
   --hds-accordion-item-icon-size: 20px;
+  --hds-accordion-item-border-radius: 6px;
 }
 
 .hds-accordion-item--size-large {
@@ -62,12 +64,13 @@
   --hds-accordion-item-content-padding-left: 16px;
   --hds-accordion-item-gap: 12px;
   --hds-accordion-item-icon-size: 24px;
+  --hds-accordion-item-border-radius: 6px;
 }
 
 .hds-accordion-item--type-card {
   --hds-accordion-item-focus-ring-offset: 0;
   background: var(--token-color-surface-primary);
-  border-radius: 6px;
+  border-radius: var(--hds-accordion-item-border-radius);
 
   &.hds-accordion-item--does-not-contain-interactive:not(.hds-accordion-item--is-static) {
     box-shadow: var(--token-surface-mid-box-shadow);


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the border radius of the `Accordion::Item` small variant to 3px, matching Figma. 

### :hammer_and_wrench: Detailed description

However, a more systematic approach might be to scale the border radius for _all_ items corresponding with the size ([as outlined in this thread and examples](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF?node-id=36870-71031#977041939)):
- Small, 3px (requires change in code)
- Medium, 5px (requires change in Figma and code)
- Large, 6px (requires no change)

Are there any thoughts around this topic?

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3952](https://hashicorp.atlassian.net/browse/HDS-3952)
Figma file: [Thread](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF?node-id=37555-77311#964785115)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3952]: https://hashicorp.atlassian.net/browse/HDS-3952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ