### PR TITLE
Fix: `CodeEditor` changset entry name alignment

### DIFF
--- a/.changeset/long-poets-wonder.md
+++ b/.changeset/long-poets-wonder.md
@@ -2,5 +2,5 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`Hds::CodeEditor` - Added new CodeMirror 6 supported code editor component
+`CodeEditor` - Added new CodeMirror 6 supported code editor component
 `hds-code-editor` modifier - Added new code editor modifier which converts the element it is applied to into a CodeMirror 6 code editor


### PR DESCRIPTION
### :pushpin: Summary

The changeset for the new `CodeEditor` component needs to be updated so that it can get properly updated when the new `website generate-component-changelog-entries` command is run. 

### :hammer_and_wrench: Detailed description

The recently added `website generate-component-changelog-entries` command updates various changelog and documentation files based on grabbing information on changes from the changesets. It requires that the name used in the changeset match the exact name of the component. The `Hds::` prefix for this entry was causing it to be ignored by the script.

