### PR TITLE
`Tag` - Text truncation for overflow fix

### DIFF
--- a/.changeset/brown-wolves-admire.md
+++ b/.changeset/brown-wolves-admire.md
@@ -2,6 +2,6 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`Tag` - Truncate any text that is longer than 150px and add a tooltip with the full text when truncation occurs
+`Tag` - Truncate any text that is longer than about 20 characters (160px) and add a tooltip with the full text when truncation occurs
 
 `Tag` - Added `@tooltipPlacement` argument

--- a/.changeset/brown-wolves-admire.md
+++ b/.changeset/brown-wolves-admire.md
@@ -3,3 +3,5 @@
 ---
 
 `Tag` - Truncate any text that wraps to multiple lines and add a tooltip with the full text when truncation occurs
+
+`Tag` - Added `@tooltipPlacement` argument

--- a/.changeset/brown-wolves-admire.md
+++ b/.changeset/brown-wolves-admire.md
@@ -2,6 +2,6 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`Tag` - Truncate any text that is longer than about 20 characters (160px) and add a tooltip with the full text when truncation occurs
+`Tag` - Truncate any text that is longer than about 20 characters, and add a tooltip with the full text when truncation occurs
 
 `Tag` - Added `@tooltipPlacement` argument

--- a/.changeset/brown-wolves-admire.md
+++ b/.changeset/brown-wolves-admire.md
@@ -2,6 +2,6 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`Tag` - Truncate any text that wraps to multiple lines and add a tooltip with the full text when truncation occurs
+`Tag` - Truncate any text that is longer than 150px and add a tooltip with the full text when truncation occurs
 
 `Tag` - Added `@tooltipPlacement` argument

--- a/.changeset/brown-wolves-admire.md
+++ b/.changeset/brown-wolves-admire.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Tag` - Truncate any text that wraps to multiple lines and add a tooltip with the full text when truncation occurs

--- a/packages/components/src/components/hds/tag/index.hbs
+++ b/packages/components/src/components/hds/tag/index.hbs
@@ -2,14 +2,23 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<Hds::Text::Body class={{this.classNames}} @tag="span" @size="100" @weight="medium" @color="primary" ...attributes>
+<Hds::Text::Body
+  class={{this.classNames}}
+  @tag="span"
+  @size="100"
+  @weight="medium"
+  @color="primary"
+  {{did-insert this.didInsert}}
+  {{will-destroy this.willDestroyNode}}
+  ...attributes
+>
   {{#if this.onDismiss}}
     <button class="hds-tag__dismiss" type="button" aria-label={{this.ariaLabel}} {{on "click" this.onDismiss}}>
       <Hds::Icon class="hds-tag__dismiss-icon" @name="x" @size="16" />
     </button>
   {{/if}}
   {{#if (or @href @route)}}
-    {{#if this.isTextTruncated}}
+    {{#if this._isTextOverflow}}
       <Hds::Interactive
         class="hds-tag__link"
         @current-when={{@current-when}}
@@ -22,7 +31,9 @@
         @isHrefExternal={{@isHrefExternal}}
         {{hds-tooltip this.text options=(hash placement="right")}}
       >
-        {{this.text}}
+        <div class="hds-tag__text-container">
+          {{this.text}}
+        </div>
       </Hds::Interactive>
     {{else}}
       <Hds::Interactive
@@ -42,15 +53,12 @@
       </Hds::Interactive>
     {{/if}}
   {{else}}
-    {{#if this.isTextTruncated}}
-      <span
-        class="hds-tag__text"
-        {{hds-tooltip this.text options=(hash placement="right")}}
-      >
+    {{#if this._isTextOverflow}}
+      <Hds::TooltipButton class="hds-tag__text" @text={{this.text}} @placement="right">
         <div class="hds-tag__text-container">
           {{this.text}}
         </div>
-      </span>
+      </Hds::TooltipButton>
     {{else}}
       <span class="hds-tag__text">
         <div class="hds-tag__text-container">

--- a/packages/components/src/components/hds/tag/index.hbs
+++ b/packages/components/src/components/hds/tag/index.hbs
@@ -8,8 +8,7 @@
   @size="100"
   @weight="medium"
   @color="primary"
-  {{did-insert this.didInsert}}
-  {{will-destroy this.willDestroyNode}}
+  {{this._setUpObserver}}
   ...attributes
 >
   {{#if this.onDismiss}}

--- a/packages/components/src/components/hds/tag/index.hbs
+++ b/packages/components/src/components/hds/tag/index.hbs
@@ -36,7 +36,9 @@
         @href={{@href}}
         @isHrefExternal={{@isHrefExternal}}
       >
-        {{this.text}}
+        <div class="hds-tag__text-container">
+          {{this.text}}
+        </div>
       </Hds::Interactive>
     {{/if}}
   {{else}}
@@ -45,11 +47,15 @@
         class="hds-tag__text"
         {{hds-tooltip this.text options=(hash placement="right")}}
       >
-        {{this.text}}
+        <div class="hds-tag__text-container">
+          {{this.text}}
+        </div>
       </span>
     {{else}}
       <span class="hds-tag__text">
-        {{this.text}}
+        <div class="hds-tag__text-container">
+          {{this.text}}
+        </div>
       </span>
     {{/if}}
   {{/if}}

--- a/packages/components/src/components/hds/tag/index.hbs
+++ b/packages/components/src/components/hds/tag/index.hbs
@@ -28,7 +28,7 @@
         @isRouteExternal={{@isRouteExternal}}
         @href={{@href}}
         @isHrefExternal={{@isHrefExternal}}
-        {{hds-tooltip this.text options=(hash placement="right")}}
+        {{hds-tooltip this.text options=(hash placement=this.tooltipPlacement)}}
       >
         <div class="hds-tag__text-container">
           {{this.text}}
@@ -53,7 +53,7 @@
     {{/if}}
   {{else}}
     {{#if this._isTextOverflow}}
-      <Hds::TooltipButton class="hds-tag__text" @text={{this.text}} @placement="right">
+      <Hds::TooltipButton class="hds-tag__text" @text={{this.text}} @placement={{this.tooltipPlacement}}>
         <div class="hds-tag__text-container">
           {{this.text}}
         </div>

--- a/packages/components/src/components/hds/tag/index.hbs
+++ b/packages/components/src/components/hds/tag/index.hbs
@@ -9,22 +9,48 @@
     </button>
   {{/if}}
   {{#if (or @href @route)}}
-    <Hds::Interactive
-      class="hds-tag__link"
-      @current-when={{@current-when}}
-      @models={{hds-link-to-models @model @models}}
-      @query={{hds-link-to-query @query}}
-      @replace={{@replace}}
-      @route={{@route}}
-      @isRouteExternal={{@isRouteExternal}}
-      @href={{@href}}
-      @isHrefExternal={{@isHrefExternal}}
-    >
-      {{this.text}}
-    </Hds::Interactive>
+    {{#if this.isTextTruncated}}
+      <Hds::Interactive
+        class="hds-tag__link"
+        @current-when={{@current-when}}
+        @models={{hds-link-to-models @model @models}}
+        @query={{hds-link-to-query @query}}
+        @replace={{@replace}}
+        @route={{@route}}
+        @isRouteExternal={{@isRouteExternal}}
+        @href={{@href}}
+        @isHrefExternal={{@isHrefExternal}}
+        {{hds-tooltip this.text options=(hash placement="right")}}
+      >
+        {{this.text}}
+      </Hds::Interactive>
+    {{else}}
+      <Hds::Interactive
+        class="hds-tag__link"
+        @current-when={{@current-when}}
+        @models={{hds-link-to-models @model @models}}
+        @query={{hds-link-to-query @query}}
+        @replace={{@replace}}
+        @route={{@route}}
+        @isRouteExternal={{@isRouteExternal}}
+        @href={{@href}}
+        @isHrefExternal={{@isHrefExternal}}
+      >
+        {{this.text}}
+      </Hds::Interactive>
+    {{/if}}
   {{else}}
-    <span class="hds-tag__text">
-      {{this.text}}
-    </span>
+    {{#if this.isTextTruncated}}
+      <span
+        class="hds-tag__text"
+        {{hds-tooltip this.text options=(hash placement="right")}}
+      >
+        {{this.text}}
+      </span>
+    {{else}}
+      <span class="hds-tag__text">
+        {{this.text}}
+      </span>
+    {{/if}}
   {{/if}}
 </Hds::Text::Body>

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -125,7 +125,7 @@ export default class HdsTag extends Component<HdsTagSignature> {
             this._isTextOverflow
           );
         });
-      })
+      });
     });
     this._observer.observe(textElement);
   }

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -112,22 +112,17 @@ export default class HdsTag extends Component<HdsTagSignature> {
 
   @action
   didInsert(element: HTMLElement): void {
-    const textElement = element.querySelector(
-      '.hds-tag__text-container'
-    ) as HTMLElement;
-
     // Used to detect when text is clipped to one line, and tooltip should be added
     this._observer = new ResizeObserver((entries) => {
       requestAnimationFrame(() => {
         entries.forEach((entry) => {
           this._isTextOverflow = this._isOverflow(
-            entry.target,
-            this._isTextOverflow
+            entry.target.querySelector('.hds-tag__text-container')!
           );
         });
       });
     });
-    this._observer.observe(textElement);
+    this._observer.observe(element);
   }
 
   @action
@@ -136,10 +131,8 @@ export default class HdsTag extends Component<HdsTagSignature> {
     this._observer.disconnect();
   }
 
-  private _isOverflow(el: Element, previousOverflow: boolean): boolean {
-    // If any overflow was present previously and was clipped the scroll height and client height will then be equal
-    // Any future resizes will incorrectly see the element as not overflowing unless the previous value is accounted for
-    if (previousOverflow || el.scrollHeight > el.clientHeight) {
+  private _isOverflow(el: Element): boolean {
+    if (el.scrollHeight > el.clientHeight) {
       return true;
     } else {
       return false;

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -25,6 +25,8 @@ export interface HdsTagSignature {
 }
 
 export default class HdsTag extends Component<HdsTagSignature> {
+  private _characterLimit = 20;
+
   /**
    * @param onDismiss
    * @type {function}
@@ -52,6 +54,10 @@ export default class HdsTag extends Component<HdsTagSignature> {
     assert('@text for "Hds::Tag" must have a valid value', text !== undefined);
 
     return text;
+  }
+
+  get isTextTruncated(): boolean {
+    return this.args.text.length > this._characterLimit;
   }
 
   /**

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -16,7 +16,9 @@ import type { HdsInteractiveSignature } from '../interactive/';
 
 export const COLORS: string[] = Object.values(HdsTagColorValues);
 export const DEFAULT_COLOR = HdsTagColorValues.Primary;
-export const TOOLTIP_PLACEMENTS: string[] = Object.values(HdsTagTooltipPlacementValues);
+export const TOOLTIP_PLACEMENTS: string[] = Object.values(
+  HdsTagTooltipPlacementValues
+);
 export const DEFAULT_TOOLTIP_PLACEMENT = HdsTagTooltipPlacementValues.Top;
 
 export interface HdsTagSignature {
@@ -62,7 +64,8 @@ export default class HdsTag extends Component<HdsTagSignature> {
 
     assert(
       '@tooltipPlacement for "Hds::Tag" must have a valid value',
-      tooltipPlacement == undefined || TOOLTIP_PLACEMENTS.includes(tooltipPlacement)
+      tooltipPlacement == undefined ||
+        TOOLTIP_PLACEMENTS.includes(tooltipPlacement)
     );
 
     return tooltipPlacement;

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -118,12 +118,14 @@ export default class HdsTag extends Component<HdsTagSignature> {
 
     // Used to detect when text is clipped to one line, and tooltip should be added
     this._observer = new ResizeObserver((entries) => {
-      entries.forEach((entry) => {
-        this._isTextOverflow = this._isOverflow(
-          entry.target,
-          this._isTextOverflow
-        );
-      });
+      requestAnimationFrame(() => {
+        entries.forEach((entry) => {
+          this._isTextOverflow = this._isOverflow(
+            entry.target,
+            this._isTextOverflow
+          );
+        });
+      })
     });
     this._observer.observe(textElement);
   }

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -10,16 +10,21 @@ import { modifier } from 'ember-modifier';
 
 import { HdsTagColorValues } from './types.ts';
 import type { HdsTagColors } from './types.ts';
+import { HdsTagTooltipPlacementValues } from './types.ts';
+import type { HdsTagTooltipPlacements } from './types.ts';
 import type { HdsInteractiveSignature } from '../interactive/';
 
 export const COLORS: string[] = Object.values(HdsTagColorValues);
 export const DEFAULT_COLOR = HdsTagColorValues.Primary;
+export const TOOLTIP_PLACEMENTS: string[] = Object.values(HdsTagTooltipPlacementValues);
+export const DEFAULT_TOOLTIP_PLACEMENT = HdsTagTooltipPlacementValues.Top;
 
 export interface HdsTagSignature {
   Args: HdsInteractiveSignature['Args'] & {
     color?: HdsTagColors;
     text: string;
     ariaLabel?: string;
+    tooltipPlacement: HdsTagTooltipPlacements;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onDismiss?: (event: MouseEvent, ...args: any[]) => void;
   };
@@ -45,6 +50,23 @@ export default class HdsTag extends Component<HdsTagSignature> {
       this._observer.disconnect();
     };
   });
+
+  /**
+   * @param tooltioPlacement
+   * @type {string}
+   * @default top
+   * @description The placement property of the tooltip attached to the tag text.
+   */
+  get tooltipPlacement(): HdsTagTooltipPlacements {
+    const { tooltipPlacement = DEFAULT_TOOLTIP_PLACEMENT } = this.args;
+
+    assert(
+      '@tooltipPlacement for "Hds::Tag" must have a valid value',
+      tooltipPlacement == undefined || TOOLTIP_PLACEMENTS.includes(tooltipPlacement)
+    );
+
+    return tooltipPlacement;
+  }
 
   /**
    * @param onDismiss

--- a/packages/components/src/components/hds/tag/types.ts
+++ b/packages/components/src/components/hds/tag/types.ts
@@ -8,3 +8,20 @@ export enum HdsTagColorValues {
   Secondary = 'secondary',
 }
 export type HdsTagColors = `${HdsTagColorValues}`;
+
+export enum HdsTagTooltipPlacementValues {
+  Top = 'top',
+  TopStart = 'top-start',
+  TopEnd = 'top-end',
+  Right = 'right',
+  RightStart = 'right-start',
+  RightEnd = 'right-end',
+  Bottom = 'bottom',
+  BottomStart = 'bottom-start',
+  BottomEnd = 'bottom-end',
+  Left = 'left',
+  LeftStart = 'left-start',
+  LeftEnd = 'left-end',
+}
+
+export type HdsTagTooltipPlacements = `${HdsTagTooltipPlacementValues}`;

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -43,7 +43,7 @@ $hds-tag-border-radius: 50px;
 .hds-tag__text,
 .hds-tag__link {
   flex: 1 0 0;
-  max-width: 160px;
+  max-width: 166px;
   padding: 3px 10px 5px 10px;
   border-radius: inherit;
 }
@@ -51,6 +51,7 @@ $hds-tag-border-radius: 50px;
 .hds-tag__text-container {
   display: -webkit-box;
   overflow: hidden;
+  word-break: break-all;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 1;
   line-clamp: 1;
@@ -58,6 +59,7 @@ $hds-tag-border-radius: 50px;
 
 .hds-tag__dismiss ~ .hds-tag__text,
 .hds-tag__dismiss ~ .hds-tag__link {
+  max-width: 160px;
   padding: 3px 8px 5px 6px;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -20,6 +20,7 @@ $hds-tag-border-radius: 50px;
   background-color: var(--token-color-surface-interactive);
   border: 1px solid var(--token-color-border-strong);
   border-radius: $hds-tag-border-radius;
+  max-width: 20ch;
 }
 
 .hds-tag__dismiss {
@@ -43,6 +44,9 @@ $hds-tag-border-radius: 50px;
   flex: 1 0 0;
   padding: 3px 10px 5px 10px;
   border-radius: inherit;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .hds-tag__dismiss ~ .hds-tag__text,

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -43,7 +43,7 @@ $hds-tag-border-radius: 50px;
 .hds-tag__text,
 .hds-tag__link {
   flex: 1 0 0;
-  max-width: 150px;
+  max-width: 160px;
   padding: 3px 10px 5px 10px;
   border-radius: inherit;
 }

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -15,6 +15,7 @@ $hds-tag-border-radius: 50px;
 .hds-tag {
   display: inline-flex;
   align-items: stretch;
+  width: fit-content;
   line-height: 1rem; // 16px - override `body-100`
   vertical-align: middle;
   background-color: var(--token-color-surface-interactive);

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -87,6 +87,9 @@ $hds-tag-border-radius: 50px;
 }
 
 .hds-tooltip-button.hds-tag__text {
+  cursor: text;
+  user-select: text;
+
   &:focus,
   &.mock-focus {
     @include hds-focus-ring-basic();

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -16,6 +16,7 @@ $hds-tag-border-radius: 50px;
   display: inline-flex;
   align-items: stretch;
   width: fit-content;
+  max-width: 100%;
   line-height: 1rem; // 16px - override `body-100`
   vertical-align: middle;
   background-color: var(--token-color-surface-interactive);

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -46,11 +46,11 @@ $hds-tag-border-radius: 50px;
 }
 
 .hds-tag__text-container {
-  overflow: hidden;
   display: -webkit-box;
+  overflow: hidden;
   -webkit-box-orient: vertical;
-  line-clamp: 1;
   -webkit-line-clamp: 1;
+  line-clamp: 1;
 }
 
 .hds-tag__dismiss ~ .hds-tag__text,
@@ -81,6 +81,18 @@ $hds-tag-border-radius: 50px;
   &.mock-focus {
     @include hds-focus-ring-basic();
     z-index: 1; // ensures focus is not obscured by adjacent elements
+  }
+}
+
+.hds-tooltip-button.hds-tag__text {
+  &:focus,
+  &.mock-focus {
+    @include hds-focus-ring-basic();
+    z-index: 1; // ensures focus is not obscured by adjacent elements
+  }
+
+  &:focus-visible::before {
+    box-shadow: none; // override default tooltip button focus styles
   }
 }
 

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -20,7 +20,6 @@ $hds-tag-border-radius: 50px;
   background-color: var(--token-color-surface-interactive);
   border: 1px solid var(--token-color-border-strong);
   border-radius: $hds-tag-border-radius;
-  max-width: 20ch;
 }
 
 .hds-tag__dismiss {
@@ -44,9 +43,14 @@ $hds-tag-border-radius: 50px;
   flex: 1 0 0;
   padding: 3px 10px 5px 10px;
   border-radius: inherit;
+}
+
+.hds-tag__text-container {
   overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
 }
 
 .hds-tag__dismiss ~ .hds-tag__text,

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -43,7 +43,7 @@ $hds-tag-border-radius: 50px;
 .hds-tag__text,
 .hds-tag__link {
   flex: 1 0 0;
-  max-width: 166px;
+  max-width: 166px; // account for excess horizontal padding of text in non-dismissible variant
   padding: 3px 10px 5px 10px;
   border-radius: inherit;
 }

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -43,9 +43,9 @@ $hds-tag-border-radius: 50px;
 .hds-tag__text,
 .hds-tag__link {
   flex: 1 0 0;
+  max-width: 150px;
   padding: 3px 10px 5px 10px;
   border-radius: inherit;
-  max-width: 150px;
 }
 
 .hds-tag__text-container {

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -45,6 +45,7 @@ $hds-tag-border-radius: 50px;
   flex: 1 0 0;
   padding: 3px 10px 5px 10px;
   border-radius: inherit;
+  max-width: 150px;
 }
 
 .hds-tag__text-container {

--- a/showcase/app/routes/components/tag.js
+++ b/showcase/app/routes/components/tag.js
@@ -5,11 +5,12 @@
 
 import Route from '@ember/routing/route';
 import { COLORS } from '@hashicorp/design-system-components/components/hds/tag';
+import { TOOLTIP_PLACEMENTS } from '@hashicorp/design-system-components/components/hds/tag';
 
 export default class ComponentsTagRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase
     const STATES = ['default', 'hover', 'active', 'focus'];
-    return { COLORS, STATES };
+    return { COLORS, TOOLTIP_PLACEMENTS, STATES };
   }
 }

--- a/showcase/app/templates/components/tag.hbs
+++ b/showcase/app/templates/components/tag.hbs
@@ -33,20 +33,20 @@
   </Shw::Flex>
 
   <Shw::Flex @label="With long text" as |SF|>
-    <SF.Item {{style width="176px"}}>
+    <SF.Item>
       <Hds::Tag @text="This is a very long text that should go on multiple lines" @onDismiss={{this.noop}} />
     </SF.Item>
-    <SF.Item {{style width="150px"}}>
+    <SF.Item>
       <Hds::Tag @text="This is a very long text that should go on multiple lines" />
     </SF.Item>
-    <SF.Item {{style width="176px"}}>
+    <SF.Item>
       <Hds::Tag
         @text="This is a very long text that should go on multiple lines"
         @onDismiss={{this.noop}}
         @route="components.tag"
       />
     </SF.Item>
-    <SF.Item {{style width="150px"}}>
+    <SF.Item>
       <Hds::Tag @text="This is a very long text that should go on multiple lines" @route="components.tag" />
     </SF.Item>
   </Shw::Flex>

--- a/showcase/app/templates/components/tag.hbs
+++ b/showcase/app/templates/components/tag.hbs
@@ -39,6 +39,16 @@
     <SF.Item {{style width="200px"}}>
       <Hds::Tag @text="This is a very long text that should go on multiple lines" />
     </SF.Item>
+    <SF.Item {{style width="200px"}}>
+      <Hds::Tag
+        @text="This is a very long text that should go on multiple lines"
+        @onDismiss={{this.noop}}
+        @route="components.tag"
+      />
+    </SF.Item>
+    <SF.Item {{style width="200px"}}>
+      <Hds::Tag @text="This is a very long text that should go on multiple lines" @route="components.tag" />
+    </SF.Item>
   </Shw::Flex>
 
   <Shw::Divider @level={{2}} />

--- a/showcase/app/templates/components/tag.hbs
+++ b/showcase/app/templates/components/tag.hbs
@@ -33,20 +33,20 @@
   </Shw::Flex>
 
   <Shw::Flex @label="With long text" as |SF|>
-    <SF.Item {{style width="200px"}}>
+    <SF.Item {{style width="176px"}}>
       <Hds::Tag @text="This is a very long text that should go on multiple lines" @onDismiss={{this.noop}} />
     </SF.Item>
-    <SF.Item {{style width="200px"}}>
+    <SF.Item {{style width="150px"}}>
       <Hds::Tag @text="This is a very long text that should go on multiple lines" />
     </SF.Item>
-    <SF.Item {{style width="200px"}}>
+    <SF.Item {{style width="176px"}}>
       <Hds::Tag
         @text="This is a very long text that should go on multiple lines"
         @onDismiss={{this.noop}}
         @route="components.tag"
       />
     </SF.Item>
-    <SF.Item {{style width="200px"}}>
+    <SF.Item {{style width="150px"}}>
       <Hds::Tag @text="This is a very long text that should go on multiple lines" @route="components.tag" />
     </SF.Item>
   </Shw::Flex>
@@ -127,6 +127,21 @@
         </SG.Item>
       {{/each}}
     {{/let}}
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H2>Tooltip Placements</Shw::Text::H2>
+
+  <Shw::Grid @columns={{3}} as |SG|>
+    {{#each @model.TOOLTIP_PLACEMENTS as |place|}}
+      <SG.Item>
+        <Hds::Tag
+          @text="{{place}} This is a very long text that should go on multiple lines"
+          @tooltipPlacement={{place}}
+        />
+      </SG.Item>
+    {{/each}}
   </Shw::Grid>
 
 </section>

--- a/showcase/tests/integration/components/hds/tag/index-test.js
+++ b/showcase/tests/integration/components/hds/tag/index-test.js
@@ -5,7 +5,12 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, resetOnerror, setupOnerror, waitFor } from '@ember/test-helpers';
+import {
+  render,
+  resetOnerror,
+  setupOnerror,
+  waitFor,
+} from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | hds/tag/index', function (hooks) {

--- a/showcase/tests/integration/components/hds/tag/index-test.js
+++ b/showcase/tests/integration/components/hds/tag/index-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
+import { render, resetOnerror, setupOnerror, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | hds/tag/index', function (hooks) {
@@ -103,6 +103,7 @@ module('Integration | Component | hds/tag/index', function (hooks) {
         <Hds::Tag @text="This is a very long text that should go on multiple lines" id="test-tag"/>
       </div>
     `);
+    await waitFor('.hds-tooltip-button', { timeout: 1000 });
     assert.dom('.hds-tooltip-button').exists();
   });
 });

--- a/showcase/tests/integration/components/hds/tag/index-test.js
+++ b/showcase/tests/integration/components/hds/tag/index-test.js
@@ -25,6 +25,7 @@ module('Integration | Component | hds/tag/index', function (hooks) {
     await render(hbs`<Hds::Tag @text="My tag" />`);
     assert.dom('button.hds-tag__dismiss').doesNotExist();
   });
+
   test('it should render the "dismiss" button if a callback function is passed to the @onDismiss argument', async function (assert) {
     this.set('NOOP', () => {});
     await render(hbs`<Hds::Tag @text="My tag" @onDismiss={{this.NOOP}} />`);
@@ -44,6 +45,7 @@ module('Integration | Component | hds/tag/index', function (hooks) {
       .dom('button.hds-tag__dismiss')
       .hasAttribute('aria-label', 'Please dismiss My tag');
   });
+
   // COLOR
 
   test('it should render the primary color as the default if no @color prop is declared when the text is a link', async function (assert) {
@@ -52,12 +54,14 @@ module('Integration | Component | hds/tag/index', function (hooks) {
     );
     assert.dom('#test-link-tag').hasClass('hds-tag--color-primary');
   });
+
   test('it should render the correct CSS color class if the @color prop is declared when the text is a link', async function (assert) {
     await render(
       hbs`<Hds::Tag @text="My text tag" @href="/" @color="secondary" id="test-link-tag"/>`
     );
     assert.dom('#test-link-tag').hasClass('hds-tag--color-secondary');
   });
+
   test('it should throw an assertion if an incorrect value for @color is provided when the text is a link', async function (assert) {
     const errorMessage =
       '@color for "Hds::Tag" must be one of the following: primary, secondary; received: foo';
@@ -70,6 +74,7 @@ module('Integration | Component | hds/tag/index', function (hooks) {
       throw new Error(errorMessage);
     });
   });
+
   test('it should throw an assertion if @color is provided without @href or @route', async function (assert) {
     const errorMessage =
       '@color can only be applied to "Hds::Tag" along with either @href or @route';
@@ -81,5 +86,23 @@ module('Integration | Component | hds/tag/index', function (hooks) {
     assert.throws(function () {
       throw new Error(errorMessage);
     });
+  });
+
+  // OVERFLOW
+
+  test('it should not render a tooltip if the text does not overflow', async function (assert) {
+    await render(hbs`
+        <Hds::Tag @text="My text tag" id="test-tag"/>
+    `);
+    assert.dom('.hds-tooltip-button').doesNotExist();
+  });
+
+  test('it should render a tooltip if the text overflows', async function (assert) {
+    await render(hbs`
+      <div style="width: 50px;">
+        <Hds::Tag @text="This is a very long text that should go on multiple lines" id="test-tag"/>
+      </div>
+    `);
+    assert.dom('.hds-tooltip-button').exists();
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes an overflow issue present in the `Tag` when text wraps to > 3 lines. It implements the intended design change to address this, which truncates any text that goes to multiple lines. When truncation occurs, an ellipsis is rendered, and a tooltip showing the full text is added.

It also adds `width: fit-content;` to the tag to ensure a tag's width never goes beyond its content.

### :hammer_and_wrench: Detailed description

It was observed in the Tag in [HDS-3854](https://hashicorp.atlassian.net/browse/HDS-3854) that when the text exceeds 3 lines, the background of the dismiss button obscures the border of the element. 

Per design guidance, the chosen solution has been to truncate any text in the tag that goes beyond one line, and add an ellipsis and tooltip with the full text when this truncation occurs. 

The text is truncated when the text would wrap to multiple lines using `overflow: hidden` and `-webkit-line-clamp: 1`. When this occurs a tooltip is also added using the `hds-tooltip` modifier, and the `Hds::TooltipButton`.

There are several other changes related to this fix.

- The `max-width` of the text is set to `150px`
- A new property `@tooltipPlacement` has been added to allow for customization of the tooltip placement
- `width: fit-content` has been added to prevent the tag width from ever exceeding its content. This was present previously when the tag had a parent with `display: grid`. 

### :camera_flash: Screenshots

#### Text Truncation

**Before**
<img width="300" alt="Screenshot 2025-01-24 at 9 24 43 AM" src="https://github.com/user-attachments/assets/2541acbd-7b2a-402a-99f7-373fcaa276ce" />

**After**
<img width="350" alt="Screenshot 2025-02-10 at 4 27 06 PM" src="https://github.com/user-attachments/assets/8a9b905c-1b4d-4085-89dd-0ab3ee5fa2ec" />

**After - Hover / Focus**
<img width="307" alt="Screenshot 2025-02-10 at 4 25 52 PM" src="https://github.com/user-attachments/assets/962d5636-0686-4bff-90ad-86d3d9d49514" />

#### Width

**Before**
<img width="362" alt="Screenshot 2025-02-05 at 9 28 22 AM" src="https://github.com/user-attachments/assets/048d71c2-98ae-4fde-a1ce-94c2f6d0374b" />

**After**
<img width="285" alt="Screenshot 2025-02-10 at 4 26 07 PM" src="https://github.com/user-attachments/assets/8ed56b31-4e5a-405a-adde-e6d3740d2da5" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4317](https://hashicorp.atlassian.net/browse/HDS-4317)
Figma file: [Link](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/branch/TQ8Xv7T6DPmLtpFMbe9Bv7/HDS-Components-v2.0?m=auto&node-id=72325-1458&t=2szZ94wgmze0xjgO-1)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4317]: https://hashicorp.atlassian.net/browse/HDS-4317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HDS-3854]: https://hashicorp.atlassian.net/browse/HDS-3854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ