### PR TITLE
Website - Force order for “Table” items in sidenav

### DIFF
--- a/website/docs/components/table/advanced-table/index.md
+++ b/website/docs/components/table/advanced-table/index.md
@@ -20,6 +20,7 @@ navigation:
     - datagrid
     - grid
     - list
+  order: 101
 status:
   added: 4.16.0
 ---

--- a/website/docs/components/table/table/index.md
+++ b/website/docs/components/table/table/index.md
@@ -20,6 +20,7 @@ navigation:
     - datagrid
     - grid
     - list
+  order: 100
 status:
   updated: 4.16.0
 ---


### PR DESCRIPTION
### :pushpin: Summary

Small PR to update the order of the items in the `Table` group of the sidenav

Context: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1739454331483399 

👉 👉 👉 **Preview**: https://hds-website-git-website-sidenav-table-order-hashicorp.vercel.app/components

### :camera_flash: Screenshots

**Before**:

<img width="319" alt="screenshot_4658" src="https://github.com/user-attachments/assets/e2115cfb-0ea1-4de2-a38f-b1c3f1eb7890" />

**After**:

<img width="318" alt="screenshot_4657" src="https://github.com/user-attachments/assets/e05ca700-28f9-401d-aee0-8effc8c70a8a" />

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
