### PR TITLE
`SideNav` - Prevent hidden panels from triggering unnecessary overflow scrolling

### DIFF
--- a/.changeset/smooth-cameras-yawn.md
+++ b/.changeset/smooth-cameras-yawn.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav` - Fixed bug with hidden panels sometimes causing unnecessary overflow scrolling

--- a/packages/components/src/styles/components/side-nav/content.scss
+++ b/packages/components/src/styles/components/side-nav/content.scss
@@ -35,6 +35,11 @@
 
 .hds-side-nav__content-panel {
   padding: 0 var(--token-side-nav-wrapper-padding-horizontal);
+  overflow: hidden; // the panel itself does not need to be scrollable
+
+  &[aria-hidden="true"] {
+    max-height: 0; // prevents hidden panels from causing scrolling
+  }
 }
 
 // (LIST) TITLE


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will prevent unwanted scrollbars from being triggered by hidden panels.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Original AppSideNav PRed fix: https://github.com/hashicorp/design-system/pull/2487
* Related ticket: [HDS-3892](https://hashicorp.atlassian.net/browse/HDS-3892)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3892]: https://hashicorp.atlassian.net/browse/HDS-3892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ