### PR TITLE
`Badge` - Update colors to increase contrast for a11y (HDS-4335)

### DIFF
--- a/.changeset/old-snakes-judge.md
+++ b/.changeset/old-snakes-judge.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Badge` - Update foreground and background colors to improve contrast for a11y

--- a/.changeset/old-snakes-judge.md
+++ b/.changeset/old-snakes-judge.md
@@ -4,4 +4,4 @@
 
 `Badge` - Update foreground and background colors to improve contrast for a11y
 
-`BadgeCount` - Update foreground color of eutral variant to improve contrast for a11y
+`BadgeCount` - Update foreground color of neutral variant to improve contrast for a11y

--- a/.changeset/old-snakes-judge.md
+++ b/.changeset/old-snakes-judge.md
@@ -1,5 +1,7 @@
 ---
-"@hashicorp/design-system-components": patch
+"@hashicorp/design-system-components": minor
 ---
 
 `Badge` - Update foreground and background colors to improve contrast for a11y
+
+`BadgeCount` - Update foreground color of eutral variant to improve contrast for a11y

--- a/packages/components/src/styles/components/badge-count.scss
+++ b/packages/components/src/styles/components/badge-count.scss
@@ -67,7 +67,7 @@ $hds-badge-count-size-props: (
 .hds-badge-count--color-neutral {
   &.hds-badge-count--type-filled {
     color: var(--token-color-foreground-primary);
-    background-color: var(--token-color-surface-strong);
+    background-color: var(--token-color-palette-neutral-200);
   }
 
   &.hds-badge-count--type-inverted {

--- a/packages/components/src/styles/components/badge.scss
+++ b/packages/components/src/styles/components/badge.scss
@@ -34,6 +34,16 @@ $hds-badge-colors-props: (
 
 
 .hds-badge {
+  // Redefine color values to increase contrast
+  --token-color-surface-success: var(--token-color-palette-green-100);
+  --token-color-foreground-success-on-surface: var(--token-color-palette-green-400);
+  --token-color-surface-warning: var(--token-color-palette-amber-100);
+  --token-color-foreground-warning-on-surface: var(--token-color-palette-amber-400);
+  --token-color-surface-critical: var(--token-color-palette-red-100);
+  --token-color-foreground-critical-on-surface: var(--token-color-palette-red-400);
+  --token-color-surface-highlight: var(--token-color-palette-purple-100);
+  --token-color-foreground-highlight-on-surface: var(--token-color-palette-purple-400);
+
   display: inline-flex;
   align-items: center;
   max-width: 100%;
@@ -111,7 +121,7 @@ $hds-badge-size-props: (
 .hds-badge--color-neutral {
   &.hds-badge--type-filled {
     color: var(--token-color-foreground-primary);
-    background-color: var(--token-color-surface-strong);
+    background-color: var(--token-color-palette-neutral-200);
   }
 
   &.hds-badge--type-inverted {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the background color for the `Badge` & `BadgeCount` neutral variants. It also updates `Badge` background & foreground colors for success, warning, critical, and highlight variants.

**Doc updates PR**: https://github.com/hashicorp/design-system/pull/2697

#### Showcase previews: 

* Badge: https://hds-showcase-git-hds-4335-badge-fill-color-update-hashicorp.vercel.app/components/badge
* BadgeCount: https://hds-showcase-git-hds-4335-badge-fill-color-update-hashicorp.vercel.app/components/badge-count

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<img width="172" alt="image" src="https://github.com/user-attachments/assets/43119b64-b45f-4e8b-8018-a508b75f168b" />

<img width="311" alt="image" src="https://github.com/user-attachments/assets/2ec8cfd6-f4e3-4f07-a1a7-c7f72218b431" />

<img width="315" alt="image" src="https://github.com/user-attachments/assets/1062a470-043d-49b6-823c-a4704cb9b4ef" />

### :link: External links

- Jira ticket: [HDS-4335](https://hashicorp.atlassian.net/browse/HDS-4335)
- Figma file: https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/branch/i8MgjzjqhgOEhglGfRf3D4/HDS-Components-v2.0?node-id=2-8&p=f&t=OsVYXq9lF0Oz5tev-0

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4335]: https://hashicorp.atlassian.net/browse/HDS-4335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ