### PR TITLE
`Clipboard` & `Copy Button` - Fix handling of empty string and zero values (HDS-4447)

### DIFF
--- a/packages/components/src/modifiers/hds-clipboard.ts
+++ b/packages/components/src/modifiers/hds-clipboard.ts
@@ -37,7 +37,7 @@ export const getTextToCopy = (text: TextToCopy): string => {
       textToCopy = text.toString();
     } else {
       assert(
-        `\`hds-clipboard\` modifier - \`text\` argument must be a string - provided: ${typeof text}`
+        `\`hds-clipboard\` modifier - \`text\` argument must be a string or number - provided: ${typeof text}`
       );
     }
   }
@@ -109,7 +109,7 @@ export const writeTextToClipboard = async (
 ): Promise<boolean> => {
   // finally copy the text to the clipboard using the Clipboard API
   // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
-  if (textToCopy) {
+  if (textToCopy || textToCopy === '') {
     try {
       // notice: the "clipboard-write" permission is granted automatically to pages when they are in the active tab
       // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/write
@@ -151,7 +151,11 @@ export const copyToClipboard = async (
 ): Promise<boolean> => {
   let textToCopy: string = '';
 
-  if (text) {
+  if (text === '') {
+    textToCopy = '';
+  } else if (text === 0) {
+    textToCopy = '0';
+  } else if (text) {
     textToCopy = getTextToCopy(text);
   } else if (target) {
     const targetElement = getTargetElement(target);

--- a/showcase/app/templates/components/copy/button.hbs
+++ b/showcase/app/templates/components/copy/button.hbs
@@ -142,6 +142,17 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Text::H4>Edge cases</Shw::Text::H4>
+
+  <Shw::Flex as |SF|>
+    <SF.Item>
+      <Hds::Copy::Button @text="Copy an empty string" @textToCopy="" />
+    </SF.Item>
+    <SF.Item>
+      <Hds::Copy::Button @text="Copy the number '0'" @textToCopy={{0}} />
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>With <code>target</code> element</Shw::Text::H3>

--- a/showcase/tests/integration/components/hds/copy/button/index-test.js
+++ b/showcase/tests/integration/components/hds/copy/button/index-test.js
@@ -46,6 +46,22 @@ module('Integration | Component | hds/copy/button/index', function (hooks) {
     assert.true(this.success);
   });
 
+  test('it should copy an empty string value passed in', async function (assert) {
+    await render(
+      hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy empty string"  @textToCopy="" @onSuccess={{this.onSuccess}} @onError={{this.onError}} />`
+    );
+    await click('button#test-copy-button');
+    assert.true(this.success);
+  });
+
+  test('it should copy a zero number value passed in', async function (assert) {
+    await render(
+      hbs`<Hds::Copy::Button id="test-copy-button" @text="Copy zero number value"  @textToCopy={{0}} @onSuccess={{this.onSuccess}} @onError={{this.onError}} />`
+    );
+    await click('button#test-copy-button');
+    assert.true(this.success);
+  });
+
   // @TARGET ARGUMENT
 
   test('it should allow to target an element using a `string` selector for the `@target` argument', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a fix to allow empty strings and zero number values passed into the Copy Button to copy the values.

### :hammer_and_wrench: Detailed description

* Update clipboard modifier used by Copy Button to handle passed in empty string and zero number values
* Add Showcase examples
* Add integration tests

<!-- 
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-4447](https://hashicorp.atlassian.net/browse/HDS-4447)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
