### PR TITLE
add designers as approved codeowners for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Default owners
 *       @hashicorp/hds-engineering
+
+# co-ownership of website docs
+/website/docs/ @hashicorp/hds-engineering @hashicorp/hds-design

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,5 @@
 *       @hashicorp/hds-engineering
 
 # co-ownership of website docs & assets
-/website/docs/ /website/public/assets/ @hashicorp/hds-engineering @hashicorp/hds-design
+/website/docs/ @hashicorp/hds-engineering @hashicorp/hds-design
+/website/public/assets/ @hashicorp/hds-engineering @hashicorp/hds-design

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners
 *       @hashicorp/hds-engineering
 
-# co-ownership of website docs
-/website/docs/ @hashicorp/hds-engineering @hashicorp/hds-design
+# co-ownership of website docs & assets
+/website/docs/ /website/public/assets/ @hashicorp/hds-engineering @hashicorp/hds-design


### PR DESCRIPTION
### :pushpin: Summary

This would allow for designers to independently approve and merge documentation changes