### PR TITLE
Private props standardization - 1st components batch

### DIFF
--- a/packages/components/src/components/hds/accordion/item/index.hbs
+++ b/packages/components/src/components/hds/accordion/item/index.hbs
@@ -14,7 +14,7 @@
       <Hds::Accordion::Item::Button
         @isOpen={{t.isOpen}}
         @onClickToggle={{t.onClickToggle}}
-        @contentId={{this.contentId}}
+        @contentId={{this._contentId}}
         @ariaLabel={{@ariaLabel}}
         @ariaLabelledBy={{this.ariaLabelledBy}}
         @size={{this.size}}
@@ -41,7 +41,7 @@
       @size="200"
       @weight="regular"
       @color="primary"
-      id={{this.contentId}}
+      id={{this._contentId}}
     >
       {{yield (hash close=c.close) to="content"}}
     </Hds::Text::Body>

--- a/packages/components/src/components/hds/accordion/item/index.hbs
+++ b/packages/components/src/components/hds/accordion/item/index.hbs
@@ -26,7 +26,7 @@
         @size={{this.toggleTextSize}}
         @weight="semibold"
         @color="strong"
-        id={{this.titleId}}
+        id={{this._titleId}}
         class="hds-accordion-item__toggle-content"
       >
         {{yield to="toggle"}}

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -60,14 +60,14 @@ export default class HdsAccordionItem extends Component<HdsAccordionItemSignatur
   /**
    * Generates a unique ID for the Content
    *
-   * @param contentId
+   * @param _contentId
    */
-  contentId = 'content-' + guidFor(this);
-  titleId = 'title-' + guidFor(this);
+  private _contentId = 'content-' + guidFor(this);
+  private _titleId = 'title-' + guidFor(this);
 
   get ariaLabelledBy(): string | undefined {
     if (!this.args.ariaLabel) {
-      return this.titleId;
+      return this._titleId;
     }
     return undefined;
   }

--- a/packages/components/src/components/hds/alert/index.hbs
+++ b/packages/components/src/components/hds/alert/index.hbs
@@ -4,9 +4,9 @@
 }}
 <div
   class={{this.classNames}}
-  role={{this.role}}
-  aria-live={{if this.role "polite"}}
-  aria-labelledby={{this.ariaLabelledBy}}
+  role={{this._role}}
+  aria-live={{if this._role "polite"}}
+  aria-labelledby={{this._ariaLabelledBy}}
   {{did-insert this.didInsert}}
   ...attributes
 >

--- a/packages/components/src/components/hds/alert/index.ts
+++ b/packages/components/src/components/hds/alert/index.ts
@@ -62,8 +62,8 @@ export interface HdsAlertSignature {
 }
 
 export default class HdsAlert extends Component<HdsAlertSignature> {
-  @tracked role?: string;
-  @tracked ariaLabelledBy?: string;
+  @tracked private _role?: string;
+  @tracked private _ariaLabelledBy?: string;
 
   constructor(owner: unknown, args: HdsAlertSignature['Args']) {
     super(owner, args);
@@ -162,9 +162,9 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
       this.color === 'success';
 
     if (isSemanticAlert && actions.length) {
-      this.role = 'alertdialog';
+      this._role = 'alertdialog';
     } else if (isSemanticAlert) {
-      this.role = 'alert';
+      this._role = 'alert';
     }
 
     // `alertdialog` must have an accessible name so we use either the
@@ -175,7 +175,7 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
     if (label) {
       const labelId = label.getAttribute('id') || guidFor(element);
       label.setAttribute('id', labelId);
-      this.ariaLabelledBy = labelId;
+      this._ariaLabelledBy = labelId;
     }
   }
 }

--- a/packages/components/src/components/hds/app-header/index.hbs
+++ b/packages/components/src/components/hds/app-header/index.hbs
@@ -22,7 +22,7 @@
 
   {{yield to="logo"}}
 
-  {{#if (not this.isDesktop)}}
+  {{#if (not this._isDesktop)}}
     <Hds::AppHeader::MenuButton
       @onClickToggle={{this.onClickToggle}}
       @isOpen={{this._isOpen}}

--- a/packages/components/src/components/hds/app-header/index.hbs
+++ b/packages/components/src/components/hds/app-header/index.hbs
@@ -9,7 +9,7 @@
   {{focus-trap isActive=this.shouldTrapFocus}}
   ...attributes
 >
-  {{#if (and this.hasA11yRefocus (not this.isOpen))}}
+  {{#if (and this.hasA11yRefocus (not this._isOpen))}}
     {{! @glint-expect-error - `ember-a11y-refocus` doesn't expose types yet }}
     <NavigationNarrator
       @routeChangeValidator={{@a11yRefocusRouteChangeValidator}}
@@ -25,12 +25,12 @@
   {{#if (not this.isDesktop)}}
     <Hds::AppHeader::MenuButton
       @onClickToggle={{this.onClickToggle}}
-      @isOpen={{this.isOpen}}
-      @menuContentId={{this.menuContentId}}
+      @isOpen={{this._isOpen}}
+      @menuContentId={{this._menuContentId}}
     />
   {{/if}}
 
-  <div class="hds-app-header__actions" id={{this.menuContentId}}>
+  <div class="hds-app-header__actions" id={{this._menuContentId}}>
     <div class="hds-app-header__global-actions">
       {{yield to="globalActions"}}
     </div>

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -61,7 +61,11 @@ export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
 
   addEventListeners(): void {
     document.addEventListener('keydown', this.escapePress, true);
-    this._desktopMQ.addEventListener('change', this.updateDesktopVariable, true);
+    this._desktopMQ.addEventListener(
+      'change',
+      this.updateDesktopVariable,
+      true
+    );
 
     // set initial state based on viewport using a "synthetic" event
     const syntheticEvent = new MediaQueryListEvent('change', {

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -28,23 +28,23 @@ export interface HdsAppHeaderSignature {
 }
 
 export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
-  @tracked isOpen = false;
-  @tracked isDesktop = true;
-  @tracked hasOverflowContent = false;
-  desktopMQ: MediaQueryList;
+  @tracked private _isOpen = false;
+  @tracked private _isDesktop = true;
+  @tracked private _hasOverflowContent = false;
+  private _desktopMQ: MediaQueryList;
   hasA11yRefocus = this.args.hasA11yRefocus ?? true;
   a11yRefocusSkipTo = '#' + (this.args.a11yRefocusSkipTo ?? 'hds-main');
 
   // Generates a unique ID for the Menu Content
-  menuContentId = 'hds-menu-content-' + guidFor(this);
+  private _menuContentId = 'hds-menu-content-' + guidFor(this);
 
-  breakpoint = parseInt(
+  private _breakpoint = parseInt(
     getComputedStyle(document.documentElement).getPropertyValue(
       '--hds-app-desktop-breakpoint'
     )
   );
 
-  desktopMQVal =
+  private _desktopMQVal =
     this.args.breakpoint ??
     getComputedStyle(document.documentElement).getPropertyValue(
       '--hds-app-desktop-breakpoint'
@@ -52,7 +52,7 @@ export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
 
   constructor(owner: unknown, args: Record<string, never>) {
     super(owner, args);
-    this.desktopMQ = window.matchMedia(`(min-width: ${this.desktopMQVal})`);
+    this._desktopMQ = window.matchMedia(`(min-width: ${this._desktopMQVal})`);
     this.addEventListeners();
     registerDestructor(this, (): void => {
       this.removeEventListeners();
@@ -61,19 +61,19 @@ export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
 
   addEventListeners(): void {
     document.addEventListener('keydown', this.escapePress, true);
-    this.desktopMQ.addEventListener('change', this.updateDesktopVariable, true);
+    this._desktopMQ.addEventListener('change', this.updateDesktopVariable, true);
 
     // set initial state based on viewport using a "synthetic" event
     const syntheticEvent = new MediaQueryListEvent('change', {
-      matches: this.desktopMQ.matches,
-      media: this.desktopMQ.media,
+      matches: this._desktopMQ.matches,
+      media: this._desktopMQ.media,
     });
     this.updateDesktopVariable(syntheticEvent);
   }
 
   removeEventListeners(): void {
     document.removeEventListener('keydown', this.escapePress, true);
-    this.desktopMQ.removeEventListener(
+    this._desktopMQ.removeEventListener(
       'change',
       this.updateDesktopVariable,
       true
@@ -82,20 +82,20 @@ export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
 
   // In mobile view when the menu is open, trap focus within the AppHeader
   get shouldTrapFocus(): boolean {
-    return !this.isDesktop && this.isOpen;
+    return !this._isDesktop && this._isOpen;
   }
 
   // Get the class names to apply to the component.
   get classNames(): string {
     const classes = ['hds-app-header'];
 
-    if (this.isDesktop) {
+    if (this._isDesktop) {
       classes.push('hds-app-header--is-desktop');
     } else {
       classes.push('hds-app-header--is-mobile');
 
       // open and closed menu states are only relevant on mobile
-      if (this.isOpen) {
+      if (this._isOpen) {
         classes.push('hds-app-header--menu-is-open');
       } else {
         classes.push('hds-app-header--menu-is-closed');
@@ -107,24 +107,24 @@ export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
 
   @action
   escapePress(event: KeyboardEvent): void {
-    if (event.key === 'Escape' && this.isOpen && !this.isDesktop) {
-      this.isOpen = false;
+    if (event.key === 'Escape' && this._isOpen && !this._isDesktop) {
+      this._isOpen = false;
     }
   }
 
   @action
   onClickToggle(): void {
-    this.isOpen = !this.isOpen;
+    this._isOpen = !this._isOpen;
   }
 
   @action
   updateDesktopVariable(event: MediaQueryListEvent): void {
-    this.isDesktop = event.matches;
+    this._isDesktop = event.matches;
 
     // Close the menu when switching to desktop view
     // (prevents menu from being open when resizing which causes Skip button to not render)
-    if (this.isDesktop) {
-      this.isOpen = false;
+    if (this._isDesktop) {
+      this._isOpen = false;
     }
   }
 }

--- a/packages/components/src/components/hds/app-side-nav/index.hbs
+++ b/packages/components/src/components/hds/app-side-nav/index.hbs
@@ -21,8 +21,8 @@
       {{! template-lint-enable no-invalid-interactive}}
       <Hds::AppSideNav::ToggleButton
         aria-labelledby="hds-app-side-nav-header"
-        aria-expanded={{if this.isMinimized "false" "true"}}
-        @icon={{if this.isMinimized "chevrons-right" "chevrons-left"}}
+        aria-expanded={{if this._isMinimized "false" "true"}}
+        @icon={{if this._isMinimized "chevrons-right" "chevrons-left"}}
         {{on "click" this.toggleMinimizedStatus}}
       />
     {{/if}}

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -23,23 +23,23 @@ export interface HdsAppSideNavSignature {
 }
 
 export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
-  @tracked isMinimized;
-  @tracked isAnimating = false;
-  @tracked isDesktop = true;
+  @tracked private _isMinimized;
+  @tracked private _isAnimating = false;
+  @tracked private _isDesktop = true;
 
-  body!: HTMLElement;
-  bodyInitialOverflowValue = '';
-  desktopMQ: MediaQueryList;
-  containersToHide!: NodeListOf<Element>;
+  private _body!: HTMLElement;
+  private _bodyInitialOverflowValue = '';
+  private _desktopMQ: MediaQueryList;
+  private _containersToHide!: NodeListOf<Element>;
 
-  desktopMQVal = getComputedStyle(document.documentElement).getPropertyValue(
+  private _desktopMQVal = getComputedStyle(document.documentElement).getPropertyValue(
     '--hds-app-desktop-breakpoint'
   );
 
   constructor(owner: unknown, args: HdsAppSideNavSignature['Args']) {
     super(owner, args);
-    this.isMinimized = this.args.isMinimized ?? false; // sets the default state on 'desktop' viewports
-    this.desktopMQ = window.matchMedia(`(min-width:${this.desktopMQVal})`);
+    this._isMinimized = this.args.isMinimized ?? false; // sets the default state on 'desktop' viewports
+    this._desktopMQ = window.matchMedia(`(min-width:${this._desktopMQVal})`);
     this.addEventListeners();
     registerDestructor(this, (): void => {
       this.removeEventListeners();
@@ -48,13 +48,13 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
 
   addEventListeners(): void {
     document.addEventListener('keydown', this.escapePress, true);
-    this.desktopMQ.addEventListener('change', this.updateDesktopVariable, true);
+    this._desktopMQ.addEventListener('change', this.updateDesktopVariable, true);
     // if not instantiated as minimized via arguments
     if (!this.args.isMinimized) {
       // set initial state based on viewport using a "synthetic" event
       const syntheticEvent = new MediaQueryListEvent('change', {
-        matches: this.desktopMQ.matches,
-        media: this.desktopMQ.media,
+        matches: this._desktopMQ.matches,
+        media: this._desktopMQ.media,
       });
       this.updateDesktopVariable(syntheticEvent);
     }
@@ -62,7 +62,7 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
 
   removeEventListeners(): void {
     document.removeEventListener('keydown', this.escapePress, true);
-    this.desktopMQ.removeEventListener(
+    this._desktopMQ.removeEventListener(
       'change',
       this.updateDesktopVariable,
       true
@@ -80,11 +80,11 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   }
 
   get shouldTrapFocus(): boolean {
-    return this.isResponsive && !this.isDesktop && !this.isMinimized;
+    return this.isResponsive && !this._isDesktop && !this._isMinimized;
   }
 
   get showToggleButton(): boolean {
-    return (this.isResponsive && !this.isDesktop) || this.isCollapsible;
+    return (this.isResponsive && !this._isDesktop) || this.isCollapsible;
   }
 
   get classNames(): string {
@@ -94,17 +94,17 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
     if (this.isResponsive) {
       classes.push('hds-app-side-nav--is-responsive');
     }
-    if (!this.isDesktop && this.isResponsive) {
+    if (!this._isDesktop && this.isResponsive) {
       classes.push('hds-app-side-nav--is-mobile');
     } else {
       classes.push('hds-app-side-nav--is-desktop');
     }
-    if (this.isMinimized && this.isResponsive) {
+    if (this._isMinimized && this.isResponsive) {
       classes.push('hds-app-side-nav--is-minimized');
     } else {
       classes.push('hds-app-side-nav--is-not-minimized');
     }
-    if (this.isAnimating) {
+    if (this._isAnimating) {
       classes.push('hds-app-side-nav--is-animating');
     }
 
@@ -112,8 +112,8 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   }
 
   synchronizeInert(): void {
-    this.containersToHide?.forEach((element): void => {
-      if (this.isMinimized) {
+    this._containersToHide?.forEach((element): void => {
+      if (this._isMinimized) {
         element.setAttribute('inert', '');
       } else {
         element.removeAttribute('inert');
@@ -122,46 +122,46 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   }
 
   lockBodyScroll(): void {
-    if (this.body) {
+    if (this._body) {
       // Prevent page from scrolling when the dialog is open
-      this.body.style.setProperty('overflow', 'hidden');
+      this._body.style.setProperty('overflow', 'hidden');
     }
   }
 
   unlockBodyScroll(): void {
     // Reset page `overflow` property
-    if (this.body) {
-      this.body.style.removeProperty('overflow');
-      if (this.bodyInitialOverflowValue === '') {
-        if (this.body.style.length === 0) {
-          this.body.removeAttribute('style');
+    if (this._body) {
+      this._body.style.removeProperty('overflow');
+      if (this._bodyInitialOverflowValue === '') {
+        if (this._body.style.length === 0) {
+          this._body.removeAttribute('style');
         }
       } else {
-        this.body.style.setProperty('overflow', this.bodyInitialOverflowValue);
+        this._body.style.setProperty('overflow', this._bodyInitialOverflowValue);
       }
     }
   }
 
   @action
   escapePress(event: KeyboardEvent): void {
-    if (event.key === 'Escape' && !this.isMinimized && !this.isDesktop) {
-      this.isMinimized = true;
+    if (event.key === 'Escape' && !this._isMinimized && !this._isDesktop) {
+      this._isMinimized = true;
       this.synchronizeInert();
     }
   }
 
   @action
   toggleMinimizedStatus(): void {
-    this.isMinimized = !this.isMinimized;
+    this._isMinimized = !this._isMinimized;
     this.synchronizeInert();
 
     const { onToggleMinimizedStatus } = this.args;
 
     if (typeof onToggleMinimizedStatus === 'function') {
-      onToggleMinimizedStatus(this.isMinimized);
+      onToggleMinimizedStatus(this._isMinimized);
     }
 
-    if (this.isMinimized) {
+    if (this._isMinimized) {
       this.unlockBodyScroll();
     } else {
       this.lockBodyScroll();
@@ -170,13 +170,13 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
 
   @action
   didInsert(element: HTMLElement): void {
-    this.containersToHide = element.querySelectorAll(
+    this._containersToHide = element.querySelectorAll(
       '.hds-app-side-nav-hide-when-minimized'
     );
-    this.body = document.body;
+    this._body = document.body;
     // Store the initial `overflow` value of `<body>` so we can reset to it
-    this.bodyInitialOverflowValue =
-      this.body.style.getPropertyValue('overflow');
+    this._bodyInitialOverflowValue =
+      this._body.style.getPropertyValue('overflow');
   }
 
   @action
@@ -186,25 +186,25 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
       return;
     }
     if (phase === 'start') {
-      this.isAnimating = true;
+      this._isAnimating = true;
     } else {
-      this.isAnimating = false;
+      this._isAnimating = false;
     }
   }
 
   @action
   updateDesktopVariable(event: MediaQueryListEvent): void {
-    this.isDesktop = event.matches;
+    this._isDesktop = event.matches;
 
     // automatically minimize on narrow viewports (when not in desktop mode)
-    this.isMinimized = !this.isDesktop;
+    this._isMinimized = !this._isDesktop;
 
     this.synchronizeInert();
 
     const { onDesktopViewportChange } = this.args;
 
     if (typeof onDesktopViewportChange === 'function') {
-      onDesktopViewportChange(this.isDesktop);
+      onDesktopViewportChange(this._isDesktop);
     }
   }
 }

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -32,9 +32,9 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   private _desktopMQ: MediaQueryList;
   private _containersToHide!: NodeListOf<Element>;
 
-  private _desktopMQVal = getComputedStyle(document.documentElement).getPropertyValue(
-    '--hds-app-desktop-breakpoint'
-  );
+  private _desktopMQVal = getComputedStyle(
+    document.documentElement
+  ).getPropertyValue('--hds-app-desktop-breakpoint');
 
   constructor(owner: unknown, args: HdsAppSideNavSignature['Args']) {
     super(owner, args);
@@ -48,7 +48,11 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
 
   addEventListeners(): void {
     document.addEventListener('keydown', this.escapePress, true);
-    this._desktopMQ.addEventListener('change', this.updateDesktopVariable, true);
+    this._desktopMQ.addEventListener(
+      'change',
+      this.updateDesktopVariable,
+      true
+    );
     // if not instantiated as minimized via arguments
     if (!this.args.isMinimized) {
       // set initial state based on viewport using a "synthetic" event
@@ -137,7 +141,10 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
           this._body.removeAttribute('style');
         }
       } else {
-        this._body.style.setProperty('overflow', this._bodyInitialOverflowValue);
+        this._body.style.setProperty(
+          'overflow',
+          this._bodyInitialOverflowValue
+        );
       }
     }
   }

--- a/packages/components/src/components/hds/app-side-nav/list/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/list/index.ts
@@ -30,7 +30,7 @@ export interface HdsAppSideNavListSignature {
 }
 
 export default class HdsAppSideNavList extends Component<HdsAppSideNavListSignature> {
-  @tracked _titleIds: string[] = [];
+  @tracked private _titleIds: string[] = [];
 
   get titleIds(): string {
     return this._titleIds.join(' ');

--- a/packages/components/src/components/hds/app-side-nav/list/title.hbs
+++ b/packages/components/src/components/hds/app-side-nav/list/title.hbs
@@ -6,7 +6,7 @@
 <Hds::AppSideNav::List::Item>
   <div
     class="hds-app-side-nav__list-title hds-typography-body-100 hds-font-weight-semibold"
-    id={{this.titleId}}
+    id={{this._titleId}}
     {{did-insert this.didInsertTitle}}
     ...attributes
   >{{~yield~}}</div>

--- a/packages/components/src/components/hds/app-side-nav/list/title.ts
+++ b/packages/components/src/components/hds/app-side-nav/list/title.ts
@@ -19,7 +19,7 @@ export interface HdsAppSideNavListTitleSignature {
 
 export default class HdsAppSideNavListTitle extends Component<HdsAppSideNavListTitleSignature> {
   /*  Generate a unique ID for each Title */
-  titleId = 'title-' + guidFor(this);
+  private _titleId = 'title-' + guidFor(this);
 
   @action
   didInsertTitle(element: HTMLElement): void {

--- a/packages/components/src/components/hds/app-side-nav/portal/target.hbs
+++ b/packages/components/src/components/hds/app-side-nav/portal/target.hbs
@@ -9,6 +9,6 @@
     @onChange={{this.panelsChanged}}
     @name={{if @targetName @targetName "hds-app-side-nav-portal-target"}}
     class="hds-app-side-nav__content-panels hds-app-side-nav-hide-when-minimized"
-    {{did-update this.didUpdateSubnav this.numSubnavs}}
+    {{did-update this.didUpdateSubnav this._numSubnavs}}
   />
 </div>

--- a/packages/components/src/components/hds/app-side-nav/portal/target.ts
+++ b/packages/components/src/components/hds/app-side-nav/portal/target.ts
@@ -37,27 +37,27 @@ interface HdsAppSideNavPortalTargetSignature {
 export default class HdsAppSideNavPortalTarget extends Component<HdsAppSideNavPortalTargetSignature> {
   @service router!: Services['router'];
 
-  @tracked numSubnavs = 0;
-  @tracked lastPanelEl: Element | undefined;
+  @tracked private _numSubnavs = 0;
+  @tracked private _lastPanelEl: Element | undefined;
 
   static get prefersReducedMotionOverride(): boolean {
     return macroCondition(isTesting()) ? true : false;
   }
 
-  prefersReducedMotionMQ = window.matchMedia(
+  private _prefersReducedMotionMQ = window.matchMedia(
     '(prefers-reduced-motion: reduce)'
   );
 
   get prefersReducedMotion(): boolean {
     return (
       HdsAppSideNavPortalTarget.prefersReducedMotionOverride ||
-      (this.prefersReducedMotionMQ && this.prefersReducedMotionMQ.matches)
+      (this._prefersReducedMotionMQ && this._prefersReducedMotionMQ.matches)
     );
   }
 
   @action
   panelsChanged(portalCount: number): void {
-    this.numSubnavs = portalCount;
+    this._numSubnavs = portalCount;
   }
 
   @action
@@ -173,15 +173,15 @@ export default class HdsAppSideNavPortalTarget extends Component<HdsAppSideNavPo
       nextPanelEl.style.setProperty('visibility', 'visible');
       // this eliminates a flicker if there's only one subnav rendering or if we
       // already just rendered this panel.
-      if (this.lastPanelEl) {
-        if (activeIndex === 0 || nextPanelEl.isSameNode(this.lastPanelEl)) {
+      if (this._lastPanelEl) {
+        if (activeIndex === 0 || nextPanelEl.isSameNode(this._lastPanelEl)) {
           fadeDelay = 0;
           fadeDuration = 0;
         }
       }
 
       // remember the last panel
-      this.lastPanelEl = lastPanelEl;
+      this._lastPanelEl = lastPanelEl;
 
       nextPanelEl.animate([{ opacity: '0' }, { opacity: '1' }], {
         delay: fadeDelay,

--- a/packages/components/src/components/hds/code-block/index.hbs
+++ b/packages/components/src/components/hds/code-block/index.hbs
@@ -15,14 +15,14 @@
       {{style maxHeight=@maxHeight}}
       data-line={{@highlightLines}}
       data-start={{@lineNumberStart}}
-      id={{this.preCodeId}}
+      id={{this._preCodeId}}
       tabindex="0"
     ><code {{did-insert this.setPrismCode}} {{did-update this.setPrismCode this.code @language}}>
-        {{~this.prismCode~}}
+        {{~this._prismCode~}}
       </code></pre>
 
     {{#if @hasCopyButton}}
-      <Hds::CodeBlock::CopyButton @targetToCopy="#{{this.preCodeId}}" aria-describedby={{this.preCodeId}} />
+      <Hds::CodeBlock::CopyButton @targetToCopy="#{{this._preCodeId}}" aria-describedby={{this._preCodeId}} />
     {{/if}}
   </div>
 </div>

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -65,14 +65,14 @@ export interface HdsCodeBlockSignature {
 }
 
 export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
-  @tracked prismCode: SafeString = htmlSafe('');
+  @tracked private _prismCode: SafeString = htmlSafe('');
 
   /**
    * Generates a unique ID for the code content
    *
-   * @param preCodeId
+   * @param _preCodeId
    */
-  preCodeId = 'pre-code-' + guidFor(this);
+  private _preCodeId = 'pre-code-' + guidFor(this);
 
   /**
    * @param code
@@ -144,9 +144,9 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
       // eslint-disable-next-line ember/no-runloop
       next(() => {
         if (language && grammar) {
-          this.prismCode = htmlSafe(Prism.highlight(code, grammar, language));
+          this._prismCode = htmlSafe(Prism.highlight(code, grammar, language));
         } else {
-          this.prismCode = htmlSafe(Prism.util.encode(code).toString());
+          this._prismCode = htmlSafe(Prism.util.encode(code).toString());
         }
 
         // Force prism-line-numbers plugin initialization, required for Prism.highlight usage

--- a/packages/components/src/components/hds/copy/button/index.ts
+++ b/packages/components/src/components/hds/copy/button/index.ts
@@ -32,8 +32,8 @@ export interface HdsCopyButtonSignature {
 }
 
 export default class HdsCopyButton extends Component<HdsCopyButtonSignature> {
-  @tracked status = DEFAULT_STATUS;
-  @tracked timer: ReturnType<typeof setTimeout> | undefined;
+  @tracked private _status = DEFAULT_STATUS;
+  @tracked private _timer: ReturnType<typeof setTimeout> | undefined;
 
   /**
    * @param icon
@@ -42,9 +42,9 @@ export default class HdsCopyButton extends Component<HdsCopyButtonSignature> {
    */
   get icon(): HdsIconSignature['Args']['name'] {
     let icon: HdsIconSignature['Args']['name'] = DEFAULT_ICON;
-    if (this.status === 'success') {
+    if (this._status === 'success') {
       icon = SUCCESS_ICON;
-    } else if (this.status === 'error') {
+    } else if (this._status === 'error') {
       icon = ERROR_ICON;
     }
     return icon;
@@ -80,7 +80,7 @@ export default class HdsCopyButton extends Component<HdsCopyButtonSignature> {
     // add a class based on the @size argument
     classes.push(`hds-button--size-${this.size}`);
 
-    classes.push(`hds-copy-button--status-${this.status}`);
+    classes.push(`hds-copy-button--status-${this._status}`);
 
     return classes.join(' ');
   }
@@ -89,7 +89,7 @@ export default class HdsCopyButton extends Component<HdsCopyButtonSignature> {
   onSuccess(
     args: HdsClipboardModifierSignature['Args']['Named']['onSuccess']
   ): void {
-    this.status = 'success';
+    this._status = 'success';
     this.resetStatusDelayed();
 
     const { onSuccess } = this.args;
@@ -103,7 +103,7 @@ export default class HdsCopyButton extends Component<HdsCopyButtonSignature> {
   onError(
     args: HdsClipboardModifierSignature['Args']['Named']['onError']
   ): void {
-    this.status = 'error';
+    this._status = 'error';
     this.resetStatusDelayed();
 
     const { onError } = this.args;
@@ -114,10 +114,10 @@ export default class HdsCopyButton extends Component<HdsCopyButtonSignature> {
   }
 
   resetStatusDelayed(): void {
-    clearTimeout(this.timer);
+    clearTimeout(this._timer);
     // make it fade back to the default state
-    this.timer = setTimeout((): void => {
-      this.status = DEFAULT_STATUS;
+    this._timer = setTimeout((): void => {
+      this._status = DEFAULT_STATUS;
     }, 1500);
   }
 }

--- a/packages/components/src/components/hds/copy/snippet/index.ts
+++ b/packages/components/src/components/hds/copy/snippet/index.ts
@@ -33,8 +33,8 @@ export interface HdsCopySnippetSignature {
 }
 
 export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
-  @tracked status = DEFAULT_STATUS;
-  @tracked timer: ReturnType<typeof setTimeout> | undefined;
+  @tracked private _status = DEFAULT_STATUS;
+  @tracked private _timer: ReturnType<typeof setTimeout> | undefined;
 
   /**
    * @method textToShow
@@ -58,9 +58,9 @@ export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
    */
   get icon(): HdsIconSignature['Args']['name'] {
     let icon: HdsIconSignature['Args']['name'] = DEFAULT_ICON;
-    if (this.status === 'success') {
+    if (this._status === 'success') {
       icon = SUCCESS_ICON;
-    } else if (this.status === 'error') {
+    } else if (this._status === 'error') {
       icon = ERROR_ICON;
     }
     return icon;
@@ -117,7 +117,7 @@ export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
     classes.push(`hds-copy-snippet--color-${this.color}`);
 
     // add a class based on the tracked status (idle/success/error)
-    classes.push(`hds-copy-snippet--status-${this.status}`);
+    classes.push(`hds-copy-snippet--status-${this._status}`);
 
     // add a class based on the @isTruncated argument
     if (this.isTruncated) {
@@ -136,7 +136,7 @@ export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
   onSuccess(
     args: HdsClipboardModifierSignature['Args']['Named']['onSuccess']
   ): void {
-    this.status = 'success';
+    this._status = 'success';
     this.resetStatusDelayed();
 
     const { onSuccess } = this.args;
@@ -150,7 +150,7 @@ export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
   onError(
     args: HdsClipboardModifierSignature['Args']['Named']['onError']
   ): void {
-    this.status = 'error';
+    this._status = 'error';
     this.resetStatusDelayed();
 
     const { onError } = this.args;
@@ -161,10 +161,10 @@ export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
   }
 
   resetStatusDelayed(): void {
-    clearTimeout(this.timer);
+    clearTimeout(this._timer);
     // make it fade back to the default state
-    this.timer = setTimeout((): void => {
-      this.status = DEFAULT_STATUS;
+    this._timer = setTimeout((): void => {
+      this._status = DEFAULT_STATUS;
     }, 1500);
   }
 }

--- a/packages/components/src/components/hds/disclosure-primitive/index.ts
+++ b/packages/components/src/components/hds/disclosure-primitive/index.ts
@@ -35,8 +35,8 @@ export interface HdsDisclosurePrimitiveSignature {
 }
 
 export default class HdsDisclosurePrimitive extends Component<HdsDisclosurePrimitiveSignature> {
-  @tracked _isOpen = false;
-  @tracked _isControlled = this.args.isOpen !== undefined;
+  @tracked private _isOpen = false;
+  @tracked private _isControlled = this.args.isOpen !== undefined;
 
   get isOpen(): boolean {
     if (this._isControlled) {

--- a/packages/components/src/components/hds/dropdown/toggle/button.hbs
+++ b/packages/components/src/components/hds/dropdown/toggle/button.hbs
@@ -4,7 +4,7 @@
 }}
 <button
   class={{this.classNames}}
-  id={{this.toggleButtonId}}
+  id={{this._toggleButtonId}}
   ...attributes
   type="button"
   aria-expanded={{if @isOpen "true" "false"}}

--- a/packages/components/src/components/hds/dropdown/toggle/button.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/button.ts
@@ -48,9 +48,9 @@ export default class HdsDropdownToggleButton extends Component<HdsDropdownToggle
   /**
    * Generates a unique ID for the button
    *
-   * @param toggleButtonId
+   * @param _toggleButtonId
    */
-  toggleButtonId = 'toggle-button-' + guidFor(this);
+  private _toggleButtonId = 'toggle-button-' + guidFor(this);
 
   /**
    * @param text

--- a/packages/components/src/components/hds/dropdown/toggle/icon.hbs
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.hbs
@@ -13,7 +13,7 @@
 >
   <div class="hds-dropdown-toggle-icon__wrapper">
     {{#if @imageSrc}}
-      {{#if this.hasImage}}
+      {{#if this._hasImage}}
         <img src={{@imageSrc}} alt="" role="presentation" {{on "error" this.onImageLoadError}} />
       {{else}}
         <Hds::Icon @name="user" @size={{this.iconSize}} />

--- a/packages/components/src/components/hds/dropdown/toggle/icon.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.ts
@@ -31,7 +31,7 @@ export interface HdsDropdownToggleIconSignature {
 }
 
 export default class HdsDropdownToggleIcon extends Component<HdsDropdownToggleIconSignature> {
-  @tracked hasImage = true;
+  @tracked private _hasImage = true;
 
   constructor(owner: unknown, args: HdsDropdownToggleIconSignature['Args']) {
     super(owner, args);
@@ -44,12 +44,12 @@ export default class HdsDropdownToggleIcon extends Component<HdsDropdownToggleIc
 
   @action
   onDidUpdateImageSrc(): void {
-    this.hasImage = true;
+    this._hasImage = true;
   }
 
   @action
   onImageLoadError(): void {
-    this.hasImage = false;
+    this._hasImage = false;
   }
 
   /**


### PR DESCRIPTION
### :pushpin: Summary

As part of the ongoing standardization of private properties and methods, the private properties of several components have been updated to reflect the new naming convention of `private _propertyName`. 

### :hammer_and_wrench: Detailed description

In this PR I have updated the properties for the following components
- `Accordion`
- `Alert`
- `AppHeader`
- `AppSideNav`
- `CodeBlock`
- `Copy::Button`
- `Copy::Snippet`
- `DisclosurePrimative`
- `Dropdown`

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2508](https://hashicorp.atlassian.net/browse/HDS-2508)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2508]: https://hashicorp.atlassian.net/browse/HDS-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ