### PR TITLE
`SideNav` - Update docs & showcase to add `hds-side-nav-hide-when-minimized` class examples (HDS-4544)

### DIFF
--- a/showcase/app/templates/components/side-nav.hbs
+++ b/showcase/app/templates/components/side-nav.hbs
@@ -102,14 +102,10 @@
             <Shw::Placeholder @text="header" />
           </:header>
           <:body>
-            <div class="hds-side-nav-hide-when-minimized">
-              <Shw::Placeholder @text="body" />
-            </div>
+            <Shw::Placeholder @text="body" class="hds-side-nav-hide-when-minimized" />
           </:body>
           <:footer>
-            <div class="hds-side-nav-hide-when-minimized">
-              <Shw::Placeholder @text="footer" />
-            </div>
+            <Shw::Placeholder @text="footer" class="hds-side-nav-hide-when-minimized" />
           </:footer>
         </Hds::SideNav>
       </div>

--- a/showcase/app/templates/components/side-nav.hbs
+++ b/showcase/app/templates/components/side-nav.hbs
@@ -77,40 +77,7 @@
     </SF.Item>
   </Shw::Flex>
 
-  <Shw::Text::H3>Collapsible</Shw::Text::H3>
-
-  <Shw::Flex @gap="3rem" as |SF|>
-    <SF.Item @label="w/o special class used on content">
-      <div class="shw-component-sim-side-nav-root-container">
-        <Hds::SideNav @isResponsive={{this.isResponsive}} @hasA11yRefocus={{false}} @isCollapsible={{true}}>
-          <:header>
-            <Shw::Placeholder @text="header" />
-          </:header>
-          <:body>
-            <Shw::Placeholder @text="body" />
-          </:body>
-          <:footer>
-            <Shw::Placeholder @text="footer" />
-          </:footer>
-        </Hds::SideNav>
-      </div>
-    </SF.Item>
-    <SF.Item @label="with special class used on body & footer content">
-      <div class="shw-component-sim-side-nav-root-container">
-        <Hds::SideNav @isResponsive={{this.isResponsive}} @hasA11yRefocus={{false}} @isCollapsible={{true}}>
-          <:header>
-            <Shw::Placeholder @text="header" />
-          </:header>
-          <:body>
-            <Shw::Placeholder @text="body" class="hds-side-nav-hide-when-minimized" />
-          </:body>
-          <:footer>
-            <Shw::Placeholder @text="footer" class="hds-side-nav-hide-when-minimized" />
-          </:footer>
-        </Hds::SideNav>
-      </div>
-    </SF.Item>
-  </Shw::Flex>
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>With content injected via "portal"</Shw::Text::H3>
 
@@ -314,6 +281,160 @@
       </:body>
     </Hds::SideNav>
   </div>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Collapsible</Shw::Text::H3>
+
+  <Shw::Grid @columns="3" @gap="3rem" as |SG|>
+    <SG.Item @label="w/o special class used on content">
+      <div class="shw-component-sim-side-nav-root-container">
+        <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{false}} @isCollapsible={{true}}>
+          <:header>
+            <Shw::Placeholder @text="header" @height="72px" />
+          </:header>
+          <:body>
+            <Shw::Placeholder @text="body" />
+          </:body>
+          <:footer>
+            <Shw::Placeholder @text="footer" @height="36px" />
+          </:footer>
+        </Hds::SideNav>
+      </div>
+    </SG.Item>
+    <SG.Item @label="with special class used on body & footer">
+      <div class="shw-component-sim-side-nav-root-container">
+        <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{false}} @isCollapsible={{true}}>
+          <:header>
+            <Shw::Placeholder @text="header" @height="72px" />
+          </:header>
+          <:body>
+            <Shw::Placeholder @text="body (hide class)" class="hds-side-nav-hide-when-minimized" />
+          </:body>
+          <:footer>
+            <Shw::Placeholder @text="footer (hide class)" @height="36px" class="hds-side-nav-hide-when-minimized" />
+          </:footer>
+        </Hds::SideNav>
+      </div>
+    </SG.Item>
+    <SG.Item @label="generic body injected via portal">
+      <div class="shw-component-sim-side-nav-root-container">
+        <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{false}} @isCollapsible={{true}}>
+          <:header>
+            <Shw::Placeholder @height="72px" @text="header (hide class)" class="hds-side-nav-hide-when-minimized" />
+          </:header>
+          <:body>
+            <Hds::SideNav::Portal::Target @targetName="sidenav-portal-demo-3a" />
+          </:body>
+          <:footer>
+            <Shw::Placeholder @height="36px" @text="footer (hide class)" class="hds-side-nav-hide-when-minimized" />
+          </:footer>
+        </Hds::SideNav>
+      </div>
+    </SG.Item>
+    <SG.Item as |SGI|>
+      <SGI.Label><code>SideNav::List</code> as body</SGI.Label>
+      <div class="shw-component-sim-side-nav-root-container">
+        <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{false}} @isCollapsible={{true}}>
+          <:header>
+            <Shw::Placeholder @height="72px" @text="header (hide class)" class="hds-side-nav-hide-when-minimized" />
+          </:header>
+          <:body>
+            <Hds::SideNav::List as |SNL|>
+              <SNL.BackLink @text="A “back” link" @href="#" />
+              <SNL.Title>A section title</SNL.Title>
+              <SNL.Link @text="A link with just text" @href="#" />
+              <SNL.Link @text="A link with an icon" @icon="network" @href="#" />
+              <SNL.Link @text="With a “count”" @icon="users" @count="12" @href="#" />
+              <SNL.Link @text="With a “badge” " @icon="credit-card" @badge="Beta" @href="#" />
+              <SNL.Link @text="With “sub items” indicator" @icon="settings" @hasSubItems={{true}} />
+              <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="As an “external” link" />
+              <SNL.Link @icon="hexagon" @href="#">
+                <Shw::Placeholder @height="20px" @text="With generic yielded content" @background="#e4e4e4" />
+              </SNL.Link>
+              <SNL.Item>
+                <Shw::Placeholder @height="20px" @text="Generic yielded content" @background="#e4e4e4" />
+              </SNL.Item>
+            </Hds::SideNav::List>
+          </:body>
+          <:footer>
+            <Shw::Placeholder @height="36px" @text="footer (hide class)" class="hds-side-nav-hide-when-minimized" />
+          </:footer>
+        </Hds::SideNav>
+      </div>
+    </SG.Item>
+    <SG.Item as |SGI|>
+      <SGI.Label><code>SideNav::List</code> with special class</SGI.Label>
+      <div class="shw-component-sim-side-nav-root-container">
+        <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{false}} @isCollapsible={{true}}>
+          <:header>
+            <Shw::Placeholder @height="72px" @text="header (hide class)" class="hds-side-nav-hide-when-minimized" />
+          </:header>
+          <:body>
+            <Hds::SideNav::List class="hds-side-nav-hide-when-minimized" as |SNL|>
+              <SNL.BackLink @text="A “back” link" @href="#" />
+              <SNL.Title>A section title</SNL.Title>
+              <SNL.Link @text="A link with just text" @href="#" />
+              <SNL.Link @text="A link with an icon" @icon="network" @href="#" />
+              <SNL.Link @text="With a “count”" @icon="users" @count="12" @href="#" />
+              <SNL.Link @text="With a “badge” " @icon="credit-card" @badge="Beta" @href="#" />
+              <SNL.Link @text="With “sub items” indicator" @icon="settings" @hasSubItems={{true}} />
+              <SNL.Link @href="#" @isHrefExternal="true" @icon="guide" @text="As an “external” link" />
+              <SNL.Link @icon="hexagon" @href="#">
+                <Shw::Placeholder @height="20px" @text="With generic yielded content" @background="#e4e4e4" />
+              </SNL.Link>
+              <SNL.Item>
+                <Shw::Placeholder @height="20px" @text="Generic yielded content" @background="#e4e4e4" />
+              </SNL.Item>
+            </Hds::SideNav::List>
+          </:body>
+          <:footer>
+            <Shw::Placeholder @height="36px" @text="footer (hide class)" class="hds-side-nav-hide-when-minimized" />
+          </:footer>
+        </Hds::SideNav>
+      </div>
+    </SG.Item>
+    <SG.Item as |SGI|>
+      <SGI.Label><code>SideNav::List</code> body injected via portal</SGI.Label>
+      <div class="shw-component-sim-side-nav-root-container">
+        <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{false}} @isCollapsible={{true}}>
+          <:header>
+            <Shw::Placeholder @height="72px" @text="header (hide class)" class="hds-side-nav-hide-when-minimized" />
+          </:header>
+          <:body>
+            <Hds::SideNav::Portal::Target @targetName="sidenav-portal-demo-3b" />
+          </:body>
+          <:footer>
+            <Shw::Placeholder @height="36px" @text="footer (hide class)" class="hds-side-nav-hide-when-minimized" />
+          </:footer>
+        </Hds::SideNav>
+      </div>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Hds::SideNav::Portal @targetName="sidenav-portal-demo-3a" @ariaLabel="Primary on portal demo 3a" as |Nav|>
+    <Nav.extraBefore><Shw::Placeholder @height="72px" @text="extraBefore" @background="#f3d9c5" /></Nav.extraBefore>
+    <Nav.Item><Shw::Placeholder @height="200px" @text="portaled content" /></Nav.Item>
+    <Nav.extraAfter><Shw::Placeholder @height="72px" @text="extraAfter" @background="#f3d9c5" /></Nav.extraAfter>
+  </Hds::SideNav::Portal>
+
+  <Hds::SideNav::Portal @targetName="sidenav-portal-demo-3b" @ariaLabel="Primary on portal demo 3b" as |Nav|>
+    <Nav.BackLink @text="A “back” link" @href="#" />
+    <Nav.Title>A section title</Nav.Title>
+    <Nav.Link @text="A link with just text" @href="#" />
+    <Nav.Link @text="A link with an icon" @icon="network" @href="#" />
+    <Nav.Link @text="With a “count”" @icon="users" @count="12" @href="#" />
+    <Nav.Link @text="With a “badge” " @icon="credit-card" @badge="Beta" @href="#" />
+    <Nav.Link @text="With “sub items” indicator" @icon="settings" @hasSubItems={{true}} />
+    <Nav.Link @href="#" @isHrefExternal="true" @icon="guide" @text="As an “external” link" />
+    <Nav.Link @icon="hexagon" @href="#">
+      <Shw::Placeholder @height="20px" @text="With generic yielded content" @background="#e4e4e4" />
+    </Nav.Link>
+    <Nav.Item>
+      <Shw::Placeholder @height="20px" @text="Generic yielded content" @background="#e4e4e4" />
+    </Nav.Item>
+  </Hds::SideNav::Portal>
+
 </section>
 
 <Shw::Divider />

--- a/showcase/app/templates/components/side-nav.hbs
+++ b/showcase/app/templates/components/side-nav.hbs
@@ -77,6 +77,45 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Text::H3>Collapsible</Shw::Text::H3>
+
+  <Shw::Flex @gap="3rem" as |SF|>
+    <SF.Item @label="w/o special class used on content">
+      <div class="shw-component-sim-side-nav-root-container">
+        <Hds::SideNav @isResponsive={{this.isResponsive}} @hasA11yRefocus={{false}} @isCollapsible={{true}}>
+          <:header>
+            <Shw::Placeholder @text="header" />
+          </:header>
+          <:body>
+            <Shw::Placeholder @text="body" />
+          </:body>
+          <:footer>
+            <Shw::Placeholder @text="footer" />
+          </:footer>
+        </Hds::SideNav>
+      </div>
+    </SF.Item>
+    <SF.Item @label="with special class used on body & footer content">
+      <div class="shw-component-sim-side-nav-root-container">
+        <Hds::SideNav @isResponsive={{this.isResponsive}} @hasA11yRefocus={{false}} @isCollapsible={{true}}>
+          <:header>
+            <Shw::Placeholder @text="header" />
+          </:header>
+          <:body>
+            <div class="hds-side-nav-hide-when-minimized">
+              <Shw::Placeholder @text="body" />
+            </div>
+          </:body>
+          <:footer>
+            <div class="hds-side-nav-hide-when-minimized">
+              <Shw::Placeholder @text="footer" />
+            </div>
+          </:footer>
+        </Hds::SideNav>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Text::H3>With content injected via "portal"</Shw::Text::H3>
 
   <Shw::Flex as |SF|>

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -16,13 +16,13 @@ This is the full-fledged component (responsive and animated).
   </C.Property>
   <C.Property @name="isResponsive" @type="boolean" @default="true">
     Controls whether the Side Nav is responsive to viewport changes. It can be programmatically turned off by passing `false`.
-    <br>
+    <br><br>
     <em>Notice: even if the `@isResponsive` parameter is set to false, some JavaScript is still executed in the background, and event listeners are attached to some DOM elements (even if this functionality is not used).</em>
   </C.Property>
   <C.Property @name="isCollapsible" @type="boolean" @default="false">
     Controls whether the Side Nav is collapsible on large viewports. When this argument and `isResponsive` are set to `true`, a toggle button will permanently be rendered to collapse and expand the Side Nav.
-    <br>
-    <em>Notice: if `@isResponsive` is set to false, this argument has no effect.</em>
+    <br><br>
+    <em>Notice: if `@isResponsive` is set to false, this argument has no effect. If you are not injecting content via portals, you can apply the special `hds-side-nav-hide-when-minimized` class name to the top-level elements of your content to have it automatically fade in/out when the Side Nav changes its "minimization" state.</em>
   </C.Property>
   <C.Property @name="isMinimized" @type="boolean" @default="false">
     Controls if the Side Nav is rendered collapsed or expanded when initialized. This allows an application to preserve the collapsed/expanded state across sessions. After the initial render, this argument is altered based on user interactions (collapse/expand the Side Nav or resize the window) and it is not a suitable way of controlling the Side Nav state from outside after render (it’s an internal state).

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -22,7 +22,7 @@ This is the full-fledged component (responsive and animated).
   <C.Property @name="isCollapsible" @type="boolean" @default="false">
     Controls whether the Side Nav is collapsible on large viewports. When this argument and `isResponsive` are set to `true`, a toggle button will permanently be rendered to collapse and expand the Side Nav.
     <br><br>
-    <em>Notice: if `@isResponsive` is set to false, this argument has no effect. If you are not injecting content via portals, you can apply the special `hds-side-nav-hide-when-minimized` class name to the top-level elements of your content to have it automatically fade in/out when the Side Nav changes its "minimization" state.</em>
+    <em>Notice: if `@isResponsive` is set to false, this argument has no effect. If you are not injecting content via portals, and you want your content to automatically fade in/out when the Side Nav changes its "minimization" state, you will have to have apply the special `hds-side-nav-hide-when-minimized` class name to the top-level elements of the content you're adding.</em>
   </C.Property>
   <C.Property @name="isMinimized" @type="boolean" @default="false">
     Controls if the Side Nav is rendered collapsed or expanded when initialized. This allows an application to preserve the collapsed/expanded state across sessions. After the initial render, this argument is altered based on user interactions (collapse/expand the Side Nav or resize the window) and it is not a suitable way of controlling the Side Nav state from outside after render (it’s an internal state).

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -406,12 +406,6 @@ When the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) 
 
 ### Responsiveness
 
-!!! Info
-
-If not injecting content via portals, add `hds-side-nav-hide-when-minimized` class name to the top-level elements of your content to have it automatically fade in/out when the Side Nav changes its "minimization" state.
-
-!!!
-
 As mentioned previously, the full-fledged `Hds::SideNav` component is "responsive" by default:
 
 - when the **viewport is `desktop`** the sidebar navigation is static and has a fixed width

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -354,7 +354,7 @@ When the Side Nav is used in conjunction with portals, the nesting of navigation
 
 This area usually contains a “context switcher” (e.g., “org switcher” or “project switcher”) control, but technically it can contain anything (it depends on the context/application where the Side Nav is used).
 
-If you want (and you probably do) the content automatically fades in/out when the Side Nav changes its "minimization" state, you have to apply the specific class `hds-side-nav-hide-when-minimized` to the top-level elements of your content.
+Note: To make the content automatically fade in/out when the Side Nav changes its "minimization" state, apply the special class `hds-side-nav-hide-when-minimized` to the top-level elements of your content.
 
 ```handlebars{data-execute=false}
 <Hds::SideNav>
@@ -406,7 +406,13 @@ When the Side Nav is paired with the [`Hds::AppHeader`](/components/app-header) 
 
 ### Responsiveness
 
-As mentioned above, the full-fledged `Hds::SideNav` component is "responsive" by default:
+!!! Info
+
+If not injecting content via portals, add `hds-side-nav-hide-when-minimized` class name to the top-level elements of your content to have it automatically fade in/out when the Side Nav changes its "minimization" state.
+
+!!!
+
+As mentioned previously, the full-fledged `Hds::SideNav` component is "responsive" by default:
 
 - when the **viewport is `desktop`** the sidebar navigation is static and has a fixed width
     - the width at which the viewport is considered "desktop" is controlled by a dedicated CSS variable `--hds-app-desktop-breakpoint`; if needed it can be overwritten (at `:root` level) to define a custom "desktop" breakpoint


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds clearer mentions within the SideNav documentation of when & why to add the `hds-side-nav-hide-when-minimized` class and adds responsive/collapsible examples to the SideNav Showcase demonstrating use of `hds-side-nav-hide-when-minimized` class name on content.

#### Previews:
* https://hds-showcase-git-hds-4544-update-sidenav-docs-37c934-hashicorp.vercel.app/components/side-nav#collapsible
* https://hds-website-git-hds-4544-update-sidenav-docs-examples-hashicorp.vercel.app/components/side-nav?tab=code

<!-- 
### :hammer_and_wrench: Detailed description

If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots

Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-4544](https://hashicorp.atlassian.net/browse/HDS-4544)
* Related consumer issue discussed on Slack: https://hashicorp.slack.com/archives/C7KTUHNUS/p1739994536212039

Related:
* https://hashicorp.atlassian.net/browse/HDSP-172

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~ _- There were no changes to component code_

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4544]: https://hashicorp.atlassian.net/browse/HDS-4544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ