### PR TITLE
`Time` - Update visual style when tooltip is present (HDS-4550)

### DIFF
--- a/.changeset/tidy-eels-doubt.md
+++ b/.changeset/tidy-eels-doubt.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Time` - Updated visual style to display a dotted underline when the `hasTooltip` argument is true

--- a/.changeset/tidy-eels-doubt.md
+++ b/.changeset/tidy-eels-doubt.md
@@ -3,3 +3,5 @@
 ---
 
 `Time` - Updated visual style to display a dotted underline when the `hasTooltip` argument is true
+
+`RichTooltip` - Fixed Safari bug causing the dotted underline style not to display

--- a/packages/components/src/styles/components/rich-tooltip.scss
+++ b/packages/components/src/styles/components/rich-tooltip.scss
@@ -65,6 +65,8 @@
 
 .hds-rich-tooltip__toggle-text {
   color: var(--text-color);
+  // stylelint-disable-next-line property-no-vendor-prefix
+  -webkit-text-decoration: underline dotted; // Safari
   text-decoration: underline dotted;
 }
 

--- a/packages/components/src/styles/components/rich-tooltip.scss
+++ b/packages/components/src/styles/components/rich-tooltip.scss
@@ -65,9 +65,8 @@
 
 .hds-rich-tooltip__toggle-text {
   color: var(--text-color);
-  // stylelint-disable-next-line property-no-vendor-prefix
-  -webkit-text-decoration: underline dotted; // Safari
-  text-decoration: underline dotted;
+  text-decoration: underline;
+  text-decoration-style: dotted;
 }
 
 // icon

--- a/packages/components/src/styles/components/rich-tooltip.scss
+++ b/packages/components/src/styles/components/rich-tooltip.scss
@@ -65,6 +65,7 @@
 
 .hds-rich-tooltip__toggle-text {
   color: var(--text-color);
+  // decoration style is specified separately to fix a bug in Safari causing it not to render
   text-decoration: underline;
   text-decoration-style: dotted;
 }

--- a/packages/components/src/styles/components/time.scss
+++ b/packages/components/src/styles/components/time.scss
@@ -14,5 +14,7 @@
 
 // Note: The time-wrapper is only present when time is wrapped by a tooltip button
 .hds-time-wrapper {
+  // stylelint-disable-next-line property-no-vendor-prefix
+  -webkit-text-decoration: underline dotted;
   text-decoration: underline dotted;
 }

--- a/packages/components/src/styles/components/time.scss
+++ b/packages/components/src/styles/components/time.scss
@@ -14,6 +14,7 @@
 
 // Note: The time-wrapper is only present when time is wrapped by a tooltip button
 .hds-time-wrapper .hds-time {
+  // decoration style is specified separately to fix a bug in Safari causing it not to render
   text-decoration: underline;
   text-decoration-style: dotted;
 }

--- a/packages/components/src/styles/components/time.scss
+++ b/packages/components/src/styles/components/time.scss
@@ -14,7 +14,6 @@
 
 // Note: The time-wrapper is only present when time is wrapped by a tooltip button
 .hds-time-wrapper .hds-time {
-  // stylelint-disable-next-line property-no-vendor-prefix
-  -webkit-text-decoration: underline dotted; // Safari
-  text-decoration: underline dotted;
+  text-decoration: underline;
+  text-decoration-style: dotted;
 }

--- a/packages/components/src/styles/components/time.scss
+++ b/packages/components/src/styles/components/time.scss
@@ -11,3 +11,8 @@
   display: inline-flex; // remove excess space between time range elements
   gap: 2px; // add a bit of space around en dash so it doesn't touch some number characters
 }
+
+// Note: The time-wrapper is only present when time is wrapped by a tooltip button
+.hds-time-wrapper {
+  text-decoration: underline dotted;
+}

--- a/showcase/app/templates/components/time.hbs
+++ b/showcase/app/templates/components/time.hbs
@@ -10,7 +10,7 @@
 <section>
   <Shw::Text::H2>Has tooltip</Shw::Text::H2>
 
-  {{! Only limited sections are tested using Percy due to dynamic nature of the Time component }}
+  {{! Only very limited sections are tested using Percy due to dynamic nature of the Time component }}
   <div data-test-percy>
     <Shw::Flex @gap="2rem" as |SF|>
       <SF.Item @label="With tooltip (default)">
@@ -56,17 +56,19 @@
 
 <Shw::Divider />
 
-{{! Only limited sections are tested using Percy due to dynamic nature of the Time component }}
-<section data-test-percy>
+<section>
   <Shw::Text::H2>Date range</Shw::Text::H2>
-  
+
   <Shw::Flex @gap="4rem 9rem" {{style marginBottom="80px"}} as |SF|>
     <SF.Item @label="With tooltip & same year range">
       <Hds::Time @startDate="20 September 2024" @endDate="25 September 2024" @isOpen={{true}} />
     </SF.Item>
 
     <SF.Item @label="With different year range & no tooltip">
-      <Hds::Time @startDate="8 November 2024" @endDate="20 January 2025" @hasTooltip={{false}} />
+      {{! Only very limited sections are tested using Percy due to dynamic nature of the Time component }}
+      <div data-test-percy>
+        <Hds::Time @startDate="8 November 2024" @endDate="20 January 2025" @hasTooltip={{false}} />
+      </div>
     </SF.Item>
   </Shw::Flex>
 </section>

--- a/showcase/app/templates/components/time.hbs
+++ b/showcase/app/templates/components/time.hbs
@@ -7,21 +7,20 @@
 
 <Shw::Text::H1>Time</Shw::Text::H1>
 
+{{! Note: The dynamic nature of the Time component triggers an infinite rendering invalidation error when attempting to test in Percy}}
+
 <section>
   <Shw::Text::H2>Has tooltip</Shw::Text::H2>
 
-  {{! Only very limited sections are tested using Percy due to dynamic nature of the Time component }}
-  <div data-test-percy>
-    <Shw::Flex @gap="2rem" as |SF|>
-      <SF.Item @label="With tooltip (default)">
-        <Hds::Time @date="05 September 2018 14:48" />
-      </SF.Item>
+  <Shw::Flex @gap="2rem" as |SF|>
+    <SF.Item @label="With tooltip (default)">
+      <Hds::Time @date="05 September 2018 14:48" />
+    </SF.Item>
 
-      <SF.Item @label="Without tooltip">
-        <Hds::Time @date="05 September 2018 14:48" @hasTooltip={{false}} />
-      </SF.Item>
-    </Shw::Flex>
-  </div>
+    <SF.Item @label="Without tooltip">
+      <Hds::Time @date="05 September 2018 14:48" @hasTooltip={{false}} />
+    </SF.Item>
+  </Shw::Flex>
 
   <Shw::Text::H2>Display</Shw::Text::H2>
 
@@ -65,10 +64,7 @@
     </SF.Item>
 
     <SF.Item @label="With different year range & no tooltip">
-      {{! Only very limited sections are tested using Percy due to dynamic nature of the Time component }}
-      <div data-test-percy>
-        <Hds::Time @startDate="8 November 2024" @endDate="20 January 2025" @hasTooltip={{false}} />
-      </div>
+      <Hds::Time @startDate="8 November 2024" @endDate="20 January 2025" @hasTooltip={{false}} />
     </SF.Item>
   </Shw::Flex>
 </section>

--- a/showcase/app/templates/components/time.hbs
+++ b/showcase/app/templates/components/time.hbs
@@ -7,20 +7,21 @@
 
 <Shw::Text::H1>Time</Shw::Text::H1>
 
-{{! Time component does not include styling so we do not test in Percy at this time }}
-
 <section>
   <Shw::Text::H2>Has tooltip</Shw::Text::H2>
 
-  <Shw::Flex @gap="2rem" as |SF|>
-    <SF.Item @label="With tooltip (default)">
-      <Hds::Time @date="05 September 2018 14:48" />
-    </SF.Item>
+  {{! Only limited sections are tested using Percy due to dynamic nature of the Time component }}
+  <div data-test-percy>
+    <Shw::Flex @gap="2rem" as |SF|>
+      <SF.Item @label="With tooltip (default)">
+        <Hds::Time @date="05 September 2018 14:48" />
+      </SF.Item>
 
-    <SF.Item @label="Without tooltip">
-      <Hds::Time @date="05 September 2018 14:48" @hasTooltip={{false}} />
-    </SF.Item>
-  </Shw::Flex>
+      <SF.Item @label="Without tooltip">
+        <Hds::Time @date="05 September 2018 14:48" @hasTooltip={{false}} />
+      </SF.Item>
+    </Shw::Flex>
+  </div>
 
   <Shw::Text::H2>Display</Shw::Text::H2>
 
@@ -55,9 +56,10 @@
 
 <Shw::Divider />
 
-<section>
+{{! Only limited sections are tested using Percy due to dynamic nature of the Time component }}
+<section data-test-percy>
   <Shw::Text::H2>Date range</Shw::Text::H2>
-
+  
   <Shw::Flex @gap="4rem 9rem" {{style marginBottom="80px"}} as |SF|>
     <SF.Item @label="With tooltip & same year range">
       <Hds::Time @startDate="20 September 2024" @endDate="25 September 2024" @isOpen={{true}} />

--- a/showcase/app/templates/components/time.hbs
+++ b/showcase/app/templates/components/time.hbs
@@ -63,7 +63,7 @@
       <Hds::Time @startDate="20 September 2024" @endDate="25 September 2024" @isOpen={{true}} />
     </SF.Item>
 
-    <SF.Item @label="With different year range">
+    <SF.Item @label="With different year range & no tooltip">
       <Hds::Time @startDate="8 November 2024" @endDate="20 January 2025" @hasTooltip={{false}} />
     </SF.Item>
   </Shw::Flex>

--- a/showcase/tests/acceptance/percy-test.js
+++ b/showcase/tests/acceptance/percy-test.js
@@ -169,8 +169,9 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/components/text');
     await percySnapshot('Text');
 
-    await visit('/components/time');
-    await percySnapshot('Time');
+    // Note: The dynamic nature of the Time component triggers an infinite rendering invalidation error so we are skipping this component for now.
+    // await visit('/components/time');
+    // await percySnapshot('Time');
 
     await visit('/components/toast');
     await percySnapshot('Toast');

--- a/showcase/tests/acceptance/percy-test.js
+++ b/showcase/tests/acceptance/percy-test.js
@@ -169,6 +169,9 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/components/text');
     await percySnapshot('Text');
 
+    await visit('/components/time');
+    await percySnapshot('Time');
+
     await visit('/components/toast');
     await percySnapshot('Toast');
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR:
* updates the visual style of the `Time` component to display a dotted underline when `hasTooltip` is true matching the visual style of the `RichTooltip` in order to add a visual indication of interactivity.
* fixes a Safari bug in the original `RichTooltip` styles which caused the dotted underline not to display.

**Showcase:** https://hds-showcase-git-hds-4550-update-time-visual-design-hashicorp.vercel.app/components/time

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?
-->

### :camera_flash: Screenshots
**_Chrome screenshot:_**
<img width="451" alt="visual difference with tooltip vs. without" src="https://github.com/user-attachments/assets/0beab15f-69af-4e55-9a22-d2469417cf20" />

### :link: External links

* Jira ticket: [HDS-4550](https://hashicorp.atlassian.net/browse/HDS-4550)

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~ _- Percy snapshot not included due to dynamic nature of component which triggers an infinite rendering invalidation error_
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4550]: https://hashicorp.atlassian.net/browse/HDS-4550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ