### PR TITLE
feat: enable `embroider-safe` scenario

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -10,8 +10,8 @@ env:
   NODE_VERSION: '22.x'
 
 concurrency:
-   group: ci-components-${{ github.head_ref || github.ref }}
-   cancel-in-progress: true
+  group: ci-components-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   conditional-skip:
@@ -28,7 +28,7 @@ jobs:
         run: ./.github/scripts/filter_changed_files.sh "packages/components" "packages/flight-icons/catalog.json" "showcase" ".github/workflows/ci-components.yml" "packages/tokens"
 
   test:
-    name: "Tests"
+    name: 'Tests'
     runs-on: ubuntu-latest
     needs: [conditional-skip]
     if: needs.conditional-skip.outputs.trigger-ci == 'true'
@@ -75,7 +75,7 @@ jobs:
           - ember-beta
           # - ember-canary
           - embroider-safe
-          # - embroider-optimized
+          - embroider-optimized
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/showcase/config/ember-try.js
+++ b/showcase/config/ember-try.js
@@ -76,7 +76,7 @@ module.exports = async function () {
           },
         },
       },
-      embroiderSafe({ allowedToFail: true }),
+      embroiderSafe(),
       embroiderOptimized({ allowedToFail: true }),
     ],
   };

--- a/showcase/tests/unit/services/hds-time-test.js
+++ b/showcase/tests/unit/services/hds-time-test.js
@@ -11,7 +11,7 @@ import {
   DEFAULT_DISPLAY_MAPPING,
   MINUTE_IN_MS,
   WEEK_IN_MS,
-  RELATIVE_UNIT_SECOND,
+  HdsTimeRelativeUnitValues,
 } from '@hashicorp/design-system-components/services/hds-time';
 
 let table = [
@@ -96,7 +96,7 @@ module('Unit | Service | time', function (hooks) {
 
   test(`it can formatTimeRelativeUnit`, function (assert) {
     let value = -1.523423423;
-    let unit = RELATIVE_UNIT_SECOND;
+    let unit = HdsTimeRelativeUnitValues.Second;
     let relativeUnit = this.service.formatTimeRelativeUnit(value, unit);
 
     assert.ok(relativeUnit, 'relativeUnit is defined');


### PR DESCRIPTION
### :pushpin: Summary

Enable `embroider-safe`  and remove `allowedToFail`  flag, as part of this work all warnings should be addressed which is not a lot (this allows consumers to actually run embroider/webpack (not vite) with `staticInvokables` turned off

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4524](https://hashicorp.atlassian.net/browse/HDS-4524)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4524]: https://hashicorp.atlassian.net/browse/HDS-4524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ