### PR TITLE
Update 'Release notes' section in website

### DIFF
--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -14,15 +14,17 @@
 
 ## 4.14.0
 
+[4.14.0 documentation](https://hds-website-4-14-0.vercel.app/)
+
 **Minor changes**
 
-`Dropdown` - added `@matchToggleWidth` argument
+`Dropdown` - Added `@matchToggleWidth` argument
 
 <small class="doc-whats-new-changelog-metadata">[#2530](https://github.com/hashicorp/design-system/pull/2530)</small>
 
 <div class="doc-whats-new-changelog-separator"></div>
 
-`hds-clipboard`: added `clipboard-polyfill` to support product usage in non-secure environments. This impacts `Copy::Button`, `Copy::Snippet`, `CodeBlock`, and `MaskedInput`.
+`hds-clipboard` - Added `clipboard-polyfill` to support product usage in non-secure environments; this impacts `Copy::Button`, `Copy::Snippet`, `CodeBlock`, and `MaskedInput`
 
 <small class="doc-whats-new-changelog-metadata">[#2525](https://github.com/hashicorp/design-system/pull/2525)</small>
 
@@ -60,7 +62,7 @@ Fixed instances where arguments are passed into tracked properties at declaratio
 
 <div class="doc-whats-new-changelog-separator"></div>
 
-`Dropdown`: fixed the height of the chevron in `ToggleButton`.
+`Dropdown` - Fixed the height of the chevron in `ToggleButton`
 
 <small class="doc-whats-new-changelog-metadata">[#2522](https://github.com/hashicorp/design-system/pull/2522)</small>
 
@@ -88,7 +90,7 @@ Export TypeScript signatures for all components and modifiers
 
 <div class="doc-whats-new-changelog-separator"></div>
 
-`Alert` - Removed role="alert" and aria-live="polite" attributes from Alerts with color set to "neutral" or "highlight"
+`Alert` - Removed `role="alert"` and `aria-live="polite"` attributes from Alerts with color set to "neutral" or "highlight"
 
 <small class="doc-whats-new-changelog-metadata">[#2500](https://github.com/hashicorp/design-system/pull/2500)</small>
 
@@ -100,15 +102,15 @@ Export TypeScript signatures for all components and modifiers
 
 **Minor changes**
 
-`Modal` - Added `returnFocusTo` argument to control where the browser focus is returned once the modal is closed
+`Modal` - Added `@returnFocusTo` argument to control where the browser focus is returned once the modal is closed
 
-`Flyout` - Added `returnFocusTo` argument to control where the browser focus is returned once the flyout is closed
+`Flyout` - Added `@returnFocusTo` argument to control where the browser focus is returned once the flyout is closed
 
 <small class="doc-whats-new-changelog-metadata">[#2497](https://github.com/hashicorp/design-system/pull/2497)</small>
 
 <div class="doc-whats-new-changelog-separator"></div>
 
-`CodeBlock` - Added `lineNumberStart` option to set custom starting number for line numbering
+`CodeBlock` - Added `@lineNumberStart` option to set custom starting number for line numbering
 
 <small class="doc-whats-new-changelog-metadata">[#2467](https://github.com/hashicorp/design-system/pull/2467)</small>
 
@@ -125,7 +127,7 @@ Export TypeScript signatures for all components and modifiers
 `Dropdown`
 
 - Fixed content being preserved in the DOM when closed
-- Removed the `isOpen` yielded argument
+- Removed the `@isOpen` yielded argument
 - Added `@preserveContentInDom` to optionally control rendering of the content
 
 <small class="doc-whats-new-changelog-metadata">[#2490](https://github.com/hashicorp/design-system/pull/2490)</small>
@@ -139,7 +141,7 @@ Export TypeScript signatures for all components and modifiers
 
 <div class="doc-whats-new-changelog-separator"></div>
 
-`SuperSelect` - Update the the default state of selected list items to `Foreground / Primary` to match other list items and the `Dropdown`.
+`SuperSelect` - Update the the default state of selected list items to `Foreground` / `Primary` to match other list items and the `Dropdown`.
 
 <small class="doc-whats-new-changelog-metadata">[#2479](https://github.com/hashicorp/design-system/pull/2479)</small>
 
@@ -267,7 +269,7 @@ Removed `ember-keyboard` dependency
 
 <div class="doc-whats-new-changelog-separator"></div>
 
-`DialogPrimitive` - added a guard so the yielded close function is always defined'
+`DialogPrimitive` - added a guard so the yielded close function is always defined
 
 <small class="doc-whats-new-changelog-metadata">[#2453](https://github.com/hashicorp/design-system/pull/2453)</small>
 


### PR DESCRIPTION
### :pushpin: Summary

Update 'Release notes' section in `website`

### :hammer_and_wrench: Detailed description

Ran `yarn run generate-changelog-markdown-files` to update the release notes.

This script usually runs when the changeset PR is merged to `main`. For some reason, in a chain of PRs getting merged, the script was not completed or was overridden by another PR.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
