### PR TITLE
`hds-code-editor` modifier - Dynamically update line wrapping

### DIFF
--- a/.changeset/tricky-games-lay.md
+++ b/.changeset/tricky-games-lay.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`hds-code-editor` modifier - Added `isLineWrappingEnabled` named argument that sets line wrapping behavior within the code editor.
+
+`CodeEditor` - Added `@isLineWrappingEnabled` argument that is passed to the `hds-code-editor` modifier

--- a/.changeset/tricky-games-lay.md
+++ b/.changeset/tricky-games-lay.md
@@ -2,6 +2,6 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`hds-code-editor` modifier - Added `isLineWrappingEnabled` named argument that sets line wrapping behavior within the code editor.
+`hds-code-editor` modifier - Added `hasLineWrapping` named argument that sets line wrapping behavior within the code editor.
 
-`CodeEditor` - Added `@isLineWrappingEnabled` argument that is passed to the `hds-code-editor` modifier
+`CodeEditor` - Added `@hasLineWrapping` argument that is passed to the `hds-code-editor` modifier

--- a/packages/components/src/components/hds/code-editor/index.hbs
+++ b/packages/components/src/components/hds/code-editor/index.hbs
@@ -55,8 +55,9 @@
       ariaDescribedBy=this.ariaDescribedBy
       ariaLabel=@ariaLabel
       ariaLabelledBy=this.ariaLabelledBy
-      value=@value
+      isLineWrappingEnabled=@isLineWrappingEnabled
       language=@language
+      value=@value
       onBlur=@onBlur
       onInput=this.onInput
       onSetup=this.onSetup

--- a/packages/components/src/components/hds/code-editor/index.hbs
+++ b/packages/components/src/components/hds/code-editor/index.hbs
@@ -55,7 +55,7 @@
       ariaDescribedBy=this.ariaDescribedBy
       ariaLabel=@ariaLabel
       ariaLabelledBy=this.ariaLabelledBy
-      isLineWrappingEnabled=@isLineWrappingEnabled
+      hasLineWrapping=@hasLineWrapping
       language=@language
       value=@value
       onBlur=@onBlur

--- a/packages/components/src/modifiers/hds-code-editor.ts
+++ b/packages/components/src/modifiers/hds-code-editor.ts
@@ -39,7 +39,7 @@ export interface HdsCodeEditorSignature {
       ariaDescribedBy?: string;
       ariaLabel?: string;
       ariaLabelledBy?: string;
-      isLineWrappingEnabled?: boolean;
+      hasLineWrapping?: boolean;
       language?: HdsCodeEditorLanguages;
       value?: string;
       onInput?: (newVal: string) => void;
@@ -127,13 +127,13 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
     positional: PositionalArgs<HdsCodeEditorSignature>,
     named: NamedArgs<HdsCodeEditorSignature>
   ): void {
-    const { isLineWrappingEnabled = false } = named;
+    const { hasLineWrapping = false } = named;
 
     // if the editor already exists, update the line wrapping
     if (this.editor) {
       this.editor.dispatch({
         effects: this.lineWrappingCompartment.reconfigure(
-          isLineWrappingEnabled ? EditorView.lineWrapping : []
+          hasLineWrapping ? EditorView.lineWrapping : []
         ),
       });
     }
@@ -263,7 +263,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
 
   private _buildExtensionsTask = task(
     { drop: true },
-    async ({ language, isLineWrappingEnabled }) => {
+    async ({ language, hasLineWrapping }) => {
       const [
         {
           keymap,
@@ -301,7 +301,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
       );
 
       const lineWrappingExtension = this.lineWrappingCompartment.of(
-        isLineWrappingEnabled ? EditorView.lineWrapping : []
+        hasLineWrapping ? EditorView.lineWrapping : []
       );
 
       let extensions = [
@@ -335,10 +335,10 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
       {
         language,
         value,
-        isLineWrappingEnabled,
+        hasLineWrapping,
       }: Pick<
         HdsCodeEditorSignature['Args']['Named'],
-        'language' | 'value' | 'isLineWrappingEnabled'
+        'language' | 'value' | 'hasLineWrapping'
       >
     ) => {
       try {
@@ -346,7 +346,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
 
         const extensions = await this._buildExtensionsTask.perform({
           language,
-          isLineWrappingEnabled: isLineWrappingEnabled ?? false,
+          hasLineWrapping: hasLineWrapping ?? false,
         });
 
         const state = EditorState.create({
@@ -382,7 +382,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
         ariaDescribedBy,
         ariaLabel,
         ariaLabelledBy,
-        isLineWrappingEnabled,
+        hasLineWrapping,
         language,
         value,
       } = named;
@@ -395,7 +395,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
       const editor = await this._createEditorTask.perform(element, {
         language,
         value,
-        isLineWrappingEnabled,
+        hasLineWrapping,
       });
 
       if (editor === undefined) {

--- a/showcase/app/controllers/components/code-editor.js
+++ b/showcase/app/controllers/components/code-editor.js
@@ -4,12 +4,14 @@
  */
 
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class CodeEditorController extends Controller {
-  demoCode = `lorem ipsum dolor sit amet
-consectetur adipiscing elit
-sed do eiusmod tempor incididunt
-ut labore et dolore magna aliqua`;
+  @tracked isLineWrappingEnabled = true;
+
+  @tracked demoCode =
+    `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
 
   languages = [
     {
@@ -99,4 +101,14 @@ SELECT 'Enjoy coding!';`,
     name: example_db`,
     },
   ];
+
+  @action
+  toggleLineWrapping(event) {
+    this.isLineWrappingEnabled = event.target.checked;
+  }
+
+  @action
+  setDemoCode(value) {
+    this.demoCode = value;
+  }
 }

--- a/showcase/app/controllers/components/code-editor.js
+++ b/showcase/app/controllers/components/code-editor.js
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class CodeEditorController extends Controller {
-  @tracked isLineWrappingEnabled = true;
+  @tracked hasLineWrapping = true;
 
   @tracked demoCode =
     `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
@@ -104,7 +104,7 @@ SELECT 'Enjoy coding!';`,
 
   @action
   toggleLineWrapping(event) {
-    this.isLineWrappingEnabled = event.target.checked;
+    this.hasLineWrapping = event.target.checked;
   }
 
   @action

--- a/showcase/app/styles/showcase-pages/code-editor.scss
+++ b/showcase/app/styles/showcase-pages/code-editor.scss
@@ -10,3 +10,7 @@
   gap: 8px;
   align-items: center;
 }
+
+.hds-code-editor-line-wrapper-controls {
+  margin-bottom: 8px;
+}

--- a/showcase/app/templates/components/code-editor.hbs
+++ b/showcase/app/templates/components/code-editor.hbs
@@ -134,4 +134,26 @@
       <div {{hds-code-editor ariaLabel="Standalone modifier usage" value=this.demoCode}} />
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Flex @direction="column" as |SF|>
+    <SF.Item @label="toggle line wrapping">
+      <Hds::Form::Checkbox::Field
+        name="enable-line-wrapping"
+        checked={{this.isLineWrappingEnabled}}
+        class="hds-code-editor-line-wrapper-controls"
+        {{on "change" this.toggleLineWrapping}}
+        as |F|
+      >
+        <F.Label>Line wrapping: {{if this.isLineWrappingEnabled "Enabled" "Disabled"}}</F.Label>
+      </Hds::Form::Checkbox::Field>
+      <div
+        {{hds-code-editor
+          ariaLabel="Standalone modifier usage"
+          value=this.demoCode
+          isLineWrappingEnabled=this.isLineWrappingEnabled
+          onInput=this.setDemoCode
+        }}
+      />
+    </SF.Item>
+  </Shw::Flex>
 </section>

--- a/showcase/app/templates/components/code-editor.hbs
+++ b/showcase/app/templates/components/code-editor.hbs
@@ -139,18 +139,18 @@
     <SF.Item @label="toggle line wrapping">
       <Hds::Form::Checkbox::Field
         name="enable-line-wrapping"
-        checked={{this.isLineWrappingEnabled}}
+        checked={{this.hasLineWrapping}}
         class="hds-code-editor-line-wrapper-controls"
         {{on "change" this.toggleLineWrapping}}
         as |F|
       >
-        <F.Label>Line wrapping: {{if this.isLineWrappingEnabled "Enabled" "Disabled"}}</F.Label>
+        <F.Label>Line wrapping: {{if this.hasLineWrapping "Enabled" "Disabled"}}</F.Label>
       </Hds::Form::Checkbox::Field>
       <div
         {{hds-code-editor
           ariaLabel="Standalone modifier usage"
           value=this.demoCode
-          isLineWrappingEnabled=this.isLineWrappingEnabled
+          hasLineWrapping=this.hasLineWrapping
           onInput=this.setDemoCode
         }}
       />

--- a/showcase/tests/integration/components/hds/code-editor/index-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/index-test.js
@@ -260,12 +260,12 @@ module('Integration | Component | hds/code-editor/index', function (hooks) {
       hbs`<Hds::CodeEditor @ariaLabel="test" @isLineWrappingEnabled={{this.isLineWrappingEnabled}} />`
     );
     assert
-      .dom('#code-editor-wrapper .cm-editor .cm-content')
+      .dom('.hds-code-editor__editor .cm-editor .cm-content')
       .hasClass('cm-lineWrapping');
 
     this.set('isLineWrappingEnabled', false);
     assert
-      .dom('#code-editor-wrapper .cm-editor .cm-content')
+      .dom('.hds-code-editor__editor .cm-editor .cm-content')
       .doesNotHaveClass('cm-lineWrapping');
   });
 

--- a/showcase/tests/integration/components/hds/code-editor/index-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/index-test.js
@@ -252,18 +252,18 @@ module('Integration | Component | hds/code-editor/index', function (hooks) {
       .doesNotHaveAttribute('aria-labelledby');
   });
 
-  // @isLineWrappingEnabled
-  test('it should render the editor with line wrapping enabled when isLineWrappingEnabled is true and not when it is false', async function (assert) {
-    this.set('isLineWrappingEnabled', true);
+  // @hasLineWrapping
+  test('it should render the editor with line wrapping enabled when hasLineWrapping is true and not when it is false', async function (assert) {
+    this.set('hasLineWrapping', true);
 
     await setupCodeEditor(
-      hbs`<Hds::CodeEditor @ariaLabel="test" @isLineWrappingEnabled={{this.isLineWrappingEnabled}} />`
+      hbs`<Hds::CodeEditor @ariaLabel="test" @hasLineWrapping={{this.hasLineWrapping}} />`
     );
     assert
       .dom('.hds-code-editor__editor .cm-editor .cm-content')
       .hasClass('cm-lineWrapping');
 
-    this.set('isLineWrappingEnabled', false);
+    this.set('hasLineWrapping', false);
     assert
       .dom('.hds-code-editor__editor .cm-editor .cm-content')
       .doesNotHaveClass('cm-lineWrapping');

--- a/showcase/tests/integration/components/hds/code-editor/index-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/index-test.js
@@ -252,6 +252,23 @@ module('Integration | Component | hds/code-editor/index', function (hooks) {
       .doesNotHaveAttribute('aria-labelledby');
   });
 
+  // @isLineWrappingEnabled
+  test('it should render the editor with line wrapping enabled when isLineWrappingEnabled is true and not when it is false', async function (assert) {
+    this.set('isLineWrappingEnabled', true);
+
+    await setupCodeEditor(
+      hbs`<Hds::CodeEditor @ariaLabel="test" @isLineWrappingEnabled={{this.isLineWrappingEnabled}} />`
+    );
+    assert
+      .dom('#code-editor-wrapper .cm-editor .cm-content')
+      .hasClass('cm-lineWrapping');
+
+    this.set('isLineWrappingEnabled', false);
+    assert
+      .dom('#code-editor-wrapper .cm-editor .cm-content')
+      .doesNotHaveClass('cm-lineWrapping');
+  });
+
   // @value
   test('it should render the component with the provided value', async function (assert) {
     await setupCodeEditor(

--- a/showcase/tests/integration/modifiers/hds-code-editor-test.js
+++ b/showcase/tests/integration/modifiers/hds-code-editor-test.js
@@ -113,18 +113,18 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
       .hasAttribute('aria-labelledby', 'test-label');
   });
 
-  // isLineWrappingEnabled
-  test('it should render the editor with line wrapping enabled when isLineWrappingEnabled is true and not when it is false', async function (assert) {
-    this.set('isLineWrappingEnabled', true);
+  // hasLineWrapping
+  test('it should render the editor with line wrapping enabled when hasLineWrapping is true and not when it is false', async function (assert) {
+    this.set('hasLineWrapping', true);
 
     await setupCodeEditor(
-      hbs`<div id="code-editor-wrapper" {{hds-code-editor ariaLabel="test" isLineWrappingEnabled=this.isLineWrappingEnabled}} />`
+      hbs`<div id="code-editor-wrapper" {{hds-code-editor ariaLabel="test" hasLineWrapping=this.hasLineWrapping}} />`
     );
     assert
       .dom('#code-editor-wrapper .cm-editor .cm-content')
       .hasClass('cm-lineWrapping');
 
-    this.set('isLineWrappingEnabled', false);
+    this.set('hasLineWrapping', false);
     assert
       .dom('#code-editor-wrapper .cm-editor .cm-content')
       .doesNotHaveClass('cm-lineWrapping');

--- a/showcase/tests/integration/modifiers/hds-code-editor-test.js
+++ b/showcase/tests/integration/modifiers/hds-code-editor-test.js
@@ -113,6 +113,23 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
       .hasAttribute('aria-labelledby', 'test-label');
   });
 
+  // isLineWrappingEnabled
+  test('it should render the editor with line wrapping enabled when isLineWrappingEnabled is true and not when it is false', async function (assert) {
+    this.set('isLineWrappingEnabled', true);
+
+    await setupCodeEditor(
+      hbs`<div id="code-editor-wrapper" {{hds-code-editor ariaLabel="test" isLineWrappingEnabled=this.isLineWrappingEnabled}} />`
+    );
+    assert
+      .dom('#code-editor-wrapper .cm-editor .cm-content')
+      .hasClass('cm-lineWrapping');
+
+    this.set('isLineWrappingEnabled', false);
+    assert
+      .dom('#code-editor-wrapper .cm-editor .cm-content')
+      .doesNotHaveClass('cm-lineWrapping');
+  });
+
   // ASSERTIONS
 
   test('it should throw an assertion if both ariaLabel and ariaLabelledBy are ommitted', async function (assert) {

--- a/website/docs/components/code-editor/partials/code/component-api.md
+++ b/website/docs/components/code-editor/partials/code/component-api.md
@@ -29,6 +29,9 @@ This component uses [CodeMirror 6](https://codemirror.net/) under the hood.
   <C.Property @name="hasFullScreenButton" @type="boolean" @default="false">
     Used to control whether a toggle button for toggling full-screen mode will be displayed.
   </C.Property>
+  <C.Property @name="isLineWrappingEnabled" @type="boolean" @default="false">
+    Enables line wrapping within the editor.
+  </C.Property>
   <C.Property @name="isStandalone" @type="boolean" @default="true">
     Applies rounded borders to the component. When used within another component or when the context requires it, you can turn it off.
   </C.Property>

--- a/website/docs/components/code-editor/partials/code/component-api.md
+++ b/website/docs/components/code-editor/partials/code/component-api.md
@@ -29,7 +29,7 @@ This component uses [CodeMirror 6](https://codemirror.net/) under the hood.
   <C.Property @name="hasFullScreenButton" @type="boolean" @default="false">
     Used to control whether a toggle button for toggling full-screen mode will be displayed.
   </C.Property>
-  <C.Property @name="isLineWrappingEnabled" @type="boolean" @default="false">
+  <C.Property @name="hasLineWrapping" @type="boolean" @default="false">
     Enables line wrapping within the editor.
   </C.Property>
   <C.Property @name="isStandalone" @type="boolean" @default="true">

--- a/website/docs/components/code-editor/partials/code/how-to-use.md
+++ b/website/docs/components/code-editor/partials/code/how-to-use.md
@@ -89,3 +89,10 @@ Set `hasFullScreenButton` to `true` to display a button for users to toggle betw
 ```handlebars
 <Hds::CodeEditor @ariaLabel="full screen mode" @hasFullScreenButton={{true}} @value={{this.loremIpsum}} />
 ```
+
+### Line wrapping
+
+Set `hasLineWrapping` to `true` to enable line wrapping within the editor.
+
+```handlebars
+<Hds::CodeEditor @ariaLabel="line wrapping example" @hasLineWrapping={{true}} @value={{this.loremIpsum}} />

--- a/website/docs/components/code-editor/partials/code/how-to-use.md
+++ b/website/docs/components/code-editor/partials/code/how-to-use.md
@@ -96,3 +96,4 @@ Set `hasLineWrapping` to `true` to enable line wrapping within the editor.
 
 ```handlebars
 <Hds::CodeEditor @ariaLabel="line wrapping example" @hasLineWrapping={{true}} @value={{this.loremIpsum}} />
+```

--- a/website/docs/components/code-editor/partials/code/how-to-use.md
+++ b/website/docs/components/code-editor/partials/code/how-to-use.md
@@ -82,7 +82,6 @@ Set `hasCopyButton` to `true` to display a button for users to copy Code Editor 
 />
 ```
 
-
 ### Full screen mode
 
 Set `hasFullScreenButton` to `true` to display a button for users to toggle between a full screen view and normal placement within the page.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will allow users to externally update whether line wrapping is active in the code editor.

### :hammer_and_wrench: Detailed description

- Adds a `hasLineWrapping` named argument to the `hds-code-editor` modifier. Changing this value after render updates the line wrapping setting for the CodeMirror editor.

### :camera_flash: Screenshots

![toggle](https://github.com/user-attachments/assets/2a4b16ee-409b-4794-bc39-62e2710207aa)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4451](https://hashicorp.atlassian.net/browse/HDS-4451)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4451]: https://hashicorp.atlassian.net/browse/HDS-4451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ