### PR TITLE
Upgrade `ember-qunit` to `9.0.1`

### DIFF
--- a/showcase/package.json
+++ b/showcase/package.json
@@ -78,7 +78,7 @@
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^8.2.3",
     "ember-power-select": "^8.6.0",
-    "ember-qunit": "^8.1.1",
+    "ember-qunit": "^9.0.1",
     "ember-resolver": "^13.1.0",
     "ember-set-helper": "^3.0.1",
     "ember-source": "~5.12.0",

--- a/showcase/tests/test-helper.ts
+++ b/showcase/tests/test-helper.ts
@@ -8,7 +8,8 @@ import config from 'showcase/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
-import { start } from 'ember-qunit';
+import { loadTests } from 'ember-qunit/test-loader';
+import { start, setupEmberOnerrorValidation } from 'ember-qunit';
 import {
   DEFAULT_A11Y_TEST_HELPER_NAMES,
   setRunOptions,
@@ -64,4 +65,6 @@ if (useMiddlewareReporter()) {
 
 setup(QUnit.assert);
 
+setupEmberOnerrorValidation();
+loadTests();
 start();

--- a/website/package.json
+++ b/website/package.json
@@ -87,7 +87,7 @@
     "ember-page-title": "^8.2.3",
     "ember-power-select": "^8.6.0",
     "ember-prism": "^0.13.0",
-    "ember-qunit": "^8.1.1",
+    "ember-qunit": "^9.0.1",
     "ember-resolver": "^13.1.0",
     "ember-router-scroll": "^4.1.2",
     "ember-source": "~5.12.0",

--- a/website/tests/test-helper.js
+++ b/website/tests/test-helper.js
@@ -8,7 +8,8 @@ import config from 'website/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
-import { start } from 'ember-qunit';
+import { loadTests } from 'ember-qunit/test-loader';
+import { start, setupEmberOnerrorValidation } from 'ember-qunit';
 import {
   DEFAULT_A11Y_TEST_HELPER_NAMES,
   setRunOptions,
@@ -64,4 +65,6 @@ if (useMiddlewareReporter()) {
 
 setup(QUnit.assert);
 
+setupEmberOnerrorValidation();
+loadTests();
 start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -12928,21 +12928,6 @@ __metadata:
   linkType: hard
 
 "ember-qunit@npm:*":
-  version: 9.0.1
-  resolution: "ember-qunit@npm:9.0.1"
-  dependencies:
-    "@embroider/addon-shim": "npm:^1.8.6"
-    "@embroider/macros": "npm:^1.13.1"
-    qunit-theme-ember: "npm:^1.0.0"
-  peerDependencies:
-    "@ember/test-helpers": ">=3.0.3"
-    ember-source: ">=4.0.0"
-    qunit: ^2.13.0
-  checksum: 10/547d7e6de8aac5f78c1ef07a4922d2885bff344acf2ae125d0646b4c1eb96e660cdfd114ad6088203ed01d4ca3df04804469e2e3538bc9421979e99e935de5ba
-  languageName: node
-  linkType: hard
-
-"ember-qunit@npm:^8.1.1":
   version: 8.1.1
   resolution: "ember-qunit@npm:8.1.1"
   dependencies:
@@ -12955,6 +12940,21 @@ __metadata:
     ember-source: ">=4.0.0"
     qunit: ^2.13.0
   checksum: 10/547256738a2fddddfffea1a1f0a2b1b66076b0d99548a2c3cc4a89bfa001897fd94cd1a24234149fbd72a13ef7a7ae6586599e51db9d21a0e7ad06ac9719d909
+  languageName: node
+  linkType: hard
+
+"ember-qunit@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "ember-qunit@npm:9.0.1"
+  dependencies:
+    "@embroider/addon-shim": "npm:^1.8.6"
+    "@embroider/macros": "npm:^1.13.1"
+    qunit-theme-ember: "npm:^1.0.0"
+  peerDependencies:
+    "@ember/test-helpers": ">=3.0.3"
+    ember-source: ">=4.0.0"
+    qunit: ^2.13.0
+  checksum: 10/547d7e6de8aac5f78c1ef07a4922d2885bff344acf2ae125d0646b4c1eb96e660cdfd114ad6088203ed01d4ca3df04804469e2e3538bc9421979e99e935de5ba
   languageName: node
   linkType: hard
 
@@ -24118,7 +24118,7 @@ __metadata:
     ember-modifier: "npm:^4.1.0"
     ember-page-title: "npm:^8.2.3"
     ember-power-select: "npm:^8.6.0"
-    ember-qunit: "npm:^8.1.1"
+    ember-qunit: "npm:^9.0.1"
     ember-resolver: "npm:^13.1.0"
     ember-set-helper: "npm:^3.0.1"
     ember-source: "npm:~5.12.0"
@@ -27241,7 +27241,7 @@ __metadata:
     ember-page-title: "npm:^8.2.3"
     ember-power-select: "npm:^8.6.0"
     ember-prism: "npm:^0.13.0"
-    ember-qunit: "npm:^8.1.1"
+    ember-qunit: "npm:^9.0.1"
     ember-resolver: "npm:^13.1.0"
     ember-router-scroll: "npm:^4.1.2"
     ember-source: "npm:~5.12.0"


### PR DESCRIPTION
### :pushpin: Summary

Upgrade the `ember-qunit` package from `8.1.0` to `9.0.1` in the showcase and website `devDependencies`. 

### :hammer_and_wrench: Detailed description

This upgrade of the `ember-qunit` package is part of the ongoing `devDependency` upgrades. This upgrade takes the library up to the latest version of `ember-qunit`.

The one code change required was due to a [breaking change](https://github.com/emberjs/ember-qunit/pull/1182) in the [9.0.0 release](https://github.com/emberjs/ember-qunit/releases/tag/v9.0.0) of `ember-qunit`. Changes to the `start` function required additional imports and function calls to align with the new blueprint recommended for starting tests. 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4251](https://hashicorp.atlassian.net/browse/HDS-4251)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4251]: https://hashicorp.atlassian.net/browse/HDS-4251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ