### PR TITLE
Removed references to the AppHeader

### DIFF
--- a/website/docs/components/side-nav/index.md
+++ b/website/docs/components/side-nav/index.md
@@ -5,7 +5,7 @@ caption: A side navigation menu that provides access to subpages within a produc
 links:
   figma: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components?node-id=26174%3A58558&t=kVEJBi3HIfTpV8nG-1
   github: https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/side-nav
-related: ['components/breadcrumb','components/tabs','layouts/app-frame','components/app-header']
+related: ['components/breadcrumb','components/tabs','layouts/app-frame']
 previewImage: assets/illustrations/components/side-nav.jpg
 navigation:
   hidden: false

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -7,16 +7,12 @@ This is the full-fledged component (responsive and animated).
 <Doc::ComponentApi as |C|>
   <C.Property @name="<:header>" @type="named block">
     A named block where the content for the “header” area of the Side Nav is rendered. The `SideNav::Header` component should be added here. It yields the value of `isMinimized` too.
-    <br><br>
-    When the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) component, the `<:header>` block normally doesn’t need to be included.
   </C.Property>
   <C.Property @name="<:body>" @type="named block">
     A named block where the content for the “body” or main content of the Side Nav is rendered. The `SideNav::List` and `SideNav::PortalTarget` components should be added here when used. It yields the value of `isMinimized` too.
   </C.Property>
   <C.Property @name="<:footer>" @type="named block">
     A named block where the content for the “footer” section of the Side Nav is rendered. It yields the value of `isMinimized` too.
-    <br><br>
-    When the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) component, you may not need to include the `<:footer>` block or related content.
   </C.Property>
   <C.Property @name="isResponsive" @type="boolean" @default="true">
     Controls whether the Side Nav is responsive to viewport changes. It can be programmatically turned off by passing `false`.

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -50,8 +50,6 @@ Typically the `Hds::SideNav::Header` sub-component should be added here. It prov
 - the `<:logo>` block should contain the `<Hds::SideNav::Header::HomeLink>` (but it could contain also custom content, if necessary)
 - the `<:actions>` block should contain optional top-level actions (eg. global search, user menu, help menu, etc.)
 
-Note: When the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) component, the `<:header>` slot normally is not used.
-
 ```handlebars
 <div class="doc-sidenav-demo--short">
   <Hds::SideNav>
@@ -358,8 +356,6 @@ This area usually contains a “context switcher” (e.g., “org switcher” or
 
 If you want (and you probably do) the content automatically fades in/out when the Side Nav changes its "minimization" state, you have to apply the specific class `hds-side-nav-hide-when-minimized` to the top-level elements of your content.
 
-Note: When the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) component, the `<:footer>` slot is not used.
-
 ```handlebars{data-execute=false}
 <Hds::SideNav>
   ...
@@ -394,7 +390,7 @@ Alternatively, if you want to create a custom transition (or respond in a differ
 </Hds::SideNav>
 ```
 
-### Used with App Header
+<!-- ### Used with App Header
 
 When the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) component, only the `<:body>` slot need be used.
 
@@ -406,7 +402,7 @@ When the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) 
     </:body>
   </Hds::SideNav>
 </div>
-```
+``` -->
 
 ### Responsiveness
 

--- a/website/docs/components/side-nav/partials/guidelines/guidelines.md
+++ b/website/docs/components/side-nav/partials/guidelines/guidelines.md
@@ -2,11 +2,10 @@
 
 ### When to use
 
-- When navigating between subpages and nested pages within the application.
+- For global navigation across an application, use the [App Header](/components/app-header) instead.
 
 ### When not to use
 
-- For global navigation across an application, use the [App Header](/components/app-header) instead.
 - To move between views within the same context or page, consider [Tabs](/components/tabs).
 
 ## Body

--- a/website/docs/components/side-nav/partials/guidelines/guidelines.md
+++ b/website/docs/components/side-nav/partials/guidelines/guidelines.md
@@ -2,7 +2,7 @@
 
 ### When to use
 
-- For global navigation across an application, use the [App Header](/components/app-header) instead.
+- For global navigation across an application.
 
 ### When not to use
 

--- a/website/docs/components/side-nav/partials/guidelines/overview.md
+++ b/website/docs/components/side-nav/partials/guidelines/overview.md
@@ -1,7 +1,1 @@
 The Side Nav provides users with access to contextual navigation within areas of the application and generally includes subpages and nested pages within projects and organizations.
-
-!!! Info
-
-Some elements that were previously contained within the Side Nav, including the home link, help dropdown, user dropdown, and context switcher, have been migrated to the [App Header](/components/app-header). To avoid introducing a breaking change, we’ve created a Side Nav - v2.0 component that should be used along with App Header. In Ember, the elements removed were yielded in the component, incurring no breaking change.
-
-!!!

--- a/website/docs/components/side-nav/partials/version-history/4.10.0.md
+++ b/website/docs/components/side-nav/partials/version-history/4.10.0.md
@@ -4,7 +4,7 @@
 
 `SideNav`
 
-- Added a default value of "#hds-main" for `a11yRefocusSkipTo`
+- Added a default value of "#hds-main" for `a11yRefocusSkipTo`.
 - Fixed styling issue to prevent `Button` and `Dropdown` nested within another `Dropdown` from inheriting dark theme.
 
 ### Deprecated
@@ -13,6 +13,6 @@
 
 Deprecated the `withAppHeader` argument as it is no longer needed. If you are using this argument, simply remove it.
 
-`SideNav::Header::IconButton` 
+`SideNav::Header::IconButton`
 
 Deprecated the component. Use the [`Hds::Button` component](/components/button) with isIconOnly set to true as a replacement.

--- a/website/docs/components/side-nav/partials/version-history/4.14.0.md
+++ b/website/docs/components/side-nav/partials/version-history/4.14.0.md
@@ -5,8 +5,8 @@
 `SideNav`
 
 - Made a11y related improvements including:
-  - Changed `List::Title` to h3 & added visually hidden h2 to AppSideNav
-  - Replaced aria-label for `ToggleButton` with aria-labelledby and aria-expanded
+  - Changed `List::Title` to h3 & added visually hidden h2 to SideNav.
+  - Replaced aria-label for `ToggleButton` with aria-labelledby and aria-expanded.
 - Fixed bug with hidden panels sometimes causing unnecessary overflow scrolling.
 
 ### Deprecated

--- a/website/docs/layouts/app-frame/partials/code/component-api.md
+++ b/website/docs/layouts/app-frame/partials/code/component-api.md
@@ -78,7 +78,7 @@ To be used as container for the application's main page content.
     Elements passed as children are yielded as inner content of a `<main>` HTML element.
   </C.Property>
   <C.Property @name="id" @default='"hds-main"'>
-    A default id value is set which serves as the target of the skip link included in the `AppHeader` and standalone `SideNav` components. This id can be overridden if needed but be sure to update the `a11yRefocusSkipTo` argument of the [`AppHeader`](/components/app-header?tab=code#appheader) or [`SideNav`](/components/side-nav?tab=code#side-nav) to match.
+    A default id value is set which serves as the target of the skip link included in the `SideNav` component. This id can be overridden if needed but be sure to update the `a11yRefocusSkipTo` argument of the [`SideNav`](/components/side-nav?tab=code#side-nav) to match.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/layouts/app-frame/partials/code/how-to-use.md
+++ b/website/docs/layouts/app-frame/partials/code/how-to-use.md
@@ -4,7 +4,7 @@ The `AppFrame` is a pure layout component that can be used to build the top-leve
 
 ### “Main” container
 
-The `AppFrame::Main` child component includes a default `id` with the value `hds-main` on the HTML `<main>` element it renders. This serves as a target for the `hasA11yRefocus` feature skip links which are built into the [`AppHeader`](/components/app-header?tab=code#appheader) and the standalone [`SideNav`](/components/side-nav?tab=code#side-nav) components.
+The `AppFrame::Main` child component includes a default `id` with the value `hds-main` on the HTML `<main>` element it renders. This serves as a target for the `hasA11yRefocus` feature skip link which is built into the [`SideNav`](/components/side-nav?tab=code#side-nav) component.
 
 ### Basic use
 

--- a/website/docs/layouts/app-frame/partials/version-history/4.10.0.md
+++ b/website/docs/layouts/app-frame/partials/version-history/4.10.0.md
@@ -3,9 +3,9 @@
 ### Updated
 
 `AppFrame`
-- Modified sticky/fixed position to turn off when viewport height is under 480px in height
-- Refactored styles to make `AppFrame` responsible for sticky/fixed layout of `SideNav` and `AppHeader`
+- Modified sticky/fixed position to turn off when viewport height is under 480px in height.
+- Refactored styles to make `AppFrame` responsible for sticky/fixed layout of `SideNav`.
 
 `AppFrame::Main`
 
-- Added `id` with default value of "hds-main" which the `SideNav` and `AppHeader` `a11yRefocusSkipTo` arguments point to.
+- Added `id` with default value of "hds-main" which the `SideNav` `a11yRefocusSkipTo` argument points to.


### PR DESCRIPTION
### :pushpin: Summary

Removed additional irrelevant references to the `AppHeader` in the `SideNav` docs. I considered just commenting these out and leaving them for later, but the content will likely change when we actually release the component.

**SideNav docs preview:** https://hds-website-git-jt-remove-app-header-banner-hashicorp.vercel.app/components/side-nav

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
