### PR TITLE
Showcase - Added extra demo to `Dropdown` for `width="100%"`

### DIFF
--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -1539,6 +1539,19 @@
         </Hds::Dropdown>
       </div>
     </SG.Item>
+    <SG.Item @label="With 100% width">
+      <div class="shw-component-dropdown-fixed-height-container">
+        <Hds::Dropdown @listPosition="bottom-left" @width="100%" as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Interactive @href="#">
+            Lorem ipsum dolor sit amet
+          </D.Interactive>
+          <D.Interactive @href="#">
+            Consectetur adipisicing elit
+          </D.Interactive>
+        </Hds::Dropdown>
+      </div>
+    </SG.Item>
     <SG.Item as |SG|>
       <SG.Label>Using <code>preserveContentInDom</code> argument</SG.Label>
       <div class="shw-component-dropdown-fixed-height-container">


### PR DESCRIPTION
### :pushpin: Summary

Small PR to add extra demo to the `Dropdown` showcase, to demonstrate the issue with setting `width="100%"` (so it can be used to try to fix it).

<img width="1372" alt="screenshot_4375" src="https://github.com/user-attachments/assets/e26c8241-aa53-4ee7-906d-542909588ca7">

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
