### PR TITLE
fix: make css selector more specific

### DIFF
--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -138,7 +138,7 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   padding-right: 0.375rem;
 
   // For small variant with chevron, force the icon size to custom (even if the SGV size is `16px`)
-  .hds-icon {
+  .hds-dropdown-toggle-chevron .hds-icon {
     width: 12px;
     height: 12px;
   }


### PR DESCRIPTION
### :pushpin: Summary

Make the styles to force the size of the dropdown chevron more specific. 


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3996](https://hashicorp.atlassian.net/browse/HDS-3996)


***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
