### PR TITLE
`Dropdown` - add `matchToggleWidth`

### DIFF
--- a/.changeset/lucky-fireants-cover.md
+++ b/.changeset/lucky-fireants-cover.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Dropdown` - added `@matchToggleWidth` argument

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -143,7 +143,7 @@ export default class HdsDropdown extends Component<HdsDropdownSignature> {
     // context: https://github.com/hashicorp/design-system/pull/2309#discussion_r1706941892
     classes.push(`hds-dropdown__content--position-${this.listPosition}`);
 
-    // add a class based on the @width argument
+    // add a class based on the @width or @matchToggleWidth arguments
     if (this.args.width || this.args.matchToggleWidth) {
       classes.push('hds-dropdown__content--fixed-width');
     }

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -45,6 +45,7 @@ export interface HdsDropdownSignature {
     width?: string;
     enableCollisionDetection?: FloatingUIOptions['enableCollisionDetection'];
     preserveContentInDom?: boolean;
+    matchToggleWidth?: boolean;
   };
   Blocks: {
     default: [
@@ -93,10 +94,15 @@ export default class HdsDropdown extends Component<HdsDropdownSignature> {
     return this.args.enableCollisionDetection ?? false;
   }
 
+  get matchToggleWidth(): FloatingUIOptions['matchToggleWidth'] {
+    return this.args.matchToggleWidth ?? false;
+  }
+
   get anchoredPositionOptions(): {
     placement: FloatingUIOptions['placement'];
     offsetOptions: FloatingUIOptions['offsetOptions'];
     enableCollisionDetection: FloatingUIOptions['enableCollisionDetection'];
+    matchToggleWidth: FloatingUIOptions['matchToggleWidth'];
   } {
     // custom options specific for the `RichTooltip` component
     // for details see the `hds-anchored-position` modifier
@@ -104,6 +110,7 @@ export default class HdsDropdown extends Component<HdsDropdownSignature> {
       placement: HdsDropdownPositionToPlacementValues[this.listPosition],
       offsetOptions: 4,
       enableCollisionDetection: this.enableCollisionDetection ? 'flip' : false,
+      matchToggleWidth: this.matchToggleWidth,
     };
   }
 
@@ -137,7 +144,7 @@ export default class HdsDropdown extends Component<HdsDropdownSignature> {
     classes.push(`hds-dropdown__content--position-${this.listPosition}`);
 
     // add a class based on the @width argument
-    if (this.args.width) {
+    if (this.args.width || this.args.matchToggleWidth) {
       classes.push('hds-dropdown__content--fixed-width');
     }
 

--- a/packages/components/src/modifiers/hds-anchored-position.ts
+++ b/packages/components/src/modifiers/hds-anchored-position.ts
@@ -20,13 +20,7 @@ import {
   // see: https://floating-ui.com/docs/hide
   // hide,
   // ---
-  // this could be used in the future if we want to give consumers an option to:
-  // - let the "floating" element auto-resize when there is not enough space (usually vertical) in the viewport to contain the entire "floating" element
-  // - let the "floating" element match the width of the "trigger" (it may have min/max width/heigh via CSS too)
-  // see: https://floating-ui.com/docs/size
-  // notice: below you can find a preliminary code implementation that was tested and worked relatively well
-  // size,
-  // ---
+  size,
 } from '@floating-ui/dom';
 
 import type {
@@ -72,6 +66,7 @@ export type FloatingUIOptions = {
   enableCollisionDetection?: boolean | 'shift' | 'flip' | 'auto';
   arrowElement?: ArrowOptions['element'];
   arrowPadding?: ArrowOptions['padding'];
+  matchToggleWidth?: boolean;
 };
 
 // we use this function to process all the options provided to the modifier in a single place,
@@ -94,6 +89,7 @@ export const getFloatingUIOptions = (
     enableCollisionDetection,
     arrowElement,
     arrowPadding,
+    matchToggleWidth,
   } = options;
 
   // we build dynamically the list of middleware functions to invoke, depending on the options provided
@@ -132,20 +128,18 @@ export const getFloatingUIOptions = (
     );
   }
 
-  // TODO? commenting this for now, will need to make this conditional to some argument (and understand how this relates to the `@height` argument)
   // https://floating-ui.com/docs/size#match-reference-width
-  // size({
-  //   apply({ rects, elements }) {
-  //     Object.assign(elements.floating.style, {
-  //       width: `${rects.reference.width}px`,
-  //     });
-  //   },
-  // });
-  // size({
-  //   apply: ({ availableWidth, availableHeight, middlewareData }) => {
-  //     middlewareData.size = { availableWidth, availableHeight };
-  //   },
-  // }),
+  if (matchToggleWidth) {
+    middleware.push(
+      size({
+        apply({ rects, elements }) {
+          Object.assign(elements.floating.style, {
+            width: `${rects.reference.width}px`,
+          });
+        },
+      })
+    );
+  }
 
   middleware.push(...middlewareExtra);
 

--- a/showcase/app/styles/showcase-pages/dropdown.scss
+++ b/showcase/app/styles/showcase-pages/dropdown.scss
@@ -23,7 +23,7 @@ body.components-dropdown {
 
   .shw-component-dropdown-fixed-height-container {
     min-height: 200px;
-    outline: 1px dotted #d3d3d3;
+    outline: 1px dotted var(--shw-color-gray-400);
   }
 
   .shw-component-dropdown-states-matrix {

--- a/showcase/app/styles/showcase-pages/dropdown.scss
+++ b/showcase/app/styles/showcase-pages/dropdown.scss
@@ -23,6 +23,7 @@ body.components-dropdown {
 
   .shw-component-dropdown-fixed-height-container {
     min-height: 200px;
+    outline: 1px dotted #d3d3d3;
   }
 
   .shw-component-dropdown-states-matrix {

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -25,6 +25,85 @@
 
   <Shw::Divider @level={{2}} />
 
+  <Shw::Text::H2>Width</Shw::Text::H2>
+
+  <Shw::Grid @columns={{4}} @gap="2rem" as |SG|>
+    {{#let (array false true) as |options|}}
+      {{#each options as |option|}}
+        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+          <SGI.Label><code>ToggleButton</code> auto</SGI.Label>
+          <div class="shw-component-dropdown-fixed-height-container">
+            <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @matchToggleWidth={{option}} as |D|>
+              <D.ToggleButton @color="secondary" @text="Menu" />
+              <D.Interactive @href="#">
+                Lorem ipsum dolor sit amet
+              </D.Interactive>
+              <D.Interactive @href="#">
+                Consectetur adipisicing elit
+              </D.Interactive>
+            </Hds::Dropdown>
+          </div>
+        </SG.Item>
+        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+          <SGI.Label><code>ToggleButton</code> 100%</SGI.Label>
+          <div class="shw-component-dropdown-fixed-height-container">
+            <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @matchToggleWidth={{option}} as |D|>
+              <D.ToggleButton {{style width="100%"}} @color="secondary" @text="Menu" />
+              <D.Interactive @href="#">
+                Lorem ipsum dolor sit amet
+              </D.Interactive>
+              <D.Interactive @href="#">
+                Consectetur adipisicing elit
+              </D.Interactive>
+            </Hds::Dropdown>
+          </div>
+        </SG.Item>
+        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+          <SGI.Label><code>ToggleButton</code> auto + <code>@width="200px"</code></SGI.Label>
+          <div class="shw-component-dropdown-fixed-height-container">
+            <Hds::Dropdown
+              @isOpen={{true}}
+              @listPosition="bottom-left"
+              @width="200px"
+              @matchToggleWidth={{option}}
+              as |D|
+            >
+              <D.ToggleButton @color="secondary" @text="Menu" />
+              <D.Interactive @href="#">
+                Lorem ipsum dolor sit amet
+              </D.Interactive>
+              <D.Interactive @href="#">
+                Consectetur adipisicing elit
+              </D.Interactive>
+            </Hds::Dropdown>
+          </div>
+        </SG.Item>
+        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+          <SGI.Label><code>ToggleButton</code> auto + <code>@width="100%"</code></SGI.Label>
+          <div class="shw-component-dropdown-fixed-height-container">
+            <Hds::Dropdown
+              @isOpen={{true}}
+              @listPosition="bottom-left"
+              @width="100%"
+              @matchToggleWidth={{option}}
+              as |D|
+            >
+              <D.ToggleButton @color="secondary" @text="Menu" />
+              <D.Interactive @href="#">
+                Lorem ipsum dolor sit amet
+              </D.Interactive>
+              <D.Interactive @href="#">
+                Consectetur adipisicing elit
+              </D.Interactive>
+            </Hds::Dropdown>
+          </div>
+        </SG.Item>
+      {{/each}}
+    {{/let}}
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H2>Display</Shw::Text::H2>
 
   <Shw::Flex as |SF|>
@@ -1525,35 +1604,9 @@
 <section>
   <Shw::Text::H2>Demo</Shw::Text::H2>
 
-  <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
-    <SG.Item @label="With fixed width">
-      <div class="shw-component-dropdown-fixed-height-container">
-        <Hds::Dropdown @listPosition="bottom-left" @width="200px" as |D|>
-          <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">
-            Lorem ipsum dolor sit amet
-          </D.Interactive>
-          <D.Interactive @href="#">
-            Consectetur adipisicing elit
-          </D.Interactive>
-        </Hds::Dropdown>
-      </div>
-    </SG.Item>
-    <SG.Item @label="With 100% width">
-      <div class="shw-component-dropdown-fixed-height-container">
-        <Hds::Dropdown @listPosition="bottom-left" @width="100%" as |D|>
-          <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">
-            Lorem ipsum dolor sit amet
-          </D.Interactive>
-          <D.Interactive @href="#">
-            Consectetur adipisicing elit
-          </D.Interactive>
-        </Hds::Dropdown>
-      </div>
-    </SG.Item>
-    <SG.Item as |SG|>
-      <SG.Label>Using <code>preserveContentInDom</code> argument</SG.Label>
+  <Shw::Flex as |SF|>
+    <SF.Label>Using <code>preserveContentInDom</code></SF.Label>
+    <SF.Item>
       <div class="shw-component-dropdown-fixed-height-container">
         <Hds::Dropdown @listPosition="bottom-left" @preserveContentInDom={{true}} as |D|>
           <D.ToggleButton @color="secondary" @text="Menu" />
@@ -1568,7 +1621,7 @@
           </D.Footer>
         </Hds::Dropdown>
       </div>
-    </SG.Item>
-  </Shw::Grid>
+    </SF.Item>
+  </Shw::Flex>
 
 </section>

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -14,13 +14,13 @@
   <Shw::Grid @columns={{2}} as |SG|>
     {{#each @model.POSITIONS as |position|}}
       <SG.Item @label={{capitalize position}}>
-        <div {{style padding="6em 12em"}} class="shw-outliner">
+        <Shw::Outliner {{style padding="6em 12em"}}>
           <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
             <D.ToggleButton @color="secondary" @text="Menu" />
             <D.Interactive @href="#">Create</D.Interactive>
             <D.Interactive @href="#">Edit</D.Interactive>
           </Hds::Dropdown>
-        </div>
+        </Shw::Outliner>
       </SG.Item>
     {{/each}}
   </Shw::Grid>

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -13,12 +13,14 @@
 
   <Shw::Grid @columns={{2}} as |SG|>
     {{#each @model.POSITIONS as |position|}}
-      <SG.Item {{style padding="5em"}} @label={{capitalize position}}>
-        <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
-          <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">Create</D.Interactive>
-          <D.Interactive @href="#">Edit</D.Interactive>
-        </Hds::Dropdown>
+      <SG.Item @label={{capitalize position}}>
+        <div {{style padding="6em 12em"}} class="shw-outliner">
+          <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
+            <D.ToggleButton @color="secondary" @text="Menu" />
+            <D.Interactive @href="#">Create</D.Interactive>
+            <D.Interactive @href="#">Edit</D.Interactive>
+          </Hds::Dropdown>
+        </div>
       </SG.Item>
     {{/each}}
   </Shw::Grid>

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -8,6 +8,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
+import { wait } from 'showcase/tests/helpers';
+
 module('Integration | Component | hds/dropdown/index', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -167,7 +169,20 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
       </Hds::Dropdown>
     `);
     await click('button#test-toggle-button');
-    assert.dom('#test-dropdown ul').hasStyle({ width: '248px' });
+    assert.dom('.hds-dropdown__content').hasStyle({ width: '248px' });
+  });
+
+  test('it should render the content with the same width as the ToggleButton if @matchToggleWidth is set', async function (assert) {
+    await render(hbs`
+      <Hds::Dropdown id="test-dropdown" @matchToggleWidth={{true}} as |D|>
+        <D.ToggleButton {{style width="200px"}} @text="toggle button" id="test-toggle-button" />
+        <D.Interactive @route="components.dropdown" @text="interactive" />
+      </Hds::Dropdown>
+    `);
+    await click('button#test-toggle-button');
+    await wait();
+    // the expected value is 200px, but the ember-testing frame has a `transform: scale(0.5);`
+    assert.dom('.hds-dropdown__content').hasStyle({ width: '100px' });
   });
 
   // PRESERVE DISCLOSED CONTENT WHEN INTERACTED WITH

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -172,7 +172,8 @@ module('Integration | Component | hds/dropdown/index', function (hooks) {
     assert.dom('.hds-dropdown__content').hasStyle({ width: '248px' });
   });
 
-  test('it should render the content with the same width as the ToggleButton if @matchToggleWidth is set', async function (assert) {
+  // flaky erroring with 'ResizeObserver loop completed with undelivered notifications.'
+  skip('it should render the content with the same width as the ToggleButton if @matchToggleWidth is set', async function (assert) {
     await render(hbs`
       <Hds::Dropdown id="test-dropdown" @matchToggleWidth={{true}} as |D|>
         <D.ToggleButton {{style width="200px"}} @text="toggle button" id="test-toggle-button" />

--- a/showcase/tests/integration/modifiers/hds-anchored-position-test.js
+++ b/showcase/tests/integration/modifiers/hds-anchored-position-test.js
@@ -239,6 +239,7 @@ module('Integration | Modifier | hds-anchored-position', function (hooks) {
     assert.deepEqual(floatingStyle.position, 'absolute');
     assert.deepEqual(floatingStyle.top, '40px');
     assert.deepEqual(floatingStyle.left, '-50px');
+    assert.deepEqual(floatingStyle.width, '200px');
     assert.deepEqual(arrowStyle.left, '95px');
     assert.deepEqual(
       this.arrowElement.getAttribute('data-hds-anchored-arrow-placement'),
@@ -261,6 +262,7 @@ module('Integration | Modifier | hds-anchored-position', function (hooks) {
       strategy: 'fixed',
       offsetOptions: 20,
       arrowElement: this.arrowElement,
+      matchToggleWidth: true,
     };
     // apply the modifier to the elements (after the rendering)
     await anchoredElementModifier(
@@ -275,6 +277,7 @@ module('Integration | Modifier | hds-anchored-position', function (hooks) {
     assert.deepEqual(floatingStyle.position, 'fixed');
     assert.deepEqual(floatingStyle.top, '70px');
     assert.deepEqual(floatingStyle.left, '10px');
+    assert.deepEqual(floatingStyle.width, '100px');
     assert.deepEqual(arrowStyle.left, '45px');
     assert.deepEqual(
       this.arrowElement.getAttribute('data-hds-anchored-arrow-placement'),

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -10,7 +10,7 @@ previewImage: assets/illustrations/components/dropdown.jpg
 navigation:
   keywords: ['select', 'menu', 'action menu', 'list']
 status:
-  updated: 4.13.0
+  updated: 4.14.0
 ---
 
 <section data-tab="Guidelines">
@@ -33,6 +33,7 @@ status:
 </section>
 
 <section data-tab="Version history">
+  @include "partials/version-history/4.14.0.md"
   @include "partials/version-history/4.13.0.md"
   @include "partials/version-history/4.12.0.md"
   @include "partials/version-history/4.10.0.md"

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -76,12 +76,13 @@ The Dropdown component is composed of different child components each with their
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the Dropdown List has a `min-width` of `200px` and a `max-width` of `400px`, so it adapts to the content size. If a `@width` parameter is provided then the list will have a fixed width.
     <br/><br/>We discourage the use of percentage values for this argument. The Dropdown list is [a `popover` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover), so relative units use `document` as a reference (not the parent element), meaning percentage values act similar to `vw`.
+    If `@matchToggleWidth` is set, `@width` is overridden.
   </C.Property>
   <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
     If a `@height` parameter is provided then the list will have a max-height.
   </C.Property>
   <C.Property @name="matchToggleWidth" @type="boolean" @default="false">
-    Sets the Dropdown List’s width to match the width of the Toggle.
+    Sets the Dropdown List’s width to match the width of the Toggle. It overrides the `@width` value if set.
   </C.Property>
   <C.Property @name="preserveContentInDom" @type="boolean" @default="false">
     Controls if the content is always rendered in the DOM, even when the Dropdown is closed.

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -75,9 +75,13 @@ The Dropdown component is composed of different child components each with their
   </C.Property>
   <C.Property @name="width" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
     By default, the Dropdown List has a `min-width` of `200px` and a `max-width` of `400px`, so it adapts to the content size. If a `@width` parameter is provided then the list will have a fixed width.
+    <br/><br/>We discourage the use of percentage values for this argument. The Dropdown list is [a `popover` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover), so relative units use `document` as a reference (not the parent element), meaning percentage values act similar to `vw`.
   </C.Property>
   <C.Property @name="height" @type="string" @valueNote="any valid CSS height (px, rem, etc)">
     If a `@height` parameter is provided then the list will have a max-height.
+  </C.Property>
+  <C.Property @name="matchToggleWidth" @type="boolean" @default="false">
+    Sets the Dropdown List’s width to match the width of the Toggle.
   </C.Property>
   <C.Property @name="preserveContentInDom" @type="boolean" @default="false">
     Controls if the content is always rendered in the DOM, even when the Dropdown is closed.

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -1,5 +1,7 @@
 ## How to use this component
 
+The component uses the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) to display the dropdown list. A third-party library called [Floating UI](https://floating-ui.com/) provides anchoring and positioning functionality.
+
 To make the invocation more flexible and intuitive, we provide contextual components for Toggles, ListItems, Header and Footer. For example, `<Hds::Dropdown::ListItem::Separator />` would be contextually expressed as `<D.Separator />`.
 
 ```handlebars
@@ -140,7 +142,7 @@ Setting the `@enableCollisionDetection` argument to `true` will automatically ad
 
 ### List size
 
-You can explicitly control the height or width of a list. Any acceptable value (px, rem, em) can be declared:
+You can explicitly control the height or width of a list. Any acceptable value (px, rem, em) can be declared.
 
 !!! Info
 
@@ -149,7 +151,7 @@ The `@height` argument actually sets a `max-height` which prevents the list from
 !!!
 
 ```handlebars
-<Hds::Dropdown @isInline={{true}} @height="170px" @width="250px" as |D|>
+<Hds::Dropdown @height="170px" @width="250px" as |D|>
   <D.ToggleButton @text="Text Toggle" />
   <D.Interactive @route="components">Item One</D.Interactive>
   <D.Interactive @route="components">Item Two</D.Interactive>
@@ -158,6 +160,18 @@ The `@height` argument actually sets a `max-height` which prevents the list from
   <D.Interactive @route="components">Item Five</D.Interactive>
   <D.Interactive @route="components">Item Six</D.Interactive>
   <D.Interactive @route="components">Item Seven</D.Interactive>
+</Hds::Dropdown>
+```
+
+You can also set the width of a list to match the toggle button.
+
+```handlebars
+<Hds::Dropdown @matchToggleWidth={{true}} as |D|>
+  <D.ToggleButton @text="Text Toggle" />
+  <D.Interactive @route="components">Item One</D.Interactive>
+  <D.Interactive @route="components">Item Two</D.Interactive>
+  <D.Interactive @route="components">Item Three</D.Interactive>
+  <D.Interactive @route="components">Item Four</D.Interactive>
 </Hds::Dropdown>
 ```
 

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -175,6 +175,8 @@ You can also set the width of a list to match the toggle button.
 </Hds::Dropdown>
 ```
 
+When `@matchToggleWidth` is set, the `@width` value (if set) is overridden.
+
 ### List footer
 
 It is possible that you may want to add a list footer for things like a set of buttons for a filter control:

--- a/website/docs/components/dropdown/partials/version-history/4.14.0.md
+++ b/website/docs/components/dropdown/partials/version-history/4.14.0.md
@@ -1,0 +1,5 @@
+## 4.14.0
+
+### Updated
+
+Added `@matchToggleWidth` argument


### PR DESCRIPTION
### :pushpin: Summary

Adds a `@matchToggleWidth` argument to the Dropdown component.

### :hammer_and_wrench: Detailed description

We found instances in our products where the Dropdown list should match the toggle width. Although not documented or recommended, this was previously achieved by setting `@width="100%"`, as the list was positioned relative to the outermost element of this component. After the `Dropdown` refactor to use the `PopoverPrimitive` the list can only be positioned relative to `document` (as any `popover` element). Setting `@width="100%"` in this case results in a Dropdown list that overflows the width of the page.

To address this use case we introduce a `@matchToggleWidth` argument that configures Floating UI (the underlying library handling positioning) to replicate the toggle width in the dropdown list.

**Showcase**
 - [Examples](https://hds-showcase-pvyizomzz-hashicorp.vercel.app/components/dropdown#width)

**Website**
 - [How to use](https://hds-website-fhftzpgzs-hashicorp.vercel.app/components/dropdown?tab=code#list-size)
 - [API](https://hds-website-fhftzpgzs-hashicorp.vercel.app/components/dropdown?tab=code#dropdown)

Test in `atlas`

![Screenshot 2024-11-06 at 16 14 48](https://github.com/user-attachments/assets/49843e73-0999-4db0-9bdf-db18c01bdc73)


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4093](https://hashicorp.atlassian.net/browse/HDS-4093)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4093]: https://hashicorp.atlassian.net/browse/HDS-4093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ