### PR TITLE
`PageHeader` -  Fix for extra spacing when no metadata present

### DIFF
--- a/.changeset/eighty-lobsters-brush.md
+++ b/.changeset/eighty-lobsters-brush.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`PageHeader` - Fixed issue with extra space below title when no metadata is present

--- a/packages/components/src/styles/components/page-header.scss
+++ b/packages/components/src/styles/components/page-header.scss
@@ -51,7 +51,6 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  gap: 8px;
   min-width: 0; // this is important or it will blow beyond the parent flexbox width with long non-breaking names
   max-width: 100%;
 }
@@ -79,6 +78,10 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+
+  > *:first-child {
+    margin-top: 8px;
+  }
 }
 
 .hds-page-header__subtitle,

--- a/showcase/app/controllers/components/page-header.js
+++ b/showcase/app/controllers/components/page-header.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+
+export default class PageHeaderController extends Controller {
+  @service router;
+
+  @tracked showHighlight = false;
+
+  // =============================
+  // GENERIC HANDLERS
+  // =============================
+
+  @action
+  toggleHighlight() {
+    this.showHighlight = !this.showHighlight;
+  }
+}

--- a/showcase/app/controllers/components/page-header.js
+++ b/showcase/app/controllers/components/page-header.js
@@ -6,11 +6,8 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
 
 export default class PageHeaderController extends Controller {
-  @service router;
-
   @tracked showHighlight = false;
 
   // =============================

--- a/showcase/app/styles/app.scss
+++ b/showcase/app/styles/app.scss
@@ -60,6 +60,7 @@
 @import "./showcase-pages/link-inline";
 @import "./showcase-pages/menu-primitive";
 @import "./showcase-pages/modal";
+@import "./showcase-pages/page-header";
 @import "./showcase-pages/pagination";
 @import "./showcase-pages/popover-primitive";
 @import "./showcase-pages/power-select";

--- a/showcase/app/styles/showcase-pages/page-header.scss
+++ b/showcase/app/styles/showcase-pages/page-header.scss
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Page Header
+
+body.components-page-header {
+  .shw-component-page-header-layout-highlight {
+    .hds-page-header {
+      outline: 1px dashed #78909c;
+      outline-offset: -1px;
+    }
+  }
+}

--- a/showcase/app/templates/components/page-header.hbs
+++ b/showcase/app/templates/components/page-header.hbs
@@ -7,122 +7,109 @@ SPDX-License-Identifier: MPL-2.0
 
 <Shw::Text::H1>PageHeader</Shw::Text::H1>
 
-<section data-test-percy>
+<section data-test-percy class={{if this.showHighlight "shw-component-page-header-layout-highlight"}}>
+
+  <button id="shw-component-toggle-highlight" type="button" {{on "click" this.toggleHighlight}}>
+    {{if this.showHighlight "Hide" "Show"}}
+    layout highlight
+  </button>
 
   <Shw::Text::H2>Basic examples</Shw::Text::H2>
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="Only title">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Page title</PH.Title>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Page title</PH.Title>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Badge">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Page title</PH.Title>
-          <PH.Badges>
-            <Hds::Badge @text="Badge" @icon="beaker" @color="highlight" />
-          </PH.Badges>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Page title</PH.Title>
+        <PH.Badges>
+          <Hds::Badge @text="Badge" @icon="beaker" @color="highlight" />
+        </PH.Badges>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="IconTile">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Page title</PH.Title>
-          <PH.IconTile @icon="server-cluster" />
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Page title</PH.Title>
+        <PH.IconTile @icon="server-cluster" />
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Breadcrumb">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Page title</PH.Title>
-          <PH.Breadcrumb>
-            <Hds::Breadcrumb aria-label="breadcrumbs with page title example">
-              <Hds::Breadcrumb::Item @text="Organization" @icon="org" />
-              <Hds::Breadcrumb::Item @text="Project" @icon="folder" />
-              <Hds::Breadcrumb::Item @text="User" @icon="user" />
-            </Hds::Breadcrumb>
-          </PH.Breadcrumb>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Page title</PH.Title>
+        <PH.Breadcrumb>
+          <Hds::Breadcrumb aria-label="breadcrumbs with page title example">
+            <Hds::Breadcrumb::Item @text="Organization" @icon="org" />
+            <Hds::Breadcrumb::Item @text="Project" @icon="folder" />
+            <Hds::Breadcrumb::Item @text="User" @icon="user" />
+          </Hds::Breadcrumb>
+        </PH.Breadcrumb>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Subtitle + description">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Page title</PH.Title>
-          <PH.Subtitle>Subtitle lorem ipsum</PH.Subtitle>
-          <PH.Description>Description lorem ipsum dolor sit amet.</PH.Description>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Page title</PH.Title>
+        <PH.Subtitle>Subtitle lorem ipsum</PH.Subtitle>
+        <PH.Description>Description lorem ipsum dolor sit amet.</PH.Description>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Single action">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Page title</PH.Title>
-          <PH.Actions>
-            <Hds::Button @text="Create registry" @icon="plus" @iconPosition="leading" @color="primary" />
-          </PH.Actions>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Page title</PH.Title>
+        <PH.Actions>
+          <Hds::Button @text="Create registry" @icon="plus" @iconPosition="leading" @color="primary" />
+        </PH.Actions>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Two actions">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Page title</PH.Title>
-          <PH.Actions>
-            <Hds::Dropdown as |D|>
-              <D.ToggleButton @text="Manage" @color="secondary" />
-              <D.Interactive>Manage cluster externally</D.Interactive>
-              <D.Interactive>Launch desktop</D.Interactive>
-              <D.Interactive @color="critical" @icon="trash">Delete</D.Interactive>
-            </Hds::Dropdown>
-            <Hds::Button @text="Create" @icon="plus" @iconPosition="leading" @color="primary" />
-          </PH.Actions>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Page title</PH.Title>
+        <PH.Actions>
+          <Hds::Dropdown as |D|>
+            <D.ToggleButton @text="Manage" @color="secondary" />
+            <D.Interactive>Manage cluster externally</D.Interactive>
+            <D.Interactive>Launch desktop</D.Interactive>
+            <D.Interactive @color="critical" @icon="trash">Delete</D.Interactive>
+          </Hds::Dropdown>
+          <Hds::Button @text="Create" @icon="plus" @iconPosition="leading" @color="primary" />
+        </PH.Actions>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Three actions">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Page title</PH.Title>
-          <PH.Actions>
-            <Hds::Button @color="tertiary" @text="Migrate instructions" @icon="migrate" @iconPosition="leading" />
-            <Hds::Button @color="secondary" @text="Edit cluster" />
-            <Hds::Button @color="primary" @text="Create cluster" @icon="plus" @iconPosition="leading" />
-          </PH.Actions>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Page title</PH.Title>
+        <PH.Actions>
+          <Hds::Button @color="tertiary" @text="Migrate instructions" @icon="migrate" @iconPosition="leading" />
+          <Hds::Button @color="secondary" @text="Edit cluster" />
+          <Hds::Button @color="primary" @text="Create cluster" @icon="plus" @iconPosition="leading" />
+        </PH.Actions>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Custom metadata">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Page title</PH.Title>
-          <PH.Generic>
-            <Shw::Placeholder @text="generic content" @width="500" @height="36" @background="#e1f5fe" />
-          </PH.Generic>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Page title</PH.Title>
+        <PH.Generic>
+          <Shw::Placeholder @text="generic content" @width="500" @height="36" @background="#e1f5fe" />
+        </PH.Generic>
+      </Hds::PageHeader>
     </SF.Item>
   </Shw::Flex>
 
@@ -132,119 +119,109 @@ SPDX-License-Identifier: MPL-2.0
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="Product landing page">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>HCP Packer</PH.Title>
-          <PH.Breadcrumb>
-            <Hds::Breadcrumb aria-label="breadcrumbs with complex examples">
-              <Hds::Breadcrumb::Item @text="Sandbox" @icon="org" />
-              <Hds::Breadcrumb::Item @text="HCP Packer" @icon="packer" />
-              <Hds::Breadcrumb::Item @text="jane-doe" @icon="file-text" />
-            </Hds::Breadcrumb>
-          </PH.Breadcrumb>
-          <PH.IconTile @icon="packer-color" @color="packer" />
-          <PH.Description>Create and view Packer registries in HCP.
-          </PH.Description>
-          <PH.Actions>
-            <Hds::Button @text="Create Packer registery" @icon="plus" @iconPosition="leading" />
-          </PH.Actions>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>HCP Packer</PH.Title>
+        <PH.Breadcrumb>
+          <Hds::Breadcrumb aria-label="breadcrumbs with complex examples">
+            <Hds::Breadcrumb::Item @text="Sandbox" @icon="org" />
+            <Hds::Breadcrumb::Item @text="HCP Packer" @icon="packer" />
+            <Hds::Breadcrumb::Item @text="jane-doe" @icon="file-text" />
+          </Hds::Breadcrumb>
+        </PH.Breadcrumb>
+        <PH.IconTile @icon="packer-color" @color="packer" />
+        <PH.Description>Create and view Packer registries in HCP.
+        </PH.Description>
+        <PH.Actions>
+          <Hds::Button @text="Create Packer registery" @icon="plus" @iconPosition="leading" />
+        </PH.Actions>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Item page">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Boundary clusters</PH.Title>
-          <PH.IconTile @icon="boundary-color" @color="boundary" />
-          <PH.Breadcrumb>
-            <Hds::Breadcrumb aria-label="breadcrumb example with item page">
-              <Hds::Breadcrumb::Item @text="Cloud sandbox" @icon="org" />
-              <Hds::Breadcrumb::Item @text="Boundary clusters" @icon="boundary" />
-            </Hds::Breadcrumb>
-          </PH.Breadcrumb>
-          <PH.Badges>
-            <Hds::Badge @text="Active" @icon="check" @color="success" />
-          </PH.Badges>
-          <PH.Subtitle>boundary-cluster-name</PH.Subtitle>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Boundary clusters</PH.Title>
+        <PH.IconTile @icon="boundary-color" @color="boundary" />
+        <PH.Breadcrumb>
+          <Hds::Breadcrumb aria-label="breadcrumb example with item page">
+            <Hds::Breadcrumb::Item @text="Cloud sandbox" @icon="org" />
+            <Hds::Breadcrumb::Item @text="Boundary clusters" @icon="boundary" />
+          </Hds::Breadcrumb>
+        </PH.Breadcrumb>
+        <PH.Badges>
+          <Hds::Badge @text="Active" @icon="check" @color="success" />
+        </PH.Badges>
+        <PH.Subtitle>boundary-cluster-name</PH.Subtitle>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Multiple badges">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Consul cluster</PH.Title>
-          <PH.Badges>
-            <Hds::Badge @text="Active" @icon="check" @color="success" />
-            <Hds::Badge @text="Deployed to AWS west-2" @color="highlight" @icon="rocket" />
-            <Hds::BadgeCount @text="v1.5" @color="neutral" />
-            <Hds::Badge @text="Locked by jane-doe" @color="warning" @icon="lock" />
-          </PH.Badges>
-          <PH.Description>
-            While this is supported by the contextual component, this many badges being used to represent metadata can
-            be problematic.
-          </PH.Description>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Consul cluster</PH.Title>
+        <PH.Badges>
+          <Hds::Badge @text="Active" @icon="check" @color="success" />
+          <Hds::Badge @text="Deployed to AWS west-2" @color="highlight" @icon="rocket" />
+          <Hds::BadgeCount @text="v1.5" @color="neutral" />
+          <Hds::Badge @text="Locked by jane-doe" @color="warning" @icon="lock" />
+        </PH.Badges>
+        <PH.Description>
+          While this is supported by the contextual component, this many badges being used to represent metadata can be
+          problematic.
+        </PH.Description>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Kitchen sink example">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Users</PH.Title>
-          <PH.Subtitle>Access control (IAM)</PH.Subtitle>
-          <PH.Description>Manage organization users, roles, and access control.
-          </PH.Description>
-          <PH.Description>This is a second description, in case multiple paragraphs are needed.</PH.Description>
-          <PH.Breadcrumb>
-            <Hds::Breadcrumb>
-              <Hds::Breadcrumb::Item @text="Cloud sandbox" @icon="org" />
-              <Hds::Breadcrumb::Item @text="jane-doe" @icon="file-text" />
-              <Hds::Breadcrumb::Item @text="Access control (IAM)" @icon="users" />
-            </Hds::Breadcrumb>
-          </PH.Breadcrumb>
-          <PH.IconTile @icon="users" @color="terraform" />
-          <PH.Actions>
-            <Hds::Dropdown as |D|>
-              <D.ToggleButton @text="Manage users" @color="secondary" />
-              <D.Interactive @icon="user">Assign roles</D.Interactive>
-              <D.Interactive @icon="edit">Batch edit</D.Interactive>
-              <D.Interactive @icon="trash">Delete user</D.Interactive>
-            </Hds::Dropdown>
-            <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
-          </PH.Actions>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Users</PH.Title>
+        <PH.Subtitle>Access control (IAM)</PH.Subtitle>
+        <PH.Description>Manage organization users, roles, and access control.
+        </PH.Description>
+        <PH.Description>This is a second description, in case multiple paragraphs are needed.</PH.Description>
+        <PH.Breadcrumb>
+          <Hds::Breadcrumb>
+            <Hds::Breadcrumb::Item @text="Cloud sandbox" @icon="org" />
+            <Hds::Breadcrumb::Item @text="jane-doe" @icon="file-text" />
+            <Hds::Breadcrumb::Item @text="Access control (IAM)" @icon="users" />
+          </Hds::Breadcrumb>
+        </PH.Breadcrumb>
+        <PH.IconTile @icon="users" @color="terraform" />
+        <PH.Actions>
+          <Hds::Dropdown as |D|>
+            <D.ToggleButton @text="Manage users" @color="secondary" />
+            <D.Interactive @icon="user">Assign roles</D.Interactive>
+            <D.Interactive @icon="edit">Batch edit</D.Interactive>
+            <D.Interactive @icon="trash">Delete user</D.Interactive>
+          </Hds::Dropdown>
+          <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
+        </PH.Actions>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="With custom metadata">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Custom metadata</PH.Title>
-          <PH.Subtitle>beta-feature-cluster</PH.Subtitle>
-          <PH.Generic>
-            <Hds::Alert @type="compact" @color="warning" as |A|>
-              <A.Title>Beta feature</A.Title>
-              <A.Description>
-                This feature is in beta and is subject to change. Refer to the
-                <Hds::Link::Inline @href="#" @icon="external-link">HCP documentation</Hds::Link::Inline>
-                for more information and roadmap.
-              </A.Description>
-            </Hds::Alert>
-          </PH.Generic>
-          <PH.Actions>
-            <Hds::Button @text="Get started" @icon="beaker" @iconPosition="leading" />
-          </PH.Actions>
-          <PH.Badges>
-            <Hds::Badge @text="Beta feature" @icon="wand" @color="highlight" />
-          </PH.Badges>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Custom metadata</PH.Title>
+        <PH.Subtitle>beta-feature-cluster</PH.Subtitle>
+        <PH.Generic>
+          <Hds::Alert @type="compact" @color="warning" as |A|>
+            <A.Title>Beta feature</A.Title>
+            <A.Description>
+              This feature is in beta and is subject to change. Refer to the
+              <Hds::Link::Inline @href="#" @icon="external-link">HCP documentation</Hds::Link::Inline>
+              for more information and roadmap.
+            </A.Description>
+          </Hds::Alert>
+        </PH.Generic>
+        <PH.Actions>
+          <Hds::Button @text="Get started" @icon="beaker" @iconPosition="leading" />
+        </PH.Actions>
+        <PH.Badges>
+          <Hds::Badge @text="Beta feature" @icon="wand" @color="highlight" />
+        </PH.Badges>
+      </Hds::PageHeader>
     </SF.Item>
   </Shw::Flex>
 
@@ -259,63 +236,57 @@ SPDX-License-Identifier: MPL-2.0
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="Long title">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>Boundary cluster access control and clusters</PH.Title>
-          <PH.IconTile @icon="boundary-color" @color="boundary" />
-          <PH.Actions>
-            <Hds::Dropdown as |D|>
-              <D.ToggleButton @text="Manage users" @color="secondary" />
-              <D.Interactive @icon="user">Assign roles</D.Interactive>
-              <D.Interactive @icon="edit">Batch edit</D.Interactive>
-              <D.Interactive @icon="trash">Delete user</D.Interactive>
-            </Hds::Dropdown>
-            <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
-          </PH.Actions>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>Boundary cluster access control and clusters</PH.Title>
+        <PH.IconTile @icon="boundary-color" @color="boundary" />
+        <PH.Actions>
+          <Hds::Dropdown as |D|>
+            <D.ToggleButton @text="Manage users" @color="secondary" />
+            <D.Interactive @icon="user">Assign roles</D.Interactive>
+            <D.Interactive @icon="edit">Batch edit</D.Interactive>
+            <D.Interactive @icon="trash">Delete user</D.Interactive>
+          </Hds::Dropdown>
+          <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
+        </PH.Actions>
+      </Hds::PageHeader>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Long title + badge">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>
-            Page title with a very very very very long string that can span multiple lines
-          </PH.Title>
-          <PH.IconTile @logo="vagrant" />
-          <PH.Badges>
-            <Hds::Badge @text="Wrapping badge" @icon="mic" @color="critical" />
-          </PH.Badges>
-          <PH.Actions>
-            <Hds::Button @text="Get started" @icon="terminal-screen" @iconPosition="trailing" />
-          </PH.Actions>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>
+          Page title with a very very very very long string that can span multiple lines
+        </PH.Title>
+        <PH.IconTile @logo="vagrant" />
+        <PH.Badges>
+          <Hds::Badge @text="Wrapping badge" @icon="mic" @color="critical" />
+        </PH.Badges>
+        <PH.Actions>
+          <Hds::Button @text="Get started" @icon="terminal-screen" @iconPosition="trailing" />
+        </PH.Actions>
+      </Hds::PageHeader>
 
       <Shw::Text::Body @tag="p">
         In the case of a badge, the title and badge will wrap if the available space is exceeded.
       </Shw::Text::Body>
     </SF.Item>
     <SF.Item @label="Non-breaking Title/Subtitle/Description + badge">
-      <Shw::Outliner>
-        <Hds::PageHeader as |PH|>
-          <PH.Title>
-            Pagetitlewithaveryveryveryverylongnonbreakingstringthatcanspanmultiplelines
-          </PH.Title>
-          <PH.Subtitle
-          >Subtitlewithaveryveryveryveryveryveryveryveryveryveryveryveryveryveveryveryveryveryveryveryveryveryveryveryveryveryryveryverylongnonbreakingstringthatcanspanmultiplelines</PH.Subtitle>
-          <PH.Description
-          >Descriptionwithaveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongnonbreakingstringthatcanspanmultiplelines.</PH.Description>
-          <PH.IconTile @logo="vagrant" />
-          <PH.Badges>
-            <Hds::Badge @text="Wrapping badge" @icon="mic" @color="critical" />
-          </PH.Badges>
-          <PH.Actions>
-            <Hds::Button @text="Get started" @icon="terminal-screen" @iconPosition="trailing" />
-          </PH.Actions>
-        </Hds::PageHeader>
-      </Shw::Outliner>
+      <Hds::PageHeader as |PH|>
+        <PH.Title>
+          Pagetitlewithaveryveryveryverylongnonbreakingstringthatcanspanmultiplelines
+        </PH.Title>
+        <PH.Subtitle
+        >Subtitlewithaveryveryveryveryveryveryveryveryveryveryveryveryveryveveryveryveryveryveryveryveryveryveryveryveryveryryveryverylongnonbreakingstringthatcanspanmultiplelines</PH.Subtitle>
+        <PH.Description
+        >Descriptionwithaveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongnonbreakingstringthatcanspanmultiplelines.</PH.Description>
+        <PH.IconTile @logo="vagrant" />
+        <PH.Badges>
+          <Hds::Badge @text="Wrapping badge" @icon="mic" @color="critical" />
+        </PH.Badges>
+        <PH.Actions>
+          <Hds::Button @text="Get started" @icon="terminal-screen" @iconPosition="trailing" />
+        </PH.Actions>
+      </Hds::PageHeader>
 
       <Shw::Text::Body @tag="p">
         In the case of non-breaking text the long string will be forced to wrap using the

--- a/showcase/app/templates/components/page-header.hbs
+++ b/showcase/app/templates/components/page-header.hbs
@@ -13,98 +13,116 @@ SPDX-License-Identifier: MPL-2.0
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="Only title">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Page title</PH.Title>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Page title</PH.Title>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Badge">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Page title</PH.Title>
-        <PH.Badges>
-          <Hds::Badge @text="Badge" @icon="beaker" @color="highlight" />
-        </PH.Badges>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Page title</PH.Title>
+          <PH.Badges>
+            <Hds::Badge @text="Badge" @icon="beaker" @color="highlight" />
+          </PH.Badges>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="IconTile">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Page title</PH.Title>
-        <PH.IconTile @icon="server-cluster" />
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Page title</PH.Title>
+          <PH.IconTile @icon="server-cluster" />
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Breadcrumb">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Page title</PH.Title>
-        <PH.Breadcrumb>
-          <Hds::Breadcrumb aria-label="breadcrumbs with page title example">
-            <Hds::Breadcrumb::Item @text="Organization" @icon="org" />
-            <Hds::Breadcrumb::Item @text="Project" @icon="folder" />
-            <Hds::Breadcrumb::Item @text="User" @icon="user" />
-          </Hds::Breadcrumb>
-        </PH.Breadcrumb>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Page title</PH.Title>
+          <PH.Breadcrumb>
+            <Hds::Breadcrumb aria-label="breadcrumbs with page title example">
+              <Hds::Breadcrumb::Item @text="Organization" @icon="org" />
+              <Hds::Breadcrumb::Item @text="Project" @icon="folder" />
+              <Hds::Breadcrumb::Item @text="User" @icon="user" />
+            </Hds::Breadcrumb>
+          </PH.Breadcrumb>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Subtitle + description">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Page title</PH.Title>
-        <PH.Subtitle>Subtitle lorem ipsum</PH.Subtitle>
-        <PH.Description>Description lorem ipsum dolor sit amet.</PH.Description>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Page title</PH.Title>
+          <PH.Subtitle>Subtitle lorem ipsum</PH.Subtitle>
+          <PH.Description>Description lorem ipsum dolor sit amet.</PH.Description>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Single action">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Page title</PH.Title>
-        <PH.Actions>
-          <Hds::Button @text="Create registry" @icon="plus" @iconPosition="leading" @color="primary" />
-        </PH.Actions>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Page title</PH.Title>
+          <PH.Actions>
+            <Hds::Button @text="Create registry" @icon="plus" @iconPosition="leading" @color="primary" />
+          </PH.Actions>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Two actions">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Page title</PH.Title>
-        <PH.Actions>
-          <Hds::Dropdown as |D|>
-            <D.ToggleButton @text="Manage" @color="secondary" />
-            <D.Interactive>Manage cluster externally</D.Interactive>
-            <D.Interactive>Launch desktop</D.Interactive>
-            <D.Interactive @color="critical" @icon="trash">Delete</D.Interactive>
-          </Hds::Dropdown>
-          <Hds::Button @text="Create" @icon="plus" @iconPosition="leading" @color="primary" />
-        </PH.Actions>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Page title</PH.Title>
+          <PH.Actions>
+            <Hds::Dropdown as |D|>
+              <D.ToggleButton @text="Manage" @color="secondary" />
+              <D.Interactive>Manage cluster externally</D.Interactive>
+              <D.Interactive>Launch desktop</D.Interactive>
+              <D.Interactive @color="critical" @icon="trash">Delete</D.Interactive>
+            </Hds::Dropdown>
+            <Hds::Button @text="Create" @icon="plus" @iconPosition="leading" @color="primary" />
+          </PH.Actions>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Three actions">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Page title</PH.Title>
-        <PH.Actions>
-          <Hds::Button @color="tertiary" @text="Migrate instructions" @icon="migrate" @iconPosition="leading" />
-          <Hds::Button @color="secondary" @text="Edit cluster" />
-          <Hds::Button @color="primary" @text="Create cluster" @icon="plus" @iconPosition="leading" />
-        </PH.Actions>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Page title</PH.Title>
+          <PH.Actions>
+            <Hds::Button @color="tertiary" @text="Migrate instructions" @icon="migrate" @iconPosition="leading" />
+            <Hds::Button @color="secondary" @text="Edit cluster" />
+            <Hds::Button @color="primary" @text="Create cluster" @icon="plus" @iconPosition="leading" />
+          </PH.Actions>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Custom metadata">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Page title</PH.Title>
-        <PH.Generic>
-          <Shw::Placeholder @text="generic content" @width="500" @height="36" @background="#e1f5fe" />
-        </PH.Generic>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Page title</PH.Title>
+          <PH.Generic>
+            <Shw::Placeholder @text="generic content" @width="500" @height="36" @background="#e1f5fe" />
+          </PH.Generic>
+        </Hds::PageHeader>
+      </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>
 
@@ -114,109 +132,119 @@ SPDX-License-Identifier: MPL-2.0
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="Product landing page">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>HCP Packer</PH.Title>
-        <PH.Breadcrumb>
-          <Hds::Breadcrumb aria-label="breadcrumbs with complex examples">
-            <Hds::Breadcrumb::Item @text="Sandbox" @icon="org" />
-            <Hds::Breadcrumb::Item @text="HCP Packer" @icon="packer" />
-            <Hds::Breadcrumb::Item @text="jane-doe" @icon="file-text" />
-          </Hds::Breadcrumb>
-        </PH.Breadcrumb>
-        <PH.IconTile @icon="packer-color" @color="packer" />
-        <PH.Description>Create and view Packer registries in HCP.
-        </PH.Description>
-        <PH.Actions>
-          <Hds::Button @text="Create Packer registery" @icon="plus" @iconPosition="leading" />
-        </PH.Actions>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>HCP Packer</PH.Title>
+          <PH.Breadcrumb>
+            <Hds::Breadcrumb aria-label="breadcrumbs with complex examples">
+              <Hds::Breadcrumb::Item @text="Sandbox" @icon="org" />
+              <Hds::Breadcrumb::Item @text="HCP Packer" @icon="packer" />
+              <Hds::Breadcrumb::Item @text="jane-doe" @icon="file-text" />
+            </Hds::Breadcrumb>
+          </PH.Breadcrumb>
+          <PH.IconTile @icon="packer-color" @color="packer" />
+          <PH.Description>Create and view Packer registries in HCP.
+          </PH.Description>
+          <PH.Actions>
+            <Hds::Button @text="Create Packer registery" @icon="plus" @iconPosition="leading" />
+          </PH.Actions>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Item page">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Boundary clusters</PH.Title>
-        <PH.IconTile @icon="boundary-color" @color="boundary" />
-        <PH.Breadcrumb>
-          <Hds::Breadcrumb aria-label="breadcrumb example with item page">
-            <Hds::Breadcrumb::Item @text="Cloud sandbox" @icon="org" />
-            <Hds::Breadcrumb::Item @text="Boundary clusters" @icon="boundary" />
-          </Hds::Breadcrumb>
-        </PH.Breadcrumb>
-        <PH.Badges>
-          <Hds::Badge @text="Active" @icon="check" @color="success" />
-        </PH.Badges>
-        <PH.Subtitle>boundary-cluster-name</PH.Subtitle>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Boundary clusters</PH.Title>
+          <PH.IconTile @icon="boundary-color" @color="boundary" />
+          <PH.Breadcrumb>
+            <Hds::Breadcrumb aria-label="breadcrumb example with item page">
+              <Hds::Breadcrumb::Item @text="Cloud sandbox" @icon="org" />
+              <Hds::Breadcrumb::Item @text="Boundary clusters" @icon="boundary" />
+            </Hds::Breadcrumb>
+          </PH.Breadcrumb>
+          <PH.Badges>
+            <Hds::Badge @text="Active" @icon="check" @color="success" />
+          </PH.Badges>
+          <PH.Subtitle>boundary-cluster-name</PH.Subtitle>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Multiple badges">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Consul cluster</PH.Title>
-        <PH.Badges>
-          <Hds::Badge @text="Active" @icon="check" @color="success" />
-          <Hds::Badge @text="Deployed to AWS west-2" @color="highlight" @icon="rocket" />
-          <Hds::BadgeCount @text="v1.5" @color="neutral" />
-          <Hds::Badge @text="Locked by jane-doe" @color="warning" @icon="lock" />
-        </PH.Badges>
-        <PH.Description>
-          While this is supported by the contextual component, this many badges being used to represent metadata can be
-          problematic.
-        </PH.Description>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Consul cluster</PH.Title>
+          <PH.Badges>
+            <Hds::Badge @text="Active" @icon="check" @color="success" />
+            <Hds::Badge @text="Deployed to AWS west-2" @color="highlight" @icon="rocket" />
+            <Hds::BadgeCount @text="v1.5" @color="neutral" />
+            <Hds::Badge @text="Locked by jane-doe" @color="warning" @icon="lock" />
+          </PH.Badges>
+          <PH.Description>
+            While this is supported by the contextual component, this many badges being used to represent metadata can
+            be problematic.
+          </PH.Description>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Kitchen sink example">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Users</PH.Title>
-        <PH.Subtitle>Access control (IAM)</PH.Subtitle>
-        <PH.Description>Manage organization users, roles, and access control.
-        </PH.Description>
-        <PH.Description>This is a second description, in case multiple paragraphs are needed.</PH.Description>
-        <PH.Breadcrumb>
-          <Hds::Breadcrumb>
-            <Hds::Breadcrumb::Item @text="Cloud sandbox" @icon="org" />
-            <Hds::Breadcrumb::Item @text="jane-doe" @icon="file-text" />
-            <Hds::Breadcrumb::Item @text="Access control (IAM)" @icon="users" />
-          </Hds::Breadcrumb>
-        </PH.Breadcrumb>
-        <PH.IconTile @icon="users" @color="terraform" />
-        <PH.Actions>
-          <Hds::Dropdown as |D|>
-            <D.ToggleButton @text="Manage users" @color="secondary" />
-            <D.Interactive @icon="user">Assign roles</D.Interactive>
-            <D.Interactive @icon="edit">Batch edit</D.Interactive>
-            <D.Interactive @icon="trash">Delete user</D.Interactive>
-          </Hds::Dropdown>
-          <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
-        </PH.Actions>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Users</PH.Title>
+          <PH.Subtitle>Access control (IAM)</PH.Subtitle>
+          <PH.Description>Manage organization users, roles, and access control.
+          </PH.Description>
+          <PH.Description>This is a second description, in case multiple paragraphs are needed.</PH.Description>
+          <PH.Breadcrumb>
+            <Hds::Breadcrumb>
+              <Hds::Breadcrumb::Item @text="Cloud sandbox" @icon="org" />
+              <Hds::Breadcrumb::Item @text="jane-doe" @icon="file-text" />
+              <Hds::Breadcrumb::Item @text="Access control (IAM)" @icon="users" />
+            </Hds::Breadcrumb>
+          </PH.Breadcrumb>
+          <PH.IconTile @icon="users" @color="terraform" />
+          <PH.Actions>
+            <Hds::Dropdown as |D|>
+              <D.ToggleButton @text="Manage users" @color="secondary" />
+              <D.Interactive @icon="user">Assign roles</D.Interactive>
+              <D.Interactive @icon="edit">Batch edit</D.Interactive>
+              <D.Interactive @icon="trash">Delete user</D.Interactive>
+            </Hds::Dropdown>
+            <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
+          </PH.Actions>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="With custom metadata">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Custom metadata</PH.Title>
-        <PH.Subtitle>beta-feature-cluster</PH.Subtitle>
-        <PH.Generic>
-          <Hds::Alert @type="compact" @color="warning" as |A|>
-            <A.Title>Beta feature</A.Title>
-            <A.Description>
-              This feature is in beta and is subject to change. Refer to the
-              <Hds::Link::Inline @href="#" @icon="external-link">HCP documentation</Hds::Link::Inline>
-              for more information and roadmap.
-            </A.Description>
-          </Hds::Alert>
-        </PH.Generic>
-        <PH.Actions>
-          <Hds::Button @text="Get started" @icon="beaker" @iconPosition="leading" />
-        </PH.Actions>
-        <PH.Badges>
-          <Hds::Badge @text="Beta feature" @icon="wand" @color="highlight" />
-        </PH.Badges>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Custom metadata</PH.Title>
+          <PH.Subtitle>beta-feature-cluster</PH.Subtitle>
+          <PH.Generic>
+            <Hds::Alert @type="compact" @color="warning" as |A|>
+              <A.Title>Beta feature</A.Title>
+              <A.Description>
+                This feature is in beta and is subject to change. Refer to the
+                <Hds::Link::Inline @href="#" @icon="external-link">HCP documentation</Hds::Link::Inline>
+                for more information and roadmap.
+              </A.Description>
+            </Hds::Alert>
+          </PH.Generic>
+          <PH.Actions>
+            <Hds::Button @text="Get started" @icon="beaker" @iconPosition="leading" />
+          </PH.Actions>
+          <PH.Badges>
+            <Hds::Badge @text="Beta feature" @icon="wand" @color="highlight" />
+          </PH.Badges>
+        </Hds::PageHeader>
+      </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>
 
@@ -231,57 +259,63 @@ SPDX-License-Identifier: MPL-2.0
 
   <Shw::Flex @direction="column" as |SF|>
     <SF.Item @label="Long title">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>Boundary cluster access control and clusters</PH.Title>
-        <PH.IconTile @icon="boundary-color" @color="boundary" />
-        <PH.Actions>
-          <Hds::Dropdown as |D|>
-            <D.ToggleButton @text="Manage users" @color="secondary" />
-            <D.Interactive @icon="user">Assign roles</D.Interactive>
-            <D.Interactive @icon="edit">Batch edit</D.Interactive>
-            <D.Interactive @icon="trash">Delete user</D.Interactive>
-          </Hds::Dropdown>
-          <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
-        </PH.Actions>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>Boundary cluster access control and clusters</PH.Title>
+          <PH.IconTile @icon="boundary-color" @color="boundary" />
+          <PH.Actions>
+            <Hds::Dropdown as |D|>
+              <D.ToggleButton @text="Manage users" @color="secondary" />
+              <D.Interactive @icon="user">Assign roles</D.Interactive>
+              <D.Interactive @icon="edit">Batch edit</D.Interactive>
+              <D.Interactive @icon="trash">Delete user</D.Interactive>
+            </Hds::Dropdown>
+            <Hds::Button @text="Add user" @icon="plus" @iconPosition="leading" />
+          </PH.Actions>
+        </Hds::PageHeader>
+      </Shw::Outliner>
       <Shw::Divider @level={{2}} />
     </SF.Item>
 
     <SF.Item @label="Long title + badge">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>
-          Page title with a very very very very long string that can span multiple lines
-        </PH.Title>
-        <PH.IconTile @logo="vagrant" />
-        <PH.Badges>
-          <Hds::Badge @text="Wrapping badge" @icon="mic" @color="critical" />
-        </PH.Badges>
-        <PH.Actions>
-          <Hds::Button @text="Get started" @icon="terminal-screen" @iconPosition="trailing" />
-        </PH.Actions>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>
+            Page title with a very very very very long string that can span multiple lines
+          </PH.Title>
+          <PH.IconTile @logo="vagrant" />
+          <PH.Badges>
+            <Hds::Badge @text="Wrapping badge" @icon="mic" @color="critical" />
+          </PH.Badges>
+          <PH.Actions>
+            <Hds::Button @text="Get started" @icon="terminal-screen" @iconPosition="trailing" />
+          </PH.Actions>
+        </Hds::PageHeader>
+      </Shw::Outliner>
 
       <Shw::Text::Body @tag="p">
         In the case of a badge, the title and badge will wrap if the available space is exceeded.
       </Shw::Text::Body>
     </SF.Item>
     <SF.Item @label="Non-breaking Title/Subtitle/Description + badge">
-      <Hds::PageHeader as |PH|>
-        <PH.Title>
-          Pagetitlewithaveryveryveryverylongnonbreakingstringthatcanspanmultiplelines
-        </PH.Title>
-        <PH.Subtitle
-        >Subtitlewithaveryveryveryveryveryveryveryveryveryveryveryveryveryveveryveryveryveryveryveryveryveryveryveryveryveryryveryverylongnonbreakingstringthatcanspanmultiplelines</PH.Subtitle>
-        <PH.Description
-        >Descriptionwithaveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongnonbreakingstringthatcanspanmultiplelines.</PH.Description>
-        <PH.IconTile @logo="vagrant" />
-        <PH.Badges>
-          <Hds::Badge @text="Wrapping badge" @icon="mic" @color="critical" />
-        </PH.Badges>
-        <PH.Actions>
-          <Hds::Button @text="Get started" @icon="terminal-screen" @iconPosition="trailing" />
-        </PH.Actions>
-      </Hds::PageHeader>
+      <Shw::Outliner>
+        <Hds::PageHeader as |PH|>
+          <PH.Title>
+            Pagetitlewithaveryveryveryverylongnonbreakingstringthatcanspanmultiplelines
+          </PH.Title>
+          <PH.Subtitle
+          >Subtitlewithaveryveryveryveryveryveryveryveryveryveryveryveryveryveveryveryveryveryveryveryveryveryveryveryveryveryryveryverylongnonbreakingstringthatcanspanmultiplelines</PH.Subtitle>
+          <PH.Description
+          >Descriptionwithaveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongnonbreakingstringthatcanspanmultiplelines.</PH.Description>
+          <PH.IconTile @logo="vagrant" />
+          <PH.Badges>
+            <Hds::Badge @text="Wrapping badge" @icon="mic" @color="critical" />
+          </PH.Badges>
+          <PH.Actions>
+            <Hds::Button @text="Get started" @icon="terminal-screen" @iconPosition="trailing" />
+          </PH.Actions>
+        </Hds::PageHeader>
+      </Shw::Outliner>
 
       <Shw::Text::Body @tag="p">
         In the case of non-breaking text the long string will be forced to wrap using the

--- a/showcase/tests/acceptance/percy-test.js
+++ b/showcase/tests/acceptance/percy-test.js
@@ -126,6 +126,7 @@ module('Acceptance | Percy test', function (hooks) {
     await percySnapshot('Modal');
 
     await visit('/components/page-header');
+    await click('button#shw-component-toggle-highlight');
     await percySnapshot('PageHeader');
 
     await visit('/components/pagination');

--- a/website/docs/components/page-header/index.md
+++ b/website/docs/components/page-header/index.md
@@ -29,3 +29,7 @@ navigation:
 <section data-tab="Accessibility">
   @include "partials/accessibility/accessibility.md"
 </section>
+
+<section data-tab="Version history">
+  @include "partials/version-history/4.15.0.md"
+</section>

--- a/website/docs/components/page-header/partials/version-history/4.15.0.md
+++ b/website/docs/components/page-header/partials/version-history/4.15.0.md
@@ -1,0 +1,5 @@
+## 4.15.0
+
+### Updated
+
+Fixed issue with extra space below title when no metadata is present


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue present on the `PageHeader` where extra spacing is added below the title if no metadata is present.

### :hammer_and_wrench: Detailed description

In the `PageHeader` component the `hds-page-header__metadata` div is present even when it contains no content. This led to extra spacing being added below the title as the gap between the title and the metadata.

```handlebars
<div class="hds-page-header__content">
  <div class="hds-page-header__title-wrapper">
    {{yield (hash Title=(component "hds/page-header/title"))}}
    {{yield (hash Badges=(component "hds/page-header/badges"))}}
  </div>
  <div class="hds-page-header__metadata">
    {{yield
      (hash
        Subtitle=(component "hds/page-header/subtitle")
        Description=(component "hds/page-header/description")
        Generic=(component "hds/yield")
      )
    }}
  </div>
</div>
``` 
Due to the component containing multiple yields, the `has-block` modifier could not be used to conditionally remove the metadata block. Instead a solution was found to apply the needed spacing between metadata items and the title using `margin-top` on the first metadata child. 

**Additional Changes**
- The `Shw::Outliner` was added to wrap around all `PageHeader` instances in the showcase to ensure any future spacing issues can be caught via visual regression. 

### :camera_flash: Screenshots

Current: 
<img width="389" alt="Screenshot 2024-11-21 at 9 36 39 AM" src="https://github.com/user-attachments/assets/52b39399-6365-4307-8dfa-efd87b7e6b03">

Updated:
<img width="340" alt="Screenshot 2024-11-21 at 9 37 08 AM" src="https://github.com/user-attachments/assets/8a3b9b00-650a-4b2c-8096-c0b21e2f769a">

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4154](https://hashicorp.atlassian.net/browse/HDS-4154)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4154]: https://hashicorp.atlassian.net/browse/HDS-4154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ