### PR TITLE
Web Docs - Fix remaining z-index issues with Modal and Flyout examples

### DIFF
--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -63,11 +63,6 @@ body.application:not(.index) {
   &.doc-page-wrapper:has(.hds-code-editor--is-full-screen) {
     --doc-z-index-sidebar: 1;
 
-    .doc-scroll-to-top {z-index: 1;}
-  }
-
-  // if code editor is in full screen mode, set page header & scroll to top z-index to 1
-  &.doc-page-wrapper:has(.hds-code-editor--is-full-screen) {
     .doc-page-header, .doc-scroll-to-top {z-index: 1;}
   }
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes z-index issues causing the docs page header to appear above open `Flyout` & `Modal` backdrops in documentation examples

#### Previews:

* CodeEditor: [coming...](https://hds-website-git-page-header-interactivity-w-modal-bug-hashicorp.vercel.app/components/code-editor?tab=code#full-screen-mode)
* Flyout: [ coming...](https://hds-website-git-page-header-interactivity-w-modal-bug-hashicorp.vercel.app/components/flyout?tab=code#how-to-use-this-component)
* Modal: [ coming...](https://hds-website-git-page-header-interactivity-w-modal-bug-hashicorp.vercel.app/components/modal?tab=code#how-to-use-this-component)

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser

### :link: External links
Issues, RFC, etc.
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]
 -->

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
