### PR TITLE
Table: add borders around the cells

### DIFF
--- a/.changeset/gorgeous-days-call.md
+++ b/.changeset/gorgeous-days-call.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Table` - Updated the visual design of `Table` cells by adding borders, making them more distinguishable when spanning rows or columns.

--- a/packages/components/src/styles/components/table.scss
+++ b/packages/components/src/styles/components/table.scss
@@ -35,6 +35,14 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
   table-layout: fixed;
 }
 
+// table border
+
+.hds-table, 
+.hds-table__th, 
+.hds-table__td {
+  border: calc(#{$hds-table-border-width} / 2) solid $hds-table-border-color;
+  // box-shadow: 0 0 0 calc(#{$hds-table-border-width} / 2) $hds-table-border-color;
+}
 
 // ----------------------------------------------------------------
 
@@ -48,13 +56,13 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
     .hds-table__th {
       padding: $hds-table-cell-padding-medium;
       text-align: left;
-      border-top: $hds-table-border-width solid $hds-table-border-color;
-      border-left: $hds-table-border-width solid $hds-table-border-color;
+      // border-top: $hds-table-border-width solid $hds-table-border-color;
+      // border-left: $hds-table-border-width solid $hds-table-border-color;
     }
 
-    .hds-table__th:last-child {
-      border-right: $hds-table-border-width solid $hds-table-border-color;
-    }
+    // .hds-table__th:last-child {
+    //   border-right: $hds-table-border-width solid $hds-table-border-color;
+    // }
 
     // horizontal alignment
 
@@ -174,10 +182,10 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
     // border radius: target first th (scope of row) and td, and last td elements in the last row
 
     &:last-of-type {
-      .hds-table__th,
-      .hds-table__td {
-        border-bottom: $hds-table-border-width solid $hds-table-border-color;
-      }
+      // .hds-table__th,
+      // .hds-table__td {
+      //   border-bottom: $hds-table-border-width solid $hds-table-border-color;
+      // }
 
       .hds-table__th:first-child,
       .hds-table__td:first-child {
@@ -194,8 +202,8 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
   .hds-table__th,
   .hds-table__td {
     text-align: left;
-    border-top: $hds-table-border-width solid $hds-table-border-color;
-    border-left: $hds-table-border-width solid $hds-table-border-color;
+    // border-top: $hds-table-border-width solid $hds-table-border-color;
+    // border-left: $hds-table-border-width solid $hds-table-border-color;
 
     // density
 
@@ -212,9 +220,9 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
     }
   }
 
-  .hds-table__td:last-child {
-    border-right: $hds-table-border-width solid $hds-table-border-color;
-  }
+  // .hds-table__td:last-child {
+  //   border-right: $hds-table-border-width solid $hds-table-border-color;
+  // }
 
   // horizontal alignment
 

--- a/packages/components/src/styles/components/table.scss
+++ b/packages/components/src/styles/components/table.scss
@@ -41,7 +41,6 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
 .hds-table__th, 
 .hds-table__td {
   border: calc(#{$hds-table-border-width} / 2) solid $hds-table-border-color;
-  // box-shadow: 0 0 0 calc(#{$hds-table-border-width} / 2) $hds-table-border-color;
 }
 
 // ----------------------------------------------------------------
@@ -56,13 +55,7 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
     .hds-table__th {
       padding: $hds-table-cell-padding-medium;
       text-align: left;
-      // border-top: $hds-table-border-width solid $hds-table-border-color;
-      // border-left: $hds-table-border-width solid $hds-table-border-color;
     }
-
-    // .hds-table__th:last-child {
-    //   border-right: $hds-table-border-width solid $hds-table-border-color;
-    // }
 
     // horizontal alignment
 
@@ -182,11 +175,6 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
     // border radius: target first th (scope of row) and td, and last td elements in the last row
 
     &:last-of-type {
-      // .hds-table__th,
-      // .hds-table__td {
-      //   border-bottom: $hds-table-border-width solid $hds-table-border-color;
-      // }
-
       .hds-table__th:first-child,
       .hds-table__td:first-child {
         border-bottom-left-radius: $hds-table-inner-border-radius;
@@ -202,8 +190,6 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
   .hds-table__th,
   .hds-table__td {
     text-align: left;
-    // border-top: $hds-table-border-width solid $hds-table-border-color;
-    // border-left: $hds-table-border-width solid $hds-table-border-color;
 
     // density
 
@@ -219,11 +205,7 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
       padding: $hds-table-cell-padding-tall;
     }
   }
-
-  // .hds-table__td:last-child {
-  //   border-right: $hds-table-border-width solid $hds-table-border-color;
-  // }
-
+  
   // horizontal alignment
 
   .hds-table__th--align-center,

--- a/packages/components/src/styles/components/table.scss
+++ b/packages/components/src/styles/components/table.scss
@@ -205,7 +205,6 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
       padding: $hds-table-cell-padding-tall;
     }
   }
-  
   // horizontal alignment
 
   .hds-table__th--align-center,

--- a/packages/components/src/styles/components/table.scss
+++ b/packages/components/src/styles/components/table.scss
@@ -193,7 +193,6 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
 
   .hds-table__th,
   .hds-table__td {
-    padding: $hds-table-cell-padding-medium;
     text-align: left;
     border-top: $hds-table-border-width solid $hds-table-border-color;
     border-left: $hds-table-border-width solid $hds-table-border-color;

--- a/packages/components/src/styles/components/table.scss
+++ b/packages/components/src/styles/components/table.scss
@@ -24,7 +24,6 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
 
 .hds-table {
   width: 100%;
-  border: $hds-table-border-width solid $hds-table-border-color;
   border-radius: $hds-table-border-radius;
   border-spacing: 0;
 }
@@ -50,23 +49,12 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
       position: relative;
       padding: $hds-table-cell-padding-medium;
       text-align: left;
-      border-top: none;
+      border: $hds-table-border-width solid $hds-table-border-color;
       border-right: none;
-      border-bottom: $hds-table-border-width solid $hds-table-border-color;
-      border-left: none;
+    }
 
-      // border between two cells (we emulate a cell border slightly detached from the top/bottom borders)
-
-      + .hds-table__th::before {
-        position: absolute;
-        top: 6px;
-        bottom: 6px;
-        left: -1px; // we need to offset the border by 1px to render a right border of the previous cell
-        width: 1px;
-        background-color: $hds-table-border-color;
-        content: "";
-        pointer-events: none;
-      }
+    .hds-table__th:last-child {
+      border-right: $hds-table-border-width solid $hds-table-border-color;
     }
 
     // horizontal alignment
@@ -184,12 +172,16 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
       background-color: var(--token-color-surface-faint);
     }
 
+    .hds-table__td:last-child {
+      border-right: $hds-table-border-width solid $hds-table-border-color;
+    }
+
     // border radius: target first th (scope of row) and td, and last td elements in the last row
 
     &:last-of-type {
       .hds-table__th,
       .hds-table__td {
-        border-bottom: none;
+        border-bottom: $hds-table-border-width solid $hds-table-border-color;
       }
 
       .hds-table__th:first-child,
@@ -206,11 +198,12 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
 
   .hds-table__th,
   .hds-table__td {
+    position: relative;
+    padding: $hds-table-cell-padding-medium;
     text-align: left;
+    border: $hds-table-border-width solid $hds-table-border-color;
     border-top: none;
     border-right: none;
-    border-bottom: $hds-table-border-width solid $hds-table-border-color;
-    border-left: none;
 
     // density
 
@@ -225,7 +218,6 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
     .hds-table--density-tall & {
       padding: $hds-table-cell-padding-tall;
     }
-
   }
 
   // horizontal alignment

--- a/packages/components/src/styles/components/table.scss
+++ b/packages/components/src/styles/components/table.scss
@@ -46,11 +46,10 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
     background-color: var(--token-color-surface-strong);
 
     .hds-table__th {
-      position: relative;
       padding: $hds-table-cell-padding-medium;
       text-align: left;
-      border: $hds-table-border-width solid $hds-table-border-color;
-      border-right: none;
+      border-top: $hds-table-border-width solid $hds-table-border-color;
+      border-left: $hds-table-border-width solid $hds-table-border-color;
     }
 
     .hds-table__th:last-child {
@@ -172,10 +171,6 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
       background-color: var(--token-color-surface-faint);
     }
 
-    .hds-table__td:last-child {
-      border-right: $hds-table-border-width solid $hds-table-border-color;
-    }
-
     // border radius: target first th (scope of row) and td, and last td elements in the last row
 
     &:last-of-type {
@@ -198,12 +193,10 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
 
   .hds-table__th,
   .hds-table__td {
-    position: relative;
     padding: $hds-table-cell-padding-medium;
     text-align: left;
-    border: $hds-table-border-width solid $hds-table-border-color;
-    border-top: none;
-    border-right: none;
+    border-top: $hds-table-border-width solid $hds-table-border-color;
+    border-left: $hds-table-border-width solid $hds-table-border-color;
 
     // density
 
@@ -218,6 +211,10 @@ $hds-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to a
     .hds-table--density-tall & {
       padding: $hds-table-cell-padding-tall;
     }
+  }
+
+  .hds-table__td:last-child {
+    border-right: $hds-table-border-width solid $hds-table-border-color;
   }
 
   // horizontal alignment


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add a full border around all the cells. This is in an effort to improve the styling when cells span multiple rows or columns.

### :hammer_and_wrench: Detailed description

The existing borders were made with the `::before` pseudo selector to make the borders not the full height and a border around the whole table. Now, it just uses borders on the cells.

### :camera_flash: Screenshots
#### Before
![Screenshot 2024-12-04 at 10 27 28 AM](https://github.com/user-attachments/assets/f778aef8-ce9b-43b5-9667-56584351e7c5)
![Screenshot 2024-12-04 at 10 27 41 AM](https://github.com/user-attachments/assets/c2410c3f-6ef2-4e79-a7e1-e4a463a8163e)


#### After
![Screenshot 2024-12-04 at 10 21 17 AM](https://github.com/user-attachments/assets/83215634-6c5f-4e12-9b31-331d2678d3f0)
![Screenshot 2024-12-04 at 10 21 32 AM](https://github.com/user-attachments/assets/6e744532-8dfa-49dd-87bf-414fe1906443)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3956](https://hashicorp.atlassian.net/browse/HDS-3956)
Figma file: https://www.figma.com/design/FfPRXgqDb67jlXNhMrvfub/ME%2BAG%2FAdvancedTable?node-id=16727-59704

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3956]: https://hashicorp.atlassian.net/browse/HDS-3956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ