### PR TITLE
`MaskedInput`: add ability to control content masking externally

### DIFF
--- a/.changeset/gentle-frogs-talk.md
+++ b/.changeset/gentle-frogs-talk.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`MaskedInput`: added support for externally controlled content masking

--- a/.changeset/gentle-frogs-talk.md
+++ b/.changeset/gentle-frogs-talk.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`MaskedInput`: added support for externally controlled content masking
+`MaskedInput` - added support for externally controlled content masking

--- a/packages/components/src/components/hds/form/masked-input/base.hbs
+++ b/packages/components/src/components/hds/form/masked-input/base.hbs
@@ -2,7 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class={{this.classNames}} {{style width=@width}}>
+<div class={{this.classNames}} {{style width=@width}} {{did-update this.onStateChange @isContentMasked}}>
   {{#if @isMultiline}}
     <Hds::Form::Textarea::Base
       class="hds-form-masked-input__control"

--- a/packages/components/src/components/hds/form/masked-input/base.hbs
+++ b/packages/components/src/components/hds/form/masked-input/base.hbs
@@ -2,7 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<div class={{this.classNames}} {{style width=@width}} {{did-update this.onStateChange @isContentMasked}}>
+<div class={{this.classNames}} {{style width=@width}} {{this._manageState}}>
   {{#if @isMultiline}}
     <Hds::Form::Textarea::Base
       class="hds-form-masked-input__control"

--- a/packages/components/src/components/hds/form/masked-input/base.ts
+++ b/packages/components/src/components/hds/form/masked-input/base.ts
@@ -5,11 +5,11 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
 import { getElementId } from '../../../../utils/hds-get-element-id.ts';
 import type { HdsCopyButtonSignature } from '../../copy/button/index.ts';
 import type { HdsFormVisibilityToggleSignature } from '../visibility-toggle/index.ts';
-import { tracked } from '@glimmer/tracking';
-import type Owner from '@ember/owner';
 
 export interface HdsFormMaskedInputBaseSignature {
   Args: {
@@ -29,16 +29,35 @@ export interface HdsFormMaskedInputBaseSignature {
 }
 
 export default class HdsFormMaskedInputBase extends Component<HdsFormMaskedInputBaseSignature> {
-  @tracked isContentMasked;
+  @tracked _isContentMasked = true;
+  @tracked private _isControlled = this.args.isContentMasked !== undefined;
 
-  constructor(owner: Owner, args: HdsFormMaskedInputBaseSignature['Args']) {
-    super(owner, args);
-    this.isContentMasked = this.args.isContentMasked ?? true;
+  get isContentMasked(): boolean {
+    if (this._isControlled) {
+      // if the state is controlled from outside, the argument overrides the internal state
+      return this.args.isContentMasked ?? this._isContentMasked;
+    } else {
+      // if the state changes internally, the internal state overrides the argument
+      return this._isContentMasked;
+    }
+  }
+
+  set isContentMasked(value) {
+    this._isContentMasked = value || false;
   }
 
   @action
   onClickToggleMasking(): void {
     this.isContentMasked = !this.isContentMasked;
+    this._isControlled = false;
+  }
+
+  @action
+  onStateChange(): void {
+    if (this.args.isContentMasked !== undefined) {
+      this.isContentMasked = this.args.isContentMasked;
+    }
+    this._isControlled = true;
   }
 
   get id(): string {

--- a/packages/components/src/components/hds/form/masked-input/base.ts
+++ b/packages/components/src/components/hds/form/masked-input/base.ts
@@ -6,6 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
 
 import { getElementId } from '../../../../utils/hds-get-element-id.ts';
 import type { HdsCopyButtonSignature } from '../../copy/button/index.ts';
@@ -52,13 +53,14 @@ export default class HdsFormMaskedInputBase extends Component<HdsFormMaskedInput
     this._isControlled = false;
   }
 
-  @action
-  onStateChange(): void {
+  private _manageState = modifier(() => {
     if (this.args.isContentMasked !== undefined) {
       this.isContentMasked = this.args.isContentMasked;
     }
     this._isControlled = true;
-  }
+
+    return () => {};
+  });
 
   get id(): string {
     return getElementId(this);

--- a/showcase/app/controllers/components/form/masked-input.js
+++ b/showcase/app/controllers/components/form/masked-input.js
@@ -14,6 +14,7 @@ export default class FormMaskedInputController extends Controller {
   @tracked multilineDefaultText = 'Lorem ipsum dolor';
   @tracked multilineCustomText = 'Lorem ipsum dolor';
   @tracked multilineWithErrorMessage = 'Lorem ipsum dolor sit amet';
+  @tracked isContentMasked = true;
 
   multilineText1 = 'Lorem\nipsum\ndolor';
   multilineText2 = `Lorem
@@ -31,5 +32,9 @@ dolor`;
 
   @action updateValue(propName, event) {
     this[propName] = event.target.value;
+  }
+
+  @action updateIsMasked() {
+    this.isContentMasked = !this.isContentMasked;
   }
 }

--- a/showcase/app/styles/app.scss
+++ b/showcase/app/styles/app.scss
@@ -52,6 +52,7 @@
 @use "./showcase-pages/form/base-elements" as showcase-form-base-elements;
 @use "./showcase-pages/form/checkbox" as showcase-checkbox;
 @use "./showcase-pages/form/file-input" as showcase-file-input;
+@use "./showcase-pages/form/masked-input.scss" as showcase-masked-input;
 @use "./showcase-pages/form/radio" as showcase-radio;
 @use "./showcase-pages/form/select" as showcase-select;
 @use "./showcase-pages/form/super-select" as showcase-super-select;

--- a/showcase/app/styles/showcase-pages/form/masked-input.scss
+++ b/showcase/app/styles/showcase-pages/form/masked-input.scss
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// FORM > MASKED-INPUT
+
+
+body.components-form-masked-input {
+  .shw-component-form-masked-input-controls {
+    margin-bottom: 8px;
+  }
+}

--- a/showcase/app/templates/components/form/masked-input.hbs
+++ b/showcase/app/templates/components/form/masked-input.hbs
@@ -192,6 +192,26 @@
     {{/each}}
   {{/let}}
 
+  <Shw::Text::H3>Functional examples</Shw::Text::H3>
+
+  <Shw::Text::H4>Externally controlled</Shw::Text::H4>
+
+  <Shw::Flex as |SF|>
+    <SF.Item>
+      <div class="shw-component-form-masked-input-controls">
+        <Hds::Form::Checkbox::Field
+          name="toggle-visibility"
+          checked={{this.isContentMasked}}
+          {{on "change" this.updateIsMasked}}
+          as |F|
+        >
+          <F.Label>Content masking: {{if this.isContentMasked "Enabled" "Disabled"}}</F.Label>
+        </Hds::Form::Checkbox::Field>
+      </div>
+      <Hds::Form::MaskedInput::Base @isContentMasked={{this.isContentMasked}} @value="Lorem ipsum dolor" />
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Divider />
 
   <Shw::Text::H2>"Field" control</Shw::Text::H2>

--- a/showcase/app/templates/components/form/masked-input.hbs
+++ b/showcase/app/templates/components/form/masked-input.hbs
@@ -192,9 +192,9 @@
     {{/each}}
   {{/let}}
 
-  <Shw::Text::H3>Functional examples</Shw::Text::H3>
+  <Shw::Divider @level="2" />
 
-  <Shw::Text::H4>Externally controlled</Shw::Text::H4>
+  <Shw::Text::H3>Externally controlled</Shw::Text::H3>
 
   <Shw::Flex as |SF|>
     <SF.Item>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would let developers control the isContentMasked state externally. 

**[See showcase example](https://hds-showcase-git-hds-4387-masked-input-controlled-hashicorp.vercel.app/components/form/masked-input#functional-examples)**


### :camera_flash: Screenshots
<img width="283" alt="Screenshot 2025-02-19 at 4 13 10 PM" src="https://github.com/user-attachments/assets/3f5f9b5e-d0a4-4daa-8d10-900c34d62950" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4387](https://hashicorp.atlassian.net/browse/HDS-4387)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4387]: https://hashicorp.atlassian.net/browse/HDS-4387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ