### PR TITLE
[Spike] Get theming “support” in the Showcase app

### DIFF
--- a/showcase/app/components/shw/theme/switcher.gts
+++ b/showcase/app/components/shw/theme/switcher.gts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+
+interface ShwThemeSwitcherSignature {
+  // Args: {};
+  Element: HTMLDivElement;
+}
+
+export default class ShwThemeSwitcher extends Component<ShwThemeSwitcherSignature> {
+  @action
+  onChangePageTheme(event: Event) {
+    const select = event.target as HTMLSelectElement;
+    console.log(`Theme: ${select.value}`);
+  }
+
+  <template>
+    <div class="shw-theme-switcher" ...attributes>
+      <label
+        for="shw-theme-switcher-control"
+        class="shw-theme-switcher__label"
+      >Theme:</label>
+      <select
+        id="shw-theme-switcher-control"
+        class="shw-theme-switcher__control"
+        {{on "change" this.onChangePageTheme}}
+      >
+        <option value="auto">Auto (prefers-color-scheme)</option>
+        <option value="light-data-attribute">Light (data-attribute)</option>
+        <option value="light-css-class">Light (CSS class)</option>
+        <option value="dark-data-attribute">Dark (data-attribute)</option>
+        <option value="dark-css-class">Dark (CSS class)</option>
+      </select>
+    </div>
+  </template>
+}

--- a/showcase/app/components/shw/theme/switcher.gts
+++ b/showcase/app/components/shw/theme/switcher.gts
@@ -64,10 +64,10 @@ export default class ShwThemeSwitcher extends Component<ShwThemeSwitcherSignatur
         {{on "change" this.onChangePageTheme}}
       >
         <option value="auto">Auto (prefers-color-scheme)</option>
-        <option value="light-data-attribute">Light (data-attribute)</option>
         <option value="light-css-class">Light (CSS class)</option>
-        <option value="dark-data-attribute">Dark (data-attribute)</option>
+        <option value="light-data-attribute">Light (data-attribute)</option>
         <option value="dark-css-class">Dark (CSS class)</option>
+        <option value="dark-data-attribute">Dark (data-attribute)</option>
       </select>
     </div>
   </template>

--- a/showcase/app/components/shw/theme/switcher.gts
+++ b/showcase/app/components/shw/theme/switcher.gts
@@ -6,6 +6,9 @@
 import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+import type ShwThemingService from 'showcase/services/theming';
 
 interface ShwThemeSwitcherSignature {
   // Args: {};
@@ -13,10 +16,40 @@ interface ShwThemeSwitcherSignature {
 }
 
 export default class ShwThemeSwitcher extends Component<ShwThemeSwitcherSignature> {
+  @service declare readonly theming: ShwThemingService;
+
   @action
   onChangePageTheme(event: Event) {
     const select = event.target as HTMLSelectElement;
     console.log(`Theme: ${select.value}`);
+    console.log(`theming.getTheme: ${this.theming.getTheme()}`);
+
+    let theme;
+    let type;
+    switch (select.value) {
+      case 'light-data-attribute':
+        theme = 'light';
+        type = 'data-attribute';
+        break;
+      case 'light-css-class':
+        theme = 'light';
+        type = 'css-class';
+        break;
+      case 'dark-data-attribute':
+        theme = 'dark';
+        type = 'data-attribute';
+        break;
+      case 'dark-css-class':
+        theme = 'dark';
+        type = 'css-class';
+        break;
+      default:
+        theme = 'auto';
+        break;
+    }
+
+    // we set the theme in the global service
+    this.theming.setTheme(theme, type, 'body');
   }
 
   <template>

--- a/showcase/app/controllers/application.js
+++ b/showcase/app/controllers/application.js
@@ -6,6 +6,7 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class ApplicationController extends Controller {
   @service router;
@@ -20,5 +21,10 @@ export default class ApplicationController extends Controller {
   routeDidChange() {
     // it's a "framless" page (we infer it from the URL for simplicity)
     this.isFrameless = this.router?.currentURL?.includes('frameless');
+  }
+
+  @action
+  onChangePageTheme(event) {
+    console.log(`Theme: ${event.target.value}`);
   }
 }

--- a/showcase/app/controllers/application.js
+++ b/showcase/app/controllers/application.js
@@ -6,7 +6,6 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 
 export default class ApplicationController extends Controller {
   @service router;
@@ -21,10 +20,5 @@ export default class ApplicationController extends Controller {
   routeDidChange() {
     // it's a "framless" page (we infer it from the URL for simplicity)
     this.isFrameless = this.router?.currentURL?.includes('frameless');
-  }
-
-  @action
-  onChangePageTheme(event) {
-    console.log(`Theme: ${event.target.value}`);
   }
 }

--- a/showcase/app/controllers/foundations/theming.js
+++ b/showcase/app/controllers/foundations/theming.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class ThemingController extends Controller {
+  @service theming;
+
+  get currentTheme() {
+    return this.theming.getTheme();
+  }
+}

--- a/showcase/app/controllers/foundations/theming.js
+++ b/showcase/app/controllers/foundations/theming.js
@@ -12,4 +12,8 @@ export default class ThemingController extends Controller {
   get currentTheme() {
     return this.theming.getTheme();
   }
+
+  get inverseTheme() {
+    return this.theming.getInverseTheme();
+  }
 }

--- a/showcase/app/index.html
+++ b/showcase/app/index.html
@@ -17,8 +17,8 @@
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/showcase.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/showcase-theme-light.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/showcase-theme-dark.css">
+    <!-- <link integrity="" rel="stylesheet" href="{{rootURL}}assets/showcase-theme-light.css"> -->
+    <!-- <link integrity="" rel="stylesheet" href="{{rootURL}}assets/showcase-theme-dark.css"> -->
 
     <link rel="shortcut icon" href="/assets/logos/favicon.png" />
 

--- a/showcase/app/index.html
+++ b/showcase/app/index.html
@@ -17,6 +17,8 @@
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/showcase.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/showcase-theme-light.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/showcase-theme-dark.css">
 
     <link rel="shortcut icon" href="/assets/logos/favicon.png" />
 

--- a/showcase/app/router.ts
+++ b/showcase/app/router.ts
@@ -16,6 +16,7 @@ Router.map(function () {
     this.route('typography');
     this.route('elevation');
     this.route('focus-ring');
+    this.route('theming');
   });
   this.route('components', function () {
     this.route('accordion');

--- a/showcase/app/services/theming.js
+++ b/showcase/app/services/theming.js
@@ -1,0 +1,31 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class ShwThemingService extends Service {
+  // undefined means to use the default in the browser, which is "prefers-color-scheme"
+  @tracked currentTheme = 'auto';
+
+  getTheme() {
+    return this.currentTheme;
+    // return localStorage.getItem('shwCurrentTheme');
+  }
+
+  setTheme(theme, type, target) {
+    // const fullKey = this.#buildKey(key, appName);
+    this.currentTheme = theme;
+    // localStorage.setItem('shwCurrentTheme', theme);
+    console.log('setting theme', theme, type, target);
+
+    const bodyElement = document.querySelector('body');
+    bodyElement.removeAttribute('data-shw-theme');
+    bodyElement.classList.remove('shw-theme-dark');
+    bodyElement.classList.remove('shw-theme-light');
+
+    if (type === 'data-attribute') {
+      bodyElement.setAttribute('data-shw-theme', theme);
+    } else if (type === 'css-class') {
+      bodyElement.classList.add(`shw-theme-${theme}`);
+    }
+    // }
+  }
+}

--- a/showcase/app/services/theming.js
+++ b/showcase/app/services/theming.js
@@ -10,6 +10,11 @@ export default class ShwThemingService extends Service {
     // return localStorage.getItem('shwCurrentTheme');
   }
 
+  getInverseTheme() {
+    // TODO what happens if we have four themes, like IBM, instead of just two?
+    return this.currentTheme === 'dark' ? 'light' : 'dark';
+  }
+
   setTheme(theme, type, target) {
     // const fullKey = this.#buildKey(key, appName);
     this.currentTheme = theme;

--- a/showcase/app/styles/_globals.scss
+++ b/showcase/app/styles/_globals.scss
@@ -66,6 +66,10 @@ body {
   line-height: 1;
 }
 
+.shw-page-header__theme-toggle {
+  margin-left: auto;
+}
+
 .shw-page-aside {
   padding: 1rem;
 

--- a/showcase/app/styles/_globals.scss
+++ b/showcase/app/styles/_globals.scss
@@ -30,7 +30,7 @@ body {
   height: 68px;
   padding: 0 24px;
   color: var(--shw-color-black);
-  border-bottom: 1px solid #eaeaea;
+  border-bottom: 1px solid var(--shw-color-gray-500);
 }
 
 .shw-page-header__logo {

--- a/showcase/app/styles/_tokens.scss
+++ b/showcase/app/styles/_tokens.scss
@@ -6,36 +6,6 @@
 // TOKENS (CSS PROPS)
 
 :root {
-  // COLORS
-  --shw-color-white: #fff;
-  --shw-color-gray-600: #f2f2f3;
-  --shw-color-gray-500: #dbdbdc;
-  --shw-color-gray-400: #bfbfc0;
-  --shw-color-gray-300: #727374;
-  --shw-color-gray-200: #343536;
-  --shw-color-gray-100: #1d1e1f;
-  --shw-color-black: #000;
-  --shw-color-link-on-black: #4294ff;
-  --shw-color-link-on-white: #2264d6;
-  --shw-color-feedback-information-100: #0d44cc;
-  --shw-color-feedback-information-200: #1563ff;
-  --shw-color-feedback-information-300: #d0e0ff;
-  --shw-color-feedback-information-400: #eff5ff;
-  --shw-color-feedback-success-100: #007854;
-  --shw-color-feedback-success-200: #00bc7f;
-  --shw-color-feedback-success-300: #c1f1e0;
-  --shw-color-feedback-success-400: #ebfdf7;
-  --shw-color-feedback-warning-100: #975b06;
-  --shw-color-feedback-warning-200: #eaaa32;
-  --shw-color-feedback-warning-300: #f9eacd;
-  --shw-color-feedback-warning-400: #fcf6ea;
-  --shw-color-feedback-critical-100: #ba2226;
-  --shw-color-feedback-critical-200: #f25054;
-  --shw-color-feedback-critical-300: #ffd4d6;
-  --shw-color-feedback-critical-400: #fcf0f2;
-  --shw-color-action-active-foreground: #00f; // HTML "blue"
-  --shw-color-action-active-border: #00f; // HTML "blue"
-  --shw-color-action-active-background: #f0f8ff; // HTML "aliceblue"
   // "FLEX/GRID" COMPONENTS
   --shw-layout-gap-base: 1rem;
 }

--- a/showcase/app/styles/_typography.scss
+++ b/showcase/app/styles/_typography.scss
@@ -86,6 +86,7 @@ $show-font-family-mono: ui-monospace, menlo, consolas, monospace;
 
 @mixin shw-font-style-h1() {
   @include shw-font-family("gilmer");
+  color: var(--shw-color-black);
   font-weight: 700;
   font-size: 3rem;
   line-height: 1.3;
@@ -95,6 +96,7 @@ $show-font-family-mono: ui-monospace, menlo, consolas, monospace;
 
 @mixin shw-font-style-h2() {
   @include shw-font-family("gilmer");
+  color: var(--shw-color-black);
   font-weight: 400;
   font-size: 1.8rem;
   line-height: 1.3;
@@ -104,6 +106,7 @@ $show-font-family-mono: ui-monospace, menlo, consolas, monospace;
 
 @mixin shw-font-style-h3() {
   @include shw-font-family("gilmer");
+  color: var(--shw-color-black);
   font-weight: 400;
   font-size: 1.4rem;
   line-height: 1.3;
@@ -113,7 +116,7 @@ $show-font-family-mono: ui-monospace, menlo, consolas, monospace;
 
 @mixin shw-font-style-h4() {
   @include shw-font-family("gilmer");
-  color: #666; // equivalent to `opacity: 0.5`
+  color: var(--shw-color-gray-300);
   font-weight: 500;
   font-size: 1.2rem;
   line-height: 1.3;
@@ -123,6 +126,7 @@ $show-font-family-mono: ui-monospace, menlo, consolas, monospace;
 
 @mixin shw-font-style-body {
   @include shw-font-family("gilmer");
+  color: var(--shw-color-black);
   font-size: 1rem;
   line-height: 1.4;
 }

--- a/showcase/app/styles/app.scss
+++ b/showcase/app/styles/app.scss
@@ -71,6 +71,7 @@
 @import "./showcase-pages/tabs";
 @import "./showcase-pages/tag";
 @import "./showcase-pages/text";
+@import "./showcase-pages/theming";
 @import "./showcase-pages/tooltip";
 @import "./showcase-pages/typography";
 // END COMPONENT PAGES IMPORTS

--- a/showcase/app/styles/app.scss
+++ b/showcase/app/styles/app.scss
@@ -23,6 +23,7 @@
 @import "./showcase-components/label";
 @import "./showcase-components/outliner";
 @import "./showcase-components/placeholder";
+@import "./showcase-components/theme-switcher";
 @import "./mock-components/app";
 
 

--- a/showcase/app/styles/app.scss
+++ b/showcase/app/styles/app.scss
@@ -9,6 +9,8 @@
 // global declarations
 
 @import "./tokens";
+@import "./showcase-theming/light";
+@import "./showcase-theming/dark";
 @import "./layout";
 @import "./typography";
 @import "./globals";

--- a/showcase/app/styles/showcase-components/divider.scss
+++ b/showcase/app/styles/showcase-components/divider.scss
@@ -6,9 +6,9 @@
 .shw-divider {
   margin: 3rem 0;
   border: none;
-  border-top: 2px solid #ccc;
+  border-top: 2px solid var(--shw-color-gray-500);
 }
 
 .shw-divider--level-2 {
-  border-top: 2px dotted #ddd;
+  border-top-style: dotted;
 }

--- a/showcase/app/styles/showcase-components/frame.scss
+++ b/showcase/app/styles/showcase-components/frame.scss
@@ -15,7 +15,7 @@ $shw-frame-navigation-bar-height: 48px;
   max-width: 100%;
   height: calc(var(--iframe-height) + #{$shw-frame-navigation-bar-height});
   max-height: 100%;
-  outline: 1px solid #e4e4d4;
+  outline: 1px solid var(--shw-color-gray-500);
 }
 
 .shw-frame__browser-navigation {
@@ -25,12 +25,12 @@ $shw-frame-navigation-bar-height: 48px;
   height: $shw-frame-navigation-bar-height;
   // safe area for the dots
   padding: 8px 24px 8px 120px;
-  background-color: #fafafa;
+  background-color: var(--shw-frame-browser-navigation-background);
   background-image: url('data:image/svg+xml,<svg width="56" height="14" viewBox="0 0 56 14" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="7" cy="7" r="7" fill="%23FC4847"/><circle cx="28" cy="7" r="7" fill="%23FDAF24"/><circle cx="49" cy="7" r="7" fill="%232AC131"/></svg>');
   background-repeat: no-repeat;
   background-position: 24px 50%;
   background-size: 56px 14px;
-  border-bottom: 1px solid #e4e4d4;
+  border-bottom: 1px solid var(--shw-color-gray-500);
 }
 
 .shw-frame__open-link {

--- a/showcase/app/styles/showcase-components/label.scss
+++ b/showcase/app/styles/showcase-components/label.scss
@@ -8,7 +8,7 @@
 .shw-label {
   @include shw-font-family("rubik");
   margin: 0 0 10px 0;
-  color: #545454;
+  color: var(--shw-label-text-color);
   font-size: 0.8rem;
   line-height: 1.2;
 }

--- a/showcase/app/styles/showcase-components/placeholder.scss
+++ b/showcase/app/styles/showcase-components/placeholder.scss
@@ -11,18 +11,18 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #6b6b6b; // if background is #EEE then this has the appropriate color contrast (4.59:1)
+  color: var(--shw-placeholder-text-color);
   font-weight: bold;
   font-size: 10px;
   font-family: monaco, Consolas, "Lucida Console", monospace;
   line-height: 1.2;
   text-align: center;
-  text-shadow: 0 0 5px #fff;
-  background-color: #eee;
+  text-shadow: 0 0 5px var(--shw-color-white);
+  background-color: var(--shw-placeholder-background-color);
 
   a,
   a > & {
-    color: #333;
+    color: var(--shw-placeholder-link-color);
     text-decoration: underline;
   }
 }

--- a/showcase/app/styles/showcase-components/theme-switcher.scss
+++ b/showcase/app/styles/showcase-components/theme-switcher.scss
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+.shw-theme-switcher {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.shw-theme-switcher__label {
+  color: var(--shw-color-black);
+  font-size: 0.75rem;
+  font-family: monaco, Consolas, "Lucida Console", monospace;
+}
+
+.shw-theme-switcher__control {
+  height: 24px;
+  padding: 2px 24px 2px 8px;
+  color: var(--shw-color-gray-100);
+  font-size: 0.75rem;
+  font-family: monaco, Consolas, "Lucida Console", monospace;
+  background-color: var(--shw-color-gray-600);
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3.34572 7H20.6543C21.8517 7 22.4504 8.4463 21.6028 9.29391L12.9519 17.9515C12.4272 18.4763 11.5728 18.4763 11.0481 17.9515L2.39722 9.29391C1.54961 8.4463 2.14832 7 3.34572 7Z' fill='%23808080'/%3E%3C/svg%3E"); // notice: the 'caret' color is hardcoded here!
+  background-repeat: no-repeat;
+  background-position: right 6px top 4px;
+  background-size: 12px 12px;
+  border: 1px solid var(--shw-color-gray-400);
+  border-radius: 3px;
+  appearance: none;
+}

--- a/showcase/app/styles/showcase-pages/theming.scss
+++ b/showcase/app/styles/showcase-pages/theming.scss
@@ -12,6 +12,16 @@ body.foundations-theming {
     background-color: var(--shw-test-theme-background-color);
   }
 
+  .shw-test-placeholder-with-theme--class {
+    color: var(--shw-test-theme-class-foreground-color, var(--shw-test-theme-foreground-color));
+    background-color: var(--shw-test-theme-class-background-color, var(--shw-test-theme-background-color));
+  }
+
+  .shw-test-placeholder-with-theme--data {
+    color: var(--shw-test-theme-data-foreground-color, var(--shw-test-theme-foreground-color));
+    background-color: var(--shw-test-theme-data-background-color, var(--shw-test-theme-background-color));
+  }
+
   .shw-theming-container-background-light {
     background-color: #fff;
   }

--- a/showcase/app/styles/showcase-pages/theming.scss
+++ b/showcase/app/styles/showcase-pages/theming.scss
@@ -11,4 +11,12 @@ body.foundations-theming {
     text-shadow: none;
     background-color: var(--shw-test-theme-background-color);
   }
+
+  .shw-theming-container-background-light {
+    background-color: #fff;
+  }
+
+  .shw-theming-container-background-dark {
+    background-color: #000;
+  }
 }

--- a/showcase/app/styles/showcase-pages/theming.scss
+++ b/showcase/app/styles/showcase-pages/theming.scss
@@ -6,20 +6,42 @@
 // TYPOGRAPHY
 
 body.foundations-theming {
-  .shw-test-placeholder-with-theme {
+  .shw-theming-demo-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: fit-content;
+    min-width: 120px;
+    min-height: 120px;
+    padding: 50px;
     color: var(--shw-test-theme-foreground-color);
-    text-shadow: none;
+    font-weight: bold;
+    font-size: 10px;
+    font-family: monaco, Consolas, "Lucida Console", monospace;
+    line-height: 1.2;
     background-color: var(--shw-test-theme-background-color);
   }
 
-  .shw-test-placeholder-with-theme--class {
-    color: var(--shw-test-theme-class-foreground-color, var(--shw-test-theme-foreground-color));
-    background-color: var(--shw-test-theme-class-background-color, var(--shw-test-theme-background-color));
+  .shw-theming-demo-container--class {
+    color: var(
+      --shw-test-theme-class-foreground-color,
+      var(--shw-test-theme-foreground-color)
+    );
+    background-color: var(
+      --shw-test-theme-class-background-color,
+      var(--shw-test-theme-background-color)
+    );
   }
 
-  .shw-test-placeholder-with-theme--data {
-    color: var(--shw-test-theme-data-foreground-color, var(--shw-test-theme-foreground-color));
-    background-color: var(--shw-test-theme-data-background-color, var(--shw-test-theme-background-color));
+  .shw-theming-demo-container--data {
+    color: var(
+      --shw-test-theme-data-foreground-color,
+      var(--shw-test-theme-foreground-color)
+    );
+    background-color: var(
+      --shw-test-theme-data-background-color,
+      var(--shw-test-theme-background-color)
+    );
   }
 
   .shw-theming-container-background-light {

--- a/showcase/app/styles/showcase-pages/theming.scss
+++ b/showcase/app/styles/showcase-pages/theming.scss
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// TYPOGRAPHY
+
+body.foundations-theming {
+  .shw-test-placeholder-with-theme {
+    color: var(--shw-test-theme-foreground-color);
+    text-shadow: none;
+    background-color: var(--shw-test-theme-background-color);
+  }
+}

--- a/showcase/app/styles/showcase-pages/typography.scss
+++ b/showcase/app/styles/showcase-pages/typography.scss
@@ -7,11 +7,12 @@
 
 body.foundations-typography {
   .shw-label {
-    color: #999;
+    color: var(--shw-color-gray-300);
   }
 
   p[class^="hds-"] {
     margin: 0;
     padding: 0;
+    color: var(--shw-color-black);
   }
 }

--- a/showcase/app/styles/showcase-theming/dark.scss
+++ b/showcase/app/styles/showcase-theming/dark.scss
@@ -1,6 +1,7 @@
 // SHOWCASE COLORS > DARK THEME
 
 @mixin shw-theme-color-variables-dark() {
+  // SEMANTIC PALETTE
   --shw-color-white: #1a1a1a;
   --shw-color-gray-600: #222225;
   --shw-color-gray-500: #353537;
@@ -30,6 +31,12 @@
   --shw-color-action-active-foreground: #1a1ae5;
   --shw-color-action-active-border: #1a1ae5;
   --shw-color-action-active-background: #062139;
+  // COMPONENTS
+  --shw-frame-browser-navigation-background: #050505;
+  --shw-label-text-color: #c4c4c4;
+  --shw-placeholder-text-color: #949494;
+  --shw-placeholder-background-color: #121212;
+  --shw-placeholder-link-color: #ccc;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/showcase/app/styles/showcase-theming/dark.scss
+++ b/showcase/app/styles/showcase-theming/dark.scss
@@ -1,3 +1,52 @@
+// SHOWCASE COLORS > DARK THEME
+
+@mixin shw-theme-color-variables-dark() {
+  --shw-color-white: #1a1a1a;
+  --shw-color-gray-600: #222225;
+  --shw-color-gray-500: #353537;
+  --shw-color-gray-400: #4c4c4d;
+  --shw-color-gray-300: #89898a;
+  --shw-color-gray-200: #babbbc;
+  --shw-color-gray-100: #cccdcf;
+  --shw-color-black: #e5e5e5;
+  --shw-color-link-on-black: #145ab6;
+  --shw-color-link-on-white: #3a6fcb;
+  --shw-color-feedback-information-100: #406dde;
+  --shw-color-feedback-information-200: #1857d6;
+  --shw-color-feedback-information-300: #092150;
+  --shw-color-feedback-information-400: #061a39;
+  --shw-color-feedback-success-100: #7bf0cd;
+  --shw-color-feedback-success-200: #4aebb7;
+  --shw-color-feedback-success-300: #1c5440;
+  --shw-color-feedback-success-400: #0c392a;
+  --shw-color-feedback-warning-100: #e8b265;
+  --shw-color-feedback-warning-200: #bf8b28;
+  --shw-color-feedback-warning-300: #4e3912;
+  --shw-color-feedback-warning-400: #382a0e;
+  --shw-color-feedback-critical-100: #cc4f52;
+  --shw-color-feedback-critical-200: #aa1f23;
+  --shw-color-feedback-critical-300: #4d090c;
+  --shw-color-feedback-critical-400: #320f15;
+  --shw-color-action-active-foreground: #1a1ae5;
+  --shw-color-action-active-border: #1a1ae5;
+  --shw-color-action-active-background: #062139;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    @include shw-theme-color-variables-dark();
+  }
+}
+
+.shw-theme-dark,
+[data-shw-theme="dark"] {
+  @include shw-theme-color-variables-dark();
+}
+
+// ######################################################
+
+// TEST COLORS
+
 $shw-test-theme-foreground-color: #eee;
 $shw-test-theme-background-color: #111;
 

--- a/showcase/app/styles/showcase-theming/dark.scss
+++ b/showcase/app/styles/showcase-theming/dark.scss
@@ -1,0 +1,15 @@
+$shw-test-theme-foreground-color: #eee;
+$shw-test-theme-background-color: #111;
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --shw-test-theme-foreground-color: #{$shw-test-theme-foreground-color};
+    --shw-test-theme-background-color: #{$shw-test-theme-background-color};
+  }
+}
+
+.shw-theme-dark,
+[data-shw-theme="dark"] {
+  --shw-test-theme-foreground-color: #{$shw-test-theme-foreground-color};
+  --shw-test-theme-background-color: #{$shw-test-theme-background-color};
+}

--- a/showcase/app/styles/showcase-theming/dark.scss
+++ b/showcase/app/styles/showcase-theming/dark.scss
@@ -66,3 +66,19 @@
   --shw-test-theme-foreground-color: #eee;
   --shw-test-theme-background-color: #111;
 }
+
+
+// ---
+
+// special variables used in the "theming" showcase page to demonstrate different ways to apply a theme to a page
+
+body.shw-theme-dark {
+  --shw-test-theme-class-foreground-color: #e0ffd9;
+  --shw-test-theme-class-background-color: #008217;
+}
+
+body[data-shw-theme="dark"] {
+  --shw-test-theme-data-foreground-color: #f7d9ff;
+  --shw-test-theme-data-background-color: #b01fe3;
+}
+

--- a/showcase/app/styles/showcase-theming/dark.scss
+++ b/showcase/app/styles/showcase-theming/dark.scss
@@ -54,18 +54,15 @@
 
 // TEST COLORS
 
-$shw-test-theme-foreground-color: #eee;
-$shw-test-theme-background-color: #111;
-
 @media (prefers-color-scheme: dark) {
   :root {
-    --shw-test-theme-foreground-color: #{$shw-test-theme-foreground-color};
-    --shw-test-theme-background-color: #{$shw-test-theme-background-color};
+    --shw-test-theme-foreground-color: #eee;
+    --shw-test-theme-background-color: #111;
   }
 }
 
 .shw-theme-dark,
 [data-shw-theme="dark"] {
-  --shw-test-theme-foreground-color: #{$shw-test-theme-foreground-color};
-  --shw-test-theme-background-color: #{$shw-test-theme-background-color};
+  --shw-test-theme-foreground-color: #eee;
+  --shw-test-theme-background-color: #111;
 }

--- a/showcase/app/styles/showcase-theming/light.scss
+++ b/showcase/app/styles/showcase-theming/light.scss
@@ -1,3 +1,52 @@
+// SHOWCASE COLORS > LIGHT THEME
+
+@mixin shw-theme-color-variables-light() {
+  --shw-color-white: #fff;
+  --shw-color-gray-600: #f2f2f3;
+  --shw-color-gray-500: #dbdbdc;
+  --shw-color-gray-400: #bfbfc0;
+  --shw-color-gray-300: #727374;
+  --shw-color-gray-200: #343536;
+  --shw-color-gray-100: #1d1e1f;
+  --shw-color-black: #000;
+  --shw-color-link-on-black: #4294ff;
+  --shw-color-link-on-white: #2264d6;
+  --shw-color-feedback-information-100: #0d44cc;
+  --shw-color-feedback-information-200: #1563ff;
+  --shw-color-feedback-information-300: #d0e0ff;
+  --shw-color-feedback-information-400: #eff5ff;
+  --shw-color-feedback-success-100: #007854;
+  --shw-color-feedback-success-200: #00bc7f;
+  --shw-color-feedback-success-300: #c1f1e0;
+  --shw-color-feedback-success-400: #ebfdf7;
+  --shw-color-feedback-warning-100: #975b06;
+  --shw-color-feedback-warning-200: #eaaa32;
+  --shw-color-feedback-warning-300: #f9eacd;
+  --shw-color-feedback-warning-400: #fcf6ea;
+  --shw-color-feedback-critical-100: #ba2226;
+  --shw-color-feedback-critical-200: #f25054;
+  --shw-color-feedback-critical-300: #ffd4d6;
+  --shw-color-feedback-critical-400: #fcf0f2;
+  --shw-color-action-active-foreground: #00f; // HTML "blue"
+  --shw-color-action-active-border: #00f; // HTML "blue"
+  --shw-color-action-active-background: #f0f8ff; // HTML "aliceblue"
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    @include shw-theme-color-variables-light();
+  }
+}
+
+.shw-theme-light,
+[data-shw-theme="light"] {
+  @include shw-theme-color-variables-light();
+}
+
+// ######################################################
+
+// TEST COLORS
+
 $shw-test-theme-foreground-color: #111;
 $shw-test-theme-background-color: #eee;
 

--- a/showcase/app/styles/showcase-theming/light.scss
+++ b/showcase/app/styles/showcase-theming/light.scss
@@ -71,3 +71,18 @@
   --shw-test-theme-foreground-color: #111;
   --shw-test-theme-background-color: #eee;
 }
+
+// ---
+
+// special variables used in the "theming" showcase page to demonstrate different ways to apply a theme to a page
+
+body.shw-theme-light {
+  --shw-test-theme-class-foreground-color: #008217;
+  --shw-test-theme-class-background-color: #e0ffd9;
+}
+
+body[data-shw-theme="light"] {
+  --shw-test-theme-data-foreground-color: #b01fe3;
+  --shw-test-theme-data-background-color: #f7d9ff;
+}
+

--- a/showcase/app/styles/showcase-theming/light.scss
+++ b/showcase/app/styles/showcase-theming/light.scss
@@ -39,6 +39,11 @@
   --shw-placeholder-link-color: #333;
 }
 
+// TODO! should we add an entry to act as default for browser that may not support `prefers-color-scheme`?
+// :root {
+//   @include shw-theme-color-variables-light();
+// }
+
 @media (prefers-color-scheme: light) {
   :root {
     @include shw-theme-color-variables-light();
@@ -54,18 +59,15 @@
 
 // TEST COLORS
 
-$shw-test-theme-foreground-color: #111;
-$shw-test-theme-background-color: #eee;
-
 @media (prefers-color-scheme: light) {
   :root {
-    --shw-test-theme-foreground-color: #{$shw-test-theme-foreground-color};
-    --shw-test-theme-background-color: #{$shw-test-theme-background-color};
+    --shw-test-theme-foreground-color: #111;
+    --shw-test-theme-background-color: #eee;
   }
 }
 
 .shw-theme-light,
 [data-shw-theme="light"] {
-  --shw-test-theme-foreground-color: #{$shw-test-theme-foreground-color};
-  --shw-test-theme-background-color: #{$shw-test-theme-background-color};
+  --shw-test-theme-foreground-color: #111;
+  --shw-test-theme-background-color: #eee;
 }

--- a/showcase/app/styles/showcase-theming/light.scss
+++ b/showcase/app/styles/showcase-theming/light.scss
@@ -1,0 +1,15 @@
+$shw-test-theme-foreground-color: #111;
+$shw-test-theme-background-color: #eee;
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --shw-test-theme-foreground-color: #{$shw-test-theme-foreground-color};
+    --shw-test-theme-background-color: #{$shw-test-theme-background-color};
+  }
+}
+
+.shw-theme-light,
+[data-shw-theme="light"] {
+  --shw-test-theme-foreground-color: #{$shw-test-theme-foreground-color};
+  --shw-test-theme-background-color: #{$shw-test-theme-background-color};
+}

--- a/showcase/app/styles/showcase-theming/light.scss
+++ b/showcase/app/styles/showcase-theming/light.scss
@@ -1,6 +1,7 @@
 // SHOWCASE COLORS > LIGHT THEME
 
 @mixin shw-theme-color-variables-light() {
+  // SEMANTIC PALETTE
   --shw-color-white: #fff;
   --shw-color-gray-600: #f2f2f3;
   --shw-color-gray-500: #dbdbdc;
@@ -30,6 +31,12 @@
   --shw-color-action-active-foreground: #00f; // HTML "blue"
   --shw-color-action-active-border: #00f; // HTML "blue"
   --shw-color-action-active-background: #f0f8ff; // HTML "aliceblue"
+  // COMPONENTS
+  --shw-frame-browser-navigation-background: #fafafa;
+  --shw-label-text-color: #545454;
+  --shw-placeholder-text-color: #6b6b6b; // if background is #EEE then this has the appropriate color contrast (4.59:1)
+  --shw-placeholder-background-color: #eee;
+  --shw-placeholder-link-color: #333;
 }
 
 @media (prefers-color-scheme: light) {

--- a/showcase/app/templates/application.hbs
+++ b/showcase/app/templates/application.hbs
@@ -13,6 +13,16 @@
       <Shw::Logo::DesignSystem />
     </LinkTo>
     <div class="shw-page-header__title">Components showcase</div>
+    <div class="shw-page-header__theme-toggle">
+      <label for="theme-switcher">Theme:</label>
+      <select id="theme-switcher" {{on "change" this.onChangePageTheme}}>
+        <option value="auto">Auto (browser prefers-color-scheme)</option>
+        <option value="light-data-attribute">Light (data-attribute)</option>
+        <option value="light-css-class">Light (CSS class)</option>
+        <option value="dark-data-attribute">Dark (data-attribute)</option>
+        <option value="dark-css-class">Dark (CSS class)</option>
+      </select>
+    </div>
   </header>
 
   <aside class="shw-page-aside">

--- a/showcase/app/templates/application.hbs
+++ b/showcase/app/templates/application.hbs
@@ -14,14 +14,7 @@
     </LinkTo>
     <div class="shw-page-header__title">Components showcase</div>
     <div class="shw-page-header__theme-toggle">
-      <label for="theme-switcher">Theme:</label>
-      <select id="theme-switcher" {{on "change" this.onChangePageTheme}}>
-        <option value="auto">Auto (browser prefers-color-scheme)</option>
-        <option value="light-data-attribute">Light (data-attribute)</option>
-        <option value="light-css-class">Light (CSS class)</option>
-        <option value="dark-data-attribute">Dark (data-attribute)</option>
-        <option value="dark-css-class">Dark (CSS class)</option>
-      </select>
+      <Shw::Theme::Switcher />
     </div>
   </header>
 

--- a/showcase/app/templates/foundations/theming.hbs
+++ b/showcase/app/templates/foundations/theming.hbs
@@ -30,6 +30,8 @@
 
   <Shw::Text::H2>Contextual theming</Shw::Text::H2>
 
+  <pre>Current theme: {{this.currentTheme}}</pre>
+
   <Shw::Flex as |SF|>
     <SF.Item as |SFI|>
       <SFI.Label><code>.theme</code> class</SFI.Label>

--- a/showcase/app/templates/foundations/theming.hbs
+++ b/showcase/app/templates/foundations/theming.hbs
@@ -7,36 +7,84 @@
 
 <Shw::Text::H1>Theming</Shw::Text::H1>
 
+<Shw::Text::Body>Current theme: {{this.currentTheme}} / Inverse theme: {{this.inverseTheme}}</Shw::Text::Body>
+
 <section data-test-percy>
 
   <Shw::Text::H2>Page-level theming</Shw::Text::H2>
 
-  <Shw::Grid @columns={{3}} as |SF|>
-    <SF.Item as |SFI|>
-      <SFI.Label><code>prefers-color-scheme</code></SFI.Label>
+  <Shw::Grid @columns={{3}} as |SG|>
+    <SG.Item as |SGI|>
+      <SGI.Label><code>prefers-color-scheme</code></SGI.Label>
       <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
-    </SF.Item>
-    <SF.Item as |SFI|>
-      <SFI.Label><code>[data-theme]</code> attribute</SFI.Label>
+    </SG.Item>
+    <SG.Item as |SGI|>
+      <SGI.Label><code>body[data-theme]</code> attribute</SGI.Label>
       <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
-    </SF.Item>
-    <SF.Item as |SFI|>
-      <SFI.Label><code>.theme</code> class</SFI.Label>
+    </SG.Item>
+    <SG.Item as |SGI|>
+      <SGI.Label><code>body.theme</code> class</SGI.Label>
       <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
-    </SF.Item>
+    </SG.Item>
   </Shw::Grid>
 
   <Shw::Divider />
 
   <Shw::Text::H2>Contextual theming</Shw::Text::H2>
 
-  <pre>Current theme: {{this.currentTheme}}</pre>
-
-  <Shw::Flex as |SF|>
+  <Shw::Flex @gap="4rem" as |SF|>
     <SF.Item as |SFI|>
-      <SFI.Label><code>.theme</code> class</SFI.Label>
+      <SFI.Label><code>.theme-light</code> class</SFI.Label>
+      <div class="shw-theme-light">
+        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+      </div>
+    </SF.Item>
+    <SF.Item as |SFI|>
+      <SFI.Label><code>.theme-dark</code> class</SFI.Label>
       <div class="shw-theme-dark">
         <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Text::H4 @tag="h3">Nested</Shw::Text::H4>
+
+  <Shw::Flex @gap="4rem" as |SF|>
+    <SF.Item as |SFI|>
+      <SFI.Label><code>.theme</code> class / light</SFI.Label>
+      <div class="shw-theme-light">
+        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+      </div>
+    </SF.Item>
+    <SF.Item as |SFI|>
+      <SFI.Label><code>.theme</code> class / dark</SFI.Label>
+      <div class="shw-theme-dark">
+        <Shw::Placeholder class="shw-test-placeholder-with-theme" @width="200" @height="200">
+          <div class="shw-theme-light">
+            <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+          </div>
+        </Shw::Placeholder>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Divider />
+
+  <Shw::Text::H2>Components</Shw::Text::H2>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="AppFooter with theme={{this.inverseTheme}}">
+      <div class="shw-theming-container-background-{{this.inverseTheme}}">
+        <Hds::AppFooter @theme={{this.inverseTheme}} as |AF|>
+          <AF.StatusLink @status="operational" />
+          <AF.LegalLinks />
+          <AF.Item>
+            <Hds::Text::Body @tag="span" @size="100">v.2.0</Hds::Text::Body>
+          </AF.Item>
+          <AF.Item>
+            <Hds::Text::Body @tag="span" @size="100">Product Name</Hds::Text::Body>
+          </AF.Item>
+        </Hds::AppFooter>
       </div>
     </SF.Item>
   </Shw::Flex>

--- a/showcase/app/templates/foundations/theming.hbs
+++ b/showcase/app/templates/foundations/theming.hbs
@@ -16,25 +16,15 @@
   <Shw::Grid @columns={{3}} as |SG|>
     <SG.Item as |SGI|>
       <SGI.Label><code>prefers-color-scheme</code></SGI.Label>
-      <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEXT" @width="100" @height="100" />
+      <div class="shw-theming-demo-container">TEXT</div>
     </SG.Item>
     <SG.Item as |SGI|>
       <SGI.Label><code>body.theme</code> class</SGI.Label>
-      <Shw::Placeholder
-        class="shw-test-placeholder-with-theme shw-test-placeholder-with-theme--class"
-        @text="TEXT"
-        @width="100"
-        @height="100"
-      />
+      <div class="shw-theming-demo-container shw-theming-demo-container--class">TEXT</div>
     </SG.Item>
     <SG.Item as |SGI|>
       <SGI.Label><code>body[data-theme]</code> attribute</SGI.Label>
-      <Shw::Placeholder
-        class="shw-test-placeholder-with-theme shw-test-placeholder-with-theme--data"
-        @text="TEXT"
-        @width="100"
-        @height="100"
-      />
+      <div class="shw-theming-demo-container shw-theming-demo-container--data">TEXT</div>
     </SG.Item>
   </Shw::Grid>
 
@@ -46,13 +36,13 @@
     <SF.Item as |SFI|>
       <SFI.Label><code>.theme-light</code> class</SFI.Label>
       <div class="shw-theme-light">
-        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEXT" @width="100" @height="100" />
+        <div class="shw-theming-demo-container">TEXT</div>
       </div>
     </SF.Item>
     <SF.Item as |SFI|>
       <SFI.Label><code>.theme-dark</code> class</SFI.Label>
       <div class="shw-theme-dark">
-        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEXT" @width="100" @height="100" />
+        <div class="shw-theming-demo-container">TEXT</div>
       </div>
     </SF.Item>
   </Shw::Flex>
@@ -61,19 +51,43 @@
 
   <Shw::Flex @gap="4rem" as |SF|>
     <SF.Item as |SFI|>
-      <SFI.Label><code>.theme</code> class / light</SFI.Label>
+      <SFI.Label><code>.theme-light</code> &gt; <code>.theme-dark</code></SFI.Label>
       <div class="shw-theme-light">
-        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEXT" @width="100" @height="100" />
+        <div class="shw-theming-demo-container">
+          <div class="shw-theme-dark">
+            <div class="shw-theming-demo-container">
+              TEXT
+            </div>
+          </div>
+        </div>
       </div>
     </SF.Item>
     <SF.Item as |SFI|>
-      <SFI.Label><code>.theme</code> class / dark</SFI.Label>
+      <SFI.Label><code>.theme-dark</code> &gt; <code>.theme-light</code></SFI.Label>
       <div class="shw-theme-dark">
-        <Shw::Placeholder class="shw-test-placeholder-with-theme" @width="200" @height="200">
+        <div class="shw-theming-demo-container">
           <div class="shw-theme-light">
-            <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEXT" @width="100" @height="100" />
+            <div class="shw-theming-demo-container">
+              TEXT
+            </div>
           </div>
-        </Shw::Placeholder>
+        </div>
+      </div>
+    </SF.Item>
+    <SF.Item as |SFI|>
+      <SFI.Label><code>.theme-dark</code> &gt; <code>.theme-light</code> &gt; <code>.theme-dark</code></SFI.Label>
+      <div class="shw-theme-dark">
+        <div class="shw-theming-demo-container">
+          <div class="shw-theme-light">
+            <div class="shw-theming-demo-container">
+              <div class="shw-theme-dark">
+                <div class="shw-theming-demo-container">
+                  TEXT
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </SF.Item>
   </Shw::Flex>

--- a/showcase/app/templates/foundations/theming.hbs
+++ b/showcase/app/templates/foundations/theming.hbs
@@ -16,15 +16,25 @@
   <Shw::Grid @columns={{3}} as |SG|>
     <SG.Item as |SGI|>
       <SGI.Label><code>prefers-color-scheme</code></SGI.Label>
-      <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
-    </SG.Item>
-    <SG.Item as |SGI|>
-      <SGI.Label><code>body[data-theme]</code> attribute</SGI.Label>
-      <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+      <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEXT" @width="100" @height="100" />
     </SG.Item>
     <SG.Item as |SGI|>
       <SGI.Label><code>body.theme</code> class</SGI.Label>
-      <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+      <Shw::Placeholder
+        class="shw-test-placeholder-with-theme shw-test-placeholder-with-theme--class"
+        @text="TEXT"
+        @width="100"
+        @height="100"
+      />
+    </SG.Item>
+    <SG.Item as |SGI|>
+      <SGI.Label><code>body[data-theme]</code> attribute</SGI.Label>
+      <Shw::Placeholder
+        class="shw-test-placeholder-with-theme shw-test-placeholder-with-theme--data"
+        @text="TEXT"
+        @width="100"
+        @height="100"
+      />
     </SG.Item>
   </Shw::Grid>
 
@@ -36,13 +46,13 @@
     <SF.Item as |SFI|>
       <SFI.Label><code>.theme-light</code> class</SFI.Label>
       <div class="shw-theme-light">
-        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEXT" @width="100" @height="100" />
       </div>
     </SF.Item>
     <SF.Item as |SFI|>
       <SFI.Label><code>.theme-dark</code> class</SFI.Label>
       <div class="shw-theme-dark">
-        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEXT" @width="100" @height="100" />
       </div>
     </SF.Item>
   </Shw::Flex>
@@ -53,7 +63,7 @@
     <SF.Item as |SFI|>
       <SFI.Label><code>.theme</code> class / light</SFI.Label>
       <div class="shw-theme-light">
-        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEXT" @width="100" @height="100" />
       </div>
     </SF.Item>
     <SF.Item as |SFI|>
@@ -61,7 +71,7 @@
       <div class="shw-theme-dark">
         <Shw::Placeholder class="shw-test-placeholder-with-theme" @width="200" @height="200">
           <div class="shw-theme-light">
-            <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+            <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEXT" @width="100" @height="100" />
           </div>
         </Shw::Placeholder>
       </div>

--- a/showcase/app/templates/foundations/theming.hbs
+++ b/showcase/app/templates/foundations/theming.hbs
@@ -11,18 +11,28 @@
 
   <Shw::Text::H2>Page-level theming</Shw::Text::H2>
 
-  <Shw::Flex as |SF|>
-    <SF.Item>
+  <Shw::Grid @columns={{3}} as |SF|>
+    <SF.Item as |SFI|>
+      <SFI.Label><code>prefers-color-scheme</code></SFI.Label>
       <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
     </SF.Item>
-  </Shw::Flex>
+    <SF.Item as |SFI|>
+      <SFI.Label><code>[data-theme]</code> attribute</SFI.Label>
+      <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+    </SF.Item>
+    <SF.Item as |SFI|>
+      <SFI.Label><code>.theme</code> class</SFI.Label>
+      <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
+    </SF.Item>
+  </Shw::Grid>
 
   <Shw::Divider />
 
   <Shw::Text::H2>Contextual theming</Shw::Text::H2>
 
   <Shw::Flex as |SF|>
-    <SF.Item>
+    <SF.Item as |SFI|>
+      <SFI.Label><code>.theme</code> class</SFI.Label>
       <div class="shw-theme-dark">
         <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
       </div>

--- a/showcase/app/templates/foundations/theming.hbs
+++ b/showcase/app/templates/foundations/theming.hbs
@@ -13,9 +13,7 @@
 
   <Shw::Flex as |SF|>
     <SF.Item>
-      <div class="shw-xyz">
-        <Shw::Placeholder @text="TEMP" @width="100" @height="100" />
-      </div>
+      <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
     </SF.Item>
   </Shw::Flex>
 
@@ -25,8 +23,8 @@
 
   <Shw::Flex as |SF|>
     <SF.Item>
-      <div class="shw-xyz">
-        <Shw::Placeholder @text="TEMP" @width="100" @height="100" />
+      <div class="shw-theme-dark">
+        <Shw::Placeholder class="shw-test-placeholder-with-theme" @text="TEMP" @width="100" @height="100" />
       </div>
     </SF.Item>
   </Shw::Flex>

--- a/showcase/app/templates/foundations/theming.hbs
+++ b/showcase/app/templates/foundations/theming.hbs
@@ -1,0 +1,34 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{page-title "Theming"}}
+
+<Shw::Text::H1>Theming</Shw::Text::H1>
+
+<section data-test-percy>
+
+  <Shw::Text::H2>Page-level theming</Shw::Text::H2>
+
+  <Shw::Flex as |SF|>
+    <SF.Item>
+      <div class="shw-xyz">
+        <Shw::Placeholder @text="TEMP" @width="100" @height="100" />
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Divider />
+
+  <Shw::Text::H2>Contextual theming</Shw::Text::H2>
+
+  <Shw::Flex as |SF|>
+    <SF.Item>
+      <div class="shw-xyz">
+        <Shw::Placeholder @text="TEMP" @width="100" @height="100" />
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+</section>

--- a/showcase/app/templates/index.hbs
+++ b/showcase/app/templates/index.hbs
@@ -22,6 +22,11 @@
           Focus ring
         </LinkTo>
       </li>
+      <li>
+        <LinkTo @route="foundations.theming">
+          Theming
+        </LinkTo>
+      </li>
     </ol>
   </div>
 

--- a/showcase/ember-cli-build.js
+++ b/showcase/ember-cli-build.js
@@ -16,15 +16,15 @@ module.exports = function (defaults) {
     // See https://cli.emberjs.com/release/advanced-use/asset-compilation/#configuringoutputpaths
     // Notice: this triggers the warning "Using the `outputPaths` build option is deprecated, as output paths will no longer be predetermined under Embroider."
     // but I was not able to find online documentation or help about what one is supposed to do in alternative
-    outputPaths: {
-      app: {
-        css: {
-          app: '/assets/showcase.css',
-          'showcase-theming/dark': '/assets/showcase-theme-dark.css',
-          'showcase-theming/light': '/assets/showcase-theme-light.css',
-        },
-      },
-    },
+    // outputPaths: {
+    //   app: {
+    //     css: {
+    //       app: '/assets/showcase.css',
+    //       'showcase-theming/dark': '/assets/showcase-theme-dark.css',
+    //       'showcase-theming/light': '/assets/showcase-theme-light.css',
+    //     },
+    //   },
+    // },
 
     // See https://github.com/adopted-ember-addons/ember-cli-sass
     sassOptions: {

--- a/showcase/ember-cli-build.js
+++ b/showcase/ember-cli-build.js
@@ -13,6 +13,19 @@ module.exports = function (defaults) {
       enableTypeScriptTransform: true,
     },
 
+    // See https://cli.emberjs.com/release/advanced-use/asset-compilation/#configuringoutputpaths
+    // Notice: this triggers the warning "Using the `outputPaths` build option is deprecated, as output paths will no longer be predetermined under Embroider."
+    // but I was not able to find online documentation or help about what one is supposed to do in alternative
+    outputPaths: {
+      app: {
+        css: {
+          app: '/assets/showcase.css',
+          'showcase-theming/dark': '/assets/showcase-theme-dark.css',
+          'showcase-theming/light': '/assets/showcase-theme-light.css',
+        },
+      },
+    },
+
     // See https://github.com/adopted-ember-addons/ember-cli-sass
     sassOptions: {
       precision: 4,


### PR DESCRIPTION
# 🚨 DO NOT MERGE 🚨

### :pushpin: Summary

Branch used for exploring what needs to be done to have "support" for theming in the Showcase app.

In the process, we will use the Showcase app as proxy to understand what a consumer would need from HDS to use the themes provided by the system (eg. should HDS provide a "toggle" or "switcher" for themes? should provide a service that returns the themes, sets the theme in the hosting app, saves the user preference in a local storage?)

### :link: External links

Jira tickets: 
- Epic: https://hashicorp.atlassian.net/browse/HDS-3595
- Task: https://hashicorp.atlassian.net/browse/HDS-4232