### PR TITLE
Website - sticky tabs

### DIFF
--- a/website/app/components/doc/page/cover.hbs
+++ b/website/app/components/doc/page/cover.hbs
@@ -31,7 +31,4 @@
   {{#if @description}}
     <p class="doc-page-cover__description">{{@description}}</p>
   {{/if}}
-  <div class="doc-page-cover__tabs">
-    <Doc::Page::Tabs @tabs={{@tabs}} />
-  </div>
 </div>

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -150,6 +150,10 @@ export default class ShowController extends Controller {
     return converter.makeHtml(this.model.content);
   }
 
+  get hasTabs() {
+    return this.tabs.length > 0;
+  }
+
   didInsertContent = () => {
     let sections = [];
     let tabs = [];

--- a/website/app/styles/pages/application/content.scss
+++ b/website/app/styles/pages/application/content.scss
@@ -53,7 +53,7 @@
 // special classes for headings with anchor links
 
 .doc-page-heading-scroll-margin-top {
-  scroll-margin-top: calc(var(--doc-page-header-height) + 20px);
+  scroll-margin-top: calc(var(--doc-page-offset-height) + 20px);
 }
 
 .doc-page-heading-link {

--- a/website/app/styles/pages/application/cover.scss
+++ b/website/app/styles/pages/application/cover.scss
@@ -63,6 +63,6 @@
 }
 
 .doc-page-stage--tabs .doc-page-cover {
-  border-bottom: none;
   padding-bottom: 0;
+  border-bottom: none;
 }

--- a/website/app/styles/pages/application/cover.scss
+++ b/website/app/styles/pages/application/cover.scss
@@ -12,7 +12,7 @@
   position: relative;
   grid-area: cover;
   min-width: 0; // This is needed to allow the scrolling of the tabs
-  padding: 32px var(--doc-page-stage-gutter-small) 0;
+  padding: 32px var(--doc-page-stage-gutter-small) 24px;
   background-color: var(--doc-color-white);
   border-bottom: 1px solid var(--doc-color-gray-500);
 
@@ -62,19 +62,7 @@
   color: var(--doc-color-gray-300);
 }
 
-.doc-page-cover__tabs {
-  display: flex;
-  flex-wrap: nowrap;
-  height: min-content;
-  margin-top: 24px;
-  overflow-x: auto;
-  overflow-y: hidden; // .doc-page-tabs__tab--is-current has an ::after pseudoelement that always overflows with 3px, so we disable the vertical scrollbar and rely on the horizontal one
-  -webkit-overflow-scrolling: touch;
-
-  @include breakpoint.medium () {
-    position: absolute;
-    bottom: 0;
-    display: block;
-    overflow: visible;
-  }
+.doc-page-stage--tabs .doc-page-cover {
+  border-bottom: none;
+  padding-bottom: 0;
 }

--- a/website/app/styles/pages/application/index.scss
+++ b/website/app/styles/pages/application/index.scss
@@ -24,6 +24,7 @@
 
 :root {
   --doc-page-header-height: 68px;
+  --doc-page-tabs-height: 58px;
   --doc-page-sidebar-width: 260px;
   --doc-page-stage-gutter-small: 24px;
   --doc-page-stage-gutter-medium: 48px;

--- a/website/app/styles/pages/application/sidecar.scss
+++ b/website/app/styles/pages/application/sidecar.scss
@@ -13,7 +13,7 @@
 
   @include breakpoint.large () {
     position: sticky;
-    top: var(--doc-page-header-height);
+    top: var(--doc-page-offset-height);
     display: block;
     grid-area: sidecar;
     // TIL this is needed because is inside a grid, otherwise the stickyness will not work

--- a/website/app/styles/pages/application/stage.scss
+++ b/website/app/styles/pages/application/stage.scss
@@ -40,8 +40,8 @@
       auto;
     margin: 0 auto 0 0;
   }
+}
 
-  &.doc-page-stage--tabs {
-    --doc-page-offset-height: calc(var(--doc-page-header-height) + var(--doc-page-tabs-height));
-  }
+.doc-page-stage--tabs {
+  --doc-page-offset-height: calc(var(--doc-page-header-height) + var(--doc-page-tabs-height));
 }

--- a/website/app/styles/pages/application/stage.scss
+++ b/website/app/styles/pages/application/stage.scss
@@ -8,10 +8,13 @@
 @use "../../breakpoints" as breakpoint;
 
 .doc-page-stage {
+  --doc-page-offset-height: var(--doc-page-header-height);
+
   display: grid;
   grid-area: stage;
   grid-template-areas:
     "cover"
+    "tabs"
     "content";
   grid-template-rows: auto 1fr;
   grid-template-columns: 1fr;
@@ -25,6 +28,7 @@
     --max-content-width: calc(var(--doc-page-content-max-width) + 2 * var(--doc-page-stage-gutter-large));
     grid-template-areas:
       "cover cover cover"
+      "tabs tabs tabs"
       "content sidecar _extra";
     grid-template-columns:
       // content
@@ -35,5 +39,9 @@
       // extra space
       auto;
     margin: 0 auto 0 0;
+  }
+
+  &.doc-page-stage--tabs {
+    --doc-page-offset-height: calc(var(--doc-page-header-height) + var(--doc-page-tabs-height));
   }
 }

--- a/website/app/styles/pages/application/tabs.scss
+++ b/website/app/styles/pages/application/tabs.scss
@@ -10,10 +10,38 @@
 
 .doc-page-tabs {
   display: flex;
+  flex-wrap: nowrap;
+  grid-area: tabs;
   gap: 16px;
-  margin: 0;
-  padding: 0;
   list-style: none;
+  height: min-content;
+  overflow-x: auto;
+  overflow-y: hidden; // .doc-page-tabs__tab--is-current has an ::after pseudoelement that always overflows with 3px, so we disable the vertical scrollbar and rely on the horizontal one
+  -webkit-overflow-scrolling: touch;
+  padding: 24px var(--doc-page-stage-gutter-small) 0;
+  margin: 0;
+  background-color: var(--doc-color-white);
+  border-bottom: 1px solid var(--doc-color-gray-500);
+  z-index: var(--doc-z-index-tabs);
+
+  @include breakpoint.medium () {
+    padding: 24px var(--doc-page-stage-gutter-medium) 0;
+    overflow: visible;
+  }
+
+  @include breakpoint.large () {
+    padding: 24px var(--doc-page-stage-gutter-large) 0;
+  }
+
+  @include breakpoint.x-large() {
+    padding: 24px var(--doc-page-stage-gutter-x-large) 0;
+  }
+
+  // Make tabs position sticky/fixed if the viewport height is greater than 480px
+  @media (height >= 480px) {
+    position: sticky;
+    top: var(--doc-page-header-height);
+  }
 }
 
 .doc-page-tabs__tab {
@@ -27,7 +55,12 @@
     font-weight: 600;
     background-color: transparent;
     border: 1px solid transparent;
+    white-space: nowrap;
     cursor: pointer;
+
+    @include breakpoint.medium () {
+      white-space: normal;
+    }
 
     &:hover {
       color: var(--doc-color-black);

--- a/website/app/styles/pages/application/tabs.scss
+++ b/website/app/styles/pages/application/tabs.scss
@@ -9,20 +9,20 @@
 @use "../../typography/mixins" as *;
 
 .doc-page-tabs {
+  z-index: var(--doc-z-index-tabs);
   display: flex;
   flex-wrap: nowrap;
   grid-area: tabs;
   gap: 16px;
-  list-style: none;
   height: min-content;
+  margin: 0;
+  padding: 24px var(--doc-page-stage-gutter-small) 0;
   overflow-x: auto;
   overflow-y: hidden; // .doc-page-tabs__tab--is-current has an ::after pseudoelement that always overflows with 3px, so we disable the vertical scrollbar and rely on the horizontal one
-  -webkit-overflow-scrolling: touch;
-  padding: 24px var(--doc-page-stage-gutter-small) 0;
-  margin: 0;
+  list-style: none;
   background-color: var(--doc-color-white);
   border-bottom: 1px solid var(--doc-color-gray-500);
-  z-index: var(--doc-z-index-tabs);
+  -webkit-overflow-scrolling: touch;
 
   @include breakpoint.medium () {
     padding: 24px var(--doc-page-stage-gutter-medium) 0;
@@ -53,9 +53,9 @@
     padding: 3px 11px; // we need to take in account the transparent border
     color: var(--doc-color-gray-300);
     font-weight: 600;
+    white-space: nowrap;
     background-color: transparent;
     border: 1px solid transparent;
-    white-space: nowrap;
     cursor: pointer;
 
     @include breakpoint.medium () {

--- a/website/app/styles/tokens.scss
+++ b/website/app/styles/tokens.scss
@@ -35,8 +35,9 @@
   --doc-color-feedback-critical-400: #fcf0f2;
   // Z-INDEXES
   --doc-z-index-header: 20;
-  --doc-z-index-sidebar: 2;
+  --doc-z-index-sidebar: 4;
   --doc-z-index-footer: 10;
+  --doc-z-index-tabs: 3;
   // FOCUS RING
   --doc-focus-ring-color: #005fcc; // picked from `-webkit-focus-ring-color` in Chrome
 }

--- a/website/app/templates/show.hbs
+++ b/website/app/templates/show.hbs
@@ -1,14 +1,16 @@
 {{page-title this.title}}
 
-<Doc::Page::Stage>
+<Doc::Page::Stage class={{if this.hasTabs "doc-page-stage--tabs"}}>
   {{#if this.model.hasCover}}
     <Doc::Page::Cover
       @title={{this.title}}
       @description={{this.description}}
-      @tabs={{this.tabs}}
       @status={{this.status}}
       @extra={{this.extra}}
     />
+  {{/if}}
+  {{#if this.hasTabs}}
+    <Doc::Page::Tabs @tabs={{this.tabs}} />
   {{/if}}
 
   <Doc::Page::Content @breakthrough={{not this.model.hasSidecar}} id={{this.model.showContentId}}>


### PR DESCRIPTION
### :pushpin: Summary

Implementing sticky behavior for page tabs on the website to remain visible as the user scrolls down the page. 

### :hammer_and_wrench: Detailed description

In this PR I have
- Updated `Doc::Page::Tabs` to have a sticky behavior
- Moved `Doc::Page::Tabs` outside of `Doc::Page::Cover` to be a direct child of `Doc::Page::Stage`. This was necessary to implement the sticky interaction
- Updated the styles of `Doc::Page::Cover` to account for `Doc::Page::Tabs` no longer being a direct child
- Adjusted the scroll behavior of the header links and `Doc::Page::Sidecar` to account for the sticky tabs
- Updated the `z-index` of the sidecar and tabs to account for when the tabs overlay the code blocks

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3297](https://hashicorp.atlassian.net/browse/HDS-3297)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3297]: https://hashicorp.atlassian.net/browse/HDS-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ