### PR TITLE
`SuperSelect::Multiple` - allow custom result count message

### DIFF
--- a/.changeset/spotty-boxes-do.md
+++ b/.changeset/spotty-boxes-do.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`SuperSelect::Multiple` - Added `@resultCountMessage` argument to enable override

--- a/packages/components/src/components/hds/form/super-select/multiple/base.ts
+++ b/packages/components/src/components/hds/form/super-select/multiple/base.ts
@@ -55,7 +55,10 @@ export default class HdsFormSuperSelectMultipleBase extends Component<HdsFormSup
   }
 
   get resultCountMessage(): string {
-    return `${this.selectedCount} selected of ${this.optionsCount} total`;
+    return (
+      this.args.resultCountMessage ||
+      `${this.selectedCount} selected of ${this.optionsCount} total`
+    );
   }
 
   @action calculatePosition(

--- a/showcase/app/templates/components/form/super-select.hbs
+++ b/showcase/app/templates/components/form/super-select.hbs
@@ -859,6 +859,25 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Text::H4>Custom result count message</Shw::Text::H4>
+
+  <Shw::Flex {{style padding-bottom="15em"}} @direction="row" as |SF|>
+    <SF.Item>
+      <Hds::Form::SuperSelect::Multiple::Base
+        @resultCountMessage="{{@model.PLACES_OPTIONS.length}} total"
+        @onChange={{fn (mut @model.SELECTED_PLACES_OPTIONS)}}
+        @options={{@model.PLACES_OPTIONS}}
+        @selected={{@model.SELECTED_PLACES_OPTIONS}}
+        @initiallyOpened={{true}}
+        @verticalPosition="below"
+        @ariaLabel="Label"
+        as |option|
+      >
+        {{option}}
+      </Hds::Form::SuperSelect::Multiple::Base>
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Divider />
 
   <Shw::Text::H2>Form::SuperSelect::Multiple::Field</Shw::Text::H2>

--- a/showcase/tests/integration/components/hds/form/super-select/multiple/base-test.js
+++ b/showcase/tests/integration/components/hds/form/super-select/multiple/base-test.js
@@ -163,6 +163,25 @@ module(
       assert.dom('.hds-form-super-select__after-options').doesNotExist();
     });
 
+    test('it should render the default after options block with custom result count message when `@resultCountMessage` exists', async function (assert) {
+      setOptionsData(this);
+      await render(
+        hbs`<Hds::Form::SuperSelect::Multiple::Base @onChange={{this.NOOP}} @options={{this.OPTIONS}} @resultCountMessage="custom result count message" as |option|>{{option}}</Hds::Form::SuperSelect::Multiple::Base>`
+      );
+      await click('.hds-form-super-select .ember-basic-dropdown-trigger');
+      assert
+        .dom(
+          '.hds-form-super-select__after-options .hds-form-super-select__result-count'
+        )
+        .hasText('custom result count message');
+      assert
+        .dom('.hds-form-super-select__after-options .hds-button')
+        .hasText('Show selected');
+      assert
+        .dom('.hds-form-super-select__after-options .hds-button')
+        .doesNotHaveTextContaining('Clear selected');
+    });
+
     // MATCH TRIGGER WIDTH
 
     test('`@matchTriggerWidth` should be true by default', async function (assert) {

--- a/website/docs/components/form/super-select/partials/code/component-api.md
+++ b/website/docs/components/form/super-select/partials/code/component-api.md
@@ -185,6 +185,9 @@ The default values of some [ember-power-select](https://ember-power-select.com/d
   <C.Property @name="afterOptionsContent" @type="string" @default="resultCountMessage">
     Sets the content of the default `afterOptions` component overriding the default content.
   </C.Property>
+  <C.Property @name="resultCountMessage" @type="string">
+    Overrides the default result count message. The default message follows this pattern: X selected of Y total.
+  </C.Property>
   <C.Property @name="closeOnSelect" @type="boolean" @default="false">
     Defaults to true instead for `SuperSelect::Single`.
   </C.Property>


### PR DESCRIPTION
### :pushpin: Summary

Allow override of custom result count message via `@resultCountMessage` argument. This argument is already part of the PowerSelect signature, but we currently provide a default value in the SuperSelect wrapper without allowing consumers to override it.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3986](https://hashicorp.atlassian.net/browse/HDS-3986)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3986]: https://hashicorp.atlassian.net/browse/HDS-3986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ