### PR TITLE
Website - Fix z-index issues on the `AppFrame` documentation page

### DIFF
--- a/website/app/styles/pages/layouts/app-frame.scss
+++ b/website/app/styles/pages/layouts/app-frame.scss
@@ -9,6 +9,7 @@
   .doc-app-frame-mock-viewport {
     width: 100%;
     aspect-ratio: 16 / 9;
+    isolation: isolate;
 
     .hds-app-frame {
       position: relative;
@@ -23,7 +24,6 @@
 
     .hds-app-frame__modals {
       position: absolute;
-      z-index: 10;
       width: 100%;
       height: 100%;
     }


### PR DESCRIPTION
### :pushpin: Summary

I noticed a couple of issues in how the `AppFrame` in the rendered code snippets was not correctly overlaying the content.

This PR fixes these two issues.

👉 **Preview**: https://hds-website-git-website-appframe-fix-z-index-hashicorp.vercel.app/layouts/app-frame

### :camera_flash: Screenshots

**Before:**
<img width="963" alt="screenshot_4712" src="https://github.com/user-attachments/assets/f58efa4b-f520-434b-967c-eb28804b0b87" />
<img width="880" alt="screenshot_4711" src="https://github.com/user-attachments/assets/5e744d6f-9026-4110-83aa-885e9c0daa5e" />

**After:**
<img width="874" alt="screenshot_4713" src="https://github.com/user-attachments/assets/69a29ac5-fe21-4909-b5a0-7ded167c5515" />
<img width="851" alt="screenshot_4714" src="https://github.com/user-attachments/assets/0a4f1b53-95ab-499c-83e6-3c6c512eaf4e" />

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
