### PR TITLE
Dropdown Interactive Codemod Enhancements

### DIFF
--- a/.changeset/lucky-hotels-sell.md
+++ b/.changeset/lucky-hotels-sell.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-codemods": minor
+---
+
+v4/dropdown-list-item-interactive - Update codemod to successfully parse nested content blocks such as conditionals

--- a/.changeset/lucky-hotels-sell.md
+++ b/.changeset/lucky-hotels-sell.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-codemods": minor
 ---
 
-v4/dropdown-list-item-interactive - Update codemod to successfully parse nested content blocks such as conditionals
+Update `v4/dropdown-list-item-interactive` codemod to successfully parse nested content blocks such as conditionals

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -30,6 +30,7 @@ node ./packages/codemods/bin/cli.js v3/dropdown path/to/some/glob/**/*.hbs
 ### v4
 <!--TRANSFORMS_START-->
 * [v4/contextual-components](transforms/v4/contextual-components/README.md)
+* [v4/dropdown-list-item-interactive](transforms/v4/dropdown-list-item-interactive/README.md)
 * [v4/table](transforms/v4/table/README.md)
 * [v4/icon](transforms/v4/icon/README.md)
 <!--TRANSFORMS_END-->

--- a/packages/codemods/transforms/v4/dropdown-list-item-interactive/__testfixtures__/inside-conditional.input.hbs
+++ b/packages/codemods/transforms/v4/dropdown-list-item-interactive/__testfixtures__/inside-conditional.input.hbs
@@ -1,0 +1,10 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+<Hds::Dropdown as |dd|>
+  <dd.Title @text='Title text' />
+  {{#if this.conditional}}
+    <dd.Interactive @href='#' @text='Test' />
+  {{/if}}
+</Hds::Dropdown>

--- a/packages/codemods/transforms/v4/dropdown-list-item-interactive/__testfixtures__/inside-conditional.output.hbs
+++ b/packages/codemods/transforms/v4/dropdown-list-item-interactive/__testfixtures__/inside-conditional.output.hbs
@@ -1,0 +1,10 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+<Hds::Dropdown as |dd|>
+  <dd.Title @text='Title text' />
+  {{#if this.conditional}}
+    <dd.Interactive @href='#'>Test</dd.Interactive>
+  {{/if}}
+</Hds::Dropdown>

--- a/packages/codemods/transforms/v4/dropdown-list-item-interactive/index.js
+++ b/packages/codemods/transforms/v4/dropdown-list-item-interactive/index.js
@@ -5,6 +5,81 @@
 
 const CODEMOD_ANALYSIS = process.env.CODEMOD_ANALYSIS;
 
+function processChildren(children, asPrefix, b) {
+  let hasUpdatedChildren = false;
+  let processedChildren = [];
+
+  children.forEach((child) => {
+    let updatedChild;
+    let isProcessed = false;
+
+    if (child.type === 'ElementNode' && child.tag === `${asPrefix}.Interactive`) {
+      const textAttr = child.attributes.find((a) => a.name === '@text');
+
+      if (textAttr) {
+        const childOutputAttributes = child.attributes.filter((a) => a.name !== '@text');
+
+        const isHandlebarsAttr = textAttr.value.type === 'MustacheStatement';
+
+        let children = [];
+
+        if (isHandlebarsAttr) {
+          if (textAttr.value.path.type === 'NumberLiteral') {
+            children = [b.mustache(b.number(textAttr.value.path.value))];
+          } else if (textAttr.value.path.type === 'StringLiteral') {
+            children = [b.mustache(b.string(textAttr.value.path.value))];
+          } else {
+            children = [
+              b.mustache(
+                textAttr.value.path.original,
+                [...textAttr.value.params],
+                textAttr.value.hash
+              ),
+            ];
+          }
+        } else {
+          children = [b.text(textAttr.value.chars)];
+        }
+
+        updatedChild = b.element(
+          { name: child.tag, selfClosing: false },
+          {
+            children,
+            attrs: childOutputAttributes,
+            modifiers: child.modifiers,
+            blockParams: child.blockParams,
+          }
+        );
+
+        isProcessed = true;
+      } else {
+        updatedChild = child;
+      }
+    } else if (child.type === 'BlockStatement') {
+      const { hasUpdatedChildren: nestedHasUpdated, processedChildren: nestedProcessed } =
+        processChildren(child.program.body, asPrefix, b);
+
+      if (nestedHasUpdated) {
+        updatedChild = b.block(
+          child.path,
+          child.params,
+          child.hash,
+          b.program(nestedProcessed, child.program.blockParams),
+          child.inverse
+        );
+        isProcessed = true;
+      } else {
+        updatedChild = child;
+      }
+    }
+
+    processedChildren.push(updatedChild || child);
+    hasUpdatedChildren = hasUpdatedChildren || isProcessed;
+  });
+
+  return { hasUpdatedChildren, processedChildren };
+}
+
 module.exports = function ({ source /*, path*/ }, { parse, visit }) {
   const ast = parse(source);
 
@@ -14,83 +89,28 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
     return {
       ElementNode(node) {
         if (node.type === 'ElementNode' && node.tag === 'Hds::Dropdown') {
-          let hasUpdatedChildren = false;
-          let processedChildren;
-
           if (node.blockParams && node.blockParams.length > 0) {
             const asPrefix = node.blockParams[0];
 
-            processedChildren = [];
+            const { hasUpdatedChildren, processedChildren } = processChildren(
+              node.children,
+              asPrefix,
+              b
+            );
 
-            if (node.children) {
-              node.children.forEach((child) => {
-                let updatedChild;
-                let isProcessed = false;
-
-                if (child.type === 'ElementNode' && child.tag === `${asPrefix}.Interactive`) {
-                  const textAttr = child.attributes.find((a) => a.name === '@text');
-
-                  if (textAttr) {
-                    const childOutputAttributes = child.attributes.filter(
-                      (a) => a.name !== '@text'
-                    );
-
-                    const isHandlebarsAttr = textAttr.value.type === 'MustacheStatement';
-
-                    let children = [];
-
-                    if (isHandlebarsAttr) {
-                      if (textAttr.value.path.type === 'NumberLiteral') {
-                        children = [b.mustache(b.number(textAttr.value.path.value))];
-                      } else if (textAttr.value.path.type === 'StringLiteral') {
-                        children = [b.mustache(b.string(textAttr.value.path.value))];
-                      } else {
-                        children = [
-                          b.mustache(
-                            textAttr.value.path.original,
-                            [...textAttr.value.params],
-                            textAttr.value.hash
-                          ),
-                        ];
-                      }
-                    } else {
-                      children = [b.text(textAttr.value.chars)];
-                    }
-
-                    updatedChild = b.element(
-                      { name: child.tag, selfClosing: false },
-                      {
-                        children,
-                        attrs: childOutputAttributes,
-                        modifiers: child.modifiers,
-                        blockParams: child.blockParams,
-                      }
-                    );
-
-                    isProcessed = true;
-                  } else {
-                    updatedChild = child;
+            if (hasUpdatedChildren && !CODEMOD_ANALYSIS) {
+              return [
+                b.element(
+                  { name: node.tag, selfClosing: false },
+                  {
+                    attrs: node.attributes,
+                    children: processedChildren,
+                    modifiers: node.modifiers,
+                    blockParams: node.blockParams,
                   }
-                }
-
-                processedChildren.push(updatedChild || child);
-                hasUpdatedChildren = hasUpdatedChildren || isProcessed;
-              });
+                ),
+              ];
             }
-          }
-
-          if (hasUpdatedChildren && !CODEMOD_ANALYSIS) {
-            return [
-              b.element(
-                { name: node.tag, selfClosing: false },
-                {
-                  attrs: node.attributes,
-                  children: processedChildren || node.children,
-                  modifiers: node.modifiers,
-                  blockParams: node.blockParams,
-                }
-              ),
-            ];
           }
         }
       },

--- a/packages/codemods/transforms/v4/dropdown-list-item-interactive/index.js
+++ b/packages/codemods/transforms/v4/dropdown-list-item-interactive/index.js
@@ -13,6 +13,7 @@ function processChildren(children, asPrefix, b) {
     let updatedChild;
     let isProcessed = false;
 
+    // Check if the child is an ElementNode with the specified tag
     if (child.type === 'ElementNode' && child.tag === `${asPrefix}.Interactive`) {
       const textAttr = child.attributes.find((a) => a.name === '@text');
 
@@ -23,6 +24,7 @@ function processChildren(children, asPrefix, b) {
 
         let children = [];
 
+        // Handle different types of MustacheStatement values
         if (isHandlebarsAttr) {
           if (textAttr.value.path.type === 'NumberLiteral') {
             children = [b.mustache(b.number(textAttr.value.path.value))];
@@ -41,6 +43,7 @@ function processChildren(children, asPrefix, b) {
           children = [b.text(textAttr.value.chars)];
         }
 
+        // Create a new element with the updated children and attributes
         updatedChild = b.element(
           { name: child.tag, selfClosing: false },
           {
@@ -56,6 +59,7 @@ function processChildren(children, asPrefix, b) {
         updatedChild = child;
       }
     } else if (child.type === 'BlockStatement') {
+      // Recursively process children of BlockStatement nodes
       const { hasUpdatedChildren: nestedHasUpdated, processedChildren: nestedProcessed } =
         processChildren(child.program.body, asPrefix, b);
 
@@ -88,16 +92,19 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
 
     return {
       ElementNode(node) {
+        // Check if the node is an Hds::Dropdown element
         if (node.type === 'ElementNode' && node.tag === 'Hds::Dropdown') {
           if (node.blockParams && node.blockParams.length > 0) {
             const asPrefix = node.blockParams[0];
 
+            // Process the children of the Hds::Dropdown element
             const { hasUpdatedChildren, processedChildren } = processChildren(
               node.children,
               asPrefix,
               b
             );
 
+            // Return the updated element if any children were updated
             if (hasUpdatedChildren && !CODEMOD_ANALYSIS) {
               return [
                 b.element(


### PR DESCRIPTION
### :pushpin: Summary

We received a report that the `dropdown-list-item-interactive` codemod didn't work correctly on yielded `Interactive` components that are rendered conditionally.

Example:

```
{{!
  Copyright (c) HashiCorp, Inc.
  SPDX-License-Identifier: MPL-2.0
}}
<Hds::Dropdown as |dd|>
  <dd.Title @text='Title text' />
  <dd.Interactive @href='#' @text={{or @text (t "components.generate-service-principal-key-button.default-text")}} />
</Hds::Dropdown>
```

The `Interactive` component was ignored because it was nested in another block.

### :hammer_and_wrench: Detailed description

- Changed the logic in the codemod to recursively traverse blocks in order to reach nested children
- Added another test case
- Added some clarifying comments

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4151](https://hashicorp.atlassian.net/browse/HDS-4151)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4151]: https://hashicorp.atlassian.net/browse/HDS-4151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ