### PR TITLE
Website: Scroll to top goes to top of page

### DIFF
--- a/website/app/styles/pages/application/stage.scss
+++ b/website/app/styles/pages/application/stage.scss
@@ -19,6 +19,7 @@
   grid-template-rows: auto auto 1fr;
   grid-template-columns: 1fr;
   width: 100%; // needed (otherwise it collapses, because is in a grid)
+  scroll-margin-top: var(--doc-page-stage-gutter-large);
 
   @include breakpoint.with-fixed-sidebar() {
     padding-left: var(--doc-page-sidebar-width); // we need to compensate for the fixed position of the sidebar

--- a/website/app/styles/pages/application/stage.scss
+++ b/website/app/styles/pages/application/stage.scss
@@ -19,7 +19,7 @@
   grid-template-rows: auto auto 1fr;
   grid-template-columns: 1fr;
   width: 100%; // needed (otherwise it collapses, because is in a grid)
-  scroll-margin-top: var(--doc-page-stage-gutter-large);
+  scroll-margin-top: var(--doc-page-header-height);
 
   @include breakpoint.with-fixed-sidebar() {
     padding-left: var(--doc-page-sidebar-width); // we need to compensate for the fixed position of the sidebar


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes an issue in the website back-to-top button, where upon clicking the button the page was scrolled only until the page title was in view, not the entire way back to the top of the page. 

[Preview page](https://hds-website-git-dchyun-website-scroll-to-top-i-64561a-hashicorp.vercel.app/components/accordion)

### :camera_flash: Screenshots

Screenshots show appearance after scrolling down page and pressing back-to-top button.

**Before**
<img width="1734" alt="Screenshot 2025-02-05 at 2 34 53 PM" src="https://github.com/user-attachments/assets/520e0a77-b242-4687-a811-fe9f8f4d69a5" />

**After**
<img width="1740" alt="Screenshot 2025-02-05 at 2 35 27 PM" src="https://github.com/user-attachments/assets/484f94a5-59bd-402c-b258-d54785c6d27d" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4472](https://hashicorp.atlassian.net/browse/HDS-4472)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4472]: https://hashicorp.atlassian.net/browse/HDS-4472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ