### PR TITLE
Fix Vercel alias creation when running from Actions

### DIFF
--- a/.github/workflows/create-vercel-alias.yml
+++ b/.github/workflows/create-vercel-alias.yml
@@ -13,6 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Determine Branch Name
+        id: determine_branch
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            BRANCH_NAME=$(echo "${{ github.ref }}" | sed 's|refs/heads/||')
+          else
+            BRANCH_NAME="${{ github.ref_name }}"
+          fi
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "Branch Name: $BRANCH_NAME"
       - name: Extract Current Version
         id: extract_version
         run: echo "VERSION=$(jq -r .version packages/components/package.json | sed 's/\./-/g')" >> $GITHUB_ENV
@@ -21,7 +31,7 @@ jobs:
         run: |
           DEPLOYMENT_ID=$(curl -s -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" \
           "https://api.vercel.com/v6/deployments?teamId=${{ secrets.VERCEL_TEAM_ID }}&projectId=${{ secrets.VERCEL_WEBSITE_PROJECT_ID }}" \
-          | jq -r --arg branch "${{ github.head_ref }}" '.deployments[] | select(.meta.githubCommitRef == $branch) | .uid' | head -n 1)
+          | jq -r --arg branch "${{ env.BRANCH_NAME }}" '.deployments[] | select(.meta.githubCommitRef == $branch) | .uid' | head -n 1)
           echo "DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_ENV
       - name: Alias Vercel Deployment
         id: alias_vercel_deployment


### PR DESCRIPTION
### :pushpin: Summary

In #2658 we introduced a GitHub workflow to automate the creation of a Vercel alias for new releases. At the time we tested the result of this workflow by triggering it in the PR, but not by running the GitHub Action.

It turns out we need a different logic to extract the branch name depending on where we run the action.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
