### PR TITLE
Add `@identity` to the list of possible values for the `@identityKey` argument of `Table` and `AdvancedTable`

### DIFF
--- a/website/docs/components/table/advanced-table/partials/code/component-api.md
+++ b/website/docs/components/table/advanced-table/partials/code/component-api.md
@@ -104,7 +104,7 @@ The Advanced Table component itself is where most of the options will be applied
   <C.Property @name="caption" @type="string">
     Adds a (non-visible) caption for users with assistive technology. If set on a sortable table, the provided caption is paired with the automatically generated sorted message text.
   </C.Property>
-  <C.Property @name="identityKey" @type="'none'|string" @default="@identity">
+  <C.Property @name="identityKey" @type="'@identity'|'none'|string" @default="@identity">
     Option to [specify a custom key](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each#:~:text=%3C/ul%3E-,Specifying%20Keys,-In%20order%20to) to the `each` iterator. If `identityKey="none"`, this is interpreted as an `undefined` value for the `@identity` key option.
   </C.Property>
   <C.Property @name="sortedMessageText" @type="string" @default="Sorted by (label), (asc/desc)ending">

--- a/website/docs/components/table/table/partials/code/component-api.md
+++ b/website/docs/components/table/table/partials/code/component-api.md
@@ -106,7 +106,7 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="caption" @type="string">
     Adds a (non-visible) caption for users with assistive technology. If set on a sortable table, the provided table caption is paired with the automatically generated sorted message text.
   </C.Property>
-  <C.Property @name="identityKey" @type="'none'|string" @default="@identity">
+  <C.Property @name="identityKey" @type="'@identity'|'none'|string" @default="@identity">
     Option to [specify a custom key](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each#:~:text=%3C/ul%3E-,Specifying%20Keys,-In%20order%20to) to the `each` iterator. If `identityKey="none"`, this is interpreted as an `undefined` value for the `@identity` key option.
   </C.Property>
   <C.Property @name="sortedMessageText" @type="string" @default="Sorted by (label), (asc/desc)ending">


### PR DESCRIPTION
### :pushpin: Summary

Simple PR to add `@identity` to the list of possible values for the `@identityKey` argument of `Table` and `AdvancedTable`

### :camera_flash: Screenshots

**Before:**
<img width="834" alt="screenshot_4644" src="https://github.com/user-attachments/assets/827de0e9-fd9e-481c-9333-38f2cbd90634" />

**After:**
<img width="830" alt="screenshot_4645" src="https://github.com/user-attachments/assets/e176bca6-8764-43f6-8061-868f446c5e11" />

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-4376

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
