### PR TITLE
`Dropdown` - Small changes to logic for content being preserved in the DOM (on top of #2490)

### DIFF
--- a/.changeset/curly-apples-share.md
+++ b/.changeset/curly-apples-share.md
@@ -2,4 +2,8 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Dropdown` - Fixed content being preserved in the DOM when closed and removed the `isOpen` yielded argument
+`Dropdown`
+
+- Fixed content being preserved in the DOM when closed
+- Removed the `isOpen` yielded argument
+- Added `@preserveContentInDom` to optionally control rendering of the content

--- a/packages/components/src/components/hds/dropdown/index.hbs
+++ b/packages/components/src/components/hds/dropdown/index.hbs
@@ -17,7 +17,7 @@
       {{style width=@width max-height=@height}}
       {{PP.setupPrimitivePopover anchoredPositionOptions=this.anchoredPositionOptions}}
     >
-      {{#if PP.isOpen}}
+      {{#if (or PP.isOpen @preserveContentInDom)}}
         {{yield (hash Header=(component "hds/dropdown/header"))}}
         <ul class="hds-dropdown__list" {{did-insert this.didInsertList}}>
           {{yield

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -44,6 +44,7 @@ export interface HdsDropdownSignature {
     listPosition?: HdsDropdownPositions;
     width?: string;
     enableCollisionDetection?: FloatingUIOptions['enableCollisionDetection'];
+    preserveContentInDom?: boolean;
   };
   Blocks: {
     default: [

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -1539,6 +1539,23 @@
         </Hds::Dropdown>
       </div>
     </SG.Item>
+    <SG.Item as |SG|>
+      <SG.Label>Using <code>preserveContentInDom</code> argument</SG.Label>
+      <div class="shw-component-dropdown-fixed-height-container">
+        <Hds::Dropdown @listPosition="bottom-left" @preserveContentInDom={{true}} as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Header @hasDivider={{true}}>
+            This header should always be present in the DOM, regardless of whether the dropdown is open or closed
+          </D.Header>
+          <D.Interactive @href="#">
+            This item should always be present in the DOM, regardless of whether the dropdown is open or closed
+          </D.Interactive>
+          <D.Footer @hasDivider={{true}}>
+            This footer should always be present in the DOM, regardless of whether the dropdown is open or closed
+          </D.Footer>
+        </Hds::Dropdown>
+      </div>
+    </SG.Item>
   </Shw::Grid>
 
 </section>

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -83,7 +83,7 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
       .hasClass('hds-dropdown__footer--with-divider');
   });
 
-  test('it does not render the "list-item" sub-components when closed', async function (assert) {
+  test('it does not render the content sub-components when closed, by default', async function (assert) {
     await render(hbs`
       <Hds::Dropdown id="test-dropdown" as |D|>
         <D.ToggleButton @text="toggle button" id="test-toggle-button" />
@@ -99,6 +99,25 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown #test-header').doesNotExist();
     assert.dom('#test-dropdown .hds-dropdown__list').doesNotExist();
     assert.dom('#test-dropdown #test-footer').doesNotExist();
+  });
+
+  test('it renders the content sub-components even when closed, when `@preserveContentInDom` is `true`', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" @preserveContentInDom={{true}} as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Header id="test-header">Header</D.Header>
+        <D.Interactive id="test-list-item" @route="components.dropdown" @text="interactive-always-rendered" />
+        <D.Footer id="test-footer">Footer</D.Footer>
+      </Hds::Dropdown>
+    `);
+
+    // the container should exist in the DOM
+    assert.dom('#test-dropdown .hds-dropdown__content').exists();
+    // the list content should too
+    assert.dom('#test-dropdown #test-header').exists();
+    assert.dom('#test-dropdown .hds-dropdown__list').exists();
+    assert.dom('#test-dropdown #test-list-item').exists();
+    assert.dom('#test-dropdown #test-footer').exists();
   });
 
   // POSITION

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -79,6 +79,9 @@ The Dropdown component is composed of different child components each with their
   <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
     If a `@height` parameter is provided then the list will have a max-height.
   </C.Property>
+  <C.Property @name="preserveContentInDom" @type="boolean" @default="false">
+    Controls if the content is always rendered in the DOM, even when the Dropdown is closed.
+  </C.Property>
   <C.Property @name="onClose" @type="function">
     Callback function invoked when the Dropdown is closed, if provided.
   </C.Property>

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -187,6 +187,19 @@ It is possible that you may want to add a list footer for things like a set of b
 </Hds::Dropdown>
 ```
 
+### Content rendering in DOM
+
+By default, the content of the Dropdown is not rendered into the browser when the Dropdown is closed.
+
+To change this behavior, you can use the `@preserveContentInDom` argument so that the content is rendered in the DOM, regardless of whether the Dropdown is open or closed.
+
+```handlebars
+<Hds::Dropdown @preserveContentInDom={{true}} as |D|>
+  <D.ToggleButton @text="Text Toggle" />
+  <D.Interactive @route="components" @text="This item should always be present in the DOM, regardless of whether the dropdown is open or closed" />
+</Hds::Dropdown>
+```
+
 ### ListItem::Interactive
 
 `ListItem::Interactive` renders the correct element based on the passing of a `@route`, `@href`, or the addition of a click event (e.g.,


### PR DESCRIPTION
### :pushpin: Summary

_⚠️ This PR is built on top of #2490, which is still in review. ⚠️_

The intent of this PR is to propose a middle ground between the previous implementation, where the content was always present in the DOM, even when the dropdown is closed, and the changes (rollback) done in #2490, where the content is never present in the DOM when the dropdown is closed.

The idea is to give consumers a way - through a dedicated `@ preserveContentInDom ` argument - to opt-in in rendering the list content also when the dropdown is closed.

_Notice: in a previous iteration (see https://github.com/hashicorp/design-system/pull/2491) we also reintroduced the yielded `isOpen` status, but in review feedback was decided to remove it, hence this new PR._

### :hammer_and_wrench: Detailed description

In this PR I have:
- introduced `preserveContentInDom` argument to control rendering of the list in the DOM
- added a showcase demo where we use the `@preserveContentInDom` argument
- updated the integration tests
- updated the changeset description

**Preview**: TODO

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
