### PR TITLE
Website - Add alt text to keyboard arrow icons

### DIFF
--- a/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
@@ -27,10 +27,10 @@ Move focus to the selected card. If nothing is selected, focus will move to the 
 
 ![Keyboard tab focus in a RadioCard group](/assets/components/form/radio-card/radio-card-accessibility-tab.png =980x*)
 
-<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-left" /></Doc::Badge>
-<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-right" /></Doc::Badge>
-<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-up" /></Doc::Badge>
-<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-down" /></Doc::Badge>
+<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-left" @title="Left arrow" /></Doc::Badge>
+<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-right" @title="Right arrow" /></Doc::Badge>
+<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-up" @title="Up arrow" /></Doc::Badge>
+<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-down" @title="Down arrow" /></Doc::Badge>
 
 Navigate between Radio Cards. As the card is focused it also becomes selected.
 

--- a/website/docs/components/tabs/partials/accessibility/accessibility.md
+++ b/website/docs/components/tabs/partials/accessibility/accessibility.md
@@ -21,8 +21,8 @@ Activate tab to display matching content area
 
 ![Keyboard tab navigation example](/assets/components/tabs/tab-spacebar-enter.png =402x*)
 
-<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-left" /></Doc::Badge>
-<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-right" /></Doc::Badge>
+<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-left" @title="Left arrow" /></Doc::Badge>
+<Doc::Badge @type="neutral"><Hds::Icon @name="arrow-right" @title="Right arrow" /></Doc::Badge>
 
 Move between tabs
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add alt text to arrow icons used in the accessibility docs of the `Tabs` and `Form::RadioCard` components. 

### :hammer_and_wrench: Detailed description

Originally caught by @shleewhite in #2727 there was an issue with the `Stepper::Nav` docs where the icons used in the accessibility docs did not have alt text added to them. These icons were copied from the `Tabs` component docs. This PR adds alt text to these icons in the `Tabs` and `Form::RadioCard` component docs. 

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
