### PR TITLE
`Tag` - Make `@tooltipPlacement` optional

### DIFF
--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -26,7 +26,7 @@ export interface HdsTagSignature {
     color?: HdsTagColors;
     text: string;
     ariaLabel?: string;
-    tooltipPlacement: HdsTagTooltipPlacements;
+    tooltipPlacement?: HdsTagTooltipPlacements;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onDismiss?: (event: MouseEvent, ...args: any[]) => void;
   };


### PR DESCRIPTION
### :pushpin: Summary

Marked `tooltipPlacement` as optional. Discovered during smoke testing in HCP.

Follow up on #2655

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
