### PR TITLE
`Modal`/` Flyout` - Add `returnFocusTo` argument for consumer-side focus management on close

### DIFF
--- a/.changeset/brown-eagles-fry.md
+++ b/.changeset/brown-eagles-fry.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Modal` - added `returnFocusTo` argument to control where the browser focus is returned once the modal is closed
+
+`Flyout` - added `returnFocusTo` argument to control where the browser focus is returned once the flyout is closed

--- a/packages/components/src/components/hds/flyout/index.ts
+++ b/packages/components/src/components/hds/flyout/index.ts
@@ -28,6 +28,7 @@ export const SIZES: string[] = Object.values(HdsFlyoutSizesValues);
 export interface HdsFlyoutSignature {
   Args: {
     size?: HdsFlyoutSizes;
+    returnFocusTo?: string;
     onOpen?: () => void;
     onClose?: (event: Event) => void;
   };
@@ -185,6 +186,14 @@ export default class HdsFlyout extends Component<HdsFlyoutSignature> {
         }
       } else {
         this.body.style.setProperty('overflow', this.bodyInitialOverflowValue);
+      }
+    }
+
+    // Return focus to a specific element (if provided)
+    if (this.args.returnFocusTo) {
+      const initiator = document.getElementById(this.args.returnFocusTo);
+      if (initiator) {
+        initiator.focus();
       }
     }
   }

--- a/packages/components/src/components/hds/modal/index.ts
+++ b/packages/components/src/components/hds/modal/index.ts
@@ -31,6 +31,7 @@ export interface HdsModalSignature {
     isDismissDisabled?: boolean;
     size?: HdsModalSizes;
     color?: HdsModalColors;
+    returnFocusTo?: string;
     onOpen?: () => void;
     onClose?: (event: Event) => void;
   };
@@ -203,6 +204,14 @@ export default class HdsModal extends Component<HdsModalSignature> {
         }
       } else {
         this.body.style.setProperty('overflow', this.bodyInitialOverflowValue);
+      }
+    }
+
+    // Return focus to a specific element (if provided)
+    if (this.args.returnFocusTo) {
+      const initiator = document.getElementById(this.args.returnFocusTo);
+      if (initiator) {
+        initiator.focus();
       }
     }
   }

--- a/showcase/app/controllers/components/flyout.js
+++ b/showcase/app/controllers/components/flyout.js
@@ -10,6 +10,8 @@ import { tracked } from '@glimmer/tracking';
 export default class FlyoutController extends Controller {
   @tracked mediumFlyoutActive = false;
   @tracked largeFlyoutActive = false;
+  @tracked dropdownInitiatedFlyoutActive = false;
+  @tracked dropdownInitiatedWithReturnedFocusFlyoutActive = false;
 
   @action
   activateFlyout(Flyout) {

--- a/showcase/app/controllers/components/modal.js
+++ b/showcase/app/controllers/components/modal.js
@@ -18,6 +18,8 @@ export default class ModalController extends Controller {
   @tracked superselectModalActive3 = false;
   @tracked dismissDisabledModalActive = false;
   @tracked isDismissDisabled;
+  @tracked dropdownInitiatedModalActive = false;
+  @tracked dropdownInitiatedWithReturnedFocusModalActive = false;
 
   @action
   activateModal(modal) {

--- a/showcase/app/templates/components/flyout.hbs
+++ b/showcase/app/templates/components/flyout.hbs
@@ -251,4 +251,64 @@
       </F.Footer>
     </Hds::Flyout>
   {{/if}}
+
+  <br />
+  <br />
+
+  <Hds::Dropdown @listPosition="bottom-left" @isInline={{true}} as |D|>
+    <D.ToggleButton @color="secondary" @size="small" @text="Open flyout via dropdown" />
+    <D.Interactive {{on "click" (fn this.activateFlyout "dropdownInitiatedFlyoutActive")}}>
+      Open flyout
+    </D.Interactive>
+  </Hds::Dropdown>
+
+  {{#if this.dropdownInitiatedFlyoutActive}}
+    <Hds::Flyout
+      id="dropdown-initiated-flyout"
+      @onClose={{fn this.deactivateFlyout "dropdownInitiatedFlyoutActive"}}
+      as |M|
+    >
+      <M.Header>
+        Flyout title
+      </M.Header>
+      <M.Body>
+        <p class="hds-typography-body-300 hds-foreground-primary">Flyout content</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />
+      </M.Footer>
+    </Hds::Flyout>
+  {{/if}}
+
+  <Hds::Dropdown @listPosition="bottom-left" @isInline={{true}} as |D|>
+    <D.ToggleButton
+      id="dropdown-initiated-flyout-with-returned-focus-toggle"
+      @color="secondary"
+      @size="small"
+      @text="Open flyout via dropdown (with returned focus)"
+    />
+    <D.Interactive {{on "click" (fn this.activateFlyout "dropdownInitiatedWithReturnedFocusFlyoutActive")}}>
+      Open flyout
+    </D.Interactive>
+  </Hds::Dropdown>
+
+  {{#if this.dropdownInitiatedWithReturnedFocusFlyoutActive}}
+    <Hds::Flyout
+      id="dropdown-initiated-flyout-with-returned-focus"
+      @onClose={{fn this.deactivateFlyout "dropdownInitiatedWithReturnedFocusFlyoutActive"}}
+      @returnFocusTo="dropdown-initiated-flyout-with-returned-focus-toggle"
+      as |M|
+    >
+      <M.Header>
+        Flyout title
+      </M.Header>
+      <M.Body>
+        <p class="hds-typography-body-300 hds-foreground-primary">Flyout content</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />
+      </M.Footer>
+    </Hds::Flyout>
+  {{/if}}
+
 </section>

--- a/showcase/app/templates/components/modal.hbs
+++ b/showcase/app/templates/components/modal.hbs
@@ -509,5 +509,64 @@
     </Hds::Modal>
   {{/if}}
 
+  <br />
+  <br />
+
+  <Hds::Dropdown @listPosition="bottom-left" @isInline={{true}} as |D|>
+    <D.ToggleButton @color="secondary" @size="small" @text="Open modal via dropdown" />
+    <D.Interactive {{on "click" (fn this.activateModal "dropdownInitiatedModalActive")}}>
+      Open modal
+    </D.Interactive>
+  </Hds::Dropdown>
+
+  {{#if this.dropdownInitiatedModalActive}}
+    <Hds::Modal
+      id="dropdown-initiated-modal"
+      @onClose={{fn this.deactivateModal "dropdownInitiatedModalActive"}}
+      as |M|
+    >
+      <M.Header>
+        Modal title
+      </M.Header>
+      <M.Body>
+        <p class="hds-typography-body-300 hds-foreground-primary">Modal content</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
+
+  <Hds::Dropdown @listPosition="bottom-left" @isInline={{true}} as |D|>
+    <D.ToggleButton
+      id="dropdown-initiated-modal-with-returned-focus-toggle"
+      @color="secondary"
+      @size="small"
+      @text="Open modal via dropdown (with returned focus)"
+    />
+    <D.Interactive {{on "click" (fn this.activateModal "dropdownInitiatedWithReturnedFocusModalActive")}}>
+      Open modal
+    </D.Interactive>
+  </Hds::Dropdown>
+
+  {{#if this.dropdownInitiatedWithReturnedFocusModalActive}}
+    <Hds::Modal
+      id="dropdown-initiated-modal-with-returned-focus"
+      @onClose={{fn this.deactivateModal "dropdownInitiatedWithReturnedFocusModalActive"}}
+      @returnFocusTo="dropdown-initiated-modal-with-returned-focus-toggle"
+      as |M|
+    >
+      <M.Header>
+        Modal title
+      </M.Header>
+      <M.Body>
+        <p class="hds-typography-body-300 hds-foreground-primary">Modal content</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::Button type="button" @text="Confirm" {{on "click" F.close}} />
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
+
 </section>
 {{! template-lint-enable no-autofocus-attribute }}

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -80,6 +80,7 @@
     "ember-power-select": "^8.2.0",
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
+    "ember-set-helper": "^3.0.1",
     "ember-source": "~5.9.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-style-modifier": "^4.4.0",

--- a/showcase/tests/integration/components/hds/flyout/index-test.js
+++ b/showcase/tests/integration/components/hds/flyout/index-test.js
@@ -160,6 +160,63 @@ module('Integration | Component | hds/flyout/index', function (hooks) {
     assert.dom('button.hds-flyout__dismiss').isFocused();
   });
 
+  test('it returns focus to the element that initiated the open event, if is still in the DOM', async function (assert) {
+    await render(
+      hbs`<button id="test-button" type="button" {{on "click" (set this "showFlyout" true)}}>open flyout</button>
+          {{#if this.showFlyout}}
+            <Hds::Flyout id="test-flyout" as |M|>
+              <M.Header>Title</M.Header>
+            </Hds::Flyout>
+          {{/if}}
+          `
+    );
+    await click('#test-button');
+    assert.true(this.showFlyout);
+    await click('button.hds-flyout__dismiss');
+    assert.dom('#test-button').isFocused();
+  });
+
+  // not sure how to reach the `body` element, it says "body is not a valid root element"
+  skip('it returns focus to the `body` element, if the one that initiated the open event not anymore in the DOM', async function (assert) {
+    await render(
+      hbs`<Hds::Dropdown as |D|>
+            <D.ToggleButton id="test-toggle" @text="open flyout" />
+            <D.Interactive id="test-interactive" {{on "click" (set this "showFlyout" true)}}>open flyout</D.Interactive>
+          </Hds::Dropdown>
+          {{#if this.showFlyout}}
+            <Hds::Flyout id="test-flyout" as |M|>
+              <M.Header>Title</M.Header>
+            </Hds::Flyout>
+          {{/if}}
+          `
+    );
+    await click('#test-toggle');
+    await click('#test-interactive');
+    assert.true(this.showFlyout);
+    await click('button.hds-flyout__dismiss');
+    assert.dom('body', 'body').isFocused();
+  });
+
+  test('it returns focus to a specific element if provided via`@returnFocusTo`', async function (assert) {
+    await render(
+      hbs`<Hds::Dropdown as |D|>
+            <D.ToggleButton id="test-toggle" @text="open flyout" />
+            <D.Interactive id="test-interactive" {{on "click" (set this "showFlyout" true)}}>open flyout</D.Interactive>
+          </Hds::Dropdown>
+          {{#if this.showFlyout}}
+            <Hds::Flyout id="test-flyout" @returnFocusTo="test-toggle" as |M|>
+              <M.Header>Title</M.Header>
+            </Hds::Flyout>
+          {{/if}}
+          `
+    );
+    await click('#test-toggle');
+    await click('#test-interactive');
+    assert.true(this.showFlyout);
+    await click('button.hds-flyout__dismiss');
+    assert.dom('#test-toggle').isFocused();
+  });
+
   // CALLBACKS
 
   test('it should call `onOpen` function if provided', async function (assert) {

--- a/showcase/tests/integration/components/hds/modal/index-test.js
+++ b/showcase/tests/integration/components/hds/modal/index-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
   click,
@@ -192,6 +192,63 @@ module('Integration | Component | hds/modal/index', function (hooks) {
           </Hds::Modal>`
     );
     assert.dom('button.hds-modal__dismiss').isFocused();
+  });
+
+  test('it returns focus to the element that initiated the open event, if is still in the DOM', async function (assert) {
+    await render(
+      hbs`<button id="test-button" type="button" {{on "click" (set this "showModal" true)}}>open modal</button>
+          {{#if this.showModal}}
+            <Hds::Modal id="test-modal" as |M|>
+              <M.Header>Title</M.Header>
+            </Hds::Modal>
+          {{/if}}
+          `
+    );
+    await click('#test-button');
+    assert.true(this.showModal);
+    await click('button.hds-modal__dismiss');
+    assert.dom('#test-button').isFocused();
+  });
+
+  // not sure how to reach the `body` element, it says "body is not a valid root element"
+  skip('it returns focus to the `body` element, if the one that initiated the open event not anymore in the DOM', async function (assert) {
+    await render(
+      hbs`<Hds::Dropdown as |D|>
+            <D.ToggleButton id="test-toggle" @text="open modal" />
+            <D.Interactive id="test-interactive" {{on "click" (set this "showModal" true)}}>open modal</D.Interactive>
+          </Hds::Dropdown>
+          {{#if this.showModal}}
+            <Hds::Modal id="test-modal" as |M|>
+              <M.Header>Title</M.Header>
+            </Hds::Modal>
+          {{/if}}
+          `
+    );
+    await click('#test-toggle');
+    await click('#test-interactive');
+    assert.true(this.showModal);
+    await click('button.hds-modal__dismiss');
+    assert.dom('body', 'body').isFocused();
+  });
+
+  test('it returns focus to a specific element if provided via`@returnFocusTo`', async function (assert) {
+    await render(
+      hbs`<Hds::Dropdown as |D|>
+            <D.ToggleButton id="test-toggle" @text="open modal" />
+            <D.Interactive id="test-interactive" {{on "click" (set this "showModal" true)}}>open modal</D.Interactive>
+          </Hds::Dropdown>
+          {{#if this.showModal}}
+            <Hds::Modal id="test-modal" @returnFocusTo="test-toggle" as |M|>
+              <M.Header>Title</M.Header>
+            </Hds::Modal>
+          {{/if}}
+          `
+    );
+    await click('#test-toggle');
+    await click('#test-interactive');
+    assert.true(this.showModal);
+    await click('button.hds-modal__dismiss');
+    assert.dom('#test-toggle').isFocused();
   });
 
   // CALLBACKS

--- a/yarn.lock
+++ b/yarn.lock
@@ -13547,6 +13547,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ember-set-helper@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ember-set-helper@npm:3.0.1"
+  dependencies:
+    "@embroider/addon-shim": "npm:^1.8.7"
+    decorator-transforms: "npm:^1.0.1"
+  checksum: 10/c8a4204602e067835251f8b3bbb4e6b6cc762f054ebd43fbfe44a13cef40248466f4f2f6df310d1cd0490feeff18a013ac8e3b50322e884e8d008d9f1ddaa9cb
+  languageName: node
+  linkType: hard
+
 "ember-source-channel-url@npm:^3.0.0":
   version: 3.0.0
   resolution: "ember-source-channel-url@npm:3.0.0"
@@ -24902,6 +24912,7 @@ __metadata:
     ember-power-select: "npm:^8.2.0"
     ember-qunit: "npm:^8.1.0"
     ember-resolver: "npm:^11.0.1"
+    ember-set-helper: "npm:^3.0.1"
     ember-source: "npm:~5.9.0"
     ember-source-channel-url: "npm:^3.0.0"
     ember-style-modifier: "npm:^4.4.0"


### PR DESCRIPTION
### :pushpin: Summary

While working on the `HdsPlus::ChallengeModal` one argument that is missing from our `Hds::Modal`, looking at the implementation of similar components in our consumers' codebases, is the `returnFocusTo` ([see here](https://github.com/hashicorp/cloud-ui/blob/main/addons/core/package/src/components/modal-dialog.ts#L236-L241)).

As you can see from the attached video, the focus could be "lost" once the `<dialog>` element is closed (it's returned to the `body`) if the original element that opened the modal is deleted from the DOM (eg. think of a modal opened via a dropdown interactive item).

The intent of this PR is to introduce, in our `Modal` and `Flyout` components, a similar functionality to allow consumers to control where the focus is returned, if the element that initiated the event is not in the DOM anymore once closed. 

### :hammer_and_wrench: Detailed description

In this PR I have:
- added `returnToFocus` argument and logic to `Modal` and `Flyout` components
- added demos to `Modal` and `Flyout` showcase pages where the modal is opened via `Dropdown`
    - added `ember-set-helper` as dev-dependency for the showcase
- added more focus-management integration tests for `Modal` and `Flyout` components

Notice: I'll add the documentation update in a separate PR, if we agree this is the way forward.

👀  **Previews**: 
- Modal: https://hds-showcase-git-modal-flyout-return-focus-to-hashicorp.vercel.app/components/modal
- Flyout: https://hds-showcase-git-modal-flyout-return-focus-to-hashicorp.vercel.app/components/flyout

### 🎬 Video

You can see how the focus is returned to the `body` once the Modal is closed (look at the `document.activeElement` live variable in the devtools on the right)

https://github.com/user-attachments/assets/5ad62dc0-3bfa-40f4-a25f-548aac9e44f6

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changeset was added

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
