### PR TITLE
docs: add a title example to icon component page

### DIFF
--- a/website/docs/components/icon/partials/code/how-to-use.md
+++ b/website/docs/components/icon/partials/code/how-to-use.md
@@ -66,6 +66,14 @@ We don’t validate the CSS color string to ensure that the value used is correc
 
 !!!
 
+### Title
+
+To add an accessible name to an icon that conveys information to users, set the `@title` argument. 
+
+```handlebars
+<Hds::Icon @name="alert-circle" @title="Warning" />
+```
+
 ### Stretched
 
 To have the icon fill the parent container (width: 100%, height: 100%), set the `@stretched` attribute to true:


### PR DESCRIPTION
### :pushpin: Summary

I noticed that there is no example for adding an accessible name to an icon on the icon component page. I think it would be useful to surface this information more visibly to consumers.

### :camera_flash: Screenshots
<img width="679" alt="Screenshot 2025-03-07 at 12 02 02 PM" src="https://github.com/user-attachments/assets/deccae17-6a3c-449e-8925-15171f42e5c2" />

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
