### PR TITLE
fix: usage of @tracked modifier across components

### DIFF
--- a/.changeset/purple-poets-smoke.md
+++ b/.changeset/purple-poets-smoke.md
@@ -2,7 +2,7 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Fixed usage of the `@tracked` modifier in several components:
+Fixed instances where arguments are passed into tracked properties at declaration:
   * `MaskedInput`
   * `TextInput`
   * `Pagination::Compact`

--- a/.changeset/purple-poets-smoke.md
+++ b/.changeset/purple-poets-smoke.md
@@ -1,0 +1,13 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fixed usage of the `@tracked` modifier in several components:
+  * `MaskedInput`
+  * `TextInput`
+  * `Pagination::Compact`
+  * `Pagination::Numbered`
+  * `SideNav`
+  * `Table`
+  * `Table::ThSelectable`
+  * `Tabs`

--- a/packages/components/src/components/hds/form/masked-input/base.ts
+++ b/packages/components/src/components/hds/form/masked-input/base.ts
@@ -4,11 +4,11 @@
  */
 
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { getElementId } from '../../../../utils/hds-get-element-id.ts';
 import type { HdsCopyButtonSignature } from '../../copy/button/index.ts';
 import type { HdsFormVisibilityToggleSignature } from '../visibility-toggle/index.ts';
+import { tracked } from '@glimmer/tracking';
 
 export interface HdsFormMaskedInputBaseSignature {
   Args: {
@@ -28,25 +28,22 @@ export interface HdsFormMaskedInputBaseSignature {
 }
 
 export default class HdsFormMaskedInputBase extends Component<HdsFormMaskedInputBaseSignature> {
-  @tracked isContentMasked = this.args.isContentMasked ?? true;
+  @tracked isContentMasked;
+
+  constructor(owner: unknown, args: HdsFormMaskedInputBaseSignature['Args']) {
+    super(owner, args);
+    this.isContentMasked = this.args.isContentMasked ?? true;
+  }
 
   @action
   onClickToggleMasking(): void {
     this.isContentMasked = !this.isContentMasked;
   }
 
-  /**
-   * Calculates the unique ID to assign to the form control
-   */
   get id(): string {
     return getElementId(this);
   }
 
-  /**
-   * @param ariaLabel
-   * @type {string}
-   * @default 'Show masked content'
-   */
   get visibilityToggleAriaLabel(): string {
     if (this.args.visibilityToggleAriaLabel) {
       return this.args.visibilityToggleAriaLabel;
@@ -57,11 +54,6 @@ export default class HdsFormMaskedInputBase extends Component<HdsFormMaskedInput
     }
   }
 
-  /**
-   * @param ariaMessageText
-   * @type {string}
-   * @default 'Input content is now hidden'
-   */
   get visibilityToggleAriaMessageText(): string {
     if (this.args.visibilityToggleAriaMessageText) {
       return this.args.visibilityToggleAriaMessageText;
@@ -72,11 +64,6 @@ export default class HdsFormMaskedInputBase extends Component<HdsFormMaskedInput
     }
   }
 
-  /**
-   * @param copyButtonText
-   * @type {string}
-   * @default 'Copy masked content'
-   */
   get copyButtonText(): string {
     if (this.args.copyButtonText) {
       return this.args.copyButtonText;
@@ -85,11 +72,6 @@ export default class HdsFormMaskedInputBase extends Component<HdsFormMaskedInput
     }
   }
 
-  /**
-   * Get the class names to apply to the component.
-   * @method classNames
-   * @return {string} The "class" attribute to apply to the component.
-   */
   get classNames(): string {
     const classes = ['hds-form-masked-input'];
 

--- a/packages/components/src/components/hds/form/text-input/field.ts
+++ b/packages/components/src/components/hds/form/text-input/field.ts
@@ -40,23 +40,21 @@ export interface HdsFormTextInputFieldSignature {
 
 export default class HdsFormTextInputField extends Component<HdsFormTextInputFieldSignature> {
   @tracked isPasswordMasked = true;
-  @tracked hasVisibilityToggle = this.args.hasVisibilityToggle ?? true;
-  @tracked type = this.args.type ?? 'text';
+  @tracked type;
 
-  /**
-   * @param showVisibilityToggle
-   * @type {boolean}
-   * @default false
-   */
+  constructor(owner: unknown, args: HdsFormTextInputFieldSignature['Args']) {
+    super(owner, args);
+    this.type = this.args.type ?? 'text';
+  }
+
+  get hasVisibilityToggle(): boolean {
+    return this.args.hasVisibilityToggle ?? true;
+  }
+
   get showVisibilityToggle(): boolean {
     return this.args.type === 'password' && this.hasVisibilityToggle;
   }
 
-  /**
-   * @param visibilityToggleAriaLabel
-   * @type {string}
-   * @default 'Show password'
-   */
   get visibilityToggleAriaLabel(): string | undefined {
     if (this.args.visibilityToggleAriaLabel) {
       return this.args.visibilityToggleAriaLabel;
@@ -67,11 +65,6 @@ export default class HdsFormTextInputField extends Component<HdsFormTextInputFie
     }
   }
 
-  /**
-   * @param visibilityToggleAriaMessageText
-   * @type {string}
-   * @default 'Password is now hidden'
-   */
   get visibilityToggleAriaMessageText(): string | undefined {
     if (this.args.visibilityToggleAriaMessageText) {
       return this.args.visibilityToggleAriaMessageText;

--- a/packages/components/src/components/hds/pagination/compact/index.ts
+++ b/packages/components/src/components/hds/pagination/compact/index.ts
@@ -89,7 +89,7 @@ export default class HdsPaginationCompact extends Component<HdsPaginationCompact
   // In the second case, the variable stores *only* the initial state of the component (coming from the arguments)
   // at rendering time, but from that moment on it's not updated anymore, no matter what interaction the user
   // has with the component (the state is controlled externally, eg. via query parameters)
-  @tracked _currentPageSize = this.args.currentPageSize ?? this.pageSizes[0];
+  @tracked _currentPageSize;
   @tracked isControlled;
 
   showLabels = this.args.showLabels ?? true; // if the labels for the "prev/next" controls are visible
@@ -123,6 +123,9 @@ export default class HdsPaginationCompact extends Component<HdsPaginationCompact
       );
       this.isControlled = true;
     }
+
+    // we assert that `this.pageSizes` will always be an array with at least one item
+    this._currentPageSize = this.args.currentPageSize ?? this.pageSizes[0];
   }
 
   get ariaLabel(): string {

--- a/packages/components/src/components/hds/pagination/numbered/index.ts
+++ b/packages/components/src/components/hds/pagination/numbered/index.ts
@@ -167,9 +167,8 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
   // In the second case, these variables store *only* the initial state of the component (coming from the arguments)
   // at rendering time, but from that moment on they're not updated anymore, no matter what interaction the user
   // has with the component (the state is controlled externally, eg. via query parameters)
-  @tracked _currentPage = this.args.currentPage ?? 1;
-  // we assert that `this.pageSizes` will always be an array with at least one item
-  @tracked _currentPageSize = this.args.currentPageSize ?? this.pageSizes[0]!;
+  @tracked _currentPage;
+  @tracked _currentPageSize;
   @tracked isControlled;
 
   showInfo = this.args.showInfo ?? true; // if the "info" block is visible
@@ -217,6 +216,10 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
       '@totalItems for "Hds::Pagination::Numbered" must be defined as an integer number',
       typeof this.args.totalItems === 'number'
     );
+
+    this._currentPage = this.args.currentPage ?? 1;
+    // we assert that `this.pageSizes` will always be an array with at least one item
+    this._currentPageSize = this.args.currentPageSize ?? this.pageSizes[0];
   }
 
   get ariaLabel(): string {
@@ -258,7 +261,7 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
       // if the component is controlled, `@currentPageSize` is asserted to be a number
       return this.args.currentPageSize as number;
     } else {
-      return this._currentPageSize;
+      return this._currentPageSize as number;
     }
   }
   set currentPageSize(value) {

--- a/packages/components/src/components/hds/popover-primitive/index.ts
+++ b/packages/components/src/components/hds/popover-primitive/index.ts
@@ -59,7 +59,7 @@ export interface SetupPrimitivePopoverModifier {
 }
 
 export default class HdsPopoverPrimitive extends Component<HdsPopoverPrimitiveSignature> {
-  @tracked isOpen = this.args.isOpen ?? false;
+  @tracked isOpen;
   @tracked isClosing = false;
   containerElement?: HTMLElement;
   toggleElement?: HTMLButtonElement;
@@ -69,6 +69,11 @@ export default class HdsPopoverPrimitive extends Component<HdsPopoverPrimitiveSi
   // this will enable "click" events for the toggle
   enableClickEvents = this.args.enableClickEvents ?? false;
   timer?: ReturnType<typeof setTimeout> | null;
+
+  constructor(owner: unknown, args: HdsPopoverPrimitiveSignature['Args']) {
+    super(owner, args);
+    this.isOpen = this.args.isOpen ?? false;
+  }
 
   setupPrimitiveContainer = modifier<SetupPrimitiveContainerModifier>(
     (element: HTMLElement): void => {

--- a/packages/components/src/components/hds/side-nav/index.ts
+++ b/packages/components/src/components/hds/side-nav/index.ts
@@ -51,11 +51,10 @@ export interface HdsSideNavSignature {
 }
 
 export default class HdsSideNav extends Component<HdsSideNavSignature> {
-  @tracked isResponsive = this.args.isResponsive ?? true; // controls if the component reacts to viewport changes
-  @tracked isMinimized = this.args.isMinimized ?? false; // sets the default state on 'desktop' viewports
-  @tracked isCollapsible = this.args.isCollapsible ?? false; // controls if users can collapse the sidenav on 'desktop' viewports
   @tracked isAnimating = false;
   @tracked isDesktop = true;
+  @tracked isMinimized = false;
+
   desktopMQ: MediaQueryList;
   containersToHide!: NodeListOf<Element>;
   hasA11yRefocus = this.args.hasA11yRefocus ?? true;
@@ -67,7 +66,8 @@ export default class HdsSideNav extends Component<HdsSideNavSignature> {
 
   constructor(owner: unknown, args: HdsSideNavSignature['Args']) {
     super(owner, args);
-
+    // sets the default minimized state on 'desktop' viewports
+    this.isMinimized = this.args.isMinimized ?? false;
     this.desktopMQ = window.matchMedia(`(min-width:${this.desktopMQVal})`);
     this.addEventListeners();
     registerDestructor(this, (): void => {
@@ -96,6 +96,16 @@ export default class HdsSideNav extends Component<HdsSideNavSignature> {
       this.updateDesktopVariable,
       true
     );
+  }
+
+  // controls if the component reacts to viewport changes
+  get isResponsive(): boolean {
+    return this.args.isResponsive ?? true;
+  }
+
+  // controls if users can collapse the appsidenav on 'desktop' viewports
+  get isCollapsible(): boolean {
+    return this.args.isCollapsible ?? false;
   }
 
   get shouldTrapFocus(): boolean {

--- a/packages/components/src/components/hds/table/index.ts
+++ b/packages/components/src/components/hds/table/index.ts
@@ -87,12 +87,18 @@ export interface HdsTableSignature {
 }
 
 export default class HdsTable extends Component<HdsTableSignature> {
-  @tracked sortBy = this.args.sortBy ?? undefined;
-  @tracked sortOrder = this.args.sortOrder || HdsTableThSortOrderValues.Asc;
+  @tracked sortBy;
+  @tracked sortOrder;
   @tracked selectAllCheckbox?: HdsFormCheckboxBaseSignature['Element'] =
     undefined;
   selectableRows: HdsTableSelectableRow[] = [];
   @tracked isSelectAllCheckboxSelected?: boolean = undefined;
+
+  constructor(owner: unknown, args: HdsTableSignature['Args']) {
+    super(owner, args);
+    this.sortBy = this.args.sortBy ?? undefined;
+    this.sortOrder = this.args.sortOrder ?? HdsTableThSortOrderValues.Asc;
+  }
 
   get getSortCriteria(): string | HdsTableSortingFunction<unknown> {
     // get the current column

--- a/packages/components/src/components/hds/table/th-selectable.ts
+++ b/packages/components/src/components/hds/table/th-selectable.ts
@@ -41,12 +41,16 @@ export interface HdsTableThSelectableSignature {
 }
 
 export default class HdsTableThSelectable extends Component<HdsTableThSelectableSignature> {
-  @tracked isSelected = this.args.isSelected ?? false;
-
+  @tracked isSelected: boolean;
   guid = guidFor(this);
 
   checkboxId = `checkbox-${this.guid}`;
   labelId = `label-${this.guid}`;
+
+  constructor(owner: unknown, args: HdsTableThSelectableSignature['Args']) {
+    super(owner, args);
+    this.isSelected = this.args.isSelected ?? false;
+  }
 
   get isSortable(): boolean {
     return this.args.onClickSortBySelected !== undefined;

--- a/packages/components/src/components/hds/tabs/index.ts
+++ b/packages/components/src/components/hds/tabs/index.ts
@@ -39,7 +39,7 @@ export default class HdsTabs extends Component<HdsTabsSignature> {
   @tracked tabIds: HdsTabsTabIds = [];
   @tracked panelNodes: HTMLElement[] = [];
   @tracked panelIds: HdsTabsPanelIds = [];
-  @tracked _selectedTabIndex = this.args.selectedTabIndex ?? 0;
+  @tracked _selectedTabIndex;
   @tracked selectedTabId?: string;
   @tracked isControlled: boolean;
 
@@ -69,6 +69,7 @@ export default class HdsTabs extends Component<HdsTabsSignature> {
 
     // this is to determine if the "selected" tab logic is controlled in the consumers' code or is maintained as an internal state
     this.isControlled = this.args.selectedTabIndex !== undefined;
+    this._selectedTabIndex = this.args.selectedTabIndex ?? 0;
   }
 
   get selectedTabIndex(): number {

--- a/showcase/tests/integration/components/hds/pagination/numbered-test.js
+++ b/showcase/tests/integration/components/hds/pagination/numbered-test.js
@@ -75,9 +75,10 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
   });
 
   test('it renders the passed in currentPageSize value', async function (assert) {
-    await render(hbs`
-      <Hds::Pagination::Numbered @totalItems={{100}} @currentPageSize={{40}} @pageSizes={{array 20 40 60}} />
-    `);
+    await render(
+      hbs`<Hds::Pagination::Numbered @totalItems={{100}} @currentPageSize={{40}} @pageSizes={{array 20 40 60}} />`
+    );
+
     assert.dom('.hds-pagination .hds-pagination-info').hasText('1–40 of 100');
     assert
       .dom('.hds-pagination .hds-pagination-size-selector select')

--- a/showcase/tests/integration/components/hds/popover-primitive/index-test.js
+++ b/showcase/tests/integration/components/hds/popover-primitive/index-test.js
@@ -239,6 +239,17 @@ module(
         .dom('#test-popover-primitive-content')
         .hasAttribute('popover', 'auto');
     });
+    test('the popover is open when `isOpen` is true', async function (assert) {
+      await render(hbs`
+        <Hds::PopoverPrimitive @enableClickEvents={{true}} @isOpen={{true}} as |PP|>
+          <div {{PP.setupPrimitiveContainer}}>
+            <button {{PP.setupPrimitiveToggle}} id="test-popover-primitive-toggle" />
+            <div {{PP.setupPrimitivePopover}} id="test-popover-primitive-content" />
+          </div>
+        </Hds::PopoverPrimitive>
+      `);
+      assert.dom('#test-popover-primitive-content').isVisible();
+    });
 
     // ASSERTIONS
 

--- a/website/app/components/doc/copy-button/index.js
+++ b/website/app/components/doc/copy-button/index.js
@@ -8,11 +8,13 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class DocCopyButtonComponent extends Component {
-  // options are `solid` or `ghost`
-  @tracked type = this.args.type ?? 'solid';
   @tracked status = 'idle';
   @tracked iconName = 'clipboard-copy';
   @tracked timer;
+
+  get type() {
+    return this.args.type ?? 'solid'; // options are `solid` or `ghost`
+  }
 
   get label() {
     let label;

--- a/website/app/components/doc/table-of-contents/collapsible-item.js
+++ b/website/app/components/doc/table-of-contents/collapsible-item.js
@@ -11,8 +11,8 @@ import { action } from '@ember/object';
 export default class DocTocCollapsibleItem extends Component {
   @tracked isOpen;
 
-  constructor(args) {
-    super(...args);
+  constructor(owner, args) {
+    super(owner, args);
     this.isOpen = this.args.item.isOpen ?? false;
   }
 

--- a/website/app/components/doc/table-of-contents/collapsible-item.js
+++ b/website/app/components/doc/table-of-contents/collapsible-item.js
@@ -4,11 +4,17 @@
  */
 
 import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
+import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
+
 export default class DocTocCollapsibleItem extends Component {
-  @tracked isOpen = this.args.item.isOpen ?? false;
+  @tracked isOpen;
+
+  constructor(args) {
+    super(...args);
+    this.isOpen = this.args.item.isOpen ?? false;
+  }
 
   @action toggleIsOpen() {
     this.isOpen = !this.isOpen;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix usage of the `@tracked` modifier based on [this Slack conversation](https://hashicorp.slack.com/archives/C7KTUHNUS/p1728404760159249).

### :hammer_and_wrench: Detailed description

The components that were updated are:
  * `MaskedInput`
  * `TextInput`
  * `Pagination::Compact`
  * `Pagination::Numbered`
  * `SideNav`
  * `Table`
  * `Table::ThSelectable`
  * `Tabs`

Plus a couple fixes in the website.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3975](https://hashicorp.atlassian.net/browse/HDS-3975)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3975]: https://hashicorp.atlassian.net/browse/HDS-3975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ