### PR TITLE
`Tabs` - Implement `aria-controls`

### DIFF
--- a/.changeset/short-rockets-press.md
+++ b/.changeset/short-rockets-press.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Tabs` - Implement `aria-controls` in tab for a11y improvements with toggled content

--- a/packages/components/src/components/hds/tabs/index.hbs
+++ b/packages/components/src/components/hds/tabs/index.hbs
@@ -21,6 +21,7 @@
             didUpdateNode=this.didUpdateTab
             willDestroyNode=this.willDestroyTab
             tabIds=this._tabIds
+            panelIds=this._panelIds
             selectedTabIndex=this.selectedTabIndex
             onClick=this.onClick
             onKeyUp=this.onKeyUp

--- a/packages/components/src/components/hds/tabs/tab.hbs
+++ b/packages/components/src/components/hds/tabs/tab.hbs
@@ -9,6 +9,7 @@
     role="tab"
     type="button"
     id={{this._tabId}}
+    aria-controls={{this.coupledPanelId}}
     aria-selected={{if this.isSelected "true" "false"}}
     tabindex={{unless this.isSelected "-1"}}
     {{did-insert this.didInsertNode @isSelected}}

--- a/packages/components/src/components/hds/tabs/tab.ts
+++ b/packages/components/src/components/hds/tabs/tab.ts
@@ -7,11 +7,12 @@ import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
 import type { IconName } from '@hashicorp/flight-icons/svg';
-import type { HdsTabsTabIds } from './types';
+import type { HdsTabsTabIds, HdsTabsPanelIds } from './types';
 
 export interface HdsTabsTabSignature {
   Args: {
     tabIds?: HdsTabsTabIds;
+    panelIds?: HdsTabsPanelIds;
     selectedTabIndex?: number;
     icon?: IconName;
     count?: string;
@@ -50,6 +51,16 @@ export default class HdsTabsTab extends Component<HdsTabsTabSignature> {
       this.nodeIndex !== undefined &&
       this.nodeIndex === this.args.selectedTabIndex
     );
+  }
+
+  /**
+   * Get the ID of the panel coupled/associated with the tab (it's used by the `aria-controls` attribute)
+   * @returns string}
+   */
+  get coupledPanelId(): string | undefined {
+    return this.nodeIndex !== undefined
+      ? this.args.panelIds?.[this.nodeIndex]
+      : undefined;
   }
 
   @action

--- a/showcase/tests/integration/components/hds/tabs/index-test.js
+++ b/showcase/tests/integration/components/hds/tabs/index-test.js
@@ -315,6 +315,10 @@ module('Integration | Component | hds/tabs/index', function (hooks) {
     assert
       .dom('[data-test="tab-1"] .hds-tabs__tab-button')
       .hasAttribute('role', 'tab');
+    const panelId = find('[data-test="panel-1"]').getAttribute('id');
+    assert
+      .dom('[data-test="tab-1"] .hds-tabs__tab-button')
+      .hasAttribute('aria-controls', panelId);
     assert.dom('[data-test="panel-1"]').hasAttribute('role', 'tabpanel');
     const tabId = find(
       '[data-test="tab-1"] .hds-tabs__tab-button'


### PR DESCRIPTION
### :pushpin: Summary

This PR implements usage of the `aria-controls` attribute in the `Tabs` component to align show/hide behavior across the repo as follows in the initiative from [HDS-3581](https://hashicorp.atlassian.net/browse/HDS-3581).

### :hammer_and_wrench: Detailed description

Currently in the `Tabs`, the `Tabs::Tab`  sub-component does not leverage the `aria-controls` attribute to connect the tab with the tab panel. As per a11y guidance in [HDS-3581](https://hashicorp.atlassian.net/browse/HDS-3581), all togged content should follow a pattern leveraging `aria-controls`.

In this PR we have set `aria-controls` in the `Tabs::Tab` equal to the tab panel it is connected with. This aligns with our established pattern, and with the [W3C tabs example](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-manual/).

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4326](https://hashicorp.atlassian.net/browse/HDS-4326)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3581]: https://hashicorp.atlassian.net/browse/HDS-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-3581]: https://hashicorp.atlassian.net/browse/HDS-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-4326]: https://hashicorp.atlassian.net/browse/HDS-4326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ