### PR TITLE
Showcase - Remove leftover `Component` in `Shw::**` components class names

### DIFF
--- a/showcase/app/components/shw/flex/index.gts
+++ b/showcase/app/components/shw/flex/index.gts
@@ -31,7 +31,7 @@ interface ShwFlexSignature {
   Element: HTMLDivElement;
 }
 
-export default class ShwFlexComponent extends Component<ShwFlexSignature> {
+export default class ShwFlex extends Component<ShwFlexSignature> {
   direction = this.args.direction ?? 'row';
 
   get itemsStyle(): SafeString | undefined {

--- a/showcase/app/components/shw/flex/item.gts
+++ b/showcase/app/components/shw/flex/item.gts
@@ -25,7 +25,7 @@ export interface ShwFlexItemSignature {
   Element: HTMLDivElement;
 }
 
-export default class ShwFlexItemComponent extends Component<ShwFlexItemSignature> {
+export default class ShwFlexItem extends Component<ShwFlexItemSignature> {
   get classNames(): string {
     const classes = ['shw-flex__item'];
 

--- a/showcase/app/components/shw/text/index.gts
+++ b/showcase/app/components/shw/text/index.gts
@@ -46,7 +46,7 @@ export interface ShwTextSignature {
   Element: AvailableElements;
 }
 
-export default class ShwTextComponent extends Component<ShwTextSignature> {
+export default class ShwText extends Component<ShwTextSignature> {
   /**
    * Get a tag to render based on the `@tag` argument passed or the value of `this.size` (via mapping)
    *


### PR DESCRIPTION
### :pushpin: Summary

While reviewing https://github.com/hashicorp/design-system/pull/2492 I noticed that Kristin (rightly) removed the `Component` suffix in the component class name. I checked and there are few instances where I forgot to remove it as well.

This small PR cleanups these few leftovers.

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
