### PR TITLE
`hds-tooltip` modifier -  Fix CSS import (HDS-4542)

### DIFF
--- a/.changeset/young-buses-shout.md
+++ b/.changeset/young-buses-shout.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Tooltip` - Remove style import from Tippy.js, copy arrow positioning styles into component styles

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -51,7 +51,6 @@ const plugins = [
   scss({
     fileName: 'styles/@hashicorp/design-system-components.css',
     includePaths: [
-      'node_modules/tippy.js/dist/',
       'node_modules/@hashicorp/design-system-tokens/dist/products/css',
     ],
   }),

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -51,6 +51,7 @@ const plugins = [
   scss({
     fileName: 'styles/@hashicorp/design-system-components.css',
     includePaths: [
+      'node_modules/tippy.js/dist/',
       'node_modules/@hashicorp/design-system-tokens/dist/products/css',
     ],
   }),

--- a/packages/components/src/modifiers/hds-tooltip.ts
+++ b/packages/components/src/modifiers/hds-tooltip.ts
@@ -19,8 +19,7 @@ import type {
   Instance as TippyInstance,
   Props as TippyProps,
 } from 'tippy.js';
-// used by custom SVG arrow:
-import 'tippy.js/dist/svg-arrow.css';
+
 import type Owner from '@ember/owner';
 
 export interface HdsTooltipModifierSignature {

--- a/packages/components/src/styles/components/tooltip.scss
+++ b/packages/components/src/styles/components/tooltip.scss
@@ -8,7 +8,6 @@
 //
 
 @use "../mixins/focus-ring" as *;
-@use '../../../node_modules/tippy.js/dist/svg-arrow.css';
 
 .hds-tooltip-button {
   @include hds-focus-ring-with-pseudo-element(
@@ -86,6 +85,55 @@
 
   // works with Tippy's custom SVG arrow variation:
   .tippy-svg-arrow {
+    width: 16px;
+    height: 16px;
+    text-align: initial;
     fill: var(--token-tooltip-color-surface-primary);
+
+    &, 
+    & > svg {
+      position: absolute;
+    }
+  }
+
+  // Arrow positioning styles taken from tippy.js (tippy.js/dist/svg-arrow.css)
+  &[data-placement^="top"] > .tippy-svg-arrow {
+    bottom: 0;
+  }
+
+  &[data-placement^="top"] > .tippy-svg-arrow::after,
+  &[data-placement^="top"] > .tippy-svg-arrow > svg {
+    top: 16px;
+    transform: rotate(180deg);
+  }
+
+  &[data-placement^="bottom"] > .tippy-svg-arrow {
+    top: 0;
+  }
+
+  &[data-placement^="bottom"] > .tippy-svg-arrow > svg {
+    bottom: 16px;
+  }
+
+  &[data-placement^="left"] > .tippy-svg-arrow {
+    right: 0;
+  }
+
+  &[data-placement^="left"] > .tippy-svg-arrow::after,
+  &[data-placement^="left"] > .tippy-svg-arrow > svg {
+    top: calc(50% - 3px);
+    left: 11px;
+    transform: rotate(90deg);
+  }
+
+  &[data-placement^="right"] > .tippy-svg-arrow {
+    left: 0;
+  }
+
+  &[data-placement^="right"] > .tippy-svg-arrow::after,
+  &[data-placement^="right"] > .tippy-svg-arrow > svg {
+    top: calc(50% - 3px);
+    right: 11px;
+    transform: rotate(-90deg);
   }
 }

--- a/packages/components/src/styles/components/tooltip.scss
+++ b/packages/components/src/styles/components/tooltip.scss
@@ -8,6 +8,7 @@
 //
 
 @use "../mixins/focus-ring" as *;
+@use '../../../node_modules/tippy.js/dist/svg-arrow.css';
 
 .hds-tooltip-button {
   @include hds-focus-ring-with-pseudo-element(


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR removes the tippy.js CSS import from the tooltip modifier, imports the styles into the tooltip SCSS file for the component and adds the tippy file path to rollup.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-4542](https://hashicorp.atlassian.net/browse/HDS-4542)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4542]: https://hashicorp.atlassian.net/browse/HDS-4542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ