### PR TITLE
`CodeEditor` style fast follow

### DIFF
--- a/packages/components/src/styles/components/code-editor/index.scss
+++ b/packages/components/src/styles/components/code-editor/index.scss
@@ -16,6 +16,10 @@
   background-color: var(--hds-code-editor-color-surface-primary);
   border: 1px solid var(--hds-code-editor-color-border-strong);
 
+  &.hds-code-editor--is-standalone {
+    border-radius: var(--token-border-radius-medium);
+  }
+
   &.hds-code-editor--is-full-screen {
     position: fixed;
     inset: 0;
@@ -26,10 +30,6 @@
     .hds-code-editor__editor {
       max-height: unset;
     }
-  }
-
-  &.hds-code-editor--is-standalone {
-    border-radius: var(--token-border-radius-medium);
   }
 
   .hds-code-editor__header {
@@ -93,10 +93,6 @@
     background-color: var(--hds-code-editor-color-surface-faint);
     border: 1px solid var(--hds-code-editor-color-border-strong);
 
-    &:active {
-      background-color: var(--hds-code-editor-color-surface-interactive-active)
-    }
-  
     &:focus,
     &:hover {
       background-color: var(--hds-code-editor-color-surface-primary);
@@ -104,6 +100,10 @@
       .hds-button__icon {
         color: var(--hds-code-editor-color-foreground-primary);
       }
+    }
+
+    &:active {
+      background-color: var(--hds-code-editor-color-surface-interactive-active)
     }
 
     .hds-button__icon {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes a couple of visual bugs in the code editor.

- Active style not being applied to header buttons
- Border radius remaining in full screen

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
