### PR TITLE
Fix: `Table` - Border radius variables sass error

### DIFF
--- a/packages/components/src/styles/components/table.scss
+++ b/packages/components/src/styles/components/table.scss
@@ -12,7 +12,7 @@
 
 $hds-table-border-radius: var(--token-border-radius-medium);
 $hds-table-border-width: 1px;
-$hds-table-inner-border-radius: $hds-table-border-radius - $hds-table-border-width;
+$hds-table-inner-border-radius: calc(#{$hds-table-border-radius} - #{$hds-table-border-width});
 $hds-table-border-color: var(--token-color-border-primary);
 $hds-table-header-height: 48px;
 $hds-table-cell-padding-medium: 14px 16px 13px 16px; // the 1px difference is to account for the bottom border


### PR DESCRIPTION
### :pushpin: Summary

An issue has been caught in smoke testing related to the new border radius variables. In one instance in the `Table`, the variable conversion was leading to operators being written in plain CSS. This PR fixes the issue with this file.  

### :hammer_and_wrench: Detailed description

In smoke testing upcoming changes to the `DisclosurePrimitive` an error was thrown when testing in `cloud-ui` related to improper CSS in the `Table`. The error was caused during the recent upgrade to use CSS variables for border radiuses. Two Sass variables were being subtracted, but once one was converted from a px value to a CSS variables, the Sass operation was now between one variable and one pixel value. Once this was converted into CSS the issue was thrown. 

### :camera_flash: Screenshots

Error from Cloud UI testing
<img width="843" alt="Screenshot 2025-01-13 at 1 46 26 PM" src="https://github.com/user-attachments/assets/f339c54e-10ef-42d9-bb6c-c9da7f324a58" />

CSS in `/dist` Before
<img width="547" alt="Screenshot 2025-01-13 at 1 37 01 PM" src="https://github.com/user-attachments/assets/b4fc5bee-a155-4dad-afb6-8291255037fd" />

CSS in `/dist` After
<img width="563" alt="Screenshot 2025-01-13 at 1 36 32 PM" src="https://github.com/user-attachments/assets/89e7c38f-b06c-4d95-b235-4ec8dda1ccd7" />

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
