### PR TITLE
Website - Add 4.15 link to release notes

### DIFF
--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -14,6 +14,8 @@
 
 ## 4.15.0
 
+[4.15.0 documentation](https://hds-website-4-15-0.vercel.app/)
+
 **Minor changes**
 
 `Time` - Added Time component, Time service, and related libraries including:


### PR DESCRIPTION
### :pushpin: Summary

In the recent 4.15 release, the [Vercel alias link](https://hds-website-4-15-0.vercel.app/) was not automatically added to the website [release notes](https://helios.hashicorp.design/whats-new/release-notes) due to an issue with the `generate-changelog-markdown-files` script. 

This PR manually adds that link into the file, until the issue with the script can be sorted.
