### PR TITLE
Resolve sass warnings in rollup build

### DIFF
--- a/.changeset/neat-eels-speak.md
+++ b/.changeset/neat-eels-speak.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Fixed deprecated Sass syntax (`map-get` replaced with `map.get` and `@import` with `@use`)

--- a/packages/components/src/styles/components/badge-count.scss
+++ b/packages/components/src/styles/components/badge-count.scss
@@ -8,6 +8,7 @@
 //
 
 @use "sass:math";
+@use "sass:map";
 
 $hds-badge-count-types: ( "flat","inverted","outlined" );
 $hds-badge-count-sizes: ( "small", "medium", "large" );
@@ -52,11 +53,11 @@ $hds-badge-count-size-props: (
 
 @each $size in $hds-badge-count-sizes {
   .hds-badge-count--size-#{$size} {
-    min-height: map-get($hds-badge-count-size-props, $size, "height");
-    padding: calc(#{map-get($hds-badge-count-size-props, $size, "padding-vertical")} - #{$hds-badge-count-border-width}) calc(#{map-get($hds-badge-count-size-props, $size, "padding-horizontal")} - #{$hds-badge-count-border-width});
-    font-size: map-get($hds-badge-count-size-props, $size, "font-size");
-    line-height: map-get($hds-badge-count-size-props, $size, "line-height");
-    border-radius: math.div(map-get($hds-badge-count-size-props, $size, "height"), 2);
+    min-height: map.get($hds-badge-count-size-props, $size, "height");
+    padding: calc(#{map.get($hds-badge-count-size-props, $size, "padding-vertical")} - #{$hds-badge-count-border-width}) calc(#{map.get($hds-badge-count-size-props, $size, "padding-horizontal")} - #{$hds-badge-count-border-width});
+    font-size: map.get($hds-badge-count-size-props, $size, "font-size");
+    line-height: map.get($hds-badge-count-size-props, $size, "line-height");
+    border-radius: math.div(map.get($hds-badge-count-size-props, $size, "height"), 2);
   }
 }
 

--- a/packages/components/src/styles/components/badge.scss
+++ b/packages/components/src/styles/components/badge.scss
@@ -7,6 +7,8 @@
 // BADGE COMPONENT
 //
 
+@use "sass:map";
+
 $hds-badge-types: ( "flat","inverted","outlined" );
 $hds-badge-colors-accents: ( "highlight", "success", "warning", "critical" );
 $hds-badge-sizes: ( "small", "medium", "large" );
@@ -87,18 +89,18 @@ $hds-badge-size-props: (
 
 @each $size in $hds-badge-sizes {
   .hds-badge--size-#{$size} {
-    gap: map-get($hds-badge-size-props, $size, "gap");
-    min-height: map-get($hds-badge-size-props, $size, "height");
-    padding: calc(#{map-get($hds-badge-size-props, $size, "padding-vertical")} - #{$hds-badge-border-width}) calc(#{map-get($hds-badge-size-props, $size, "padding-horizontal")} - #{$hds-badge-border-width});
+    gap: map.get($hds-badge-size-props, $size, "gap");
+    min-height: map.get($hds-badge-size-props, $size, "height");
+    padding: calc(#{map.get($hds-badge-size-props, $size, "padding-vertical")} - #{$hds-badge-border-width}) calc(#{map.get($hds-badge-size-props, $size, "padding-horizontal")} - #{$hds-badge-border-width});
 
     .hds-badge__icon {
-      width: map-get($hds-badge-size-props, $size, "icon-size");
-      height: map-get($hds-badge-size-props, $size, "icon-size");
+      width: map.get($hds-badge-size-props, $size, "icon-size");
+      height: map.get($hds-badge-size-props, $size, "icon-size");
     }
 
     .hds-badge__text {
-      font-size: map-get($hds-badge-size-props, $size, "font-size");
-      line-height: map-get($hds-badge-size-props, $size, "line-height");
+      font-size: map.get($hds-badge-size-props, $size, "font-size");
+      line-height: map.get($hds-badge-size-props, $size, "line-height");
     }
   }
 }
@@ -151,13 +153,13 @@ $hds-badge-size-props: (
 
     &.hds-badge--type-inverted {
       color: var(--token-color-foreground-high-contrast);
-      background-color: map-get($hds-badge-colors-props, $color, "inverted-background-color");
+      background-color: map.get($hds-badge-colors-props, $color, "inverted-background-color");
     }
 
     &.hds-badge--type-outlined {
       color: var(--token-color-foreground-#{$color});
       background-color: transparent;
-      border-color: map-get($hds-badge-colors-props, $color, "outlined-border-color");
+      border-color: map.get($hds-badge-colors-props, $color, "outlined-border-color");
     }
   }
 }

--- a/packages/components/src/styles/components/code-block/index.scss
+++ b/packages/components/src/styles/components/code-block/index.scss
@@ -11,7 +11,7 @@
 @use "../../mixins/focus-ring" as *;
 
 // Note: "theme" contains just color variables and syntax highlighting styles
-@import "theme";
+@use "theme";
 
 // DIMENSIONS
 $hds-code-block-line-numbers-width: 49px; // 3em ≈ 49px

--- a/packages/components/src/styles/components/icon-tile.scss
+++ b/packages/components/src/styles/components/icon-tile.scss
@@ -7,6 +7,8 @@
 // ICON-TILE COMPONENT
 //
 
+@use "sass:map";
+
 $hds-icon-tile-sizes: ( "small", "medium", "large" );
 $hds-icon-tile-types: ( "object","resource","logo" );
 $hds-icon-tile-colors-products: ( "boundary", "consul", "hcp", "nomad", "packer", "terraform", "vagrant", "vault", "vault-secrets", "vault-radar", "waypoint" );
@@ -77,29 +79,29 @@ $hds-icon-tile-size-props: (
 
 @each $size in $hds-icon-tile-sizes {
   .hds-icon-tile--size-#{$size} {
-    width: map-get($hds-icon-tile-size-props, $size, "size");
-    height: map-get($hds-icon-tile-size-props, $size, "size");
-    border-radius: map-get($hds-icon-tile-size-props, $size, "border-radius");
+    width: map.get($hds-icon-tile-size-props, $size, "size");
+    height: map.get($hds-icon-tile-size-props, $size, "size");
+    border-radius: map.get($hds-icon-tile-size-props, $size, "border-radius");
 
     .hds-icon-tile__icon {
-      width: map-get($hds-icon-tile-size-props, $size, "icon-size");
-      height: map-get($hds-icon-tile-size-props, $size, "icon-size");
+      width: map.get($hds-icon-tile-size-props, $size, "icon-size");
+      height: map.get($hds-icon-tile-size-props, $size, "icon-size");
     }
 
     .hds-icon-tile__logo {
-      width: map-get($hds-icon-tile-size-props, $size, "logo-size");
-      height: map-get($hds-icon-tile-size-props, $size, "logo-size");
+      width: map.get($hds-icon-tile-size-props, $size, "logo-size");
+      height: map.get($hds-icon-tile-size-props, $size, "logo-size");
     }
 
     .hds-icon-tile__extra {
-      width: map-get($hds-icon-tile-size-props, $size, "extra-size");
-      height: map-get($hds-icon-tile-size-props, $size, "extra-size");
-      border-radius: map-get($hds-icon-tile-size-props, $size, "extra-border-radius");
+      width: map.get($hds-icon-tile-size-props, $size, "extra-size");
+      height: map.get($hds-icon-tile-size-props, $size, "extra-size");
+      border-radius: map.get($hds-icon-tile-size-props, $size, "extra-border-radius");
     }
 
     .hds-icon-tile__extra-icon {
-      width: map-get($hds-icon-tile-size-props, $size, "extra-icon-size");
-      height: map-get($hds-icon-tile-size-props, $size, "extra-icon-size");
+      width: map.get($hds-icon-tile-size-props, $size, "extra-icon-size");
+      height: map.get($hds-icon-tile-size-props, $size, "extra-icon-size");
     }
   }
 }

--- a/packages/components/src/styles/components/link/standalone.scss
+++ b/packages/components/src/styles/components/link/standalone.scss
@@ -9,6 +9,7 @@
 // notice: pseudo-classes for the states *must* follow the order link > visited > hover > focus > active
 //
 
+@use "sass:map";
 @use "../../mixins/focus-ring" as *;
 
 $hds-link-standalone-sizes: ( "small", "medium", "large" );
@@ -67,13 +68,13 @@ $hds-link-standalone-size-props: (
 @each $size in $hds-link-standalone-sizes {
   .hds-link-standalone--size-#{$size} {
     .hds-link-standalone__icon {
-      width: map-get($hds-link-standalone-size-props, $size, "icon-size");
-      height: map-get($hds-link-standalone-size-props, $size, "icon-size");
+      width: map.get($hds-link-standalone-size-props, $size, "icon-size");
+      height: map.get($hds-link-standalone-size-props, $size, "icon-size");
     }
 
     .hds-link-standalone__text {
-      font-size: map-get($hds-link-standalone-size-props, $size, "font-size");
-      line-height: map-get($hds-link-standalone-size-props, $size, "line-height");
+      font-size: map.get($hds-link-standalone-size-props, $size, "font-size");
+      line-height: map.get($hds-link-standalone-size-props, $size, "line-height");
     }
   }
 }

--- a/packages/components/src/styles/components/stepper/step-indicator.scss
+++ b/packages/components/src/styles/components/stepper/step-indicator.scss
@@ -7,6 +7,8 @@
 // STEPPER > INDICATOR > STEP
 //
 
+@use "sass:map";
+
 $hds-stepper-indicator-step-statuses: (
   "incomplete",
   "progress",
@@ -84,7 +86,7 @@ $hds-stepper-indicator-step-non-interactive-props: (
   // For each status of the non-interactive variant, set the text color, svg fill, and svg stroke colors based on $non-interactive-props
   .hds-stepper-indicator-step--status-#{$status} {
     .hds-stepper-indicator-step__status {
-      color: map-get(
+      color: map.get(
         $hds-stepper-indicator-step-non-interactive-props,
         $status,
         "text-color"
@@ -92,12 +94,12 @@ $hds-stepper-indicator-step-non-interactive-props: (
     }
 
     .hds-stepper-indicator-step__svg-hexagon path {
-      fill: map-get(
+      fill: map.get(
         $hds-stepper-indicator-step-non-interactive-props,
         $status,
         "fill-color"
       );
-      stroke: map-get(
+      stroke: map.get(
         $hds-stepper-indicator-step-non-interactive-props,
         $status,
         "stroke-color"
@@ -155,7 +157,7 @@ $hds-stepper-indicator-step-status-props: (
     // For each status set the text, svg fill, and svg stroke color based on $hds-stepper-indicator-step-status-props
     &.hds-stepper-indicator-step--status-#{$status} {
       .hds-stepper-indicator-step__status {
-        color: map-get(
+        color: map.get(
           $hds-stepper-indicator-step-status-props,
           $status,
           "text-color-default"
@@ -163,12 +165,12 @@ $hds-stepper-indicator-step-status-props: (
       }
 
       .hds-stepper-indicator-step__svg-hexagon path {
-        fill: map-get(
+        fill: map.get(
           $hds-stepper-indicator-step-status-props,
           $status,
           "fill-color-default"
         );
-        stroke: map-get(
+        stroke: map.get(
           $hds-stepper-indicator-step-status-props,
           $status,
           "stroke-color-default"
@@ -178,7 +180,7 @@ $hds-stepper-indicator-step-status-props: (
       &:hover,
       &.mock-hover {
         .hds-stepper-indicator-step__status {
-          color: map-get(
+          color: map.get(
             $hds-stepper-indicator-step-status-props,
             $status,
             "text-color-hover"
@@ -187,12 +189,12 @@ $hds-stepper-indicator-step-status-props: (
 
         .hds-stepper-indicator-step__svg-hexagon {
           path {
-            fill: map-get(
+            fill: map.get(
               $hds-stepper-indicator-step-status-props,
               $status,
               "fill-color-hover"
             );
-            stroke: map-get(
+            stroke: map.get(
               $hds-stepper-indicator-step-status-props,
               $status,
               "stroke-color-hover"
@@ -204,7 +206,7 @@ $hds-stepper-indicator-step-status-props: (
       &:active,
       &.mock-active {
         .hds-stepper-indicator-step__status {
-          color: map-get(
+          color: map.get(
             $hds-stepper-indicator-step-status-props,
             $status,
             "text-color-active"
@@ -213,12 +215,12 @@ $hds-stepper-indicator-step-status-props: (
 
         .hds-stepper-indicator-step__svg-hexagon {
           path {
-            fill: map-get(
+            fill: map.get(
               $hds-stepper-indicator-step-status-props,
               $status,
               "fill-color-active"
             );
-            stroke: map-get(
+            stroke: map.get(
               $hds-stepper-indicator-step-status-props,
               $status,
               "stroke-color-active"

--- a/packages/components/src/styles/components/stepper/task-indicator.scss
+++ b/packages/components/src/styles/components/stepper/task-indicator.scss
@@ -7,6 +7,8 @@
 // STEPPER > INDICATOR > TASK
 //
 
+@use "sass:map";
+
 $hds-stepper-indicator-task-statuses: (
   "incomplete",
   "progress",
@@ -61,7 +63,7 @@ $hds-stepper-indicator-task-status-props: (
   @each $status in $hds-stepper-indicator-task-statuses {
     // For each status set the icon color based on the $hds-stepper-indicator-task-status-props
     &.hds-stepper-indicator-task--status-#{$status} {
-      color: map-get(
+      color: map.get(
         $hds-stepper-indicator-task-status-props,
         $status,
         "color-default"
@@ -69,7 +71,7 @@ $hds-stepper-indicator-task-status-props: (
 
       &:hover,
       &.mock-hover {
-        color: map-get(
+        color: map.get(
           $hds-stepper-indicator-task-status-props,
           $status,
           "color-hover"
@@ -78,7 +80,7 @@ $hds-stepper-indicator-task-status-props: (
 
       &:active,
       &.mock-active {
-        color: map-get(
+        color: map.get(
           $hds-stepper-indicator-task-status-props,
           $status,
           "color-active"

--- a/packages/components/src/styles/components/tabs.scss
+++ b/packages/components/src/styles/components/tabs.scss
@@ -9,6 +9,7 @@
 
 $hds-tabs-sizes: ( "medium", "large" );
 
+@use "sass:map";
 @use "../mixins/focus-ring" as *;
 
 
@@ -142,12 +143,12 @@ $hds-tabs-size-props: (
 @each $size in $hds-tabs-sizes {
   .hds-tabs--size-#{$size} {
     .hds-tabs__tab {
-      height: map-get($hds-tabs-size-props, $size, "tab-height");
-      padding: var(--token-tabs-tab-padding-vertical) map-get($hds-tabs-size-props, $size, "tab-padding-horizontal");
+      height: map.get($hds-tabs-size-props, $size, "tab-height");
+      padding: var(--token-tabs-tab-padding-vertical) map.get($hds-tabs-size-props, $size, "tab-padding-horizontal");
     }
   
     .hds-tabs__tab-button {
-      font-size: map-get($hds-tabs-size-props, $size, "tab-font-size");
+      font-size: map.get($hds-tabs-size-props, $size, "tab-font-size");
     }
   }
 }

--- a/packages/components/src/styles/mixins/_button.scss
+++ b/packages/components/src/styles/mixins/_button.scss
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+@use "sass:map";
+
 $hds-button-sizes: ( "small", "medium", "large" );
 $hds-button-border-radius: 5px;
 $hds-button-border-width: 1px;
@@ -273,24 +275,24 @@ $hds-button-size-props: (
 @mixin hds-button-size-classes($blockName) {
   @each $size in $hds-button-sizes {
     .#{$blockName}--size-#{$size} {
-      min-height: map-get($hds-button-size-props, $size, "min-height");
-      padding: map-get($hds-button-size-props, $size, "padding-vertical") map-get($hds-button-size-props, $size, "padding-horizontal");
+      min-height: map.get($hds-button-size-props, $size, "min-height");
+      padding: map.get($hds-button-size-props, $size, "padding-vertical") map.get($hds-button-size-props, $size, "padding-horizontal");
 
       .#{$blockName}__icon {
-        width: map-get($hds-button-size-props, $size, "icon-size");
-        height: map-get($hds-button-size-props, $size, "icon-size");
+        width: map.get($hds-button-size-props, $size, "icon-size");
+        height: map.get($hds-button-size-props, $size, "icon-size");
       }
 
       .#{$blockName}__text {
-        font-size: map-get($hds-button-size-props, $size, "font-size");
-        line-height: map-get($hds-button-size-props, $size, "line-height");
+        font-size: map.get($hds-button-size-props, $size, "font-size");
+        line-height: map.get($hds-button-size-props, $size, "line-height");
       }
 
       &.#{$blockName}--is-icon-only {
         // overrides to have the icon-only button squared
-        min-width: map-get($hds-button-size-props, $size, "min-height");
-        padding-right: map-get($hds-button-size-props, $size, "padding-vertical");
-        padding-left: map-get($hds-button-size-props, $size, "padding-vertical");
+        min-width: map.get($hds-button-size-props, $size, "min-height");
+        padding-right: map.get($hds-button-size-props, $size, "padding-vertical");
+        padding-left: map.get($hds-button-size-props, $size, "padding-vertical");
       }
     }
   }


### PR DESCRIPTION
### :pushpin: Summary

The following changes will silence sass warnings raised by `rollup-plugin-scss` when building our CSS via `yarn build` 
 - `map-get` is deprecated in favor of `map.get` (available via `sass:map`)
 - `@import` is deprecated in favor of `@use`

Compared the CSS output in `dist` and it is identical before and after the change.

***

### :link: External links

* Jira ticket: [HDS-4260](https://hashicorp.atlassian.net/browse/HDS-4260)

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4260]: https://hashicorp.atlassian.net/browse/HDS-4260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ