### PR TITLE
Showcase - Small fixes for `Shw::Grid` component

### DIFF
--- a/showcase/app/components/shw/grid/index.gts
+++ b/showcase/app/components/shw/grid/index.gts
@@ -20,7 +20,7 @@ interface ShwGridSignature {
   Args: {
     columns: 2 | 3 | 4 | 5 | 6 | 7;
     forceMinWidth?: boolean;
-    gap: string;
+    gap?: string;
     grow?: boolean;
     label?: string;
   };

--- a/showcase/app/components/shw/grid/index.gts
+++ b/showcase/app/components/shw/grid/index.gts
@@ -18,7 +18,7 @@ import type { ShwGridItemSignature } from './item';
 
 interface ShwGridSignature {
   Args: {
-    columns: 2 | 3 | 4 | 5 | 6 | 7;
+    columns: 1 | 2 | 3 | 4 | 5 | 6 | 7;
     forceMinWidth?: boolean;
     gap?: string;
     grow?: boolean;

--- a/showcase/app/styles/showcase-components/grid.scss
+++ b/showcase/app/styles/showcase-components/grid.scss
@@ -17,6 +17,10 @@
   flex-wrap: wrap;
   gap: var(--shw-layout-gap-base);
 
+  .shw-grid--cols-1 > & {
+    grid-template-columns: 1fr;
+  }
+
   .shw-grid--cols-2 > & {
     grid-template-columns: repeat(2, 1fr);
   }


### PR DESCRIPTION
### :pushpin: Summary

This small PR fixes a couple of issues spotted in these failing tests:
https://github.com/hashicorp/design-system/actions/runs/11525889346/job/32089039125
that were mentioned in this comment:
https://github.com/hashicorp/design-system/pull/2518#issuecomment-2443801163

### :hammer_and_wrench: Detailed description

In this PR I have:
- made the `gap` argument optional in the `Shw::Grid` signature
- added support for 1-column layout in `Shw::Grid` component

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
