### PR TITLE
Fix position for autocomplete container

### DIFF
--- a/website/app/styles/doc-components/algolia-search/index.scss
+++ b/website/app/styles/doc-components/algolia-search/index.scss
@@ -11,6 +11,7 @@
 
 // "autocomplete" target container - not used
 .doc-algolia-search__autocomplete-container {
+  // we assign it a position absolute to remove it from the layout flow, so the `gap` property of the parent flex container doesn't get applied to this as well
   position: absolute;
 }
 

--- a/website/app/styles/doc-components/algolia-search/index.scss
+++ b/website/app/styles/doc-components/algolia-search/index.scss
@@ -10,7 +10,9 @@
 @import "./results";
 
 // "autocomplete" target container - not used
-// .doc-algolia-search__autocomplete-container {}
+.doc-algolia-search__autocomplete-container {
+  position: absolute;
+}
 
 // root container of the "autocomplete" injected DOM elements (only the button, in "detached" mode)
 // notice: we hide it and trigger it via the "fake" buttons in the header


### PR DESCRIPTION
### :pushpin: Summary

Fix position for the autocomplete container

### :camera_flash: Screenshots

Before
<img width="1512" alt="Screenshot 2024-11-07 at 18 07 33" src="https://github.com/user-attachments/assets/a89de518-b34f-44b9-afbf-cfece2472c4c">

After
<img width="1511" alt="Screenshot 2024-11-07 at 18 07 26" src="https://github.com/user-attachments/assets/659ef1db-f4e4-48ff-906f-f6d95b2b492f">


### :link: External links

<!-- Issues, RFC, etc. -->
[Slack thread](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1730984851735729)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
