### PR TITLE
feat(components): exclude `app-header` components

### DIFF
--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -14,15 +14,22 @@ const addon = new Addon({
   destDir: 'dist',
 });
 
+const exclude = ['components/hds/app-header', 'components/hds/app-side-nav'];
+
 const plugins = [
   // These are the modules that users should be able to import from your
   // addon. Anything not listed here may get optimized away.
-  addon.publicEntrypoints([
-    '**/*.{js,ts}',
-    'index.js',
-    'template-registry.js',
-    'styles/@hashicorp/design-system-components.scss',
-  ]),
+  addon.publicEntrypoints(
+    [
+      '**/*.{js,ts}',
+      'index.js',
+      'template-registry.js',
+      'styles/@hashicorp/design-system-components.scss',
+    ],
+    {
+      exclude,
+    }
+  ),
 
   // These are the modules that should get reexported into the traditional
   // "app" tree. Things in here should also be in publicEntrypoints above, but
@@ -36,10 +43,7 @@ const plugins = [
       'instance-initializers/**/*.js',
     ],
     {
-      exclude: [
-        'components/**/app-header/**/*.js',
-        'components/**/app-side-nav/**/*.js',
-      ],
+      exclude,
     }
   ),
 

--- a/packages/components/src/components.ts
+++ b/packages/components/src/components.ts
@@ -43,9 +43,9 @@ export { default as HdsAppFooterStatusLink } from './components/hds/app-footer/s
 export * from './components/hds/app-footer/types.ts';
 
 // AppHeader
-export { default as HdsAppHeader } from './components/hds/app-header/index.ts';
-export { default as HdsAppHeaderHomeLink } from './components/hds/app-header/home-link.ts';
-export { default as HdsAppHeaderMenuButton } from './components/hds/app-header/menu-button.ts';
+// export { default as HdsAppHeader } from './components/hds/app-header/index.ts';
+// export { default as HdsAppHeaderHomeLink } from './components/hds/app-header/home-link.ts';
+// export { default as HdsAppHeaderMenuButton } from './components/hds/app-header/menu-button.ts';
 
 // ApplicationState
 export { default as HdsApplicationState } from './components/hds/application-state/index.ts';

--- a/showcase/app/components/mock/app/header/app-header.gts
+++ b/showcase/app/components/mock/app/header/app-header.gts
@@ -3,93 +3,93 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
+// import Component from '@glimmer/component';
 
-// HDS components
-import {
-  HdsAppHeader,
-  HdsAppHeaderHomeLink,
-  HdsDropdown,
-  HdsButton,
-} from '@hashicorp/design-system-components/components';
+// // HDS components
+// import {
+//   HdsAppHeader,
+//   HdsAppHeaderHomeLink,
+//   HdsDropdown,
+//   HdsButton,
+// } from '@hashicorp/design-system-components/components';
 
-// types
-import type { HdsAppHeaderSignature } from '@hashicorp/design-system-components/components/hds/app-header/index';
-import type Owner from '@ember/owner';
+// // types
+// import type { HdsAppHeaderSignature } from '@hashicorp/design-system-components/components/hds/app-header/index';
+// import type Owner from '@ember/owner';
 
-export interface MockAppHeaderAppHeaderSignature {
-  Args: {
-    showOrgPicker?: boolean;
-    orgPickerLabel?: string;
-    showRegionPicker?: boolean;
-    showSearch?: boolean;
-  };
-  Element: HdsAppHeaderSignature['Element'];
-}
+// export interface MockAppHeaderAppHeaderSignature {
+//   Args: {
+//     showOrgPicker?: boolean;
+//     orgPickerLabel?: string;
+//     showRegionPicker?: boolean;
+//     showSearch?: boolean;
+//   };
+//   Element: HdsAppHeaderSignature['Element'];
+// }
 
-export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHeaderSignature> {
-  showOrgPicker;
-  orgPickerLabel;
-  showRegionPicker;
-  showSearch;
+// export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHeaderSignature> {
+//   showOrgPicker;
+//   orgPickerLabel;
+//   showRegionPicker;
+//   showSearch;
 
-  constructor(owner: Owner, args: MockAppHeaderAppHeaderSignature['Args']) {
-    super(owner, args);
-    this.showOrgPicker = this.args.showOrgPicker ?? true;
-    this.orgPickerLabel = this.args.orgPickerLabel ?? 'organization-name';
-    this.showRegionPicker = this.args.showRegionPicker ?? true;
-    this.showSearch = this.args.showSearch ?? true;
-  }
+//   constructor(owner: Owner, args: MockAppHeaderAppHeaderSignature['Args']) {
+//     super(owner, args);
+//     this.showOrgPicker = this.args.showOrgPicker ?? true;
+//     this.orgPickerLabel = this.args.orgPickerLabel ?? 'organization-name';
+//     this.showRegionPicker = this.args.showRegionPicker ?? true;
+//     this.showSearch = this.args.showSearch ?? true;
+//   }
 
-  <template>
-    <HdsAppHeader>
-      <:logo>
-        <HdsAppHeaderHomeLink
-          @icon="hashicorp"
-          @ariaLabel="HashiCorp home menu"
-          @href="#"
-        />
-      </:logo>
-      <:globalActions>
-        {{#if this.showOrgPicker}}
-          <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
-            <dd.ToggleButton @text={{this.orgPickerLabel}} @icon="org" />
-            <dd.Checkmark>
-              my-organization
-            </dd.Checkmark>
-          </HdsDropdown>
-        {{/if}}
-      </:globalActions>
-      <:utilityActions>
-        {{#if this.showRegionPicker}}
-          <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
-            <dd.ToggleButton @text="Europe" @icon="globe" />
-            <dd.Checkmark @selected={{true}}>Europe</dd.Checkmark>
-            <dd.Checkmark>Americas</dd.Checkmark>
-          </HdsDropdown>
-        {{/if}}
+//   <template>
+//     <HdsAppHeader>
+//       <:logo>
+//         <HdsAppHeaderHomeLink
+//           @icon="hashicorp"
+//           @ariaLabel="HashiCorp home menu"
+//           @href="#"
+//         />
+//       </:logo>
+//       <:globalActions>
+//         {{#if this.showOrgPicker}}
+//           <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
+//             <dd.ToggleButton @text={{this.orgPickerLabel}} @icon="org" />
+//             <dd.Checkmark>
+//               my-organization
+//             </dd.Checkmark>
+//           </HdsDropdown>
+//         {{/if}}
+//       </:globalActions>
+//       <:utilityActions>
+//         {{#if this.showRegionPicker}}
+//           <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
+//             <dd.ToggleButton @text="Europe" @icon="globe" />
+//             <dd.Checkmark @selected={{true}}>Europe</dd.Checkmark>
+//             <dd.Checkmark>Americas</dd.Checkmark>
+//           </HdsDropdown>
+//         {{/if}}
 
-        {{#if this.showSearch}}
-          <HdsButton @icon="search" @isIconOnly={{true}} @text="Search" />
-        {{/if}}
-        <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
-          <dd.ToggleIcon @icon="help" @text="help menu" />
-          <dd.Title @text="Help & Support" />
-          <dd.Interactive @href="#">Documentation</dd.Interactive>
-          <dd.Interactive @href="#">Tutorials</dd.Interactive>
-          <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
-          <dd.Interactive @href="#">Changelog</dd.Interactive>
-          <dd.Separator />
-          <dd.Interactive @href="#">Create support ticket</dd.Interactive>
-          <dd.Interactive @href="#">Give feedback</dd.Interactive>
-        </HdsDropdown>
-        <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
-          <dd.ToggleIcon @icon="user" @text="user menu" />
-          <dd.Title @text="Signed In" />
-          <dd.Description @text="email@domain.com" />
-          <dd.Interactive @href="#" @text="Account Settings" />
-        </HdsDropdown>
-      </:utilityActions>
-    </HdsAppHeader>
-  </template>
-}
+//         {{#if this.showSearch}}
+//           <HdsButton @icon="search" @isIconOnly={{true}} @text="Search" />
+//         {{/if}}
+//         <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
+//           <dd.ToggleIcon @icon="help" @text="help menu" />
+//           <dd.Title @text="Help & Support" />
+//           <dd.Interactive @href="#">Documentation</dd.Interactive>
+//           <dd.Interactive @href="#">Tutorials</dd.Interactive>
+//           <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
+//           <dd.Interactive @href="#">Changelog</dd.Interactive>
+//           <dd.Separator />
+//           <dd.Interactive @href="#">Create support ticket</dd.Interactive>
+//           <dd.Interactive @href="#">Give feedback</dd.Interactive>
+//         </HdsDropdown>
+//         <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
+//           <dd.ToggleIcon @icon="user" @text="user menu" />
+//           <dd.Title @text="Signed In" />
+//           <dd.Description @text="email@domain.com" />
+//           <dd.Interactive @href="#" @text="Account Settings" />
+//         </HdsDropdown>
+//       </:utilityActions>
+//     </HdsAppHeader>
+//   </template>
+// }

--- a/showcase/app/components/mock/app/index.gts
+++ b/showcase/app/components/mock/app/index.gts
@@ -3,100 +3,100 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// import Component from '@glimmer/component';
-// import { hash } from '@ember/helper';
+import Component from '@glimmer/component';
+import { hash } from '@ember/helper';
 // import MockAppHeaderAppHeader from './header/app-header';
-// import MockAppSidebarSideNav from './sidebar/side-nav';
-// import MockAppMainPageHeader from './main/page-header';
-// import MockAppMainGenericTextContent from './main/generic-text-content';
-// import MockAppFooterAppFooter from './footer/app-footer';
+import MockAppSidebarSideNav from './sidebar/side-nav';
+import MockAppMainPageHeader from './main/page-header';
+import MockAppMainGenericTextContent from './main/generic-text-content';
+import MockAppFooterAppFooter from './footer/app-footer';
 
-// // HDS components
-// import { HdsAppFrame } from '@hashicorp/design-system-components/components';
+// HDS components
+import { HdsAppFrame } from '@hashicorp/design-system-components/components';
 
-// // types
-// import type { ComponentLike } from '@glint/template';
-// import type { HdsAppFrameSignature } from '@hashicorp/design-system-components/components/hds/app-frame/index';
+// types
+import type { ComponentLike } from '@glint/template';
+import type { HdsAppFrameSignature } from '@hashicorp/design-system-components/components/hds/app-frame/index';
 // import type { MockAppHeaderAppHeaderSignature } from './header/app-header';
-// import type { MockAppSidebarSideNavSignature } from './sidebar/side-nav';
-// import type { MockAppMainPageHeaderSignature } from './main/page-header';
-// import type { MockAppMainGenericTextContentSignature } from './main/generic-text-content';
-// import type { MockAppFooterAppFooterSignature } from './footer/app-footer';
+import type { MockAppSidebarSideNavSignature } from './sidebar/side-nav';
+import type { MockAppMainPageHeaderSignature } from './main/page-header';
+import type { MockAppMainGenericTextContentSignature } from './main/generic-text-content';
+import type { MockAppFooterAppFooterSignature } from './footer/app-footer';
 
-// export interface MockAppSignature {
-//   Args: {
-//     hasHeader?: HdsAppFrameSignature['Args']['hasHeader'];
-//     hasSidebar?: HdsAppFrameSignature['Args']['hasSidebar'];
-//     hasFooter?: HdsAppFrameSignature['Args']['hasFooter'];
-//   };
-//   Blocks: {
-//     header?: [
-//       {
-//         AppHeader?: ComponentLike<MockAppHeaderAppHeaderSignature>;
-//       },
-//     ];
-//     sidebar?: [
-//       {
-//         SideNav?: ComponentLike<MockAppSidebarSideNavSignature>;
-//       },
-//     ];
-//     main?: [
-//       {
-//         PageHeader?: ComponentLike<MockAppMainPageHeaderSignature>;
-//         GenericTextContent?: ComponentLike<MockAppMainGenericTextContentSignature>;
-//       },
-//     ];
-//     footer?: [
-//       {
-//         AppFooter?: ComponentLike<MockAppFooterAppFooterSignature>;
-//       },
-//     ];
-//   };
-//   Element: HdsAppFrameSignature['Element'];
-// }
+export interface MockAppSignature {
+  Args: {
+    hasHeader?: HdsAppFrameSignature['Args']['hasHeader'];
+    hasSidebar?: HdsAppFrameSignature['Args']['hasSidebar'];
+    hasFooter?: HdsAppFrameSignature['Args']['hasFooter'];
+  };
+  Blocks: {
+    // header?: [
+    //   {
+    //     AppHeader?: ComponentLike<MockAppHeaderAppHeaderSignature>;
+    //   },
+    // ];
+    sidebar?: [
+      {
+        SideNav?: ComponentLike<MockAppSidebarSideNavSignature>;
+      },
+    ];
+    main?: [
+      {
+        PageHeader?: ComponentLike<MockAppMainPageHeaderSignature>;
+        GenericTextContent?: ComponentLike<MockAppMainGenericTextContentSignature>;
+      },
+    ];
+    footer?: [
+      {
+        AppFooter?: ComponentLike<MockAppFooterAppFooterSignature>;
+      },
+    ];
+  };
+  Element: HdsAppFrameSignature['Element'];
+}
 
-// // eslint-disable-next-line ember/no-empty-glimmer-component-classes
-// export default class MockApp extends Component<MockAppSignature> {
-//   <template>
-//     <HdsAppFrame
-//       @hasHeader={{@hasHeader}}
-//       @hasSidebar={{@hasSidebar}}
-//       @hasFooter={{@hasFooter}}
-//       ...attributes
-//       as |Frame|
-//     >
-//       <Frame.Header>
-//         {{#if (has-block "header")}}
-//           {{yield (hash AppHeader=MockAppHeaderAppHeader) to="header"}}
-//         {{else}}
-//           <MockAppHeaderAppHeader />
-//         {{/if}}
-//       </Frame.Header>
-//       <Frame.Sidebar>
-//         {{#if (has-block "sidebar")}}
-//           {{yield (hash SideNav=MockAppSidebarSideNav) to="sidebar"}}
-//         {{else}}
-//           <MockAppSidebarSideNav />
-//         {{/if}}
-//       </Frame.Sidebar>
-//       <Frame.Main>
-//         <div class="mock-app-layout-main-content-wrapper">
-//           {{yield
-//             (hash
-//               PageHeader=MockAppMainPageHeader
-//               GenericTextContent=MockAppMainGenericTextContent
-//             )
-//             to="main"
-//           }}
-//         </div>
-//       </Frame.Main>
-//       <Frame.Footer>
-//         {{#if (has-block "footer")}}
-//           {{yield (hash AppFooter=MockAppFooterAppFooter) to="footer"}}
-//         {{else}}
-//           <MockAppFooterAppFooter />
-//         {{/if}}
-//       </Frame.Footer>
-//     </HdsAppFrame>
-//   </template>
-// }
+// eslint-disable-next-line ember/no-empty-glimmer-component-classes
+export default class MockApp extends Component<MockAppSignature> {
+  <template>
+    <HdsAppFrame
+      @hasHeader={{@hasHeader}}
+      @hasSidebar={{@hasSidebar}}
+      @hasFooter={{@hasFooter}}
+      ...attributes
+      as |Frame|
+    >
+      <Frame.Header>
+        {{!-- {{#if (has-block "header")}}
+          {{yield (hash AppHeader=MockAppHeaderAppHeader) to="header"}}
+        {{else}}
+          <MockAppHeaderAppHeader />
+        {{/if}} --}}
+      </Frame.Header>
+      <Frame.Sidebar>
+        {{#if (has-block "sidebar")}}
+          {{yield (hash SideNav=MockAppSidebarSideNav) to="sidebar"}}
+        {{else}}
+          <MockAppSidebarSideNav />
+        {{/if}}
+      </Frame.Sidebar>
+      <Frame.Main>
+        <div class="mock-app-layout-main-content-wrapper">
+          {{yield
+            (hash
+              PageHeader=MockAppMainPageHeader
+              GenericTextContent=MockAppMainGenericTextContent
+            )
+            to="main"
+          }}
+        </div>
+      </Frame.Main>
+      <Frame.Footer>
+        {{#if (has-block "footer")}}
+          {{yield (hash AppFooter=MockAppFooterAppFooter) to="footer"}}
+        {{else}}
+          <MockAppFooterAppFooter />
+        {{/if}}
+      </Frame.Footer>
+    </HdsAppFrame>
+  </template>
+}

--- a/showcase/app/components/mock/app/index.gts
+++ b/showcase/app/components/mock/app/index.gts
@@ -3,100 +3,100 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Component from '@glimmer/component';
-import { hash } from '@ember/helper';
-import MockAppHeaderAppHeader from './header/app-header';
-import MockAppSidebarSideNav from './sidebar/side-nav';
-import MockAppMainPageHeader from './main/page-header';
-import MockAppMainGenericTextContent from './main/generic-text-content';
-import MockAppFooterAppFooter from './footer/app-footer';
+// import Component from '@glimmer/component';
+// import { hash } from '@ember/helper';
+// import MockAppHeaderAppHeader from './header/app-header';
+// import MockAppSidebarSideNav from './sidebar/side-nav';
+// import MockAppMainPageHeader from './main/page-header';
+// import MockAppMainGenericTextContent from './main/generic-text-content';
+// import MockAppFooterAppFooter from './footer/app-footer';
 
-// HDS components
-import { HdsAppFrame } from '@hashicorp/design-system-components/components';
+// // HDS components
+// import { HdsAppFrame } from '@hashicorp/design-system-components/components';
 
-// types
-import type { ComponentLike } from '@glint/template';
-import type { HdsAppFrameSignature } from '@hashicorp/design-system-components/components/hds/app-frame/index';
-import type { MockAppHeaderAppHeaderSignature } from './header/app-header';
-import type { MockAppSidebarSideNavSignature } from './sidebar/side-nav';
-import type { MockAppMainPageHeaderSignature } from './main/page-header';
-import type { MockAppMainGenericTextContentSignature } from './main/generic-text-content';
-import type { MockAppFooterAppFooterSignature } from './footer/app-footer';
+// // types
+// import type { ComponentLike } from '@glint/template';
+// import type { HdsAppFrameSignature } from '@hashicorp/design-system-components/components/hds/app-frame/index';
+// import type { MockAppHeaderAppHeaderSignature } from './header/app-header';
+// import type { MockAppSidebarSideNavSignature } from './sidebar/side-nav';
+// import type { MockAppMainPageHeaderSignature } from './main/page-header';
+// import type { MockAppMainGenericTextContentSignature } from './main/generic-text-content';
+// import type { MockAppFooterAppFooterSignature } from './footer/app-footer';
 
-export interface MockAppSignature {
-  Args: {
-    hasHeader?: HdsAppFrameSignature['Args']['hasHeader'];
-    hasSidebar?: HdsAppFrameSignature['Args']['hasSidebar'];
-    hasFooter?: HdsAppFrameSignature['Args']['hasFooter'];
-  };
-  Blocks: {
-    header?: [
-      {
-        AppHeader?: ComponentLike<MockAppHeaderAppHeaderSignature>;
-      },
-    ];
-    sidebar?: [
-      {
-        SideNav?: ComponentLike<MockAppSidebarSideNavSignature>;
-      },
-    ];
-    main?: [
-      {
-        PageHeader?: ComponentLike<MockAppMainPageHeaderSignature>;
-        GenericTextContent?: ComponentLike<MockAppMainGenericTextContentSignature>;
-      },
-    ];
-    footer?: [
-      {
-        AppFooter?: ComponentLike<MockAppFooterAppFooterSignature>;
-      },
-    ];
-  };
-  Element: HdsAppFrameSignature['Element'];
-}
+// export interface MockAppSignature {
+//   Args: {
+//     hasHeader?: HdsAppFrameSignature['Args']['hasHeader'];
+//     hasSidebar?: HdsAppFrameSignature['Args']['hasSidebar'];
+//     hasFooter?: HdsAppFrameSignature['Args']['hasFooter'];
+//   };
+//   Blocks: {
+//     header?: [
+//       {
+//         AppHeader?: ComponentLike<MockAppHeaderAppHeaderSignature>;
+//       },
+//     ];
+//     sidebar?: [
+//       {
+//         SideNav?: ComponentLike<MockAppSidebarSideNavSignature>;
+//       },
+//     ];
+//     main?: [
+//       {
+//         PageHeader?: ComponentLike<MockAppMainPageHeaderSignature>;
+//         GenericTextContent?: ComponentLike<MockAppMainGenericTextContentSignature>;
+//       },
+//     ];
+//     footer?: [
+//       {
+//         AppFooter?: ComponentLike<MockAppFooterAppFooterSignature>;
+//       },
+//     ];
+//   };
+//   Element: HdsAppFrameSignature['Element'];
+// }
 
-// eslint-disable-next-line ember/no-empty-glimmer-component-classes
-export default class MockApp extends Component<MockAppSignature> {
-  <template>
-    <HdsAppFrame
-      @hasHeader={{@hasHeader}}
-      @hasSidebar={{@hasSidebar}}
-      @hasFooter={{@hasFooter}}
-      ...attributes
-      as |Frame|
-    >
-      <Frame.Header>
-        {{#if (has-block "header")}}
-          {{yield (hash AppHeader=MockAppHeaderAppHeader) to="header"}}
-        {{else}}
-          <MockAppHeaderAppHeader />
-        {{/if}}
-      </Frame.Header>
-      <Frame.Sidebar>
-        {{#if (has-block "sidebar")}}
-          {{yield (hash SideNav=MockAppSidebarSideNav) to="sidebar"}}
-        {{else}}
-          <MockAppSidebarSideNav />
-        {{/if}}
-      </Frame.Sidebar>
-      <Frame.Main>
-        <div class="mock-app-layout-main-content-wrapper">
-          {{yield
-            (hash
-              PageHeader=MockAppMainPageHeader
-              GenericTextContent=MockAppMainGenericTextContent
-            )
-            to="main"
-          }}
-        </div>
-      </Frame.Main>
-      <Frame.Footer>
-        {{#if (has-block "footer")}}
-          {{yield (hash AppFooter=MockAppFooterAppFooter) to="footer"}}
-        {{else}}
-          <MockAppFooterAppFooter />
-        {{/if}}
-      </Frame.Footer>
-    </HdsAppFrame>
-  </template>
-}
+// // eslint-disable-next-line ember/no-empty-glimmer-component-classes
+// export default class MockApp extends Component<MockAppSignature> {
+//   <template>
+//     <HdsAppFrame
+//       @hasHeader={{@hasHeader}}
+//       @hasSidebar={{@hasSidebar}}
+//       @hasFooter={{@hasFooter}}
+//       ...attributes
+//       as |Frame|
+//     >
+//       <Frame.Header>
+//         {{#if (has-block "header")}}
+//           {{yield (hash AppHeader=MockAppHeaderAppHeader) to="header"}}
+//         {{else}}
+//           <MockAppHeaderAppHeader />
+//         {{/if}}
+//       </Frame.Header>
+//       <Frame.Sidebar>
+//         {{#if (has-block "sidebar")}}
+//           {{yield (hash SideNav=MockAppSidebarSideNav) to="sidebar"}}
+//         {{else}}
+//           <MockAppSidebarSideNav />
+//         {{/if}}
+//       </Frame.Sidebar>
+//       <Frame.Main>
+//         <div class="mock-app-layout-main-content-wrapper">
+//           {{yield
+//             (hash
+//               PageHeader=MockAppMainPageHeader
+//               GenericTextContent=MockAppMainGenericTextContent
+//             )
+//             to="main"
+//           }}
+//         </div>
+//       </Frame.Main>
+//       <Frame.Footer>
+//         {{#if (has-block "footer")}}
+//           {{yield (hash AppFooter=MockAppFooterAppFooter) to="footer"}}
+//         {{else}}
+//           <MockAppFooterAppFooter />
+//         {{/if}}
+//       </Frame.Footer>
+//     </HdsAppFrame>
+//   </template>
+// }

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header-and-app-side-nav.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header-and-app-side-nav.hbs
@@ -7,7 +7,7 @@
 
 {{! NOTE: AppHeader & AppSideNav components are not published so we use placeholders here }}
 
-<Mock::App>
+{{!-- <Mock::App>
   <:header>
     {{! TODO add AppHeader to the `Mock::App` component and then instantiate it here }}
     {{! <H.AppHeader @orgPickerLabel="WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW" /> }}
@@ -29,4 +29,4 @@
     <M.GenericTextContent />
     <M.GenericTextContent />
   </:main>
-</Mock::App>
+</Mock::App> --}}

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-app-header.hbs
@@ -7,7 +7,7 @@
 
 {{! NOTE: AppHeader component is not published so we use a placeholder here }}
 
-<Mock::App>
+{{!-- <Mock::App>
   <:header>
     {{! TODO add AppHeader to the `Mock::App` component and then instantiate it here }}
     {{! <H.AppHeader @orgPickerLabel="WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW" /> }}
@@ -20,4 +20,4 @@
     <M.GenericTextContent />
     <M.GenericTextContent />
   </:main>
-</Mock::App>
+</Mock::App> --}}

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
@@ -5,7 +5,7 @@
 
 {{page-title "AppFrame Component - Frameless"}}
 
-{{!-- <Mock::App @hasHeader={{false}}>
+<Mock::App @hasHeader={{false}}>
   <:main as |M|>
     <M.PageHeader @showActionButton={{true}} />
     <M.GenericTextContent />
@@ -13,4 +13,4 @@
     <M.GenericTextContent />
     <M.GenericTextContent />
   </:main>
-</Mock::App> --}}
+</Mock::App>

--- a/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
+++ b/showcase/app/templates/layouts/app-frame/frameless/demo-full-app-frame-with-side-nav.hbs
@@ -5,7 +5,7 @@
 
 {{page-title "AppFrame Component - Frameless"}}
 
-<Mock::App @hasHeader={{false}}>
+{{!-- <Mock::App @hasHeader={{false}}>
   <:main as |M|>
     <M.PageHeader @showActionButton={{true}} />
     <M.GenericTextContent />
@@ -13,4 +13,4 @@
     <M.GenericTextContent />
     <M.GenericTextContent />
   </:main>
-</Mock::App>
+</Mock::App> --}}

--- a/showcase/types/template-registry.ts
+++ b/showcase/types/template-registry.ts
@@ -21,8 +21,8 @@ import ShwTextH2 from '../app/components/shw/text/h2';
 import ShwTextH3 from '../app/components/shw/text/h3';
 import ShwTextH4 from '../app/components/shw/text/h4';
 
-import MockApp from '../app/components/mock/app/index';
-import MockAppHeaderAppHeader from '../app/components/mock/app/header/app-header';
+// import MockApp from '../app/components/mock/app/index';
+// import MockAppHeaderAppHeader from '../app/components/mock/app/header/app-header';
 import MockAppSidebarSideNav from '../app/components/mock/app/sidebar/side-nav';
 import MockAppMainPageHeader from '../app/components/mock/app/main/page-header';
 import MockAppMainGenericTextContent from '../app/components/mock/app/main/generic-text-content';
@@ -65,10 +65,10 @@ export default interface ShowcaseTemplateRegistry {
   'Shw::Text::Body': typeof ShwTextBody;
   'shw/text/body': typeof ShwTextBody;
   // MOCK APP
-  'Mock::App': typeof MockApp;
-  'mock/app': typeof MockApp;
-  'Mock::App::Header::AppHeader': typeof MockAppHeaderAppHeader;
-  'mock/app/header/app-header': typeof MockAppHeaderAppHeader;
+  // 'Mock::App': typeof MockApp;
+  // 'mock/app': typeof MockApp;
+  // 'Mock::App::Header::AppHeader': typeof MockAppHeaderAppHeader;
+  // 'mock/app/header/app-header': typeof MockAppHeaderAppHeader;
   'Mock::App::Sidebar::AppSideNav': typeof MockAppSidebarSideNav;
   'mock/app/sidebar/app-side-nav': typeof MockAppSidebarSideNav;
   'Mock::App::Main::PageHeader': typeof MockAppMainPageHeader;

--- a/showcase/types/template-registry.ts
+++ b/showcase/types/template-registry.ts
@@ -21,7 +21,7 @@ import ShwTextH2 from '../app/components/shw/text/h2';
 import ShwTextH3 from '../app/components/shw/text/h3';
 import ShwTextH4 from '../app/components/shw/text/h4';
 
-// import MockApp from '../app/components/mock/app/index';
+import MockApp from '../app/components/mock/app/index';
 // import MockAppHeaderAppHeader from '../app/components/mock/app/header/app-header';
 import MockAppSidebarSideNav from '../app/components/mock/app/sidebar/side-nav';
 import MockAppMainPageHeader from '../app/components/mock/app/main/page-header';
@@ -65,8 +65,8 @@ export default interface ShowcaseTemplateRegistry {
   'Shw::Text::Body': typeof ShwTextBody;
   'shw/text/body': typeof ShwTextBody;
   // MOCK APP
-  // 'Mock::App': typeof MockApp;
-  // 'mock/app': typeof MockApp;
+  'Mock::App': typeof MockApp;
+  'mock/app': typeof MockApp;
   // 'Mock::App::Header::AppHeader': typeof MockAppHeaderAppHeader;
   // 'mock/app/header/app-header': typeof MockAppHeaderAppHeader;
   'Mock::App::Sidebar::AppSideNav': typeof MockAppSidebarSideNav;


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

Since this components were excluded from `appReexport` it actually confuses `embroider/vite` and breaks the build. We can either exclude them completely including disabling some parts of showcase or we keep them in the `appReexport`

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
