### PR TITLE
Showcase `.gts` - Convert some components to TemplateOnly

### DIFF
--- a/showcase/app/components/shw/divider/index.gts
+++ b/showcase/app/components/shw/divider/index.gts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { concat } from '@ember/helper';
 
 export interface ShwDividerSignature {
@@ -13,10 +13,8 @@ export interface ShwDividerSignature {
   Element: HTMLHRElement;
 }
 
-export default class ShwDivider extends Component<ShwDividerSignature> {
-  <template>
-    <hr
-      class="shw-divider {{if @level (concat 'shw-divider--level-' @level)}}"
-    />
-  </template>
-}
+const ShwDivider: TemplateOnlyComponent<ShwDividerSignature> = <template>
+  <hr class="shw-divider {{if @level (concat 'shw-divider--level-' @level)}}" />
+</template>;
+
+export default ShwDivider;

--- a/showcase/app/components/shw/label/index.gts
+++ b/showcase/app/components/shw/label/index.gts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 export interface ShwLabelSignature {
   Blocks: {
@@ -12,10 +12,10 @@ export interface ShwLabelSignature {
   Element: HTMLParagraphElement;
 }
 
-export default class ShwLabel extends Component<ShwLabelSignature> {
-  <template>
-    <p class="shw-label shw-text-body-small" ...attributes>
-      {{yield}}
-    </p>
-  </template>
-}
+const ShwLabel: TemplateOnlyComponent<ShwLabelSignature> = <template>
+  <p class="shw-label shw-text-body-small" ...attributes>
+    {{yield}}
+  </p>
+</template>;
+
+export default ShwLabel;

--- a/showcase/app/components/shw/outliner/index.gts
+++ b/showcase/app/components/shw/outliner/index.gts
@@ -2,7 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-import Component from '@glimmer/component';
+
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 export interface ShwOutlinerSignature {
   Blocks: {
@@ -11,10 +12,10 @@ export interface ShwOutlinerSignature {
   Element: HTMLDivElement;
 }
 
-export default class ShwOutliner extends Component<ShwOutlinerSignature> {
-  <template>
-    <div class="shw-outliner" ...attributes>
-      {{yield}}
-    </div>
-  </template>
-}
+const ShwOutliner: TemplateOnlyComponent<ShwOutlinerSignature> = <template>
+  <div class="shw-outliner" ...attributes>
+    {{yield}}
+  </div>
+</template>;
+
+export default ShwOutliner;

--- a/showcase/app/components/shw/text/body.gts
+++ b/showcase/app/components/shw/text/body.gts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import ShwText from './index';
 import type { ShwTextSignature } from './index';
@@ -20,14 +20,14 @@ export interface ShwBodySignature {
   Element: ShwTextSignature['Element'];
 }
 
-export default class ShwTextBody extends Component<ShwBodySignature> {
-  <template>
-    <ShwText
-      @variant="body"
-      @align={{@align}}
-      @weight={{@weight}}
-      @tag={{@tag}}
-      ...attributes
-    >{{yield}}</ShwText>
-  </template>
-}
+const ShwTextBody: TemplateOnlyComponent<ShwBodySignature> = <template>
+  <ShwText
+    @variant="body"
+    @align={{@align}}
+    @weight={{@weight}}
+    @tag={{@tag}}
+    ...attributes
+  >{{yield}}</ShwText>
+</template>;
+
+export default ShwTextBody;

--- a/showcase/app/components/shw/text/h1.gts
+++ b/showcase/app/components/shw/text/h1.gts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import ShwText from './index';
 import type { ShwTextSignature } from './index';
@@ -20,14 +20,14 @@ export interface ShwTextH1Signature {
   Element: ShwTextSignature['Element'];
 }
 
-export default class ShwTextH1 extends Component<ShwTextH1Signature> {
-  <template>
-    <ShwText
-      @variant="h1"
-      @align={{@align}}
-      @weight={{@weight}}
-      @tag={{@tag}}
-      ...attributes
-    >{{yield}}</ShwText>
-  </template>
-}
+const ShwTextH1: TemplateOnlyComponent<ShwTextH1Signature> = <template>
+  <ShwText
+    @variant="h1"
+    @align={{@align}}
+    @weight={{@weight}}
+    @tag={{@tag}}
+    ...attributes
+  >{{yield}}</ShwText>
+</template>;
+
+export default ShwTextH1;

--- a/showcase/app/components/shw/text/h2.gts
+++ b/showcase/app/components/shw/text/h2.gts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import ShwText from './index';
 import type { ShwTextSignature } from './index';
@@ -20,14 +20,14 @@ export interface ShwTextH2Signature {
   Element: ShwTextSignature['Element'];
 }
 
-export default class ShwTextH2 extends Component<ShwTextH2Signature> {
-  <template>
-    <ShwText
-      @variant="h2"
-      @align={{@align}}
-      @weight={{@weight}}
-      @tag={{@tag}}
-      ...attributes
-    >{{yield}}</ShwText>
-  </template>
-}
+const ShwTextH2: TemplateOnlyComponent<ShwTextH2Signature> = <template>
+  <ShwText
+    @variant="h2"
+    @align={{@align}}
+    @weight={{@weight}}
+    @tag={{@tag}}
+    ...attributes
+  >{{yield}}</ShwText>
+</template>;
+
+export default ShwTextH2;

--- a/showcase/app/components/shw/text/h3.gts
+++ b/showcase/app/components/shw/text/h3.gts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import ShwText from './index';
 import type { ShwTextSignature } from './index';
@@ -20,14 +20,14 @@ export interface ShwTextH3Signature {
   Element: ShwTextSignature['Element'];
 }
 
-export default class ShwTextH3 extends Component<ShwTextH3Signature> {
-  <template>
-    <ShwText
-      @variant="h3"
-      @align={{@align}}
-      @weight={{@weight}}
-      @tag={{@tag}}
-      ...attributes
-    >{{yield}}</ShwText>
-  </template>
-}
+const ShwTextH3: TemplateOnlyComponent<ShwTextH3Signature> = <template>
+  <ShwText
+    @variant="h3"
+    @align={{@align}}
+    @weight={{@weight}}
+    @tag={{@tag}}
+    ...attributes
+  >{{yield}}</ShwText>
+</template>;
+
+export default ShwTextH3;

--- a/showcase/app/components/shw/text/h4.gts
+++ b/showcase/app/components/shw/text/h4.gts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import ShwText from './index';
 import type { ShwTextSignature } from './index';
@@ -20,14 +20,14 @@ export interface ShwTextH4Signature {
   Element: ShwTextSignature['Element'];
 }
 
-export default class ShwTextH4 extends Component<ShwTextH4Signature> {
-  <template>
-    <ShwText
-      @variant="h4"
-      @align={{@align}}
-      @weight={{@weight}}
-      @tag={{@tag}}
-      ...attributes
-    >{{yield}}</ShwText>
-  </template>
-}
+const ShwTextH4: TemplateOnlyComponent<ShwTextH4Signature> = <template>
+  <ShwText
+    @variant="h4"
+    @align={{@align}}
+    @weight={{@weight}}
+    @tag={{@tag}}
+    ...attributes
+  >{{yield}}</ShwText>
+</template>;
+
+export default ShwTextH4;


### PR DESCRIPTION
### :pushpin: Summary

This PR is the last in the epic to convert the showcase components to the `.gts` format, and intends to convert some of the components that don't need a "backing class" to the simplest TemplateOnly format.

### :hammer_and_wrench: Detailed description

In this PR I have:
- converted `Shw::Divider` to TemplateOnlyComponent
- converted `Shw::Label` to TemplateOnlyComponent
- converted `Shw::Outliner` to TemplateOnlyComponent
- converted `Shw::Text::[Body/H1/H2/H3/H4]` to TemplateOnlyComponent

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-3920

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
