### PR TITLE
`hds-tooltip` - Implement a11y toggle content pattern

### DIFF
--- a/.changeset/dry-frogs-smash.md
+++ b/.changeset/dry-frogs-smash.md
@@ -2,6 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`hds-tooltip` - Changed DOM structure of tooltip content to add a wrapper around the tooltip content that is always in the DOM, and set `aria-controls` on trigger elements for a11y improvements with toggled content
+`hds-tooltip` - Changed structure of tooltip content to add a wrapper that is always in the DOM and set `aria-controls` on trigger elements for a11y improvements with toggled content
 
-`TooltipButton` - Changed DOM structure of tooltip content to add a wrapper around the tooltip content that is always in the DOM, and set `aria-controls` on button for a11y improvements with toggled content
+`TooltipButton` - Changed structure of tooltip content to add a wrapper that is always in the DOM and set `aria-controls` on button for a11y improvements with toggled content

--- a/.changeset/dry-frogs-smash.md
+++ b/.changeset/dry-frogs-smash.md
@@ -2,5 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`hds-tooltip` - Changed DOM structure of tooltip content and set `aria-controls` on trigger elements for a11y improvements with toggled content
-`TooltipButton` - Changed DOM structure of tooltip content and set `aria-controls` on button for a11y improvements with toggled content
+`hds-tooltip` - Changed DOM structure of tooltip content to add a wrapper around the tooltip content that is always in the DOM, and set `aria-controls` on trigger elements for a11y improvements with toggled content
+
+`TooltipButton` - Changed DOM structure of tooltip content to add a wrapper around the tooltip content that is always in the DOM, and set `aria-controls` on button for a11y improvements with toggled content

--- a/.changeset/dry-frogs-smash.md
+++ b/.changeset/dry-frogs-smash.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`hds-tooltip` - Changed DOM structure of tooltip content and set `aria-controls` on trigger elements for a11y improvements with toggled content
+`TooltipButton` - Changed DOM structure of tooltip content and set `aria-controls` on button for a11y improvements with toggled content

--- a/packages/components/src/modifiers/hds-tooltip.ts
+++ b/packages/components/src/modifiers/hds-tooltip.ts
@@ -131,14 +131,12 @@ export default class HdsTooltipModifier extends Modifier<HdsTooltipModifierSigna
     const containerElement = document.createElement('div');
     containerElement.setAttribute('id', this._containerId);
     containerElement.classList.add('hds-tooltip-container');
+    containerElement.style.setProperty('position', 'absolute');
+    containerElement.style.setProperty('width', '100%');
     element.setAttribute('aria-controls', this._containerId);
     element.setAttribute('aria-describedby', this._containerId);
+    element.after(containerElement);
     this._containerElement = containerElement;
-
-    const parent = element.parentElement;
-    if (parent) {
-      parent?.appendChild(containerElement);
-    }
   }
 
   #getTooltipProps(

--- a/packages/components/src/modifiers/hds-tooltip.ts
+++ b/packages/components/src/modifiers/hds-tooltip.ts
@@ -11,6 +11,7 @@ import type { ArgsFor } from 'ember-modifier';
 
 import { assert } from '@ember/debug';
 import { registerDestructor } from '@ember/destroyable';
+import { guidFor } from '@ember/object/internals';
 
 import tippy, { followCursor } from 'tippy.js';
 import type {
@@ -32,9 +33,12 @@ export interface HdsTooltipModifierSignature {
 }
 
 function cleanup(instance: HdsTooltipModifier): void {
-  const { _interval, _needsTabIndex, _tooltip } = instance;
+  const { _interval, _needsTabIndex, _tooltip, _containerElement } = instance;
   if (_needsTabIndex) {
     _tooltip?.reference?.removeAttribute('tabindex');
+  }
+  if (_containerElement) {
+    _containerElement.remove();
   }
   clearInterval(_interval);
   _tooltip?.destroy();
@@ -55,9 +59,11 @@ function cleanup(instance: HdsTooltipModifier): void {
  */
 export default class HdsTooltipModifier extends Modifier<HdsTooltipModifierSignature> {
   private _didSetup = false;
+  private _containerId: string = 'container-' + guidFor(this);
   _interval: number | undefined = undefined;
   _needsTabIndex = false;
   _tooltip: TippyInstance | undefined = undefined;
+  _containerElement?: HTMLElement;
 
   constructor(owner: unknown, args: ArgsFor<HdsTooltipModifierSignature>) {
     super(owner, args);
@@ -105,6 +111,7 @@ export default class HdsTooltipModifier extends Modifier<HdsTooltipModifierSigna
     positional: HdsTooltipModifierSignature['Args']['Positional'],
     named: HdsTooltipModifierSignature['Args']['Named']
   ): void {
+    this.#createPopoverContainer(element);
     const tooltipProps = this.#getTooltipProps(element, positional, named);
     this._tooltip = tippy(element, tooltipProps);
   }
@@ -116,6 +123,22 @@ export default class HdsTooltipModifier extends Modifier<HdsTooltipModifierSigna
   ): void {
     const tooltipProps = this.#getTooltipProps(element, positional, named);
     this._tooltip?.setProps(tooltipProps);
+  }
+
+  #createPopoverContainer(
+    element: HdsTooltipModifierSignature['Element']
+  ): void {
+    const containerElement = document.createElement('div');
+    containerElement.setAttribute('id', this._containerId);
+    containerElement.classList.add('hds-tooltip-container');
+    element.setAttribute('aria-controls', this._containerId);
+    element.setAttribute('aria-describedby', this._containerId);
+    this._containerElement = containerElement;
+
+    const parent = element.parentElement;
+    if (parent) {
+      parent?.appendChild(containerElement);
+    }
   }
 
   #getTooltipProps(
@@ -200,9 +223,9 @@ export default class HdsTooltipModifier extends Modifier<HdsTooltipModifierSigna
         </svg>`,
       // keeps tooltip itself open on hover:
       interactive: true,
+      appendTo: this._containerElement,
       // fix accessibility features that get messed up with setting interactive: true
       aria: {
-        content: 'describedby',
         expanded: false,
       },
       content: () => content,

--- a/showcase/tests/integration/components/hds/tooltip/tooltip-button-test.js
+++ b/showcase/tests/integration/components/hds/tooltip/tooltip-button-test.js
@@ -81,19 +81,27 @@ module('Integration | Component | hds/tooltip/index', function (hooks) {
     assert.dom('.tippy-box').hasAttribute('role', 'tooltip');
   });
 
-  test('the button has an aria-describedby attribute with a value matching the tooltip id', async function (assert) {
+  test('the button has an aria-describedby and aria-controls attribute with a value matching the tooltip container', async function (assert) {
     await render(
       hbs`<Hds::TooltipButton @text="Hello" data-test-tooltip-button>info</Hds::TooltipButton>`
     );
     await focus('[data-test-tooltip-button]');
     assert.dom('[data-test-tooltip-button]').hasAttribute('aria-describedby');
-    assert.dom('[data-tippy-root]').hasAttribute('id');
+    assert.dom('[data-test-tooltip-button]').hasAttribute('aria-controls');
+    assert.dom('.hds-tooltip-container').hasAttribute('id');
 
     assert.strictEqual(
       this.element
         .querySelector('[data-test-tooltip-button]')
         .getAttribute('aria-describedby'),
-      this.element.querySelector('[data-tippy-root]').getAttribute('id')
+      this.element.querySelector('.hds-tooltip-container').getAttribute('id')
+    );
+
+    assert.strictEqual(
+      this.element
+        .querySelector('[data-test-tooltip-button]')
+        .getAttribute('aria-controls'),
+      this.element.querySelector('.hds-tooltip-container').getAttribute('id')
     );
   });
 

--- a/showcase/tests/integration/components/hds/tooltip/tooltip-button-test.js
+++ b/showcase/tests/integration/components/hds/tooltip/tooltip-button-test.js
@@ -86,23 +86,9 @@ module('Integration | Component | hds/tooltip/index', function (hooks) {
       hbs`<Hds::TooltipButton @text="Hello" data-test-tooltip-button>info</Hds::TooltipButton>`
     );
     await focus('[data-test-tooltip-button]');
-    assert.dom('[data-test-tooltip-button]').hasAttribute('aria-describedby');
-    assert.dom('[data-test-tooltip-button]').hasAttribute('aria-controls');
-    assert.dom('.hds-tooltip-container').hasAttribute('id');
-
-    assert.strictEqual(
-      this.element
-        .querySelector('[data-test-tooltip-button]')
-        .getAttribute('aria-describedby'),
-      this.element.querySelector('.hds-tooltip-container').getAttribute('id')
-    );
-
-    assert.strictEqual(
-      this.element
-        .querySelector('[data-test-tooltip-button]')
-        .getAttribute('aria-controls'),
-      this.element.querySelector('.hds-tooltip-container').getAttribute('id')
-    );
+    const tooltipContainerId = this.element.querySelector('.hds-tooltip-container').getAttribute('id');
+    assert.dom('[data-test-tooltip-button]').hasAttribute('aria-describedby', tooltipContainerId);
+    assert.dom('[data-test-tooltip-button]').hasAttribute('aria-controls', tooltipContainerId);
   });
 
   // PLACEMENT

--- a/showcase/tests/integration/components/hds/tooltip/tooltip-button-test.js
+++ b/showcase/tests/integration/components/hds/tooltip/tooltip-button-test.js
@@ -86,9 +86,15 @@ module('Integration | Component | hds/tooltip/index', function (hooks) {
       hbs`<Hds::TooltipButton @text="Hello" data-test-tooltip-button>info</Hds::TooltipButton>`
     );
     await focus('[data-test-tooltip-button]');
-    const tooltipContainerId = this.element.querySelector('.hds-tooltip-container').getAttribute('id');
-    assert.dom('[data-test-tooltip-button]').hasAttribute('aria-describedby', tooltipContainerId);
-    assert.dom('[data-test-tooltip-button]').hasAttribute('aria-controls', tooltipContainerId);
+    const tooltipContainerId = this.element
+      .querySelector('.hds-tooltip-container')
+      .getAttribute('id');
+    assert
+      .dom('[data-test-tooltip-button]')
+      .hasAttribute('aria-describedby', tooltipContainerId);
+    assert
+      .dom('[data-test-tooltip-button]')
+      .hasAttribute('aria-controls', tooltipContainerId);
   });
 
   // PLACEMENT

--- a/showcase/tests/integration/components/hds/tooltip/tooltip-modifier-test.js
+++ b/showcase/tests/integration/components/hds/tooltip/tooltip-modifier-test.js
@@ -22,12 +22,19 @@ module('Integration | Component | hds/tooltip/index', function (hooks) {
 
     // test the expected accessibility related attributes:
     assert.dom('#test-tooltip-modifier').hasAttribute('aria-describedby');
-    assert.dom('[data-tippy-root]').hasAttribute('id');
+    assert.dom('.hds-tooltip-container').exists();
+    assert.dom('.hds-tooltip-container').hasAttribute('id');
     assert.strictEqual(
       this.element
         .querySelector('#test-tooltip-modifier')
         .getAttribute('aria-describedby'),
-      this.element.querySelector('[data-tippy-root]').getAttribute('id')
+      this.element.querySelector('.hds-tooltip-container').getAttribute('id')
+    );
+    assert.strictEqual(
+      this.element
+        .querySelector('#test-tooltip-modifier')
+        .getAttribute('aria-controls'),
+      this.element.querySelector('.hds-tooltip-container').getAttribute('id')
     );
   });
 });


### PR DESCRIPTION
📌 Summary
This PR implements usage of the `aria-controls` attribute in the `hds-tooltip` modifier to align show/hide behavior across the repo as follows in the initiative from [HDS-3581](https://hashicorp.atlassian.net/browse/HDS-3581).

The `hds-tooltip` modifier is used in the `TooltipButton`.

🛠️ Detailed description
Currently in the `hds-tooltip` modifier, the toggled content does not follow the proper a11y structure for toggled content, or leverage `aria-controls`.

As per a11y guidance in [HDS-3581](https://hashicorp.atlassian.net/browse/HDS-3581), all togged content should follow a pattern leveraging `aria-controls`, and all toggled containers should not be removed from the DOM on each toggle. They should always be present, and only the content inside them is added and removed.

Currently the `hds-tooltip` follows a pattern where the entire content block is added and removed on each toggle, and any `aria-` attributes are set to the `id` of this removable block. 

In this PR a new `hds-tooltip-container` block is now added as a sibling of the tooltip button, and is present in the DOM at all times. The yielded content is removed or added inside this container based on the tooltip visibility.

The `aria-describedby` and `aria-controls` attributes of the tooltip element now reference the `hds-tooltip-container`.

Note: The tooltip library leveraged, [tippy.js](https://atomiks.github.io/tippyjs/v6/accessibility/), does not support this DOM structure out of the box or with any properties, so the container element has been created manually, and the tippy propery `appendTo` has been used to attach the tooltip content to this element.

### :camera_flash: Screenshots

**Before**

Inactive
<img width="411" alt="Screenshot 2025-01-22 at 9 42 30 AM" src="https://github.com/user-attachments/assets/ff974654-b23a-47ed-9df5-111862a4605c" />

Active
<img width="413" alt="Screenshot 2025-01-22 at 9 45 49 AM" src="https://github.com/user-attachments/assets/0ba2bca4-519c-4623-b30a-26aac4bd21bd" />

**After**

Inactive
<img width="410" alt="Screenshot 2025-01-22 at 9 40 33 AM" src="https://github.com/user-attachments/assets/fdcdb282-c405-465c-96d5-51fc843f24d7" />

Active
<img width="414" alt="Screenshot 2025-01-22 at 9 41 59 AM" src="https://github.com/user-attachments/assets/b360a0e5-9210-4558-93f7-0b59b6938290" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4327](https://hashicorp.atlassian.net/browse/HDS-4327)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3581]: https://hashicorp.atlassian.net/browse/HDS-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-3581]: https://hashicorp.atlassian.net/browse/HDS-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-4327]: https://hashicorp.atlassian.net/browse/HDS-4327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ