### PR TITLE
Fix - Website tabs grid structure

### DIFF
--- a/website/app/styles/pages/application/stage.scss
+++ b/website/app/styles/pages/application/stage.scss
@@ -16,7 +16,7 @@
     "cover"
     "tabs"
     "content";
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto auto 1fr;
   grid-template-columns: 1fr;
   width: 100%; // needed (otherwise it collapses, because is in a grid)
 


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR would fix a bug on the website components pages, where there is extra spacing added between the content and the tabs, if the content is shorter than the height of the window. This bug was introduced during the [recent update](https://github.com/hashicorp/design-system/pull/2548) to make the tabs sticky.

### :camera_flash: Screenshots

Current View:
<img width="1728" alt="Screenshot 2024-11-15 at 5 06 18 PM" src="https://github.com/user-attachments/assets/8f3ce90e-89a8-4e1d-ab15-8154116709d8">

Expected View:
<img width="1728" alt="Screenshot 2024-11-15 at 5 06 37 PM" src="https://github.com/user-attachments/assets/cdd6a71e-9289-4800-a80b-c9d4347f30be">


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3297](https://hashicorp.atlassian.net/browse/HDS-3297)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3297]: https://hashicorp.atlassian.net/browse/HDS-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ