### PR TITLE
AdvancedTable: set checkbox column width to `min-content`

### DIFF
--- a/.changeset/purple-poems-battle.md
+++ b/.changeset/purple-poems-battle.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+AdvancedTable - always set the select checkbox column width to `50px` so it does not grow when the AdvancedTable narrower than the container

--- a/.changeset/purple-poems-battle.md
+++ b/.changeset/purple-poems-battle.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-AdvancedTable - always set the select checkbox column width to `min-content` so it does not grow when the AdvancedTable is narrower than the container
+`AdvancedTable` - always set the select checkbox column width to `min-content` so it does not grow when the `AdvancedTable` is narrower than the container

--- a/.changeset/purple-poems-battle.md
+++ b/.changeset/purple-poems-battle.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-AdvancedTable - always set the select checkbox column width to `50px` so it does not grow when the AdvancedTable narrower than the container
+AdvancedTable - always set the select checkbox column width to `min-content` so it does not grow when the AdvancedTable narrower than the container

--- a/.changeset/purple-poems-battle.md
+++ b/.changeset/purple-poems-battle.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-AdvancedTable - always set the select checkbox column width to `min-content` so it does not grow when the AdvancedTable narrower than the container
+AdvancedTable - always set the select checkbox column width to `min-content` so it does not grow when the AdvancedTable is narrower than the container

--- a/.changeset/purple-poems-battle.md
+++ b/.changeset/purple-poems-battle.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`AdvancedTable` - always set the select checkbox column width to `min-content` so it does not grow when the `AdvancedTable` is narrower than the container
+`AdvancedTable` - Always set the select checkbox column width to `min-content` so it does not grow when the `AdvancedTable` is narrower than the container

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -246,11 +246,11 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
 
     // if there is no custom column widths, each column is the same width and they take up the available space (except the select checkbox)
     if (!this.columnWidths) {
-      return `${isSelectable ? '50px ' : ''}repeat(${columns.length}, 1fr)`;
+      return `${isSelectable ? 'min-content ' : ''}repeat(${columns.length}, 1fr)`;
     }
 
-    // if there is a select checkbox, the first column is '50px' width to hug the checkbox content
-    let style = isSelectable ? '50px ' : '';
+    // if there is a select checkbox, the first column is 'min-content' width to hug the checkbox content
+    let style = isSelectable ? 'min-content ' : '';
 
     // check the custom column widths, if the current column has a custom width use the custom width. otherwise take the available space.
     for (let i = 0; i < this.columnWidths.length; i++) {

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -249,7 +249,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
       return `${isSelectable ? 'min-content ' : ''}repeat(${columns.length}, 1fr)`;
     }
 
-    // if there is a select checkbox, the first column is 'min-content' width to hug the checkbox content
+    // if there is a select checkbox, the first column has a 'min-content' width to hug the checkbox content
     let style = isSelectable ? 'min-content ' : '';
 
     // check the custom column widths, if the current column has a custom width use the custom width. otherwise take the available space.

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -244,17 +244,17 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
   get gridTemplateColumns(): string {
     const { isSelectable, columns } = this.args;
 
-    // if there is no custom column widths, each column is the same width and they take up the available space (except the select checkbox)
-    if (!this.columnWidths) {
-      return `${isSelectable ? 'min-content ' : ''}repeat(${columns.length}, 1fr)`;
-    }
-
     // if there is a select checkbox, the first column has a 'min-content' width to hug the checkbox content
     let style = isSelectable ? 'min-content ' : '';
 
-    // check the custom column widths, if the current column has a custom width use the custom width. otherwise take the available space.
-    for (let i = 0; i < this.columnWidths.length; i++) {
-      style += ` ${this.columnWidths[i] ? this.columnWidths[i] : '1fr'}`;
+    if (!this.columnWidths) {
+      // if there are no custom column widths, each column is the same width and they take up the available space
+      style += `repeat(${columns.length}, 1fr)`;
+    } else {
+      // check the custom column widths, if the current column has a custom width use the custom width. otherwise take the available space.
+      for (let i = 0; i < this.columnWidths.length; i++) {
+        style += `${this.columnWidths[i] ? this.columnWidths[i] : '1fr'}`;
+      }
     }
 
     return style;

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -246,11 +246,11 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
 
     // if there is no custom column widths, each column is the same width and they take up the available space (except the select checkbox)
     if (!this.columnWidths) {
-      return `${isSelectable ? 'auto ' : ''}repeat(${columns.length}, 1fr)`;
+      return `${isSelectable ? '50px ' : ''}repeat(${columns.length}, 1fr)`;
     }
 
-    // if there is a select checkbox, the first column is 'auto' width to hug the checkbox content
-    let style = isSelectable ? 'auto' : '';
+    // if there is a select checkbox, the first column is '50px' width to hug the checkbox content
+    let style = isSelectable ? '50px ' : '';
 
     // check the custom column widths, if the current column has a custom width use the custom width. otherwise take the available space.
     for (let i = 0; i < this.columnWidths.length; i++) {

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -253,7 +253,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     } else {
       // check the custom column widths, if the current column has a custom width use the custom width. otherwise take the available space.
       for (let i = 0; i < this.columnWidths.length; i++) {
-        style += `${this.columnWidths[i] ? this.columnWidths[i] : '1fr'}`;
+        style += ` ${this.columnWidths[i] ? this.columnWidths[i] : '1fr'}`;
       }
     }
 

--- a/showcase/app/styles/showcase-pages/advanced-table.scss
+++ b/showcase/app/styles/showcase-pages/advanced-table.scss
@@ -18,6 +18,10 @@ body.components-advanced-table {
     overflow-x: auto;
   }
 
+  .shw-component-advanced-table-narrow-wrapper {
+    width: fit-content;
+  }
+
     // align table cell content for icon plus text in cell
     .shw-component-advanced-table-cell-content-div {
       display: flex;

--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -928,19 +928,16 @@
     </Hds::AdvancedTable>
   </div>
 
-    <Shw::Divider @level={{2}} />
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>Wide container with a narrow AdvancedTable</Shw::Text::H3>
 
-    <div class="shw-component-advanced-table-narrow-wrapper">
+  <div class="shw-component-advanced-table-narrow-wrapper">
     <Hds::AdvancedTable
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
       @model={{this.model.userData}}
-      @columns={{array
-        (hash key="id" label="ID" width="150px")
-        (hash key="name" label="Name" width='150px')
-      }}
+      @columns={{array (hash key="id" label="ID" width="150px") (hash key="name" label="Name" width="150px")}}
       @hasStickyHeader={{true}}
       @isStriped={{true}}
     >

--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -928,6 +928,35 @@
     </Hds::AdvancedTable>
   </div>
 
+    <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Wide container with a narrow AdvancedTable</Shw::Text::H3>
+
+    <div class="shw-component-advanced-table-narrow-wrapper">
+    <Hds::AdvancedTable
+      @isSelectable={{true}}
+      @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
+      @model={{this.model.userData}}
+      @columns={{array
+        (hash key="id" label="ID" width="150px")
+        (hash key="name" label="Name" width='150px')
+      }}
+      @hasStickyHeader={{true}}
+      @isStriped={{true}}
+    >
+      <:body as |B|>
+        <B.Tr
+          @selectionKey={{B.data.id}}
+          @isSelected={{B.data.isSelected}}
+          @selectionAriaLabelSuffix="row #{{B.data.id}}"
+        >
+          <B.Td>{{B.data.id}}</B.Td>
+          <B.Td>{{B.data.name}}</B.Td>
+        </B.Tr>
+      </:body>
+    </Hds::AdvancedTable>
+  </div>
+
   <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>AdvancedTable with <code>colspan/rowspan</code> attributes</Shw::Text::H3>

--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -936,10 +936,8 @@
     <Hds::AdvancedTable
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
-      @model={{this.model.userData}}
+      @model={{this.model.userDataShort}}
       @columns={{array (hash key="id" label="ID" width="150px") (hash key="name" label="Name" width="150px")}}
-      @hasStickyHeader={{true}}
-      @isStriped={{true}}
     >
       <:body as |B|>
         <B.Tr


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue the explorer table had when converting to AdvancedTable. Basically, because every column in explorer has a set pixel width, if the user hides many columns then the checkbox column grows to fill the available space.

This PR also adds an example to the showcase that mimics the explorer use case.

### :camera_flash: Screenshots

**Before**
<img width="1170" alt="Screenshot 2025-03-11 at 4 07 27 PM" src="https://github.com/user-attachments/assets/50c45504-df28-4b31-8435-135e72c04f39" />

**After**
<img width="1075" alt="Screenshot 2025-03-11 at 4 18 38 PM" src="https://github.com/user-attachments/assets/304c372b-c045-4fa9-a390-cc6c40cfe069" />

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
