### PR TITLE
Quick update for Code Editor docs

### DIFF
--- a/website/docs/components/code-editor/partials/guidelines/guidelines.md
+++ b/website/docs/components/code-editor/partials/guidelines/guidelines.md
@@ -41,7 +41,7 @@ Provide an accessible name for the Code Editor so that users of assistive techno
 
 !!! Dont
 
-Assume all users will understand the purpose of the Code Editor without providing an accessible name. Not providing one may cause confusion and is an accessibility failure.
+Don't assume all users will understand the purpose of the Code Editor without providing an accessible name. Not providing one may cause confusion and is an accessibility failure.
 ![A Code Editor embedded in a form following a set of radio buttons. The Code Editor has no title labelling it.](/assets/components/code-editor/code-editor-dont-external-accessible-name.png)
 
 !!!
@@ -54,7 +54,7 @@ The secondary actions section supports two optional buttons: the [Copy Button](/
 
 ## Custom actions
 
-This space is intended for custom primary actions. Primary actions are those which are necessary for the user to complete their work.
+Custom primary actions can be added to the header. Primary actions include those necessary for the user to complete their work.
 
 ![The Code Editor with the title “CodeEditor title”. The custom yielded element section shows a placeholder and is between the title and the editor.](/assets/components/code-editor/code-editor-yielded-actions-placeholder.png)
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add two minor updates to the guidelines to improve accessibility. 

### :camera_flash: Screenshots

**Before**
<img width="867" alt="Screenshot 2025-01-22 at 2 44 59 PM" src="https://github.com/user-attachments/assets/895550a1-ecc8-4505-b7e8-6c589190e974" />

**After**
<img width="838" alt="Screenshot 2025-01-22 at 2 44 10 PM" src="https://github.com/user-attachments/assets/069fe5bb-bbe7-466f-a704-fc9bef1f2843" />

**Before**
<img width="865" alt="Screenshot 2025-01-22 at 2 44 51 PM" src="https://github.com/user-attachments/assets/c17a5372-a920-453c-b431-ade2cf020023" />

**After**
<img width="883" alt="Screenshot 2025-01-22 at 2 43 47 PM" src="https://github.com/user-attachments/assets/abbdb4cc-c527-415b-b069-75f5136bb232" />

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
