### PR TITLE
`Time` - Docs broken link fix

### DIFF
--- a/website/docs/components/time/partials/code/how-to-use.md
+++ b/website/docs/components/time/partials/code/how-to-use.md
@@ -1,6 +1,6 @@
 !!! Info
 
-The Time component exists only in code. The Figma equivalent would be a manually input text object with a formatted string. For writing guidelines related to this component, read our content [Date and Time](content/writing-guidelines#date-and-time) section.
+The Time component exists only in code. The Figma equivalent would be a manually input text object with a formatted string. For writing guidelines related to this component, read our content [Date and Time](/content/writing-guidelines#date-and-time) section.
 
 !!!
 


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes a broken link in the recently published [docs](https://helios.hashicorp.design/components/time) for the `Time` component. The broken link is in the alert at the top of the page pointing to the [Date and Time writing guidelines](https://helios.hashicorp.design/content/writing-guidelines#date-and-time). 

Clicking on this link in the current docs causes an error to occur.

<img width="959" alt="Screenshot 2024-12-13 at 8 14 02 AM" src="https://github.com/user-attachments/assets/1a148205-5634-49c1-8376-64995a1bbcb5" />
