### PR TITLE
Fix Dropdown-related deprecation warnings in `website` and `showcase`

### DIFF
--- a/showcase/app/templates/components/app-footer.hbs
+++ b/showcase/app/templates/components/app-footer.hbs
@@ -80,9 +80,9 @@
           <AF.ExtraBefore>
             <Hds::Dropdown as |D|>
               <D.ToggleButton @text="Theme" @color="secondary" @size="small" />
-              <D.Interactive @icon="monitor" {{on "click" D.close}} @text="System" />
-              <D.Interactive @icon="moon" {{on "click" D.close}} @text="Dark" />
-              <D.Interactive @icon="sun" {{on "click" D.close}} @text="Light" />
+              <D.Interactive @icon="monitor" {{on "click" D.close}}>System</D.Interactive>
+              <D.Interactive @icon="moon" {{on "click" D.close}}>Dark</D.Interactive>
+              <D.Interactive @icon="sun" {{on "click" D.close}}>Light</D.Interactive>
             </Hds::Dropdown>
           </AF.ExtraBefore>
           <AF.StatusLink @status="operational" />

--- a/showcase/app/templates/components/app-header.hbs
+++ b/showcase/app/templates/components/app-header.hbs
@@ -56,20 +56,20 @@
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Terraform Provider" @href="#" />
-            <dd.Interactive @text="Changelog" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+            <dd.Interactive @href="#">Changelog</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @text="Create support ticket" @href="#" />
-            <dd.Interactive @text="Give feedback" @href="#" />
+            <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+            <dd.Interactive @href="#">Give feedback</dd.Interactive>
           </Hds::Dropdown>
 
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
-            <dd.Interactive @href="#" @text="Account Settings" />
+            <dd.Interactive @href="#">Account Settings</dd.Interactive>
           </Hds::Dropdown>
         </:utilityActions>
       </Hds::AppHeader>
@@ -95,20 +95,20 @@
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Terraform Provider" @href="#" />
-            <dd.Interactive @text="Changelog" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+            <dd.Interactive @href="#">Changelog</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @text="Create support ticket" @href="#" />
-            <dd.Interactive @text="Give feedback" @href="#" />
+            <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+            <dd.Interactive @href="#">Give feedback</dd.Interactive>
           </Hds::Dropdown>
 
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
-            <dd.Interactive @href="#" @text="Account Settings" />
+            <dd.Interactive @href="#">Account Settings</dd.Interactive>
           </Hds::Dropdown>
         </:utilityActions>
       </Hds::AppHeader>
@@ -141,20 +141,20 @@
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Terraform Provider" @href="#" />
-            <dd.Interactive @text="Changelog" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+            <dd.Interactive @href="#">Changelog</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @text="Create support ticket" @href="#" />
-            <dd.Interactive @text="Give feedback" @href="#" />
+            <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+            <dd.Interactive @href="#">Give feedback</dd.Interactive>
           </Hds::Dropdown>
 
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
-            <dd.Interactive @href="#" @text="Account Settings" />
+            <dd.Interactive @href="#">Account Settings</dd.Interactive>
           </Hds::Dropdown>
         </:utilityActions>
       </Hds::AppHeader>
@@ -184,19 +184,19 @@
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Terraform Provider" @href="#" />
-            <dd.Interactive @text="Changelog" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+            <dd.Interactive @href="#">Changelog</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @text="Create support ticket" @href="#" />
-            <dd.Interactive @text="Give feedback" @href="#" />
+            <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+            <dd.Interactive @href="#">Give feedback</dd.Interactive>
           </Hds::Dropdown>
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
-            <dd.Interactive @href="#" @text="Account Settings" />
+            <dd.Interactive @href="#">Account Settings</dd.Interactive>
           </Hds::Dropdown>
         </:utilityActions>
       </Hds::AppHeader>
@@ -220,19 +220,19 @@
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Terraform Provider" @href="#" />
-            <dd.Interactive @text="Changelog" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+            <dd.Interactive @href="#">Changelog</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @text="Create support ticket" @href="#" />
-            <dd.Interactive @text="Give feedback" @href="#" />
+            <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+            <dd.Interactive @href="#">Give feedback</dd.Interactive>
           </Hds::Dropdown>
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
-            <dd.Interactive @href="#" @text="Account Settings" />
+            <dd.Interactive @href="#">Account Settings</dd.Interactive>
           </Hds::Dropdown>
         </:utilityActions>
       </Hds::AppHeader>
@@ -262,20 +262,20 @@
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Terraform Provider" @href="#" />
-            <dd.Interactive @text="Changelog" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+            <dd.Interactive @href="#">Changelog</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @text="Create support ticket" @href="#" />
-            <dd.Interactive @text="Give feedback" @href="#" />
+            <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+            <dd.Interactive @href="#">Give feedback</dd.Interactive>
           </Hds::Dropdown>
 
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
-            <dd.Interactive @href="#" @text="Account Settings" />
+            <dd.Interactive @href="#">Account Settings</dd.Interactive>
           </Hds::Dropdown>
         </:utilityActions>
       </Hds::AppHeader>
@@ -548,9 +548,9 @@
           <D.Generic>
             <Hds::Dropdown as |D|>
               <D.ToggleButton @text="Menu" />
-              <D.Interactive @href="#" @text="Add" />
-              <D.Interactive @href="#" @text="Add More" />
-              <D.Interactive @href="#" @text="Add Another Thing Too" />
+              <D.Interactive @href="#">Add</D.Interactive>
+              <D.Interactive @href="#">Add More</D.Interactive>
+              <D.Interactive @href="#">Add Another Thing Too</D.Interactive>
             </Hds::Dropdown>
           </D.Generic>
           <D.Checkbox>access</D.Checkbox>
@@ -561,9 +561,9 @@
               <Hds::Button @text="Cancel" @color="secondary" @size="small" />
               <Hds::Dropdown as |D|>
                 <D.ToggleButton @text="Menu" />
-                <D.Interactive @href="#" @text="Add" />
-                <D.Interactive @href="#" @text="Add More" />
-                <D.Interactive @href="#" @text="Add Another Thing Too" />
+                <D.Interactive @href="#">Add</D.Interactive>
+                <D.Interactive @href="#">Add More</D.Interactive>
+                <D.Interactive @href="#">Add Another Thing Too</D.Interactive>
               </Hds::Dropdown>
             </Hds::ButtonSet>
           </D.Footer>

--- a/showcase/app/templates/components/application-state.hbs
+++ b/showcase/app/templates/components/application-state.hbs
@@ -191,9 +191,9 @@
           <F.Dropdown @listPosition="bottom-right" as |dd|>
             <dd.ToggleButton @text="Choose an option" />
             <dd.Title @text="Categories" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Changelogs" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Changelogs</dd.Interactive>
           </F.Dropdown>
         </A.Footer>
       </Hds::ApplicationState>
@@ -208,9 +208,9 @@
           <F.Dropdown @listPosition="bottom-right" as |dd|>
             <dd.ToggleButton @text="Choose an option" />
             <dd.Title @text="Categories" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Changelogs" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Changelogs</dd.Interactive>
           </F.Dropdown>
           <F.Button @color="secondary" @text="Secondary action" />
         </A.Footer>
@@ -226,9 +226,9 @@
           <F.Dropdown @listPosition="bottom-right" as |dd|>
             <dd.ToggleButton @text="Choose an option" />
             <dd.Title @text="Categories" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Changelogs" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Changelogs</dd.Interactive>
           </F.Dropdown>
           <F.Button @color="secondary" @text="Secondary action" />
           <F.LinkStandalone @icon="docs-link" @text="Learn more" @iconPosition="trailing" @href="#" />
@@ -301,9 +301,9 @@
             <F.Dropdown @color="secondary" @listPosition="bottom-right" as |dd|>
               <dd.ToggleButton @text="Choose an option" />
               <dd.Title @text="Categories" />
-              <dd.Interactive @text="Documentation" @href="#" />
-              <dd.Interactive @text="Tutorials" @href="#" />
-              <dd.Interactive @text="Changelogs" @href="#" />
+              <dd.Interactive @href="#">Documentation</dd.Interactive>
+              <dd.Interactive @href="#">Tutorials</dd.Interactive>
+              <dd.Interactive @href="#">Changelogs</dd.Interactive>
             </F.Dropdown>
           </A.Footer>
         </Hds::ApplicationState>
@@ -321,9 +321,9 @@
             <F.Dropdown @color="secondary" @listPosition="bottom-right" as |dd|>
               <dd.ToggleButton @text="Choose an option" />
               <dd.Title @text="Categories" />
-              <dd.Interactive @text="Documentation" @href="#" />
-              <dd.Interactive @text="Tutorials" @href="#" />
-              <dd.Interactive @text="Changelogs" @href="#" />
+              <dd.Interactive @href="#">Documentation</dd.Interactive>
+              <dd.Interactive @href="#">Tutorials</dd.Interactive>
+              <dd.Interactive @href="#">Changelogs</dd.Interactive>
             </F.Dropdown>
             <F.LinkStandalone @icon="docs-link" @text="Learn more" @iconPosition="trailing" @href="#" />
           </A.Footer>

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -16,8 +16,8 @@
       <SG.Item {{style padding="5em"}} @label={{capitalize position}}>
         <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
           <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#" @text="Create" />
-          <D.Interactive @href="#" @text="Edit" />
+          <D.Interactive @href="#">Create</D.Interactive>
+          <D.Interactive @href="#">Edit</D.Interactive>
         </Hds::Dropdown>
       </SG.Item>
     {{/each}}
@@ -70,8 +70,8 @@
             <div class="shw-component-dropdown-collision-detection-wrapper">
               <Hds::Dropdown @isOpen={{true}} @enableCollisionDetection={{detection}} as |D|>
                 <D.ToggleButton @color="secondary" @text="Menu" />
-                <D.Interactive @href="#" @text="Create" />
-                <D.Interactive @href="#" @text="Edit" />
+                <D.Interactive @href="#">Create</D.Interactive>
+                <D.Interactive @href="#">Edit</D.Interactive>
               </Hds::Dropdown>
             </div>
           </Shw::Autoscrollable>
@@ -377,7 +377,7 @@
           <Hds::Dropdown::ListItem::Title @text="A simple title" />
           <Hds::Dropdown::ListItem::Description @text="A description." />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive @route="index" @text="Item" />
+          <Hds::Dropdown::ListItem::Interactive @route="index">Item</Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
@@ -1343,8 +1343,8 @@
           <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Create" />
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Edit" />
+          <Hds::Dropdown::ListItem::Interactive @route="components">Create</Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components">Edit</Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
@@ -1354,8 +1354,8 @@
           <Hds::Link::Standalone @icon="list" @text="Organizations" @color="secondary" @href="#" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Create" />
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Edit" />
+          <Hds::Dropdown::ListItem::Interactive @route="components">Create</Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components">Edit</Hds::Dropdown::ListItem::Interactive>
         </ul>
       </div>
     </SF.Item>
@@ -1405,9 +1405,9 @@
     <SF.Item @label="Button">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization A" />
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization A</Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization B</Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization C</Hds::Dropdown::ListItem::Interactive>
         </ul>
         <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Hds::Button @text="Apply filters" @isFullWidth={{true}} @size="small" />
@@ -1417,9 +1417,9 @@
     <SF.Item @label="Link">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization A" />
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization A</Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization B</Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization C</Hds::Dropdown::ListItem::Interactive>
         </ul>
         <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Hds::Link::Standalone @icon="list" @text="Organizations" @color="secondary" @href="#" />
@@ -1462,7 +1462,7 @@
           <Shw::Placeholder @text="generic header content" @width="200" @height="36" @background="#e1f5fe" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Interactive for testing" />
+          <Hds::Dropdown::ListItem::Interactive @route="components">Interactive for testing</Hds::Dropdown::ListItem::Interactive>
           <Hds::Dropdown::ListItem::Generic>
             <Shw::Placeholder @text="generic item content" @height="36" @background="#e1f5fe" />
           </Hds::Dropdown::ListItem::Generic>
@@ -1488,9 +1488,9 @@
           <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization A" />
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization A</Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization B</Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization C</Hds::Dropdown::ListItem::Interactive>
         </ul>
         <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Hds::ButtonSet>
@@ -1507,9 +1507,9 @@
           <Hds::Form::TextInput::Base @type="search" placeholder="Narrow results" />
         </Hds::Dropdown::Header>
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization A" />
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization B" />
-          <Hds::Dropdown::ListItem::Interactive @route="components" @text="Organization C" />
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization A</Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization B</Hds::Dropdown::ListItem::Interactive>
+          <Hds::Dropdown::ListItem::Interactive @route="components">Organization C</Hds::Dropdown::ListItem::Interactive>
         </ul>
         <Hds::Dropdown::Footer @hasDivider={{true}}>
           <Hds::Link::Standalone @icon="plus" @text="Add organization" @href="#" />

--- a/showcase/app/templates/components/modal.hbs
+++ b/showcase/app/templates/components/modal.hbs
@@ -356,9 +356,9 @@
           dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
         <Hds::Dropdown @listPosition="bottom-left" as |dd|>
           <dd.ToggleButton @color="secondary" @text="Generic dropdown" />
-          <dd.Interactive @href="#" @text="Lorem" />
-          <dd.Interactive @href="#" @text="Ipsum" />
-          <dd.Interactive @href="#" @text="Dolor" />
+          <dd.Interactive @href="#">Lorem</dd.Interactive>
+          <dd.Interactive @href="#">Ipsum</dd.Interactive>
+          <dd.Interactive @href="#">Dolor</dd.Interactive>
         </Hds::Dropdown>
       </M.Body>
       <M.Footer as |F|>

--- a/showcase/app/templates/components/page-header.hbs
+++ b/showcase/app/templates/components/page-header.hbs
@@ -76,9 +76,9 @@ SPDX-License-Identifier: MPL-2.0
         <PH.Actions>
           <Hds::Dropdown as |D|>
             <D.ToggleButton @text="Manage" @color="secondary" />
-            <D.Interactive @text="Manage cluster externally" />
-            <D.Interactive @text="Launch desktop" />
-            <D.Interactive @text="Delete" @color="critical" @icon="trash" />
+            <D.Interactive>Manage cluster externally</D.Interactive>
+            <D.Interactive>Launch desktop</D.Interactive>
+            <D.Interactive @color="critical" @icon="trash">Delete</D.Interactive>
           </Hds::Dropdown>
           <Hds::Button @text="Create" @icon="plus" @iconPosition="leading" @color="primary" />
         </PH.Actions>
@@ -186,9 +186,9 @@ SPDX-License-Identifier: MPL-2.0
         <PH.Actions>
           <Hds::Dropdown as |D|>
             <D.ToggleButton @text="Manage users" @color="secondary" />
-            <D.Interactive @text="Assign roles" @icon="user" />
-            <D.Interactive @text="Batch edit" @icon="edit" />
-            <D.Interactive @text="Delete user" @icon="trash" />
+            <D.Interactive @icon="user">Assign roles</D.Interactive>
+            <D.Interactive @icon="edit">Batch edit</D.Interactive>
+            <D.Interactive @icon="trash">Delete user</D.Interactive>
           </Hds::Dropdown>
           <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
         </PH.Actions>
@@ -237,9 +237,9 @@ SPDX-License-Identifier: MPL-2.0
         <PH.Actions>
           <Hds::Dropdown as |D|>
             <D.ToggleButton @text="Manage users" @color="secondary" />
-            <D.Interactive @text="Assign roles" @icon="user" />
-            <D.Interactive @text="Batch edit" @icon="edit" />
-            <D.Interactive @text="Delete user" @icon="trash" />
+            <D.Interactive @icon="user">Assign roles</D.Interactive>
+            <D.Interactive @icon="edit">Batch edit</D.Interactive>
+            <D.Interactive @icon="trash">Delete user</D.Interactive>
           </Hds::Dropdown>
           <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
         </PH.Actions>

--- a/showcase/app/templates/components/segmented-group.hbs
+++ b/showcase/app/templates/components/segmented-group.hbs
@@ -48,7 +48,7 @@
         <SGR.TextInput aria-label="segmented-text-input-dropdown-trailing" />
         <SGR.Dropdown as |D|>
           <D.ToggleButton @color="secondary" @text="Dropdown" />
-          <D.Interactive @href="#" @text="Dropdown Item" />
+          <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
@@ -56,7 +56,7 @@
       <Hds::SegmentedGroup as |SGR|>
         <SGR.Dropdown as |D|>
           <D.ToggleButton @color="secondary" @text="Dropdown" />
-          <D.Interactive @href="#" @text="Dropdown Item" />
+          <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
         <SGR.TextInput aria-label="segmented-text-input-dropdown-leading" />
       </Hds::SegmentedGroup>
@@ -290,7 +290,7 @@
         </SGR.Select>
         <SGR.Dropdown as |D|>
           <D.ToggleButton @color="secondary" @text="Dropdown" mock-state-value="focus" />
-          <D.Interactive @href="#" @text="Dropdown Item" />
+          <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
@@ -311,7 +311,7 @@
         </SGR.Select>
         <SGR.Dropdown as |D|>
           <D.ToggleButton @color="secondary" @text="Dropdown" disabled />
-          <D.Interactive @href="#" @text="Dropdown Item" />
+          <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
@@ -332,7 +332,7 @@
         </SGR.Select>
         <SGR.Dropdown as |D|>
           <D.ToggleButton @color="secondary" @text="Dropdown" />
-          <D.Interactive @href="#" @text="Dropdown Item" />
+          <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
@@ -353,7 +353,7 @@
         </SGR.Select>
         <SGR.Dropdown as |D|>
           <D.ToggleButton @color="secondary" @text="Dropdown" />
-          <D.Interactive @href="#" @text="Dropdown Item" />
+          <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
       </Hds::SegmentedGroup>
     </SG.Item>
@@ -374,7 +374,7 @@
       <Hds::SegmentedGroup as |SGR|>
         <SGR.Dropdown as |D|>
           <D.ToggleButton @color="secondary" @text="Dropdown" mock-state-value="focus" />
-          <D.Interactive @href="#" @text="Dropdown Item" />
+          <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
         <SGR.Select aria-label="segmented-select-leading-dropdown-focused" as |SEL|>
           <SEL.Options>
@@ -395,7 +395,7 @@
       <Hds::SegmentedGroup as |SGR|>
         <SGR.Dropdown as |D|>
           <D.ToggleButton @color="secondary" @text="Dropdown" disabled />
-          <D.Interactive @href="#" @text="Dropdown Item" />
+          <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
         <SGR.Select aria-label="segmented-select-leading-dropdown-disabled" as |SEL|>
           <SEL.Options>
@@ -416,7 +416,7 @@
       <Hds::SegmentedGroup as |SGR|>
         <SGR.Dropdown as |D|>
           <D.ToggleButton @color="secondary" @text="Dropdown" />
-          <D.Interactive @href="#" @text="Dropdown Item" />
+          <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
         <SGR.Select aria-label="segmented-trailing-select-focused" mock-state-value="focus" as |SEL|>
           <SEL.Options>
@@ -437,7 +437,7 @@
       <Hds::SegmentedGroup as |SGR|>
         <SGR.Dropdown as |D|>
           <D.ToggleButton @color="secondary" @text="Dropdown" />
-          <D.Interactive @href="#" @text="Dropdown Item" />
+          <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
         <SGR.Select aria-label="segmented-trailing-select-disabled" disabled as |SEL|>
           <SEL.Options>

--- a/showcase/app/templates/components/side-nav.hbs
+++ b/showcase/app/templates/components/side-nav.hbs
@@ -127,19 +127,19 @@
                     <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
                       <dd.ToggleIcon @icon="help" @text="help menu" />
                       <dd.Title @text="Help & Support" />
-                      <dd.Interactive @text="Documentation" @href="#" />
-                      <dd.Interactive @text="Tutorials" @href="#" />
-                      <dd.Interactive @text="Terraform Provider" @href="#" />
-                      <dd.Interactive @text="Changelog" @href="#" />
+                      <dd.Interactive @href="#">Documentation</dd.Interactive>
+                      <dd.Interactive @href="#">Tutorials</dd.Interactive>
+                      <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+                      <dd.Interactive @href="#">Changelog</dd.Interactive>
                       <dd.Separator />
-                      <dd.Interactive @text="Create support ticket" @href="#" />
-                      <dd.Interactive @text="Give feedback" @href="#" />
+                      <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+                      <dd.Interactive @href="#">Give feedback</dd.Interactive>
                     </Hds::Dropdown>
                     <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
                       <dd.ToggleIcon @icon="user" @text="user menu" />
                       <dd.Title @text="Signed In" />
                       <dd.Description @text="email@domain.com" />
-                      <dd.Interactive @href="#" @text="Account Settings" />
+                      <dd.Interactive @href="#">Account Settings</dd.Interactive>
                     </Hds::Dropdown>
                   </:actions>
                 </Hds::SideNav::Header>
@@ -191,19 +191,19 @@
                     <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
                       <dd.ToggleIcon @icon="help" @text="help menu" />
                       <dd.Title @text="Help & Support" />
-                      <dd.Interactive @text="Documentation" @href="#" />
-                      <dd.Interactive @text="Tutorials" @href="#" />
-                      <dd.Interactive @text="Terraform Provider" @href="#" />
-                      <dd.Interactive @text="Changelog" @href="#" />
+                      <dd.Interactive @href="#">Documentation</dd.Interactive>
+                      <dd.Interactive @href="#">Tutorials</dd.Interactive>
+                      <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+                      <dd.Interactive @href="#">Changelog</dd.Interactive>
                       <dd.Separator />
-                      <dd.Interactive @text="Create support ticket" @href="#" />
-                      <dd.Interactive @text="Give feedback" @href="#" />
+                      <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+                      <dd.Interactive @href="#">Give feedback</dd.Interactive>
                     </Hds::Dropdown>
                     <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
                       <dd.ToggleIcon @icon="user" @text="user menu" />
                       <dd.Title @text="Signed In" />
                       <dd.Description @text="email@domain.com" />
-                      <dd.Interactive @href="#" @text="Account Settings" />
+                      <dd.Interactive @href="#">Account Settings</dd.Interactive>
                     </Hds::Dropdown>
                   </:actions>
                 </Hds::SideNav::Header>
@@ -339,19 +339,19 @@
             <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
               <dd.ToggleIcon @icon="help" @text="help menu" />
               <dd.Title @text="Help & Support" />
-              <dd.Interactive @text="Documentation" @href="#" />
-              <dd.Interactive @text="Tutorials" @href="#" />
-              <dd.Interactive @text="Terraform Provider" @href="#" />
-              <dd.Interactive @text="Changelog" @href="#" />
+              <dd.Interactive @href="#">Documentation</dd.Interactive>
+              <dd.Interactive @href="#">Tutorials</dd.Interactive>
+              <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+              <dd.Interactive @href="#">Changelog</dd.Interactive>
               <dd.Separator />
-              <dd.Interactive @text="Create support ticket" @href="#" />
-              <dd.Interactive @text="Give feedback" @href="#" />
+              <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+              <dd.Interactive @href="#">Give feedback</dd.Interactive>
             </Hds::Dropdown>
             <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
               <dd.ToggleIcon @icon="user" @text="user menu" />
               <dd.Title @text="Signed In" />
               <dd.Description @text="email@domain.com" />
-              <dd.Interactive @href="#" @text="Account Settings" />
+              <dd.Interactive @href="#">Account Settings</dd.Interactive>
             </Hds::Dropdown>
           </:actions>
         </Hds::SideNav::Header>
@@ -368,13 +368,13 @@
             <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
               <dd.ToggleButton @text="Help" />
               <dd.Title @text="Help & Support" />
-              <dd.Interactive @text="Documentation" @href="#" />
-              <dd.Interactive @text="Tutorials" @href="#" />
-              <dd.Interactive @text="Terraform Provider" @href="#" />
-              <dd.Interactive @text="Changelog" @href="#" />
+              <dd.Interactive @href="#">Documentation</dd.Interactive>
+              <dd.Interactive @href="#">Tutorials</dd.Interactive>
+              <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+              <dd.Interactive @href="#">Changelog</dd.Interactive>
               <dd.Separator />
-              <dd.Interactive @text="Create support ticket" @href="#" />
-              <dd.Interactive @text="Give feedback" @href="#" />
+              <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+              <dd.Interactive @href="#">Give feedback</dd.Interactive>
             </Hds::Dropdown>
           </:actions>
         </Hds::SideNav::Header>
@@ -850,9 +850,9 @@
           <D.Generic>
             <Hds::Dropdown as |D|>
               <D.ToggleButton @text="Menu" />
-              <D.Interactive @href="#" @text="Add" />
-              <D.Interactive @href="#" @text="Add More" />
-              <D.Interactive @href="#" @text="Add Another Thing Too" />
+              <D.Interactive @href="#">Add</D.Interactive>
+              <D.Interactive @href="#">Add More</D.Interactive>
+              <D.Interactive @href="#">Add Another Thing Too</D.Interactive>
             </Hds::Dropdown>
           </D.Generic>
           <D.Checkbox>access</D.Checkbox>
@@ -863,9 +863,9 @@
               <Hds::Button @text="Cancel" @color="secondary" @size="small" />
               <Hds::Dropdown as |D|>
                 <D.ToggleButton @text="Menu" />
-                <D.Interactive @href="#" @text="Add" />
-                <D.Interactive @href="#" @text="Add More" />
-                <D.Interactive @href="#" @text="Add Another Thing Too" />
+                <D.Interactive @href="#">Add</D.Interactive>
+                <D.Interactive @href="#">Add More</D.Interactive>
+                <D.Interactive @href="#">Add Another Thing Too</D.Interactive>
               </Hds::Dropdown>
             </Hds::ButtonSet>
           </D.Footer>

--- a/showcase/app/templates/components/table.hbs
+++ b/showcase/app/templates/components/table.hbs
@@ -184,11 +184,11 @@
         <B.Td @align="right">
           <Hds::Dropdown @isInline={{true}} as |dd|>
             <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-            <dd.Interactive @route="components.table" @text="Create" />
-            <dd.Interactive @route="components.table" @text="Read" />
-            <dd.Interactive @route="components.table" @text="Update" />
+            <dd.Interactive @route="components.table">Create</dd.Interactive>
+            <dd.Interactive @route="components.table">Read</dd.Interactive>
+            <dd.Interactive @route="components.table">Update</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @route="components.table" @text="Delete" @color="critical" @icon="trash" />
+            <dd.Interactive @route="components.table" @color="critical" @icon="trash">Delete</dd.Interactive>
           </Hds::Dropdown>
         </B.Td>
       </B.Tr>
@@ -235,11 +235,11 @@
         <B.Td @align="right">
           <Hds::Dropdown @isInline={{true}} as |dd|>
             <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-            <dd.Interactive @route="components.table" @text="Create" />
-            <dd.Interactive @route="components.table" @text="Read" />
-            <dd.Interactive @route="components.table" @text="Update" />
+            <dd.Interactive @route="components.table">Create</dd.Interactive>
+            <dd.Interactive @route="components.table">Read</dd.Interactive>
+            <dd.Interactive @route="components.table">Update</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @route="components.table" @text="Delete" @color="critical" @icon="trash" />
+            <dd.Interactive @route="components.table" @color="critical" @icon="trash">Delete</dd.Interactive>
           </Hds::Dropdown>
         </B.Td>
       </B.Tr>
@@ -295,11 +295,11 @@
           <B.Td @align="right">
             <Hds::Dropdown @isInline={{true}} as |dd|>
               <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-              <dd.Interactive @route="components.table" @text="Create" />
-              <dd.Interactive @route="components.table" @text="Read" />
-              <dd.Interactive @route="components.table" @text="Update" />
+              <dd.Interactive @route="components.table">Create</dd.Interactive>
+              <dd.Interactive @route="components.table">Read</dd.Interactive>
+              <dd.Interactive @route="components.table">Update</dd.Interactive>
               <dd.Separator />
-              <dd.Interactive @route="components.table" @text="Delete" @color="critical" @icon="trash" />
+              <dd.Interactive @route="components.table" @color="critical" @icon="trash">Delete</dd.Interactive>
             </Hds::Dropdown>
           </B.Td>
         </B.Tr>
@@ -357,11 +357,11 @@
           <B.Td @align="right">
             <Hds::Dropdown @isInline={{true}} as |dd|>
               <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-              <dd.Interactive @route="components.table" @text="Create" />
-              <dd.Interactive @route="components.table" @text="Read" />
-              <dd.Interactive @route="components.table" @text="Update" />
+              <dd.Interactive @route="components.table">Create</dd.Interactive>
+              <dd.Interactive @route="components.table">Read</dd.Interactive>
+              <dd.Interactive @route="components.table">Update</dd.Interactive>
               <dd.Separator />
-              <dd.Interactive @route="components.table" @text="Delete" @color="critical" @icon="trash" />
+              <dd.Interactive @route="components.table" @color="critical" @icon="trash">Delete</dd.Interactive>
             </Hds::Dropdown>
           </B.Td>
         </B.Tr>
@@ -968,11 +968,11 @@
         <B.Td @align="right">
           <Hds::Dropdown @isInline={{true}} as |dd|>
             <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-            <dd.Interactive @route="components.table" @text="Create" />
-            <dd.Interactive @route="components.table" @text="Read" />
-            <dd.Interactive @route="components.table" @text="Update" />
+            <dd.Interactive @route="components.table">Create</dd.Interactive>
+            <dd.Interactive @route="components.table">Read</dd.Interactive>
+            <dd.Interactive @route="components.table">Update</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @route="components.table" @text="Delete" @color="critical" @icon="trash" />
+            <dd.Interactive @route="components.table" @color="critical" @icon="trash">Delete</dd.Interactive>
           </Hds::Dropdown>
         </B.Td>
       </B.Tr>
@@ -1665,19 +1665,19 @@
             <B.Td @align="left">
               <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
                 <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-                <dd.Interactive @route="components.table" @text="Dropdown" />
+                <dd.Interactive @route="components.table">Dropdown</dd.Interactive>
               </Hds::Dropdown>
             </B.Td>
             <B.Td @align="center">
               <Hds::Dropdown @isInline={{true}} as |dd|>
                 <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-                <dd.Interactive @route="components.table" @text="Dropdown" />
+                <dd.Interactive @route="components.table">Dropdown</dd.Interactive>
               </Hds::Dropdown>
             </B.Td>
             <B.Td @align="right">
               <Hds::Dropdown @isInline={{true}} as |dd|>
                 <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-                <dd.Interactive @route="components.table" @text="Dropdown" />
+                <dd.Interactive @route="components.table">Dropdown</dd.Interactive>
               </Hds::Dropdown>
             </B.Td>
           </B.Tr>
@@ -1735,7 +1735,7 @@
             <B.Td>
               <Hds::Dropdown as |D|>
                 <D.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-                <D.Interactive @route="components.table" @text="Dropdown" />
+                <D.Interactive @route="components.table">Dropdown</D.Interactive>
               </Hds::Dropdown>
             </B.Td>
             <B.Td>
@@ -1777,7 +1777,7 @@
             <B.Td>
               <Hds::Dropdown as |D|>
                 <D.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-                <D.Interactive @route="components.table" @text="Dropdown" />
+                <D.Interactive @route="components.table">Dropdown</D.Interactive>
               </Hds::Dropdown>
             </B.Td>
             <B.Td>
@@ -1819,7 +1819,7 @@
             <B.Td>
               <Hds::Dropdown as |D|>
                 <D.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-                <D.Interactive @route="components.table" @text="Dropdown" />
+                <D.Interactive @route="components.table">Dropdown</D.Interactive>
               </Hds::Dropdown>
             </B.Td>
             <B.Td>

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
@@ -31,19 +31,19 @@
         <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
           <dd.ToggleIcon @icon="help" @text="help menu" />
           <dd.Title @text="Help & Support" />
-          <dd.Interactive @text="Documentation" @href="#" />
-          <dd.Interactive @text="Tutorials" @href="#" />
-          <dd.Interactive @text="Terraform Provider" @href="#" />
-          <dd.Interactive @text="Changelog" @href="#" />
+          <dd.Interactive @href="#">Documentation</dd.Interactive>
+          <dd.Interactive @href="#">Tutorials</dd.Interactive>
+          <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+          <dd.Interactive @href="#">Changelog</dd.Interactive>
           <dd.Separator />
-          <dd.Interactive @text="Create support ticket" @href="#" />
-          <dd.Interactive @text="Give feedback" @href="#" />
+          <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+          <dd.Interactive @href="#">Give feedback</dd.Interactive>
         </Hds::Dropdown>
         <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
           <dd.ToggleIcon @icon="user" @text="user menu" />
           <dd.Title @text="Signed In" />
           <dd.Description @text="email@domain.com" />
-          <dd.Interactive @href="#" @text="Account Settings" />
+          <dd.Interactive @href="#">Account Settings</dd.Interactive>
         </Hds::Dropdown>
       </:utilityActions>
     </Hds::AppHeader>

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
@@ -18,19 +18,19 @@
             <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
               <dd.ToggleIcon @icon="help" @text="help menu" />
               <dd.Title @text="Help & Support" />
-              <dd.Interactive @text="Documentation" @href="#" />
-              <dd.Interactive @text="Tutorials" @href="#" />
-              <dd.Interactive @text="Terraform Provider" @href="#" />
-              <dd.Interactive @text="Changelog" @href="#" />
+              <dd.Interactive @href="#">Documentation</dd.Interactive>
+              <dd.Interactive @href="#">Tutorials</dd.Interactive>
+              <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+              <dd.Interactive @href="#">Changelog</dd.Interactive>
               <dd.Separator />
-              <dd.Interactive @text="Create support ticket" @href="#" />
-              <dd.Interactive @text="Give feedback" @href="#" />
+              <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+              <dd.Interactive @href="#">Give feedback</dd.Interactive>
             </Hds::Dropdown>
             <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
               <dd.ToggleIcon @icon="user" @text="user menu" />
               <dd.Title @text="Signed In" />
               <dd.Description @text="email@domain.com" />
-              <dd.Interactive @href="#" @text="Account Settings" />
+              <dd.Interactive @href="#">Account Settings</dd.Interactive>
             </Hds::Dropdown>
           </:actions>
         </Hds::SideNav::Header>

--- a/showcase/tests/integration/components/hds/dropdown/list-item/interactive-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/interactive-test.js
@@ -140,7 +140,7 @@ module(
         assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
       });
       await render(
-        hbs`<Hds::Dropdown::ListItem::Interactive @text="interactive text" @color="foo" />`
+        hbs`<Hds::Dropdown::ListItem::Interactive @color="foo" @text="interactive text" />`
       );
       assert.throws(function () {
         throw new Error(errorMessage);

--- a/website/config/deprecation-workflow.js
+++ b/website/config/deprecation-workflow.js
@@ -11,6 +11,15 @@ self.deprecationWorkflow.config = {
     { handler: "silence", matchId: "remove-owner-inject" },
     { handler: "silence", matchId: "ember-modifier.function-based-options" },
     { handler: "throw", matchId: "deprecate-auto-location" },
-    { handler: "silence", matchId: "ember-string.add-package" }
+    { handler: "silence", matchId: "ember-string.add-package" },
+    { handler: "throw", matchId: "hds.dropdown.list-item.interactive" },
+    { handler: "throw", matchId: "hds.components.flyout.body" },
+    { handler: "throw", matchId: "hds.components.flyout.description" },
+    { handler: "throw", matchId: "hds.components.flyout.footer" },
+    { handler: "throw", matchId: "hds.components.flyout.header" },
+    { handler: "throw", matchId: "hds.components.modal.body" },
+    { handler: "throw", matchId: "hds.components.modal.footer" },
+    { handler: "throw", matchId: "hds.components.modal.header" },
+    { handler: "throw", matchId: "hds.components.sidenav.header.iconbutton" },
   ]
 };

--- a/website/docs/components/app-header/partials/code/how-to-use.md
+++ b/website/docs/components/app-header/partials/code/how-to-use.md
@@ -178,20 +178,20 @@ probably need to be set to `true` (or omitted to rely on defaults)
     <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
       <dd.ToggleIcon @icon="help" @text="help menu" />
       <dd.Title @text="Help & Support" />
-      <dd.Interactive @text="Documentation" @href="#" />
-      <dd.Interactive @text="Tutorials" @href="#" />
-      <dd.Interactive @text="Terraform Provider" @href="#" />
-      <dd.Interactive @text="Changelog" @href="#" />
+      <dd.Interactive @href="#">Documentation</dd.Interactive>
+      <dd.Interactive @href="#">Tutorials</dd.Interactive>
+      <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+      <dd.Interactive @href="#">Changelog</dd.Interactive>
       <dd.Separator />
-      <dd.Interactive @text="Create support ticket" @href="#" />
-      <dd.Interactive @text="Give feedback" @href="#" />
+      <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+      <dd.Interactive @href="#">Give feedback</dd.Interactive>
     </Hds::Dropdown>
 
     <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
       <dd.ToggleIcon @icon="user" @text="user menu" />
       <dd.Title @text="Signed In" />
       <dd.Description @text="email@domain.com" />
-      <dd.Interactive @href="#" @text="Account Settings" />
+      <dd.Interactive @href="#">Account settings</dd.Interactive>
     </Hds::Dropdown>
   </:utilityActions>
 </Hds::AppHeader>

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -7,11 +7,11 @@ To make the invocation more flexible and intuitive, we provide contextual compon
   <D.ToggleButton @text="Menu" />
   <D.Title @text="Title Text" />
   <D.Description @text="Descriptive text goes here." />
-  <D.Interactive @href="#" @text="Add" />
-  <D.Interactive @href="#" @text="Add More" />
-  <D.Interactive @href="#" @text="Add Another Thing Too" />
+  <D.Interactive @href="#">Add</D.Interactive>
+  <D.Interactive @href="#">Add More</D.Interactive>
+  <D.Interactive @href="#">Add Another Thing Too</D.Interactive>
   <D.Separator />
-  <D.Interactive @route="components" @icon="trash" @text="Delete" @color="critical" />
+  <D.Interactive @route="components" @icon="trash" @color="critical">Delete</D.Interactive>
 </Hds::Dropdown>
 ```
 
@@ -22,12 +22,12 @@ The basic invocation of ToggleButton requires `@text` to be passed. By default, 
 ```handlebars
 <Hds::Dropdown as |D|>
   <D.ToggleButton @text="Text Toggle" />
-  <D.Interactive @route="components" @text="Item One" />
-  <D.Interactive @route="components" @text="Item Two" />
-  <D.Interactive @route="components" @text="Item Three" />
-  <D.Interactive @text="Item Four (closes on click)" {{on "click" D.close}} />
+  <D.Interactive @route="components">Item One</D.Interactive>
+  <D.Interactive @route="components">Item Two</D.Interactive>
+  <D.Interactive @route="components">Item Three</D.Interactive>
+  <D.Interactive {{on "click" D.close}}>Item Four (closes on click)</D.Interactive>
   <D.Separator />
-  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+  <D.Interactive @route="components" @color="critical" @icon="trash">Delete</D.Interactive>
 </Hds::Dropdown>
 ```
 
@@ -36,12 +36,12 @@ Alternatively, pass `secondary` to `@color` to display a secondary button with a
 ```handlebars
 <Hds::Dropdown as |D|>
   <D.ToggleButton @text="Text Toggle" @color="secondary" />
-  <D.Interactive @route="components" @text="Item One" />
-  <D.Interactive @route="components" @text="Item Two" />
-  <D.Interactive @route="components" @text="Item Three" />
-  <D.Interactive @text="Item Four (closes on click)" {{on "click" D.close}} />
+  <D.Interactive @route="components">Item One</D.Interactive>
+  <D.Interactive @route="components">Item Two</D.Interactive>
+  <D.Interactive @route="components">Item Three</D.Interactive>
+  <D.Interactive {{on "click" D.close}}>Item Four (closes on click)</D.Interactive>
   <D.Separator />
-  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+  <D.Interactive @route="components" @color="critical" @icon="trash">Delete</D.Interactive>
 </Hds::Dropdown>
 ```
 
@@ -55,11 +55,11 @@ Overflow menus are often found in the last column of a [Tables](/components/tabl
 ```handlebars
 <Hds::Dropdown as |D|>
   <D.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} />
-  <D.Interactive @route="components" @text="Create" />
-  <D.Interactive @route="components" @text="Read" />
-  <D.Interactive @route="components" @text="Update" />
+  <D.Interactive @route="components">Create</D.Interactive>
+  <D.Interactive @route="components">Read</D.Interactive>
+  <D.Interactive @route="components">Update</D.Interactive>
   <D.Separator />
-  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+  <D.Interactive @route="components" @icon="trash" @color="critical">Delete</D.Interactive>
 </Hds::Dropdown>
 ```
 
@@ -73,8 +73,8 @@ Overflow menus are often found in the last column of a [Tables](/components/tabl
   <D.Title @text="Signed In" />
   <D.Description @text="email@domain.com" />
   <D.Separator />
-  <D.Interactive @route="components" @text="Settings and Preferences" />
-  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+  <D.Interactive @route="components">Settings and Preferences</D.Interactive>
+  <D.Interactive @route="components" @icon="trash" @color="critical">Delete</D.Interactive>
 </Hds::Dropdown>
 ```
 
@@ -88,8 +88,8 @@ Pass any [icon](/icons/library) name to `@icon` to change the icon used in Toggl
   <D.Title @text="Signed In" />
   <D.Description @text="email@domain.com" />
   <D.Separator />
-  <D.Interactive @route="components" @text="Settings and Preferences" />
-  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+  <D.Interactive @route="components">Settings and Preferences</D.Interactive>
+  <D.Interactive @route="components" @icon="trash" @color="critical">Delete</D.Interactive>
 </Hds::Dropdown>
 ```
 
@@ -100,12 +100,12 @@ By default, the list is positioned below the button, aligned to the right. To ch
 ```handlebars
 <Hds::Dropdown @listPosition="bottom-left" as |D|>
   <D.ToggleButton @text="Text Toggle" />
-  <D.Interactive @route="components" @text="Item One" />
-  <D.Interactive @route="components" @text="Item Two" />
-  <D.Interactive @route="components" @text="Item Three" />
-  <D.Interactive @text="Item Four (closes on click)" {{on "click" D.close}} />
+  <D.Interactive @route="components">Item One</D.Interactive>
+  <D.Interactive @route="components">Item Two</D.Interactive>
+  <D.Interactive @route="components">Item Three</D.Interactive>
+  <D.Interactive {{on "click" D.close}}>Item Four (closes on click)</D.Interactive>
   <D.Separator />
-  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+  <D.Interactive @route="components" @icon="trash" @color="critical">Delete</D.Interactive>
 </Hds::Dropdown>
 ```
 
@@ -115,9 +115,9 @@ In contexts where the Dropdown needs to be _inline_, to inherit the alignment fr
 <div class="doc-dropdown-mock-text-align-right">
   <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |D|>
     <D.ToggleButton @text="Text Toggle" @color="secondary" />
-    <D.Interactive @route="components" @text="Item One" />
-    <D.Interactive @route="components" @text="Item Two" />
-    <D.Interactive @route="components" @text="Item Three" />
+    <D.Interactive @route="components">Item One</D.Interactive>
+    <D.Interactive @route="components">Item Two</D.Interactive>
+    <D.Interactive @route="components">Item Three</D.Interactive>
   </Hds::Dropdown>
 </div>
 ```
@@ -129,12 +129,12 @@ Setting the `@enableCollisionDetection` argument to `true` will automatically ad
 ```handlebars
 <Hds::Dropdown @enableCollisionDetection={{true}} as |D|>
   <D.ToggleButton @text="Text Toggle" />
-  <D.Interactive @route="components" @text="Item One" />
-  <D.Interactive @route="components" @text="Item Two" />
-  <D.Interactive @route="components" @text="Item Three" />
-  <D.Interactive @text="Item Four (closes on click)" {{on "click" D.close}} />
+  <D.Interactive @route="components">Item One</D.Interactive>
+  <D.Interactive @route="components">Item Two</D.Interactive>
+  <D.Interactive @route="components">Item Three</D.Interactive>
+  <D.Interactive {{on "click" D.close}}>Item Four (closes on click)</D.Interactive>
   <D.Separator />
-  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+  <D.Interactive @route="components" @icon="trash" @color="critical">Delete</D.Interactive>
 </Hds::Dropdown>
 ```
 
@@ -151,13 +151,13 @@ The `@height` argument actually sets a `max-height` which prevents the list from
 ```handlebars
 <Hds::Dropdown @isInline={{true}} @height="170px" @width="250px" as |D|>
   <D.ToggleButton @text="Text Toggle" />
-  <D.Interactive @route="components" @text="Item One" />
-  <D.Interactive @route="components" @text="Item Two" />
-  <D.Interactive @route="components" @text="Item Three" />
-  <D.Interactive @route="components" @text="Item Four" />
-  <D.Interactive @route="components" @text="Item Five" />
-  <D.Interactive @route="components" @text="Item Six" />
-  <D.Interactive @route="components" @text="Item Seven" />
+  <D.Interactive @route="components">Item One</D.Interactive>
+  <D.Interactive @route="components">Item Two</D.Interactive>
+  <D.Interactive @route="components">Item Three</D.Interactive>
+  <D.Interactive @route="components">Item Four</D.Interactive>
+  <D.Interactive @route="components">Item Five</D.Interactive>
+  <D.Interactive @route="components">Item Six</D.Interactive>
+  <D.Interactive @route="components">Item Seven</D.Interactive>
 </Hds::Dropdown>
 ```
 
@@ -196,7 +196,7 @@ To change this behavior, you can use the `@preserveContentInDom` argument so tha
 ```handlebars
 <Hds::Dropdown @preserveContentInDom={{true}} as |D|>
   <D.ToggleButton @text="Text Toggle" />
-  <D.Interactive @route="components" @text="This item should always be present in the DOM, regardless of whether the dropdown is open or closed" />
+  <D.Interactive @route="components">This item should always be present in the DOM, regardless of whether the dropdown is open or closed</D.Interactive>
 </Hds::Dropdown>
 ```
 
@@ -211,7 +211,9 @@ If you add an event handler (no `@href` or `@route`), a `<button>` element will 
 
 ```handlebars
 <ul class="hds-dropdown__list">
-  <Hds::Dropdown::ListItem::Interactive {{on "click" this.myAction}} @text="Run command" />
+  <Hds::Dropdown::ListItem::Interactive {{on "click" this.myAction}}>
+    Run command
+  </Hds::Dropdown::ListItem::Interactive>
 </ul>
 ```
 
@@ -219,7 +221,9 @@ You can pass an `@icon` argument to add a leading icon:
 
 ```handlebars
 <ul class="hds-dropdown__list">
-  <Hds::Dropdown::ListItem::Interactive {{on "click" this.myAction}} @text="Run command" @icon="build" />
+  <Hds::Dropdown::ListItem::Interactive {{on "click" this.myAction}} @icon="build">
+    Run command
+  </Hds::Dropdown::ListItem::Interactive>
 </ul>
 ```
 
@@ -236,7 +240,9 @@ If you pass an `@href` argument, a link (`<a>` element) will be generated:
 
 ```handlebars
 <ul class="hds-dropdown__list">
-  <Hds::Dropdown::ListItem::Interactive @href="https://www.hashicorp.com/request-demo/terraform" @text="Request a demo" />
+  <Hds::Dropdown::ListItem::Interactive @href="https://www.hashicorp.com/request-demo/terraform">
+    Request a demo
+  </Hds::Dropdown::ListItem::Interactive>
 </ul>
 ```
 
@@ -244,7 +250,9 @@ To indicate that the link points to an external resource, you can use `@trailing
 
 ```handlebars
 <ul class="hds-dropdown__list">
-  <Hds::Dropdown::ListItem::Interactive @href="https://www.hashicorp.com/request-demo/terraform" @text="Request a demo" @trailingIcon="external-link" />
+  <Hds::Dropdown::ListItem::Interactive @href="https://www.hashicorp.com/request-demo/terraform" @trailingIcon="external-link">
+    Request a demo
+  </Hds::Dropdown::ListItem::Interactive>
 </ul>
 ```
 
@@ -254,7 +262,9 @@ Pass a `@route` to render Ember `<LinkTo>`. If the route is external to your cur
 
 ```handlebars
 <ul class="hds-dropdown__list">
-  <Hds::Dropdown::ListItem::Interactive @route="my.page.route" @model="my.page.model" @text="Activate cluster" />
+  <Hds::Dropdown::ListItem::Interactive @route="my.page.route" @model="my.page.model">
+    Activate cluster
+  </Hds::Dropdown::ListItem::Interactive>
 </ul>
 ```
 
@@ -267,8 +277,8 @@ Pass the argument `@isLoading={{true}}` to the item. This will show a “loading
 ```handlebars
 <Hds::Dropdown as |D|>
   <D.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} />
-  <D.Interactive @route="components" @isLoading={{true}} @text="Edit cluster" @color="action" @icon="edit" />
-  <D.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+  <D.Interactive @route="components" @isLoading={{true}} @color="action" @icon="edit">Edit cluster</D.Interactive>
+  <D.Interactive @route="components" @icon="trash" @color="critical">Delete</D.Interactive>
 </Hds::Dropdown>
 ```
 

--- a/website/docs/components/dropdown/partials/guidelines/guidelines.md
+++ b/website/docs/components/dropdown/partials/guidelines/guidelines.md
@@ -19,17 +19,17 @@ Toggles come in two variant types: **button** and **icon**.
 <Doc::Layout @spacing="24px">
   <Hds::Dropdown as |D|>
     <D.ToggleButton @text="Primary" />
-    <D.Interactive @text="Item One" />
-    <D.Interactive @text="Item Two" />
-    <D.Interactive @text="Item Three" />
-    <D.Interactive @text="Item Four" />
+    <D.Interactive>Item One</D.Interactive>
+    <D.Interactive>Item Two</D.Interactive>
+    <D.Interactive>Item Three</D.Interactive>
+    <D.Interactive>Item Four</D.Interactive>
   </Hds::Dropdown>
   <Hds::Dropdown as |D|>
     <D.ToggleIcon @icon="user" @text="user menu" />
-    <D.Interactive @text="Item One" />
-    <D.Interactive @text="Item Two" />
-    <D.Interactive @text="Item Three" />
-    <D.Interactive @text="Item Four" />
+    <D.Interactive>Item One</D.Interactive>
+    <D.Interactive>Item Two</D.Interactive>
+    <D.Interactive>Item Three</D.Interactive>
+    <D.Interactive>Item Four</D.Interactive>
   </Hds::Dropdown>
 </Doc::Layout>
 
@@ -41,33 +41,33 @@ ToggleButtons come in two sizes: **small** and **medium**. This allows for place
   <Hds::ButtonSet>
     <Hds::Dropdown as |D|>
       <D.ToggleButton @text="Primary" @size="small"/>
-      <D.Interactive @text="Item One" />
-      <D.Interactive @text="Item Two" />
-      <D.Interactive @text="Item Three" />
-      <D.Interactive @text="Item Four" />
+      <D.Interactive>Item One</D.Interactive>
+      <D.Interactive>Item Two</D.Interactive>
+      <D.Interactive>Item Three</D.Interactive>
+      <D.Interactive>Item Four</D.Interactive>
     </Hds::Dropdown>
     <Hds::Dropdown as |D|>
       <D.ToggleButton @text="Secondary" @color="secondary" @size="small" />
-      <D.Interactive @text="Item One" />
-      <D.Interactive @text="Item Two" />
-      <D.Interactive @text="Item Three" />
-      <D.Interactive @text="Item Four" />
+      <D.Interactive>Item One</D.Interactive>
+      <D.Interactive>Item Two</D.Interactive>
+      <D.Interactive>Item Three</D.Interactive>
+      <D.Interactive>Item Four</D.Interactive>
     </Hds::Dropdown>
   </Hds::ButtonSet>
   <Hds::ButtonSet>
     <Hds::Dropdown as |D|>
       <D.ToggleButton @text="Primary" />
-      <D.Interactive @text="Item One" />
-      <D.Interactive @text="Item Two" />
-      <D.Interactive @text="Item Three" />
-      <D.Interactive @text="Item Four" />
+      <D.Interactive>Item One</D.Interactive>
+      <D.Interactive>Item Two</D.Interactive>
+      <D.Interactive>Item Three</D.Interactive>
+      <D.Interactive>Item Four</D.Interactive>
     </Hds::Dropdown>
     <Hds::Dropdown as |D|>
       <D.ToggleButton @text="Secondary" @color="secondary" />
-      <D.Interactive @text="Item One" />
-      <D.Interactive @text="Item Two" />
-      <D.Interactive @text="Item Three" />
-      <D.Interactive @text="Item Four" />
+      <D.Interactive>Item One</D.Interactive>
+      <D.Interactive>Item Two</D.Interactive>
+      <D.Interactive>Item Three</D.Interactive>
+      <D.Interactive>Item Four</D.Interactive>
     </Hds::Dropdown>
   </Hds::ButtonSet>
 </Doc::Layout>
@@ -82,17 +82,17 @@ While we provide a small size variant, we recommend only using this for the Over
 <Doc::Layout @spacing="24px">
   <Hds::Dropdown as |D|>
     <D.ToggleIcon @icon="more-horizontal" @size="small" @text="Overflow Options" @hasChevron={{false}} />
-    <D.Interactive @text="Item One" />
-    <D.Interactive @text="Item Two" />
-    <D.Interactive @text="Item Three" />
-    <D.Interactive @text="Item Four" />
+    <D.Interactive>Item One</D.Interactive>
+    <D.Interactive>Item Two</D.Interactive>
+    <D.Interactive>Item Three</D.Interactive>
+    <D.Interactive>Item Four</D.Interactive>
   </Hds::Dropdown>
   <Hds::Dropdown as |D|>
     <D.ToggleIcon @icon="user" @text="user menu" />
-    <D.Interactive @text="Item One" />
-    <D.Interactive @text="Item Two" />
-    <D.Interactive @text="Item Three" />
-    <D.Interactive @text="Item Four" />
+    <D.Interactive>Item One</D.Interactive>
+    <D.Interactive>Item Two</D.Interactive>
+    <D.Interactive>Item Three</D.Interactive>
+    <D.Interactive>Item Four</D.Interactive>
   </Hds::Dropdown>
 </Doc::Layout>
 
@@ -127,9 +127,9 @@ By default, Lists have a minimum width of 200px and a maximum width of 400px. Th
     <Hds::Dropdown::ListItem::Title @text="Signed in as" />
     <Hds::Dropdown::ListItem::Description @text="name@email.com" />
     <Hds::Dropdown::ListItem::Separator />
-    <Hds::Dropdown::ListItem::Interactive @text="User settings" />
-    <Hds::Dropdown::ListItem::Interactive @text="Admin" />
-    <Hds::Dropdown::ListItem::Interactive @text="Sign out" />
+    <Hds::Dropdown::ListItem::Interactive>User settings</Hds::Dropdown::ListItem::Interactive>
+    <Hds::Dropdown::ListItem::Interactive>Admin</Hds::Dropdown::ListItem::Interactive>
+    <Hds::Dropdown::ListItem::Interactive>Sign out</Hds::Dropdown::ListItem::Interactive>
   </ul>
 </div>
 
@@ -138,8 +138,8 @@ If you do not want the width of the List to expand automatically to accommodate 
 <div class="hds-dropdown__content" style="width: 320px">
   <ul class="hds-dropdown__list">
     <Hds::Dropdown::ListItem::Title @text="Consul version v1.10.6" />
-    <Hds::Dropdown::ListItem::Interactive @text="Update Consul version" @icon="sync" />
-    <Hds::Dropdown::ListItem::Interactive @text="Edit cluster" @icon="edit" />
+    <Hds::Dropdown::ListItem::Interactive @icon="sync">Update Consul version</Hds::Dropdown::ListItem::Interactive>
+    <Hds::Dropdown::ListItem::Interactive @icon="edit">Edit cluster</Hds::Dropdown::ListItem::Interactive>
     <Hds::Dropdown::ListItem::Separator />
     <Hds::Dropdown::ListItem::Title @text="Import to Terraform" />
     <Hds::Dropdown::ListItem::Description @text="Copy and run this command in Terraform to import and manage this resource via our Terraform Provider" />
@@ -148,7 +148,7 @@ If you do not want the width of the List to expand automatically to accommodate 
     </Hds::Dropdown::ListItem::Generic>
     <Hds::Dropdown::ListItem::CopyItem @text="terraform import hcp_connect" />
     <Hds::Dropdown::ListItem::Separator />
-    <Hds::Dropdown::ListItem::Interactive @text="Delete cluster" @color="critical" @icon="trash" />
+    <Hds::Dropdown::ListItem::Interactive @color="critical" @icon="trash">Delete cluster</Hds::Dropdown::ListItem::Interactive>
   </ul>
 </div>
 
@@ -293,11 +293,11 @@ Use icons consistently and when they reinforce the content.
 
 <div class="hds-dropdown__content">
   <ul class="hds-dropdown__list">
-    <Hds::Dropdown::ListItem::Interactive @text="Rename cluster" @color="action" @icon="edit" />
-    <Hds::Dropdown::ListItem::Interactive @text="Restore cluster" @color="action" @icon="reload" />
-    <Hds::Dropdown::ListItem::Interactive @text="Reference cluster" @color="action" @icon="github" @trailingIcon="external-link" />
+    <Hds::Dropdown::ListItem::Interactive @color="action" @icon="edit">Rename cluster</Hds::Dropdown::ListItem::Interactive>
+    <Hds::Dropdown::ListItem::Interactive @color="action" @icon="reload">Restore cluster</Hds::Dropdown::ListItem::Interactive>
+    <Hds::Dropdown::ListItem::Interactive @color="action" @icon="github" @trailingIcon="external-link">Reference cluster</Hds::Dropdown::ListItem::Interactive>
     <Hds::Dropdown::ListItem::Separator />
-    <Hds::Dropdown::ListItem::Interactive @text="Delete cluster" @color="critical" @icon="trash" />
+    <Hds::Dropdown::ListItem::Interactive @color="critical" @icon="trash">Delete cluster</Hds::Dropdown::ListItem::Interactive>
   </ul>
 </div>
 !!!
@@ -308,10 +308,10 @@ Avoid inconsistent icon use.
 
 <div class="hds-dropdown__content">
   <ul class="hds-dropdown__list">
-    <Hds::Dropdown::ListItem::Interactive @text="Rename cluster" @color="action" />
-    <Hds::Dropdown::ListItem::Interactive @text="Restore cluster" @color="action" @icon="reload" />
+    <Hds::Dropdown::ListItem::Interactive @color="action">Rename cluster</Hds::Dropdown::ListItem::Interactive>
+    <Hds::Dropdown::ListItem::Interactive @color="action" @icon="reload">Restore cluster</Hds::Dropdown::ListItem::Interactive>
     <Hds::Dropdown::ListItem::Separator />
-    <Hds::Dropdown::ListItem::Interactive @text="Delete cluster" @color="critical" @icon="trash" />
+    <Hds::Dropdown::ListItem::Interactive @color="critical" @icon="trash">Delete cluster</Hds::Dropdown::ListItem::Interactive>
   </ul>
 </div>
 !!!

--- a/website/docs/components/page-header/partials/code/how-to-use.md
+++ b/website/docs/components/page-header/partials/code/how-to-use.md
@@ -58,16 +58,11 @@ Pass custom metadata to the component with a `generic` contextual component that
   <PH.Actions>
     <Hds::Dropdown as |D|>
       <D.ToggleButton @text="Manage" @color="secondary" />
-      <D.Interactive @route="components" @text="Item One" />
-      <D.Interactive @route="components" @text="Item Two" />
-      <D.Interactive @route="components" @text="Item Three" />
+      <D.Interactive @route="components">Item One</D.Interactive>
+      <D.Interactive @route="components">Item Two</D.Interactive>
+      <D.Interactive @route="components">Item Three</D.Interactive>
       <D.Separator />
-      <D.Interactive
-        @route="components"
-        @text="Delete"
-        @color="critical"
-        @icon="trash"
-      />
+      <D.Interactive @route="components" @color="critical" @icon="trash">Delete</D.Interactive>
     </Hds::Dropdown>
   </PH.Actions>
   <PH.Generic>

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -144,19 +144,19 @@ Here is an example of some possible actions:
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="settings menu" />
             <dd.Title @text="Help & Support" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Terraform Provider" @href="#" />
-            <dd.Interactive @text="Changelog" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+            <dd.Interactive @href="#">Changelog</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @text="Create support ticket" @href="#" />
-            <dd.Interactive @text="Give feedback" @href="#" />
+            <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+            <dd.Interactive @href="#">Give feedback</dd.Interactive>
           </Hds::Dropdown>
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
-            <dd.Interactive @href="#" @text="Account Settings" />
+            <dd.Interactive @href="#">Account Settings</dd.Interactive>
           </Hds::Dropdown>
         </:actions>
       </Hds::SideNav::Header>
@@ -281,19 +281,19 @@ but in your app they will probably need to be set to `true` (or omitted to rely 
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="help" @text="help menu" />
             <dd.Title @text="Help & Support" />
-            <dd.Interactive @text="Documentation" @href="#" />
-            <dd.Interactive @text="Tutorials" @href="#" />
-            <dd.Interactive @text="Terraform Provider" @href="#" />
-            <dd.Interactive @text="Changelog" @href="#" />
+            <dd.Interactive @href="#">Documentation</dd.Interactive>
+            <dd.Interactive @href="#">Tutorials</dd.Interactive>
+            <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+            <dd.Interactive @href="#">Changelog</dd.Interactive>
             <dd.Separator />
-            <dd.Interactive @text="Create support ticket" @href="#" />
-            <dd.Interactive @text="Give feedback" @href="#" />
+            <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+            <dd.Interactive @href="#">Give feedback</dd.Interactive>
           </Hds::Dropdown>
           <Hds::Dropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleIcon @icon="user" @text="user menu" />
             <dd.Title @text="Signed In" />
             <dd.Description @text="email@domain.com" />
-            <dd.Interactive @href="#" @text="Account Settings" />
+            <dd.Interactive @href="#">Account Settings</dd.Interactive>
           </Hds::Dropdown>
         </:actions>
       </Hds::SideNav::Header>

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -442,11 +442,11 @@ To create a column that has right-aligned content, set `@align` to `right` on bo
       <B.Td @align="right">
         <Hds::Dropdown @isInline={{true}} as |dd|>
           <dd.ToggleIcon @icon="more-horizontal" @text="Overflow Options" @hasChevron={{false}} @size="small" />
-          <dd.Interactive @route="components" @text="Create" />
-          <dd.Interactive @route="components" @text="Read" />
-          <dd.Interactive @route="components" @text="Update" />
+          <dd.Interactive @route="components">Create</dd.Interactive>
+          <dd.Interactive @route="components">Read</dd.Interactive>
+          <dd.Interactive @route="components">Update</dd.Interactive>
           <dd.Separator />
-          <dd.Interactive @route="components" @text="Delete" @color="critical" @icon="trash" />
+          <dd.Interactive @route="components" @color="critical" @icon="trash">Delete</dd.Interactive>
         </Hds::Dropdown>
       </B.Td>
     </B.Tr>
@@ -828,10 +828,9 @@ In this example we’re visually hiding the label in the last column by passing 
             />
             <D.Interactive
               @href="#"
-              @text="Delete"
               @color="critical"
               @icon="trash"
-            />
+            >Delete</D.Interactive>
           </Hds::Dropdown>
         </B.Td>
     </B.Tr>
@@ -868,16 +867,11 @@ Here’s a Table implementation that uses an array hash with localized strings f
               @hasChevron={{false}}
               @size="small"
             />
-            <D.Interactive @href="#" @text="Create" />
-            <D.Interactive @href="#" @text="Read" />
-            <D.Interactive @href="#" @text="Update" />
+            <D.Interactive @href="#">Create</D.Interactive>
+            <D.Interactive @href="#">Read</D.Interactive>
+            <D.Interactive @href="#">Update</D.Interactive>
             <D.Separator />
-            <D.Interactive
-              @href="#"
-              @text='Delete'
-              @color='critical'
-              @icon='trash'
-            />
+            <D.Interactive @href="#" @color="critical" @icon="trash">Delete</D.Interactive>
           </Hds::Dropdown>
         </B.Td>
     </B.Tr>

--- a/website/docs/patterns/table-multi-select/partials/accessibility/accessibility.md
+++ b/website/docs/patterns/table-multi-select/partials/accessibility/accessibility.md
@@ -18,11 +18,11 @@ This is a _representative_ example of how this could be accomplished using HDS c
     </Hds::Text::Body>
     <Hds::Dropdown as |D|>
       <D.ToggleButton @size="small" @text="Actions" @color="secondary" />
-      <D.Interactive @text="Edit" @icon="edit" />
-      <D.Interactive @text="Delete" @icon="trash" @color="critical" />
+      <D.Interactive @icon="edit">Edit</D.Interactive>
+      <D.Interactive @icon="trash" @color="critical">Delete</D.Interactive>
       <D.Separator />
-      <D.Interactive @text="Select all" />
-      <D.Interactive @text="Reset selection" />
+      <D.Interactive>Select all</D.Interactive>
+      <D.Interactive>Reset selection</D.Interactive>
     </Hds::Dropdown>
   </div>
 </div>


### PR DESCRIPTION
### :pushpin: Summary

Replace the deprecated `@text` argument in `Hds::Dropdown::ListItem::Interactive` to silence warnings.
Alternatively, we could've updated the `deprecation-workflow.js` to silence these warnings until fixed.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3999](https://hashicorp.atlassian.net/browse/HDS-3999)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3999]: https://hashicorp.atlassian.net/browse/HDS-3999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ