### PR TITLE
`PopoverPrimitive` - Implement `aria-controls`

### DIFF
--- a/.changeset/many-apples-film.md
+++ b/.changeset/many-apples-film.md
@@ -2,7 +2,7 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Breadcrumb` - Implement `aria-controls` in `Breadcrumb::Truncation` for a11y improvements with toggled content from `PopoverPrimitive`
-`Dropdown` - Implement `aria-controls` in `Dropdown::Toggle::Button` for a11y improvements with toggled content from `PopoverPrimitive`
-`PopoverPrimitve` - Implement `aria-controls` in toggle element for a11y improvements with toggled content
-`RichTooltip` - Remove explicitly setting `aria-controls` in `RichTooltip::Toggle` as it is now set through the `PopoverPrimitive`
+`Breadcrumb` - Implemented `aria-controls` in `Breadcrumb::Truncation` for a11y improvements with toggled content from `PopoverPrimitive`
+`Dropdown` - Implemented `aria-controls` in `Dropdown::Toggle::Button` for a11y improvements with toggled content from `PopoverPrimitive`
+`PopoverPrimitve` - Implemented `aria-controls` in toggle element for a11y improvements with toggled content
+`RichTooltip` - Removed explicitly setting `aria-controls` in `RichTooltip::Toggle` as it is now set through the `PopoverPrimitive`

--- a/.changeset/many-apples-film.md
+++ b/.changeset/many-apples-film.md
@@ -1,0 +1,8 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Breadcrumb` - Implement `aria-controls` in `Breadcrumb::Truncation` for a11y improvements with toggled content from `PopoverPrimitive`
+`Dropdown` - Implement `aria-controls` in `Dropdown::Toggle::Button` for a11y improvements with toggled content from `PopoverPrimitive`
+`PopoverPrimitve` - Implement `aria-controls` in toggle element for a11y improvements with toggled content
+`RichTooltip` - Remove explicitly setting `aria-controls` in `RichTooltip::Toggle` as it is now set through the `PopoverPrimitive`

--- a/packages/components/src/components/hds/popover-primitive/index.ts
+++ b/packages/components/src/components/hds/popover-primitive/index.ts
@@ -119,19 +119,23 @@ export default class HdsPopoverPrimitive extends Component<HdsPopoverPrimitiveSi
     ): void => {
       this._popoverElement = element;
 
-      // for the click events we don't use `onclick` event listeners, but we rely on the `popovertarget` attribute
-      // provided by the Popover API which does all the magic for us without needing JS code
-      // (important: to work it needs to be applied to a button)
-      if (this.enableClickEvents) {
+      // We need to create a popoverId in order to connect the popover and the toggle with aria-controls
+      // and an id is needed to implement `onclick` event listeners
+      if (this._toggleElement) {
         let popoverId;
         if (this._popoverElement.id) {
           popoverId = this._popoverElement.id;
         } else {
-          // we need a DOM id for the `popovertarget` attribute
+          // we need a DOM id for the `aria-controls` and `popovertarget` attributes
           popoverId = guidFor(this);
           this._popoverElement.id = popoverId;
         }
-        if (this._toggleElement) {
+        this._toggleElement.setAttribute('aria-controls', popoverId);
+
+        // for the click events we don't use `onclick` event listeners, but we rely on the `popovertarget` attribute
+        // provided by the Popover API which does all the magic for us without needing JS code
+        // (important: to work it needs to be applied to a button)
+        if (this.enableClickEvents) {
           this._toggleElement.setAttribute('popovertarget', popoverId);
         }
       }

--- a/packages/components/src/components/hds/rich-tooltip/toggle.hbs
+++ b/packages/components/src/components/hds/rich-tooltip/toggle.hbs
@@ -7,7 +7,6 @@
   class={{this.classNames}}
   ...attributes
   type="button"
-  aria-controls={{@popoverId}}
   aria-describedby={{@popoverId}}
   aria-expanded={{if @isOpen "true" "false"}}
   {{@setupPrimitiveToggle}}

--- a/showcase/tests/integration/components/hds/popover-primitive/index-test.js
+++ b/showcase/tests/integration/components/hds/popover-primitive/index-test.js
@@ -30,6 +30,7 @@ module(
       const popover = this.element.querySelector('main');
       const popoverId = popover.id;
       assert.dom('button').hasAttribute('popovertarget', popoverId);
+      assert.dom('button').hasAttribute('aria-controls', popoverId);
       assert.dom('main').hasAttribute('popover', 'auto');
     });
 

--- a/showcase/tests/integration/components/hds/rich-tooltip/toggle-test.js
+++ b/showcase/tests/integration/components/hds/rich-tooltip/toggle-test.js
@@ -111,7 +111,6 @@ module('Integration | Component | hds/rich-tooltip/toggle', function (hooks) {
       hbs`<Hds::RichTooltip::Toggle @popoverId="popoverId" @isOpen={{true}} />`
     );
     assert.dom('.hds-rich-tooltip__toggle').hasAttribute('type', 'button');
-    assert.dom('.hds-rich-tooltip__toggle').hasAria('controls', 'popoverId');
     assert.dom('.hds-rich-tooltip__toggle').hasAria('describedby', 'popoverId');
     assert.dom('.hds-rich-tooltip__toggle').hasAria('expanded', 'true');
   });


### PR DESCRIPTION
### :pushpin: Summary

This PR implements usage of the aria-controls attribute in the `PopoverPrimitive` component to align show/hide behavior across the repo as follows in the initiative from [HDS-3581](https://hashicorp.atlassian.net/browse/HDS-3581).

The `PopoverPrimitive` is leveraged in the `Breadcrumbs`, `Dropdown`, and `RichTooltip`. Prior to this change the `Breadcrumbs` and `Dropdown` were not leveraging `aria-controls`.

### :hammer_and_wrench: Detailed description

Currently in the `PopoverPrimitive`, the toggle element does not leverage the `aria-controls` attribute to connect the toggle with the popover element. As per a11y guidance in [HDS-3581](https://hashicorp.atlassian.net/browse/HDS-3581), all togged content should follow a pattern leveraging `aria-controls`.

In this PR, we have set `aria-controls` in the toggle element equal to the popover element it is connected with. This aligns with our established pattern.

For the components that leverage the `PopoverPrimitive`, the `Dropdown` and `Breadcrumbs` previously had no usage of `aria-controls`, and now implement it in their toggle elements.

The `RichTooltip` previously leveraged `aria-controls` by setting it explicitly in the `RichTooltip::Toggle`. Now that `aria-controls` is set through the `PopoverPrimitive`, we have removed setting `aria-controls` explicitly.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4325](https://hashicorp.atlassian.net/browse/HDS-4325)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3581]: https://hashicorp.atlassian.net/browse/HDS-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-3581]: https://hashicorp.atlassian.net/browse/HDS-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-4325]: https://hashicorp.atlassian.net/browse/HDS-4325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ