### PR TITLE
`DisclosurePrimitive` - Implement a11y toggled content pattern

### DIFF
--- a/.changeset/seven-eyes-whisper.md
+++ b/.changeset/seven-eyes-whisper.md
@@ -3,5 +3,7 @@
 ---
 
 `Accordion` - Set `aria-controls` of `Accordion::Item::Button` to `contentId` from `DisclosurePrimitve` for a11y improvements with toggled content
+
 `DisclosurePrimitve` - Changed DOM structure of content section and exposed `contentId` for a11y improvements with toggled content
+
 `Reveal` - Set `aria-controls` of `Reveal::Toggle` to `contentId` from `DisclosurePrimitve` for a11y improvements with toggled content

--- a/.changeset/seven-eyes-whisper.md
+++ b/.changeset/seven-eyes-whisper.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Accordion` - Set `aria-controls` of `Accordion::Item::Button` to `contentId` from `DisclosurePrimitve` for a11y improvements with toggled content
+`DisclosurePrimitve` - Changed DOM structure of content section and exposed `contentId` for a11y improvements with toggled content
+`Reveal` - Set `aria-controls` of `Reveal::Toggle` to `contentId` from `DisclosurePrimitve` for a11y improvements with toggled content

--- a/packages/components/src/components/hds/accordion/item/index.hbs
+++ b/packages/components/src/components/hds/accordion/item/index.hbs
@@ -14,7 +14,7 @@
       <Hds::Accordion::Item::Button
         @isOpen={{t.isOpen}}
         @onClickToggle={{t.onClickToggle}}
-        @contentId={{this._contentId}}
+        @contentId={{t.contentId}}
         @ariaLabel={{@ariaLabel}}
         @ariaLabelledBy={{this.ariaLabelledBy}}
         @size={{this.size}}
@@ -35,14 +35,7 @@
   </:toggle>
 
   <:content as |c|>
-    <Hds::Text::Body
-      class="hds-accordion-item__content"
-      @tag="div"
-      @size="200"
-      @weight="regular"
-      @color="primary"
-      id={{this._contentId}}
-    >
+    <Hds::Text::Body class="hds-accordion-item__content" @tag="div" @size="200" @weight="regular" @color="primary">
       {{yield (hash close=c.close) to="content"}}
     </Hds::Text::Body>
   </:content>

--- a/packages/components/src/components/hds/accordion/item/index.ts
+++ b/packages/components/src/components/hds/accordion/item/index.ts
@@ -57,12 +57,6 @@ export interface HdsAccordionItemSignature {
 }
 
 export default class HdsAccordionItem extends Component<HdsAccordionItemSignature> {
-  /**
-   * Generates a unique ID for the Content
-   *
-   * @param _contentId
-   */
-  private _contentId = 'content-' + guidFor(this);
   private _titleId = 'title-' + guidFor(this);
 
   get ariaLabelledBy(): string | undefined {

--- a/packages/components/src/components/hds/disclosure-primitive/index.hbs
+++ b/packages/components/src/components/hds/disclosure-primitive/index.hbs
@@ -4,11 +4,11 @@
 }}
 <div class="hds-disclosure-primitive" {{did-update this.onStateChange @isOpen}} ...attributes>
   <div class="hds-disclosure-primitive__toggle">
-    {{yield (hash onClickToggle=this.onClickToggle isOpen=this.isOpen) to="toggle"}}
+    {{yield (hash onClickToggle=this.onClickToggle isOpen=this.isOpen contentId=this._contentId) to="toggle"}}
   </div>
-  {{#if this.isOpen}}
-    <div class="hds-disclosure-primitive__content">
+  <div class="hds-disclosure-primitive__content" id={{this._contentId}}>
+    {{#if this.isOpen}}
       {{yield (hash close=this.close) to="content"}}
-    </div>
-  {{/if}}
+    {{/if}}
+  </div>
 </div>

--- a/packages/components/src/components/hds/disclosure-primitive/index.ts
+++ b/packages/components/src/components/hds/disclosure-primitive/index.ts
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { schedule } from '@ember/runloop';
+import { guidFor } from '@ember/object/internals';
 
 export interface HdsDisclosurePrimitiveSignature {
   Args: {
@@ -19,6 +20,7 @@ export interface HdsDisclosurePrimitiveSignature {
   Blocks: {
     toggle: [
       {
+        contentId: string;
         isOpen: boolean;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onClickToggle: (...args: any[]) => void;
@@ -37,6 +39,7 @@ export interface HdsDisclosurePrimitiveSignature {
 export default class HdsDisclosurePrimitive extends Component<HdsDisclosurePrimitiveSignature> {
   @tracked private _isOpen = false;
   @tracked private _isControlled = this.args.isOpen !== undefined;
+  private _contentId = 'content-' + guidFor(this);
 
   get isOpen(): boolean {
     if (this._isControlled) {

--- a/packages/components/src/components/hds/reveal/index.hbs
+++ b/packages/components/src/components/hds/reveal/index.hbs
@@ -6,7 +6,7 @@
 <Hds::DisclosurePrimitive class="hds-reveal" @isOpen={{@isOpen}} ...attributes>
   <:toggle as |t|>
     <Hds::Reveal::Toggle::Button
-      aria-controls={{this._contentId}}
+      aria-controls={{t.contentId}}
       @text={{this.getText t.isOpen}}
       @isOpen={{t.isOpen}}
       {{on "click" t.onClickToggle}}
@@ -14,7 +14,7 @@
   </:toggle>
 
   <:content>
-    <div class="hds-reveal__content hds-typography-body-200 hds-foreground-primary" id={{this._contentId}}>
+    <div class="hds-reveal__content hds-typography-body-200 hds-foreground-primary">
       {{yield}}
     </div>
   </:content>

--- a/packages/components/src/components/hds/reveal/index.ts
+++ b/packages/components/src/components/hds/reveal/index.ts
@@ -4,7 +4,6 @@
  */
 
 import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
 
 import type { HdsDisclosurePrimitiveSignature } from '../disclosure-primitive';
@@ -23,13 +22,6 @@ export interface HdsRevealSignature {
 }
 
 export default class HdsReveal extends Component<HdsRevealSignature> {
-  /**
-   * Generates a unique ID for the Content
-   *
-   * @param _contentId
-   */
-  private _contentId = 'content-' + guidFor(this);
-
   /**
    * @param getText
    * @type {string}

--- a/showcase/tests/integration/components/hds/accordion/index-test.js
+++ b/showcase/tests/integration/components/hds/accordion/index-test.js
@@ -208,7 +208,7 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
         .getAttribute('aria-controls'),
       this.element
         .querySelector('.hds-disclosure-primitive__content')
-        .getAttribute('id')
+        .getAttribute('id'),
     );
   });
 

--- a/showcase/tests/integration/components/hds/accordion/index-test.js
+++ b/showcase/tests/integration/components/hds/accordion/index-test.js
@@ -188,7 +188,7 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
       .hasAttribute('aria-expanded', 'true');
   });
 
-  test('the AccordionItem toggle button has an aria-controls attribute with a value matching the content id', async function (assert) {
+  test('the AccordionItem toggle button has an aria-controls attribute with a value matching the DisclosurePrimitive content id', async function (assert) {
     await render(
       hbs`
         <Hds::Accordion as |A|>
@@ -201,15 +201,14 @@ module('Integration | Component | hds/accordion/index', function (hooks) {
     );
     await click('.hds-accordion-item__button');
     assert.dom('.hds-accordion-item__button').hasAttribute('aria-controls');
-    assert.dom('.hds-accordion-item__content').hasAttribute('id');
 
     assert.strictEqual(
       this.element
         .querySelector('.hds-accordion-item__button')
         .getAttribute('aria-controls'),
       this.element
-        .querySelector('.hds-accordion-item__content')
-        .getAttribute('id'),
+        .querySelector('.hds-disclosure-primitive__content')
+        .getAttribute('id')
     );
   });
 

--- a/showcase/tests/integration/components/hds/disclosure-primitive/index-test.js
+++ b/showcase/tests/integration/components/hds/disclosure-primitive/index-test.js
@@ -34,11 +34,15 @@ module(
         <:toggle>
           <button type="button" id="test-disclosure-primitive-button" />
         </:toggle>
+        <:content>
+          <a id="test-disclosure-primitive-link" href="#">test</a>
+        </:content>
       </Hds::DisclosurePrimitive>
     `);
       assert.dom('.hds-disclosure-primitive__toggle').exists();
       assert.dom('button#test-disclosure-primitive-button').exists();
-      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
+      assert.dom('.hds-disclosure-primitive__content').exists();
+      assert.dom('a#test-disclosure-primitive-link').doesNotExist();
     });
     test('it should render the "content" when the "toggle" is clicked', async function (assert) {
       await render(hbs`
@@ -52,7 +56,6 @@ module(
       </Hds::DisclosurePrimitive>
     `);
       await click('button#test-disclosure-primitive-button');
-      assert.dom('.hds-disclosure-primitive__content').exists();
       assert.dom('a#test-disclosure-primitive-link').exists();
     });
 
@@ -70,11 +73,9 @@ module(
         </:content>
       </Hds::DisclosurePrimitive>
     `);
-      assert.dom('.hds-disclosure-primitive__content').exists();
       assert.dom('a#test-disclosure-primitive-link').exists();
 
       this.set('isOpen', false);
-      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
       assert.dom('a#test-disclosure-primitive-link').doesNotExist();
     });
 
@@ -90,11 +91,9 @@ module(
       </Hds::DisclosurePrimitive>
     `);
       await click('button#test-toggle-button');
-      assert.dom('.hds-disclosure-primitive__content').exists();
       assert.dom('a#test-disclosure-primitive-link').exists();
 
       this.set('isOpen', false);
-      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
       assert.dom('a#test-disclosure-primitive-link').doesNotExist();
     });
 
@@ -109,11 +108,9 @@ module(
         </:content>
       </Hds::DisclosurePrimitive>
     `);
-      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
       assert.dom('a#test-disclosure-primitive-link').doesNotExist();
 
       this.set('isOpen', true);
-      assert.dom('.hds-disclosure-primitive__content').exists();
       assert.dom('a#test-disclosure-primitive-link').exists();
     });
 
@@ -129,11 +126,9 @@ module(
         </:content>
       </Hds::DisclosurePrimitive>
     `);
-      assert.dom('.hds-disclosure-primitive__content').exists();
       assert.dom('a#test-disclosure-primitive-link').exists();
 
       await click('button#test-toggle-button');
-      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
       assert.dom('a#test-disclosure-primitive-link').doesNotExist();
     });
 
@@ -149,12 +144,26 @@ module(
         </:content>
       </Hds::DisclosurePrimitive>
     `);
-      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
       assert.dom('a#test-disclosure-primitive-link').doesNotExist();
 
       await click('button#test-toggle-button');
-      assert.dom('.hds-disclosure-primitive__content').exists();
       assert.dom('a#test-disclosure-primitive-link').exists();
+    });
+
+    // contentId
+
+    test('it should set the contentId on the content block', async function (assert) {
+      await render(hbs`
+      <Hds::DisclosurePrimitive>
+        <:toggle>
+          <button type="button" id="test-disclosure-primitive-button" />
+        </:toggle>
+        <:content>
+          <a id="test-disclosure-primitive-link" href="#">test</a>
+        </:content>
+      </Hds::DisclosurePrimitive>
+    `);
+      assert.dom('.hds-disclosure-primitive__content').hasAttribute('id');
     });
 
     // CLOSE DISCLOSED CONTENT ON CLICK
@@ -171,10 +180,8 @@ module(
       </Hds::DisclosurePrimitive>
     `);
       await click('button#test-toggle-button');
-      assert.dom('.hds-disclosure-primitive__content').exists();
       assert.dom('button#test-content-button').exists();
       await click('button#test-content-button');
-      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
       assert.dom('button#test-content-button').doesNotExist();
     });
 
@@ -196,11 +203,11 @@ module(
       // toggle to open
       await click('button#test-toggle-button');
       assert.true(opened);
-      assert.dom('.hds-disclosure-primitive__content').exists();
+      assert.dom('a#test-disclosure-primitive-link').exists();
       // toggle to close
       await click('button#test-toggle-button');
       assert.false(opened);
-      assert.dom('.hds-disclosure-primitive__content').doesNotExist();
+      assert.dom('a#test-disclosure-primitive-link').doesNotExist();
     });
   },
 );

--- a/showcase/tests/integration/components/hds/reveal/index-test.js
+++ b/showcase/tests/integration/components/hds/reveal/index-test.js
@@ -79,7 +79,7 @@ module('Integration | Component | hds/reveal/index', function (hooks) {
         .getAttribute('aria-controls'),
       this.element
         .querySelector('.hds-disclosure-primitive__content')
-        .getAttribute('id')
+        .getAttribute('id'),
     );
   });
 

--- a/showcase/tests/integration/components/hds/reveal/index-test.js
+++ b/showcase/tests/integration/components/hds/reveal/index-test.js
@@ -66,19 +66,18 @@ module('Integration | Component | hds/reveal/index', function (hooks) {
       .hasAttribute('aria-expanded', 'true');
   });
 
-  test('the toggle button has an aria-controls attribute with a value matching the content id', async function (assert) {
+  test('the toggle button has an aria-controls attribute with a value matching the DisclosurePrimitive content id', async function (assert) {
     await render(
       hbs`<Hds::Reveal @text="More options">Additional content</Hds::Reveal>`,
     );
     await click('.hds-reveal__toggle-button');
     assert.dom('.hds-reveal__toggle-button').hasAttribute('aria-controls');
-    assert.dom('.hds-reveal__content').hasAttribute('id');
 
     assert.strictEqual(
       this.element
         .querySelector('.hds-reveal__toggle-button')
         .getAttribute('aria-controls'),
-      this.element.querySelector('.hds-reveal__content').getAttribute('id'),
+      this.element.querySelector('.hds-disclosure-primitive__content').getAttribute('id')
     );
   });
 

--- a/showcase/tests/integration/components/hds/reveal/index-test.js
+++ b/showcase/tests/integration/components/hds/reveal/index-test.js
@@ -77,7 +77,9 @@ module('Integration | Component | hds/reveal/index', function (hooks) {
       this.element
         .querySelector('.hds-reveal__toggle-button')
         .getAttribute('aria-controls'),
-      this.element.querySelector('.hds-disclosure-primitive__content').getAttribute('id')
+      this.element
+        .querySelector('.hds-disclosure-primitive__content')
+        .getAttribute('id')
     );
   });
 


### PR DESCRIPTION
### :pushpin: Summary

This PR implements usage of the `aria-controls` attribute in the `DisclosurePrimitive` component to align show/hide behavior across the repo as follows in the initiative from [HDS-3581](https://hashicorp.atlassian.net/browse/HDS-3581).

The `DisclosurePrimitive` is leveraged in the `Accordion` and `Reveal`.

### :hammer_and_wrench: Detailed description

Currently in the `DisclosurePrimitive`, the toggled content does not follow the proper a11y structure for toggled content, or leverage `aria-controls` in the preferred way. 

As per a11y guidance in [HDS-3581](https://hashicorp.atlassian.net/browse/HDS-3581), all togged content should follow a pattern leveraging `aria-controls`, and all toggled containers should not be removed from the DOM on each toggle. They should always be present, and only the content inside them is added and removed. 

Currently the `DisclosurePrimitive` follows a pattern where the entire content block is added and removed on each toggle, and any `aria-controls` attributes are set to the `id` of this removable block. In this PR the `hds-disclosure-primitive__content` block is now in the DOM at all times, and the yielded content is removed or added based on the toggle.

In this PR, in the `Accordion` and `Reveal`, the `aria-controls` attribute of the toggle elements are now set equal to a `contentId` provided by the `DisclosurePrimitive`. They are no longer set to the `id` of content inside the yielded block.

### Smoke Testing

Since this PR involves updating the DOM structure of the `DisclosurePrimitive` it has been smoke tested in various products to ensure they are not relying on the existing structure in any of their tests. 

- ✅  [Cloud UI](https://github.com/hashicorp/cloud-ui/pull/12287) 
- ✅  [Atlas](https://github.com/hashicorp/atlas/pull/23357) 
  - Note: The one failing test is unrelated to these changes
- ✅  Nomad 
  - There was one test case relying on the old structure, but that test has been updated in a [PR](https://github.com/hashicorp/nomad/pull/25905)

### :camera_flash: Screenshots

**Before - `Accordion`**

Closed
<img width="386" alt="Screenshot 2025-01-10 at 3 08 59 PM" src="https://github.com/user-attachments/assets/37caa0af-42f1-443f-8d1f-859a55ed92ce" />

Open
<img width="390" alt="Screenshot 2025-01-10 at 3 09 14 PM" src="https://github.com/user-attachments/assets/5bd3b05f-539c-497d-8c7d-3b21bd4be243" />

**After - `Accordion`**

Closed
<img width="386" alt="Screenshot 2025-01-10 at 3 16 11 PM" src="https://github.com/user-attachments/assets/43e55f00-bb31-482d-8306-646ebeaaef46" />

Open
<img width="384" alt="Screenshot 2025-01-10 at 3 16 23 PM" src="https://github.com/user-attachments/assets/9673648c-7aa6-4daa-9763-511ef8b107e9" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4324](https://hashicorp.atlassian.net/browse/HDS-4324)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3581]: https://hashicorp.atlassian.net/browse/HDS-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-3581]: https://hashicorp.atlassian.net/browse/HDS-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-4324]: https://hashicorp.atlassian.net/browse/HDS-4324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ