### PR TITLE
Add back Figma changelog entry for January 23rd

### DIFF
--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -42,6 +42,10 @@ In many cases, replacing v1.0 library components with the components in the Figm
 
 `Dropdown` - `ListItem Interactive` added support for the `Badge` component.
 
+## August 17th, 2024
+
+`SideNav` - Changed the icon from `User` to `Help` in the first dropdown at the top of the `SideNav`.
+
 ## August 2nd, 2024
 
 `AppHeader` - Added a new navigation component to contain global and utility navigation elements.

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -1,5 +1,13 @@
 # [HDS Components UI Kit v2.0](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?m=auto&node-id=2-7&t=HYGTIoXBy2YkVWDP-1)
 
+## January 23rd, 2025
+
+`Advanced Table` - Added new component.
+
+`CodeEditor` - Added new component.
+
+`Table` - Added column borders.
+
 ## December 20th, 2024
 
 `IconTile` - Removed the border and updated the colors for improved contrast and to create a distinctive look that aligns better with the surrounding elements.

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -36,20 +36,6 @@ In many cases, replacing v1.0 library components with the components in the Figm
 - Introduced [Template] components for common combinations.
 - Improved nested component accessibility for easier customization.
 
-## September 15th, 2024
-
-`IconTile` and `IconTile-Logo` - Added a new product variant for Vault Secrets.
-
-## September 11th, 2024
-
-`Text Input` - Added support for types `Tel`, `Week` and `Month`.
-
-`Dropdown` - `ListItem Interactive` added support for the `Badge` component.
-
-## August 17th, 2024
-
-`SideNav` - Changed the icon from `User` to `Help` in the first dropdown at the top of the `SideNav`.
-
 ## August 2nd, 2024
 
 `AppHeader` - Added a new navigation component to contain global and utility navigation elements.

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -36,6 +36,10 @@ In many cases, replacing v1.0 library components with the components in the Figm
 - Introduced [Template] components for common combinations.
 - Improved nested component accessibility for easier customization.
 
+## September 15th, 2024
+
+`IconTile` and `IconTile-Logo` - Added a new product variant for Vault Secrets.
+
 ## September 11th, 2024
 
 `Text Input` - Added support for types `Tel`, `Week` and `Month`.

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -48,20 +48,6 @@ In many cases, replacing v1.0 library components with the components in the Figm
 - Introduced [Template] components for common combinations.
 - Improved nested component accessibility for easier customization.
 
-### September 15th, 2024
-
-`IconTile` and `IconTile-Logo` - Added a new product variant for Vault Secrets.
-
-### September 11th, 2024
-
-`Text Input` - Added support for types `Tel`, `Week` and `Month`.
-
-`Dropdown` - `ListItem Interactive` added support for the `Badge` component.
-
-### August 17th, 2024
-
-`SideNav` - Changed the icon from `User` to `Help` in the first dropdown at the top of the `SideNav`.
-
 ### August 2nd, 2024
 
 `AppHeader` - Added a new navigation component to contain global and utility navigation elements.
@@ -114,6 +100,20 @@ _Adding support for a `Tooltip` and updates to the `Sort Button` result in a bre
 ### November 3rd, 2023
 
 `Breadcrumb` - Updated the number of `breadcrumb / _items` to the component.
+
+### October 23rd, 2023
+
+`Button` - Updated icon only button variants to be square to match the ToggleIcon.
+
+`Dropdown / ToggleIcon` - Fixed the small variant so that it’s the correct size (28px height) to match the other small Buttons and ToggleButton.
+
+### September 15th, 2023
+
+`IconTile` and `IconTile-Logo` - Added a new product variant for Vault Secrets.
+
+### August 17th, 2023
+
+`SideNav` - Changed the icon from `User` to `Help` in the first dropdown at the top of the `SideNav`.
 
 
 ---

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -54,6 +54,10 @@ In many cases, replacing v1.0 library components with the components in the Figm
 
 `Dropdown` - `ListItem Interactive` added support for the `Badge` component.
 
+### August 17th, 2024
+
+`SideNav` - Changed the icon from `User` to `Help` in the first dropdown at the top of the `SideNav`.
+
 ### August 2nd, 2024
 
 `AppHeader` - Added a new navigation component to contain global and utility navigation elements.
@@ -112,10 +116,6 @@ _Adding support for a `Tooltip` and updates to the `Sort Button` result in a bre
 `Button` - Updated icon only button variants to be square to match the ToggleIcon.
 
 `Dropdown / ToggleIcon` - Fixed the small variant so that it’s the correct size (28px height) to match the other small Buttons and ToggleButton.
-
-### September 15th, 2023
-
-`IconTile` and `IconTile-Logo` - Added a new product variant for Vault Secrets.
 
 
 ---

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -48,6 +48,10 @@ In many cases, replacing v1.0 library components with the components in the Figm
 - Introduced [Template] components for common combinations.
 - Improved nested component accessibility for easier customization.
 
+### September 15th, 2024
+
+`IconTile` and `IconTile-Logo` - Added a new product variant for Vault Secrets.
+
 ### September 11th, 2024
 
 `Text Input` - Added support for types `Tel`, `Week` and `Month`.
@@ -110,12 +114,6 @@ _Adding support for a `Tooltip` and updates to the `Sort Button` result in a bre
 ### November 3rd, 2023
 
 `Breadcrumb` - Updated the number of `breadcrumb / _items` to the component.
-
-### October 23rd, 2023
-
-`Button` - Updated icon only button variants to be square to match the ToggleIcon.
-
-`Dropdown / ToggleIcon` - Fixed the small variant so that it’s the correct size (28px height) to match the other small Buttons and ToggleButton.
 
 
 ---

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -12,6 +12,14 @@
 </p>
 
 
+### January 23rd, 2025
+
+`Advanced Table` - Added new component.
+
+`CodeEditor` - Added new component.
+
+`Table` - Added column borders.
+
 ### December 20th, 2024
 
 `IconTile` - Removed the border and updated the colors for improved contrast and to create a distinctive look that aligns better with the surrounding elements.
@@ -108,10 +116,6 @@ _Adding support for a `Tooltip` and updates to the `Sort Button` result in a bre
 ### September 15th, 2023
 
 `IconTile` and `IconTile-Logo` - Added a new product variant for Vault Secrets.
-
-### August 17th, 2023
-
-`SideNav` - Changed the icon from `User` to `Help` in the first dropdown at the top of the `SideNav`.
 
 
 ---


### PR DESCRIPTION
### :pushpin: Summary

In adding the content for the Figma v2.0 Library Changelog (https://github.com/hashicorp/design-system/pull/2653) and attempting to rebase and resolve issues, it turns out that I accidentally removed the exact content I was trying to rebase 😢. This adds it back the content introduced in https://github.com/hashicorp/design-system/pull/2666/files

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
