### PR TITLE
Showcase - fix Sass warnings (HDS-4261)

### DIFF
--- a/showcase/app/styles/_globals.scss
+++ b/showcase/app/styles/_globals.scss
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+ @use "./typography" as *;
+
 *,
 *::before,
 *::after {

--- a/showcase/app/styles/app.scss
+++ b/showcase/app/styles/app.scss
@@ -3,75 +3,75 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-@import "@hashicorp/design-system-components";
-@import "@hashicorp/design-system-power-select-overrides";
+@use "@hashicorp/design-system-components";
+@use "@hashicorp/design-system-power-select-overrides";
 
 // global declarations
 
-@import "./tokens";
-@import "./layout";
-@import "./typography";
-@import "./globals";
+@use "./tokens";
+@use "./layout";
+@use "./typography";
+@use "./globals";
 
 // local components
 
-@import "./showcase-components/autoscrollable";
-@import "./showcase-components/divider";
-@import "./showcase-components/flex";
-@import "./showcase-components/frame";
-@import "./showcase-components/grid";
-@import "./showcase-components/label";
-@import "./showcase-components/outliner";
-@import "./showcase-components/placeholder";
-@import "./mock-components/app";
+@use "./showcase-components/autoscrollable";
+@use "./showcase-components/divider";
+@use "./showcase-components/flex";
+@use "./showcase-components/frame";
+@use "./showcase-components/grid";
+@use "./showcase-components/label";
+@use "./showcase-components/outliner";
+@use "./showcase-components/placeholder";
+@use "./mock-components/app";
 
 
 // Notice: this list can be automatically edited by the Ember blueprint, please don't remove the start/end comments
 // START COMPONENT PAGES IMPORTS
-@import "./showcase-pages/accordion";
-@import "./showcase-pages/alert";
-@import "./showcase-pages/app-header";
-@import "./showcase-pages/app-footer";
-@import "./showcase-pages/application-state";
-@import "./showcase-pages/app-frame";
-@import "./showcase-pages/app-side-nav";
-@import "./showcase-pages/badge";
-@import "./showcase-pages/breadcrumb";
-@import "./showcase-pages/button";
-@import "./showcase-pages/card";
-@import "./showcase-pages/code-block";
-@import "./showcase-pages/copy/button";
-@import "./showcase-pages/copy/snippet";
-@import "./showcase-pages/dialog-primitive";
-@import "./showcase-pages/disclosure-primitive";
-@import "./showcase-pages/dismiss-button";
-@import "./showcase-pages/dropdown";
-@import "./showcase-pages/flyout";
-@import "./showcase-pages/form/base-elements";
-@import "./showcase-pages/form/checkbox";
-@import "./showcase-pages/form/file-input";
-@import "./showcase-pages/form/radio";
-@import "./showcase-pages/form/select";
-@import "./showcase-pages/form/super-select";
-@import "./showcase-pages/form/text-input";
-@import "./showcase-pages/form/textarea";
-@import "./showcase-pages/form/toggle";
-@import "./showcase-pages/icon";
-@import "./showcase-pages/link-inline";
-@import "./showcase-pages/menu-primitive";
-@import "./showcase-pages/modal";
-@import "./showcase-pages/page-header";
-@import "./showcase-pages/pagination";
-@import "./showcase-pages/popover-primitive";
-@import "./showcase-pages/power-select";
-@import "./showcase-pages/reveal";
-@import "./showcase-pages/rich-tooltip";
-@import "./showcase-pages/separator";
-@import "./showcase-pages/side-nav";
-@import "./showcase-pages/table";
-@import "./showcase-pages/tabs";
-@import "./showcase-pages/tag";
-@import "./showcase-pages/text";
-@import "./showcase-pages/tooltip";
-@import "./showcase-pages/typography";
+@use "./showcase-pages/accordion" as showcase-accordion;
+@use "./showcase-pages/alert" as showcase-alert;
+@use "./showcase-pages/app-header" as showcase-app-header;
+@use "./showcase-pages/app-footer" as showcase-app-footer;
+@use "./showcase-pages/application-state" as showcase-application-state;
+@use "./showcase-pages/app-frame" as showcase-app-frame;
+@use "./showcase-pages/app-side-nav" as showcase-app-side-nav;
+@use "./showcase-pages/badge" as showcase-badge;
+@use "./showcase-pages/breadcrumb" as showcase-breadcrumb;
+@use "./showcase-pages/button" as showcase-button;
+@use "./showcase-pages/card" as showcase-card;
+@use "./showcase-pages/code-block" as showcase-code-block;
+@use "./showcase-pages/copy/button" as showcase-copy-button;
+@use "./showcase-pages/copy/snippet" as showcase-copy-snippet;
+@use "./showcase-pages/dialog-primitive" as showcase-dialog-primitive;
+@use "./showcase-pages/disclosure-primitive" as showcase-disclosure-primitive;
+@use "./showcase-pages/dismiss-button" as showcase-dismiss-button;
+@use "./showcase-pages/dropdown" as showcase-dropdown;
+@use "./showcase-pages/flyout" as showcase-flyout;
+@use "./showcase-pages/form/base-elements" as showcase-form-base-elements;
+@use "./showcase-pages/form/checkbox" as showcase-checkbox;
+@use "./showcase-pages/form/file-input" as showcase-file-input;
+@use "./showcase-pages/form/radio" as showcase-radio;
+@use "./showcase-pages/form/select" as showcase-select;
+@use "./showcase-pages/form/super-select" as showcase-super-select;
+@use "./showcase-pages/form/text-input" as showcase-text-input;
+@use "./showcase-pages/form/textarea" as showcase-textarea;
+@use "./showcase-pages/form/toggle" as showcase-toggle;
+@use "./showcase-pages/icon" as showcase-icon;
+@use "./showcase-pages/link-inline" as showcase-link-inline;
+@use "./showcase-pages/menu-primitive" as showcase-menu-primitive;
+@use "./showcase-pages/modal" as showcase-modal;
+@use "./showcase-pages/page-header" as showcase-page-header;
+@use "./showcase-pages/pagination" as showcase-pagination;
+@use "./showcase-pages/popover-primitive" as showcase-popover-primitive;
+@use "./showcase-pages/power-select" as showcase-power-select;
+@use "./showcase-pages/reveal" as showcase-reveal;
+@use "./showcase-pages/rich-tooltip" as showcase-rich-tooltip;
+@use "./showcase-pages/separator" as showcase-separator;
+@use "./showcase-pages/side-nav" as showcase-side-nav;
+@use "./showcase-pages/table" as showcase-table;
+@use "./showcase-pages/tabs" as showcase-tabs;
+@use "./showcase-pages/tag" as showcase-tag;
+@use "./showcase-pages/text" as showcase-text;
+@use "./showcase-pages/tooltip" as showcase-tooltip;
+@use "./showcase-pages/typography" as showcase-typography;
 // END COMPONENT PAGES IMPORTS

--- a/showcase/app/styles/showcase-components/label.scss
+++ b/showcase/app/styles/showcase-components/label.scss
@@ -5,6 +5,8 @@
 
 // LABEL
 
+@use "../typography" as *;
+
 .shw-label {
   @include shw-font-family("rubik");
   margin: 0 0 10px 0;

--- a/showcase/app/styles/showcase-pages/alert.scss
+++ b/showcase/app/styles/showcase-pages/alert.scss
@@ -5,6 +5,8 @@
 
 // ALERT
 
+@use "../typography" as *;
+
 body.components-alert {
   // we outline the "compact" variant to make its bounding box visible
   .hds-alert--type-compact {

--- a/showcase/app/styles/showcase-pages/app-footer.scss
+++ b/showcase/app/styles/showcase-pages/app-footer.scss
@@ -5,6 +5,8 @@
 
 // APP-FOOTER
 
+@use 'sass:color';
+
 body.components-app-footer {
   .shw-component-app-footer-layout-highlight {
     .hds-app-footer,
@@ -18,8 +20,8 @@ body.components-app-footer {
     .shw-component-app-footer-tablet-view,
     .shw-component-app-footer-mobile-large-view,
     .shw-component-app-footer-mobile-small-view {
-      .hds-app-footer__list-item { background: lighten(#006ae7, 30%); }
-      .hds-app-footer__legal-links { background: lighten(#006ae7, 45%); }
+      .hds-app-footer__list-item { background: color.adjust(#006ae7, $lightness: 30%, $space: hsl); }
+      .hds-app-footer__legal-links { background: color.adjust(#006ae7, $lightness: 45%, $space: hsl); }
       // using !important to override inline style:
       .shw-app-footer-extra { background: #ff7575 !important; }
 

--- a/showcase/app/styles/showcase-pages/copy/button.scss
+++ b/showcase/app/styles/showcase-pages/copy/button.scss
@@ -5,6 +5,8 @@
 
 // COPY > BUTTON
 
+@use "../../typography" as *;
+
 body.components-copy-button {
   .shw-component-copy-button-composition-masked-input-base {
     display: flex;

--- a/showcase/app/styles/showcase-pages/power-select.scss
+++ b/showcase/app/styles/showcase-pages/power-select.scss
@@ -8,4 +8,4 @@
 // this needs to be manually imported to apply the standard
 // "ember-power-select" styling to the element
 // (the file is inside the `node_modules`)
-@import "ember-power-select";
+@use "ember-power-select";

--- a/showcase/app/styles/showcase-pages/table.scss
+++ b/showcase/app/styles/showcase-pages/table.scss
@@ -5,6 +5,8 @@
 
 // TABLE
 
+@use "../typography" as *;
+
 body.components-table {
   // we need to increase spacing between sections for this page because is too crowded
   .shw-divider:not(.shw-divider--level-2) {

--- a/showcase/app/styles/showcase-pages/tabs.scss
+++ b/showcase/app/styles/showcase-pages/tabs.scss
@@ -5,6 +5,8 @@
 
 // TAB
 
+@use "../typography" as *;
+
 body.components-tabs {
 
   // we add extra spacing to increase visual separation between the different use cases and examples


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will update Sass style files for the Showcase to resolve deprecation warnings.

### :hammer_and_wrench: Detailed description

* Replaced `@import` with `@use` 
(https://sass-lang.com/documentation/breaking-changes/import/)
* More to come...

<!-- 
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-4261](https://hashicorp.atlassian.net/browse/HDS-4261)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4261]: https://hashicorp.atlassian.net/browse/HDS-4261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ