### PR TITLE
`Alert` - Removed color from parent “text” wrapper

### DIFF
--- a/packages/components/src/styles/components/alert.scss
+++ b/packages/components/src/styles/components/alert.scss
@@ -39,7 +39,6 @@
   flex-direction: column;
   gap: 4px;
   justify-content: center;
-  color: var(--token-color-foreground-warning-on-surface);
 }
 
 .hds-alert__description {


### PR DESCRIPTION
### :pushpin: Summary

While working on the theming spike, I noticed that the `hds-alert__text` element (container for `Title` and `Description` content) has a default color applied that is clearly not correct (it's yellow). Probably a leftover from the initial implementation of the component. 

### :camera_flash: Screenshots

<img width="1579" alt="screenshot_4497" src="https://github.com/user-attachments/assets/43b1ca8f-e13b-4523-90e7-97f47d38c7f4" />

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
