### PR TITLE
fix: refocus search button when close the dialog

### DIFF
--- a/website/app/components/doc/page/header/algolia-search/index.js
+++ b/website/app/components/doc/page/header/algolia-search/index.js
@@ -247,9 +247,6 @@ export default class DocAlgoliaSearchComponent extends Component {
       // add event listener to open/close the modal via `command-K` hot-key
       if (event.metaKey && event.key === 'k') {
         autocompleteInstance.setIsOpen(!this.isModalOpen);
-        if (!this.isModalOpen) {
-          document.getElementById('search-button').focus();
-        }
       }
     });
 

--- a/website/app/components/doc/page/header/algolia-search/index.js
+++ b/website/app/components/doc/page/header/algolia-search/index.js
@@ -58,9 +58,12 @@ export default class DocAlgoliaSearchComponent extends Component {
         detachedCancelButtonText: 'Close', // https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-translations
       },
       onStateChange: ({ state, prevState }) => {
+        // keep tracked state in sync with internal state so cmd+k properly opens/closes the dialog
+        this.isModalOpen = state.isOpen;
         // used to reset the query to an empty state/string when the modal is closed (via "click" or "esc" key)
         if (!state.isOpen && prevState.isOpen) {
-          autocompleteInstance.setQuery('');
+          autocompleteInstance.setQuery('');          
+          document.getElementById('search-button').focus();
         }
       },
       // onSubmit: ({ state, setQuery, setIsOpen, refresh }) => {
@@ -240,11 +243,13 @@ export default class DocAlgoliaSearchComponent extends Component {
       });
     }
 
-    // add event listener to open/close the modal via `command-K` hot-key
     document.addEventListener('keydown', (event) => {
+      // add event listener to open/close the modal via `command-K` hot-key
       if (event.metaKey && event.key === 'k') {
         autocompleteInstance.setIsOpen(!this.isModalOpen);
-        this.isModalOpen = !this.isModalOpen;
+        if (!this.isModalOpen) {
+          document.getElementById('search-button').focus();
+        }
       }
     });
 

--- a/website/app/components/doc/page/header/index.hbs
+++ b/website/app/components/doc/page/header/index.hbs
@@ -16,16 +16,18 @@
       <Doc::Page::Header::NavItem @label="Components" @route="components" @currentTopRoute={{@currentTopRoute}} />
       <Doc::Page::Header::NavItem @label="Patterns" @route="patterns" @currentTopRoute={{@currentTopRoute}} />
       <li class="doc-page-header__nav-item-generic doc-page-header__nav-item--split">
-        <div class="sr-only" id="search-button">This button opens a dialog containing an input field and some additional
-          information that you may wish to explore. An automatic search will be performed as you type text into the
-          search field, but the results may not be announced. Exploring the additional items in the modal will help you
-          discover the search results.</div>
+        <div class="sr-only" id="search-button-help">
+          This button opens a dialog containing an input field and some additional information that you may wish to
+          explore. An automatic search will be performed as you type text into the search field, but the results may not
+          be announced. Exploring the additional items in the modal will help you discover the search results.
+        </div>
         <button
           type="button"
           class="doc-page-header__desktop-icon-item"
           data-doc-algolia-search-autocomplete-secondary-trigger
-          aria-describedby="search-button"
+          aria-describedby="search-button-help"
           aria-label="Search"
+          id="search-button"
         >
           <Hds::Icon @name="search" @size="24" />
         </button>


### PR DESCRIPTION
### :pushpin: Summary

Algolia doesn't provide an onClose or onCancelSearch callback, so there is no ideal way to refocus the dialog when it closes and the user doesn't execute a search.

I ended up implementing it where any time the modal goes from open to close, refocus the search button - even though it will temporarily focus the search button before the navigation happens if the users clicks a link in the search dialog

Other options considered:
- Refactor so we don't use their "detached" UI anymore and instead build something custom (too much effort)
- Add event listeners for cmd+k, escape, and click button (if press escape anywhere on the page, focuses the search button, adds complexity) 


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4419](https://hashicorp.atlassian.net/browse/HDS-4419)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
