### PR TITLE
`AppSideNav` - Fix bug with scrolling caused by hidden panels (HDS-3892)

### DIFF
--- a/packages/components/src/styles/components/app-side-nav/content.scss
+++ b/packages/components/src/styles/components/app-side-nav/content.scss
@@ -34,7 +34,14 @@
 }
 
 .hds-app-side-nav__content-panel {
+  // Note: height is impacted by hidden panels if max-height is not set (may not matter but this prevents it)
+  height: max-content;
   padding: 0 var(--token-app-side-nav-wrapper-padding-horizontal);
+  overflow: hidden; // the panel itself does not need to be scrollable
+
+  &[aria-hidden="true"] {
+    max-height: 250px; // prevents hidden panels from causing scrolling
+  }
 }
 
 // (LIST) TITLE

--- a/packages/components/src/styles/components/app-side-nav/content.scss
+++ b/packages/components/src/styles/components/app-side-nav/content.scss
@@ -34,13 +34,11 @@
 }
 
 .hds-app-side-nav__content-panel {
-  // Note: height is impacted by hidden panels if max-height is not set (may not matter but this prevents it)
-  height: max-content;
   padding: 0 var(--token-app-side-nav-wrapper-padding-horizontal);
   overflow: hidden; // the panel itself does not need to be scrollable
 
   &[aria-hidden="true"] {
-    max-height: 220px; // prevents hidden panels from causing scrolling
+    max-height: 0; // prevents hidden panels from causing scrolling
   }
 }
 

--- a/packages/components/src/styles/components/app-side-nav/content.scss
+++ b/packages/components/src/styles/components/app-side-nav/content.scss
@@ -40,7 +40,7 @@
   overflow: hidden; // the panel itself does not need to be scrollable
 
   &[aria-hidden="true"] {
-    max-height: 250px; // prevents hidden panels from causing scrolling
+    max-height: 220px; // prevents hidden panels from causing scrolling
   }
 }
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will prevent unwanted scrollbars from being triggered by hidden panels.
(Merges into `AppSideNav` component branch.)

[AppSideNav within framed layout](https://hds-showcase-git-hds-3892-app-sidenav-scrolling-bug-hashicorp.vercel.app/layouts/app-frame/frameless/demo-full-app-frame-with-app-header-and-app-side-nav), notice you can still scroll all content as before.

### :hammer_and_wrench: Detailed description

Tested locally within Terraform/Atlas.

### :camera_flash: Screenshots

**Fix within Terraform/Atlas**
(_Lime green outline added around visible panel. Purple dashed outlines show layout of hidden panels. Their grid area heights are determined by the height of the visible panel._)

<img width="879" alt="image" src="https://github.com/user-attachments/assets/ca90e7d7-036c-41c2-b693-725feedf9a54">

_NOTE: I tested mainly using the SideNav within Terraform. (Will continue testing with AppSideNav to confirm but should be the same.)_

### :link: External links

* Jira ticket: [HDS-3892](https://hashicorp.atlassian.net/browse/HDS-3892)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3892]: https://hashicorp.atlassian.net/browse/HDS-3892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ