### PR TITLE
Adjust a few documentation headings

### DIFF
--- a/website/docs/components/accordion/partials/code/how-to-use.md
+++ b/website/docs/components/accordion/partials/code/how-to-use.md
@@ -181,7 +181,7 @@ The `@forceState` argument enables you to implement expand/collapse all function
   </Hds::Accordion>
 ```
 
-### ariaLabel
+### Accessible name
 
 The `ariaLabel` value is applied to the HTML button which controls visibility of the content block. The text does not display in the UI. The default value is "Toggle display" but you can set a custom value useful for translated text for example.
 
@@ -196,7 +196,7 @@ The `ariaLabel` value is applied to the HTML button which controls visibility of
   </Hds::Accordion>
 ```
 
-### titleTag
+### Title tag
 
 The `@titleTag` argument changes the HTML element that wraps the title block of each `Accordion::Item`. When organizing the content on a webpage, the heading levels should reflect the structure of the page. For example, if an Accordion is within a subsection of the page below a heading level 2, the value should be `"h3"`.
 
@@ -232,7 +232,7 @@ The default `@titleTag` is `"div"` because the correct value is dependent on the
 
 !!!
 
-### isOpen
+### Open
 
 Set `isOpen` to `true` on an `Accordion::Item` to display its associated content on page load instead of initially hiding it.
 
@@ -253,7 +253,7 @@ Set `isOpen` to `true` on an `Accordion::Item` to display its associated content
   </Hds::Accordion>
 ```
 
-### isStatic
+### Static
 
 Set `isStatic` to `true` on an `Accordion::Item` to remove the ability to interact with the toggle.
 
@@ -274,7 +274,7 @@ Set `isStatic` to `true` on an `Accordion::Item` to remove the ability to intera
   </Hds::Accordion>
 ```
 
-### containsInteractive
+### Contains interactive
 
 By default, the `containsInteractive` property of the `Accordion::Item` is set to `false`, meaning that the entire `Accordion::Item` toggle block can be clicked to hide and show the associated content. If set to `true`, only the chevron button of the `Accordion::Item` is clickable vs. the entire block. This allows you to add other interactive content inside the toggle block if desired.
 

--- a/website/docs/components/application-state/partials/code/how-to-use.md
+++ b/website/docs/components/application-state/partials/code/how-to-use.md
@@ -171,7 +171,7 @@ To indicate that the message is an error state, add `@errorCode` to the `[A].Hea
 </Hds::ApplicationState>
 ```
 
-### titleTag
+### Title tag
 
 The `@titleTag` argument changes the HTML element that wraps the `[A].Header` title content. When organizing the content on a webpage, the heading levels should reflect the structure of the page. For example, if an Application State is used as an empty state below the main heading of a page, the value should be `"h2"`. 
 

--- a/website/docs/components/copy/button/partials/code/how-to-use.md
+++ b/website/docs/components/copy/button/partials/code/how-to-use.md
@@ -40,7 +40,7 @@ This indicates that the component should take up the full-width of the parent co
 <Hds::Copy::Button @text="Copy" @targetToCopy="#clipboardTarget4" @isFullWidth={{true}} />
 ```
 
-### Text to Copy
+### Text to copy
 
 The consumer can also indicate a string to be copied instead of indicating a target element:
 

--- a/website/docs/components/copy/snippet/partials/code/how-to-use.md
+++ b/website/docs/components/copy/snippet/partials/code/how-to-use.md
@@ -23,7 +23,7 @@ This indicates that the component should take up the full-width of the parent co
 <Hds::Copy::Snippet @textToCopy="e4rt-yg80-39kt" @isFullWidth={{true}} />
 ```
 
-### isTruncated
+### Truncation
 
 When set to `true`, this constrains text to one-line and truncates it if it does not fit the available space.
 

--- a/website/docs/components/reveal/partials/code/how-to-use.md
+++ b/website/docs/components/reveal/partials/code/how-to-use.md
@@ -8,7 +8,7 @@ The Reveal component renders a button that triggers the display of additional co
 </Hds::Reveal>
 ```
 
-### textWhenOpen
+### Text when open
 
 You can display different text on the toggle button when the `Reveal` is open.
 
@@ -18,7 +18,7 @@ You can display different text on the toggle button when the `Reveal` is open.
 </Hds::Reveal>
 ```
 
-### isOpen
+### Open
 
 Set `isOpen` to `true` to display the content on page load instead of initially hiding it.
 

--- a/website/docs/components/rich-tooltip/partials/code/how-to-use.md
+++ b/website/docs/components/rich-tooltip/partials/code/how-to-use.md
@@ -182,7 +182,7 @@ The default option is a combination of `flip`+`shift` and is the suggested one, 
 
 !!! Info
 
-More in-depth explanations about the different alignment algorithms and how they work can be found in the Floating UI documentation. See [flip](https://floating-ui.com/docs/flip), [shift](https://floating-ui.com/docs/shift), and [autoPlacement](https://floating-ui.com/docs/autoPlacement)).
+More in-depth explanations about the different alignment algorithms and how they work can be found in the Floating UI documentation. See [flip](https://floating-ui.com/docs/flip), [shift](https://floating-ui.com/docs/shift), and [autoPlacement](https://floating-ui.com/docs/autoPlacement).
 
 !!!
 
@@ -260,7 +260,7 @@ The default spacing between the toggle and the tooltip itself can be tweaked usi
 </Hds::RichTooltip>
 ```
 
-#### isOpen
+#### Open
 
 The tooltip can be rendered as initially opened using the `@isOpen` argument:
 
@@ -281,4 +281,3 @@ The tooltip can be rendered as initially opened using the `@isOpen` argument:
 This option should be considered carefully before being implemented in production code, because in this case the popover is in what's called a "manual" state, which means it can't be dismissed via `esc` or "click outside" until the end-user has interacted with it.
 
 !!!
-

--- a/website/docs/utilities/dialog-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/dialog-primitive/partials/code/how-to-use.md
@@ -35,7 +35,7 @@ The `DialogPrimitive` serves as the foundation for dialog derived components lik
 </Hds::DialogPrimitive::Wrapper>
 ```
 
-### Header titleTag
+### Header title tag
 
 The `@titleTag` argument changes the HTML element that wraps the `DialogPrimitive::Header` tagline and "title" content. When organizing the content on a webpage, the heading levels should reflect the structure of the page. For example, if the `DialogPrimitive` is used as a Split Window, the value should be `"h2"`. 
 


### PR DESCRIPTION
### :pushpin: Summary

We generally avoid using argument names as headings, with a few exceptions making their way into our docs. I adjusted these to be more 'human-friendly' and aligned with the rest of the headings across our docs. I also checked for any potential direct links to these headings/sections to make sure we're not breaking them.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
