### PR TITLE
`Dropdown` - Focus ring on click for `ToggleIcon` fix

### DIFF
--- a/.changeset/cold-humans-mix.md
+++ b/.changeset/cold-humans-mix.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Dropdown` - Fixed an issue with the `ToggleIcon` to make the focus ring visible on mouse click

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -63,6 +63,10 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   &.mock-active {
     background-color: var(--token-color-surface-interactive-active);
     border-color: var(--token-color-border-strong);
+
+    &::before {
+      border-color: transparent;
+    }
   }
 
   &:disabled,

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -52,6 +52,7 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   &:focus,
   &.mock-focus {
     @include hds-button-state-focus();
+    border-color: var(--token-color-focus-action-internal);
 
     &::before {
       border-color: var(--token-color-focus-action-external);

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -28,6 +28,7 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
 // TOGGLE/ICON
 
 .hds-dropdown-toggle-icon {
+  position: relative;
   display: flex;
   gap: 2px;
   align-items: center;
@@ -48,13 +49,14 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
     cursor: pointer;
   }
 
-  @include hds-focus-ring-with-pseudo-element(
-    $top: -1px,
-    $right: -1px,
-    $bottom: -1px,
-    $left: -1px,
-    $radius: $hds-dropdown-toggle-border-radius
-  );
+  &:focus,
+  &.mock-focus {
+    @include hds-button-state-focus();
+
+    &::before {
+      border-color: var(--token-color-focus-action-external);
+    }
+  }
 
   &:active,
   &.mock-active {

--- a/website/docs/components/dropdown/index.md
+++ b/website/docs/components/dropdown/index.md
@@ -10,7 +10,7 @@ previewImage: assets/illustrations/components/dropdown.jpg
 navigation:
   keywords: ['select', 'menu', 'action menu', 'list']
 status:
-  updated: 4.14.0
+  updated: 4.15.0
 ---
 
 <section data-tab="Guidelines">
@@ -33,6 +33,7 @@ status:
 </section>
 
 <section data-tab="Version history">
+  @include "partials/version-history/4.15.0.md"
   @include "partials/version-history/4.14.0.md"
   @include "partials/version-history/4.13.0.md"
   @include "partials/version-history/4.12.0.md"

--- a/website/docs/components/dropdown/partials/version-history/4.15.0.md
+++ b/website/docs/components/dropdown/partials/version-history/4.15.0.md
@@ -1,0 +1,5 @@
+## 4.15.0
+
+### Updated
+
+Fixed an issue with the `ToggleIcon` to make the focus ring visible on mouse click


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an open issue with the `ToggleIcon` variation of the `Dropdown` where the focus ring does not appear on mouse click on the button. 

### 🛠️ Detailed description

Currently the `ToggleIcon` variation of the `Dropdown` only shows a focus ring when the menu is opened, if it is opened via the keyboard, not the mouse. This interaction differs from that of the `ToggleButton` variation of the `Dropdown` and from the generic `Button` component. 

The approach for this variation has been update to align with those of other button components in the library. It now will show the focus ring on both mouse click and keyboard interaction. 

### :camera_flash: Screenshots

Current behavior on mouse click
<img width="168" alt="Screenshot 2024-11-20 at 9 09 42 AM" src="https://github.com/user-attachments/assets/ce557ae8-bd6e-432d-a8c5-6268ea402802">

New behavior on mouse click
<img width="172" alt="Screenshot 2024-11-20 at 9 09 35 AM" src="https://github.com/user-attachments/assets/6eef75a2-648b-4c87-8d45-d47d8f50414a">

### :link: External links

Jira ticket: [HDS-4096](https://hashicorp.atlassian.net/browse/HDS-4096)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4096]: https://hashicorp.atlassian.net/browse/HDS-4096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ