### PR TITLE
 Helios website - update body font (HDS-4046)

### DIFF
--- a/website/app/styles/doc-components/algolia-search/form.scss
+++ b/website/app/styles/doc-components/algolia-search/form.scss
@@ -116,7 +116,7 @@ $doc-algolia-search-modal-search-input-height: 44px;
   $beta-height: 24px;
 
   &:has(input:placeholder-shown)::before {
-    @include doc-font-family("sans");
+    @include doc-font-family("system");
     position: absolute;
     top: 50%;
     left: 110px;

--- a/website/app/styles/doc-components/algolia-search/modal.scss
+++ b/website/app/styles/doc-components/algolia-search/modal.scss
@@ -125,7 +125,7 @@
 }
 
 .aa-SourceFooterLink {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   color: var(--doc-color-gray-300);
   font-weight: 500;
   font-size: 14px;
@@ -172,7 +172,7 @@
 }
 
 .aa-PanelFooter__keyboard-hints {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   display: flex;
   gap: 12px;
   align-items: center;
@@ -244,7 +244,7 @@
 }
 
 .aa-PanelFooter__algolia-text {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   color: #807ea3;
   font-size: 12px;
   text-decoration: none;

--- a/website/app/styles/doc-components/algolia-search/results.scss
+++ b/website/app/styles/doc-components/algolia-search/results.scss
@@ -88,7 +88,7 @@
 
 // token
 .aa-ItemPreview--token {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   display: flex;
   align-items: center;
   justify-content: center;

--- a/website/app/styles/doc-components/badge.scss
+++ b/website/app/styles/doc-components/badge.scss
@@ -8,7 +8,7 @@
 @use "../typography/mixins" as *;
 
 .doc-badge {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   display: inline-flex;
   align-items: center;
   max-width: 100%;

--- a/website/app/styles/doc-components/color-card.scss
+++ b/website/app/styles/doc-components/color-card.scss
@@ -28,7 +28,7 @@
 }
 
 .doc-color-card__color-name {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   color: #000;
   font-size: 1rem;
   line-height: 1;
@@ -48,7 +48,7 @@
   }
 
   span {
-    @include doc-font-family("sans");
+    @include doc-font-family("system");
     display: inline-block;
     width: 85px;
     opacity: 0.5;

--- a/website/app/styles/doc-components/color-swatch.scss
+++ b/website/app/styles/doc-components/color-swatch.scss
@@ -48,7 +48,7 @@ $doc-color-swatch-border-radius: 3px;
 }
 
 .doc-color-swatch__name {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
 
   margin: 0 0 8px 0;
   font-weight: bold;
@@ -73,7 +73,7 @@ $doc-color-swatch-border-radius: 3px;
   }
 
   &--context {
-    @include doc-font-family("sans");
+    @include doc-font-family("system");
 
     display: flex;
     align-items: center;

--- a/website/app/styles/doc-components/icons-list/index.scss
+++ b/website/app/styles/doc-components/icons-list/index.scss
@@ -22,7 +22,7 @@
 // general styles
 
 .doc-icons-list-filter__label {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   display: block;
   width: min-content;
   margin-bottom: 8px;

--- a/website/app/styles/pages/about/principles.scss
+++ b/website/app/styles/pages/about/principles.scss
@@ -27,7 +27,7 @@
 }
 
 .doc-content-principles__number {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   margin: 24px 0 0 0;
   color: var(--doc-color-black);
   font-size: 1.25rem; // 20px

--- a/website/app/styles/pages/home.scss
+++ b/website/app/styles/pages/home.scss
@@ -120,7 +120,7 @@ body.application.index {
   }
 
   p {
-    @include doc-font-family("sans");
+    @include doc-font-family("system");
     max-width: 350px;
     margin: 2em 0;
     color: var(--doc-color-gray-500);

--- a/website/app/styles/typography/mixins.scss
+++ b/website/app/styles/typography/mixins.scss
@@ -14,12 +14,10 @@
   @if ($family == "hashicorp-sans") {
     font-family: hashicorp-sans-variable, Geneva, Tahoma, Helvetica, Verdana, sans-serif;
     font-synthesis: none; // Safari makes this variable font too bold, compared to Chrome, and this fixes the issue
-  } @else if ($family == "sans") {
-    font-family: metro-web, Metro, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   } @else if ($family == "mono") {
     font-family: ui-monospace, Menlo, Consolas, monospace;
   } @else if ($family == "system") {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   }
 }
 
@@ -140,7 +138,7 @@
 // BASE
 
 @mixin doc-font-style-body {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   font-size: 1.063rem; // 17px;
   line-height: 1.765; // 30px
 }
@@ -148,7 +146,7 @@
 // SMALL
 
 @mixin doc-font-style-body-small {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   font-size: 0.938rem; // 15px
   line-height: 1.667; // 25px
 }
@@ -171,7 +169,7 @@
 }
 
 @mixin doc-font-style-label {
-  @include doc-font-family("sans");
+  @include doc-font-family("system");
   font-weight: 700;
   font-size: 0.75rem; // 12px
   line-height: 1.5;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will update the body font for the Helios website.

**Preview:** https://hds-website-git-hds-4046-update-website-font-hashicorp.vercel.app/

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

**_BEFORE:_**
<img width="581" alt="image" src="https://github.com/user-attachments/assets/86173437-ca45-4387-99f0-4751fa1d7f71">

**_AFTER:_**
<img width="637" alt="image" src="https://github.com/user-attachments/assets/674585a7-9be5-4e01-9897-8f51ec6ef2ca">

### :link: External links

Jira ticket: [HDS-4046](https://hashicorp.atlassian.net/browse/HDS-4046)

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4046]: https://hashicorp.atlassian.net/browse/HDS-4046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ