### PR TITLE
Attempt to fix the changeset version step for RC

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -45,11 +45,19 @@ jobs:
         run: pnpm build
         working-directory: packages/components
 
-      - name: Version and Publish RC Packages
-        id: changesets
+      - name: Version RC Packages
+        id: version
         uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308 # v1.4.9
         with:
           version: pnpm version-candidate-packages
+        env:
+          # Token setup in hashibot-hds' account
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+
+      - name: Publish RC Packages
+        id: changesets
+        uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308 # v1.4.9
+        with:
           publish: pnpm release-candidate-packages
           createGithubReleases: false
         env:

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "release-candidate-packages": "changeset publish --tag rc",
+    "release-candidate-packages": "pnpm changeset publish --tag rc",
     "release-packages": "pnpm changeset publish",
-    "version-candidate-packages": "pnpm changeset version --snapshot rc",
+    "version-candidate-packages": "pnpm changeset version --snapshot rc && pnpm install --lockfile-only",
     "version-packages": "pnpm changeset version && pnpm install --lockfile-only && pnpm -F website generate-changelog-markdown-files"
   },
   "devDependencies": {


### PR DESCRIPTION
### :pushpin: Summary

When [testing the Release Candidate workflow](https://github.com/hashicorp/design-system/pull/2689#event-16596793734) we discovered that [the changeset version command did not run as expected](https://github.com/hashicorp/design-system/actions/runs/13673237611/job/38227910905?pr=2689#step:7:1).

We suspect this is because the `version` and `publish` inputs are not being executed as separate commands. Instead, they are being passed as arguments to the `changesets/action`, which is probably not the intended behavior.

Attempting to fix this we separate the version and publish steps into two distinct steps in our workflow.

Follow-up on #2732.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
