### PR TITLE
Release notes formatting issue - Figma Library

### DIFF
--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -15,7 +15,9 @@
 ### January 23rd, 2025
 
 `Advanced Table` - Added new component.
+
 `Code Editor` - Added new component.
+
 `Table` - Added column borders.
 
 ### December 20th, 2024


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will adjust the formatting issues we merged in yesterday.


### :camera_flash: Screenshots

From
<img width="882" alt="image" src="https://github.com/user-attachments/assets/890c2535-d2fd-495c-a972-878c50ff0b6d" />

To
<img width="688" alt="image" src="https://github.com/user-attachments/assets/5e331baf-c834-4fb9-b704-898a58b73280" />

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
