### PR TITLE
Website: add identity key note to advanced table docs

### DIFF
--- a/website/docs/components/table/advanced-table/partials/code/how-to-use.md
+++ b/website/docs/components/table/advanced-table/partials/code/how-to-use.md
@@ -459,7 +459,14 @@ At this time, the Advanced Table does not support multi-select nested rows. If t
 
 #### Simple multi-select
 
-This is a simple example of an Advanced Table with multi-selection. Notice the `@selectionKey` argument provided to the rows, used by the `@onSelectionChange` callback to provide the list of selected/deselected rows as argument(s) for the invoked function:
+This is a simple example of an Advanced Table with multi-selection. Notice the `@selectionKey` argument provided to the rows, used by the `@onSelectionChange` callback to provide the list of selected/deselected rows as argument(s) for the invoked function.
+
+!!! Info
+
+If you want the state of the checkboxes to persist after the model updates, you will need to provide an `identityKey` value.
+
+!!!
+
 
 ```handlebars
 <Hds::AdvancedTable


### PR DESCRIPTION
### :pushpin: Summary

Following up from https://github.com/hashicorp/design-system/pull/2667, adding the same note to the AdvancedTable docs.

**[Preview](https://hds-website-2i8hji3y6-hashicorp.vercel.app/components/table/advanced-table?tab=code#multi-select-advanced-table)**

### :camera_flash: Screenshots

![Screenshot 2025-01-24 at 1 40 35 PM](https://github.com/user-attachments/assets/cf66513b-829d-4c3f-a2d7-12fab8eab3e1)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
