### PR TITLE
fix: update table docs mentioning multi-select checkbox aria-labels

### DIFF
--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -777,7 +777,7 @@ For details about the arguments provided to the `@onSelectionChange` callback fu
 
 #### Usability and accessibility considerations
 
-Since the “selected” state of a row is communicated visually via the checkbox selection and for screen-reader users via the `aria-label` applied to the checkbox, there are some important considerations to keep in mind when implementing a multi-select table.
+Since the “selected” state of a row is communicated via the checkbox selection, there are some important considerations to keep in mind when implementing a multi-select table.
 
 If the selection status of the rows is persisted even when a row is not displayed in the UI, consider what the expectations of the user might be: how are they made aware that the action they are going to perform may involve rows that were previously selected but not displayed in the current view?
 

--- a/website/docs/components/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/partials/code/how-to-use.md
@@ -777,7 +777,7 @@ For details about the arguments provided to the `@onSelectionChange` callback fu
 
 #### Usability and accessibility considerations
 
-Since the “selected” state of a row is communicated via the checkbox selection, there are some important considerations to keep in mind when implementing a multi-select table.
+Since the “selected” state of a row is communicated by the checkbox, there are some important considerations to keep in mind when implementing a multi-select table.
 
 If the selection status of the rows is persisted even when a row is not displayed in the UI, consider what the expectations of the user might be: how are they made aware that the action they are going to perform may involve rows that were previously selected but not displayed in the current view?
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would remove mention of aria-labels indicating the selection state for multi-select tables.

### :camera_flash: Screenshots

**Before** 
![Screenshot 2025-01-10 at 11 02 54 AM](https://github.com/user-attachments/assets/dd670541-046c-430e-92ae-87f433f570fd)

**After**
![Screenshot 2025-01-10 at 11 05 37 AM](https://github.com/user-attachments/assets/945c74c2-c961-434c-9975-01769ad7afa1)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
