### PR TITLE
HDS-4320 Dropdown Toggle Icon: Fix z-index issue with focus ring

### DIFF
--- a/.changeset/smooth-months-repair.md
+++ b/.changeset/smooth-months-repair.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Dropdown` - Fixed z-index bug which caused the focus ring of the toggle icon to not be visible when the component was nested in a container.

--- a/.changeset/smooth-months-repair.md
+++ b/.changeset/smooth-months-repair.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Dropdown` - Fixed z-index bug which caused the focus ring of the toggle icon to not be visible when the component was nested in a container.
+`Dropdown` - Fixed `z-index` bug which caused the focus ring of the toggle icon to not be visible when the component was nested in a container.

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -42,6 +42,7 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   border-radius: $hds-dropdown-toggle-border-radius;
   outline-style: solid; // used to avoid double outline+focus-ring in Safari (see https://github.com/hashicorp/design-system-components/issues/161#issuecomment-1031548656)
   outline-color: transparent; // We need this to be transparent for a11y
+  isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
 
   &:hover,
   &.mock-hover {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a style to Dropdown Toggle Icon to isolate it from its background and solve a z-index issue in which the focus ring was going behind parent containers (such as when the Dropdown is used within a Table).

**Showcase:** https://hds-showcase-git-hds-4320-dropdown-focus-ring-bug-hashicorp.vercel.app/components/table#custom-sorting (Tab through nested Dropdowns to test)

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

**_Before (focus ring of toggle is not visible):_**
<img width="437" alt="image" src="https://github.com/user-attachments/assets/ac7daf29-8b9a-42b1-988c-5c78074df417" />

---

**_After (focus ring of toggle is visible):_**
<img width="442" alt="image" src="https://github.com/user-attachments/assets/cb88effd-f2bf-4859-8cac-5926600c045e" />

### :link: External links

* Jira ticket: [HDS-4320](https://hashicorp.atlassian.net/browse/HDS-4320)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4320]: https://hashicorp.atlassian.net/browse/HDS-4320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ