### PR TITLE
`Table`, Multi-select:  Add note to docs (HDS-4273)

### DIFF
--- a/website/docs/components/table/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/table/partials/code/how-to-use.md
@@ -578,7 +578,11 @@ Add `isSelectable=true` to create a multi-select table. The `onSelectionChange` 
 
 This is a simple example of a table with multi-selection. Notice the `@selectionKey` argument provided to the rows, used by the `@onSelectionChange` callback to provide the list of selected/deselected rows as argument(s) for the invoked function.
 
-**Note:** If you want the state of the checkboxes to persist after the model updates, you will need to provide an `identityKey` value.
+!!! Info
+
+If you want the state of the checkboxes to persist after the model updates, you will need to provide an `identityKey` value.
+
+!!!
 
 ```handlebars
 <Hds::Table

--- a/website/docs/components/table/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/table/partials/code/how-to-use.md
@@ -576,7 +576,9 @@ Add `isSelectable=true` to create a multi-select table. The `onSelectionChange` 
 
 #### Multi-select table using a model
 
-This is a simple example of a table with multi-selection. Notice the `@selectionKey` argument provided to the rows, used by the `@onSelectionChange` callback to provide the list of selected/deselected rows as argument(s) for the invoked function:
+This is a simple example of a table with multi-selection. Notice the `@selectionKey` argument provided to the rows, used by the `@onSelectionChange` callback to provide the list of selected/deselected rows as argument(s) for the invoked function.
+
+**Note:** If you want the state of the checkboxes to persist after the model updates, you will need to provide an `identityKey` value.
 
 ```handlebars
 <Hds::Table


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the multi-select Table docs to add a note advising consumers to set an identityKey value in order to persist checkbox state.

👉 See [related comment](https://github.com/hashicorp/design-system/pull/2650#issuecomment-2609513839) in PR to fix multi select Table bug.

**Preview:** https://hds-website-git-hds-4273-table-multi-select-do-e89064-hashicorp.vercel.app/components/table/table?tab=code#multi-select-table-using-a-model

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

_**Added text is within the Info box**_

<img width="602" alt="image" src="https://github.com/user-attachments/assets/50beece9-f9ed-4d86-a783-aafa83d42e0f" />

### :link: External links

* Jira ticket: [HDS-4273](https://hashicorp.atlassian.net/browse/HDS-4273)

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4273]: https://hashicorp.atlassian.net/browse/HDS-4273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ