### PR TITLE
Showcase - Small update to the showcase for `AppFrame`

### DIFF
--- a/showcase/app/templates/layouts/app-frame/index.hbs
+++ b/showcase/app/templates/layouts/app-frame/index.hbs
@@ -165,9 +165,17 @@
   <Shw::Text::H3>Framed</Shw::Text::H3>
 
   <Shw::Frame
-    @id="demo-full-app-frame"
+    @id="demo-full-app-frame-lt-480px"
     @src="/layouts/app-frame/frameless/demo-full-app-frame"
-    @label="Full app-frame"
+    @label="Full app-frame (height < 480px)"
+    @height="400"
+  />
+
+  <Shw::Frame
+    @id="demo-full-app-frame-gt-480px"
+    @src="/layouts/app-frame/frameless/demo-full-app-frame"
+    @label="Full app-frame (height > 480px)"
+    @height="500"
   />
 
   <Shw::Frame
@@ -182,9 +190,9 @@
 
   <Shw::Text::H2>Content</Shw::Text::H2>
 
-  {{! 
+  {{!
     Note: The below examples are commented out as they are redundant to the following "Framed" examples.
-    However we still need to find a solution for adding visual regression tests for the framed examples. 
+    However we still need to find a solution for adding visual regression tests for the framed examples.
     (So we may decide to uncomment these examples to add them back to the visual regression tests depending.)
   }}
   {{!-- <Shw::Grid @columns={{1}} {{style gap="2rem"}} as |SG|>


### PR DESCRIPTION
### :pushpin: Summary

While looking at the showcase page for the `AppFrame` component, I noticed that in one of the demo the footer was not visible. I've realized that now the component has different behaviours for when its height is below or above `480px` so I've added a new example to the page, to illustrate this difference (and make sure is tested for visual regressions).

### :hammer_and_wrench: Detailed description

In this PR I have:
- did a small update to the showcase for `AppFrame`

**Preview**: https://hds-showcase-git-showcase-app-frame-update-hashicorp.vercel.app/layouts/app-frame#framed

### :camera_flash: Screenshots

![image](https://github.com/user-attachments/assets/3b5787f7-1000-4038-886c-136349f06645)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
