### PR TITLE
 `Time` interactive & `RichTooltip` - Increase dotted underline offset (HDS-4618)

### DIFF
--- a/.changeset/eight-fishes-sin.md
+++ b/.changeset/eight-fishes-sin.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`Time` - Increase spacing above dotted text decoration underline to 2px from the default.

--- a/.changeset/eight-fishes-sin.md
+++ b/.changeset/eight-fishes-sin.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`Time` - Increase spacing above dotted text decoration underline to 2px from the default.
+`Time` - Increase spacing above the dotted text decoration underline, that appears on the interactive variant, to 2px from the default.
+
+`RichTooltip` - Increase spacing above the dotted text decoration underline to 2px from the default.

--- a/packages/components/src/styles/components/rich-tooltip.scss
+++ b/packages/components/src/styles/components/rich-tooltip.scss
@@ -68,6 +68,7 @@
   // decoration style is specified separately to fix a bug in Safari causing it not to render
   text-decoration: underline;
   text-decoration-style: dotted;
+  text-underline-offset: 2px;
 }
 
 // icon

--- a/packages/components/src/styles/components/time.scss
+++ b/packages/components/src/styles/components/time.scss
@@ -17,4 +17,5 @@
   // decoration style is specified separately to fix a bug in Safari causing it not to render
   text-decoration: underline;
   text-decoration-style: dotted;
+  text-underline-offset: 2px;
 }

--- a/showcase/app/templates/components/time.hbs
+++ b/showcase/app/templates/components/time.hbs
@@ -12,7 +12,7 @@
 <section>
   <Shw::Text::H2>Has tooltip</Shw::Text::H2>
 
-  <Shw::Flex @gap="2rem" as |SF|>
+  <Shw::Flex @gap="2rem" {{style flexWrap="wrap"}} as |SF|>
     <SF.Item @label="With tooltip (default)">
       <Hds::Time @date="05 September 2018 14:48" />
     </SF.Item>
@@ -20,11 +20,15 @@
     <SF.Item @label="Without tooltip">
       <Hds::Time @date="05 September 2018 14:48" @hasTooltip={{false}} />
     </SF.Item>
+
+    <SF.Item @label="Standard body font with tooltip" {{style width="100%"}}>
+      <Hds::Text::Body @tag="p">
+        <Hds::Time @date="05 September 2018 14:48" />
+      </Hds::Text::Body>
+    </SF.Item>
   </Shw::Flex>
 
   <Shw::Text::H2>Display</Shw::Text::H2>
-
-  <p>Note: “examples” are temporary</p>
 
   <Shw::Flex @gap="4rem 9rem" as |SF|>
     <SF.Item @label="Default with display unset">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will slightly increase the dotted text-decoration underline spacing to 2px from the default spacing for the `Time` and `RichTooltip` components.

* **`Time` Showcase:** https://hds-showcase-git-hds-4618-dotted-line-spacing-update-hashicorp.vercel.app/components/time
* **`RichTooltip` Showcase:** https://hds-showcase-git-hds-4618-dotted-line-spacing-update-hashicorp.vercel.app/components/rich-tooltip

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-4618](https://hashicorp.atlassian.net/browse/HDS-4618)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4618]: https://hashicorp.atlassian.net/browse/HDS-4618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ