### PR TITLE
Showcase: Fix `Table` selectable + sortable th table examples

### DIFF
--- a/showcase/app/templates/components/table.hbs
+++ b/showcase/app/templates/components/table.hbs
@@ -1498,7 +1498,7 @@
                   <Hds::Table::ThSelectable
                     @selectionScope="col"
                     @isSelected={{bool1}}
-                    @onClickSort={{if bool2 this.noop}}
+                    @onClickSortBySelected={{if bool2 this.noop}}
                   />
                   <H.Th>Lorem</H.Th>
                 </H.Tr>
@@ -1517,7 +1517,7 @@
                   <Hds::Table::ThSelectable
                     @selectionScope="col"
                     @isSelected={{bool1}}
-                    @onClickSort={{if bool2 this.noop}}
+                    @onClickSortBySelected={{if bool2 this.noop}}
                     mock-state-value="focus"
                     mock-state-selector="input"
                   />
@@ -1549,7 +1549,7 @@
                 <Hds::Table::ThSelectable
                   @selectionScope="col"
                   @isSelected={{true}}
-                  @onClickSort={{if bool this.noop}}
+                  @onClickSortBySelected={{if bool this.noop}}
                   @didInsert={{this.mockIndeterminateState}}
                 />
                 <H.Th>Lorem</H.Th>
@@ -1574,7 +1574,7 @@
                   @selectionScope="col"
                   @isSelected={{true}}
                   @didInsert={{this.mockIndeterminateState}}
-                  @onClickSort={{if bool this.noop}}
+                  @onClickSortBySelected={{if bool this.noop}}
                   mock-state-value="focus"
                   mock-state-selector="input"
                 />


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an argument name in the Table showcase so it accurately displays a selectable th with a sort button.

### :camera_flash: Screenshots

**Before**
<img width="1002" alt="Screenshot 2024-12-13 at 4 31 43 PM" src="https://github.com/user-attachments/assets/ad62988c-913d-426a-9a39-cfb220ff585b" />

**After**
<img width="1042" alt="Screenshot 2024-12-13 at 4 31 58 PM" src="https://github.com/user-attachments/assets/91fcf744-8f6c-49aa-9c42-34dad914f197" />

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
