### PR TITLE
`Dropdown` - Small changes to logic for content being preserved in the DOM (on top of #2490)

### DIFF
--- a/.changeset/curly-apples-share.md
+++ b/.changeset/curly-apples-share.md
@@ -2,4 +2,7 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Dropdown` - Fixed content being preserved in the DOM when closed and removed the `isOpen` yielded argument
+`Dropdown`
+
+- Fixed content being preserved in the DOM when closed
+- Added `@preserveDomContent` to optionally control rendering of the content

--- a/packages/components/src/components/hds/dropdown/index.hbs
+++ b/packages/components/src/components/hds/dropdown/index.hbs
@@ -17,7 +17,7 @@
       {{style width=@width max-height=@height}}
       {{PP.setupPrimitivePopover anchoredPositionOptions=this.anchoredPositionOptions}}
     >
-      {{#if PP.isOpen}}
+      {{#if (or PP.isOpen @preserveDomContent)}}
         {{yield (hash Header=(component "hds/dropdown/header"))}}
         <ul class="hds-dropdown__list" {{did-insert this.didInsertList}}>
           {{yield

--- a/packages/components/src/components/hds/dropdown/index.hbs
+++ b/packages/components/src/components/hds/dropdown/index.hbs
@@ -23,6 +23,7 @@
           {{yield
             (hash
               close=PP.hidePopover
+              isOpen=PP.isOpen
               Checkbox=(component "hds/dropdown/list-item/checkbox")
               Checkmark=(component "hds/dropdown/list-item/checkmark")
               CopyItem=(component "hds/dropdown/list-item/copy-item")

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -44,6 +44,7 @@ export interface HdsDropdownSignature {
     listPosition?: HdsDropdownPositions;
     width?: string;
     enableCollisionDetection?: FloatingUIOptions['enableCollisionDetection'];
+    preserveDomContent?: boolean;
   };
   Blocks: {
     default: [

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -63,6 +63,7 @@ export interface HdsDropdownSignature {
         ToggleButton?: ComponentLike<HdsDropdownToggleButtonSignature>;
         ToggleIcon?: ComponentLike<HdsDropdownToggleIconSignature>;
         close?: () => void;
+        isOpen?: boolean;
       },
     ];
   };

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -1539,6 +1539,21 @@
         </Hds::Dropdown>
       </div>
     </SG.Item>
+    <SG.Item @label="Using preserveDomContent argument in combination with isOpen state">
+      <div class="shw-component-dropdown-fixed-height-container">
+        <Hds::Dropdown @listPosition="bottom-left" @preserveDomContent={{true}} as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Interactive @href="#">
+            This item should always be present in the DOM, regardless of whether the dropdown is open or closed
+          </D.Interactive>
+          {{#if D.isOpen}}
+            <D.Interactive @href="#">
+              This item should be injected in the DOM only when the dropdown is open, and removed when closed
+            </D.Interactive>
+          {{/if}}
+        </Hds::Dropdown>
+      </div>
+    </SG.Item>
   </Shw::Grid>
 
 </section>

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -83,7 +83,7 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
       .hasClass('hds-dropdown__footer--with-divider');
   });
 
-  test('it does not render the "list-item" sub-components when closed', async function (assert) {
+  test('it does not render the "list-item" sub-components when closed, by default', async function (assert) {
     await render(hbs`
       <Hds::Dropdown id="test-dropdown" as |D|>
         <D.ToggleButton @text="toggle button" id="test-toggle-button" />
@@ -99,6 +99,47 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown #test-header').doesNotExist();
     assert.dom('#test-dropdown .hds-dropdown__list').doesNotExist();
     assert.dom('#test-dropdown #test-footer').doesNotExist();
+  });
+
+  test('it renders the "list-item" sub-components even when closed, when `@preserveDomContent` is `true`', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" @preserveDomContent={{true}} as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Header id="test-header">Header</D.Header>
+        <D.Interactive id="test-list-item" @route="components.dropdown" @text="interactive-always-rendered" />
+        <D.Footer id="test-footer">Footer</D.Footer>
+      </Hds::Dropdown>
+    `);
+
+    // the container should exist in the DOM
+    assert.dom('#test-dropdown .hds-dropdown__content').exists();
+    // the list content should too
+    assert.dom('#test-dropdown #test-header').exists();
+    assert.dom('#test-dropdown .hds-dropdown__list').exists();
+    assert.dom('#test-dropdown #test-list-item').exists();
+    assert.dom('#test-dropdown #test-footer').exists();
+  });
+
+  test('it conditionally renders the "list-item" sub-components via `isOpen`, when `@preserveDomContent` is `true`', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" @preserveDomContent={{true}} as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Interactive id="test-list-item-always-rendered" @route="components.dropdown" @text="interactive-always-rendered" />
+        {{#if D.isOpen}}
+          <D.Interactive id="test-list-item-rendered-on-open" @route="components.dropdown" @text="interactive-rendered-on-open" />
+        {{/if}}
+      </Hds::Dropdown>
+    `);
+
+    // the content should be visible, unless hidden via `isOpen`
+    assert.dom('#test-dropdown #test-list-item-always-rendered').exists();
+    assert
+      .dom('#test-dropdown #test-list-item-rendered-on-open')
+      .doesNotExist();
+    // the content hidden via `isOpen` should now exist when opened
+    await click('button#test-toggle-button');
+    assert.dom('#test-dropdown #test-list-item-always-rendered').exists();
+    assert.dom('#test-dropdown #test-list-item-rendered-on-open').exists();
   });
 
   // POSITION

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -61,6 +61,9 @@ The Dropdown component is composed of different child components each with their
     <br/><br/>
     If this function is invoked using an `\{{on "click"}}` modifier applied to the `ListItem::Interactive` element, there is a quirky behavior of the Ember `<LinkTo>` component which requires a workaround to have the events executed in the right order (this happens only if it has a `@route` argument). Read more about the issue and a possible solution [in this GitHub comment](https://github.com/hashicorp/design-system/pull/399#issuecomment-1171186772).
   </C.Property>
+  <C.Property @name="[D].isOpen" @type="boolean" @default="false" @values={{array "true" "false"}}>
+    The state of the Dropdown yielded to the content.
+  </C.Property>
   <C.Property @name="listPosition" @type="string" @values={{array "bottom-left" "bottom-right" "top-left" "top-right" }} @default="bottom-right">
     _Note: If `@enableCollisionDetection` is set, the list will automatically flip position to remain visible when near the edges of the screen regardless of the starting placement._
   </C.Property>
@@ -78,6 +81,9 @@ The Dropdown component is composed of different child components each with their
   </C.Property>
   <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
     If a `@height` parameter is provided then the list will have a max-height.
+  </C.Property>
+  <C.Property @name="preserveDomContent" @type="boolean" @default="false">
+    Controls if the content is always rendered in the DOM, even when the Dropdown is closed. Can be used in combination with the `[D].isOpen` status to control what is rendered and what is not inside the content (eg. for lazy-loading some list items or the header/footer, while the rest is preloaded).
   </C.Property>
   <C.Property @name="onClose" @type="function">
     Callback function invoked when the Dropdown is closed, if provided.

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -187,6 +187,24 @@ It is possible that you may want to add a list footer for things like a set of b
 </Hds::Dropdown>
 ```
 
+### List rendering in the DOM
+
+By default, the content of the Dropdown is not rendered into the browser when the Dropdown is closed.
+
+To change this behavior, you can use the `@preserveDomContent` argument so that the content is rendered in the DOM, regardless of whether the Dropdown is open or closed.
+
+In this case, you can have a fine control of what is rendered and what is not using the yielded `[D].isOpen` state to conditionally render some of the content only when the Dropdown is open (eg. for lazy-loading some list items or the header/footer, while the rest is preloaded).
+
+```handlebars
+<Hds::Dropdown @preserveDomContent={{true}} as |D|>
+  <D.ToggleButton @text="Text Toggle" />
+  <D.Interactive @route="components" @text="This item should always be present in the DOM, regardless of whether the dropdown is open or closed" />
+  {{#if D.isOpen}}
+    <D.Interactive @route="components" @text="This item should be injected in the DOM only when the dropdown is open, and removed when closed" />
+  {{/if}}
+</Hds::Dropdown>
+```
+
 ### ListItem::Interactive
 
 `ListItem::Interactive` renders the correct element based on the passing of a `@route`, `@href`, or the addition of a click event (e.g.,


### PR DESCRIPTION
### :pushpin: Summary

_⚠️ This PR is built on top of #2490, which is still in review. ⚠️_

The intent of this PR is to propose a middle ground between the previous implementation, where the content was always present in the DOM, even when the dropdown is closed, and the changes (rollback) done in #2490, where the content is never present in the DOM when the dropdown is closed.

The idea is to give consumers a way - through a dedicated `@preserveDomContent` argument (name TBD) - to opt-in in rendering the list content also when the dropdown is closed (and potentially have a finer control of what is rendered and what is not via the `isOpen` yielded status.

### :hammer_and_wrench: Detailed description

In this PR I have:
- introduced `preserveDomContent` argument to control rendering of the list in the DOM (name TBD)
- added back the `isOpen` yielded status that was removed in #2490
- added back a showcase demo where we use the `@preserveDomContent` argument in combination with the `isOpen` state
- updated the documentation
- updated the integration tests
- updated the changeset description

**Preview**: https://hds-showcase-git-revert-2443-hds-3871-dropdown-29f41d-hashicorp.vercel.app/components/dropdown#demo

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
