### PR TITLE
`Dropdown` - fix dropdown content not being preserved when interacted with

### DIFF
--- a/.changeset/seven-taxis-develop.md
+++ b/.changeset/seven-taxis-develop.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Dropdown` - Fixed dropdown content not being preserved when interacted with

--- a/packages/components/src/components/hds/dropdown/index.hbs
+++ b/packages/components/src/components/hds/dropdown/index.hbs
@@ -13,6 +13,7 @@
       )
     }}
     <div
+      tabindex="-1"
       class={{this.classNamesContent}}
       {{style width=@width max-height=@height}}
       {{PP.setupPrimitivePopover anchoredPositionOptions=this.anchoredPositionOptions}}

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -170,6 +170,23 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('#test-dropdown ul').hasStyle({ width: '248px' });
   });
 
+  // PRESERVE DISCLOSED CONTENT WHEN INTERACTED WITH
+
+  test('it should preserve the content visible when interacted with', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" as |D|>
+        <D.ToggleButton @text="toggle button" id="test-toggle-button" />
+        <D.Interactive @route="components.dropdown" id="test-list-item-interactive" @text="interactive" />
+      </Hds::Dropdown>
+    `);
+    await click('button#test-toggle-button');
+    assert.dom('#test-dropdown #test-list-item-interactive').exists();
+    // click on the dropdown content container as a minimal interaction with the content;
+    // it could be followed by selection, a right click etc.
+    await click('.hds-dropdown__content');
+    assert.dom('#test-dropdown #test-list-item-interactive').exists();
+  });
+
   // CLOSE DISCLOSED CONTENT ON CLICK
 
   test('it should hide the content when an interactive element triggers `close`', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

Fixed an issue where the dropdown content was not preserved when interacted with.

### :hammer_and_wrench: Detailed description

The PopoverPrimitive assumes the popover element is focusable and [registers a `focusout` event](https://github.com/hashicorp/design-system/blob/main/packages/components/src/components/hds/popover-primitive/index.ts#L86-L88) on the main popover container to determine when to hide the container. When the popover element is not focusable, any interaction will trigger a `focusout` and close the popover. To resolve this we make the popover container focusable using `tabindex="-1"`.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3994](https://hashicorp.atlassian.net/browse/HDS-3994)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3994]: https://hashicorp.atlassian.net/browse/HDS-3994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ