### PR TITLE
Adds a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# Default owners
+*       @hashicorp/hds-engineering


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add a CODEOWNERS file that will automatically trigger a review request to `@hashicorp/hds-engineering` for all PRs made to the design-system repo.

>For now the easiest option is likely to set everything to @hashicorp/hds-engineering and if we want to tweak we can do so from there. The biggest implication is that we’ll get auto assigned and auto-notified for every PR now…

We can get more granular down the line, but this gets us inline with the larger eng standards assessment.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4130](https://hashicorp.atlassian.net/browse/HDS-4130)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
