### PR TITLE
 Website - Add fix for dialog z-index issue (HDS-4377)

### DIFF
--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -11,6 +11,11 @@ $doc-page-sidebar-transition-duration: 0.25s;
 
 // ⚠️ ---  the sidebar "navigation" is different between the homepage and the other pages --- ⚠️
 
+// if dialog is open, set sidebar z-index to 1
+.doc-page-wrapper:has(dialog[open]) {
+  --doc-z-index-sidebar: 1;
+}
+
 // HOME PAGE
 // This is a special case: the sidebar is horizontal and is visible *only* on small viewports (when opened)
 

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -62,11 +62,13 @@ body.application:not(.index) {
   &.doc-page-wrapper:has(dialog[open]),
   &.doc-page-wrapper:has(.hds-code-editor--is-full-screen) {
     --doc-z-index-sidebar: 1;
+
+    .doc-scroll-to-top {z-index: 1;}
   }
 
-  // if code editor is in full screen mode, set page peader z-index to 1
+  // if code editor is in full screen mode, set page header & scroll to top z-index to 1
   &.doc-page-wrapper:has(.hds-code-editor--is-full-screen) {
-    .doc-page-header {z-index: 1;}
+    .doc-page-header, .doc-scroll-to-top {z-index: 1;}
   }
 
   // Notice: for `display` and animation/transition look below

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -11,11 +11,6 @@ $doc-page-sidebar-transition-duration: 0.25s;
 
 // ⚠️ ---  the sidebar "navigation" is different between the homepage and the other pages --- ⚠️
 
-// if dialog is open, set sidebar z-index to 1
-.doc-page-wrapper:has(dialog[open]) {
-  --doc-z-index-sidebar: 1;
-}
-
 // HOME PAGE
 // This is a special case: the sidebar is horizontal and is visible *only* on small viewports (when opened)
 
@@ -63,6 +58,17 @@ body.application.index {
 // ALL THE OTHER PAGES
 
 body.application:not(.index) {
+  // if dialog is open, set sidebar z-index to 1
+  &.doc-page-wrapper:has(dialog[open]),
+  &.doc-page-wrapper:has(.hds-code-editor--is-full-screen) {
+    --doc-z-index-sidebar: 1;
+  }
+
+  // if code editor is in full screen mode, set page peader z-index to 1
+  &.doc-page-wrapper:has(.hds-code-editor--is-full-screen) {
+    .doc-page-header {z-index: 1;}
+  }
+
   // Notice: for `display` and animation/transition look below
   .doc-page-sidebar {
     position: fixed;

--- a/website/app/styles/pages/application/tabs.scss
+++ b/website/app/styles/pages/application/tabs.scss
@@ -36,11 +36,15 @@
   @include breakpoint.x-large() {
     padding: 24px var(--doc-page-stage-gutter-x-large) 0;
   }
+}
 
-  // Make tabs position sticky/fixed if the viewport height is greater than 480px
+// Make tabs position sticky/fixed if the viewport height is greater than 480px and dialog is NOT open
+.doc-page-wrapper:not(:has(dialog[open])) {
   @media (height >= 480px) {
-    position: sticky;
-    top: var(--doc-page-header-height);
+    .doc-page-tabs {
+      position: sticky;
+      top: var(--doc-page-header-height);
+    }
   }
 }
 

--- a/website/app/styles/pages/application/tabs.scss
+++ b/website/app/styles/pages/application/tabs.scss
@@ -38,8 +38,13 @@
   }
 }
 
-// Make tabs position sticky/fixed if the viewport height is greater than 480px and dialog is NOT open
-.doc-page-wrapper:not(:has(dialog[open])) {
+// Make tabs position sticky/fixed if:
+// * the viewport height is greater than 480px AND
+// * dialog is NOT open
+// * code editor is NOT in full screen mode
+.doc-page-wrapper
+  :not(:has(dialog[open]))
+  :not(:has(.hds-code-editor--is-full-screen)) {
   @media (height >= 480px) {
     .doc-page-tabs {
       position: sticky;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a fix for a z-index issue which was causing the website side navigation and tabs to appear above the backdrop of open dialogs and above the full screen Code Editor.

NOTE: The website tabs will no longer have a fixed layout while dialogs are open with this fix.

#### Previews (open/expand the components to test):
* `CodeEditor`: https://hds-website-git-hds-4377-web-fullscreen-bug-hashicorp.vercel.app/components/code-editor?tab=code#full-screen-mode
* `Flyout`: https://hds-website-git-hds-4377-web-fullscreen-bug-hashicorp.vercel.app/components/flyout?tab=code#how-to-use-this-component
* `Modal`: https://hds-website-git-hds-4377-web-fullscreen-bug-hashicorp.vercel.app/components/modal?tab=code#how-to-use-this-component

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

**WITH BUG:**
<img width="1481" alt="image" src="https://github.com/user-attachments/assets/b584336d-a2ab-4a59-ae18-5290e677fcc2" />

**FIXED:**
<img width="1479" alt="image" src="https://github.com/user-attachments/assets/12a2c7d1-bbf2-4ee7-8959-d46634151142" />

<img width="1263" alt="image" src="https://github.com/user-attachments/assets/d49fecee-1554-4e04-8bfd-eb40deab6caf" />

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/2108bf15-bb2f-4be0-acdd-7003cc629e4a" />

### :link: External links

* Jira ticket: [HDS-4377](https://hashicorp.atlassian.net/browse/HDS-4377)

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4377]: https://hashicorp.atlassian.net/browse/HDS-4377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ