### PR TITLE
Remove "2020 AP Stylebook" link

### DIFF
--- a/website/docs/content/writing-style/index.md
+++ b/website/docs/content/writing-style/index.md
@@ -5,6 +5,8 @@ description: Best practices for writing style, grammar, and formatting.
 previewImage: assets/illustrations/content/writing-style.jpg
 ---
 
+Generally, HashiCorp follows the [AP Style rules and guidelines](https://writer.com/blog/a-comprehensive-guide-to-the-ap-style-of-writing/), unless HashiCorp specific style is indicated.
+
 ## Capitalization
 
 ### Headings and labels

--- a/website/docs/content/writing-style/index.md
+++ b/website/docs/content/writing-style/index.md
@@ -5,7 +5,7 @@ description: Best practices for writing style, grammar, and formatting.
 previewImage: assets/illustrations/content/writing-style.jpg
 ---
 
-Generally, HashiCorp follows the [AP Style](https://writer.com/blog/a-comprehensive-guide-to-the-ap-style-of-writing/) rules and guidelines, unless HashiCorp specific style is indicated.
+Generally, HashiCorp follows the [AP Style](https://writer.com/blog/a-comprehensive-guide-to-the-ap-style-of-writing/) rules and guidelines unless a HashiCorp-specific style is indicated.
 
 ## Capitalization
 

--- a/website/docs/content/writing-style/index.md
+++ b/website/docs/content/writing-style/index.md
@@ -5,8 +5,6 @@ description: Best practices for writing style, grammar, and formatting.
 previewImage: assets/illustrations/content/writing-style.jpg
 ---
 
-Generally, HashiCorp follows the [2020 AP Stylebook](https://www.apstylebook.com/ap_stylebook) rules and guidelines, unless HashiCorp specific style is indicated.
-
 ## Capitalization
 
 ### Headings and labels

--- a/website/docs/content/writing-style/index.md
+++ b/website/docs/content/writing-style/index.md
@@ -5,7 +5,7 @@ description: Best practices for writing style, grammar, and formatting.
 previewImage: assets/illustrations/content/writing-style.jpg
 ---
 
-Generally, HashiCorp follows the [AP Style rules and guidelines](https://writer.com/blog/a-comprehensive-guide-to-the-ap-style-of-writing/), unless HashiCorp specific style is indicated.
+Generally, HashiCorp follows the [AP Style](https://writer.com/blog/a-comprehensive-guide-to-the-ap-style-of-writing/) rules and guidelines, unless HashiCorp specific style is indicated.
 
 ## Capitalization
 


### PR DESCRIPTION
### :pushpin: Summary

This PR will remove the "2020 AP Stylebook" link if merged. 

### :hammer_and_wrench: Detailed description

The “2020 AP Stylebook” link directs the user to a page that requires a login. Unfortunately, we do not have a company-wide login for this stylebook, so we need to remove the following sentence from the [Writing style page](https://helios.hashicorp.design/content/writing-style): 

“Generally, HashiCorp follows the 2020 AP Stylebook rules and guidelines, unless HashiCorp specific style is indicated.”

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4294](https://hashicorp.atlassian.net/browse/HDS-4294)



[HDS-4294]: https://hashicorp.atlassian.net/browse/HDS-4294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ