### PR TITLE
`Flyout` - Element prop name update

### DIFF
--- a/packages/components/src/components/hds/flyout/index.ts
+++ b/packages/components/src/components/hds/flyout/index.ts
@@ -59,6 +59,8 @@ export interface HdsFlyoutSignature {
 
 export default class HdsFlyout extends Component<HdsFlyoutSignature> {
   @tracked private _isOpen = false;
+  // TODO: make this property private; currently blocked by our consumers relying on it despite not being part of the public API: https://github.com/hashicorp/cloud-ui/blob/main/engines/waypoint/addon/components/preview-pane.ts#L15
+  // private _element!: HTMLDialogElement;
   element!: HTMLDialogElement;
   private _body!: HTMLElement;
   private _bodyInitialOverflowValue = '';

--- a/packages/components/src/components/hds/flyout/index.ts
+++ b/packages/components/src/components/hds/flyout/index.ts
@@ -59,7 +59,7 @@ export interface HdsFlyoutSignature {
 
 export default class HdsFlyout extends Component<HdsFlyoutSignature> {
   @tracked private _isOpen = false;
-  private _element!: HTMLDialogElement;
+  element!: HTMLDialogElement;
   private _body!: HTMLElement;
   private _bodyInitialOverflowValue = '';
 
@@ -116,7 +116,7 @@ export default class HdsFlyout extends Component<HdsFlyoutSignature> {
   @action
   didInsert(element: HTMLDialogElement): void {
     // Store references of `<dialog>` and `<body>` elements
-    this._element = element;
+    this.element = element;
     this._body = document.body;
 
     if (this._body) {
@@ -126,18 +126,18 @@ export default class HdsFlyout extends Component<HdsFlyoutSignature> {
     }
 
     // Register "onClose" callback function to be called when a native 'close' event is dispatched
-    this._element.addEventListener('close', this.registerOnCloseCallback, true);
+    this.element.addEventListener('close', this.registerOnCloseCallback, true);
 
     // If the flyout dialog is not already open
-    if (!this._element.open) {
+    if (!this.element.open) {
       this.open();
     }
   }
 
   @action
   willDestroyNode(): void {
-    if (this._element) {
-      this._element.removeEventListener(
+    if (this.element) {
+      this.element.removeEventListener(
         'close',
         this.registerOnCloseCallback,
         true
@@ -148,7 +148,7 @@ export default class HdsFlyout extends Component<HdsFlyoutSignature> {
   @action
   open(): void {
     // Make flyout dialog visible using the native `showModal` method
-    this._element.showModal();
+    this.element.showModal();
     this._isOpen = true;
 
     // Prevent page from scrolling when the dialog is open
@@ -165,17 +165,17 @@ export default class HdsFlyout extends Component<HdsFlyoutSignature> {
     // allow ember test helpers to be aware of when the `close` event fires
     // when using `click` or other helpers from '@ember/test-helpers'
     // Notice: this code will get stripped out in production builds (DEBUG evaluates to `true` in dev/test builds, but `false` in prod builds)
-    if (this._element.open) {
+    if (this.element.open) {
       const token = waiter.beginAsync();
       const listener = () => {
         waiter.endAsync(token);
-        this._element.removeEventListener('close', listener);
+        this.element.removeEventListener('close', listener);
       };
-      this._element.addEventListener('close', listener);
+      this.element.addEventListener('close', listener);
     }
 
     // Make flyout dialog invisible using the native `close` method
-    this._element.close();
+    this.element.close();
 
     // Reset page `overflow` property
     if (this._body) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue with the `flyout` component from the recent [private prop standardization effort](https://github.com/hashicorp/design-system/pull/2562), that caused a [failing test](https://github.com/hashicorp/cloud-ui/actions/runs/12282942326/job/34276665856?pr=11357) in `cloud-ui`. This issue was related to the private property name update of the property `element` to `_element`

### :hammer_and_wrench: Detailed description

In smoke testing the upcoming 4.15 release in Cloud UI, a [failing test](https://github.com/hashicorp/cloud-ui/actions/runs/12282942326/job/34276665856?pr=11357) was caught tied to the `Flyout` component. This failing test is related to the recent [private prop standardization effort](https://github.com/hashicorp/design-system/pull/2562).

<img width="969" alt="Screenshot 2024-12-12 at 6 59 49 AM" src="https://github.com/user-attachments/assets/3515e073-38f6-452d-9d50-922b9b70cc3d" />


In that recent update, the `element` property defined inside the `flyout` was updated to `_element`. This property is actually an extension of the Glimmer component `Element` property defined in the `HdsFlyoutSignature`.  As stated in the error message for the failing test, the `element` property is not available in ember.js apps. The only way to override the error message is by defining a class field of the same name `element`. Thus, when this name was updated to `_element`, this error message stopped being overridden. 

In this PR, I have reverted the name change of this variable back to `element`, so that the error message continues to be overridden.

This change has been [smoke tested](https://github.com/hashicorp/cloud-ui/pull/11357) in cloud-ui, and all tests are now passing.

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-2508](https://hashicorp.atlassian.net/browse/HDS-2508)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-2508]: https://hashicorp.atlassian.net/browse/HDS-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ