### PR TITLE
`hds-code-editor` add support for markdown syntax highlighting

### DIFF
--- a/.changeset/swift-wasps-happen.md
+++ b/.changeset/swift-wasps-happen.md
@@ -1,0 +1,9 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`hds-code-editor` modifier - Add language syntax highlighting suport for Markdown
+
+`CodeEditor` - Add language syntax highlighting suport for Markdown
+
+Dependencies - added @codemirror/lang-markdown

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,6 +35,7 @@
     "@codemirror/lang-go": "^6.0.1",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/lang-markdown": "^6.3.2",
     "@codemirror/lang-sql": "^6.8.0",
     "@codemirror/lang-yaml": "^6.1.2",
     "@codemirror/language": "^6.10.3",

--- a/packages/components/src/modifiers/hds-code-editor.ts
+++ b/packages/components/src/modifiers/hds-code-editor.ts
@@ -100,6 +100,9 @@ const LANGUAGES: Record<
   json: {
     load: async () => (await import('@codemirror/lang-json')).json(),
   },
+  markdown: {
+    load: async () => (await import('@codemirror/lang-markdown')).markdown(),
+  },
   sql: {
     load: async () => (await import('@codemirror/lang-sql')).sql(),
   },

--- a/packages/components/src/modifiers/hds-code-editor/highlight-styles/hds-dark-highlight-style.ts
+++ b/packages/components/src/modifiers/hds-code-editor/highlight-styles/hds-dark-highlight-style.ts
@@ -49,6 +49,19 @@ const hdsDarkHighlightStyle = HighlightStyle.define([
 
   // Gray | Used for comments across languages
   { tag: tags.comment, color: HDS_CODE_EDITOR_COLOR_FOREGROUND_PRIMARY },
+
+  // Markdown specific
+  { tag: tags.heading, color: HDS_CODE_BLOCK_BLUE, fontWeight: 'bold' },
+  { tag: tags.strong, color: HDS_CODE_BLOCK_ORANGE, fontWeight: 'bold' },
+  { tag: tags.emphasis, color: HDS_CODE_BLOCK_ORANGE, fontStyle: 'italic' },
+  { tag: tags.link, color: HDS_CODE_BLOCK_CYAN, textDecoration: 'underline' },
+  {
+    tag: tags.quote,
+    color: HDS_CODE_EDITOR_COLOR_FOREGROUND_PRIMARY,
+    fontStyle: 'italic',
+  },
+  { tag: tags.list, color: HDS_CODE_BLOCK_WHITE },
+  { tag: tags.monospace, color: HDS_CODE_BLOCK_GREEN },
 ]);
 
 export default hdsDarkHighlightStyle;

--- a/packages/components/src/modifiers/hds-code-editor/types.ts
+++ b/packages/components/src/modifiers/hds-code-editor/types.ts
@@ -11,6 +11,7 @@ export enum HdsCodeEditorLanguageValues {
   Hcl = 'hcl',
   JavaScript = 'javascript',
   Json = 'json',
+  Markdown = 'markdown',
   Sentinel = 'sentinel',
   Sql = 'sql',
   Yaml = 'yaml',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@codemirror/lang-json':
         specifier: ^6.0.1
         version: 6.0.1
+      '@codemirror/lang-markdown':
+        specifier: ^6.3.2
+        version: 6.3.2
       '@codemirror/lang-sql':
         specifier: ^6.8.0
         version: 6.8.0
@@ -2000,14 +2003,23 @@ packages:
   '@codemirror/commands@6.8.0':
     resolution: {integrity: sha512-q8VPEFaEP4ikSlt6ZxjB3zW72+7osfAYW9i8Zu943uqbKuz6utc1+F170hyLUCUltXORjQXRyYQNfkckzA/bPQ==}
 
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
   '@codemirror/lang-go@6.0.1':
     resolution: {integrity: sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==}
+
+  '@codemirror/lang-html@6.4.9':
+    resolution: {integrity: sha512-aQv37pIMSlueybId/2PVSP6NPnmurFDVmZwzc7jszd2KAF8qd4VBbvNYPXWQq90WIARjsdVkPbw29pszmHws3Q==}
 
   '@codemirror/lang-javascript@6.2.3':
     resolution: {integrity: sha512-8PR3vIWg7pSu7ur8A07pGiYHgy3hHj+mRYRCSG8q+mPIrl0F02rgpGv+DsQTHRTc30rydOsf5PZ7yjKFg2Ackw==}
 
   '@codemirror/lang-json@6.0.1':
     resolution: {integrity: sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==}
+
+  '@codemirror/lang-markdown@6.3.2':
+    resolution: {integrity: sha512-c/5MYinGbFxYl4itE9q/rgN/sMTjOr8XL5OWnC+EaRMLfCbVUmmubTJfdgpfcSS2SCaT7b+Q+xi3l6CgoE+BsA==}
 
   '@codemirror/lang-sql@6.8.0':
     resolution: {integrity: sha512-aGLmY4OwGqN3TdSx3h6QeA1NrvaYtF7kkoWR/+W7/JzB0gQtJ+VJxewlnE3+VImhA4WVlhmkJr109PefOOhjLg==}
@@ -2907,11 +2919,17 @@ packages:
   '@lezer/common@1.2.3':
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
 
+  '@lezer/css@1.1.10':
+    resolution: {integrity: sha512-V5/89eDapjeAkWPBpWEfQjZ1Hag3aYUUJOL8213X0dFRuXJ4BXa5NKl9USzOnaLod4AOpmVCkduir2oKwZYZtg==}
+
   '@lezer/go@1.0.0':
     resolution: {integrity: sha512-co9JfT3QqX1YkrMmourYw2Z8meGC50Ko4d54QEcQbEYpvdUvN4yb0NBZdn/9ertgvjsySxHsKzH3lbm3vqJ4Jw==}
 
   '@lezer/highlight@1.2.1':
     resolution: {integrity: sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==}
+
+  '@lezer/html@1.3.10':
+    resolution: {integrity: sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==}
 
   '@lezer/javascript@1.4.21':
     resolution: {integrity: sha512-lL+1fcuxWYPURMM/oFZLEDm0XuLN128QPV+VuGtKpeaOGdcl9F2LYC3nh1S9LkPqx9M0mndZFdXCipNAZpzIkQ==}
@@ -2921,6 +2939,9 @@ packages:
 
   '@lezer/lr@1.4.2':
     resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
+
+  '@lezer/markdown@1.4.2':
+    resolution: {integrity: sha512-iYewCigG/517D0xJPQd7RGaCjZAFwROiH8T9h7OTtz0bRVtkxzFhGBFJ9JGKgBBs4uuo1cvxzyQ5iKhDLMcLUQ==}
 
   '@lezer/yaml@1.0.3':
     resolution: {integrity: sha512-GuBLekbw9jDBDhGur82nuwkxKQ+a3W5H0GfaAthDXcAu+XdpS43VlnxA9E9hllkpSP5ellRDKjLLj7Lu9Wr6xA==}
@@ -9767,6 +9788,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.13.0:
@@ -12955,6 +12977,14 @@ snapshots:
       '@codemirror/view': 6.36.2
       '@lezer/common': 1.2.3
 
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.18.4
+      '@codemirror/language': 6.10.8
+      '@codemirror/state': 6.5.1
+      '@lezer/common': 1.2.3
+      '@lezer/css': 1.1.10
+
   '@codemirror/lang-go@6.0.1':
     dependencies:
       '@codemirror/autocomplete': 6.18.4
@@ -12962,6 +12992,18 @@ snapshots:
       '@codemirror/state': 6.5.1
       '@lezer/common': 1.2.3
       '@lezer/go': 1.0.0
+
+  '@codemirror/lang-html@6.4.9':
+    dependencies:
+      '@codemirror/autocomplete': 6.18.4
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.3
+      '@codemirror/language': 6.10.8
+      '@codemirror/state': 6.5.1
+      '@codemirror/view': 6.36.2
+      '@lezer/common': 1.2.3
+      '@lezer/css': 1.1.10
+      '@lezer/html': 1.3.10
 
   '@codemirror/lang-javascript@6.2.3':
     dependencies:
@@ -12977,6 +13019,16 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.10.8
       '@lezer/json': 1.0.3
+
+  '@codemirror/lang-markdown@6.3.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.18.4
+      '@codemirror/lang-html': 6.4.9
+      '@codemirror/language': 6.10.8
+      '@codemirror/state': 6.5.1
+      '@codemirror/view': 6.36.2
+      '@lezer/common': 1.2.3
+      '@lezer/markdown': 1.4.2
 
   '@codemirror/lang-sql@6.8.0':
     dependencies:
@@ -14109,6 +14161,12 @@ snapshots:
 
   '@lezer/common@1.2.3': {}
 
+  '@lezer/css@1.1.10':
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
+
   '@lezer/go@1.0.0':
     dependencies:
       '@lezer/common': 1.2.3
@@ -14118,6 +14176,12 @@ snapshots:
   '@lezer/highlight@1.2.1':
     dependencies:
       '@lezer/common': 1.2.3
+
+  '@lezer/html@1.3.10':
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
 
   '@lezer/javascript@1.4.21':
     dependencies:
@@ -14134,6 +14198,11 @@ snapshots:
   '@lezer/lr@1.4.2':
     dependencies:
       '@lezer/common': 1.2.3
+
+  '@lezer/markdown@1.4.2':
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
 
   '@lezer/yaml@1.0.3':
     dependencies:

--- a/showcase/app/controllers/components/code-editor.js
+++ b/showcase/app/controllers/components/code-editor.js
@@ -103,6 +103,20 @@ sayMessage();
 }`,
     },
     {
+      value: 'markdown',
+      label: 'Markdown',
+      code: `# Heading Example
+
+This is **bold**, *italic*, and \`monospace\`.  
+A [link](https://example.com) and a \`code snippet\`.
+
+> A blockquote example.
+
+- List item 1
+- List item 2
+`,
+    },
+    {
       value: 'sentinel',
       label: 'Sentinel',
       code: `param allowed_regions = ["us-east-1", "us-west-2"]

--- a/website/docs/components/code-editor/partials/code/component-api.md
+++ b/website/docs/components/code-editor/partials/code/component-api.md
@@ -35,7 +35,7 @@ This component uses [CodeMirror 6](https://codemirror.net/) under the hood.
   <C.Property @name="isStandalone" @type="boolean" @default="true">
     Applies rounded borders to the component. When used within another component or when the context requires it, you can turn it off.
   </C.Property>
-  <C.Property @name="language" @type="string" @values={{array "go" "hcl" "javascript" "json" "rego" "ruby" "sentinel" "shell" "sql" "yaml"}}>
+  <C.Property @name="language" @type="string" @values={{array "go" "hcl" "javascript" "json" "markdown" "rego" "ruby" "sentinel" "shell" "sql" "yaml"}}>
     The coding language to use for syntax highlighting. If you need additional languages <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>.
   </C.Property>
   <C.Property @name="value" @type="string">

--- a/website/docs/components/code-editor/partials/code/how-to-use.md
+++ b/website/docs/components/code-editor/partials/code/how-to-use.md
@@ -59,7 +59,7 @@ The default `@tag` is `"h2"`, however, the correct value is dependent on the ind
 
 ### Language
 
-The `language` argument sets the syntax highlighting used. We support the following languages: `rego`, `ruby`, `sentinel`, `shell`, `go`, `hcl`, `javascript`, `json`, `sql`, and `yaml`. If you need additional languages, <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>.
+The `language` argument sets the syntax highlighting used. We support the following languages: `rego`, `ruby`, `sentinel`, `shell`, `go`, `hcl`, `javascript`, `json`, `markdown`, `sql`, and `yaml`. If you need additional languages, <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>.
 
 ```handlebars
 <Hds::CodeEditor


### PR DESCRIPTION
### :pushpin: Summary

If merged, this will add highlighting support for markdown to the `hds-code-editor` modifier

### :hammer_and_wrench: Detailed description

- Adds `@codemirror/lang-markdown` extension
- Adds new color definitions for markdown nodes
- Updates docs with new language

### :camera_flash: Screenshots

![Screenshot 2025-03-04 at 9 00 46 PM](https://github.com/user-attachments/assets/e34f0a5c-21ac-4da6-89e6-4103e67b234d)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4631](https://hashicorp.atlassian.net/browse/HDS-4631)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4631]: https://hashicorp.atlassian.net/browse/HDS-4631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ