### PR TITLE
fix: lint:css:fix command in components and showcase

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,7 +27,7 @@
     "lint": "concurrently \"yarn:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"yarn:lint:*:fix\" --names \"fix:\"",
     "lint:css": "stylelint \"src/styles/**/*.scss\"",
-    "lint:css:fix": "concurrently \"yarn:lint:css -- --fix\"",
+    "lint:css:fix": "concurrently \"yarn:lint:css --fix\"",
     "lint:types": "glint",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -19,7 +19,7 @@
     "lint": "concurrently \"yarn:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"yarn:lint:*:fix\" --names \"fix:\"",
     "lint:css": "stylelint \"app/styles/**/*.scss\"",
-    "lint:css:fix": "concurrently \"yarn:lint:css -- --fix\"",
+    "lint:css:fix": "concurrently \"yarn:lint:css --fix\"",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue with the `lint:css:fix` command in the components package and showcase.

### :hammer_and_wrench: Detailed description

In reviewing, #2629 it was observed that the `lint:css:fix` command was not properly working across the repo. If a CSS error to a file is introduced, such as swapping the order of two properties, the linter will catch the issue, but `--fix` was not applying the fix.

### :camera_flash: Screenshots

Output after creating a linting error in a CSS file.

Before
<img width="774" alt="Screenshot 2024-12-27 at 7 40 25 AM" src="https://github.com/user-attachments/assets/c652ce0c-2af7-428a-8951-355e7eede207" />

After
<img width="386" alt="Screenshot 2024-12-27 at 7 40 30 AM" src="https://github.com/user-attachments/assets/9a5be57a-d20d-40e4-ac56-f8495c6b8ab2" />

