### PR TITLE
`RichTooltip` - Standardize private properties and methods

### DIFF
--- a/packages/components/NEW-COMPONENT-CHECKLIST.md
+++ b/packages/components/NEW-COMPONENT-CHECKLIST.md
@@ -112,6 +112,7 @@ The engineering checklist has six parts: creating the feature branch, component 
   - write API comments in the [JS doc](https://jsdoc.app/) format (look at existing components for examples)
   - use the same naming as the Figma file for the components API, unless it conflicts with a pre-existing HTML attribute. If that is the case, document the difference in a comment.
   - booleans should start with a verb (is/has/etc)
+  - private properites and methods should be declared as `private` and start with an `_`, e.g., `private _elementId`
   - assertions should match the content style of the other components, e.g., `'@text for "Hds::Button" must have a valid value'`,
   - program with intent; think about the invocation for the developer who will use the component. The goal is a terse invocation, but we also want to consider the big picture. Try to get feedback when you can.
 - [ ] **component style**

--- a/packages/components/src/components/hds/rich-tooltip/index.hbs
+++ b/packages/components/src/components/hds/rich-tooltip/index.hbs
@@ -15,14 +15,14 @@
       (hash
         Toggle=(component
           "hds/rich-tooltip/toggle"
-          popoverId=this.popoverId
+          popoverId=this._popoverId
           setupPrimitiveToggle=PP.setupPrimitiveToggle
           isOpen=PP.isOpen
         )
         Bubble=(component
           "hds/rich-tooltip/bubble"
-          arrowId=this.arrowId
-          popoverId=this.popoverId
+          arrowId=this._arrowId
+          popoverId=this._popoverId
           setupPrimitivePopover=PP.setupPrimitivePopover
           isOpen=PP.isOpen
         )

--- a/packages/components/src/components/hds/rich-tooltip/index.ts
+++ b/packages/components/src/components/hds/rich-tooltip/index.ts
@@ -32,9 +32,9 @@ export interface HdsRichTooltipSignature {
 }
 
 export default class HdsRichTooltip extends Component<HdsRichTooltipSignature> {
-  elementId: string = getElementId(this);
-  arrowId: string = `arrow-${this.elementId}`;
-  popoverId: string = `popover-${this.elementId}`;
+  private _elementId: string = getElementId(this);
+  private _arrowId: string = `arrow-${this._elementId}`;
+  private _popoverId: string = `popover-${this._elementId}`;
 
   get enableSoftEvents(): boolean {
     return this.args.enableClickEvents !== true;


### PR DESCRIPTION
### :pushpin: Summary

- Provides written standards for the usage of private properties and methods into the new component checklist guide.
- Standardizes the private properties on the `RichTooltip` as a test component for these changes that will be made throughout the components. 

### :hammer_and_wrench: Detailed description

This is the first PR in a series of updates that will implement a consistent naming convention for private properties and methods across the component library. The goal is to follow the TypeScript + underscore prefix naming convention (`private _propertyName`), and extend this across the whole library. 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2508](https://hashicorp.atlassian.net/browse/HDS-2508)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
(https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2508]: https://hashicorp.atlassian.net/browse/HDS-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ