### PR TITLE
CodeEditor - Fix import path for `HdsCodeEditorModifierSignature`

### DIFF
--- a/.changeset/neat-teachers-deny.md
+++ b/.changeset/neat-teachers-deny.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`CodeEditor` - Fixed import path for `HdsCodeEditorModifierSignature`

--- a/packages/components/src/components/hds/code-editor/index.ts
+++ b/packages/components/src/components/hds/code-editor/index.ts
@@ -9,12 +9,13 @@ import { action } from '@ember/object';
 import { modifier } from 'ember-modifier';
 
 import type { ComponentLike } from '@glint/template';
-import type { HdsCodeEditorSignature as HdsCodeEditorModifierSignature } from 'src/modifiers/hds-code-editor';
+import type { HdsCodeEditorSignature as HdsCodeEditorModifierSignature } from '../../../modifiers/hds-code-editor';
 import type { HdsCodeEditorDescriptionSignature } from './description';
 import type { HdsCodeEditorTitleSignature } from './title';
 import type { HdsCodeEditorGenericSignature } from './generic';
 import type { EditorView } from '@codemirror/view';
 import { guidFor } from '@ember/object/internals';
+
 export interface HdsCodeEditorSignature {
   Args: {
     hasCopyButton?: boolean;

--- a/packages/components/src/components/hds/code-editor/title.ts
+++ b/packages/components/src/components/hds/code-editor/title.ts
@@ -24,7 +24,7 @@ export interface HdsCodeEditorTitleSignature {
 export default class HdsCodeEditorTitle extends Component<HdsCodeEditorTitleSignature> {
   private _id = `${this.args.editorId}-title`;
 
-  get tag() {
+  get tag(): HdsTextBodySignature['Args']['tag'] {
     return this.args.tag ?? 'h2';
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

We must use relative paths in v2 addons, otherwise they won't get resolved in our consumer's apps.

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
