### PR TITLE
`Table`: make checkbox aria-labels stay the same regardless of checkbox state

### DIFF
--- a/.changeset/lovely-goats-work.md
+++ b/.changeset/lovely-goats-work.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Table` - fixed the aria-labels for select row and select all checkboxes so they do not change based on the state of the checkbox.

--- a/packages/components/src/components/hds/table/th-selectable.ts
+++ b/packages/components/src/components/hds/table/th-selectable.ts
@@ -57,13 +57,8 @@ export default class HdsTableThSelectable extends Component<HdsTableThSelectable
   }
 
   get ariaLabel(): string {
-    const { selectionAriaLabelSuffix } = this.args;
-    const prefix = this.isSelected ? 'Deselect' : 'Select';
-    if (selectionAriaLabelSuffix) {
-      return `${prefix} ${selectionAriaLabelSuffix}`;
-    } else {
-      return prefix;
-    }
+    const { selectionAriaLabelSuffix = 'row' } = this.args;
+    return `Select ${selectionAriaLabelSuffix}`;
   }
 
   get ariaSort(): HdsTableThSortOrderLabels | undefined {

--- a/showcase/tests/integration/components/hds/table/index-test.js
+++ b/showcase/tests/integration/components/hds/table/index-test.js
@@ -627,6 +627,12 @@ module('Integration | Component | hds/table/index', function (hooks) {
 
     assert.dom(selectAllCheckboxSelector).hasAria('label', 'Select all rows');
     assert.dom(rowCheckboxesSelector).hasAria('label', 'Select row');
+
+    await click(selectAllCheckboxSelector);
+    await click(rowCheckboxesSelector);
+
+    assert.dom(selectAllCheckboxSelector).hasAria('label', 'Select all rows');
+    assert.dom(rowCheckboxesSelector).hasAria('label', 'Select row');
   });
 
   test('it renders the expected `aria-label` for rows with `@selectionAriaLabelSuffix`', async function (assert) {
@@ -650,6 +656,10 @@ module('Integration | Component | hds/table/index', function (hooks) {
         </:body>
       </Hds::Table>
     `);
+
+    assert.dom(rowCheckboxesSelector).hasAria('label', 'Select custom suffix');
+
+    await click(rowCheckboxesSelector);
 
     assert.dom(rowCheckboxesSelector).hasAria('label', 'Select custom suffix');
   });

--- a/showcase/tests/integration/components/hds/table/index-test.js
+++ b/showcase/tests/integration/components/hds/table/index-test.js
@@ -606,7 +606,30 @@ module('Integration | Component | hds/table/index', function (hooks) {
 
   // aria-labels
 
-  test('it renders the expected `aria-label` values for "select all" and rows (based on provided suffix)', async function (assert) {
+  test('it renders the expected `aria-label` values for "select all" and rows by default', async function (assert) {
+    setSelectableTableData(this);
+    await render(hbs`
+      <Hds::Table
+        @isSelectable={{true}}
+        @model={{this.model}}
+        @columns={{this.columns}}
+        id="data-test-selectable-table"
+      >
+        <:body as |B|>
+          <B.Tr @selectionKey={{B.data.id}}>
+            <B.Td>{{B.data.artist}}</B.Td>
+            <B.Td>{{B.data.album}}</B.Td>
+            <B.Td>{{B.data.year}}</B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
+    `);
+
+    assert.dom(selectAllCheckboxSelector).hasAria('label', 'Select all rows');
+    assert.dom(rowCheckboxesSelector).hasAria('label', 'Select row');
+  });
+
+  test('it renders the expected `aria-label` for rows with `@selectionAriaLabelSuffix`', async function (assert) {
     setSelectableTableData(this);
     await render(hbs`
       <Hds::Table
@@ -627,31 +650,7 @@ module('Integration | Component | hds/table/index', function (hooks) {
         </:body>
       </Hds::Table>
     `);
-    const rowCheckboxes = this.element.querySelectorAll(rowCheckboxesSelector);
-    const firstRowCheckbox = rowCheckboxes[0];
-    const secondRowCheckbox = rowCheckboxes[1];
 
-    assert.dom(selectAllCheckboxSelector).hasAria('label', 'Select all rows');
     assert.dom(rowCheckboxesSelector).hasAria('label', 'Select custom suffix');
-    await click(firstRowCheckbox);
-    assert.dom(selectAllCheckboxSelector).hasAria('label', 'Select all rows');
-    assert.dom(firstRowCheckbox).hasAria('label', 'Deselect custom suffix');
-    assert.dom(secondRowCheckbox).hasAria('label', 'Select custom suffix');
-    await click(selectAllCheckboxSelector);
-    assert.dom(selectAllCheckboxSelector).hasAria('label', 'Deselect all rows');
-    assert.dom(firstRowCheckbox).hasAria('label', 'Deselect custom suffix');
-    assert.dom(secondRowCheckbox).hasAria('label', 'Deselect custom suffix');
-    await click(secondRowCheckbox);
-    assert.dom(selectAllCheckboxSelector).hasAria('label', 'Select all rows');
-    assert.dom(firstRowCheckbox).hasAria('label', 'Deselect custom suffix');
-    assert.dom(secondRowCheckbox).hasAria('label', 'Select custom suffix');
-    await click(secondRowCheckbox);
-    assert.dom(selectAllCheckboxSelector).hasAria('label', 'Deselect all rows');
-    assert.dom(firstRowCheckbox).hasAria('label', 'Deselect custom suffix');
-    assert.dom(secondRowCheckbox).hasAria('label', 'Deselect custom suffix');
-    await click(selectAllCheckboxSelector);
-    assert.dom(selectAllCheckboxSelector).hasAria('label', 'Select all rows');
-    assert.dom(firstRowCheckbox).hasAria('label', 'Select custom suffix');
-    assert.dom(secondRowCheckbox).hasAria('label', 'Select custom suffix');
   });
 });

--- a/showcase/tests/integration/components/hds/table/tr-test.js
+++ b/showcase/tests/integration/components/hds/table/tr-test.js
@@ -49,10 +49,6 @@ module('Integration | Component | hds/table/tr', function (hooks) {
       hbs`<Hds::Table::Tr id="data-test-table-tr" @isSelectable={{true}} @selectionAriaLabelSuffix="row 123" />`
     );
     assert.dom(checkboxSelector).hasAria('label', 'Select row 123');
-    await render(
-      hbs`<Hds::Table::Tr id="data-test-table-tr" @isSelectable={{true}} @isSelected={{true}} @selectionAriaLabelSuffix="row 123" />`
-    );
-    assert.dom(checkboxSelector).hasAria('label', 'Deselect row 123');
   });
 
   test('the `th` element has the correct `scope` attribute value provided via `@selectionScope`', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the select all and select row checkbox labels so the visually hidden label is always `Select {selectionAriaLabelSuffix}` and update the default of selectionAriaLabelSuffix to be 'row'.

It is not compliant to have the label of a form input change based on the state of the input because it makes it harder for users to find again / understand what the input is for. Instead, it is better to keep the input name consistent and let the screen reader use the html attributes on the input to convey the state (in this case, checked or unchecked).

### :camera_flash: Screenshots

**Before**

![Screenshot 2024-12-11 at 3 29 32 PM](https://github.com/user-attachments/assets/c4bb4a25-1f12-4271-a185-6c40e99b085a)
![Screenshot 2024-12-11 at 3 29 23 PM](https://github.com/user-attachments/assets/9bd2cc4a-41d8-4709-9f9d-4f44a3fff274)
![Screenshot 2024-12-11 at 3 29 14 PM](https://github.com/user-attachments/assets/f8f86093-eb48-4ab3-b639-c7dc7d5c9483)
![Screenshot 2024-12-11 at 3 29 04 PM](https://github.com/user-attachments/assets/47d3c06f-9e74-48b1-a614-8cde4ddb5ea3)

**After**
![Screenshot 2024-12-11 at 3 32 30 PM](https://github.com/user-attachments/assets/47c3b1da-3dc8-4b5b-964b-2efdcf6096c6)
![Screenshot 2024-12-11 at 3 32 22 PM](https://github.com/user-attachments/assets/fd85d374-633f-4553-838e-c9f1b2e90bb4)
![Screenshot 2024-12-11 at 3 32 10 PM](https://github.com/user-attachments/assets/4cc4cd55-8ece-4054-98ae-12d55b352965)
![Screenshot 2024-12-11 at 3 31 53 PM](https://github.com/user-attachments/assets/190c869b-1cd3-46cf-ba03-271a323a3304)



### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4258](https://hashicorp.atlassian.net/browse/HDS-4258)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4258]: https://hashicorp.atlassian.net/browse/HDS-4258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ