### PR TITLE
`Hds::CodeEditor` - Support Sentinel language

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -329,6 +329,7 @@
       "./modifiers/hds-clipboard.js": "./dist/_app_/modifiers/hds-clipboard.js",
       "./modifiers/hds-code-editor.js": "./dist/_app_/modifiers/hds-code-editor.js",
       "./modifiers/hds-code-editor/highlight-styles/hds-dark-highlight-style.js": "./dist/_app_/modifiers/hds-code-editor/highlight-styles/hds-dark-highlight-style.js",
+      "./modifiers/hds-code-editor/languages/sentinel.js": "./dist/_app_/modifiers/hds-code-editor/languages/sentinel.js",
       "./modifiers/hds-code-editor/palettes/hds-dark-palette.js": "./dist/_app_/modifiers/hds-code-editor/palettes/hds-dark-palette.js",
       "./modifiers/hds-code-editor/themes/hds-dark-theme.js": "./dist/_app_/modifiers/hds-code-editor/themes/hds-dark-theme.js",
       "./modifiers/hds-code-editor/types.js": "./dist/_app_/modifiers/hds-code-editor/types.js",

--- a/packages/components/src/modifiers/hds-code-editor.ts
+++ b/packages/components/src/modifiers/hds-code-editor.ts
@@ -56,6 +56,14 @@ const LANGUAGES: Record<
       return defineStreamLanguage(ruby);
     },
   },
+  sentinel: {
+    load: async () => {
+      const { sentinel } = await import(
+        './hds-code-editor/languages/sentinel.ts'
+      );
+      return defineStreamLanguage(sentinel);
+    },
+  },
   shell: {
     load: async () => {
       const { shell } = await import('@codemirror/legacy-modes/mode/shell');

--- a/packages/components/src/modifiers/hds-code-editor/languages/sentinel.ts
+++ b/packages/components/src/modifiers/hds-code-editor/languages/sentinel.ts
@@ -20,19 +20,25 @@ const wordOperators = wordRegexp(['and', 'or', 'not']);
 
 // keywords
 const sentinelKeywords = [
-  'import',
-  'main',
-  'rule',
-  'precondition',
-  'if',
-  'else',
-  'for',
-  'while',
+  'all',
+  'any',
+  'as',
   'break',
+  'case',
   'continue',
+  'default',
+  'else',
+  'empty',
+  'filter',
+  'for',
+  'func',
+  'if',
+  'import',
+  'map',
+  'param',
   'return',
-  'in',
-  'each',
+  'rule',
+  'when',
 ];
 
 // built-ins / constants

--- a/packages/components/src/modifiers/hds-code-editor/languages/sentinel.ts
+++ b/packages/components/src/modifiers/hds-code-editor/languages/sentinel.ts
@@ -42,7 +42,23 @@ const sentinelKeywords = [
 ];
 
 // built-ins / constants
-const sentinelBuiltins = ['true', 'false', 'null'];
+const sentinelBuiltins = [
+  'true',
+  'false',
+  'null',
+  'undefined',
+  'length',
+  'append',
+  'delete',
+  'keys',
+  'values',
+  'range',
+  'print',
+  'int',
+  'float',
+  'string',
+  'bool',
+];
 
 const keywords = wordRegexp(sentinelKeywords);
 const builtins = wordRegexp(sentinelBuiltins);

--- a/packages/components/src/modifiers/hds-code-editor/languages/sentinel.ts
+++ b/packages/components/src/modifiers/hds-code-editor/languages/sentinel.ts
@@ -16,7 +16,17 @@ function wordRegexp(words: string[]): RegExp {
 }
 
 // logical operators
-const wordOperators = wordRegexp(['and', 'or', 'not']);
+const wordOperators = wordRegexp([
+  'and',
+  'contains',
+  'else',
+  'in',
+  'is',
+  'matches',
+  'not',
+  'or',
+  'xor',
+]);
 
 // keywords
 const sentinelKeywords = [

--- a/packages/components/src/modifiers/hds-code-editor/languages/sentinel.ts
+++ b/packages/components/src/modifiers/hds-code-editor/languages/sentinel.ts
@@ -1,0 +1,182 @@
+import type { StringStream } from '@codemirror/language';
+
+type Quote = '"' | "'";
+
+interface ParserConfig {
+  delimiters?: RegExp;
+  operators?: RegExp;
+}
+
+interface SentinelState {
+  tokenize: (stream: StringStream, state: SentinelState) => string | null;
+}
+
+function wordRegexp(words: string[]): RegExp {
+  return new RegExp('^((' + words.join(')|(') + '))\\b');
+}
+
+// logical operators
+const wordOperators = wordRegexp(['and', 'or', 'not']);
+
+// keywords
+const sentinelKeywords = [
+  'import',
+  'main',
+  'rule',
+  'precondition',
+  'if',
+  'else',
+  'for',
+  'while',
+  'break',
+  'continue',
+  'return',
+  'in',
+  'each',
+];
+
+// built-ins / constants
+const sentinelBuiltins = ['true', 'false', 'null'];
+
+const keywords = wordRegexp(sentinelKeywords);
+const builtins = wordRegexp(sentinelBuiltins);
+
+export function mkSentinel(parserConf: ParserConfig) {
+  const ERRORCLASS = 'error';
+
+  // delimiters, operators, etc.
+  const delimiters = parserConf.delimiters ?? /^[()[\]{},:;=.]/;
+  const operators = [
+    parserConf.operators ?? /^(\+|-|\*|\/|%|<=|>=|<|>|==|!=|!|&&|\|\|)/,
+  ];
+
+  // tokenizer
+  function tokenBase(
+    stream: StringStream,
+    state: SentinelState
+  ): string | null {
+    return tokenBaseInner(stream, state);
+  }
+
+  function tokenBaseInner(
+    stream: StringStream,
+    state: SentinelState
+  ): string | null {
+    if (stream.eatSpace()) {
+      return null;
+    }
+
+    // comments
+    // single-line `//`
+    if (stream.match('//')) {
+      stream.skipToEnd();
+      return 'comment';
+    }
+    // multi-line `/* ... */`
+    if (stream.match('/*')) {
+      state.tokenize = tokenComment;
+      return state.tokenize(stream, state);
+    }
+
+    // strings
+    if (stream.match(/"/) || stream.match(/'/)) {
+      // We’ve just consumed either " or '
+      const quote = stream.current();
+      state.tokenize = tokenString(quote as Quote);
+      return state.tokenize(stream, state);
+    }
+
+    // numbers
+    if (stream.match(/^[0-9]+(\.[0-9]+)?/)) {
+      return 'number';
+    }
+
+    // operators
+    for (let i = 0; i < operators.length; i++) {
+      if (stream.match(operators[i]!)) {
+        return 'operator';
+      }
+    }
+
+    // delimiters/punctuation
+    if (stream.match(delimiters)) {
+      return 'punctuation';
+    }
+
+    // keywords, operators, builtins
+    if (stream.match(keywords) || stream.match(wordOperators)) {
+      return 'keyword';
+    }
+    if (stream.match(builtins)) {
+      return 'builtin';
+    }
+
+    // identifiers (variables, function names, etc.)
+    if (stream.match(/^[_A-Za-z][_A-Za-z0-9]*/)) {
+      return 'variable';
+    }
+
+    // if nothing matched, consume one character and mark it as error
+    stream.next();
+
+    return ERRORCLASS;
+  }
+
+  // multi-line comment tokenizer
+  function tokenComment(stream: StringStream, state: SentinelState): string {
+    while (!stream.eol()) {
+      if (stream.match('*/')) {
+        state.tokenize = tokenBase;
+        break;
+      }
+      stream.next();
+    }
+    return 'comment';
+  }
+
+  // string tokenizer factory
+  function tokenString(
+    quote: Quote
+  ): (stream: StringStream, state: SentinelState) => string {
+    return function (stream: StringStream, state: SentinelState) {
+      let escaped = false;
+      let ch = null;
+
+      while ((ch = stream.next()) != null) {
+        if (ch === quote && !escaped) {
+          // end of string
+          state.tokenize = tokenBase;
+          break;
+        }
+        escaped = !escaped && ch === '\\';
+      }
+
+      return 'string';
+    };
+  }
+
+  // CodeMirror API
+  return {
+    name: 'sentinel',
+
+    startState: function (): SentinelState {
+      return {
+        tokenize: tokenBase,
+      };
+    },
+
+    token: function (
+      stream: StringStream,
+      state: SentinelState
+    ): string | null {
+      return state.tokenize(stream, state);
+    },
+
+    languageData: {
+      commentTokens: { line: '//', block: { open: '/*', close: '*/' } },
+      closeBrackets: { brackets: ['(', '[', '{', '"', "'"] },
+    },
+  };
+}
+
+export const sentinel = mkSentinel({});

--- a/packages/components/src/modifiers/hds-code-editor/types.ts
+++ b/packages/components/src/modifiers/hds-code-editor/types.ts
@@ -9,6 +9,7 @@ export enum HdsCodeEditorLanguageValues {
   Go = 'go',
   Hcl = 'hcl',
   Json = 'json',
+  Sentinel = 'sentinel',
   Sql = 'sql',
   Yaml = 'yaml',
 }

--- a/showcase/app/controllers/components/code-editor.js
+++ b/showcase/app/controllers/components/code-editor.js
@@ -70,6 +70,14 @@ func main() {
 }`,
     },
     {
+      value: 'sentinel',
+      label: 'Sentinel',
+      code: `param allowed_regions = ["us-east-1", "us-west-2"]
+
+main = rule { all tfplan.resources[*].instances as r { r.attributes.region in allowed_regions } }
+`,
+    },
+    {
       value: 'sql',
       label: 'SQL',
       code: `SELECT 'Hello, world!';


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add support for the Sentinel language in the `Hds::CodeEditor` component.

### :hammer_and_wrench: Detailed description

- Adds a [StreamParser](https://codemirror.net/docs/ref/#language.StreamParser) for Sentinel.
- Dynamically loads the parser when `sentinel` is specified as the `@language` argument.
- Adds showcase example for Sentinel syntax highlighting.

### :camera_flash: Screenshots

![image](https://github.com/user-attachments/assets/181437fe-7238-4fc9-8f78-1c128478c4a4)

### :link: External links

Jira ticket: [HDS-4309](https://hashicorp.atlassian.net/browse/HDS-4309)

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4309]: https://hashicorp.atlassian.net/browse/HDS-4309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ