### PR TITLE
`CodeEditor` and `CodeBlock`: add ability to customize the copy button text

### DIFF
--- a/.changeset/orange-chefs-learn.md
+++ b/.changeset/orange-chefs-learn.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`CodeBlock` - Added `@copyButtonText` argument to `CodeBlock` and `@text` argument to the `CodeBlock::CopyButton` subcomponent to customize the `aria-label` of the Copy Button. The default label is still "Copy".
+
+`CodeEditor` - Added `@copyButtonText` argument to customize the `aria-label` of the Copy Button. The default label is still "Copy".

--- a/packages/components/src/components/hds/code-block/copy-button.hbs
+++ b/packages/components/src/components/hds/code-block/copy-button.hbs
@@ -5,7 +5,7 @@
 
 <Hds::Copy::Button
   class="hds-code-block__copy-button"
-  @text="Copy"
+  @text={{this.text}}
   @isIconOnly={{true}}
   @size="small"
   @targetToCopy={{@targetToCopy}}

--- a/packages/components/src/components/hds/code-block/copy-button.ts
+++ b/packages/components/src/components/hds/code-block/copy-button.ts
@@ -18,7 +18,6 @@ export interface HdsCodeBlockCopyButtonSignature {
   Element: HdsCopyButtonSignature['Element'];
 }
 
-
 export default class HdsCodeBlockCopyButton extends Component<HdsCodeBlockCopyButtonSignature> {
   get text(): HdsCopyButtonSignature['Args']['text'] {
     return this.args.text ? this.args.text : 'Copy';

--- a/packages/components/src/components/hds/code-block/copy-button.ts
+++ b/packages/components/src/components/hds/code-block/copy-button.ts
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import templateOnlyComponent from '@ember/component/template-only';
+import Component from '@glimmer/component';
+
 import type { HdsCopyButtonSignature } from '../copy/button';
 
 export interface HdsCodeBlockCopyButtonSignature {
   Args: {
     targetToCopy?: HdsCopyButtonSignature['Args']['targetToCopy'];
+    text?: HdsCopyButtonSignature['Args']['text'];
   };
   Blocks: {
     default: [];
@@ -16,7 +18,9 @@ export interface HdsCodeBlockCopyButtonSignature {
   Element: HdsCopyButtonSignature['Element'];
 }
 
-const HdsCodeBlockCopyButton =
-  templateOnlyComponent<HdsCodeBlockCopyButtonSignature>();
 
-export default HdsCodeBlockCopyButton;
+export default class HdsCodeBlockCopyButton extends Component<HdsCodeBlockCopyButtonSignature> {
+  get text(): HdsCopyButtonSignature['Args']['text'] {
+    return this.args.text ? this.args.text : 'Copy';
+  }
+}

--- a/packages/components/src/components/hds/code-block/index.hbs
+++ b/packages/components/src/components/hds/code-block/index.hbs
@@ -22,7 +22,11 @@
       </code></pre>
 
     {{#if @hasCopyButton}}
-      <Hds::CodeBlock::CopyButton @targetToCopy="#{{this._preCodeId}}" aria-describedby={{this._preCodeId}} />
+      <Hds::CodeBlock::CopyButton
+        @targetToCopy="#{{this._preCodeId}}"
+        aria-describedby={{this._preCodeId}}
+        text={{this.copyButtonText}}
+      />
     {{/if}}
   </div>
 </div>

--- a/packages/components/src/components/hds/code-block/index.hbs
+++ b/packages/components/src/components/hds/code-block/index.hbs
@@ -25,7 +25,7 @@
       <Hds::CodeBlock::CopyButton
         @targetToCopy="#{{this._preCodeId}}"
         aria-describedby={{this._preCodeId}}
-        text={{this.copyButtonText}}
+        @text={{this.copyButtonText}}
       />
     {{/if}}
   </div>

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -137,7 +137,7 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   }
 
   get copyButtonText(): HdsCopyButtonSignature['Args']['text'] {
-    return this.args.copyButtonText ? this.args.copyButtonText : 'Copy'
+    return this.args.copyButtonText ? this.args.copyButtonText : 'Copy';
   }
 
   @action

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -20,6 +20,7 @@ import type { HdsCodeBlockTitleSignature } from './title';
 import type { HdsCodeBlockDescriptionSignature } from './description';
 import { HdsCodeBlockLanguageValues } from './types.ts';
 import type { HdsCodeBlockLanguages } from './types.ts';
+import type { HdsCopyButtonSignature } from '../copy/button/index.ts';
 
 import 'prismjs/plugins/line-numbers/prism-line-numbers';
 import 'prismjs/plugins/line-highlight/prism-line-highlight';
@@ -52,6 +53,7 @@ export interface HdsCodeBlockSignature {
     language?: HdsCodeBlockLanguages;
     maxHeight?: string;
     value: string;
+    copyButtonText?: HdsCopyButtonSignature['Args']['text'];
   };
   Blocks: {
     default: [
@@ -132,6 +134,10 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
    */
   get hasLineWrapping(): boolean {
     return this.args.hasLineWrapping ?? false;
+  }
+
+  get copyButtonText(): HdsCopyButtonSignature['Args']['text'] {
+    return this.args.copyButtonText ? this.args.copyButtonText : 'Copy'
   }
 
   @action

--- a/packages/components/src/components/hds/code-editor/index.hbs
+++ b/packages/components/src/components/hds/code-editor/index.hbs
@@ -33,7 +33,7 @@
               class="hds-code-editor__button hds-code-editor__copy-button"
               @isIconOnly={{true}}
               @size="small"
-              @text="Copy"
+              @text={{this.copyButtonText}}
               @textToCopy={{this._value}}
             />
           {{/if}}

--- a/packages/components/src/components/hds/code-editor/index.ts
+++ b/packages/components/src/components/hds/code-editor/index.ts
@@ -15,12 +15,14 @@ import type { HdsCodeEditorTitleSignature } from './title';
 import type { HdsCodeEditorGenericSignature } from './generic';
 import type { EditorView } from '@codemirror/view';
 import { guidFor } from '@ember/object/internals';
+import type { HdsCopyButtonSignature } from '../copy/button/index.ts';
 
 export interface HdsCodeEditorSignature {
   Args: {
     hasCopyButton?: boolean;
     hasFullScreenButton?: boolean;
     isStandalone?: boolean;
+    copyButtonText?: HdsCopyButtonSignature['Args']['text'];
   } & HdsCodeEditorModifierSignature['Args']['Named'];
   Blocks: {
     default: [
@@ -101,6 +103,10 @@ export default class HdsCodeEditor extends Component<HdsCodeEditorSignature> {
     }
 
     return classes.join(' ');
+  }
+
+  get copyButtonText(): HdsCopyButtonSignature['Args']['text'] {
+    return this.args.copyButtonText ? this.args.copyButtonText : 'Copy'
   }
 
   @action

--- a/packages/components/src/components/hds/code-editor/index.ts
+++ b/packages/components/src/components/hds/code-editor/index.ts
@@ -106,7 +106,7 @@ export default class HdsCodeEditor extends Component<HdsCodeEditorSignature> {
   }
 
   get copyButtonText(): HdsCopyButtonSignature['Args']['text'] {
-    return this.args.copyButtonText ? this.args.copyButtonText : 'Copy'
+    return this.args.copyButtonText ? this.args.copyButtonText : 'Copy';
   }
 
   @action

--- a/showcase/tests/integration/components/hds/code-block/index-test.js
+++ b/showcase/tests/integration/components/hds/code-block/index-test.js
@@ -141,16 +141,19 @@ module('Integration | Component | hds/code-block/index', function (hooks) {
       <Hds::CodeBlock @value="console.log('Hello world');" @hasCopyButton={{true}} />
     `);
 
-    assert.dom('.hds-code-block__copy-button').exists().hasAria('label', 'Copy');
+    assert
+      .dom('.hds-code-block__copy-button')
+      .exists()
+      .hasAria('label', 'Copy');
   });
 
-  test('it renders a Copy button with custom text', async function(assert) {
+  test('it renders a Copy button with custom text', async function (assert) {
     await render(hbs`
       <Hds::CodeBlock @value="console.log('Hello world');" @hasCopyButton={{true}} @copyButtonText="Foo" />
     `);
 
     assert.dom('.hds-code-block__copy-button').exists().hasAria('label', 'Foo');
-  })
+  });
 
   // hasLineNumbers
   test('it displays line numbers by default', async function (assert) {

--- a/showcase/tests/integration/components/hds/code-block/index-test.js
+++ b/showcase/tests/integration/components/hds/code-block/index-test.js
@@ -140,8 +140,17 @@ module('Integration | Component | hds/code-block/index', function (hooks) {
     await render(hbs`
       <Hds::CodeBlock @value="console.log('Hello world');" @hasCopyButton={{true}} />
     `);
-    assert.dom('.hds-code-block__copy-button').exists();
+
+    assert.dom('.hds-code-block__copy-button').exists().hasAria('label', 'Copy');
   });
+
+  test('it renders a Copy button with custom text', async function(assert) {
+    await render(hbs`
+      <Hds::CodeBlock @value="console.log('Hello world');" @hasCopyButton={{true}} @copyButtonText="Foo" />
+    `);
+
+    assert.dom('.hds-code-block__copy-button').exists().hasAria('label', 'Foo');
+  })
 
   // hasLineNumbers
   test('it displays line numbers by default', async function (assert) {

--- a/showcase/tests/integration/components/hds/code-editor/index-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/index-test.js
@@ -87,16 +87,24 @@ module('Integration | Component | hds/code-editor/index', function (hooks) {
     await setupCodeEditor(
       hbs`<Hds::CodeEditor @ariaLabel="code editor" @hasCopyButton={{true}} />`
     );
-    assert.dom('.hds-code-editor__copy-button').exists().hasAria('label', 'Copy');
+    assert
+      .dom('.hds-code-editor__copy-button')
+      .exists()
+      .hasAria('label', 'Copy');
   });
   test('it should not render a copy button when the `@hasCopyButton` argument is not provided', async function (assert) {
     await setupCodeEditor(hbs`<Hds::CodeEditor @ariaLabel="code editor" />`);
     assert.dom('.hds-code-editor__copy-button').doesNotExist();
   });
-  test('it renders a copy button with custom text', async function(assert) {
-    await setupCodeEditor(hbs`<Hds::CodeEditor @ariaLabel="code editor" @hasCopyButton={{true}} @copyButtonText="Foo" />`);
-    assert.dom('.hds-code-editor__copy-button').exists().hasAria('label', 'Foo');
-  })
+  test('it renders a copy button with custom text', async function (assert) {
+    await setupCodeEditor(
+      hbs`<Hds::CodeEditor @ariaLabel="code editor" @hasCopyButton={{true}} @copyButtonText="Foo" />`
+    );
+    assert
+      .dom('.hds-code-editor__copy-button')
+      .exists()
+      .hasAria('label', 'Foo');
+  });
   // @isStandalone
   test('it should render the component with a standalone style when the `@isStandalone` argument is true and when the argument is ommitted', async function (assert) {
     this.set('isStandalone', true);

--- a/showcase/tests/integration/components/hds/code-editor/index-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/index-test.js
@@ -87,12 +87,16 @@ module('Integration | Component | hds/code-editor/index', function (hooks) {
     await setupCodeEditor(
       hbs`<Hds::CodeEditor @ariaLabel="code editor" @hasCopyButton={{true}} />`
     );
-    assert.dom('.hds-code-editor__copy-button').exists();
+    assert.dom('.hds-code-editor__copy-button').exists().hasAria('label', 'Copy');
   });
   test('it should not render a copy button when the `@hasCopyButton` argument is not provided', async function (assert) {
     await setupCodeEditor(hbs`<Hds::CodeEditor @ariaLabel="code editor" />`);
     assert.dom('.hds-code-editor__copy-button').doesNotExist();
   });
+  test('it renders a copy button with custom text', async function(assert) {
+    await setupCodeEditor(hbs`<Hds::CodeEditor @ariaLabel="code editor" @hasCopyButton={{true}} @copyButtonText="Foo" />`);
+    assert.dom('.hds-code-editor__copy-button').exists().hasAria('label', 'Foo');
+  })
   // @isStandalone
   test('it should render the component with a standalone style when the `@isStandalone` argument is true and when the argument is ommitted', async function (assert) {
     this.set('isStandalone', true);

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -23,6 +23,9 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
   <C.Property @name="hasCopyButton" @type="boolean" @default="false">
     Used to control whether a copy button for copying the code/text content will be displayed.
   </C.Property>
+    <C.Property @name="copyButtonText" @type="string" @default="'Copy'">
+    Override this value to provide a meaningful `aria-label` for the [`Copy::Button`](/components/copy/button) component.
+  </C.Property>
   <C.Property @name="hasLineNumbers" @type="boolean" @default="true">
     Used to control display of line numbers. Note that due to technical limitations, if the `@value` changes dynamically the line numbers will fail to update.
   </C.Property>

--- a/website/docs/components/code-block/partials/code/how-to-use.md
+++ b/website/docs/components/code-block/partials/code/how-to-use.md
@@ -81,7 +81,7 @@ func main() {
 
 ### Copy button
 
-Set `hasCopyButton` to `true` to display a button for users to copy `CodeBlock` content to their computer clipboard. Use `copyButtonText` to provide a meaningful and unique label for the Copy Button.
+Set `hasCopyButton` to `true` to display a button for users to copy `CodeBlock` content to their computer clipboard. Use `copyButtonText` to provide a meaningful and unique label for the copy button.
 
 ```handlebars
 <Hds::CodeBlock

--- a/website/docs/components/code-block/partials/code/how-to-use.md
+++ b/website/docs/components/code-block/partials/code/how-to-use.md
@@ -81,12 +81,13 @@ func main() {
 
 ### Copy button
 
-Set `hasCopyButton` to `true` to display a button for users to copy `CodeBlock` content to their computer clipboard.
+Set `hasCopyButton` to `true` to display a button for users to copy `CodeBlock` content to their computer clipboard. Use `copyButtonText` to provide a meaningful and unique label for the Copy Button.
 
 ```handlebars
 <Hds::CodeBlock
   @language="javascript"
   @hasCopyButton={{true}}
+  @copyButtonText="Copy javascript code"
   @value="let codeLang=`JavaScript`;
 console.log(`I am ${codeLang} code`);"
 />

--- a/website/docs/components/code-editor/partials/code/component-api.md
+++ b/website/docs/components/code-editor/partials/code/component-api.md
@@ -23,6 +23,9 @@ This component uses [CodeMirror 6](https://codemirror.net/) under the hood.
   <C.Property @name="hasCopyButton" @type="boolean" @default="false">
     Used to control whether a copy button for copying the code/text content will be displayed.
   </C.Property>
+  <C.Property @name="copyButtonText" @type="string" @default="'Copy'">
+    Override this value to provide a meaningful `aria-label` for the [`Copy::Button`](/components/copy/button) component.
+  </C.Property>
   <C.Property @name="hasFullScreenButton" @type="boolean" @default="false">
     Used to control whether a toggle button for toggling full-screen mode will be displayed.
   </C.Property>

--- a/website/docs/components/code-editor/partials/code/how-to-use.md
+++ b/website/docs/components/code-editor/partials/code/how-to-use.md
@@ -71,10 +71,15 @@ The `language` argument sets the syntax highlighting used. We support the follow
 
 ### Copy button
 
-Set `hasCopyButton` to `true` to display a button for users to copy Code Editor content to their computer clipboard.
+Set `hasCopyButton` to `true` to display a button for users to copy Code Editor content to their computer clipboard. Use `copyButtonText` to provide a meaningful and unique label for the Copy Button.
 
 ```handlebars
-<Hds::CodeEditor @ariaLabel="copy button" @hasCopyButton={{true}} @value={{this.loremIpsum}} />
+<Hds::CodeEditor
+  @ariaLabel="copy button"
+  @hasCopyButton={{true}}
+  @copyButtonText="Copy lorem ipsum code"
+  @value={{this.loremIpsum}}
+/>
 ```
 
 

--- a/website/docs/components/code-editor/partials/code/how-to-use.md
+++ b/website/docs/components/code-editor/partials/code/how-to-use.md
@@ -71,7 +71,7 @@ The `language` argument sets the syntax highlighting used. We support the follow
 
 ### Copy button
 
-Set `hasCopyButton` to `true` to display a button for users to copy Code Editor content to their computer clipboard. Use `copyButtonText` to provide a meaningful and unique label for the Copy Button.
+Set `hasCopyButton` to `true` to display a button for users to copy Code Editor content to their computer clipboard. Use `copyButtonText` to provide a meaningful and unique label for the copy button.
 
 ```handlebars
 <Hds::CodeEditor


### PR DESCRIPTION
### :pushpin: Summary

**CodeEditor**: add `@copyButtonText` argument
**CodeBlock**: add `@copyButtonText` argument to the CodeBlock component and `@text` argument to the CopyButton sub-component.

**[Website preview](https://hds-website-git-hds-4389-copy-btn-text-arg-hashicorp.vercel.app/components/code-editor?tab=code)**

### :hammer_and_wrench: Detailed description

- add new arguments
- add tests to ensure arguments are working
- update website content

### :camera_flash: Screenshots
<img width="684" alt="Screenshot 2025-02-11 at 11 58 44 AM" src="https://github.com/user-attachments/assets/029bbcf1-9371-4c25-8919-fef721caf927" />

<img width="663" alt="Screenshot 2025-02-11 at 11 59 06 AM" src="https://github.com/user-attachments/assets/48dc6535-62cc-4d2e-8bad-5f962dc2cf03" />

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

Jira ticket: [HDS-4389](https://hashicorp.atlassian.net/browse/HDS-4389)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4389]: https://hashicorp.atlassian.net/browse/HDS-4389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ