### PR TITLE
Add missing `devDependencies` for `website`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -895,6 +895,15 @@ importers:
       broccoli-multifilter:
         specifier: git://github.com/broccolijs/broccoli-multifilter#3ae609df0cfb1dae0da04ae041eb75c7115c9838
         version: https://codeload.github.com/broccolijs/broccoli-multifilter/tar.gz/3ae609df0cfb1dae0da04ae041eb75c7115c9838
+      broccoli-persistent-filter:
+        specifier: ^3.1.3
+        version: 3.1.3
+      broccoli-plugin:
+        specifier: ^4.0.7
+        version: 4.0.7
+      broccoli-stew:
+        specifier: ^3.0.0
+        version: 3.0.0
       chalk:
         specifier: ^5.4.0
         version: 5.4.1
@@ -1135,6 +1144,9 @@ importers:
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
+      walk-sync:
+        specifier: ^3.0.0
+        version: 3.0.0
       webpack:
         specifier: ^5.97.1
         version: 5.97.1

--- a/website/package.json
+++ b/website/package.json
@@ -58,6 +58,9 @@
     "broccoli-funnel": "^3.0.8",
     "broccoli-merge-trees": "^4.2.0",
     "broccoli-multifilter": "git://github.com/broccolijs/broccoli-multifilter#3ae609df0cfb1dae0da04ae041eb75c7115c9838",
+    "broccoli-persistent-filter": "^3.1.3",
+    "broccoli-plugin": "^4.0.7",
+    "broccoli-stew": "^3.0.0",
     "chalk": "^5.4.0",
     "concurrently": "^9.1.0",
     "cspell": "^8.17.1",
@@ -138,6 +141,7 @@
     "unist-util-remove": "^4.0.0",
     "unist-util-select": "^5.1.0",
     "unist-util-visit": "^5.0.0",
+    "walk-sync": "^3.0.0",
     "webpack": "^5.97.1",
     "yaml-front-matter": "^4.1.1"
   },


### PR DESCRIPTION
### :pushpin: Summary

Added missing `devDependencies` to resolve an issue where `ember generate` fails complaining about them.

### :link: External links

<!-- Issues, RFC, etc. -->
[Slack thread](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1741623062574809)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
