### PR TITLE
`Table`: remove last of update aria-label code

### DIFF
--- a/.changeset/three-walls-lay.md
+++ b/.changeset/three-walls-lay.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Table`: Removed unused updateAriaLabel function and event listener

--- a/.changeset/three-walls-lay.md
+++ b/.changeset/three-walls-lay.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Table`: Removed unused updateAriaLabel function and event listener
+`Table` – Removed unused `updateAriaLabel` function and event listener

--- a/packages/components/src/components/hds/table/index.ts
+++ b/packages/components/src/components/hds/table/index.ts
@@ -256,7 +256,6 @@ export default class HdsTable extends Component<HdsTableSignature> {
   onSelectionAllChange(): void {
     this._selectableRows.forEach((row) => {
       row.checkbox.checked = this._selectAllCheckbox?.checked ?? false;
-      row.checkbox.dispatchEvent(new Event('toggle', { bubbles: false }));
     });
     this._isSelectAllCheckboxSelected =
       this._selectAllCheckbox?.checked ?? false;
@@ -316,9 +315,6 @@ export default class HdsTable extends Component<HdsTableSignature> {
       this._selectAllCheckbox.indeterminate =
         selectedRowsCount > 0 && selectedRowsCount < selectableRowsCount;
       this._isSelectAllCheckboxSelected = this._selectAllCheckbox.checked;
-      this._selectAllCheckbox.dispatchEvent(
-        new Event('toggle', { bubbles: false })
-      );
     }
   }
 }

--- a/packages/components/src/components/hds/table/th-selectable.ts
+++ b/packages/components/src/components/hds/table/th-selectable.ts
@@ -82,7 +82,7 @@ export default class HdsTableThSelectable extends Component<HdsTableThSelectable
   }
 
   @action
-  willDestroyNode(checkbox: HdsFormCheckboxBaseSignature['Element']): void {
+  willDestroyNode(): void {
     super.willDestroy();
     const { willDestroy } = this.args;
     if (typeof willDestroy === 'function') {

--- a/packages/components/src/components/hds/table/th-selectable.ts
+++ b/packages/components/src/components/hds/table/th-selectable.ts
@@ -78,14 +78,6 @@ export default class HdsTableThSelectable extends Component<HdsTableThSelectable
     const { didInsert } = this.args;
     if (typeof didInsert === 'function') {
       didInsert(checkbox, this.args.selectionKey);
-      // we need to use a custom event listener here because changing the `checked` value via JS
-      // (and this happens with the "select all") doesn't trigger the `change` event
-      // and consequently the `aria-label` won't be automatically updated (and so we have to force it)
-      checkbox.addEventListener(
-        'toggle',
-        this.updateAriaLabel.bind(this),
-        true
-      );
     }
   }
 
@@ -95,13 +87,6 @@ export default class HdsTableThSelectable extends Component<HdsTableThSelectable
     const { willDestroy } = this.args;
     if (typeof willDestroy === 'function') {
       willDestroy(this.args.selectionKey);
-      if (checkbox) {
-        checkbox.removeEventListener(
-          'toggle',
-          this.updateAriaLabel.bind(this),
-          true
-        );
-      }
     }
   }
 
@@ -114,11 +99,5 @@ export default class HdsTableThSelectable extends Component<HdsTableThSelectable
     if (typeof onSelectionChange === 'function') {
       onSelectionChange(target, this.args.selectionKey);
     }
-  }
-
-  updateAriaLabel(event: Event): void {
-    // Assert event.target as HTMLInputElement to access the 'checked' property
-    const target = event.target as HdsFormCheckboxBaseSignature['Element'];
-    this.isSelected = target.checked;
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

I noticed in more testing that there was still a bit of code remaining for the changing aria-label stuff in th-selectable. It currently doesn't do anything because the state of the checkbox is not included in the checkbox label anymore. Removing it to reduce confusion.

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
