### PR TITLE
Showcase - Add a demo of `RichTooltip` applied to and within a `Dropdown`

### DIFF
--- a/showcase/app/styles/showcase-pages/rich-tooltip.scss
+++ b/showcase/app/styles/showcase-pages/rich-tooltip.scss
@@ -148,6 +148,12 @@ body.components-rich-tooltip {
       }
     }
   }
+
+  .shw-component-rich-tooltip-within-dropdown-toggle {
+    padding: 20px;
+    background-color: yellow;
+    border: 1px solid red;
+  }
 }
 
 // we need to leave this out of the main selector to keep the specificity low

--- a/showcase/app/templates/components/rich-tooltip.hbs
+++ b/showcase/app/templates/components/rich-tooltip.hbs
@@ -1039,6 +1039,57 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Flex @gap="2rem" as |SF|>
+    <SF.Item @label="Applied to Dropdown ('Soft' only)">
+      <Hds::RichTooltip @placement="top" as |RT|>
+        <RT.Toggle>
+          <Hds::Dropdown @listPosition="bottom-left" as |D|>
+            <D.ToggleButton @color="secondary" @text="Menu" />
+            <D.Interactive @href="#">
+              Lorem ipsum dolor sit amet
+            </D.Interactive>
+            <D.Interactive @href="#">
+              Consectetur adipisicing elit
+            </D.Interactive>
+          </Hds::Dropdown>
+        </RT.Toggle>
+        <RT.Bubble>
+          <Shw::Placeholder @text="generic content" @height="30" />
+        </RT.Bubble>
+      </Hds::RichTooltip>
+    </SF.Item>
+    <SF.Item @label="Within Dropdown ('Soft' only)">
+      <Hds::Dropdown @listPosition="bottom-left" as |D|>
+        <D.ToggleButton @color="secondary" @text="Menu" />
+        <D.Interactive @href="#">
+          This is a standard interactive item
+        </D.Interactive>
+        <D.Generic>
+          <Hds::RichTooltip @placement="top" as |RT|>
+            <RT.Toggle>
+              <Hds::Text::Body
+                @tag="p"
+                @size="200"
+                @color="primary"
+                class="shw-component-rich-tooltip-within-dropdown-toggle"
+              >
+                ⚠️ This is a bad idea, don't do it! ⚠️
+              </Hds::Text::Body>
+            </RT.Toggle>
+            <RT.Bubble>
+              <Shw::Placeholder @text="generic content" @height="30" />
+            </RT.Bubble>
+          </Hds::RichTooltip>
+        </D.Generic>
+        <D.Interactive @href="#">
+          This is also a standard interactive item
+        </D.Interactive>
+      </Hds::Dropdown>
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Divider />
 
   <Shw::Text::H2>Base elements</Shw::Text::H2>


### PR DESCRIPTION
### :pushpin: Summary

Small PR to add a demo of the `RichTooltip` applied to a `Dropdown`, and within a `Dropdown`.

Preview: https://hds-showcase-git-showcase-richtooltip-on-dropdown-hashicorp.vercel.app/components/rich-tooltip#demo

Context: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1730399280118789?thread_ts=1730398843.741169&cid=C025N5V4PFZ

### :camera_flash: Screenshots

Applied to Dropdown:
![image](https://github.com/user-attachments/assets/a84cc115-3085-4cfa-a2b9-8c4491a63f5f)

Within Dropdown:
![image](https://github.com/user-attachments/assets/32a9d57c-5ed7-4655-90aa-a1f1839dfba8)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
