### PR TITLE
`Table`: Multi-select bug - selected rows removed when model updates (HDS-4273)

### DIFF
--- a/packages/components/src/components/hds/table/index.ts
+++ b/packages/components/src/components/hds/table/index.ts
@@ -300,6 +300,11 @@ export default class HdsTable extends Component<HdsTableSignature> {
     );
 
     if (selectionKey) {
+      // Remove any existing item with the same `selectionKey` identifier (this may occur if the model is updated and the rows re-rendered)
+      this._selectableRows = this._selectableRows.filter(
+        (row): boolean => row.selectionKey !== selectionKey
+      );
+      // Add the new item
       this._selectableRows.push({ selectionKey, checkbox });
     }
     this.setSelectAllState();
@@ -314,22 +319,6 @@ export default class HdsTable extends Component<HdsTableSignature> {
       this._selectableRows.map((row): string => row.selectionKey)
     );
 
-    // Fix for selectableRows state not being maintained properly when model updates:
-    // Delete the first row with the given selection key you find from the selectableRows array
-    // Search for the index of the row to delete. If found, delete it.
-    // (Fixes issue of not rows not being properly selectable including "select all" functionality)
-    const rowToDeleteIndex = this._selectableRows.findIndex(
-      (row): boolean => row.selectionKey === selectionKey
-    );
-
-    if (rowToDeleteIndex > -1) {
-      this._selectableRows.splice(rowToDeleteIndex, 1);
-    }
-
-    // ORIGINAL:
-    // this._selectableRows = this._selectableRows.filter(
-    //   (row): boolean => row.selectionKey !== selectionKey
-    // );
     this.setSelectAllState();
   }
 

--- a/packages/components/src/components/hds/table/index.ts
+++ b/packages/components/src/components/hds/table/index.ts
@@ -105,7 +105,7 @@ export default class HdsTable extends Component<HdsTableSignature> {
   get getSortCriteria(): string | HdsTableSortingFunction<unknown> {
     // get the current column
     const currentColumn = this.args?.columns?.find(
-      (column) => column.key === this.sortBy
+      (column): boolean => column.key === this.sortBy
     );
     if (
       // check if there is a custom sorting function associated with the current `sortBy` column (we assume the column has `isSortable`)
@@ -124,7 +124,9 @@ export default class HdsTable extends Component<HdsTableSignature> {
     if (this.args.identityKey === 'none') {
       return undefined;
     } else {
-      return this.args.identityKey ?? '@identity';
+      // We return a default key to cause an update operation instead of replacement when the model changes to side-step
+      // a bug in Ember which would cause the table to lose its selection state
+      return this.args.identityKey ?? 'hds-table-key';
     }
   }
 
@@ -289,6 +291,13 @@ export default class HdsTable extends Component<HdsTableSignature> {
     checkbox: HdsFormCheckboxBaseSignature['Element'],
     selectionKey?: string
   ): void {
+    // TEST:
+    console.log(
+      `[${this.args.caption}] Did insert row checkbox`,
+      selectionKey,
+      this._selectableRows.map((row) => row.selectionKey)
+    );
+
     if (selectionKey) {
       this._selectableRows.push({ selectionKey, checkbox });
     }
@@ -297,8 +306,15 @@ export default class HdsTable extends Component<HdsTableSignature> {
 
   @action
   willDestroyRowCheckbox(selectionKey?: string): void {
+    // TEST:
+    console.log(
+      `[${this.args.caption}] Will destroy row checkbox`,
+      selectionKey,
+      this._selectableRows.map((row) => row.selectionKey)
+    );
+
     this._selectableRows = this._selectableRows.filter(
-      (row) => row.selectionKey !== selectionKey
+      (row): boolean => row.selectionKey !== selectionKey
     );
     this.setSelectAllState();
   }
@@ -308,7 +324,7 @@ export default class HdsTable extends Component<HdsTableSignature> {
     if (this._selectAllCheckbox) {
       const selectableRowsCount = this._selectableRows.length;
       const selectedRowsCount = this._selectableRows.filter(
-        (row) => row.checkbox.checked
+        (row): boolean => row.checkbox.checked
       ).length;
 
       this._selectAllCheckbox.checked =

--- a/packages/components/src/components/hds/table/index.ts
+++ b/packages/components/src/components/hds/table/index.ts
@@ -126,7 +126,7 @@ export default class HdsTable extends Component<HdsTableSignature> {
     } else {
       // We return a default key to cause an update operation instead of replacement when the model changes to side-step
       // a bug in Ember which would cause the table to lose its selection state
-      return this.args.identityKey ?? 'hds-table-key';
+      return this.args.identityKey ?? '@identity';
     }
   }
 
@@ -295,7 +295,7 @@ export default class HdsTable extends Component<HdsTableSignature> {
     console.log(
       `[${this.args.caption}] Did insert row checkbox`,
       selectionKey,
-      this._selectableRows.map((row) => row.selectionKey)
+      this._selectableRows.map((row): string => row.selectionKey)
     );
 
     if (selectionKey) {
@@ -310,12 +310,25 @@ export default class HdsTable extends Component<HdsTableSignature> {
     console.log(
       `[${this.args.caption}] Will destroy row checkbox`,
       selectionKey,
-      this._selectableRows.map((row) => row.selectionKey)
+      this._selectableRows.map((row): string => row.selectionKey)
     );
 
-    this._selectableRows = this._selectableRows.filter(
-      (row): boolean => row.selectionKey !== selectionKey
+    // Fix for selectableRows state not being maintained properly when model updates:
+    // Delete the first row with the given selction key you find from the selectableRows array
+    // Search for the index of the row to delete. If found, delete it.
+    // (Fixes issue of not rows not being properly selectable including "select all" functionality)
+    const rowToDeleteIndex = this._selectableRows.findIndex(
+      (row): boolean => row.selectionKey === selectionKey
     );
+
+    if (rowToDeleteIndex > -1) {
+      this._selectableRows.splice(rowToDeleteIndex, 1);
+    }
+
+    // ORIGINAL:
+    // this._selectableRows = this._selectableRows.filter(
+    //   (row): boolean => row.selectionKey !== selectionKey
+    // );
     this.setSelectAllState();
   }
 

--- a/packages/components/src/components/hds/table/index.ts
+++ b/packages/components/src/components/hds/table/index.ts
@@ -124,8 +124,9 @@ export default class HdsTable extends Component<HdsTableSignature> {
     if (this.args.identityKey === 'none') {
       return undefined;
     } else {
-      // We return a default key to cause an update operation instead of replacement when the model changes to side-step
-      // a bug in Ember which would cause the table to lose its selection state
+      // We return `@identity` as default to cause an update operation instead of replacement when the model changes to avoid unexpected side effects
+      // see: "Specifying Keys" here: https://api.emberjs.com/ember/6.1/classes/Ember.Templates.helpers/methods/each?anchor=each
+      // see also: https://github.com/hashicorp/design-system/pull/1160 + https://github.com/hashicorp/cloud-ui/pull/5178 + https://hashicorp.atlassian.net/browse/HDS-4273
       return this.args.identityKey ?? '@identity';
     }
   }
@@ -314,7 +315,7 @@ export default class HdsTable extends Component<HdsTableSignature> {
     );
 
     // Fix for selectableRows state not being maintained properly when model updates:
-    // Delete the first row with the given selction key you find from the selectableRows array
+    // Delete the first row with the given selection key you find from the selectableRows array
     // Search for the index of the row to delete. If found, delete it.
     // (Fixes issue of not rows not being properly selectable including "select all" functionality)
     const rowToDeleteIndex = this._selectableRows.findIndex(

--- a/showcase/app/controllers/components/table-multi-select-bug.js
+++ b/showcase/app/controllers/components/table-multi-select-bug.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+// prettier-ignore
+const daysOfChristmas = [
+  { key: 'one', quantity: 1, type: 'bird', line: 'A partridge in a pear tree' },
+  { key: 'two', quantity: 2, type: 'bird', line: 'Two turtle doves' },
+  { key: 'three', quantity: 3, type: 'bird', line: 'Three french hens' },
+  { key: 'four', quantity: 4, type: 'bird', line: 'Four calling birds' },
+  { key: 'five', quantity: 5, type: 'jewelry', line: 'Five gold rings' },
+  { key: 'six', quantity: 6, type: 'more bird', line: 'Six geese a-laying' },
+  { key: 'seven', quantity: 7, type: 'bird again', line: 'Seven swans a-swimming' },
+  { key: 'eight', quantity: 8, type: 'servant', line: 'Eight maids a-milking' },
+  { key: 'nine', quantity: 9, type: 'maybe royalty', line: 'Nine ladies dancing' },
+  { key: 'ten', quantity: 10, type: 'definitely royalty', line: 'Ten lords a-leaping' },
+  { key: 'eleven', quantity: 11, type: 'musician', line: 'Eleven pipers piping' },
+  { key: 'twelve', quantity: 12, type: 'musician, technically', line: 'Twelve drummers drumming' },
+];
+
+export default class extends Controller {
+  @tracked showTable = false;
+  @tracked lyrics = daysOfChristmas.slice();
+
+  @action dirtyModel() {
+    // Deep copy to destroy references
+    this.lyrics = this.lyrics.map((r) => ({ ...r }));
+  }
+
+  printSelection = (selection) =>
+    console.log('Printing selection:', selection.selectedRowsKeys);
+}

--- a/showcase/app/controllers/components/table-multi-select-bug.js
+++ b/showcase/app/controllers/components/table-multi-select-bug.js
@@ -35,6 +35,15 @@ export default class extends Controller {
       .sort(() => Math.random() - 0.5);
   }
 
+  @action dirtyModelWithLessRows() {
+    this.lyrics = this.lyrics
+      // Deep copy to destroy references
+      .map((r) => ({ ...r }))
+      // Randomly sort to see what happens in this case
+      .sort(() => Math.random() - 0.5)
+      .filter((row) => row.key !== 'five');
+  }
+
   printSelection = (selection) =>
     console.log('Printing selection:', selection.selectedRowsKeys);
 }

--- a/showcase/app/controllers/components/table-multi-select-bug.js
+++ b/showcase/app/controllers/components/table-multi-select-bug.js
@@ -28,8 +28,11 @@ export default class extends Controller {
   @tracked lyrics = daysOfChristmas.slice();
 
   @action dirtyModel() {
-    // Deep copy to destroy references
-    this.lyrics = this.lyrics.map((r) => ({ ...r }));
+    this.lyrics = this.lyrics
+      // Deep copy to destroy references
+      .map((r) => ({ ...r }))
+      // Randomly sort to see what happens in this case
+      .sort(() => Math.random() - 0.5);
   }
 
   printSelection = (selection) =>

--- a/showcase/app/router.ts
+++ b/showcase/app/router.ts
@@ -63,6 +63,7 @@ Router.map(function () {
     this.route('side-nav');
     this.route('stepper');
     this.route('table');
+    this.route('table-multi-select-bug');
     this.route('tag');
     this.route('text');
     this.route('time');

--- a/showcase/app/templates/components/table-multi-select-bug.hbs
+++ b/showcase/app/templates/components/table-multi-select-bug.hbs
@@ -1,0 +1,73 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{page-title "Table multi-select bug"}}
+
+<Shw::Text::H1>Table multi-select bug</Shw::Text::H1>
+
+<section>
+  <p>When a table isn't immediately rendered, a bug occurs where table rows render twice. Normally this is not a big
+    deal, but due to the way that row-level checkboxes are registered, we get this unfortunate sequence of events:</p>
+  <ol>
+    <li><code>didInsertRowCheckbox</code>: Insert selection keys to <code>_selectableRows</code></li>
+    <li><code>didInsertRowCheckbox</code>: Insert selection keys to
+      <code>_selectableRows</code>
+      a second time. This results in an array that's 2x of every selection key.</li>
+    <li><code>willDestroyRowCheckbox</code>: Filters
+      <code>_selectableRows</code>
+      by removed selection key, except this removes the first and second insertions resulting in an empty array.</li>
+  </ol>
+
+  <Shw::Text::H2>This will work until you click the "Force new data" button</Shw::Text::H2>
+
+  <Hds::Button @text="Force new data" {{on "click" this.dirtyModel}} />
+
+  <Hds::Table
+    @model={{this.lyrics}}
+    @caption="local property"
+    @columns={{array
+      (hash key="quantity" label="Quantity")
+      (hash key="type" label="Type")
+      (hash key="line" label="Line")
+    }}
+    @isSelectable={{true}}
+    @onSelectionChange={{this.printSelection}}
+  >
+    <:body as |B|>
+      <B.Tr @selectionKey={{B.data.key}} @selectionAriaLabelSuffix=" {{B.data.key}}">
+        <B.Td>{{B.data.quantity}}</B.Td>
+        <B.Td>{{B.data.type}}</B.Td>
+        <B.Td>{{B.data.line}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+
+  <Shw::Text::H2>This will always work because
+    <code>@identityKey</code>
+    performs an update not a replace.</Shw::Text::H2>
+
+  <Hds::Button @text="Force new data" {{on "click" this.dirtyModel}} />
+
+  <Hds::Table
+    @model={{this.lyrics}}
+    @caption="local property"
+    @columns={{array
+      (hash key="quantity" label="Quantity")
+      (hash key="type" label="Type")
+      (hash key="line" label="Line")
+    }}
+    @identityKey="key"
+    @isSelectable={{true}}
+    @onSelectionChange={{this.printSelection}}
+  >
+    <:body as |B|>
+      <B.Tr @selectionKey={{B.data.key}} @selectionAriaLabelSuffix=" {{B.data.key}}">
+        <B.Td>{{B.data.quantity}}</B.Td>
+        <B.Td>{{B.data.type}}</B.Td>
+        <B.Td>{{B.data.line}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::Table>
+</section>

--- a/showcase/app/templates/components/table-multi-select-bug.hbs
+++ b/showcase/app/templates/components/table-multi-select-bug.hbs
@@ -22,7 +22,10 @@
 
   <Shw::Text::H2>This will work until you click the "Force new data" button</Shw::Text::H2>
 
-  <Hds::Button @text="Force new data" {{on "click" this.dirtyModel}} />
+  <p>
+    <Hds::Button @text="Force new data" {{on "click" this.dirtyModel}} @isInline={{true}} />
+    <Hds::Button @text="Force new data with fewer rows" {{on "click" this.dirtyModelWithLessRows}} @isInline={{true}} />
+  </p>
 
   <Hds::Table
     @model={{this.lyrics}}

--- a/showcase/tests/integration/components/hds/table/index-test.js
+++ b/showcase/tests/integration/components/hds/table/index-test.js
@@ -74,43 +74,70 @@ const setSelectableTableData = (context) => {
   ]);
 };
 
-const hbsSortableTable = hbs`
-  <Hds::Table
-    @model={{this.model}}
-    @sortBy={{this.sortBy}}
-    @sortOrder={{this.sortOrder}}
-    @onSort={{this.onSort}}
-    @columns={{this.columns}}
-    @sortedMessageText={{this.sortedMessageText}}
-    @caption={{this.caption}}
-    id="data-test-table"
-  >
-    <:body as |B|>
-      <B.Tr>
-        <B.Td>{{B.data.artist}}</B.Td>
-        <B.Td>{{B.data.album}}</B.Td>
-        <B.Td>{{B.data.year}}</B.Td>
-      </B.Tr>
-    </:body>
-  </Hds::Table>
-`;
+const setNewSelectableTableData = (context) => {
+  context.set('model', [
+    {
+      id: '1',
+      type: 'folk',
+      artist: 'Nick Drake',
+      album: 'Pink Moon',
+      year: '1972',
+    },
+    {
+      id: '2',
+      type: 'folk',
+      artist: 'The Beatles',
+      album: 'Abbey Road',
+      year: '1969',
+    },
+    {
+      id: '3',
+      type: 'folk',
+      artist: 'Melanie',
+      album: 'Candles in the Rain',
+      year: '1971',
+    },
+  ]);
+  context.set('columns', [
+    { key: 'artist', label: 'Artist' },
+    { key: 'album', label: 'Album' },
+    { key: 'year', label: 'Year' },
+  ]);
+};
 
-const hbsSelectableTable = hbs`
-  <Hds::Table
-    @isSelectable={{true}}
-    @model={{this.model}}
-    @columns={{this.columns}}
-    id="data-test-selectable-table"
-  >
-    <:body as |B|>
-      <B.Tr @selectionKey={{B.data.id}}>
-        <B.Td>{{B.data.artist}}</B.Td>
-        <B.Td>{{B.data.album}}</B.Td>
-        <B.Td>{{B.data.year}}</B.Td>
-      </B.Tr>
-    </:body>
-  </Hds::Table>
-`;
+const hbsSortableTable = hbs`<Hds::Table
+  @model={{this.model}}
+  @sortBy={{this.sortBy}}
+  @sortOrder={{this.sortOrder}}
+  @onSort={{this.onSort}}
+  @columns={{this.columns}}
+  @sortedMessageText={{this.sortedMessageText}}
+  @caption={{this.caption}}
+  id='data-test-table'
+>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>`;
+
+const hbsSelectableTable = hbs`<Hds::Table
+  @isSelectable={{true}}
+  @model={{this.model}}
+  @columns={{this.columns}}
+  id='data-test-selectable-table'
+>
+  <:body as |B|>
+    <B.Tr @selectionKey={{B.data.id}}>
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>`;
 
 // Basic tests
 
@@ -118,33 +145,33 @@ module('Integration | Component | hds/table/index', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
-    await render(hbs`<Hds::Table id="data-test-table"/>`);
+    await render(hbs`<Hds::Table id='data-test-table' />`);
     assert.dom('#data-test-table').hasClass('hds-table');
   });
 
   test('it should render with a CSS class appropriate for the @density value', async function (assert) {
-    await render(hbs`<Hds::Table @density="short" id="data-test-table" />`);
+    await render(hbs`<Hds::Table @density='short' id='data-test-table' />`);
     assert.dom('#data-test-table').hasClass('hds-table--density-short');
   });
 
   test('it should render with a CSS class appropriate if no @density value is set', async function (assert) {
-    await render(hbs`<Hds::Table id="data-test-table"/>`);
+    await render(hbs`<Hds::Table id='data-test-table' />`);
     assert.dom('#data-test-table').hasClass('hds-table--density-medium');
   });
 
   test('it should render with a CSS class appropriate for the @valign value', async function (assert) {
-    await render(hbs`<Hds::Table @valign="middle" id="data-test-table" />`);
+    await render(hbs`<Hds::Table @valign='middle' id='data-test-table' />`);
     assert.dom('#data-test-table').hasClass('hds-table--valign-middle');
   });
 
   test('it should render with a CSS class appropriate if no @valign value is set', async function (assert) {
-    await render(hbs`<Hds::Table id="data-test-table"/>`);
+    await render(hbs`<Hds::Table id='data-test-table' />`);
     assert.dom('#data-test-table').hasClass('hds-table--valign-top');
   });
 
   test('it should support splattributes', async function (assert) {
     await render(
-      hbs`<Hds::Table id="data-test-table" aria-label="data test table" />`
+      hbs`<Hds::Table id='data-test-table' aria-label='data test table' />`
     );
     assert
       .dom('#data-test-table')
@@ -152,34 +179,32 @@ module('Integration | Component | hds/table/index', function (hooks) {
   });
 
   test('it should render the table with manual data passed and no model defined', async function (assert) {
-    await render(hbs`
-      <Hds::Table id="data-test-table">
-        <:head as |H|>
-          <H.Tr>
-            <H.Th>Cell Header 1</H.Th>
-            <H.Th>Cell Header 2</H.Th>
-            <H.Th>Cell Header 3</H.Th>
-          </H.Tr>
-        </:head>
-        <:body as |B|>
-          <B.Tr>
-            <B.Td>Cell Content 1 1</B.Td>
-            <B.Td>Cell Content 1 2</B.Td>
-            <B.Td>Cell Content 1 3</B.Td>
-          </B.Tr>
-          <B.Tr>
-            <B.Td>Cell Content 2 1</B.Td>
-            <B.Td>Cell Content 2 2</B.Td>
-            <B.Td>Cell Content 2 3</B.Td>
-          </B.Tr>
-          <B.Tr>
-            <B.Td>Cell Content 3 1</B.Td>
-            <B.Td>Cell Content 3 2</B.Td>
-            <B.Td>Cell Content 3 3</B.Td>
-          </B.Tr>
-        </:body>
-      </Hds::Table>
-    `);
+    await render(hbs`<Hds::Table id='data-test-table'>
+  <:head as |H|>
+    <H.Tr>
+      <H.Th>Cell Header 1</H.Th>
+      <H.Th>Cell Header 2</H.Th>
+      <H.Th>Cell Header 3</H.Th>
+    </H.Tr>
+  </:head>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>Cell Content 1 1</B.Td>
+      <B.Td>Cell Content 1 2</B.Td>
+      <B.Td>Cell Content 1 3</B.Td>
+    </B.Tr>
+    <B.Tr>
+      <B.Td>Cell Content 2 1</B.Td>
+      <B.Td>Cell Content 2 2</B.Td>
+      <B.Td>Cell Content 2 3</B.Td>
+    </B.Tr>
+    <B.Tr>
+      <B.Td>Cell Content 3 1</B.Td>
+      <B.Td>Cell Content 3 2</B.Td>
+      <B.Td>Cell Content 3 3</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>`);
 
     assert.dom('#data-test-table tr th:first-of-type').hasText('Cell Header 1');
     assert
@@ -194,21 +219,23 @@ module('Integration | Component | hds/table/index', function (hooks) {
       { key: 'year', name: 'Test 3', description: 'Test 3 description' },
     ]);
 
-    await render(hbs`
-      <Hds::Table id="data-test-table" @model={{this.model}} @columns={{array
-        (hash key='artist' label='components.table.headers.artist')
-        (hash key='album' label='components.table.headers.album')
-        (hash key='year' label='components.table.headers.year')
-      }}>
-        <:body as |B|>
-          <B.Tr id={{B.rowIndex}}>
-            <B.Td>{{B.data.key}}</B.Td>
-            <B.Td>{{B.data.name}}</B.Td>
-            <B.Td>{{B.data.description}}</B.Td>
-          </B.Tr>
-        </:body>
-      </Hds::Table>
-    `);
+    await render(hbs`<Hds::Table
+  id='data-test-table'
+  @model={{this.model}}
+  @columns={{array
+    (hash key='artist' label='components.table.headers.artist')
+    (hash key='album' label='components.table.headers.album')
+    (hash key='year' label='components.table.headers.year')
+  }}
+>
+  <:body as |B|>
+    <B.Tr id={{B.rowIndex}}>
+      <B.Td>{{B.data.key}}</B.Td>
+      <B.Td>{{B.data.name}}</B.Td>
+      <B.Td>{{B.data.description}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>`);
 
     assert.dom('#data-test-table tr:nth-child(3)').hasProperty('id', '2');
 
@@ -227,24 +254,26 @@ module('Integration | Component | hds/table/index', function (hooks) {
       { id: 3, name: 'Test 3', description: 'Test 3 description' },
     ]);
 
-    await render(hbs`
-      <Hds::Table id="data-test-table" @model={{this.model}} @caption="a test caption">
-        <:head as |H|>
-          <H.Tr>
-            <H.Th>Id</H.Th>
-            <H.Th>Name</H.Th>
-            <H.Th>Description</H.Th>
-          </H.Tr>
-        </:head>
-        <:body as |B|>
-          <B.Tr>
-            <B.Td>{{B.data.id}}</B.Td>
-            <B.Td>{{B.data.name}}</B.Td>
-            <B.Td>{{B.data.description}}</B.Td>
-          </B.Tr>
-        </:body>
-      </Hds::Table>
-    `);
+    await render(hbs`<Hds::Table
+  id='data-test-table'
+  @model={{this.model}}
+  @caption='a test caption'
+>
+  <:head as |H|>
+    <H.Tr>
+      <H.Th>Id</H.Th>
+      <H.Th>Name</H.Th>
+      <H.Th>Description</H.Th>
+    </H.Tr>
+  </:head>
+  <:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.data.id}}</B.Td>
+      <B.Td>{{B.data.name}}</B.Td>
+      <B.Td>{{B.data.description}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>`);
 
     assert.dom('#data-test-table caption').hasText('a test caption');
   });
@@ -438,30 +467,22 @@ module('Integration | Component | hds/table/index', function (hooks) {
       }
     });
 
-    await render(hbs`
-      <Hds::Table
-        id="data-test-table"
-        @isSelectable={{true}}
-        @selectableColumnKey={{this.selectableColumnKey}}
-        @onSelectionChange={{this.onSelectionChange}}
-        @onSort={{this.onSort}}
-        @model={{this.model}}
-        @columns={{array
-          (hash key="name" label="Name")
-          (hash key="age" label="Age")
-        }}
-      >
-        <:body as |B|>
-          <B.Tr
-            @selectionKey={{B.data.id}}
-            @isSelected={{B.data.isSelected}}
-          >
-            <B.Td>{{B.data.name}}</B.Td>
-            <B.Td>{{B.data.age}}</B.Td>
-          </B.Tr>
-        </:body>
-      </Hds::Table>
-    `);
+    await render(hbs`<Hds::Table
+  id='data-test-table'
+  @isSelectable={{true}}
+  @selectableColumnKey={{this.selectableColumnKey}}
+  @onSelectionChange={{this.onSelectionChange}}
+  @onSort={{this.onSort}}
+  @model={{this.model}}
+  @columns={{array (hash key='name' label='Name') (hash key='age' label='Age')}}
+>
+  <:body as |B|>
+    <B.Tr @selectionKey={{B.data.id}} @isSelected={{B.data.isSelected}}>
+      <B.Td>{{B.data.name}}</B.Td>
+      <B.Td>{{B.data.age}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>`);
 
     assert.dom(sortBySelectedSelector).exists();
     assert
@@ -496,34 +517,32 @@ module('Integration | Component | hds/table/index', function (hooks) {
   });
 
   test('it renders a multi-select table when isSelectable is set to true for a table without a model', async function (assert) {
-    await render(hbs`
-      <Hds::Table @isSelectable={{true}} id="data-test-selectable-table">
-        <:head as |H|>
-          <H.Tr>
-            <H.Th>Cell Header 1</H.Th>
-            <H.Th>Cell Header 2</H.Th>
-            <H.Th>Cell Header 3</H.Th>
-          </H.Tr>
-        </:head>
-        <:body as |B|>
-          <B.Tr @selectionKey="row1">
-            <B.Td>Cell Content 1 1</B.Td>
-            <B.Td>Cell Content 1 2</B.Td>
-            <B.Td>Cell Content 1 3</B.Td>
-          </B.Tr>
-          <B.Tr @selectionKey="row2">
-            <B.Td>Cell Content 2 1</B.Td>
-            <B.Td>Cell Content 2 2</B.Td>
-            <B.Td>Cell Content 2 3</B.Td>
-          </B.Tr>
-          <B.Tr @selectionKey="row3">
-            <B.Td>Cell Content 3 1</B.Td>
-            <B.Td>Cell Content 3 2</B.Td>
-            <B.Td>Cell Content 3 3</B.Td>
-          </B.Tr>
-        </:body>
-      </Hds::Table>
-    `);
+    await render(hbs`<Hds::Table @isSelectable={{true}} id='data-test-selectable-table'>
+  <:head as |H|>
+    <H.Tr>
+      <H.Th>Cell Header 1</H.Th>
+      <H.Th>Cell Header 2</H.Th>
+      <H.Th>Cell Header 3</H.Th>
+    </H.Tr>
+  </:head>
+  <:body as |B|>
+    <B.Tr @selectionKey='row1'>
+      <B.Td>Cell Content 1 1</B.Td>
+      <B.Td>Cell Content 1 2</B.Td>
+      <B.Td>Cell Content 1 3</B.Td>
+    </B.Tr>
+    <B.Tr @selectionKey='row2'>
+      <B.Td>Cell Content 2 1</B.Td>
+      <B.Td>Cell Content 2 2</B.Td>
+      <B.Td>Cell Content 2 3</B.Td>
+    </B.Tr>
+    <B.Tr @selectionKey='row3'>
+      <B.Td>Cell Content 3 1</B.Td>
+      <B.Td>Cell Content 3 2</B.Td>
+      <B.Td>Cell Content 3 3</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>`);
     assert.dom(selectAllCheckboxSelector).exists({ count: 1 });
     assert.dom(rowCheckboxesSelector).exists({ count: 3 });
   });
@@ -569,29 +588,31 @@ module('Integration | Component | hds/table/index', function (hooks) {
       'onSelectionChange',
       ({ selectedRowsKeys }) => (keys = selectedRowsKeys)
     );
-    await render(hbs`
-      <Hds::Table @isSelectable={{true}} @onSelectionChange={{this.onSelectionChange}} id="data-test-selectable-table">
-        <:head as |H|>
-          <H.Tr>
-            <H.Th>Cell Header 1</H.Th>
-            <H.Th>Cell Header 2</H.Th>
-            <H.Th>Cell Header 3</H.Th>
-          </H.Tr>
-        </:head>
-        <:body as |B|>
-          <B.Tr @selectionKey="row1">
-            <B.Td>Cell Content 1 1</B.Td>
-            <B.Td>Cell Content 1 2</B.Td>
-            <B.Td>Cell Content 1 3</B.Td>
-          </B.Tr>
-          <B.Tr @selectionKey="row2">
-            <B.Td>Cell Content 2 1</B.Td>
-            <B.Td>Cell Content 2 2</B.Td>
-            <B.Td>Cell Content 2 3</B.Td>
-          </B.Tr>
-        </:body>
-      </Hds::Table>
-    `);
+    await render(hbs`<Hds::Table
+  @isSelectable={{true}}
+  @onSelectionChange={{this.onSelectionChange}}
+  id='data-test-selectable-table'
+>
+  <:head as |H|>
+    <H.Tr>
+      <H.Th>Cell Header 1</H.Th>
+      <H.Th>Cell Header 2</H.Th>
+      <H.Th>Cell Header 3</H.Th>
+    </H.Tr>
+  </:head>
+  <:body as |B|>
+    <B.Tr @selectionKey='row1'>
+      <B.Td>Cell Content 1 1</B.Td>
+      <B.Td>Cell Content 1 2</B.Td>
+      <B.Td>Cell Content 1 3</B.Td>
+    </B.Tr>
+    <B.Tr @selectionKey='row2'>
+      <B.Td>Cell Content 2 1</B.Td>
+      <B.Td>Cell Content 2 2</B.Td>
+      <B.Td>Cell Content 2 3</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>`);
     const rowCheckboxes = this.element.querySelectorAll(rowCheckboxesSelector);
     const firstRowCheckbox = rowCheckboxes[0];
     await click(firstRowCheckbox);
@@ -602,28 +623,39 @@ module('Integration | Component | hds/table/index', function (hooks) {
     assert.deepEqual(keys, []);
   });
 
+  // test that select all functionality works after model updates
+  test('select all functionality should work after model updates', async function (assert) {
+    setSelectableTableData(this);
+    await render(hbsSelectableTable);
+    // Force a model update
+    setNewSelectableTableData(this);
+
+    // test that the select all functionality still works
+    await click(selectAllCheckboxSelector);
+    assert.dom(selectAllCheckboxSelector).isChecked();
+    assert.dom(rowCheckboxesSelector).isChecked().exists({ count: 3 });
+  });
+
   // multi-select options
 
   // aria-labels
 
   test('it renders the expected `aria-label` values for "select all" and rows by default', async function (assert) {
     setSelectableTableData(this);
-    await render(hbs`
-      <Hds::Table
-        @isSelectable={{true}}
-        @model={{this.model}}
-        @columns={{this.columns}}
-        id="data-test-selectable-table"
-      >
-        <:body as |B|>
-          <B.Tr @selectionKey={{B.data.id}}>
-            <B.Td>{{B.data.artist}}</B.Td>
-            <B.Td>{{B.data.album}}</B.Td>
-            <B.Td>{{B.data.year}}</B.Td>
-          </B.Tr>
-        </:body>
-      </Hds::Table>
-    `);
+    await render(hbs`<Hds::Table
+  @isSelectable={{true}}
+  @model={{this.model}}
+  @columns={{this.columns}}
+  id='data-test-selectable-table'
+>
+  <:body as |B|>
+    <B.Tr @selectionKey={{B.data.id}}>
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>`);
 
     assert.dom(selectAllCheckboxSelector).hasAria('label', 'Select all rows');
     assert.dom(rowCheckboxesSelector).hasAria('label', 'Select row');
@@ -637,25 +669,23 @@ module('Integration | Component | hds/table/index', function (hooks) {
 
   test('it renders the expected `aria-label` for rows with `@selectionAriaLabelSuffix`', async function (assert) {
     setSelectableTableData(this);
-    await render(hbs`
-      <Hds::Table
-        @isSelectable={{true}}
-        @model={{this.model}}
-        @columns={{this.columns}}
-        id="data-test-selectable-table"
-      >
-        <:body as |B|>
-          <B.Tr
-            @selectionKey={{B.data.id}}
-            @selectionAriaLabelSuffix="custom suffix"
-          >
-            <B.Td>{{B.data.artist}}</B.Td>
-            <B.Td>{{B.data.album}}</B.Td>
-            <B.Td>{{B.data.year}}</B.Td>
-          </B.Tr>
-        </:body>
-      </Hds::Table>
-    `);
+    await render(hbs`<Hds::Table
+  @isSelectable={{true}}
+  @model={{this.model}}
+  @columns={{this.columns}}
+  id='data-test-selectable-table'
+>
+  <:body as |B|>
+    <B.Tr
+      @selectionKey={{B.data.id}}
+      @selectionAriaLabelSuffix="custom suffix"
+    >
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::Table>`);
 
     assert.dom(rowCheckboxesSelector).hasAria('label', 'Select custom suffix');
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes the issue with selectableRows state not being maintained properly after model update.

_(**NOTE:** Initial commits include test code from Michael Lange which will be removed before merge.)_

👉 See [related PR](https://github.com/hashicorp/design-system/pull/2667) to update docs for multi select table used with a model.

### :hammer_and_wrench: Detailed description

TODO: Add/update related tests.

**PREVIEW:** https://hds-showcase-git-hds-4273-table-multi-select-bug-hashicorp.vercel.app/components/table-multi-select-bug

**Bug:** Originally, clicking "Force new data" button in the first example wiped out the selectableRows array due to timing of didInsert & willDestroy calls.

**Expected:** SelectableRows array should have the proper set of checkbox items after model update and willDestroy calls finish.

<!--
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-4273](https://hashicorp.atlassian.net/browse/HDS-4273)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4273]: https://hashicorp.atlassian.net/browse/HDS-4273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ