### PR TITLE
`CodeEditor` - Spike to refactor Title, Description, & custom content layout

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -167,6 +167,7 @@
       "./components/hds/code-block/title.js": "./dist/_app_/components/hds/code-block/title.js",
       "./components/hds/code-editor/description.js": "./dist/_app_/components/hds/code-editor/description.js",
       "./components/hds/code-editor/full-screen-button.js": "./dist/_app_/components/hds/code-editor/full-screen-button.js",
+      "./components/hds/code-editor/generic.js": "./dist/_app_/components/hds/code-editor/generic.js",
       "./components/hds/code-editor/index.js": "./dist/_app_/components/hds/code-editor/index.js",
       "./components/hds/code-editor/title.js": "./dist/_app_/components/hds/code-editor/title.js",
       "./components/hds/copy/button/index.js": "./dist/_app_/components/hds/copy/button/index.js",

--- a/packages/components/src/components/hds/code-editor/generic.hbs
+++ b/packages/components/src/components/hds/code-editor/generic.hbs
@@ -1,0 +1,7 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+<div class="hds-code-editor__header-generic" ...attributes>
+  {{yield}}
+</div>

--- a/packages/components/src/components/hds/code-editor/generic.ts
+++ b/packages/components/src/components/hds/code-editor/generic.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import TemplateOnlyComponent from '@ember/component/template-only';
+
+export interface HdsCodeEditorGenericSignature {
+  Blocks: {
+    default: [];
+  };
+  Element: HTMLDivElement;
+}
+
+const HdsCodeEditorGeneric =
+  TemplateOnlyComponent<HdsCodeEditorGenericSignature>();
+
+export default HdsCodeEditorGeneric;

--- a/packages/components/src/components/hds/code-editor/index.hbs
+++ b/packages/components/src/components/hds/code-editor/index.hbs
@@ -19,6 +19,7 @@
           (hash
             Title=(component "hds/code-editor/title" editorId=this._id onInsert=this.registerTitleElement)
             Description=(component "hds/code-editor/description")
+            Generic=(component "hds/code-editor/generic")
           )
         }}
       </div>

--- a/packages/components/src/components/hds/code-editor/index.ts
+++ b/packages/components/src/components/hds/code-editor/index.ts
@@ -13,6 +13,7 @@ import type { HdsCodeEditorSignature as HdsCodeEditorModifierSignature } from 's
 import type { HdsButtonSignature } from 'src/components/hds/button';
 import type { HdsCodeEditorDescriptionSignature } from './description';
 import type { HdsCodeEditorTitleSignature } from './title';
+import type { HdsCodeEditorGenericSignature } from './generic';
 import type { EditorView } from '@codemirror/view';
 import { guidFor } from '@ember/object/internals';
 
@@ -32,6 +33,7 @@ export interface HdsCodeEditorSignature {
       {
         Title?: ComponentLike<HdsCodeEditorTitleSignature>;
         Description?: ComponentLike<HdsCodeEditorDescriptionSignature>;
+        Generic?: ComponentLike<HdsCodeEditorGenericSignature>;
         Button?: ComponentLike<HdsButtonSignature>;
       },
     ];

--- a/packages/components/src/styles/components/code-editor/index.scss
+++ b/packages/components/src/styles/components/code-editor/index.scss
@@ -29,6 +29,27 @@
     }
   }
 
+  // KB TESTING: START -----------------
+  // Note: Move to appropriate place in styles below if kept
+  .hds-code-editor__header-content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
+
+  .hds-code-editor__title {
+    + .hds-code-editor__description {
+      margin-top: 4px;
+    }
+  }
+
+  .hds-code-editor__description {
+    + .hds-code-editor__header-generic {
+      margin-top: 12px;
+    }
+  }
+  // KB TESTING: END -------------------
+
   .hds-code-editor__header {
     display: flex;
     gap: 12px;
@@ -39,29 +60,29 @@
   }
 
   .hds-code-editor__header-content {
-    display: flex;
-    flex-grow: 1;
-    flex-wrap: wrap;
-    align-items: center;
+    // display: flex;
+    // flex-grow: 1;
+    // flex-wrap: wrap;
+    // align-items: center;
 
-    // child element that is not the title/description and has subsequent siblings
-    > :not(.hds-code-editor__title, .hds-code-editor__description):has(+ *) {
-      margin-right: 8px;
-    }
+    // // child element that is not the title/description and has subsequent siblings
+    // > :not(.hds-code-editor__title, .hds-code-editor__description):has(+ *) {
+    //   margin-right: 8px;
+    // }
   }
 
   .hds-code-editor__title,
   .hds-code-editor__description {
-    width: 100%;
+    // width: 100%;
 
-    // if the title/description has subsequent siblings, add a bottom margin
-    &:has(+ *) {
-      margin-bottom: 12px;
-    }
+    // // if the title/description has subsequent siblings, add a bottom margin
+    // &:has(+ *) {
+    //   margin-bottom: 12px;
+    // }
 
-    &:has(+ .hds-code-editor__title, + .hds-code-editor__description) {
-      margin-bottom: 4px;
-    }
+    // &:has(+ .hds-code-editor__title, + .hds-code-editor__description) {
+    //   margin-bottom: 4px;
+    // }
   }
 
   .hds-code-editor__title {

--- a/packages/components/src/styles/components/code-editor/index.scss
+++ b/packages/components/src/styles/components/code-editor/index.scss
@@ -29,27 +29,6 @@
     }
   }
 
-  // KB TESTING: START -----------------
-  // Note: Move to appropriate place in styles below if kept
-  .hds-code-editor__header-content {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-  }
-
-  .hds-code-editor__title {
-    + .hds-code-editor__description {
-      margin-top: 4px;
-    }
-  }
-
-  .hds-code-editor__description {
-    + .hds-code-editor__header-generic {
-      margin-top: 12px;
-    }
-  }
-  // KB TESTING: END -------------------
-
   .hds-code-editor__header {
     display: flex;
     gap: 12px;
@@ -60,37 +39,25 @@
   }
 
   .hds-code-editor__header-content {
-    // display: flex;
-    // flex-grow: 1;
-    // flex-wrap: wrap;
-    // align-items: center;
-
-    // // child element that is not the title/description and has subsequent siblings
-    // > :not(.hds-code-editor__title, .hds-code-editor__description):has(+ *) {
-    //   margin-right: 8px;
-    // }
-  }
-
-  .hds-code-editor__title,
-  .hds-code-editor__description {
-    // width: 100%;
-
-    // // if the title/description has subsequent siblings, add a bottom margin
-    // &:has(+ *) {
-    //   margin-bottom: 12px;
-    // }
-
-    // &:has(+ .hds-code-editor__title, + .hds-code-editor__description) {
-    //   margin-bottom: 4px;
-    // }
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
   }
 
   .hds-code-editor__title {
     color: var(--hds-code-editor-color-foreground-primary);
+
+    + .hds-code-editor__description {
+      margin-top: 4px;
+    }
   }
 
   .hds-code-editor__description {
     color: var(--hds-code-editor-color-foreground-faint);
+    
+    + .hds-code-editor__header-generic {
+      margin-top: 12px;
+    }
   }
 
   .hds-code-editor__header-actions {

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -51,6 +51,7 @@ import type HdsApplicationStateMediaComponent from './components/hds/application
 import type HdsCardContainerComponent from './components/hds/card/container.ts';
 import type HdsCodeEditorComponent from './components/hds/code-editor/index.ts';
 import type HdsCodeEditorDescriptionComponent from './components/hds/code-editor/description.ts';
+import type HdsCodeEditorGenericComponent from './components/hds/code-editor/generic.ts';
 import type HdsCodeEditorTitleComponent from './components/hds/code-editor/title.ts';
 import type HdsCodeEditorFullScreenButtonComponent from './components/hds/code-editor/full-screen-button.ts';
 import type HdsCodeBlockComponent from './components/hds/code-block';
@@ -381,6 +382,8 @@ export default interface HdsComponentsRegistry {
   'hds/code-editor': typeof HdsCodeEditorComponent;
   'Hds::CodeEditor::Description': typeof HdsCodeEditorDescriptionComponent;
   'hds/code-editor/description': typeof HdsCodeEditorDescriptionComponent;
+  'Hds::CodeEditor::Generic': typeof HdsCodeEditorGenericComponent;
+  'hds/code-editor/generic': typeof HdsCodeEditorGenericComponent;
   'Hds::CodeEditor::Title': typeof HdsCodeEditorTitleComponent;
   'hds/code-editor/title': typeof HdsCodeEditorTitleComponent;
   'Hds::CodeEditor::FullScreenButton': typeof HdsCodeEditorFullScreenButtonComponent;

--- a/showcase/app/styles/showcase-pages/code-editor.scss
+++ b/showcase/app/styles/showcase-pages/code-editor.scss
@@ -4,3 +4,9 @@
  */
 
 // CODE-EDITOR
+
+.my-code-editor-custom-content {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}

--- a/showcase/app/templates/components/code-editor.hbs
+++ b/showcase/app/templates/components/code-editor.hbs
@@ -60,8 +60,10 @@
   <Shw::Text::H3>Custom content</Shw::Text::H3>
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
     <SG.Item @label="With custom header content">
-      <Hds::CodeEditor @ariaLabel="With custom header content">
-        <Hds::Button @text="Custom button" @size="small" />
+      <Hds::CodeEditor @ariaLabel="With custom header content" as |CE|>
+        <CE.Generic class="my-code-editor-custom-content">
+          <Hds::Button @text="Custom button" @size="small" />
+        </CE.Generic>
       </Hds::CodeEditor>
     </SG.Item>
   </Shw::Grid>
@@ -78,16 +80,20 @@
       <Hds::CodeEditor as |CE|>
         <CE.Title>Code editor with title</CE.Title>
         <CE.Description>This is a code editor with a description</CE.Description>
-        <Hds::Button @text="Custom button" @size="small" />
-        <Hds::Icon @name="code" @color="#fff" />
+        <CE.Generic class="my-code-editor-custom-content">
+          <Hds::Button @text="Custom button" @size="small" />
+          <Hds::Icon @name="code" @color="#fff" />
+        </CE.Generic>
       </Hds::CodeEditor>
     </SG.Item>
     <SG.Item @label="With title, description, internal actions, and custom content">
       <Hds::CodeEditor @hasFullScreenButton={{true}} @hasCopyButton={{true}} as |CE|>
         <CE.Title>Code editor with title</CE.Title>
         <CE.Description>This is a code editor with a description</CE.Description>
-        <Hds::Button @text="Custom button" @size="small" />
-        <Hds::Icon @name="code" @color="#fff" />
+        <CE.Generic class="my-code-editor-custom-content">
+          <Hds::Button @text="Custom button" @size="small" />
+          <Hds::Icon @name="code" @color="#fff" />
+        </CE.Generic>
       </Hds::CodeEditor>
     </SG.Item>
   </Shw::Grid>


### PR DESCRIPTION
### :pushpin: Summary

This is a rough spike to test refactoring the layout of the Code Editor's Title, Description, & custom content.

**Goals:**
* Simplify layout styles
* Remove layout styling of custom content & leave up to consumer

**Showcase:** https://hds-showcase-git-kristin-code-editor-custom-co-dfd6c9-hashicorp.vercel.app/components/code-editor

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Original PR: https://github.com/hashicorp/design-system/pull/2573

<!--
***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
-->