### PR TITLE
Added changelog for AdvancedTable Updates

### DIFF
--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -1,5 +1,15 @@
 # [HDS Components UI Kit v2.0](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?m=auto&node-id=2-7&t=HYGTIoXBy2YkVWDP-1)
 
+## March 4th, 2025
+
+`Advanced Table` - Removed an unnecessary border from `Header::Selection`.
+
+### Breaking changes
+
+`Advanced Table` - Restructured `Cell::Selection` to mimic the `Table::Cell::Selection` component.
+
+_This change alters the layer structure of the component and results in a breaking change for the `Advanced Table` cell "selection" components only._
+
 ## January 23rd, 2025
 
 `Advanced Table` - Added new component.

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -12,6 +12,16 @@
 </p>
 
 
+### March 4th, 2025
+
+`Advanced Table` - Removed an unnecessary border from `Header::Selection`.
+
+#### Breaking changes
+
+`Advanced Table` - Restructured `Cell::Selection` to mimic the `Table::Cell::Selection` component.
+
+_This change alters the layer structure of the component and results in a breaking change for the `Advanced Table` cell "selection" components only._
+
 ### January 23rd, 2025
 
 `Advanced Table` - Added new component.
@@ -110,10 +120,6 @@ _Adding support for a `Tooltip` and updates to the `Sort Button` result in a bre
 ### September 15th, 2023
 
 `IconTile` and `IconTile-Logo` - Added a new product variant for Vault Secrets.
-
-### August 17th, 2023
-
-`SideNav` - Changed the icon from `User` to `Help` in the first dropdown at the top of the `SideNav`.
 
 
 ---


### PR DESCRIPTION
### :pushpin: Summary

Adds a Figma changelog entry for the changes made to the [AdvancedTable selection components](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/branch/FWZM12Cl3qKIFf24s4Zcqv/HDS-Components-v2.0?m=auto&t=hKkoVlmkVbh11a7k-1). This does result in a breaking change in the `AdvancedTable::Cell::Selection`, but usage is very low of that component is very low right now as a part of the migration.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
