### PR TITLE
chore: ignore pnpm-lock for copywrite headers

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -8,6 +8,8 @@ project {
   # Supports doublestar glob patterns for more flexibility in defining which
   # files or folders should be ignored
   header_ignore = [
+    # Dependency files
+    "pnpm-lock.yaml",
     # Generic configuration files
     "**/*.yml",
     "**/*.cjs",

--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -8,10 +8,9 @@ project {
   # Supports doublestar glob patterns for more flexibility in defining which
   # files or folders should be ignored
   header_ignore = [
-    # Dependency files
-    "pnpm-lock.yaml",
     # Generic configuration files
     "**/*.yml",
+    "**/*.yaml",
     "**/*.cjs",
     "**/*rc.js",
     # Distribution files


### PR DESCRIPTION
### :pushpin: Summary

Add an override for `.yaml` files to our `.copywrite.hcl` because they are also generic config files.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
