### PR TITLE
open icon PRs as Draft by default

### DIFF
--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -38,6 +38,7 @@ jobs:
           branch-suffix: 'short-commit-hash'
           commit-message: 'sync & build of flight icons'
           title: 'Updated export of icons from Figma'
+          draft: true
           body: |
             ### :pushpin: Summary
 


### PR DESCRIPTION
### :pushpin: Summary

With the new codeowners requirement, it seems like it would helpful for our Icon export PRs like [this one](https://github.com/hashicorp/design-system/pull/2563) to open in draft mode first and then they can be marked ready for review once the person working on it is ready for it to actually be reviewed. The PRs are not generally reviewable by default.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
