### PR TITLE
`Dropdown`: fix height for small variant

### DIFF
--- a/.changeset/violet-donuts-matter.md
+++ b/.changeset/violet-donuts-matter.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Dropdown`: fix the height of the chevron in `ToggleButton`.

--- a/.changeset/violet-donuts-matter.md
+++ b/.changeset/violet-donuts-matter.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Dropdown`: fix the height of the chevron in `ToggleButton`.
+`Dropdown`: fixed the height of the chevron in `ToggleButton`.

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -136,6 +136,12 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 
 .hds-dropdown-toggle-button--size-small {
   padding-right: 0.375rem;
+
+  // For small variant with chevron, force the icon size to custom (even if the SGV size is `16px`)
+  .hds-icon {
+    width: 12px;
+    height: 12px;
+  }
 }
 
 .hds-dropdown-toggle-button--size-medium {


### PR DESCRIPTION
### :pushpin: Summary

Currently, the small (non-icon) variant of Dropdown is 30px tall when it should be 28px. This was because the chevron icon was 16px tall instead of 12px.

This was because the styles to make the icon 12px were only applied to the chevron icon in the ToggleIcon Dropdown. To solve this, I also added those styles to the ToggleButton.

Showcase: https://hds-showcase-git-hds-3996-dropdown-size-hashicorp.vercel.app/components/dropdown

### :camera_flash: Screenshots

New dimensions for both icon only toggle and toggle with text: 

<img width="399" alt="Screenshot 2024-10-28 at 2 43 29 PM" src="https://github.com/user-attachments/assets/d15a19b1-a1dd-4d96-8b74-8c8c763e6b12">
<img width="433" alt="Screenshot 2024-10-28 at 2 43 42 PM" src="https://github.com/user-attachments/assets/a0447d2d-e9f5-4511-b915-7e1497141de0">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3996](https://hashicorp.atlassian.net/browse/HDS-3996)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3996]: https://hashicorp.atlassian.net/browse/HDS-3996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ