### PR TITLE
Showcase - Add min-height to `Shw::Label`

### DIFF
--- a/showcase/app/styles/showcase-components/label.scss
+++ b/showcase/app/styles/showcase-components/label.scss
@@ -9,6 +9,7 @@
 
 .shw-label {
   @include shw-font-family("rubik");
+  min-height: 0.96rem; // needed to avoid vertical collapsing when the label is empty
   margin: 0 0 10px 0;
   color: #545454;
   font-size: 0.8rem;


### PR DESCRIPTION
### :pushpin: Summary

Simple PR to add a `min-height` to the `Shw::Label` in the showcase, so it doesn't collapse when empty.

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
