### PR TITLE
Share the `wait` test helper across files

### DIFF
--- a/showcase/tests/helpers/index.ts
+++ b/showcase/tests/helpers/index.ts
@@ -45,4 +45,11 @@ function setupTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // Additional setup for unit tests can be done here.
 }
 
-export { setupApplicationTest, setupRenderingTest, setupTest };
+// Helper to delay execution
+function wait(timeout = 500) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout);
+  });
+}
+
+export { setupApplicationTest, setupRenderingTest, setupTest, wait };

--- a/showcase/tests/integration/components/hds/copy/button/index-test.js
+++ b/showcase/tests/integration/components/hds/copy/button/index-test.js
@@ -9,11 +9,7 @@ import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
-function wait(timeout = 2000) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, timeout);
-  });
-}
+import { wait } from 'showcase/tests/helpers';
 
 module('Integration | Component | hds/copy/button/index', function (hooks) {
   setupRenderingTest(hooks);
@@ -125,7 +121,7 @@ module('Integration | Component | hds/copy/button/index', function (hooks) {
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
     await click('button#test-copy-button');
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-success');
-    await wait(); // wait for the status to revert to "idle" automatically
+    await wait(2000); // wait for the status to revert to "idle" automatically
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
   });
 
@@ -144,7 +140,7 @@ module('Integration | Component | hds/copy/button/index', function (hooks) {
     await click('button#test-copy-button');
     assert.false(this.success);
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-error');
-    await wait(); // wait for the status to revert to "idle" automatically
+    await wait(2000); // wait for the status to revert to "idle" automatically
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
   });
 

--- a/showcase/tests/integration/components/hds/copy/snippet/index-test.js
+++ b/showcase/tests/integration/components/hds/copy/snippet/index-test.js
@@ -9,11 +9,7 @@ import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
-function wait(timeout = 2000) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, timeout);
-  });
-}
+import { wait } from 'showcase/tests/helpers';
 
 module('Integration | Component | hds/copy/snippet/index', function (hooks) {
   setupRenderingTest(hooks);
@@ -105,7 +101,7 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
     assert
       .dom('#test-copy-snippet')
       .hasClass('hds-copy-snippet--status-success');
-    await wait(); // wait for the status to revert to "idle" automatically
+    await wait(2000); // wait for the status to revert to "idle" automatically
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
   });
 
@@ -124,7 +120,7 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
     await click('button#test-copy-snippet');
     assert.false(this.success);
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-error');
-    await wait(); // wait for the status to revert to "idle" automatically
+    await wait(2000); // wait for the status to revert to "idle" automatically
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
   });
 

--- a/showcase/tests/integration/components/hds/rich-tooltip/index-test.js
+++ b/showcase/tests/integration/components/hds/rich-tooltip/index-test.js
@@ -8,11 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, resetOnerror, click, focus, blur } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-function wait(timeout = 2000) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, timeout);
-  });
-}
+import { wait } from 'showcase/tests/helpers';
 
 module('Integration | Component | hds/rich-tooltip/index', function (hooks) {
   setupRenderingTest(hooks);

--- a/showcase/tests/integration/components/hds/tooltip/tooltip-button-test.js
+++ b/showcase/tests/integration/components/hds/tooltip/tooltip-button-test.js
@@ -13,6 +13,8 @@ import {
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
+import { wait } from 'showcase/tests/helpers';
+
 module('Integration | Component | hds/tooltip/index', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -53,12 +55,6 @@ module('Integration | Component | hds/tooltip/index', function (hooks) {
   test('it displays the tooltip when focused and dismisses it if Escape key is triggered', async function (assert) {
     const escapeKey = 27;
 
-    function wait(timeout = 1000) {
-      return new Promise((resolve) => {
-        setTimeout(resolve, timeout);
-      });
-    }
-
     await render(
       hbs`<Hds::TooltipButton @text="More info." id="test-tooltip-button">info</Hds::TooltipButton>`
     );
@@ -72,7 +68,7 @@ module('Integration | Component | hds/tooltip/index', function (hooks) {
 
     // Trigger escape key to close the tooltip:
     await triggerKeyEvent('#test-tooltip-button', 'keydown', escapeKey);
-    await wait();
+    await wait(1000);
     // test that the tooltip is now gone:
     assert.dom('.tippy-box').doesNotExist();
   });

--- a/showcase/tests/integration/modifiers/hds-anchored-position-test.js
+++ b/showcase/tests/integration/modifiers/hds-anchored-position-test.js
@@ -8,6 +8,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
+import { wait } from 'showcase/tests/helpers';
+
 import { getFloatingUIOptions } from '@hashicorp/design-system-components/modifiers/hds-anchored-position';
 import anchoredElementModifier from '@hashicorp/design-system-components/modifiers/hds-anchored-position';
 
@@ -155,12 +157,6 @@ module(
 );
 
 // ================================================================
-
-function wait(timeout = 500) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, timeout);
-  });
-}
 
 module('Integration | Modifier | hds-anchored-position', function (hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
### :pushpin: Summary

We seem to be using this utility across multiple tests, so I tried abstracting it a bit and make it available via test helpers.

Extracted from #2530 to ease review.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
