### PR TITLE
(bugfix components): set width: max-content on HDS Rich Tooltip

### DIFF
--- a/.changeset/heavy-snails-ring.md
+++ b/.changeset/heavy-snails-ring.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fix ResizeObserver: loop completed with undelivered notifications error for RichTooltip by setting a fixed width

--- a/packages/components/src/styles/components/rich-tooltip.scss
+++ b/packages/components/src/styles/components/rich-tooltip.scss
@@ -132,7 +132,9 @@
 
 .hds-rich-tooltip__bubble {
   position: relative;
-  width: fit-content;
+  // Prevent ResizeObserver: loop completed with undelivered notifications error
+  // https://github.com/floating-ui/floating-ui/issues/2338#issuecomment-1558709673
+  width: max-content;
   max-width: var(--token-tooltip-max-width);
   height: fit-content;
   max-height: none;


### PR DESCRIPTION


### :pushpin: Summary

Prevent `ResizeObserver: loop completed with undelivered notifications` error by setting a fixed width on the container for Rich Tooltips.

### :hammer_and_wrench: Detailed description

Setting a fixed width seems to make these ResizeObserver notifications go away. Solution came from Floating UI repository issues:
https://github.com/floating-ui/floating-ui/issues/2338#issuecomment-1558709673

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [TF-22433](https://hashicorp.atlassian.net/browse/TF-22433)
Figma file: N/A

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[TF-22433]: https://hashicorp.atlassian.net/browse/TF-22433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ