### PR TITLE
Fix spelling mistake in docs

### DIFF
--- a/website/docs/components/accordion/partials/version-history/4.10.0.md
+++ b/website/docs/components/accordion/partials/version-history/4.10.0.md
@@ -2,7 +2,7 @@
 
 ### Updated
 
-`Accoridon`
+`Accordion`
 
 - Added `@titleTag` argument
 - Changed the default name of the `Accordion` item toggles. Now, they are labelled by the content in the `Accordion` title.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes a spelling error in the Accordion docs

Preview: https://hds-website-git-fix-docs-spelling-hashicorp.vercel.app/components/accordion?tab=version%20history

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser

### :link: External links

Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]
 -->

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
