### PR TITLE
Showcase - Added demo to `Modal` and `Flyout` pages in which the modal is opened via a `Dropdown`

### DIFF
--- a/showcase/app/controllers/components/flyout.js
+++ b/showcase/app/controllers/components/flyout.js
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 export default class FlyoutController extends Controller {
   @tracked mediumFlyoutActive = false;
   @tracked largeFlyoutActive = false;
+  @tracked dropdownInitiatedFlyoutActive = false;
 
   @action
   activateFlyout(Flyout) {

--- a/showcase/app/controllers/components/modal.js
+++ b/showcase/app/controllers/components/modal.js
@@ -18,6 +18,7 @@ export default class ModalController extends Controller {
   @tracked superselectModalActive3 = false;
   @tracked dismissDisabledModalActive = false;
   @tracked isDismissDisabled;
+  @tracked dropdownInitiatedModalActive = false;
 
   @action
   activateModal(modal) {

--- a/showcase/app/templates/components/flyout.hbs
+++ b/showcase/app/templates/components/flyout.hbs
@@ -251,4 +251,33 @@
       </F.Footer>
     </Hds::Flyout>
   {{/if}}
+
+  <br />
+  <br />
+
+  <Hds::Dropdown @listPosition="bottom-left" as |D|>
+    <D.ToggleButton @color="secondary" @size="small" @text="Open flyout via dropdown" />
+    <D.Interactive {{on "click" (fn this.activateFlyout "dropdownInitiatedFlyoutActive")}}>
+      Open flyout
+    </D.Interactive>
+  </Hds::Dropdown>
+
+  {{#if this.dropdownInitiatedFlyoutActive}}
+    <Hds::Flyout
+      id="dropdown-initiated-flyout"
+      @onClose={{fn this.deactivateFlyout "dropdownInitiatedFlyoutActive"}}
+      as |M|
+    >
+      <M.Header>
+        Flyout title
+      </M.Header>
+      <M.Body>
+        <p class="hds-typography-body-300 hds-foreground-primary">Flyout content</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />
+      </M.Footer>
+    </Hds::Flyout>
+  {{/if}}
+
 </section>

--- a/showcase/app/templates/components/modal.hbs
+++ b/showcase/app/templates/components/modal.hbs
@@ -509,5 +509,33 @@
     </Hds::Modal>
   {{/if}}
 
+  <br />
+  <br />
+
+  <Hds::Dropdown @listPosition="bottom-left" as |D|>
+    <D.ToggleButton @color="secondary" @size="small" @text="Open modal via dropdown" />
+    <D.Interactive {{on "click" (fn this.activateModal "dropdownInitiatedModalActive")}}>
+      Open modal
+    </D.Interactive>
+  </Hds::Dropdown>
+
+  {{#if this.dropdownInitiatedModalActive}}
+    <Hds::Modal
+      id="dropdown-initiated-modal"
+      @onClose={{fn this.deactivateModal "dropdownInitiatedModalActive"}}
+      as |M|
+    >
+      <M.Header>
+        Modal title
+      </M.Header>
+      <M.Body>
+        <p class="hds-typography-body-300 hds-foreground-primary">Modal content</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
+
 </section>
 {{! template-lint-enable no-autofocus-attribute }}


### PR DESCRIPTION
### :pushpin: Summary

While working on the `HdsPlus::ChallengeModal` one argument that is missing from our `Hds::Modal`, looking at the implementation of similar components in our consumers' codebases, is the `returnFocusTo` ([see here](https://github.com/hashicorp/cloud-ui/blob/main/addons/core/package/src/components/modal-dialog.ts#L236-L241)). I am thinking to introduce a similar functionality in our Modal component too (and potentially the Flyout). 

This is the first step, used to show how the focus is "lost" once the modal is closed: is not returned to the original element that opened the modal, since it's deleted from the DOM, so it's assigned to the `body`.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a small demo to `Modal` showcase page in which the modal is opened via a `Dropdown`
- added a small demo to `Flyout` showcase page in which the modal is opened via a `Dropdown`

👀  **Previews**: 
- Modal: https://hds-showcase-git-showcase-modal-add-extra-use-case-hashicorp.vercel.app/components/modal#demo
- Flyout: https://hds-showcase-git-showcase-modal-add-extra-use-case-hashicorp.vercel.app/components/flyout#demo

### 🎬 Video

You can see how the focus is returned to the `body` once the Modal is closed (look at the `document.activeElement` live variable in the devtools on the right)

https://github.com/user-attachments/assets/5ad62dc0-3bfa-40f4-a25f-548aac9e44f6

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
