### PR TITLE
[WIP] `Layout::Grid` - documentation (HDS-465 )

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -251,6 +251,7 @@
       "./components/hds/icon-tile/index.js": "./dist/_app_/components/hds/icon-tile/index.js",
       "./components/hds/icon/index.js": "./dist/_app_/components/hds/icon/index.js",
       "./components/hds/interactive/index.js": "./dist/_app_/components/hds/interactive/index.js",
+      "./components/hds/layout/flex/index.js": "./dist/_app_/components/hds/layout/flex/index.js",
       "./components/hds/link/inline.js": "./dist/_app_/components/hds/link/inline.js",
       "./components/hds/link/standalone.js": "./dist/_app_/components/hds/link/standalone.js",
       "./components/hds/menu-primitive/index.js": "./dist/_app_/components/hds/menu-primitive/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -254,6 +254,7 @@
       "./components/hds/layout/flex/index.js": "./dist/_app_/components/hds/layout/flex/index.js",
       "./components/hds/layout/flex/item.js": "./dist/_app_/components/hds/layout/flex/item.js",
       "./components/hds/layout/grid/index.js": "./dist/_app_/components/hds/layout/grid/index.js",
+      "./components/hds/layout/grid/item.js": "./dist/_app_/components/hds/layout/grid/item.js",
       "./components/hds/link/inline.js": "./dist/_app_/components/hds/link/inline.js",
       "./components/hds/link/standalone.js": "./dist/_app_/components/hds/link/standalone.js",
       "./components/hds/menu-primitive/index.js": "./dist/_app_/components/hds/menu-primitive/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -253,6 +253,7 @@
       "./components/hds/interactive/index.js": "./dist/_app_/components/hds/interactive/index.js",
       "./components/hds/layout/flex/index.js": "./dist/_app_/components/hds/layout/flex/index.js",
       "./components/hds/layout/flex/item.js": "./dist/_app_/components/hds/layout/flex/item.js",
+      "./components/hds/layout/grid/index.js": "./dist/_app_/components/hds/layout/grid/index.js",
       "./components/hds/link/inline.js": "./dist/_app_/components/hds/link/inline.js",
       "./components/hds/link/standalone.js": "./dist/_app_/components/hds/link/standalone.js",
       "./components/hds/menu-primitive/index.js": "./dist/_app_/components/hds/menu-primitive/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -252,6 +252,7 @@
       "./components/hds/icon/index.js": "./dist/_app_/components/hds/icon/index.js",
       "./components/hds/interactive/index.js": "./dist/_app_/components/hds/interactive/index.js",
       "./components/hds/layout/flex/index.js": "./dist/_app_/components/hds/layout/flex/index.js",
+      "./components/hds/layout/flex/item.js": "./dist/_app_/components/hds/layout/flex/item.js",
       "./components/hds/link/inline.js": "./dist/_app_/components/hds/link/inline.js",
       "./components/hds/link/standalone.js": "./dist/_app_/components/hds/link/standalone.js",
       "./components/hds/menu-primitive/index.js": "./dist/_app_/components/hds/menu-primitive/index.js",

--- a/packages/components/src/components/hds/layout/flex/index.hbs
+++ b/packages/components/src/components/hds/layout/flex/index.hbs
@@ -1,0 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+{{! ADD YOUR TEMPLATE CONTENT HERE }}
+<div class={{this.classNames}} ...attributes>
+  {{yield}}
+</div>

--- a/packages/components/src/components/hds/layout/flex/index.hbs
+++ b/packages/components/src/components/hds/layout/flex/index.hbs
@@ -5,5 +5,7 @@
 {{#if (eq this.componentTag "div")}}
   <div class={{this.classNames}} ...attributes>{{yield (hash Item=(component "hds/layout/flex/item"))}}</div>
 {{else}}
-  {{#let (element this.componentTag) as |Tag|}}<Tag class={{this.classNames}} ...attributes>{{yield (hash Item=(component "hds/layout/flex/item"))}}</Tag>{{/let}}
+  {{#let (element this.componentTag) as |Tag|}}<Tag class={{this.classNames}} ...attributes>{{yield
+        (hash Item=(component "hds/layout/flex/item"))
+      }}</Tag>{{/let}}
 {{/if}}

--- a/packages/components/src/components/hds/layout/flex/index.hbs
+++ b/packages/components/src/components/hds/layout/flex/index.hbs
@@ -2,7 +2,8 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-{{! ADD YOUR TEMPLATE CONTENT HERE }}
-<div class={{this.classNames}} ...attributes>
-  {{yield}}
-</div>
+{{#if (eq this.componentTag "div")}}
+  <div class={{this.classNames}} ...attributes>{{yield}}</div>
+{{else}}
+  {{#let (element this.componentTag) as |Tag|}}<Tag class={{this.classNames}} ...attributes>{{yield}}</Tag>{{/let}}
+{{/if}}

--- a/packages/components/src/components/hds/layout/flex/index.hbs
+++ b/packages/components/src/components/hds/layout/flex/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 {{#if (eq this.componentTag "div")}}
-  <div class={{this.classNames}} ...attributes>{{yield}}</div>
+  <div class={{this.classNames}} ...attributes>{{yield (hash Item=(component "hds/layout/flex/item"))}}</div>
 {{else}}
-  {{#let (element this.componentTag) as |Tag|}}<Tag class={{this.classNames}} ...attributes>{{yield}}</Tag>{{/let}}
+  {{#let (element this.componentTag) as |Tag|}}<Tag class={{this.classNames}} ...attributes>{{yield (hash Item=(component "hds/layout/flex/item"))}}</Tag>{{/let}}
 {{/if}}

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -22,6 +22,8 @@ import type {
   HdsLayoutFlexJustifys,
   HdsLayoutFlexAligns,
   HdsLayoutFlexGaps,
+  AvailableTagNames,
+  AvailableElements,
 } from './types.ts';
 
 export const DEFAULT_DIRECTION = HdsLayoutFlexDirectionValues.Row;
@@ -29,11 +31,6 @@ export const DIRECTIONS: string[] = Object.values(HdsLayoutFlexDirectionValues);
 export const JUSTIFYS: string[] = Object.values(HdsLayoutFlexJustifyValues);
 export const ALIGNS: string[] = Object.values(HdsLayoutFlexAlignValues);
 export const GAPS: string[] = Object.values(HdsLayoutFlexGapValues);
-
-// A list of all existing tag names in the HTMLElementTagNameMap interface
-type AvailableTagNames = keyof HTMLElementTagNameMap;
-// A union of all types in the HTMLElementTagNameMap interface
-type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
 
 export interface HdsLayoutFlexSignature {
   Args: {

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -58,7 +58,6 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
   }
 
   get direction(): HdsLayoutFlexDirections {
-    // TODO! discuss with Kristin if we want to have an explicit default her, or just rely on the CSS default (it's the same)
     const { direction = DEFAULT_DIRECTION } = this.args;
 
     assert(

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -13,18 +13,21 @@ import {
   HdsLayoutFlexDirectionValues,
   HdsLayoutFlexJustifyValues,
   HdsLayoutFlexAlignValues,
+  HdsLayoutFlexGapValues,
 } from './types.ts';
 
 import type {
   HdsLayoutFlexDirections,
   HdsLayoutFlexJustifys,
   HdsLayoutFlexAligns,
+  HdsLayoutFlexGaps,
 } from './types.ts';
 
 export const DEFAULT_DIRECTION = HdsLayoutFlexDirectionValues.Row;
 export const DIRECTIONS: string[] = Object.values(HdsLayoutFlexDirectionValues);
 export const JUSTIFYS: string[] = Object.values(HdsLayoutFlexJustifyValues);
 export const ALIGNS: string[] = Object.values(HdsLayoutFlexAlignValues);
+export const GAPS: string[] = Object.values(HdsLayoutFlexGapValues);
 
 // A list of all existing tag names in the HTMLElementTagNameMap interface
 type AvailableTagNames = keyof HTMLElementTagNameMap;
@@ -38,6 +41,7 @@ export interface HdsLayoutFlexSignature {
     justify?: HdsLayoutFlexJustifys;
     align?: HdsLayoutFlexAligns;
     wrap?: boolean;
+    gap?: HdsLayoutFlexGaps | [HdsLayoutFlexGaps, HdsLayoutFlexGaps];
     isInline?: boolean;
   };
   Blocks: {
@@ -67,6 +71,13 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
     return this.args.align ?? undefined;
   }
 
+  get gap():
+    | HdsLayoutFlexGaps
+    | [HdsLayoutFlexGaps, HdsLayoutFlexGaps]
+    | undefined {
+    return this.args.gap ?? undefined;
+  }
+
   get classNames() {
     const classes = ['hds-layout-flex'];
 
@@ -81,6 +92,16 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
     // add a class based on the @align argument
     if (this.align) {
       classes.push(`hds-layout-flex--align-items-${this.align}`);
+    }
+
+    // add a class based on the @gap argument
+    if (this.gap) {
+      if (Array.isArray(this.gap) && this.gap.length === 2) {
+        classes.push(`hds-layout-flex--row-gap-${this.gap[0]}`);
+        classes.push(`hds-layout-flex--column-gap-${this.gap[1]}`);
+      } else {
+        classes.push(`hds-layout-flex--gap-${this.gap}`);
+      }
     }
 
     // add a class based on the @wrap argument

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -5,34 +5,32 @@
 
 import Component from '@glimmer/component';
 
+import { HdsLayoutFlexDirectionValues } from './types.ts';
+
+import type { HdsLayoutFlexDirections } from './types.ts';
+
+export const DEFAULT_DIRECTION = HdsLayoutFlexDirectionValues.Row;
+export const DIRECTIONS: string[] = Object.values(HdsLayoutFlexDirectionValues);
 export interface HdsLayoutFlexSignature {
-  // The arguments accepted by the component
-  Args: {};
-  // Any blocks yielded by the component
+  Args: {
+    direction?: HdsLayoutFlexDirections;
+  };
   Blocks: {
     default: [];
   };
-  // The element to which `...attributes` is applied in the component template
   Element: HTMLDivElement;
 }
 
 export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
-  // UNCOMMENT THIS IF YOU NEED A CONSTRUCTOR
-  // constructor() {
-  //   super(...arguments);
-  //   // ADD YOUR ASSERTIONS HERE
-  // }
+  get direction(): HdsLayoutFlexDirections {
+    return this.args.direction ?? DEFAULT_DIRECTION;
+  }
 
-  /**
-   * Get the class names to apply to the component.
-   * @method classNames
-   * @return {string} The "class" attribute to apply to the component.
-   */
   get classNames() {
-    let classes = ['hds-layout-flex'];
+    const classes = ['hds-layout-flex'];
 
-    // add a class based on the @xxx argument
-    // classes.push(`hds-layout-flex--[variant]-${this.xxx}`);
+    // add a class based on the @direction argument
+    classes.push(`hds-layout-flex--direction-${this.direction}`);
 
     return classes.join(' ');
   }

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -22,8 +22,14 @@ export const DIRECTIONS: string[] = Object.values(HdsLayoutFlexDirectionValues);
 export const JUSTIFYS: string[] = Object.values(HdsLayoutFlexJustifyValues);
 export const ALIGNS: string[] = Object.values(HdsLayoutFlexAlignValues);
 
+// A list of all existing tag names in the HTMLElementTagNameMap interface
+type AvailableTagNames = keyof HTMLElementTagNameMap;
+// A union of all types in the HTMLElementTagNameMap interface
+type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
+
 export interface HdsLayoutFlexSignature {
   Args: {
+    tag?: AvailableTagNames;
     direction?: HdsLayoutFlexDirections;
     justify?: HdsLayoutFlexJustifys;
     align?: HdsLayoutFlexAligns;
@@ -33,10 +39,14 @@ export interface HdsLayoutFlexSignature {
   Blocks: {
     default: [];
   };
-  Element: HTMLDivElement;
+  Element: AvailableElements;
 }
 
 export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
+  get componentTag(): AvailableTagNames {
+    return this.args.tag ?? 'div';
+  }
+
   get direction(): HdsLayoutFlexDirections {
     return this.args.direction ?? DEFAULT_DIRECTION;
   }

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -14,6 +14,7 @@ export const DIRECTIONS: string[] = Object.values(HdsLayoutFlexDirectionValues);
 export interface HdsLayoutFlexSignature {
   Args: {
     direction?: HdsLayoutFlexDirections;
+    wrap?: boolean;
     isInline?: boolean;
   };
   Blocks: {
@@ -32,6 +33,11 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
 
     // add a class based on the @direction argument
     classes.push(`hds-layout-flex--direction-${this.direction}`);
+
+    // add a class based on the @wrap argument
+    if (this.args.wrap) {
+      classes.push('hds-layout-flex--has-wrapping');
+    }
 
     // add a class based on the @isInline argument
     if (this.args.isInline) {

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -5,15 +5,28 @@
 
 import Component from '@glimmer/component';
 
-import { HdsLayoutFlexDirectionValues } from './types.ts';
+import {
+  HdsLayoutFlexDirectionValues,
+  HdsLayoutFlexJustifyValues,
+  HdsLayoutFlexAlignValues,
+} from './types.ts';
 
-import type { HdsLayoutFlexDirections } from './types.ts';
+import type {
+  HdsLayoutFlexDirections,
+  HdsLayoutFlexJustifys,
+  HdsLayoutFlexAligns,
+} from './types.ts';
 
 export const DEFAULT_DIRECTION = HdsLayoutFlexDirectionValues.Row;
 export const DIRECTIONS: string[] = Object.values(HdsLayoutFlexDirectionValues);
+export const JUSTIFYS: string[] = Object.values(HdsLayoutFlexJustifyValues);
+export const ALIGNS: string[] = Object.values(HdsLayoutFlexAlignValues);
+
 export interface HdsLayoutFlexSignature {
   Args: {
     direction?: HdsLayoutFlexDirections;
+    justify?: HdsLayoutFlexJustifys;
+    align?: HdsLayoutFlexAligns;
     wrap?: boolean;
     isInline?: boolean;
   };
@@ -28,11 +41,29 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
     return this.args.direction ?? DEFAULT_DIRECTION;
   }
 
+  get justify(): HdsLayoutFlexJustifys | undefined {
+    return this.args.justify ?? undefined;
+  }
+
+  get align(): HdsLayoutFlexAligns | undefined {
+    return this.args.align ?? undefined;
+  }
+
   get classNames() {
     const classes = ['hds-layout-flex'];
 
     // add a class based on the @direction argument
     classes.push(`hds-layout-flex--direction-${this.direction}`);
+
+    // add a class based on the @justify argument
+    if (this.justify) {
+      classes.push(`hds-layout-flex--justify-content-${this.justify}`);
+    }
+
+    // add a class based on the @align argument
+    if (this.align) {
+      classes.push(`hds-layout-flex--align-items-${this.align}`);
+    }
 
     // add a class based on the @wrap argument
     if (this.args.wrap) {

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -14,6 +14,7 @@ export const DIRECTIONS: string[] = Object.values(HdsLayoutFlexDirectionValues);
 export interface HdsLayoutFlexSignature {
   Args: {
     direction?: HdsLayoutFlexDirections;
+    isInline?: boolean;
   };
   Blocks: {
     default: [];
@@ -31,6 +32,11 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
 
     // add a class based on the @direction argument
     classes.push(`hds-layout-flex--direction-${this.direction}`);
+
+    // add a class based on the @isInline argument
+    if (this.args.isInline) {
+      classes.push('hds-layout-flex--is-inline');
+    }
 
     return classes.join(' ');
   }

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+
+export interface HdsLayoutFlexSignature {
+  // The arguments accepted by the component
+  Args: {};
+  // Any blocks yielded by the component
+  Blocks: {
+    default: [];
+  };
+  // The element to which `...attributes` is applied in the component template
+  Element: HTMLDivElement;
+}
+
+export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
+  // UNCOMMENT THIS IF YOU NEED A CONSTRUCTOR
+  // constructor() {
+  //   super(...arguments);
+  //   // ADD YOUR ASSERTIONS HERE
+  // }
+
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames() {
+    let classes = ['hds-layout-flex'];
+
+    // add a class based on the @xxx argument
+    // classes.push(`hds-layout-flex--[variant]-${this.xxx}`);
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -4,6 +4,7 @@
  */
 
 import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
 
 import type { ComponentLike } from '@glint/template';
 
@@ -60,22 +61,69 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
   }
 
   get direction(): HdsLayoutFlexDirections {
-    return this.args.direction ?? DEFAULT_DIRECTION;
+    const { direction = DEFAULT_DIRECTION } = this.args;
+
+    assert(
+      `@direction for "Hds::Layout::Flex" must be one of the following: ${DIRECTIONS.join(
+        ', '
+      )}; received: ${direction}`,
+      DIRECTIONS.includes(direction)
+    );
+
+    return direction;
   }
 
   get justify(): HdsLayoutFlexJustifys | undefined {
-    return this.args.justify ?? undefined;
+    const { justify } = this.args;
+
+    if (justify) {
+      assert(
+        `@justify for "Hds::Layout::Flex" must be one of the following: ${JUSTIFYS.join(
+          ', '
+        )}; received: ${justify}`,
+        JUSTIFYS.includes(justify)
+      );
+    }
+
+    return justify;
   }
 
   get align(): HdsLayoutFlexAligns | undefined {
-    return this.args.align ?? undefined;
+    const { align } = this.args;
+
+    if (align) {
+      assert(
+        `@align for "Hds::Layout::Flex" must be one of the following: ${ALIGNS.join(
+          ', '
+        )}; received: ${align}`,
+        ALIGNS.includes(align)
+      );
+    }
+
+    return align;
   }
 
   get gap():
-    | HdsLayoutFlexGaps
+    | [HdsLayoutFlexGaps]
     | [HdsLayoutFlexGaps, HdsLayoutFlexGaps]
     | undefined {
-    return this.args.gap ?? undefined;
+    const { gap } = this.args;
+
+    if (gap) {
+      assert(
+        `@gap for "Hds::Layout::Flex" must be a single value or an array of two values of one of the following: ${GAPS.join(
+          ', '
+        )}; received: ${gap}`,
+        (!Array.isArray(gap) && GAPS.includes(gap)) ||
+          (Array.isArray(gap) &&
+            gap.length === 2 &&
+            GAPS.includes(gap[0]) &&
+            GAPS.includes(gap[1]))
+      );
+      return Array.isArray(gap) ? gap : [gap];
+    } else {
+      return undefined;
+    }
   }
 
   get classNames() {
@@ -96,11 +144,11 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
 
     // add a class based on the @gap argument
     if (this.gap) {
-      if (Array.isArray(this.gap) && this.gap.length === 2) {
+      if (this.gap.length === 2) {
         classes.push(`hds-layout-flex--row-gap-${this.gap[0]}`);
         classes.push(`hds-layout-flex--column-gap-${this.gap[1]}`);
-      } else {
-        classes.push(`hds-layout-flex--gap-${this.gap}`);
+      } else if (this.gap.length === 1) {
+        classes.push(`hds-layout-flex--gap-${this.gap[0]}`);
       }
     }
 

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -5,6 +5,10 @@
 
 import Component from '@glimmer/component';
 
+import type { ComponentLike } from '@glint/template';
+
+import type { HdsLayoutFlexItemSignature } from './item.ts';
+
 import {
   HdsLayoutFlexDirectionValues,
   HdsLayoutFlexJustifyValues,
@@ -37,7 +41,11 @@ export interface HdsLayoutFlexSignature {
     isInline?: boolean;
   };
   Blocks: {
-    default: [];
+    default: [
+      {
+        Item?: ComponentLike<HdsLayoutFlexItemSignature>;
+      }
+    ];
   };
   Element: AvailableElements;
 }

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -44,7 +44,7 @@ export interface HdsLayoutFlexSignature {
     default: [
       {
         Item?: ComponentLike<HdsLayoutFlexItemSignature>;
-      }
+      },
     ];
   };
   Element: AvailableElements;

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -61,6 +61,7 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
   }
 
   get direction(): HdsLayoutFlexDirections {
+    // TODO! discuss with Kristin if we want to have an explicit default her, or just rely on the CSS default (it's the same)
     const { direction = DEFAULT_DIRECTION } = this.args;
 
     assert(

--- a/packages/components/src/components/hds/layout/flex/item.hbs
+++ b/packages/components/src/components/hds/layout/flex/item.hbs
@@ -1,0 +1,9 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+{{#if (eq this.componentTag "div")}}
+  <div class={{this.classNames}} {{style this.inlineStyles}} ...attributes>{{yield}}</div>
+{{else}}
+  {{#let (element this.componentTag) as |Tag|}}<Tag class={{this.classNames}} {{style this.inlineStyles}} ...attributes>{{yield}}</Tag>{{/let}}
+{{/if}}

--- a/packages/components/src/components/hds/layout/flex/item.hbs
+++ b/packages/components/src/components/hds/layout/flex/item.hbs
@@ -5,5 +5,9 @@
 {{#if (eq this.componentTag "div")}}
   <div class={{this.classNames}} {{style this.inlineStyles}} ...attributes>{{yield}}</div>
 {{else}}
-  {{#let (element this.componentTag) as |Tag|}}<Tag class={{this.classNames}} {{style this.inlineStyles}} ...attributes>{{yield}}</Tag>{{/let}}
+  {{#let (element this.componentTag) as |Tag|}}<Tag
+      class={{this.classNames}}
+      {{style this.inlineStyles}}
+      ...attributes
+    >{{yield}}</Tag>{{/let}}
 {{/if}}

--- a/packages/components/src/components/hds/layout/flex/item.ts
+++ b/packages/components/src/components/hds/layout/flex/item.ts
@@ -13,7 +13,7 @@ type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
 export interface HdsLayoutFlexItemSignature {
   Args: {
     tag?: AvailableTagNames;
-    basis?: string;
+    basis?: string | 0;
     grow?: boolean | number | string;
     shrink?: boolean | number | string;
   };
@@ -36,7 +36,10 @@ export default class HdsLayoutFlexItem extends Component<HdsLayoutFlexItemSignat
     } = {};
 
     // we handle all cases of `basis` values via inline styles
-    if (this.args.basis) {
+    if (typeof this.args.basis === 'number' && this.args.basis === 0) {
+      // the `{{style}}` modifier accepts only strings
+      inlineStyles['flex-basis'] = this.args.basis.toString();
+    } else if (typeof this.args.basis === 'string') {
       inlineStyles['flex-basis'] = this.args.basis;
     }
 

--- a/packages/components/src/components/hds/layout/flex/item.ts
+++ b/packages/components/src/components/hds/layout/flex/item.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+
+// A list of all existing tag names in the HTMLElementTagNameMap interface
+type AvailableTagNames = keyof HTMLElementTagNameMap;
+// A union of all types in the HTMLElementTagNameMap interface
+type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
+
+export interface HdsLayoutFlexItemSignature {
+  Args: {
+    tag?: AvailableTagNames;
+    basis?: string;
+    grow?: boolean | number | string;
+    shrink?: boolean | number | string;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: AvailableElements;
+}
+
+export default class HdsLayoutFlexItem extends Component<HdsLayoutFlexItemSignature> {
+  get componentTag(): AvailableTagNames {
+    return this.args.tag ?? 'div';
+  }
+
+  get inlineStyles(): Record<string, unknown> {
+    const inlineStyles: {
+      'flex-basis'?: string;
+      'flex-grow'?: string;
+      'flex-shrink'?: string;
+    } = {};
+
+    // we handle all cases of `basis` values via inline styles
+    if (this.args.basis) {
+      inlineStyles['flex-basis'] = this.args.basis;
+    }
+
+    // we handle non-standard cases of `grow` values via inline styles
+    if (typeof this.args.grow === 'number' && this.args.grow > 1) {
+      // the `{{style}}` modifier accepts only strings
+      inlineStyles['flex-grow'] = this.args.grow.toString();
+    } else if (typeof this.args.grow === 'string') {
+      inlineStyles['flex-grow'] = this.args.grow;
+    }
+
+    // we handle non-standard cases of `shrink` values via inline styles
+    if (typeof this.args.shrink === 'number' && this.args.shrink > 1) {
+      // the `{{style}}` modifier accepts only strings
+      inlineStyles['flex-shrink'] = this.args.shrink.toString();
+    } else if (typeof this.args.shrink === 'string') {
+      inlineStyles['flex-shrink'] = this.args.shrink;
+    }
+
+    return inlineStyles;
+  }
+
+  get classNames() {
+    const classes = ['hds-layout-flex-item'];
+
+    // add a class based on the @grow argument (if set to `0/1` or `true/false`)
+    if (this.args.grow === 0 || this.args.grow === false) {
+      classes.push('hds-layout-flex-item--grow-0');
+    } else if (this.args.grow === 1 || this.args.grow === true) {
+      classes.push('hds-layout-flex-item--grow-1');
+    }
+
+    // add a class based on the @shrink argument (if set to `0/1` or `true/false`)
+    if (this.args.shrink === 0 || this.args.shrink === false) {
+      classes.push('hds-layout-flex-item--shrink-0');
+    } else if (this.args.shrink === 1 || this.args.shrink === true) {
+      classes.push('hds-layout-flex-item--shrink-1');
+    }
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/src/components/hds/layout/flex/item.ts
+++ b/packages/components/src/components/hds/layout/flex/item.ts
@@ -16,6 +16,8 @@ export interface HdsLayoutFlexItemSignature {
     basis?: string | 0;
     grow?: boolean | number | string;
     shrink?: boolean | number | string;
+    // TODO final name TBD
+    enableCollapseBelowContentSize?: boolean;
   };
   Blocks: {
     default: [];
@@ -77,6 +79,11 @@ export default class HdsLayoutFlexItem extends Component<HdsLayoutFlexItemSignat
       classes.push('hds-layout-flex-item--shrink-0');
     } else if (this.args.shrink === 1 || this.args.shrink === true) {
       classes.push('hds-layout-flex-item--shrink-1');
+    }
+
+    // add a class based on the @enableCollapseBelowContentSize argument (applies a `min-width: 0`)
+    if (this.args.enableCollapseBelowContentSize) {
+      classes.push('hds-layout-flex-item--enable-collapse-below-content-size');
     }
 
     return classes.join(' ');

--- a/packages/components/src/components/hds/layout/flex/item.ts
+++ b/packages/components/src/components/hds/layout/flex/item.ts
@@ -37,11 +37,8 @@ export default class HdsLayoutFlexItem extends Component<HdsLayoutFlexItemSignat
       'flex-shrink'?: string;
     } = {};
 
-    // we handle all cases of `basis` values via inline styles
-    if (typeof this.args.basis === 'number' && this.args.basis === 0) {
-      // the `{{style}}` modifier accepts only strings
-      inlineStyles['flex-basis'] = this.args.basis.toString();
-    } else if (typeof this.args.basis === 'string') {
+    // we handle all non-zero cases of `basis` values via inline styles
+    if (typeof this.args.basis === 'string') {
       inlineStyles['flex-basis'] = this.args.basis;
     }
 
@@ -66,6 +63,11 @@ export default class HdsLayoutFlexItem extends Component<HdsLayoutFlexItemSignat
 
   get classNames() {
     const classes = ['hds-layout-flex-item'];
+
+    // add a class based on the @basis argument (if set to `0`)
+    if (this.args.basis === 0) {
+      classes.push('hds-layout-flex-item--basis-0');
+    }
 
     // add a class based on the @grow argument (if set to `0/1` or `true/false`)
     if (this.args.grow === 0 || this.args.grow === false) {

--- a/packages/components/src/components/hds/layout/flex/item.ts
+++ b/packages/components/src/components/hds/layout/flex/item.ts
@@ -5,10 +5,7 @@
 
 import Component from '@glimmer/component';
 
-// A list of all existing tag names in the HTMLElementTagNameMap interface
-type AvailableTagNames = keyof HTMLElementTagNameMap;
-// A union of all types in the HTMLElementTagNameMap interface
-type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
+import type { AvailableTagNames, AvailableElements } from './types.ts';
 
 export interface HdsLayoutFlexItemSignature {
   Args: {

--- a/packages/components/src/components/hds/layout/flex/types.ts
+++ b/packages/components/src/components/hds/layout/flex/types.ts
@@ -41,3 +41,9 @@ export enum HdsLayoutFlexGapValues {
 }
 
 export type HdsLayoutFlexGaps = `${HdsLayoutFlexGapValues}`;
+
+// A list of all existing tag names in the HTMLElementTagNameMap interface
+export type AvailableTagNames = keyof HTMLElementTagNameMap;
+// A union of all types in the HTMLElementTagNameMap interface
+export type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
+

--- a/packages/components/src/components/hds/layout/flex/types.ts
+++ b/packages/components/src/components/hds/layout/flex/types.ts
@@ -29,3 +29,15 @@ export enum HdsLayoutFlexAlignValues {
 }
 
 export type HdsLayoutFlexAligns = `${HdsLayoutFlexAlignValues}`;
+
+export enum HdsLayoutFlexGapValues {
+  'Four' = '4',
+  'Eight' = '8',
+  'Twelve' = '12',
+  'Sixteen' = '16',
+  'Twentyfour' = '24',
+  'Thirtytwo' = '32',
+  'Fortyeight' = '48',
+}
+
+export type HdsLayoutFlexGaps = `${HdsLayoutFlexGapValues}`;

--- a/packages/components/src/components/hds/layout/flex/types.ts
+++ b/packages/components/src/components/hds/layout/flex/types.ts
@@ -29,4 +29,3 @@ export enum HdsLayoutFlexAlignValues {
 }
 
 export type HdsLayoutFlexAligns = `${HdsLayoutFlexAlignValues}`;
-

--- a/packages/components/src/components/hds/layout/flex/types.ts
+++ b/packages/components/src/components/hds/layout/flex/types.ts
@@ -9,3 +9,24 @@ export enum HdsLayoutFlexDirectionValues {
 }
 
 export type HdsLayoutFlexDirections = `${HdsLayoutFlexDirectionValues}`;
+
+export enum HdsLayoutFlexJustifyValues {
+  Start = 'start',
+  Center = 'center',
+  End = 'end',
+  SpaceBetween = 'space-between',
+  SpaceAround = 'space-around',
+  SpaceEvenly = 'space-evenly',
+}
+
+export type HdsLayoutFlexJustifys = `${HdsLayoutFlexJustifyValues}`;
+
+export enum HdsLayoutFlexAlignValues {
+  Start = 'start',
+  Center = 'center',
+  End = 'end',
+  Stretch = 'stretch',
+}
+
+export type HdsLayoutFlexAligns = `${HdsLayoutFlexAlignValues}`;
+

--- a/packages/components/src/components/hds/layout/flex/types.ts
+++ b/packages/components/src/components/hds/layout/flex/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export enum HdsLayoutFlexDirectionValues {
+  Row = 'row',
+  Column = 'column',
+}
+
+export type HdsLayoutFlexDirections = `${HdsLayoutFlexDirectionValues}`;

--- a/packages/components/src/components/hds/layout/grid/index.hbs
+++ b/packages/components/src/components/hds/layout/grid/index.hbs
@@ -4,12 +4,12 @@
 }}
 
 {{#if (eq this.componentTag "div")}}
-  <div class={{this.classNames}} {{style this.columnMinWidthStyle}} ...attributes>
+  <div class={{this.classNames}} {{style this.inlineStyles}} ...attributes>
     {{yield (hash Item=(component "hds/layout/grid/item"))}}
   </div>
 {{else}}
   {{#let (element this.componentTag) as |Tag|}}
-    <Tag class={{this.classNames}} {{style this.columnMinWidthStyle}} ...attributes>
+    <Tag class={{this.classNames}} {{style this.inlineStyles}} ...attributes>
       {{yield (hash Item=(component "hds/layout/grid/item"))}}
     </Tag>
   {{/let}}

--- a/packages/components/src/components/hds/layout/grid/index.hbs
+++ b/packages/components/src/components/hds/layout/grid/index.hbs
@@ -1,0 +1,21 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{!
+  TODO: Determine if Grid needs its own "Item" child component or should use the Flex::Item 
+  (if so, maybe change name to Layout::Item)
+}}
+
+{{#if (eq this.componentTag "div")}}
+  <div class={{this.classNames}} ...attributes>
+    {{yield (hash Item=(component "hds/layout/flex/item"))}}
+  </div>
+{{else}}
+  {{#let (element this.componentTag) as |Tag|}}
+    <Tag class={{this.classNames}} ...attributes>
+      {{yield (hash Item=(component "hds/layout/flex/item"))}}
+    </Tag>
+  {{/let}}
+{{/if}}

--- a/packages/components/src/components/hds/layout/grid/index.hbs
+++ b/packages/components/src/components/hds/layout/grid/index.hbs
@@ -3,19 +3,14 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{!
-  TODO: Determine if Grid needs its own "Item" child component or should use the Flex::Item 
-  (if so, maybe change name to Layout::Item)
-}}
-
 {{#if (eq this.componentTag "div")}}
-  <div class={{this.classNames}} ...attributes>
-    {{yield (hash Item=(component "hds/layout/flex/item"))}}
+  <div class={{this.classNames}} {{style this.columnMinWidthStyle}} ...attributes>
+    {{yield (hash Item=(component "hds/layout/grid/item"))}}
   </div>
 {{else}}
   {{#let (element this.componentTag) as |Tag|}}
-    <Tag class={{this.classNames}} ...attributes>
-      {{yield (hash Item=(component "hds/layout/flex/item"))}}
+    <Tag class={{this.classNames}} {{style this.columnMinWidthStyle}} ...attributes>
+      {{yield (hash Item=(component "hds/layout/grid/item"))}}
     </Tag>
   {{/let}}
 {{/if}}

--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -11,15 +11,15 @@ import type { HdsLayoutGridItemSignature } from '../grid/item.ts';
 
 import { HdsLayoutGridAlignValues, HdsLayoutGridGapValues } from './types.ts';
 
-import type { HdsLayoutGridAligns, HdsLayoutGridGaps } from './types.ts';
+import type {
+  HdsLayoutGridAligns,
+  HdsLayoutGridGaps,
+  AvailableTagNames,
+  AvailableElements,
+} from './types.ts';
 
 export const ALIGNS: string[] = Object.values(HdsLayoutGridAlignValues);
 export const GAPS: string[] = Object.values(HdsLayoutGridGapValues);
-
-// A list of all existing tag names in the HTMLElementTagNameMap interface
-type AvailableTagNames = keyof HTMLElementTagNameMap;
-// A union of all types in the HTMLElementTagNameMap interface
-type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
 
 export interface HdsLayoutGridSignature {
   Args: {
@@ -40,17 +40,6 @@ export interface HdsLayoutGridSignature {
 }
 
 export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
-  get columnMinWidthStyle(): Record<string, string> {
-    const columnMinWidthStyle: { [key: string]: string } = {};
-
-    // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as the default col min width
-    // https://drafts.csswg.org/css-values/#calc-type-checking
-    columnMinWidthStyle['--hds-layout-grid-column-min-width'] =
-      this.args.columnMinWidth ?? '0px';
-
-    return columnMinWidthStyle;
-  }
-
   get componentTag(): AvailableTagNames {
     return this.args.tag ?? 'div';
   }
@@ -91,6 +80,17 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
     } else {
       return undefined;
     }
+  }
+
+  get columnMinWidthStyle(): Record<string, string> {
+    const columnMinWidthStyle: { [key: string]: string } = {};
+
+    // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as the default col min width
+    // https://drafts.csswg.org/css-values/#calc-type-checking
+    columnMinWidthStyle['--hds-layout-grid-column-min-width'] =
+      this.args.columnMinWidth ?? '0px';
+
+    return columnMinWidthStyle;
   }
 
   get classNames(): string {

--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -53,7 +53,8 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
   get columnMinWidthStyle(): Record<string, string> {
     const columnMinWidthStyle: { [key: string]: string } = {};
 
-    // Note: 0px value requires unit to work in calculation
+    // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as the default col min width
+    // https://drafts.csswg.org/css-values/#calc-type-checking
     columnMinWidthStyle['--hds-layout-grid-column-min-width'] =
       this.args.columnMinWidth ?? '0px';
 

--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -87,11 +87,10 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
       '--hds-layout-grid-column-min-width'?: string;
     } = {};
 
-    // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as the default col min width
-    // https://drafts.csswg.org/css-values/#calc-type-checking
-    inlineStyles['--hds-layout-grid-column-min-width'] =
-      this.args.columnMinWidth ?? '0px';
-
+    if (this.args.columnMinWidth) {
+      inlineStyles['--hds-layout-grid-column-min-width'] =
+        this.args.columnMinWidth;
+    }
     return inlineStyles;
   }
 

--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import type { ComponentLike } from '@glint/template';
+// TODO: Determine if "GridItem" should be created & used instead of "FlexItem"
+import type { HdsLayoutFlexItemSignature } from '../flex/item.ts';
+
+// A list of all existing tag names in the HTMLElementTagNameMap interface
+type AvailableTagNames = keyof HTMLElementTagNameMap;
+// A union of all types in the HTMLElementTagNameMap interface
+type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
+
+export interface HdsLayoutGridSignature {
+  Args: {
+    tag?: AvailableTagNames;
+    isInline?: boolean;
+  };
+  Blocks: {
+    default: [
+      {
+        // TODO: Determine if "GridItem" should be created & used instead of "FlexItem"
+        Item?: ComponentLike<HdsLayoutFlexItemSignature>;
+      },
+    ];
+  };
+  Element: AvailableElements;
+}
+// More info on types and signatures: https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3245932580/Using+Typescript
+
+export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
+  get componentTag(): AvailableTagNames {
+    return this.args.tag ?? 'div';
+  }
+
+  /**
+   * Get the class names to apply to the component.
+   * @method classNames
+   * @return {string} The "class" attribute to apply to the component.
+   */
+  get classNames(): string {
+    const classes = ['hds-layout-grid'];
+
+    // add a class based on the @xxx argument
+    // classes.push(`hds-layout-grid--[variant]-${this.xxx}`);
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -53,6 +53,7 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
   get columnMinWidthStyle(): Record<string, string> {
     const columnMinWidthStyle: { [key: string]: string } = {};
 
+    // Note: 0px value requires unit to work in calculation
     columnMinWidthStyle['--hds-layout-grid-column-min-width'] =
       this.args.columnMinWidth ?? '0px';
 

--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -112,6 +112,11 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
   get classNames(): string {
     const classes = ['hds-layout-grid'];
 
+    // add a class based on the @justify argument
+    if (this.justify) {
+      classes.push(`hds-layout-grid--justify-content-${this.justify}`);
+    }
+
     // add a class based on the @align argument
     if (this.align) {
       classes.push(`hds-layout-grid--align-items-${this.align}`);

--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -82,15 +82,17 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
     }
   }
 
-  get columnMinWidthStyle(): Record<string, string> {
-    const columnMinWidthStyle: { [key: string]: string } = {};
+  get inlineStyles(): Record<string, unknown> {
+    const inlineStyles: {
+      '--hds-layout-grid-column-min-width'?: string;
+    } = {};
 
     // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as the default col min width
     // https://drafts.csswg.org/css-values/#calc-type-checking
-    columnMinWidthStyle['--hds-layout-grid-column-min-width'] =
+    inlineStyles['--hds-layout-grid-column-min-width'] =
       this.args.columnMinWidth ?? '0px';
 
-    return columnMinWidthStyle;
+    return inlineStyles;
   }
 
   get classNames(): string {

--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -7,8 +7,7 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
 import type { ComponentLike } from '@glint/template';
-// TODO: Determine if "GridItem" should be created & used instead of "FlexItem"
-import type { HdsLayoutFlexItemSignature } from '../flex/item.ts';
+import type { HdsLayoutGridItemSignature } from '../grid/item.ts';
 
 import {
   HdsLayoutGridJustifyValues,
@@ -34,6 +33,7 @@ type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
 export interface HdsLayoutGridSignature {
   Args: {
     tag?: AvailableTagNames;
+    columnMinWidth?: string;
     justify?: HdsLayoutGridJustifys;
     align?: HdsLayoutGridAligns;
     gap?: HdsLayoutGridGaps | [HdsLayoutGridGaps, HdsLayoutGridGaps];
@@ -42,16 +42,23 @@ export interface HdsLayoutGridSignature {
   Blocks: {
     default: [
       {
-        // TODO: Determine if "GridItem" should be created & used instead of "FlexItem"
-        Item?: ComponentLike<HdsLayoutFlexItemSignature>;
+        Item?: ComponentLike<HdsLayoutGridItemSignature>;
       },
     ];
   };
   Element: AvailableElements;
 }
-// More info on types and signatures: https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3245932580/Using+Typescript
 
 export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
+  get columnMinWidthStyle(): Record<string, string> {
+    const columnMinWidthStyle: { [key: string]: string } = {};
+
+    columnMinWidthStyle['--hds-layout-grid-column-min-width'] =
+      this.args.columnMinWidth ?? '0px';
+
+    return columnMinWidthStyle;
+  }
+
   get componentTag(): AvailableTagNames {
     return this.args.tag ?? 'div';
   }

--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -9,19 +9,10 @@ import { assert } from '@ember/debug';
 import type { ComponentLike } from '@glint/template';
 import type { HdsLayoutGridItemSignature } from '../grid/item.ts';
 
-import {
-  HdsLayoutGridJustifyValues,
-  HdsLayoutGridAlignValues,
-  HdsLayoutGridGapValues,
-} from './types.ts';
+import { HdsLayoutGridAlignValues, HdsLayoutGridGapValues } from './types.ts';
 
-import type {
-  HdsLayoutGridJustifys,
-  HdsLayoutGridAligns,
-  HdsLayoutGridGaps,
-} from './types.ts';
+import type { HdsLayoutGridAligns, HdsLayoutGridGaps } from './types.ts';
 
-export const JUSTIFYS: string[] = Object.values(HdsLayoutGridJustifyValues);
 export const ALIGNS: string[] = Object.values(HdsLayoutGridAlignValues);
 export const GAPS: string[] = Object.values(HdsLayoutGridGapValues);
 
@@ -34,7 +25,6 @@ export interface HdsLayoutGridSignature {
   Args: {
     tag?: AvailableTagNames;
     columnMinWidth?: string;
-    justify?: HdsLayoutGridJustifys;
     align?: HdsLayoutGridAligns;
     gap?: HdsLayoutGridGaps | [HdsLayoutGridGaps, HdsLayoutGridGaps];
     isInline?: boolean;
@@ -63,21 +53,6 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
 
   get componentTag(): AvailableTagNames {
     return this.args.tag ?? 'div';
-  }
-
-  get justify(): HdsLayoutGridJustifys | undefined {
-    const { justify } = this.args;
-
-    if (justify) {
-      assert(
-        `@justify for "Hds::Layout::Grid" must be one of the following: ${JUSTIFYS.join(
-          ', '
-        )}; received: ${justify}`,
-        JUSTIFYS.includes(justify)
-      );
-    }
-
-    return justify;
   }
 
   get align(): HdsLayoutGridAligns | undefined {
@@ -120,11 +95,6 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
 
   get classNames(): string {
     const classes = ['hds-layout-grid'];
-
-    // add a class based on the @justify argument
-    if (this.justify) {
-      classes.push(`hds-layout-grid--justify-content-${this.justify}`);
-    }
 
     // add a class based on the @align argument
     if (this.align) {

--- a/packages/components/src/components/hds/layout/grid/item.hbs
+++ b/packages/components/src/components/hds/layout/grid/item.hbs
@@ -4,10 +4,10 @@
 }}
 
 {{#if (eq this.componentTag "div")}}
-  <div class={{this.classNames}} ...attributes>{{yield}}</div>
+  <div class={{this.classNames}} {{style this.colSpanStyle this.rowSpanStyle}} ...attributes>{{yield}}</div>
 {{else}}
   {{#let (element this.componentTag) as |Tag|}}
-    <Tag class={{this.classNames}} ...attributes>
+    <Tag class={{this.classNames}} {{style this.colSpanStyle this.rowSpanStyle}} ...attributes>
       {{yield}}
     </Tag>
   {{/let}}

--- a/packages/components/src/components/hds/layout/grid/item.hbs
+++ b/packages/components/src/components/hds/layout/grid/item.hbs
@@ -1,0 +1,14 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{#if (eq this.componentTag "div")}}
+  <div class={{this.classNames}} ...attributes>{{yield}}</div>
+{{else}}
+  {{#let (element this.componentTag) as |Tag|}}
+    <Tag class={{this.classNames}} ...attributes>
+      {{yield}}
+    </Tag>
+  {{/let}}
+{{/if}}

--- a/packages/components/src/components/hds/layout/grid/item.hbs
+++ b/packages/components/src/components/hds/layout/grid/item.hbs
@@ -4,10 +4,10 @@
 }}
 
 {{#if (eq this.componentTag "div")}}
-  <div class={{this.classNames}} {{style this.colSpanStyle this.rowSpanStyle}} ...attributes>{{yield}}</div>
+  <div class="hds-layout-grid-item" {{style this.colSpanStyle this.rowSpanStyle}} ...attributes>{{yield}}</div>
 {{else}}
   {{#let (element this.componentTag) as |Tag|}}
-    <Tag class={{this.classNames}} {{style this.colSpanStyle this.rowSpanStyle}} ...attributes>
+    <Tag class="hds-layout-grid-item" {{style this.colSpanStyle this.rowSpanStyle}} ...attributes>
       {{yield}}
     </Tag>
   {{/let}}

--- a/packages/components/src/components/hds/layout/grid/item.hbs
+++ b/packages/components/src/components/hds/layout/grid/item.hbs
@@ -4,10 +4,10 @@
 }}
 
 {{#if (eq this.componentTag "div")}}
-  <div class="hds-layout-grid-item" {{style this.colSpanStyle this.rowSpanStyle}} ...attributes>{{yield}}</div>
+  <div class="hds-layout-grid-item" {{style this.inlineStyles}} ...attributes>{{yield}}</div>
 {{else}}
   {{#let (element this.componentTag) as |Tag|}}
-    <Tag class="hds-layout-grid-item" {{style this.colSpanStyle this.rowSpanStyle}} ...attributes>
+    <Tag class="hds-layout-grid-item" {{style this.inlineStyles}} ...attributes>
       {{yield}}
     </Tag>
   {{/let}}

--- a/packages/components/src/components/hds/layout/grid/item.ts
+++ b/packages/components/src/components/hds/layout/grid/item.ts
@@ -30,8 +30,12 @@ export default class HdsLayoutFlexItem extends Component<HdsLayoutGridItemSignat
       '--hds-layout-grid-row-span'?: string;
     } = {};
 
-    inlineStyles['--hds-layout-grid-column-span'] = this.args.colSpan ?? '1';
-    inlineStyles['--hds-layout-grid-row-span'] = this.args.rowSpan ?? '1';
+    if (this.args.colSpan) {
+      inlineStyles['--hds-layout-grid-column-span'] = this.args.colSpan;
+    }
+    if (this.args.rowSpan) {
+      inlineStyles['--hds-layout-grid-row-span'] = this.args.rowSpan;
+    }
 
     return inlineStyles;
   }

--- a/packages/components/src/components/hds/layout/grid/item.ts
+++ b/packages/components/src/components/hds/layout/grid/item.ts
@@ -13,6 +13,8 @@ type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
 export interface HdsLayoutGridItemSignature {
   Args: {
     tag?: AvailableTagNames;
+    colSpan?: string;
+    rowSpan?: string;
   };
   Blocks: {
     default: [];
@@ -23,6 +25,20 @@ export interface HdsLayoutGridItemSignature {
 export default class HdsLayoutFlexItem extends Component<HdsLayoutGridItemSignature> {
   get componentTag(): AvailableTagNames {
     return this.args.tag ?? 'div';
+  }
+
+  get colSpanStyle(): Record<string, string> {
+    const colSpanStyle: { [key: string]: string } = {};
+
+    colSpanStyle['--hds-layout-grid-column-span'] = this.args.colSpan ?? '1';
+    return colSpanStyle;
+  }
+
+  get rowSpanStyle(): Record<string, string> {
+    const rowSpanStyle: { [key: string]: string } = {};
+
+    rowSpanStyle['--hds-layout-grid-row-span'] = this.args.rowSpan ?? '1';
+    return rowSpanStyle;
   }
 
   get classNames(): string {

--- a/packages/components/src/components/hds/layout/grid/item.ts
+++ b/packages/components/src/components/hds/layout/grid/item.ts
@@ -5,10 +5,7 @@
 
 import Component from '@glimmer/component';
 
-// A list of all existing tag names in the HTMLElementTagNameMap interface
-type AvailableTagNames = keyof HTMLElementTagNameMap;
-// A union of all types in the HTMLElementTagNameMap interface
-type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
+import type { AvailableTagNames, AvailableElements } from './types.ts';
 
 export interface HdsLayoutGridItemSignature {
   Args: {
@@ -39,11 +36,5 @@ export default class HdsLayoutFlexItem extends Component<HdsLayoutGridItemSignat
 
     rowSpanStyle['--hds-layout-grid-row-span'] = this.args.rowSpan ?? '1';
     return rowSpanStyle;
-  }
-
-  get classNames(): string {
-    const classes = ['hds-layout-grid-item'];
-
-    return classes.join(' ');
   }
 }

--- a/packages/components/src/components/hds/layout/grid/item.ts
+++ b/packages/components/src/components/hds/layout/grid/item.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+
+// A list of all existing tag names in the HTMLElementTagNameMap interface
+type AvailableTagNames = keyof HTMLElementTagNameMap;
+// A union of all types in the HTMLElementTagNameMap interface
+type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
+
+export interface HdsLayoutGridItemSignature {
+  Args: {
+    tag?: AvailableTagNames;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: AvailableElements;
+}
+
+export default class HdsLayoutFlexItem extends Component<HdsLayoutGridItemSignature> {
+  get componentTag(): AvailableTagNames {
+    return this.args.tag ?? 'div';
+  }
+
+  get classNames(): string {
+    const classes = ['hds-layout-grid-item'];
+
+    return classes.join(' ');
+  }
+}

--- a/packages/components/src/components/hds/layout/grid/item.ts
+++ b/packages/components/src/components/hds/layout/grid/item.ts
@@ -24,17 +24,15 @@ export default class HdsLayoutFlexItem extends Component<HdsLayoutGridItemSignat
     return this.args.tag ?? 'div';
   }
 
-  get colSpanStyle(): Record<string, string> {
-    const colSpanStyle: { [key: string]: string } = {};
+  get inlineStyles(): Record<string, unknown> {
+    const inlineStyles: {
+      '--hds-layout-grid-column-span'?: string;
+      '--hds-layout-grid-row-span'?: string;
+    } = {};
 
-    colSpanStyle['--hds-layout-grid-column-span'] = this.args.colSpan ?? '1';
-    return colSpanStyle;
-  }
+    inlineStyles['--hds-layout-grid-column-span'] = this.args.colSpan ?? '1';
+    inlineStyles['--hds-layout-grid-row-span'] = this.args.rowSpan ?? '1';
 
-  get rowSpanStyle(): Record<string, string> {
-    const rowSpanStyle: { [key: string]: string } = {};
-
-    rowSpanStyle['--hds-layout-grid-row-span'] = this.args.rowSpan ?? '1';
-    return rowSpanStyle;
+    return inlineStyles;
   }
 }

--- a/packages/components/src/components/hds/layout/grid/types.ts
+++ b/packages/components/src/components/hds/layout/grid/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export enum HdsLayoutGridJustifyValues {
+  Start = 'start',
+  Center = 'center',
+  End = 'end',
+  SpaceBetween = 'space-between',
+  SpaceAround = 'space-around',
+  SpaceEvenly = 'space-evenly',
+}
+
+export type HdsLayoutGridJustifys = `${HdsLayoutGridJustifyValues}`;
+
+export enum HdsLayoutGridAlignValues {
+  Start = 'start',
+  Center = 'center',
+  End = 'end',
+  Stretch = 'stretch',
+}
+
+export type HdsLayoutGridAligns = `${HdsLayoutGridAlignValues}`;
+
+export enum HdsLayoutGridGapValues {
+  'Four' = '4',
+  'Eight' = '8',
+  'Twelve' = '12',
+  'Sixteen' = '16',
+  'Twentyfour' = '24',
+  'Thirtytwo' = '32',
+  'Fortyeight' = '48',
+}
+
+export type HdsLayoutGridGaps = `${HdsLayoutGridGapValues}`;

--- a/packages/components/src/components/hds/layout/grid/types.ts
+++ b/packages/components/src/components/hds/layout/grid/types.ts
@@ -3,17 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-export enum HdsLayoutGridJustifyValues {
-  Start = 'start',
-  Center = 'center',
-  End = 'end',
-  SpaceBetween = 'space-between',
-  SpaceAround = 'space-around',
-  SpaceEvenly = 'space-evenly',
-}
-
-export type HdsLayoutGridJustifys = `${HdsLayoutGridJustifyValues}`;
-
 export enum HdsLayoutGridAlignValues {
   Start = 'start',
   Center = 'center',

--- a/packages/components/src/components/hds/layout/grid/types.ts
+++ b/packages/components/src/components/hds/layout/grid/types.ts
@@ -23,3 +23,9 @@ export enum HdsLayoutGridGapValues {
 }
 
 export type HdsLayoutGridGaps = `${HdsLayoutGridGapValues}`;
+
+// A list of all existing tag names in the HTMLElementTagNameMap interface
+export type AvailableTagNames = keyof HTMLElementTagNameMap;
+// A union of all types in the HTMLElementTagNameMap interface
+export type AvailableElements =
+  HTMLElementTagNameMap[keyof HTMLElementTagNameMap];

--- a/packages/components/src/styles/@hashicorp/design-system-components.scss
+++ b/packages/components/src/styles/@hashicorp/design-system-components.scss
@@ -37,6 +37,7 @@
 @use "../components/form"; // multiple components
 @use "../components/icon";
 @use "../components/icon-tile";
+@use "../components/layout"; // multiple components
 @use "../components/link"; // multiple components
 @use "../components/menu-primitive";
 @use "../components/modal";

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -99,3 +99,8 @@
 .hds-layout-flex-item--shrink-1 {
   flex-shrink: 1;
 }
+
+.hds-layout-flex-item--enable-collapse-below-content-size {
+  // this allows the element to shrink below its content's intrinsic minimum width (eg. used with elliptized text)
+  min-width: 0;
+}

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -9,6 +9,13 @@
 
 .hds-layout-flex {
   display: flex;
+
+  // Note: The gap style is defined here to avoid setting it repeatedly for the gap size variants defined below.
+  // For the gap size variants, we override the value of the gap custom properties to set the desired sizes.
+  // These variables can be used by the consumers as escape hatch if they need to set non-standard gap values (but adds a bit of friction to it)
+  gap:
+    var(--hds-layout-flex-row-gap, 0)
+    var(--hds-layout-flex-column-gap, 0);
 }
 
 // inline
@@ -83,27 +90,60 @@
 
 // gap
 
-.hds-layout-flex--gap-4 { gap: 4px; }
-.hds-layout-flex--gap-8 { gap: 8px; }
-.hds-layout-flex--gap-12 { gap: 12px; }
-.hds-layout-flex--gap-16 { gap: 16px; }
-.hds-layout-flex--gap-24 { gap: 24px; }
-.hds-layout-flex--gap-32 { gap: 32px; }
-.hds-layout-flex--gap-48 { gap: 48px; }
-.hds-layout-flex--row-gap-4 { row-gap: 4px; }
-.hds-layout-flex--row-gap-8 { row-gap: 8px; }
-.hds-layout-flex--row-gap-12 { row-gap: 12px; }
-.hds-layout-flex--row-gap-16 { row-gap: 16px; }
-.hds-layout-flex--row-gap-24 { row-gap: 24px; }
-.hds-layout-flex--row-gap-32 { row-gap: 32px; }
-.hds-layout-flex--row-gap-48 { row-gap: 48px; }
-.hds-layout-flex--column-gap-4 { column-gap: 4px; }
-.hds-layout-flex--column-gap-8 { column-gap: 8px; }
-.hds-layout-flex--column-gap-12 { column-gap: 12px; }
-.hds-layout-flex--column-gap-16 { column-gap: 16px; }
-.hds-layout-flex--column-gap-24 { column-gap: 24px; }
-.hds-layout-flex--column-gap-32 { column-gap: 32px; }
-.hds-layout-flex--column-gap-48 { column-gap: 48px; }
+// set row & column gap size together
+.hds-layout-flex--gap-4 {
+  --hds-layout-flex-row-gap: 4px;
+  --hds-layout-flex-column-gap: 4px;
+}
+
+.hds-layout-flex--gap-8 {
+  --hds-layout-flex-row-gap: 8px;
+  --hds-layout-flex-column-gap: 8px;
+}
+
+.hds-layout-flex--gap-12 {
+  --hds-layout-flex-row-gap: 12px;
+  --hds-layout-flex-column-gap: 12px;
+}
+
+.hds-layout-flex--gap-16 {
+  --hds-layout-flex-row-gap: 16px;
+  --hds-layout-flex-column-gap: 16px;
+}
+
+.hds-layout-flex--gap-24 {
+  --hds-layout-flex-row-gap: 24px;
+  --hds-layout-flex-column-gap: 24px;
+}
+
+.hds-layout-flex--gap-32 {
+  --hds-layout-flex-row-gap: 32px;
+  --hds-layout-flex-column-gap: 32px;
+}
+
+.hds-layout-flex--gap-48 {
+  --hds-layout-flex-row-gap: 48px;
+  --hds-layout-flex-column-gap: 48px;
+}
+
+// set just row gap size
+.hds-layout-flex--row-gap-4 { --hds-layout-flex-row-gap: 4px; }
+.hds-layout-flex--row-gap-8 { --hds-layout-flex-row-gap: 8px; }
+.hds-layout-flex--row-gap-12 { --hds-layout-flex-row-gap: 12px; }
+.hds-layout-flex--row-gap-16 { --hds-layout-flex-row-gap: 16px; }
+.hds-layout-flex--row-gap-24 { --hds-layout-flex-row-gap: 24px; }
+.hds-layout-flex--row-gap-32 { --hds-layout-flex-row-gap: 32px; }
+.hds-layout-flex--row-gap-48 { --hds-layout-flex-row-gap: 48px; }
+
+// set just column gap size
+.hds-layout-flex--column-gap-4 { --hds-layout-flex-column-gap: 4px; }
+.hds-layout-flex--column-gap-8 { --hds-layout-flex-column-gap: 8px; }
+.hds-layout-flex--column-gap-12 { --hds-layout-flex-column-gap: 12px; }
+.hds-layout-flex--column-gap-16 { --hds-layout-flex-column-gap: 16px; }
+.hds-layout-flex--column-gap-24 { --hds-layout-flex-column-gap: 24px;  }
+.hds-layout-flex--column-gap-32 { --hds-layout-flex-column-gap: 32px; }
+.hds-layout-flex--column-gap-48 { --hds-layout-flex-column-gap: 48px; }
+
 
 // FLEX ITEM
 

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -26,3 +26,9 @@
 .hds-layout-flex--direction-column {
   flex-direction: column;
 }
+
+// wrap
+
+.hds-layout-flex--has-wrapping {
+  flex-wrap: wrap;
+}

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -107,6 +107,13 @@
 
 // FLEX ITEM
 
+// note: these are just the most common values for `flex-[basis|grow|shrink]`
+// all other special cases are handled via inline styles
+
+.hds-layout-flex-item--basis-0 {
+  flex-basis: 0;
+}
+
 .hds-layout-flex-item--grow-0 {
   flex-grow: 0;
 }

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -80,3 +80,22 @@
 .hds-layout-flex--align-items-stretch {
   align-items: stretch;
 }
+
+
+// FLEX ITEM
+
+.hds-layout-flex-item--grow-0 {
+  flex-grow: 0;
+}
+
+.hds-layout-flex-item--grow-1 {
+  flex-grow: 1;
+}
+
+.hds-layout-flex-item--shrink-0 {
+  flex-shrink: 0;
+}
+
+.hds-layout-flex-item--shrink-1 {
+  flex-shrink: 1;
+}

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -32,3 +32,51 @@
 .hds-layout-flex--has-wrapping {
   flex-wrap: wrap;
 }
+
+// justify
+
+.hds-layout-flex--justify-content-start {
+  justify-content: start;
+}
+
+.hds-layout-flex--justify-content-center {
+  justify-content: center;
+}
+
+.hds-layout-flex--justify-content-end {
+  justify-content: end;
+}
+
+.hds-layout-flex--justify-content-space-between {
+  justify-content: space-between;
+}
+
+.hds-layout-flex--justify-content-space-around {
+  justify-content: space-around;
+}
+
+.hds-layout-flex--justify-content-space-evenly {
+  justify-content: space-evenly;
+}
+
+.hds-layout-flex--justify-content-stretch {
+  justify-content: stretch;
+}
+
+// align
+
+.hds-layout-flex--align-items-start {
+  align-items: start;
+}
+
+.hds-layout-flex--align-items-center {
+  align-items: center;
+}
+
+.hds-layout-flex--align-items-end {
+  align-items: end;
+}
+
+.hds-layout-flex--align-items-stretch {
+  align-items: stretch;
+}

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -8,5 +8,15 @@
 //
 
 .hds-layout-flex {
-  // add the component styles here
+  display: flex;
+}
+
+// direction
+
+.hds-layout-flex--direction-row {
+  flex-direction: row;
+}
+
+.hds-layout-flex--direction-column {
+  flex-direction: column;
 }

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -11,6 +11,12 @@
   display: flex;
 }
 
+// inline
+
+.hds-layout-flex--is-inline {
+  display: inline-flex;
+}
+
 // direction
 
 .hds-layout-flex--direction-row {

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -81,6 +81,29 @@
   align-items: stretch;
 }
 
+// gap
+
+.hds-layout-flex--gap-4 { gap: 4px; }
+.hds-layout-flex--gap-8 { gap: 8px; }
+.hds-layout-flex--gap-12 { gap: 12px; }
+.hds-layout-flex--gap-16 { gap: 16px; }
+.hds-layout-flex--gap-24 { gap: 24px; }
+.hds-layout-flex--gap-32 { gap: 32px; }
+.hds-layout-flex--gap-48 { gap: 48px; }
+.hds-layout-flex--row-gap-4 { row-gap: 4px; }
+.hds-layout-flex--row-gap-8 { row-gap: 8px; }
+.hds-layout-flex--row-gap-12 { row-gap: 12px; }
+.hds-layout-flex--row-gap-16 { row-gap: 16px; }
+.hds-layout-flex--row-gap-24 { row-gap: 24px; }
+.hds-layout-flex--row-gap-32 { row-gap: 32px; }
+.hds-layout-flex--row-gap-48 { row-gap: 48px; }
+.hds-layout-flex--column-gap-4 { column-gap: 4px; }
+.hds-layout-flex--column-gap-8 { column-gap: 8px; }
+.hds-layout-flex--column-gap-12 { column-gap: 12px; }
+.hds-layout-flex--column-gap-16 { column-gap: 16px; }
+.hds-layout-flex--column-gap-24 { column-gap: 24px; }
+.hds-layout-flex--column-gap-32 { column-gap: 32px; }
+.hds-layout-flex--column-gap-48 { column-gap: 48px; }
 
 // FLEX ITEM
 

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+//
+// LAYOUT > FLEX
+//
+
+.hds-layout-flex {
+  // add the component styles here
+}

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+//
+// LAYOUT > GRID
+//
+
+.hds-layout-grid {
+  display: grid;
+  outline: 3px dotted red; // TEMP
+}

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -8,86 +8,73 @@
 //
 
 .hds-layout-grid {
-  --hds-grid-size: 48px; // TEMP
-
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(var(--hds-grid-size), 1fr));
+  grid-template-columns: 
+    repeat(
+      auto-fit, 
+      minmax( 
+        calc( 
+          var(--hds-layout-grid-column-min-width) - var(--hds-layout-grid-gap, var(--hds-layout-grid-column-gap, 0px)) ), 
+        1fr 
+      )
+    );
+
+  // gap: rowGap, columnGap
+  gap: 
+    var(--hds-layout-grid-row-gap, var(--hds-layout-grid-gap, 0)) 
+    var(--hds-layout-grid-column-gap, var(--hds-layout-grid-gap, 0));
 }
 
 // inline
 
 .hds-layout-grid--is-inline {
   display: inline-grid;
+  // prevents issue preventing grid columns from lining up in a row
+  max-width: 100%;
 }
 
 // justify
 
-.hds-layout-grid--justify-content-start {
-  justify-content: start;
-}
-
-.hds-layout-grid--justify-content-center {
-  justify-content: center;
-}
-
-.hds-layout-grid--justify-content-end {
-  justify-content: end;
-}
-
-.hds-layout-grid--justify-content-space-between {
-  justify-content: space-between;
-}
-
-.hds-layout-grid--justify-content-space-around {
-  justify-content: space-around;
-}
-
-.hds-layout-grid--justify-content-space-evenly {
-  justify-content: space-evenly;
-}
-
-.hds-layout-grid--justify-content-stretch {
-  justify-content: stretch;
-}
+.hds-layout-grid--justify-content-start { justify-content: start; }
+.hds-layout-grid--justify-content-center { justify-content: center; }
+.hds-layout-grid--justify-content-end { justify-content: end; }
+.hds-layout-grid--justify-content-space-between { justify-content: space-between; }
+.hds-layout-grid--justify-content-space-around { justify-content: space-around; }
+.hds-layout-grid--justify-content-space-evenly { justify-content: space-evenly; }
+.hds-layout-grid--justify-content-stretch { justify-content: stretch; }
 
 // align
 
-.hds-layout-grid--align-items-start {
-  align-items: start;
-}
-
-.hds-layout-grid--align-items-center {
-  align-items: center;
-}
-
-.hds-layout-grid--align-items-end {
-  align-items: end;
-}
-
-.hds-layout-grid--align-items-stretch {
-  align-items: stretch;
-}
+.hds-layout-grid--align-items-start { align-items: start;}
+.hds-layout-grid--align-items-center { align-items: center;}
+.hds-layout-grid--align-items-end { align-items: end; }
+.hds-layout-grid--align-items-stretch { align-items: stretch; }
 
 // gap
 
-.hds-layout-grid--gap-4 { gap: 4px; }
-.hds-layout-grid--gap-8 { gap: 8px; }
-.hds-layout-grid--gap-12 { gap: 12px; }
-.hds-layout-grid--gap-16 { gap: 16px; }
-.hds-layout-grid--gap-24 { gap: 24px; }
-.hds-layout-grid--gap-32 { gap: 32px; }
-.hds-layout-grid--gap-48 { gap: 48px; }
-.hds-layout-grid--row-gap-4 { row-gap: 4px; }
-.hds-layout-grid--row-gap-8 { row-gap: 8px; }
-.hds-layout-grid--row-gap-12 { row-gap: 12px; }
-.hds-layout-grid--row-gap-16 { row-gap: 16px; }
-.hds-layout-grid--row-gap-24 { row-gap: 24px; }
-.hds-layout-grid--row-gap-32 { row-gap: 32px; }
-.hds-layout-grid--row-gap-48 { row-gap: 48px; }
-.hds-layout-grid--column-gap-4 { column-gap: 4px; }
-.hds-layout-grid--column-gap-8 { column-gap: 8px; }
-.hds-layout-grid--column-gap-12 { column-gap: 12px; }
-.hds-layout-grid--column-gap-16 { column-gap: 16px; }
-.hds-layout-grid--column-gap-24 { column-gap: 24px; }
-.hds-layout-grid--column-gap-32 { column-gap: 32px; }
-.hds-layout-grid--column-gap-48 { column-gap: 48px; }
+// set row & column gap together
+.hds-layout-grid--gap-4 { --hds-layout-grid-gap: 4px;}
+.hds-layout-grid--gap-8 { --hds-layout-grid-gap: 8px; }
+.hds-layout-grid--gap-12 { --hds-layout-grid-gap: 12px; }
+.hds-layout-grid--gap-16 { --hds-layout-grid-gap: 16px; }
+.hds-layout-grid--gap-24 { --hds-layout-grid-gap: 24px; }
+.hds-layout-grid--gap-32 { --hds-layout-grid-gap: 32px; }
+.hds-layout-grid--gap-48 { --hds-layout-grid-gap: 48px; }
+
+// set just row gap
+.hds-layout-grid--row-gap-4 { --hds-layout-grid-row-gap: 4px; }
+.hds-layout-grid--row-gap-8 { --hds-layout-grid-row-gap: 8px; }
+.hds-layout-grid--row-gap-12 { --hds-layout-grid-row-gap: 12px; }
+.hds-layout-grid--row-gap-16 { --hds-layout-grid-row-gap: 16px; }
+.hds-layout-grid--row-gap-24 { --hds-layout-grid-row-gap: 24px; }
+.hds-layout-grid--row-gap-32 { --hds-layout-grid-row-gap: 32px; }
+.hds-layout-grid--row-gap-48 { --hds-layout-grid-row-gap: 48px; }
+
+// set just column gap
+.hds-layout-grid--column-gap-4 { --hds-layout-grid-column-gap: 4px; }
+.hds-layout-grid--column-gap-8 { --hds-layout-grid-column-gap: 8px; }
+.hds-layout-grid--column-gap-12 { --hds-layout-grid-column-gap: 12px; }
+.hds-layout-grid--column-gap-16 { --hds-layout-grid-column-gap: 16px; }
+.hds-layout-grid--column-gap-24 { --hds-layout-grid-column-gap: 24px;  }
+.hds-layout-grid--column-gap-32 { --hds-layout-grid-column-gap: 32px; }
+.hds-layout-grid--column-gap-48 { --hds-layout-grid-column-gap: 48px; }

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -8,6 +8,86 @@
 //
 
 .hds-layout-grid {
+  --hds-grid-size: 48px; // TEMP
+
   display: grid;
-  outline: 3px dotted red; // TEMP
+  grid-template-columns: repeat(auto-fit, minmax(var(--hds-grid-size), 1fr));
 }
+
+// inline
+
+.hds-layout-grid--is-inline {
+  display: inline-grid;
+}
+
+// justify
+
+.hds-layout-grid--justify-content-start {
+  justify-content: start;
+}
+
+.hds-layout-grid--justify-content-center {
+  justify-content: center;
+}
+
+.hds-layout-grid--justify-content-end {
+  justify-content: end;
+}
+
+.hds-layout-grid--justify-content-space-between {
+  justify-content: space-between;
+}
+
+.hds-layout-grid--justify-content-space-around {
+  justify-content: space-around;
+}
+
+.hds-layout-grid--justify-content-space-evenly {
+  justify-content: space-evenly;
+}
+
+.hds-layout-grid--justify-content-stretch {
+  justify-content: stretch;
+}
+
+// align
+
+.hds-layout-grid--align-items-start {
+  align-items: start;
+}
+
+.hds-layout-grid--align-items-center {
+  align-items: center;
+}
+
+.hds-layout-grid--align-items-end {
+  align-items: end;
+}
+
+.hds-layout-grid--align-items-stretch {
+  align-items: stretch;
+}
+
+// gap
+
+.hds-layout-grid--gap-4 { gap: 4px; }
+.hds-layout-grid--gap-8 { gap: 8px; }
+.hds-layout-grid--gap-12 { gap: 12px; }
+.hds-layout-grid--gap-16 { gap: 16px; }
+.hds-layout-grid--gap-24 { gap: 24px; }
+.hds-layout-grid--gap-32 { gap: 32px; }
+.hds-layout-grid--gap-48 { gap: 48px; }
+.hds-layout-grid--row-gap-4 { row-gap: 4px; }
+.hds-layout-grid--row-gap-8 { row-gap: 8px; }
+.hds-layout-grid--row-gap-12 { row-gap: 12px; }
+.hds-layout-grid--row-gap-16 { row-gap: 16px; }
+.hds-layout-grid--row-gap-24 { row-gap: 24px; }
+.hds-layout-grid--row-gap-32 { row-gap: 32px; }
+.hds-layout-grid--row-gap-48 { row-gap: 48px; }
+.hds-layout-grid--column-gap-4 { column-gap: 4px; }
+.hds-layout-grid--column-gap-8 { column-gap: 8px; }
+.hds-layout-grid--column-gap-12 { column-gap: 12px; }
+.hds-layout-grid--column-gap-16 { column-gap: 16px; }
+.hds-layout-grid--column-gap-24 { column-gap: 24px; }
+.hds-layout-grid--column-gap-32 { column-gap: 32px; }
+.hds-layout-grid--column-gap-48 { column-gap: 48px; }

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -79,3 +79,10 @@
 .hds-layout-grid--column-gap-24 { --hds-layout-grid-column-gap: 24px;  }
 .hds-layout-grid--column-gap-32 { --hds-layout-grid-column-gap: 32px; }
 .hds-layout-grid--column-gap-48 { --hds-layout-grid-column-gap: 48px; }
+
+// LAYOUT > GRID > ITEM
+
+.hds-layout-grid-item {
+  grid-row-start: span var(--hds-layout-grid-row-span);
+  grid-column-start: span var(--hds-layout-grid-column-span);
+}

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -37,16 +37,6 @@
   max-width: 100%;
 }
 
-// justify
-
-.hds-layout-grid--justify-content-start { justify-content: start; }
-.hds-layout-grid--justify-content-center { justify-content: center; }
-.hds-layout-grid--justify-content-end { justify-content: end; }
-.hds-layout-grid--justify-content-space-between { justify-content: space-between; }
-.hds-layout-grid--justify-content-space-around { justify-content: space-around; }
-.hds-layout-grid--justify-content-space-evenly { justify-content: space-evenly; }
-.hds-layout-grid--justify-content-stretch { justify-content: stretch; }
-
 // align
 
 .hds-layout-grid--align-items-start { align-items: start;}

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -9,6 +9,7 @@
 
 .hds-layout-grid {
   display: grid;
+  // Note: 0px value requires unit to work in calculation
   grid-template-columns: 
     repeat(
       auto-fit, 

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -9,16 +9,17 @@
 
 .hds-layout-grid {
   display: grid;
-  // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as the default col min width
-  // https://drafts.csswg.org/css-values/#calc-type-checking
+  // The column gap value is subtracted from the column-min-width to prevent overflow & simplify API for consumers
 
-  // Gap is subtracted from column-min-width to prevent overflow & simplify API for consumers
+  // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as a fallback value within calc()
+  // https://drafts.csswg.org/css-values/#calc-type-checking
   grid-template-columns: 
     repeat(
       auto-fit, 
       minmax( 
         calc( 
-          var(--hds-layout-grid-column-min-width, 0px) - var(--hds-layout-grid-gap, var(--hds-layout-grid-column-gap, 0px)) ), 
+          var(--hds-layout-grid-column-min-width, 0px) - var(--hds-layout-grid-column-gap, 0px)
+        ), 
         1fr 
       )
     );
@@ -26,8 +27,8 @@
   // Note: The gap style is defined here to avoid setting it repeatedly for the gap size variants defined below.
   // For the gap size variants, we override the value of the gap custom properties to set the desired sizes.
   gap: 
-    var(--hds-layout-grid-row-gap, var(--hds-layout-grid-gap, 0)) // rowGap
-    var(--hds-layout-grid-column-gap, var(--hds-layout-grid-gap, 0)); // columnGap
+    var(--hds-layout-grid-row-gap, 0)
+    var(--hds-layout-grid-column-gap, 0);
 }
 
 // inline
@@ -47,18 +48,45 @@
 
 // gap
 
-// We set the values of the gap custom properties overriding the default value of 0px
+// We set the values of the gap custom properties overriding the default value of 0
 
-// set row & column gap together
-.hds-layout-grid--gap-4 { --hds-layout-grid-gap: 4px;}
-.hds-layout-grid--gap-8 { --hds-layout-grid-gap: 8px; }
-.hds-layout-grid--gap-12 { --hds-layout-grid-gap: 12px; }
-.hds-layout-grid--gap-16 { --hds-layout-grid-gap: 16px; }
-.hds-layout-grid--gap-24 { --hds-layout-grid-gap: 24px; }
-.hds-layout-grid--gap-32 { --hds-layout-grid-gap: 32px; }
-.hds-layout-grid--gap-48 { --hds-layout-grid-gap: 48px; }
+// set row & column gap size together
+.hds-layout-grid--gap-4 {
+  --hds-layout-grid-row-gap: 4px;
+  --hds-layout-grid-column-gap: 4px;
+}
 
-// set just row gap
+.hds-layout-grid--gap-8 {
+  --hds-layout-grid-row-gap: 8px;
+  --hds-layout-grid-column-gap: 8px;
+}
+
+.hds-layout-grid--gap-12 {
+  --hds-layout-grid-row-gap: 12px;
+  --hds-layout-grid-column-gap: 12px;
+}
+
+.hds-layout-grid--gap-16 {
+  --hds-layout-grid-row-gap: 16px;
+  --hds-layout-grid-column-gap: 16px;
+}
+
+.hds-layout-grid--gap-24 {
+  --hds-layout-grid-row-gap: 24px;
+  --hds-layout-grid-column-gap: 24px;
+}
+
+.hds-layout-grid--gap-32 {
+  --hds-layout-grid-row-gap: 32px;
+  --hds-layout-grid-column-gap: 32px;
+}
+
+.hds-layout-grid--gap-48 {
+  --hds-layout-grid-row-gap: 48px;
+  --hds-layout-grid-column-gap: 48px;
+}
+
+// set just row gap size
 .hds-layout-grid--row-gap-4 { --hds-layout-grid-row-gap: 4px; }
 .hds-layout-grid--row-gap-8 { --hds-layout-grid-row-gap: 8px; }
 .hds-layout-grid--row-gap-12 { --hds-layout-grid-row-gap: 12px; }
@@ -67,7 +95,7 @@
 .hds-layout-grid--row-gap-32 { --hds-layout-grid-row-gap: 32px; }
 .hds-layout-grid--row-gap-48 { --hds-layout-grid-row-gap: 48px; }
 
-// set just column gap
+// set just column gap size
 .hds-layout-grid--column-gap-4 { --hds-layout-grid-column-gap: 4px; }
 .hds-layout-grid--column-gap-8 { --hds-layout-grid-column-gap: 8px; }
 .hds-layout-grid--column-gap-12 { --hds-layout-grid-column-gap: 12px; }

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -9,7 +9,9 @@
 
 .hds-layout-grid {
   display: grid;
-  // Note: 0px value requires unit to work in calculation
+  // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as the default col min width
+  // https://drafts.csswg.org/css-values/#calc-type-checking
+
   // Gap is subtracted from column-min-width to prevent overflow & simplify API for consumers
   grid-template-columns: 
     repeat(

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -10,6 +10,7 @@
 .hds-layout-grid {
   display: grid;
   // Note: 0px value requires unit to work in calculation
+  // Gap is subtracted from column-min-width to prevent overflow & simplify API for consumers
   grid-template-columns: 
     repeat(
       auto-fit, 

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -23,10 +23,11 @@
       )
     );
 
-  // gap: rowGap, columnGap
+  // Note: The gap style is defined here to avoid setting it repeatedly for the gap size variants defined below.
+  // For the gap size variants, we override the value of the gap custom properties to set the desired sizes.
   gap: 
-    var(--hds-layout-grid-row-gap, var(--hds-layout-grid-gap, 0)) 
-    var(--hds-layout-grid-column-gap, var(--hds-layout-grid-gap, 0));
+    var(--hds-layout-grid-row-gap, var(--hds-layout-grid-gap, 0)) // rowGap
+    var(--hds-layout-grid-column-gap, var(--hds-layout-grid-gap, 0)); // columnGap
 }
 
 // inline
@@ -45,6 +46,8 @@
 .hds-layout-grid--align-items-stretch { align-items: stretch; }
 
 // gap
+
+// We set the values of the gap custom properties overriding the default value of 0px
 
 // set row & column gap together
 .hds-layout-grid--gap-4 { --hds-layout-grid-gap: 4px;}

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -18,7 +18,7 @@
       auto-fit, 
       minmax( 
         calc( 
-          var(--hds-layout-grid-column-min-width) - var(--hds-layout-grid-gap, var(--hds-layout-grid-column-gap, 0px)) ), 
+          var(--hds-layout-grid-column-min-width, 0px) - var(--hds-layout-grid-gap, var(--hds-layout-grid-column-gap, 0px)) ), 
         1fr 
       )
     );
@@ -76,6 +76,6 @@
 // LAYOUT > GRID > ITEM
 
 .hds-layout-grid-item {
-  grid-row-start: span var(--hds-layout-grid-row-span);
-  grid-column-start: span var(--hds-layout-grid-column-span);
+  grid-row-start: span var(--hds-layout-grid-row-span, 1);
+  grid-column-start: span var(--hds-layout-grid-column-span, 1);
 }

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -33,7 +33,7 @@
 
 .hds-layout-grid--is-inline {
   display: inline-grid;
-  // prevents issue preventing grid columns from lining up in a row
+  // prevents issue where grid columns don't line up in a row
   max-width: 100%;
 }
 

--- a/packages/components/src/styles/components/layout/index.scss
+++ b/packages/components/src/styles/components/layout/index.scss
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+@use "./flex";

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -144,6 +144,7 @@ import type HdsInteractiveComponent from './components/hds/interactive';
 import type HdsLayoutFlexComponent from './components/hds/layout/flex';
 import type HdsLayoutFlexItemComponent from './components/hds/layout/flex/item';
 import type HdsLayoutGridComponent from './components/hds/layout/grid';
+import type HdsLayoutGridItemComponent from './components/hds/layout/flex/item';
 import type HdsLinkInlineComponent from './components/hds/link/inline';
 import type HdsLinkStandaloneComponent from './components/hds/link/standalone';
 import type HdsMenuPrimitiveComponent from './components/hds/menu-primitive';
@@ -706,6 +707,8 @@ export default interface HdsComponentsRegistry {
   // Layout Grid
   'Hds::Layout::Grid': typeof HdsLayoutGridComponent;
   'hds/layout/grid': typeof HdsLayoutGridComponent;
+  'Hds::Layout::Grid::Item': typeof HdsLayoutGridItemComponent;
+  'hds/layout/grid/item': typeof HdsLayoutGridItemComponent;
 
   // Link Inline
   'Hds::Link::Inline': typeof HdsLinkInlineComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -141,6 +141,7 @@ import type HdsFormVisibilityToggleComponent from './components/hds/form/visibil
 import type HdsIconComponent from './components/hds/icon';
 import type HdsIconTileComponent from './components/hds/icon-tile';
 import type HdsInteractiveComponent from './components/hds/interactive';
+import type HdsLayoutFlexComponent from './components/hds/layout/flex';
 import type HdsLinkInlineComponent from './components/hds/link/inline';
 import type HdsLinkStandaloneComponent from './components/hds/link/standalone';
 import type HdsMenuPrimitiveComponent from './components/hds/menu-primitive';
@@ -693,6 +694,10 @@ export default interface HdsComponentsRegistry {
   // Interactive
   'Hds::Interactive': typeof HdsInteractiveComponent;
   'hds/interactive': typeof HdsInteractiveComponent;
+
+  // Layout Flex
+  'Hds::Layout::Flex': typeof HdsLayoutFlexComponent;
+  'hds/layout/flex': typeof HdsLayoutFlexComponent;
 
   // Link Inline
   'Hds::Link::Inline': typeof HdsLinkInlineComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -143,6 +143,7 @@ import type HdsIconTileComponent from './components/hds/icon-tile';
 import type HdsInteractiveComponent from './components/hds/interactive';
 import type HdsLayoutFlexComponent from './components/hds/layout/flex';
 import type HdsLayoutFlexItemComponent from './components/hds/layout/flex/item';
+import type HdsLayoutGridComponent from './components/hds/layout/grid';
 import type HdsLinkInlineComponent from './components/hds/link/inline';
 import type HdsLinkStandaloneComponent from './components/hds/link/standalone';
 import type HdsMenuPrimitiveComponent from './components/hds/menu-primitive';
@@ -701,6 +702,10 @@ export default interface HdsComponentsRegistry {
   'hds/layout/flex': typeof HdsLayoutFlexComponent;
   'Hds::Layout::Flex::Item': typeof HdsLayoutFlexItemComponent;
   'hds/layout/flex/item': typeof HdsLayoutFlexItemComponent;
+
+  // Layout Grid
+  'Hds::Layout::Grid': typeof HdsLayoutGridComponent;
+  'hds/layout/grid': typeof HdsLayoutGridComponent;
 
   // Link Inline
   'Hds::Link::Inline': typeof HdsLinkInlineComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -142,6 +142,7 @@ import type HdsIconComponent from './components/hds/icon';
 import type HdsIconTileComponent from './components/hds/icon-tile';
 import type HdsInteractiveComponent from './components/hds/interactive';
 import type HdsLayoutFlexComponent from './components/hds/layout/flex';
+import type HdsLayoutFlexItemComponent from './components/hds/layout/flex/item';
 import type HdsLinkInlineComponent from './components/hds/link/inline';
 import type HdsLinkStandaloneComponent from './components/hds/link/standalone';
 import type HdsMenuPrimitiveComponent from './components/hds/menu-primitive';
@@ -698,6 +699,8 @@ export default interface HdsComponentsRegistry {
   // Layout Flex
   'Hds::Layout::Flex': typeof HdsLayoutFlexComponent;
   'hds/layout/flex': typeof HdsLayoutFlexComponent;
+  'Hds::Layout::Flex::Item': typeof HdsLayoutFlexItemComponent;
+  'hds/layout/flex/item': typeof HdsLayoutFlexItemComponent;
 
   // Link Inline
   'Hds::Link::Inline': typeof HdsLinkInlineComponent;

--- a/showcase/app/router.ts
+++ b/showcase/app/router.ts
@@ -85,6 +85,7 @@ Router.map(function () {
         this.route('demo-full-app-frame-with-side-nav');
       });
     });
+    this.route('flex');
   });
   this.route('utilities', function () {
     this.route('dialog-primitive');

--- a/showcase/app/router.ts
+++ b/showcase/app/router.ts
@@ -86,6 +86,7 @@ Router.map(function () {
       });
     });
     this.route('flex');
+    this.route('grid');
   });
   this.route('utilities', function () {
     this.route('dialog-primitive');

--- a/showcase/app/routes/components/layout/grid.js
+++ b/showcase/app/routes/components/layout/grid.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+
+export default class ComponentsLayoutGridRoute extends Route {}

--- a/showcase/app/routes/layouts/flex.js
+++ b/showcase/app/routes/layouts/flex.js
@@ -5,4 +5,14 @@
 
 import Route from '@ember/routing/route';
 
-export default class LayoutsFlexRoute extends Route {}
+import {
+  DIRECTIONS,
+  JUSTIFYS,
+  ALIGNS,
+} from '@hashicorp/design-system-components/components/hds/layout/flex';
+
+export default class LayoutsFlexRoute extends Route {
+  model() {
+    return { DIRECTIONS, JUSTIFYS, ALIGNS };
+  }
+}

--- a/showcase/app/routes/layouts/flex.js
+++ b/showcase/app/routes/layouts/flex.js
@@ -9,10 +9,11 @@ import {
   DIRECTIONS,
   JUSTIFYS,
   ALIGNS,
+  GAPS,
 } from '@hashicorp/design-system-components/components/hds/layout/flex';
 
 export default class LayoutsFlexRoute extends Route {
   model() {
-    return { DIRECTIONS, JUSTIFYS, ALIGNS };
+    return { DIRECTIONS, JUSTIFYS, ALIGNS, GAPS };
   }
 }

--- a/showcase/app/routes/layouts/flex.js
+++ b/showcase/app/routes/layouts/flex.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+
+export default class LayoutsFlexRoute extends Route {}

--- a/showcase/app/routes/layouts/grid.js
+++ b/showcase/app/routes/layouts/grid.js
@@ -6,13 +6,12 @@
 import Route from '@ember/routing/route';
 
 import {
-  JUSTIFYS,
   ALIGNS,
   GAPS,
 } from '@hashicorp/design-system-components/components/hds/layout/grid';
 
 export default class LayoutsGridRoute extends Route {
   model() {
-    return { JUSTIFYS, ALIGNS, GAPS };
+    return { ALIGNS, GAPS };
   }
 }

--- a/showcase/app/routes/layouts/grid.js
+++ b/showcase/app/routes/layouts/grid.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+
+import {
+  JUSTIFYS,
+  ALIGNS,
+  GAPS,
+} from '@hashicorp/design-system-components/components/hds/layout/grid';
+
+export default class LayoutsGridRoute extends Route {
+  model() {
+    return { JUSTIFYS, ALIGNS, GAPS };
+  }
+}

--- a/showcase/app/styles/app.scss
+++ b/showcase/app/styles/app.scss
@@ -61,6 +61,7 @@
 @use "./showcase-pages/form/toggle" as showcase-toggle;
 @use "./showcase-pages/icon" as showcase-icon;
 @use "./showcase-pages/layout/flex" as showcase-layout-flex;
+@use "./showcase-pages/layout/grid" as showcase-layout-grid;
 @use "./showcase-pages/link-inline" as showcase-link-inline;
 @use "./showcase-pages/menu-primitive" as showcase-menu-primitive;
 @use "./showcase-pages/modal" as showcase-modal;

--- a/showcase/app/styles/app.scss
+++ b/showcase/app/styles/app.scss
@@ -60,6 +60,7 @@
 @use "./showcase-pages/form/textarea" as showcase-textarea;
 @use "./showcase-pages/form/toggle" as showcase-toggle;
 @use "./showcase-pages/icon" as showcase-icon;
+@use "./showcase-pages/layout/flex" as showcase-layout-flex;
 @use "./showcase-pages/link-inline" as showcase-link-inline;
 @use "./showcase-pages/menu-primitive" as showcase-menu-primitive;
 @use "./showcase-pages/modal" as showcase-modal;

--- a/showcase/app/styles/showcase-pages/layout/flex.scss
+++ b/showcase/app/styles/showcase-pages/layout/flex.scss
@@ -38,4 +38,8 @@ body.layouts-flex {
     height: 50px;
     border-radius: 8px;
   }
+
+  .shw-layout-flex-example-gap-override {
+    --hds-layout-flex-column-gap: 20px;
+  }
 }

--- a/showcase/app/styles/showcase-pages/layout/flex.scss
+++ b/showcase/app/styles/showcase-pages/layout/flex.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// LAYOUTS > FLEX
+
+body.layouts-flex {
+  //
+}

--- a/showcase/app/styles/showcase-pages/layout/flex.scss
+++ b/showcase/app/styles/showcase-pages/layout/flex.scss
@@ -6,6 +6,12 @@
 // LAYOUTS > FLEX
 
 body.layouts-flex {
+  .shw-layout-flex-example-outline-flex-container {
+    .hds-layout-flex {
+      outline: 1px dotted var(--shw-color-gray-400);
+    }
+  }
+
   .shw-layout-flex-example-outline-flex-blocks {
     .hds-layout-flex {
       outline: 1px dashed var(--shw-color-gray-400);
@@ -16,10 +22,8 @@ body.layouts-flex {
     }
   }
 
-  .shw-layout-flex-example-outline-flex-blocks--with-backgrounds {
+  .shw-layout-flex-example-tint-flex-items {
     .hds-layout-flex > * {
-      padding: 4px 8px;
-
       &:nth-child(6n+1) { background-color: #e4c5f3; }
       &:nth-child(6n+2) { background-color: #e5ffd2; }
       &:nth-child(6n+3) { background-color: #d2f4ff; }

--- a/showcase/app/styles/showcase-pages/layout/flex.scss
+++ b/showcase/app/styles/showcase-pages/layout/flex.scss
@@ -6,5 +6,32 @@
 // LAYOUTS > FLEX
 
 body.layouts-flex {
-  //
+  .shw-layout-flex-example-outline-flex-blocks {
+    .hds-layout-flex {
+      outline: 1px dashed var(--shw-color-gray-400);
+
+      > * {
+        outline: 1px dotted var(--shw-color-gray-400);
+      }
+    }
+  }
+
+  .shw-layout-flex-example-outline-flex-blocks--with-backgrounds {
+    .hds-layout-flex > * {
+      padding: 4px 8px;
+
+      &:nth-child(6n+1) { background-color: #e4c5f3; }
+      &:nth-child(6n+2) { background-color: #e5ffd2; }
+      &:nth-child(6n+3) { background-color: #d2f4ff; }
+      &:nth-child(6n+4) { background-color: #fff8d2; }
+      &:nth-child(6n+5) { background-color: #f3d9c5; }
+      &:nth-child(6n+6) { background-color: #fee1ec; }
+    }
+  }
+
+  .shw-layout-flex-example-avatar {
+    width: 50px;
+    height: 50px;
+    border-radius: 8px;
+  }
 }

--- a/showcase/app/styles/showcase-pages/layout/grid.scss
+++ b/showcase/app/styles/showcase-pages/layout/grid.scss
@@ -3,5 +3,4 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-@use "./flex";
-@use "./grid";
+// LAYOUT > GRID

--- a/showcase/app/templates/index.hbs
+++ b/showcase/app/templates/index.hbs
@@ -289,6 +289,11 @@
           AppFrame
         </LinkTo>
       </li>
+      <li>
+        <LinkTo @route="layouts.flex">
+          Layout::Flex
+        </LinkTo>
+      </li>
     </ol>
     <Shw::Text::H2>Overrides</Shw::Text::H2>
     <ol class="shw-text-body">

--- a/showcase/app/templates/index.hbs
+++ b/showcase/app/templates/index.hbs
@@ -294,6 +294,11 @@
           Layout::Flex
         </LinkTo>
       </li>
+      <li>
+        <LinkTo @route="layouts.grid">
+          Layout::Grid
+        </LinkTo>
+      </li>
     </ol>
     <Shw::Text::H2>Overrides</Shw::Text::H2>
     <ol class="shw-text-body">

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -299,4 +299,55 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Text::H3>enableCollapseBelowContentSize</Shw::Text::H3>
+
+  <Shw::Text::Body>This property applies a
+    <code>min-width: 0</code>
+    to the flex item to allow the element to shrink below its content's intrinsic minimum width.</Shw::Text::Body>
+
+  <Shw::Grid @columns={{1}} as |SG|>
+    <SG.Item @label="first flex item has enableCollapseBelowContentSize=true">
+      <Shw::Outliner {{style max-width="600px"}}>
+        <Hds::Layout::Flex as |HLF|>
+          <HLF.Item @enableCollapseBelowContentSize={{true}}>
+            <Shw::Placeholder @height="40" @background="#e4c5f3">
+              <span {{style display="block" white-space="nowrap" overflow="hidden" text-overflow="ellipsis"}}>item #1
+                with a very long text that might cause overflow issues</span>
+            </Shw::Placeholder>
+          </HLF.Item>
+          <HLF.Item>
+            <Shw::Placeholder @text="item #2 with width=150px" @width="150px" @height="40" @background="#e5ffd2" />
+          </HLF.Item>
+          <HLF.Item>
+            <Shw::Placeholder @text="item #3 with width=150px" @width="150px" @height="40" @background="#d2f4ff" />
+          </HLF.Item>
+          <HLF.Item>
+            <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
+          </HLF.Item>
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SG.Item>
+    <SG.Item @label="first flex item has basis=0px">
+      <Shw::Outliner {{style max-width="600px"}}>
+        <Hds::Layout::Flex as |HLF|>
+          <HLF.Item @basis="0px">
+            <Shw::Placeholder @height="40" @background="#e4c5f3">
+              <pre {{style white-space="nowrap" overflow="hidden" text-overflow="ellipsis"}}>item #1 with a very long
+                text that might cause overflow issues</pre>
+            </Shw::Placeholder>
+          </HLF.Item>
+          <HLF.Item>
+            <Shw::Placeholder @text="item #2 with width=150px" @width="150px" @height="40" @background="#e5ffd2" />
+          </HLF.Item>
+          <HLF.Item>
+            <Shw::Placeholder @text="item #3 with width=150px" @width="150px" @height="40" @background="#d2f4ff" />
+          </HLF.Item>
+          <HLF.Item>
+            <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
+          </HLF.Item>
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
 </section>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -36,6 +36,28 @@
 
   <Shw::Divider @level={{2}} />
 
+  <Shw::Text::H2>Wrap</Shw::Text::H2>
+
+  <Shw::Flex @direction="column" as |SF|>
+    {{#let (array false true) as |booleans|}}
+      {{#each booleans as |wrap|}}
+        <SF.Item @label={{if wrap "wrap" "nowrap (default)"}}>
+          <Shw::Outliner {{style width="650px" max-width="100%"}}>
+            <Hds::Layout::Flex @wrap={{wrap}}>
+              <Shw::Placeholder @text="#1" @width="200" @height="40" @background="#e4c5f3" {{style flex="none"}} />
+              <Shw::Placeholder @text="#2" @width="200" @height="40" @background="#e5ffd2" {{style flex="none"}} />
+              <Shw::Placeholder @text="#3" @width="200" @height="40" @background="#d2f4ff" {{style flex="none"}} />
+              <Shw::Placeholder @text="#4" @width="200" @height="40" @background="#fff8d2" {{style flex="none"}} />
+              <Shw::Placeholder @text="#5" @width="200" @height="40" @background="#f3d9c5" {{style flex="none"}} />
+            </Hds::Layout::Flex>
+          </Shw::Outliner>
+        </SF.Item>
+      {{/each}}
+    {{/let}}
+  </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Display</Shw::Text::H3>
 
   <Shw::Flex @gap="2rem" as |SF|>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -351,3 +351,84 @@
   </Shw::Grid>
 
 </section>
+
+<Shw::Divider />
+
+<section data-test-percy>
+
+  <Shw::Text::H2>Examples</Shw::Text::H2>
+
+  <Shw::Flex @direction="column" @gap="2rem" as |SF|>
+    <SF.Item @label="icon + text" class="shw-layout-flex-example-outline-flex-blocks">
+      {{! TODO! add the right value of gap here }}
+      <Hds::Layout::Flex @align="center" @gap="4px">
+        <Hds::Icon @name="info" @size="24" />
+        <Hds::Text::Body @size="200" @tag="p">Lorem ipsum dolor sit amet</Hds::Text::Body>
+      </Hds::Layout::Flex>
+    </SF.Item>
+    <SF.Item @label="media + text" class="shw-layout-flex-example-outline-flex-blocks">
+      {{! TODO! add the right value of gap here }}
+      <Hds::Layout::Flex @align="center" @gap="4px">
+        <img
+          src="/assets/images/avatar.png"
+          alt="portrait of a cat wearing old-fashioned formal wear"
+          class="shw-layout-flex-example-avatar"
+        />
+        <Hds::Text::Body @size="200" @tag="p">Lorem ipsum dolor sit amet</Hds::Text::Body>
+      </Hds::Layout::Flex>
+    </SF.Item>
+    <SF.Item @label="generic input + button" class="shw-layout-flex-example-outline-flex-blocks">
+      {{! TODO! add the right value of gap here }}
+      <Hds::Layout::Flex @align="center" @gap="4px">
+        <input id="example-input-1" type="text" placeholder="Just a generic input" />
+        <button type="button">Button</button>
+      </Hds::Layout::Flex>
+    </SF.Item>
+    <SF.Item
+      @label="centered content"
+      class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
+    >
+      <Hds::Layout::Flex @justify="center" @align="center" {{style width="300px" height="200px"}}>
+        <Hds::Text::Body @size="200" @tag="p">I am centered</Hds::Text::Body>
+      </Hds::Layout::Flex>
+    </SF.Item>
+    <SF.Item
+      @label="equally spaced"
+      class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
+    >
+      <Hds::Layout::Flex @justify="space-between" @align="center">
+        <Hds::Text::Body @size="200" @tag="p">We</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p">Should</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p">All</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p">Be</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p">Equally</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p">Spaced</Hds::Text::Body>
+      </Hds::Layout::Flex>
+    </SF.Item>
+    <SF.Item
+      @label="one item growing"
+      class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
+    >
+      {{! TODO! add the right value of gap here }}
+      <Hds::Layout::Flex @gap="4px" as |HLF|>
+        <Hds::Text::Body @size="200" @tag="p">I use only the content width</Hds::Text::Body>
+        <HLF.Item @grow={{1}}>
+          <Hds::Text::Body @size="200" @tag="p">I use all the rest of the available space</Hds::Text::Body>
+        </HLF.Item>
+        <Hds::Text::Body @size="200" @tag="p">I use only the content width</Hds::Text::Body>
+      </Hds::Layout::Flex>
+    </SF.Item>
+    <SF.Item
+      @label="one item at the end"
+      class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
+    >
+      {{! TODO! add the right value of gap here }}
+      <Hds::Layout::Flex @gap="4px">
+        <Hds::Text::Body @size="200" @tag="p">I am on the left side</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p">I am on the left side too</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style margin-left="auto"}}>I on the right side (using margin-left auto)</Hds::Text::Body>
+      </Hds::Layout::Flex>
+    </SF.Item>
+  </Shw::Flex>
+
+</section>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -58,6 +58,65 @@
 
   <Shw::Divider @level={{2}} />
 
+  <Shw::Text::H2>Justify + Align</Shw::Text::H2>
+  <Shw::Text::Body>These are the
+    <code>justify-content</code>
+    and
+    <code>align-items</code>
+    CSS properties of
+    <code>flexbox</code>.</Shw::Text::Body>
+
+  {{#each @model.DIRECTIONS as |direction|}}
+    <Shw::Text::H3>direction={{direction}}</Shw::Text::H3>
+    <Shw::Grid @columns={{@model.JUSTIFYS.length}} @gap="2rem" as |SG|>
+      {{#each @model.ALIGNS as |align ac|}}
+        {{#if (eq ac 0)}}
+          {{#each @model.JUSTIFYS as |justify|}}
+            <SG.Item>
+              <span class="shw-label">justify={{justify}}</span>
+            </SG.Item>
+          {{/each}}
+        {{/if}}
+        {{#each @model.JUSTIFYS as |justify jc|}}
+          <SG.Item @label={{if (eq jc 0) (concat "align=" align) "​"}}>
+            <Shw::Outliner {{style width="120px" height="120px"}}>
+              <Hds::Layout::Flex
+                @direction={{direction}}
+                @justify={{justify}}
+                @align={{align}}
+                {{style width="100%" height="100%"}}
+              >
+                <Shw::Placeholder
+                  @text="#A"
+                  @width="auto"
+                  @height="auto"
+                  {{style min-width="24px" min-height="24px"}}
+                  @background="#e4c5f3"
+                />
+                <Shw::Placeholder
+                  @text="#B"
+                  @width="auto"
+                  @height="auto"
+                  {{style min-width="24px" min-height="24px"}}
+                  @background="#e5ffd2"
+                />
+                <Shw::Placeholder
+                  @text="#C"
+                  @width="auto"
+                  @height="auto"
+                  {{style min-width="24px" min-height="24px"}}
+                  @background="#d2f4ff"
+                />
+              </Hds::Layout::Flex>
+            </Shw::Outliner>
+          </SG.Item>
+        {{/each}}
+      {{/each}}
+    </Shw::Grid>
+  {{/each}}
+
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Display</Shw::Text::H3>
 
   <Shw::Flex @gap="2rem" as |SF|>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -146,3 +146,157 @@
   </Shw::Flex>
 
 </section>
+
+<Shw::Divider />
+
+<section data-test-percy>
+
+  <Shw::Text::H2>Flex::Item</Shw::Text::H2>
+
+  <Shw::Grid @columns={{1}} as |SG|>
+    <SG.Item @label="used directly or via yielded component">
+      <Shw::Outliner>
+        <Hds::Layout::Flex as |HLF|>
+          <Shw::Placeholder @text="item #1" @height="40" @background="#e4c5f3" />
+          <Hds::Layout::Flex::Item>
+            <Shw::Placeholder @text="item #2 within Flex::Item" @height="40" @background="#e5ffd2" />
+          </Hds::Layout::Flex::Item>
+          <Shw::Placeholder @text="item #3" @height="40" @background="#d2f4ff" />
+          <HLF.Item>
+            <Shw::Placeholder @text="item #4 within HLF.Item" @height="40" @background="#fff8d2" />
+          </HLF.Item>
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Text::H3>Basis</Shw::Text::H3>
+
+  <Shw::Grid @columns={{1}} as |SG|>
+    <SG.Item as |SGI|>
+      <SGI.Label>with <code>size</code> values</SGI.Label>
+      <Shw::Outliner>
+        <Hds::Layout::Flex as |HLF|>
+          <Hds::Layout::Flex::Item @basis="10em">
+            <Shw::Placeholder @text="item #1 with basis=10em" @height="40" @background="#e4c5f3" />
+          </Hds::Layout::Flex::Item>
+          <Hds::Layout::Flex::Item @basis="200px">
+            <Shw::Placeholder @text="item #2 with basis=200px" @height="40" @background="#e5ffd2" />
+          </Hds::Layout::Flex::Item>
+          <HLF.Item @basis="40%">
+            <Shw::Placeholder @text="item #3 with basis=40%" @height="40" @background="#d2f4ff" />
+          </HLF.Item>
+          <HLF.Item @basis="auto">
+            <Shw::Placeholder @text="item #4 with basis=auto" @height="40" @background="#fff8d2" />
+          </HLF.Item>
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SG.Item>
+    <SG.Item as |SGI|>
+      <SGI.Label>with <code>keyword</code> values</SGI.Label>
+      <Shw::Outliner>
+        <Hds::Layout::Flex as |HLF|>
+          <Hds::Layout::Flex::Item @basis="auto">
+            <Shw::Placeholder @text="item #1 with basis=auto" @height="40" @background="#e4c5f3" />
+          </Hds::Layout::Flex::Item>
+          <Hds::Layout::Flex::Item @basis="content">
+            <Shw::Placeholder @text="item #2 with basis=content" @height="40" @background="#e5ffd2" />
+          </Hds::Layout::Flex::Item>
+          <HLF.Item @basis="max-content">
+            <Shw::Placeholder @text="item #3 with basis=max-content" @height="40" @background="#d2f4ff" />
+          </HLF.Item>
+          <HLF.Item @basis="fit-content">
+            <Shw::Placeholder @text="item #4 with basis=fit-content" @height="40" @background="#fff8d2" />
+          </HLF.Item>
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Text::H3>Grow</Shw::Text::H3>
+
+  <Shw::Grid @columns={{1}} as |SG|>
+    <SG.Item as |SGI|>
+      <SGI.Label>with <code>0/1</code> and <code>true/false</code> values</SGI.Label>
+      <Shw::Outliner>
+        <Hds::Layout::Flex as |HLF|>
+          <Hds::Layout::Flex::Item @grow={{0}}>
+            <Shw::Placeholder @text="item #1 with grow=0" @height="40" @background="#e4c5f3" />
+          </Hds::Layout::Flex::Item>
+          <Hds::Layout::Flex::Item @grow={{1}}>
+            <Shw::Placeholder @text="item #2 with grow=1" @height="40" @background="#e5ffd2" />
+          </Hds::Layout::Flex::Item>
+          <HLF.Item @grow={{false}}>
+            <Shw::Placeholder @text="item #3 with grow=false" @height="40" @background="#d2f4ff" />
+          </HLF.Item>
+          <HLF.Item @grow={{true}}>
+            <Shw::Placeholder @text="item #4 with grow=true" @height="40" @background="#fff8d2" />
+          </HLF.Item>
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SG.Item>
+    <SG.Item as |SGI|>
+      <SGI.Label>with <code>numeric/string</code> values (to handle special cases)</SGI.Label>
+      <Shw::Outliner>
+        <Hds::Layout::Flex as |HLF|>
+          <Hds::Layout::Flex::Item @grow={{1}}>
+            <Shw::Placeholder @text="item #1 with grow=1" @height="40" @background="#e4c5f3" />
+          </Hds::Layout::Flex::Item>
+          <Hds::Layout::Flex::Item @grow={{2}}>
+            <Shw::Placeholder @text="item #2 with grow=2" @height="40" @background="#e5ffd2" />
+          </Hds::Layout::Flex::Item>
+          <HLF.Item @grow="3">
+            <Shw::Placeholder @text="item #3 with grow='3'" @height="40" @background="#d2f4ff" />
+          </HLF.Item>
+          <HLF.Item @grow="4">
+            <Shw::Placeholder @text="item #4 with grow='4'" @height="40" @background="#fff8d2" />
+          </HLF.Item>
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Text::H3>Shrink</Shw::Text::H3>
+
+  <Shw::Grid @columns={{1}} as |SG|>
+    <SG.Item as |SGI|>
+      <SGI.Label>with <code>0/1</code> and <code>true/false</code> values</SGI.Label>
+      <Shw::Outliner {{style max-width="600px"}}>
+        <Hds::Layout::Flex as |HLF|>
+          <Hds::Layout::Flex::Item @basis="300px" @shrink={{0}}>
+            <Shw::Placeholder @text="item #1 with shrink=0" @height="40" @background="#e4c5f3" />
+          </Hds::Layout::Flex::Item>
+          <Hds::Layout::Flex::Item @basis="300px" @shrink={{1}}>
+            <Shw::Placeholder @text="item #2 with shrink=1" @height="40" @background="#e5ffd2" />
+          </Hds::Layout::Flex::Item>
+          <HLF.Item @basis="300px" @shrink={{false}}>
+            <Shw::Placeholder @text="item #3 with shrink=false" @height="40" @background="#d2f4ff" />
+          </HLF.Item>
+          <HLF.Item @basis="300px" @shrink={{true}}>
+            <Shw::Placeholder @text="item #4 with shrink=true" @height="40" @background="#fff8d2" />
+          </HLF.Item>
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SG.Item>
+    <SG.Item as |SGI|>
+      <SGI.Label>with <code>numeric/string</code> values (to handle special cases)</SGI.Label>
+      <Shw::Outliner {{style max-width="600px"}}>
+        <Hds::Layout::Flex as |HLF|>
+          <Hds::Layout::Flex::Item @basis="300px" @shrink={{1}}>
+            <Shw::Placeholder @text="item #1 with shrink=1" @height="40" @background="#e4c5f3" />
+          </Hds::Layout::Flex::Item>
+          <Hds::Layout::Flex::Item @basis="300px" @shrink={{2}}>
+            <Shw::Placeholder @text="item #2 with shrink=2" @height="40" @background="#e5ffd2" />
+          </Hds::Layout::Flex::Item>
+          <HLF.Item @basis="300px" @shrink="3">
+            <Shw::Placeholder @text="item #3 with shrink='3'" @height="40" @background="#d2f4ff" />
+          </HLF.Item>
+          <HLF.Item @basis="300px" @shrink="4">
+            <Shw::Placeholder @text="item #4 with shrink='4'" @height="40" @background="#fff8d2" />
+          </HLF.Item>
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
+</section>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -9,9 +9,29 @@
 
 <section data-test-percy>
 
-  {{! ADD YOUR CONTENT HERE }}
+  <Shw::Text::H2>Direction</Shw::Text::H2>
 
-  {{! This below is just an example of invocation, to get started }}
-  <Hds::Layout::Flex>This is the Hds::Layout::Flex component </Hds::Layout::Flex>
+  <Shw::Flex @direction="column" as |SF|>
+    <SF.Item @label="row (default)">
+      <Shw::Outliner>
+        <Hds::Layout::Flex @direction="row">
+          <Shw::Placeholder @text="item #1" @height="40" @background="#e4c5f3" />
+          <Shw::Placeholder @text="item #2" @height="40" @background="#e5ffd2" />
+          <Shw::Placeholder @text="item #3" @height="40" @background="#d2f4ff" />
+          <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SF.Item>
+    <SF.Item @label="column" {{style width="25%"}}>
+      <Shw::Outliner>
+        <Hds::Layout::Flex @direction="column">
+          <Shw::Placeholder @text="item #1" @height="40" @background="#e4c5f3" />
+          <Shw::Placeholder @text="item #2" @height="40" @background="#e5ffd2" />
+          <Shw::Placeholder @text="item #3" @height="40" @background="#d2f4ff" />
+          <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
+        </Hds::Layout::Flex>
+      </Shw::Outliner>
+    </SF.Item>
+  </Shw::Flex>
 
 </section>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -434,6 +434,7 @@
     <SF.Item
       @label="centered content"
       class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
+      @tag="section"
     >
       <Hds::Layout::Flex @justify="center" @align="center" {{style width="300px" height="200px"}}>
         <Hds::Text::Body @size="200" @tag="p">I am centered</Hds::Text::Body>
@@ -443,7 +444,7 @@
       @label="equally spaced"
       class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
     >
-      <Hds::Layout::Flex @justify="space-between" @align="center">
+      <Hds::Layout::Flex @justify="space-between" @align="center" @tag="section">
         <Hds::Text::Body @size="200" @tag="p">We</Hds::Text::Body>
         <Hds::Text::Body @size="200" @tag="p">Should</Hds::Text::Body>
         <Hds::Text::Body @size="200" @tag="p">All</Hds::Text::Body>
@@ -458,7 +459,7 @@
     >
       <Hds::Layout::Flex @gap="16" as |HLF|>
         <Hds::Text::Body @size="200" @tag="p">I use only the content width</Hds::Text::Body>
-        <HLF.Item @grow={{1}}>
+        <HLF.Item @grow={{1}} @tag="article">
           <Hds::Text::Body @size="200" @tag="p">I use all the rest of the available space</Hds::Text::Body>
         </HLF.Item>
         <Hds::Text::Body @size="200" @tag="p">I use only the content width</Hds::Text::Body>
@@ -468,7 +469,7 @@
       @label="one item at the end"
       class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
     >
-      <Hds::Layout::Flex @gap="16">
+      <Hds::Layout::Flex @gap="16" @tag="section">
         <Hds::Text::Body @size="200" @tag="p">I am on the left side</Hds::Text::Body>
         <Hds::Text::Body @size="200" @tag="p">I am on the left side too</Hds::Text::Body>
         <Hds::Text::Body @size="200" @tag="p" {{style margin-left="auto"}}>I on the right side (using margin-left auto)</Hds::Text::Body>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -34,4 +34,34 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Display</Shw::Text::H3>
+
+  <Shw::Flex @gap="2rem" as |SF|>
+    {{#let (array false true) as |booleans|}}
+      {{#each booleans as |isInline|}}
+        <SF.Item @label={{if isInline "inline-flex (isInline=true)" "flex (default)"}}>
+          <Hds::Text::Body @size="200" @tag="p">
+            Lorem
+            <Hds::Layout::Flex @isInline={{isInline}}>
+              <Shw::Placeholder @text="#1" @width="24" @height="24" @background="#e4c5f3" />
+              <Shw::Placeholder @text="#2" @width="24" @height="24" @background="#e5ffd2" />
+              <Shw::Placeholder @text="#3" @width="24" @height="24" @background="#d2f4ff" />
+              <Shw::Placeholder @text="#4" @width="24" @height="24" @background="#fff8d2" />
+            </Hds::Layout::Flex>
+            sit amet
+            <Hds::Layout::Flex @isInline={{isInline}}>
+              <Shw::Placeholder @text="#A" @width="24" @height="24" @background="#e4c5f3" />
+              <Shw::Placeholder @text="#B" @width="24" @height="24" @background="#e5ffd2" />
+              <Shw::Placeholder @text="#C" @width="24" @height="24" @background="#d2f4ff" />
+              <Shw::Placeholder @text="#D" @width="24" @height="24" @background="#fff8d2" />
+            </Hds::Layout::Flex>
+            elit.
+          </Hds::Text::Body>
+        </SF.Item>
+      {{/each}}
+    {{/let}}
+  </Shw::Flex>
+
 </section>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -224,17 +224,20 @@
       <SGI.Label>with <code>size</code> values</SGI.Label>
       <Shw::Outliner>
         <Hds::Layout::Flex as |HLF|>
+          <Hds::Layout::Flex::Item @basis={{0}}>
+            <Shw::Placeholder @text="item #1 with basis=0" @height="40" @background="#e4c5f3" />
+          </Hds::Layout::Flex::Item>
           <Hds::Layout::Flex::Item @basis="10em">
-            <Shw::Placeholder @text="item #1 with basis=10em" @height="40" @background="#e4c5f3" />
+            <Shw::Placeholder @text="item #2 with basis=10em" @height="40" @background="#e5ffd2" />
           </Hds::Layout::Flex::Item>
           <Hds::Layout::Flex::Item @basis="200px">
-            <Shw::Placeholder @text="item #2 with basis=200px" @height="40" @background="#e5ffd2" />
+            <Shw::Placeholder @text="item #3 with basis=200px" @height="40" @background="#d2f4ff" />
           </Hds::Layout::Flex::Item>
           <HLF.Item @basis="40%">
-            <Shw::Placeholder @text="item #3 with basis=40%" @height="40" @background="#d2f4ff" />
+            <Shw::Placeholder @text="item #4 with basis=40%" @height="40" @background="#fff8d2" />
           </HLF.Item>
-          <HLF.Item @basis="auto">
-            <Shw::Placeholder @text="item #4 with basis=auto" @height="40" @background="#fff8d2" />
+          <HLF.Item @basis="6vw">
+            <Shw::Placeholder @text="item #5 with basis=6vw" @height="40" @background="#f3d9c5" />
           </HLF.Item>
         </Hds::Layout::Flex>
       </Shw::Outliner>
@@ -286,17 +289,17 @@
       <SGI.Label>with <code>numeric/string</code> values (to handle special cases)</SGI.Label>
       <Shw::Outliner>
         <Hds::Layout::Flex as |HLF|>
-          <Hds::Layout::Flex::Item @grow={{1}}>
-            <Shw::Placeholder @text="item #1 with grow=1" @height="40" @background="#e4c5f3" />
-          </Hds::Layout::Flex::Item>
           <Hds::Layout::Flex::Item @grow={{2}}>
-            <Shw::Placeholder @text="item #2 with grow=2" @height="40" @background="#e5ffd2" />
+            <Shw::Placeholder @text="item #1 with grow=2" @height="40" @background="#e4c5f3" />
           </Hds::Layout::Flex::Item>
-          <HLF.Item @grow="3">
-            <Shw::Placeholder @text="item #3 with grow='3'" @height="40" @background="#d2f4ff" />
-          </HLF.Item>
+          <Hds::Layout::Flex::Item @grow={{3}}>
+            <Shw::Placeholder @text="item #2 with grow=3" @height="40" @background="#e5ffd2" />
+          </Hds::Layout::Flex::Item>
           <HLF.Item @grow="4">
-            <Shw::Placeholder @text="item #4 with grow='4'" @height="40" @background="#fff8d2" />
+            <Shw::Placeholder @text="item #3 with grow='4'" @height="40" @background="#d2f4ff" />
+          </HLF.Item>
+          <HLF.Item @grow="5">
+            <Shw::Placeholder @text="item #4 with grow='5'" @height="40" @background="#fff8d2" />
           </HLF.Item>
         </Hds::Layout::Flex>
       </Shw::Outliner>
@@ -329,17 +332,17 @@
       <SGI.Label>with <code>numeric/string</code> values (to handle special cases)</SGI.Label>
       <Shw::Outliner {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
-          <Hds::Layout::Flex::Item @basis="300px" @shrink={{1}}>
-            <Shw::Placeholder @text="item #1 with shrink=1" @height="40" @background="#e4c5f3" />
-          </Hds::Layout::Flex::Item>
           <Hds::Layout::Flex::Item @basis="300px" @shrink={{2}}>
-            <Shw::Placeholder @text="item #2 with shrink=2" @height="40" @background="#e5ffd2" />
+            <Shw::Placeholder @text="item #1 with shrink=2" @height="40" @background="#e4c5f3" />
           </Hds::Layout::Flex::Item>
-          <HLF.Item @basis="300px" @shrink="3">
-            <Shw::Placeholder @text="item #3 with shrink='3'" @height="40" @background="#d2f4ff" />
-          </HLF.Item>
+          <Hds::Layout::Flex::Item @basis="300px" @shrink={{3}}>
+            <Shw::Placeholder @text="item #2 with shrink=3" @height="40" @background="#e5ffd2" />
+          </Hds::Layout::Flex::Item>
           <HLF.Item @basis="300px" @shrink="4">
-            <Shw::Placeholder @text="item #4 with shrink='4'" @height="40" @background="#fff8d2" />
+            <Shw::Placeholder @text="item #3 with shrink='4'" @height="40" @background="#d2f4ff" />
+          </HLF.Item>
+          <HLF.Item @basis="300px" @shrink="5">
+            <Shw::Placeholder @text="item #4 with shrink='5'" @height="40" @background="#fff8d2" />
           </HLF.Item>
         </Hds::Layout::Flex>
       </Shw::Outliner>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -224,15 +224,15 @@
       <SGI.Label>with <code>size</code> values</SGI.Label>
       <Shw::Outliner>
         <Hds::Layout::Flex as |HLF|>
-          <Hds::Layout::Flex::Item @basis={{0}}>
+          <HLF.Item @basis={{0}}>
             <Shw::Placeholder @text="item #1 with basis=0" @height="40" @background="#e4c5f3" />
-          </Hds::Layout::Flex::Item>
-          <Hds::Layout::Flex::Item @basis="10em">
+          </HLF.Item>
+          <HLF.Item @basis="10em">
             <Shw::Placeholder @text="item #2 with basis=10em" @height="40" @background="#e5ffd2" />
-          </Hds::Layout::Flex::Item>
-          <Hds::Layout::Flex::Item @basis="200px">
+          </HLF.Item>
+          <HLF.Item @basis="200px">
             <Shw::Placeholder @text="item #3 with basis=200px" @height="40" @background="#d2f4ff" />
-          </Hds::Layout::Flex::Item>
+          </HLF.Item>
           <HLF.Item @basis="40%">
             <Shw::Placeholder @text="item #4 with basis=40%" @height="40" @background="#fff8d2" />
           </HLF.Item>
@@ -246,12 +246,12 @@
       <SGI.Label>with <code>keyword</code> values</SGI.Label>
       <Shw::Outliner>
         <Hds::Layout::Flex as |HLF|>
-          <Hds::Layout::Flex::Item @basis="auto">
+          <HLF.Item @basis="auto">
             <Shw::Placeholder @text="item #1 with basis=auto" @height="40" @background="#e4c5f3" />
-          </Hds::Layout::Flex::Item>
-          <Hds::Layout::Flex::Item @basis="content">
+          </HLF.Item>
+          <HLF.Item @basis="content">
             <Shw::Placeholder @text="item #2 with basis=content" @height="40" @background="#e5ffd2" />
-          </Hds::Layout::Flex::Item>
+          </HLF.Item>
           <HLF.Item @basis="max-content">
             <Shw::Placeholder @text="item #3 with basis=max-content" @height="40" @background="#d2f4ff" />
           </HLF.Item>
@@ -270,12 +270,12 @@
       <SGI.Label>with <code>0/1</code> and <code>true/false</code> values</SGI.Label>
       <Shw::Outliner>
         <Hds::Layout::Flex as |HLF|>
-          <Hds::Layout::Flex::Item @grow={{0}}>
+          <HLF.Item @grow={{0}}>
             <Shw::Placeholder @text="item #1 with grow=0" @height="40" @background="#e4c5f3" />
-          </Hds::Layout::Flex::Item>
-          <Hds::Layout::Flex::Item @grow={{1}}>
+          </HLF.Item>
+          <HLF.Item @grow={{1}}>
             <Shw::Placeholder @text="item #2 with grow=1" @height="40" @background="#e5ffd2" />
-          </Hds::Layout::Flex::Item>
+          </HLF.Item>
           <HLF.Item @grow={{false}}>
             <Shw::Placeholder @text="item #3 with grow=false" @height="40" @background="#d2f4ff" />
           </HLF.Item>
@@ -289,12 +289,12 @@
       <SGI.Label>with <code>numeric/string</code> values (to handle special cases)</SGI.Label>
       <Shw::Outliner>
         <Hds::Layout::Flex as |HLF|>
-          <Hds::Layout::Flex::Item @grow={{2}}>
+          <HLF.Item @grow={{2}}>
             <Shw::Placeholder @text="item #1 with grow=2" @height="40" @background="#e4c5f3" />
-          </Hds::Layout::Flex::Item>
-          <Hds::Layout::Flex::Item @grow={{3}}>
+          </HLF.Item>
+          <HLF.Item @grow={{3}}>
             <Shw::Placeholder @text="item #2 with grow=3" @height="40" @background="#e5ffd2" />
-          </Hds::Layout::Flex::Item>
+          </HLF.Item>
           <HLF.Item @grow="4">
             <Shw::Placeholder @text="item #3 with grow='4'" @height="40" @background="#d2f4ff" />
           </HLF.Item>
@@ -313,12 +313,12 @@
       <SGI.Label>with <code>0/1</code> and <code>true/false</code> values</SGI.Label>
       <Shw::Outliner {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
-          <Hds::Layout::Flex::Item @basis="300px" @shrink={{0}}>
+          <HLF.Item @basis="300px" @shrink={{0}}>
             <Shw::Placeholder @text="item #1 with shrink=0" @height="40" @background="#e4c5f3" />
-          </Hds::Layout::Flex::Item>
-          <Hds::Layout::Flex::Item @basis="300px" @shrink={{1}}>
+          </HLF.Item>
+          <HLF.Item @basis="300px" @shrink={{1}}>
             <Shw::Placeholder @text="item #2 with shrink=1" @height="40" @background="#e5ffd2" />
-          </Hds::Layout::Flex::Item>
+          </HLF.Item>
           <HLF.Item @basis="300px" @shrink={{false}}>
             <Shw::Placeholder @text="item #3 with shrink=false" @height="40" @background="#d2f4ff" />
           </HLF.Item>
@@ -332,12 +332,12 @@
       <SGI.Label>with <code>numeric/string</code> values (to handle special cases)</SGI.Label>
       <Shw::Outliner {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
-          <Hds::Layout::Flex::Item @basis="300px" @shrink={{2}}>
+          <HLF.Item @basis="300px" @shrink={{2}}>
             <Shw::Placeholder @text="item #1 with shrink=2" @height="40" @background="#e4c5f3" />
-          </Hds::Layout::Flex::Item>
-          <Hds::Layout::Flex::Item @basis="300px" @shrink={{3}}>
+          </HLF.Item>
+          <HLF.Item @basis="300px" @shrink={{3}}>
             <Shw::Placeholder @text="item #2 with shrink=3" @height="40" @background="#e5ffd2" />
-          </Hds::Layout::Flex::Item>
+          </HLF.Item>
           <HLF.Item @basis="300px" @shrink="4">
             <Shw::Placeholder @text="item #3 with shrink='4'" @height="40" @background="#d2f4ff" />
           </HLF.Item>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -117,6 +117,53 @@
 
   <Shw::Divider @level={{2}} />
 
+  <Shw::Text::H3>Gap</Shw::Text::H3>
+
+  <Shw::Text::H4>Single value</Shw::Text::H4>
+
+  {{#each @model.DIRECTIONS as |direction|}}
+    <Shw::Grid @columns={{@model.GAPS.length}} @gap="2rem" as |SG|>
+      {{#each @model.GAPS as |gap|}}
+        <SG.Item @label="gap={{gap}}">
+          <Shw::Outliner>
+            <Hds::Layout::Flex @direction={{direction}} @gap={{gap}}>
+              <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+              <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+              <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+              <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+            </Hds::Layout::Flex>
+          </Shw::Outliner>
+        </SG.Item>
+      {{/each}}
+    </Shw::Grid>
+  {{/each}}
+
+  <Shw::Text::H4>Double value (row/column)</Shw::Text::H4>
+
+  <Shw::Flex @gap="2rem 4rem" as |SF|>
+    {{! we use only a subset of possible combinations, just for testing purposes }}
+    {{#let (array (array "4" "48") (array "8" "32") (array "12" "24") (array "16" "16")) as |gapsList|}}
+      {{#each gapsList as |gapsArray|}}
+        <SF.Item @label="gap=[{{gapsArray}}]">
+          <Shw::Outliner {{style width="500px"}}>
+            <Hds::Layout::Flex @gap={{gapsArray}} @wrap={{true}}>
+              <Shw::Placeholder @text="item #1" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #2" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #3" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #4" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #5" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #6" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #7" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #8" @width="100px" @height="24" />
+            </Hds::Layout::Flex>
+          </Shw::Outliner>
+        </SF.Item>
+      {{/each}}
+    {{/let}}
+  </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Display</Shw::Text::H3>
 
   <Shw::Flex @gap="2rem" as |SF|>
@@ -360,15 +407,13 @@
 
   <Shw::Flex @direction="column" @gap="2rem" as |SF|>
     <SF.Item @label="icon + text" class="shw-layout-flex-example-outline-flex-blocks">
-      {{! TODO! add the right value of gap here }}
-      <Hds::Layout::Flex @align="center" @gap="4px">
+      <Hds::Layout::Flex @align="center" @gap="8">
         <Hds::Icon @name="info" @size="24" />
         <Hds::Text::Body @size="200" @tag="p">Lorem ipsum dolor sit amet</Hds::Text::Body>
       </Hds::Layout::Flex>
     </SF.Item>
     <SF.Item @label="media + text" class="shw-layout-flex-example-outline-flex-blocks">
-      {{! TODO! add the right value of gap here }}
-      <Hds::Layout::Flex @align="center" @gap="4px">
+      <Hds::Layout::Flex @align="center" @gap="8">
         <img
           src="/assets/images/avatar.png"
           alt="portrait of a cat wearing old-fashioned formal wear"
@@ -378,8 +423,7 @@
       </Hds::Layout::Flex>
     </SF.Item>
     <SF.Item @label="generic input + button" class="shw-layout-flex-example-outline-flex-blocks">
-      {{! TODO! add the right value of gap here }}
-      <Hds::Layout::Flex @align="center" @gap="4px">
+      <Hds::Layout::Flex @align="center" @gap="8">
         <input id="example-input-1" type="text" placeholder="Just a generic input" />
         <button type="button">Button</button>
       </Hds::Layout::Flex>
@@ -409,8 +453,7 @@
       @label="one item growing"
       class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
     >
-      {{! TODO! add the right value of gap here }}
-      <Hds::Layout::Flex @gap="4px" as |HLF|>
+      <Hds::Layout::Flex @gap="16" as |HLF|>
         <Hds::Text::Body @size="200" @tag="p">I use only the content width</Hds::Text::Body>
         <HLF.Item @grow={{1}}>
           <Hds::Text::Body @size="200" @tag="p">I use all the rest of the available space</Hds::Text::Body>
@@ -422,12 +465,12 @@
       @label="one item at the end"
       class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
     >
-      {{! TODO! add the right value of gap here }}
-      <Hds::Layout::Flex @gap="4px">
+      <Hds::Layout::Flex @gap="16">
         <Hds::Text::Body @size="200" @tag="p">I am on the left side</Hds::Text::Body>
         <Hds::Text::Body @size="200" @tag="p">I am on the left side too</Hds::Text::Body>
         <Hds::Text::Body @size="200" @tag="p" {{style margin-left="auto"}}>I on the right side (using margin-left auto)</Hds::Text::Body>
       </Hds::Layout::Flex>
+
     </SF.Item>
   </Shw::Flex>
 

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -124,9 +124,9 @@
 
   <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H3>Gap</Shw::Text::H3>
+  <Shw::Text::H2>Gap</Shw::Text::H2>
 
-  <Shw::Text::H4>Single value</Shw::Text::H4>
+  <Shw::Text::H4 @tag="h3">Single value</Shw::Text::H4>
 
   {{#each @model.DIRECTIONS as |direction|}}
     <Shw::Grid @columns={{@model.GAPS.length}} @gap="2rem" as |SG|>
@@ -146,7 +146,7 @@
     </Shw::Grid>
   {{/each}}
 
-  <Shw::Text::H4>Double value (row/column)</Shw::Text::H4>
+  <Shw::Text::H4 @tag="h3">Double value (row/column)</Shw::Text::H4>
 
   <Shw::Flex @gap="2rem 4rem" as |SF|>
     {{! we use only a subset of possible combinations, just for testing purposes }}
@@ -172,7 +172,7 @@
 
   <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H3>Display</Shw::Text::H3>
+  <Shw::Text::H2>Display</Shw::Text::H2>
 
   <Shw::Flex @gap="2rem" as |SF|>
     {{#let (array false true) as |booleans|}}

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -12,25 +12,28 @@
   <Shw::Text::H2>Direction</Shw::Text::H2>
 
   <Shw::Flex @direction="column" as |SF|>
-    <SF.Item @label="row (default)">
-      <Shw::Outliner>
-        <Hds::Layout::Flex @direction="row">
-          <Shw::Placeholder @text="item #1" @height="40" @background="#e4c5f3" />
-          <Shw::Placeholder @text="item #2" @height="40" @background="#e5ffd2" />
-          <Shw::Placeholder @text="item #3" @height="40" @background="#d2f4ff" />
-          <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
-        </Hds::Layout::Flex>
-      </Shw::Outliner>
+    <SF.Item
+      @label="row (default)"
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+    >
+      <Hds::Layout::Flex @direction="row">
+        <Shw::Placeholder @text="item #1" @height="40" />
+        <Shw::Placeholder @text="item #2" @height="40" />
+        <Shw::Placeholder @text="item #3" @height="40" />
+        <Shw::Placeholder @text="item #4" @height="40" />
+      </Hds::Layout::Flex>
     </SF.Item>
-    <SF.Item @label="column" {{style width="25%"}}>
-      <Shw::Outliner>
-        <Hds::Layout::Flex @direction="column">
-          <Shw::Placeholder @text="item #1" @height="40" @background="#e4c5f3" />
-          <Shw::Placeholder @text="item #2" @height="40" @background="#e5ffd2" />
-          <Shw::Placeholder @text="item #3" @height="40" @background="#d2f4ff" />
-          <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
-        </Hds::Layout::Flex>
-      </Shw::Outliner>
+    <SF.Item
+      @label="column"
+      {{style width="25%"}}
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+    >
+      <Hds::Layout::Flex @direction="column">
+        <Shw::Placeholder @text="item #1" @height="40" />
+        <Shw::Placeholder @text="item #2" @height="40" />
+        <Shw::Placeholder @text="item #3" @height="40" />
+        <Shw::Placeholder @text="item #4" @height="40" />
+      </Hds::Layout::Flex>
     </SF.Item>
   </Shw::Flex>
 
@@ -41,16 +44,19 @@
   <Shw::Flex @direction="column" as |SF|>
     {{#let (array false true) as |booleans|}}
       {{#each booleans as |wrap|}}
-        <SF.Item @label={{if wrap "wrap" "nowrap (default)"}}>
-          <Shw::Outliner {{style width="650px" max-width="100%"}}>
+        <SF.Item
+          @label={{if wrap "wrap" "nowrap (default)"}}
+          class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+        >
+          <div {{style width="650px" max-width="100%"}}>
             <Hds::Layout::Flex @wrap={{wrap}}>
-              <Shw::Placeholder @text="#1" @width="200" @height="40" @background="#e4c5f3" {{style flex="none"}} />
-              <Shw::Placeholder @text="#2" @width="200" @height="40" @background="#e5ffd2" {{style flex="none"}} />
-              <Shw::Placeholder @text="#3" @width="200" @height="40" @background="#d2f4ff" {{style flex="none"}} />
-              <Shw::Placeholder @text="#4" @width="200" @height="40" @background="#fff8d2" {{style flex="none"}} />
-              <Shw::Placeholder @text="#5" @width="200" @height="40" @background="#f3d9c5" {{style flex="none"}} />
+              <Shw::Placeholder @text="#1" @width="200" @height="40" {{style flex-shrink="0"}} />
+              <Shw::Placeholder @text="#2" @width="200" @height="40" {{style flex-shrink="0"}} />
+              <Shw::Placeholder @text="#3" @width="200" @height="40" {{style flex-shrink="0"}} />
+              <Shw::Placeholder @text="#4" @width="200" @height="40" {{style flex-shrink="0"}} />
+              <Shw::Placeholder @text="#5" @width="200" @height="40" {{style flex-shrink="0"}} />
             </Hds::Layout::Flex>
-          </Shw::Outliner>
+          </div>
         </SF.Item>
       {{/each}}
     {{/let}}
@@ -78,8 +84,12 @@
           {{/each}}
         {{/if}}
         {{#each @model.JUSTIFYS as |justify jc|}}
-          <SG.Item @label={{if (eq jc 0) (concat "align=" align) "​"}}>
-            <Shw::Outliner {{style width="120px" height="120px"}}>
+          {{! Notice: we're  using an invisible character here to preserve the alignment of the items }}
+          <SG.Item
+            @label={{if (eq jc 0) (concat "align=" align) "​"}}
+            class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+          >
+            <div {{style width="120px" height="120px"}}>
               <Hds::Layout::Flex
                 @direction={{direction}}
                 @justify={{justify}}
@@ -91,24 +101,21 @@
                   @width="auto"
                   @height="auto"
                   {{style min-width="24px" min-height="24px"}}
-                  @background="#e4c5f3"
                 />
                 <Shw::Placeholder
                   @text="#B"
                   @width="auto"
                   @height="auto"
                   {{style min-width="24px" min-height="24px"}}
-                  @background="#e5ffd2"
                 />
                 <Shw::Placeholder
                   @text="#C"
                   @width="auto"
                   @height="auto"
                   {{style min-width="24px" min-height="24px"}}
-                  @background="#d2f4ff"
                 />
               </Hds::Layout::Flex>
-            </Shw::Outliner>
+            </div>
           </SG.Item>
         {{/each}}
       {{/each}}
@@ -124,15 +131,16 @@
   {{#each @model.DIRECTIONS as |direction|}}
     <Shw::Grid @columns={{@model.GAPS.length}} @gap="2rem" as |SG|>
       {{#each @model.GAPS as |gap|}}
-        <SG.Item @label="gap={{gap}}">
-          <Shw::Outliner>
-            <Hds::Layout::Flex @direction={{direction}} @gap={{gap}}>
-              <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
-              <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
-              <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
-              <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
-            </Hds::Layout::Flex>
-          </Shw::Outliner>
+        <SG.Item
+          @label="gap={{gap}}"
+          class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+        >
+          <Hds::Layout::Flex @direction={{direction}} @gap={{gap}}>
+            <Shw::Placeholder @text="#1" @height="24" />
+            <Shw::Placeholder @text="#2" @height="24" />
+            <Shw::Placeholder @text="#3" @height="24" />
+            <Shw::Placeholder @text="#4" @height="24" />
+          </Hds::Layout::Flex>
         </SG.Item>
       {{/each}}
     </Shw::Grid>
@@ -144,8 +152,8 @@
     {{! we use only a subset of possible combinations, just for testing purposes }}
     {{#let (array (array "4" "48") (array "8" "32") (array "12" "24") (array "16" "16")) as |gapsList|}}
       {{#each gapsList as |gapsArray|}}
-        <SF.Item @label="gap=[{{gapsArray}}]">
-          <Shw::Outliner {{style width="500px"}}>
+        <SF.Item @label="gap=[{{gapsArray}}]" class="shw-layout-flex-example-outline-flex-container">
+          <div {{style width="500px"}}>
             <Hds::Layout::Flex @gap={{gapsArray}} @wrap={{true}}>
               <Shw::Placeholder @text="item #1" @width="100px" @height="24" />
               <Shw::Placeholder @text="item #2" @width="100px" @height="24" />
@@ -156,7 +164,7 @@
               <Shw::Placeholder @text="item #7" @width="100px" @height="24" />
               <Shw::Placeholder @text="item #8" @width="100px" @height="24" />
             </Hds::Layout::Flex>
-          </Shw::Outliner>
+          </div>
         </SF.Item>
       {{/each}}
     {{/let}}
@@ -169,21 +177,24 @@
   <Shw::Flex @gap="2rem" as |SF|>
     {{#let (array false true) as |booleans|}}
       {{#each booleans as |isInline|}}
-        <SF.Item @label={{if isInline "inline-flex (isInline=true)" "flex (default)"}}>
+        <SF.Item
+          @label={{if isInline "inline-flex (isInline=true)" "flex (default)"}}
+          class="shw-layout-flex-example-tint-flex-items"
+        >
           <Hds::Text::Body @size="200" @tag="p">
             Lorem
             <Hds::Layout::Flex @isInline={{isInline}}>
-              <Shw::Placeholder @text="#1" @width="24" @height="24" @background="#e4c5f3" />
-              <Shw::Placeholder @text="#2" @width="24" @height="24" @background="#e5ffd2" />
-              <Shw::Placeholder @text="#3" @width="24" @height="24" @background="#d2f4ff" />
-              <Shw::Placeholder @text="#4" @width="24" @height="24" @background="#fff8d2" />
+              <Shw::Placeholder @text="#1" @width="24" @height="24" />
+              <Shw::Placeholder @text="#2" @width="24" @height="24" />
+              <Shw::Placeholder @text="#3" @width="24" @height="24" />
+              <Shw::Placeholder @text="#4" @width="24" @height="24" />
             </Hds::Layout::Flex>
             sit amet
             <Hds::Layout::Flex @isInline={{isInline}}>
-              <Shw::Placeholder @text="#A" @width="24" @height="24" @background="#e4c5f3" />
-              <Shw::Placeholder @text="#B" @width="24" @height="24" @background="#e5ffd2" />
-              <Shw::Placeholder @text="#C" @width="24" @height="24" @background="#d2f4ff" />
-              <Shw::Placeholder @text="#D" @width="24" @height="24" @background="#fff8d2" />
+              <Shw::Placeholder @text="#A" @width="24" @height="24" />
+              <Shw::Placeholder @text="#B" @width="24" @height="24" />
+              <Shw::Placeholder @text="#C" @width="24" @height="24" />
+              <Shw::Placeholder @text="#D" @width="24" @height="24" />
             </Hds::Layout::Flex>
             elit.
           </Hds::Text::Body>
@@ -201,117 +212,113 @@
   <Shw::Text::H2>Flex::Item</Shw::Text::H2>
 
   <Shw::Grid @columns={{1}} as |SG|>
-    <SG.Item @label="used directly or via yielded component">
-      <Shw::Outliner>
-        <Hds::Layout::Flex as |HLF|>
-          <Shw::Placeholder @text="item #1" @height="40" @background="#e4c5f3" />
-          <Hds::Layout::Flex::Item>
-            <Shw::Placeholder @text="item #2 within Flex::Item" @height="40" @background="#e5ffd2" />
-          </Hds::Layout::Flex::Item>
-          <Shw::Placeholder @text="item #3" @height="40" @background="#d2f4ff" />
-          <HLF.Item>
-            <Shw::Placeholder @text="item #4 within HLF.Item" @height="40" @background="#fff8d2" />
-          </HLF.Item>
-        </Hds::Layout::Flex>
-      </Shw::Outliner>
+    <SG.Item
+      @label="used directly or via yielded component"
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+    >
+      <Hds::Layout::Flex as |HLF|>
+        <Shw::Placeholder @text="item #1" @height="40" />
+        <Hds::Layout::Flex::Item>
+          <Shw::Placeholder @text="item #2 within Flex::Item" @height="40" @background="transparent" />
+        </Hds::Layout::Flex::Item>
+        <Shw::Placeholder @text="item #3" @height="40" />
+        <HLF.Item>
+          <Shw::Placeholder @text="item #4 within HLF.Item" @height="40" @background="transparent" />
+        </HLF.Item>
+      </Hds::Layout::Flex>
     </SG.Item>
   </Shw::Grid>
 
   <Shw::Text::H3>Basis</Shw::Text::H3>
 
   <Shw::Grid @columns={{1}} as |SG|>
-    <SG.Item as |SGI|>
+    <SG.Item class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items" as |SGI|>
       <SGI.Label>with <code>size</code> values</SGI.Label>
-      <Shw::Outliner>
-        <Hds::Layout::Flex as |HLF|>
-          <HLF.Item @basis={{0}}>
-            <Shw::Placeholder @text="item #1 with basis=0" @height="40" @background="#e4c5f3" />
-          </HLF.Item>
-          <HLF.Item @basis="10em">
-            <Shw::Placeholder @text="item #2 with basis=10em" @height="40" @background="#e5ffd2" />
-          </HLF.Item>
-          <HLF.Item @basis="200px">
-            <Shw::Placeholder @text="item #3 with basis=200px" @height="40" @background="#d2f4ff" />
-          </HLF.Item>
-          <HLF.Item @basis="40%">
-            <Shw::Placeholder @text="item #4 with basis=40%" @height="40" @background="#fff8d2" />
-          </HLF.Item>
-          <HLF.Item @basis="6vw">
-            <Shw::Placeholder @text="item #5 with basis=6vw" @height="40" @background="#f3d9c5" />
-          </HLF.Item>
-        </Hds::Layout::Flex>
-      </Shw::Outliner>
+      <Hds::Layout::Flex as |HLF|>
+        <HLF.Item @basis={{0}}>
+          <Shw::Placeholder @text="item #1 with basis=0" @height="40" @background="transparent" />
+        </HLF.Item>
+        <HLF.Item @basis="10em">
+          <Shw::Placeholder @text="item #2 with basis=10em" @height="40" @background="transparent" />
+        </HLF.Item>
+        <HLF.Item @basis="200px">
+          <Shw::Placeholder @text="item #3 with basis=200px" @height="40" @background="transparent" />
+        </HLF.Item>
+        <HLF.Item @basis="40%">
+          <Shw::Placeholder @text="item #4 with basis=40%" @height="40" @background="transparent" />
+        </HLF.Item>
+        <HLF.Item @basis="6vw">
+          <Shw::Placeholder @text="item #5 with basis=6vw" @height="40" @background="transparent" />
+        </HLF.Item>
+      </Hds::Layout::Flex>
     </SG.Item>
     <SG.Item as |SGI|>
       <SGI.Label>with <code>keyword</code> values</SGI.Label>
-      <Shw::Outliner>
-        <Hds::Layout::Flex as |HLF|>
-          <HLF.Item @basis="auto">
-            <Shw::Placeholder @text="item #1 with basis=auto" @height="40" @background="#e4c5f3" />
-          </HLF.Item>
-          <HLF.Item @basis="content">
-            <Shw::Placeholder @text="item #2 with basis=content" @height="40" @background="#e5ffd2" />
-          </HLF.Item>
-          <HLF.Item @basis="max-content">
-            <Shw::Placeholder @text="item #3 with basis=max-content" @height="40" @background="#d2f4ff" />
-          </HLF.Item>
-          <HLF.Item @basis="fit-content">
-            <Shw::Placeholder @text="item #4 with basis=fit-content" @height="40" @background="#fff8d2" />
-          </HLF.Item>
-        </Hds::Layout::Flex>
-      </Shw::Outliner>
+      <Hds::Layout::Flex
+        class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+        as |HLF|
+      >
+        <HLF.Item @basis="auto">
+          <Shw::Placeholder @text="item #1 with basis=auto" @height="40" @background="transparent" />
+        </HLF.Item>
+        <HLF.Item @basis="content">
+          <Shw::Placeholder @text="item #2 with basis=content" @height="40" @background="transparent" />
+        </HLF.Item>
+        <HLF.Item @basis="max-content">
+          <Shw::Placeholder @text="item #3 with basis=max-content" @height="40" @background="transparent" />
+        </HLF.Item>
+        <HLF.Item @basis="fit-content">
+          <Shw::Placeholder @text="item #4 with basis=fit-content" @height="40" @background="transparent" />
+        </HLF.Item>
+      </Hds::Layout::Flex>
     </SG.Item>
   </Shw::Grid>
 
   <Shw::Text::H3>Grow</Shw::Text::H3>
 
   <Shw::Grid @columns={{1}} as |SG|>
-    <SG.Item as |SGI|>
+    <SG.Item class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items" as |SGI|>
       <SGI.Label>with <code>0/1</code> and <code>true/false</code> values</SGI.Label>
-      <Shw::Outliner>
-        <Hds::Layout::Flex as |HLF|>
-          <HLF.Item @grow={{0}}>
-            <Shw::Placeholder @text="item #1 with grow=0" @height="40" @background="#e4c5f3" />
-          </HLF.Item>
-          <HLF.Item @grow={{1}}>
-            <Shw::Placeholder @text="item #2 with grow=1" @height="40" @background="#e5ffd2" />
-          </HLF.Item>
-          <HLF.Item @grow={{false}}>
-            <Shw::Placeholder @text="item #3 with grow=false" @height="40" @background="#d2f4ff" />
-          </HLF.Item>
-          <HLF.Item @grow={{true}}>
-            <Shw::Placeholder @text="item #4 with grow=true" @height="40" @background="#fff8d2" />
-          </HLF.Item>
-        </Hds::Layout::Flex>
-      </Shw::Outliner>
+      <Hds::Layout::Flex as |HLF|>
+        <HLF.Item @grow={{0}}>
+          <Shw::Placeholder @text="item #1 with grow=0" @height="40" @background="transparent" />
+        </HLF.Item>
+        <HLF.Item @grow={{1}}>
+          <Shw::Placeholder @text="item #2 with grow=1" @height="40" @background="transparent" />
+        </HLF.Item>
+        <HLF.Item @grow={{false}}>
+          <Shw::Placeholder @text="item #3 with grow=false" @height="40" @background="transparent" />
+        </HLF.Item>
+        <HLF.Item @grow={{true}}>
+          <Shw::Placeholder @text="item #4 with grow=true" @height="40" @background="transparent" />
+        </HLF.Item>
+      </Hds::Layout::Flex>
     </SG.Item>
-    <SG.Item as |SGI|>
+    <SG.Item class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items" as |SGI|>
       <SGI.Label>with <code>numeric/string</code> values (to handle special cases)</SGI.Label>
-      <Shw::Outliner>
-        <Hds::Layout::Flex as |HLF|>
-          <HLF.Item @grow={{2}}>
-            <Shw::Placeholder @text="item #1 with grow=2" @height="40" @background="#e4c5f3" />
-          </HLF.Item>
-          <HLF.Item @grow={{3}}>
-            <Shw::Placeholder @text="item #2 with grow=3" @height="40" @background="#e5ffd2" />
-          </HLF.Item>
-          <HLF.Item @grow="4">
-            <Shw::Placeholder @text="item #3 with grow='4'" @height="40" @background="#d2f4ff" />
-          </HLF.Item>
-          <HLF.Item @grow="5">
-            <Shw::Placeholder @text="item #4 with grow='5'" @height="40" @background="#fff8d2" />
-          </HLF.Item>
-        </Hds::Layout::Flex>
-      </Shw::Outliner>
+      <Hds::Layout::Flex as |HLF|>
+        <HLF.Item @grow={{2}}>
+          <Shw::Placeholder @text="item #1 with grow=2" @height="40" @background="#e4c5f3" />
+        </HLF.Item>
+        <HLF.Item @grow={{3}}>
+          <Shw::Placeholder @text="item #2 with grow=3" @height="40" @background="#e5ffd2" />
+        </HLF.Item>
+        <HLF.Item @grow="4">
+          <Shw::Placeholder @text="item #3 with grow='4'" @height="40" @background="#d2f4ff" />
+        </HLF.Item>
+        <HLF.Item @grow="5">
+          <Shw::Placeholder @text="item #4 with grow='5'" @height="40" @background="#fff8d2" />
+        </HLF.Item>
+      </Hds::Layout::Flex>
     </SG.Item>
   </Shw::Grid>
 
   <Shw::Text::H3>Shrink</Shw::Text::H3>
 
   <Shw::Grid @columns={{1}} as |SG|>
-    <SG.Item as |SGI|>
+    <SG.Item class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items" as |SGI|>
       <SGI.Label>with <code>0/1</code> and <code>true/false</code> values</SGI.Label>
-      <Shw::Outliner {{style max-width="600px"}}>
+      <div {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
           <HLF.Item @basis="300px" @shrink={{0}}>
             <Shw::Placeholder @text="item #1 with shrink=0" @height="40" @background="#e4c5f3" />
@@ -326,11 +333,11 @@
             <Shw::Placeholder @text="item #4 with shrink=true" @height="40" @background="#fff8d2" />
           </HLF.Item>
         </Hds::Layout::Flex>
-      </Shw::Outliner>
+      </div>
     </SG.Item>
-    <SG.Item as |SGI|>
+    <SG.Item class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items" as |SGI|>
       <SGI.Label>with <code>numeric/string</code> values (to handle special cases)</SGI.Label>
-      <Shw::Outliner {{style max-width="600px"}}>
+      <div {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
           <HLF.Item @basis="300px" @shrink={{2}}>
             <Shw::Placeholder @text="item #1 with shrink=2" @height="40" @background="#e4c5f3" />
@@ -345,7 +352,7 @@
             <Shw::Placeholder @text="item #4 with shrink='5'" @height="40" @background="#fff8d2" />
           </HLF.Item>
         </Hds::Layout::Flex>
-      </Shw::Outliner>
+      </div>
     </SG.Item>
   </Shw::Grid>
 
@@ -356,8 +363,11 @@
     to the flex item to allow the element to shrink below its content's intrinsic minimum width.</Shw::Text::Body>
 
   <Shw::Grid @columns={{1}} as |SG|>
-    <SG.Item @label="first flex item has enableCollapseBelowContentSize=true">
-      <Shw::Outliner {{style max-width="600px"}}>
+    <SG.Item
+      @label="first flex item has enableCollapseBelowContentSize=true"
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+    >
+      <div {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
           <HLF.Item @enableCollapseBelowContentSize={{true}}>
             <Shw::Placeholder @height="40" @background="#e4c5f3">
@@ -375,10 +385,13 @@
             <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
           </HLF.Item>
         </Hds::Layout::Flex>
-      </Shw::Outliner>
+      </div>
     </SG.Item>
-    <SG.Item @label="first flex item has basis=0px">
-      <Shw::Outliner {{style max-width="600px"}}>
+    <SG.Item
+      @label="first flex item has basis=0px"
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+    >
+      <div {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
           <HLF.Item @basis="0px">
             <Shw::Placeholder @height="40" @background="#e4c5f3">
@@ -396,7 +409,7 @@
             <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
           </HLF.Item>
         </Hds::Layout::Flex>
-      </Shw::Outliner>
+      </div>
     </SG.Item>
   </Shw::Grid>
 
@@ -433,46 +446,47 @@
     </SF.Item>
     <SF.Item
       @label="centered content"
-      class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
       @tag="section"
     >
       <Hds::Layout::Flex @justify="center" @align="center" {{style width="300px" height="200px"}}>
-        <Hds::Text::Body @size="200" @tag="p">I am centered</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>I am centered</Hds::Text::Body>
       </Hds::Layout::Flex>
     </SF.Item>
     <SF.Item
       @label="equally spaced"
-      class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
     >
       <Hds::Layout::Flex @justify="space-between" @align="center" @tag="section">
-        <Hds::Text::Body @size="200" @tag="p">We</Hds::Text::Body>
-        <Hds::Text::Body @size="200" @tag="p">Should</Hds::Text::Body>
-        <Hds::Text::Body @size="200" @tag="p">All</Hds::Text::Body>
-        <Hds::Text::Body @size="200" @tag="p">Be</Hds::Text::Body>
-        <Hds::Text::Body @size="200" @tag="p">Equally</Hds::Text::Body>
-        <Hds::Text::Body @size="200" @tag="p">Spaced</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>We</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>Should</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>All</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>Be</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>Equally</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>Spaced</Hds::Text::Body>
       </Hds::Layout::Flex>
     </SF.Item>
     <SF.Item
       @label="one item growing"
-      class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
     >
       <Hds::Layout::Flex @gap="16" as |HLF|>
-        <Hds::Text::Body @size="200" @tag="p">I use only the content width</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>I use only the content width</Hds::Text::Body>
         <HLF.Item @grow={{1}} @tag="article">
-          <Hds::Text::Body @size="200" @tag="p">I use all the rest of the available space</Hds::Text::Body>
+          <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>I use all the rest of the available space</Hds::Text::Body>
         </HLF.Item>
-        <Hds::Text::Body @size="200" @tag="p">I use only the content width</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>I use only the content width</Hds::Text::Body>
       </Hds::Layout::Flex>
     </SF.Item>
     <SF.Item
       @label="one item at the end"
-      class="shw-layout-flex-example-outline-flex-blocks shw-layout-flex-example-outline-flex-blocks--with-backgrounds"
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
     >
       <Hds::Layout::Flex @gap="16" @tag="section">
-        <Hds::Text::Body @size="200" @tag="p">I am on the left side</Hds::Text::Body>
-        <Hds::Text::Body @size="200" @tag="p">I am on the left side too</Hds::Text::Body>
-        <Hds::Text::Body @size="200" @tag="p" {{style margin-left="auto"}}>I on the right side (using margin-left auto)</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>I am on the left side</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}}>I am on the left side too</Hds::Text::Body>
+        <Hds::Text::Body @size="200" @tag="p" {{style padding="4px 8px"}} {{style margin-left="auto"}}>I on the right
+          side (using margin-left auto)</Hds::Text::Body>
       </Hds::Layout::Flex>
 
     </SF.Item>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -170,6 +170,39 @@
     {{/let}}
   </Shw::Flex>
 
+  <br />
+  <br />
+
+  <Shw::Text::H4 @tag="h3">Custom values (overrides)</Shw::Text::H4>
+
+  <Shw::Flex @direction="column" @gap="2rem" as |SF|>
+    <SF.Item
+      @label="gap-column=20px (via classname)"
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+    >
+      <Hds::Layout::Flex class="shw-layout-flex-example-gap-override">
+        <Shw::Placeholder @text="#1" @height="24" />
+        <Shw::Placeholder @text="#2" @height="24" />
+        <Shw::Placeholder @text="#3" @height="24" />
+        <Shw::Placeholder @text="#4" @height="24" />
+      </Hds::Layout::Flex>
+    </SF.Item>
+    <SF.Item
+      @label="gap-column=1.25rem / gap-row=20px (via inline style)"
+      class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
+    >
+      <Hds::Layout::Flex
+        @wrap={{true}}
+        {{style --hds-layout-flex-row-gap="20px" --hds-layout-flex-column-gap="1.25rem"}}
+      >
+        <Shw::Placeholder @text="#1" @width="45%" @height="24" />
+        <Shw::Placeholder @text="#2" @width="45%" @height="24" />
+        <Shw::Placeholder @text="#3" @width="45%" @height="24" />
+        <Shw::Placeholder @text="#4" @width="45%" @height="24" />
+      </Hds::Layout::Flex>
+    </SF.Item>
+  </Shw::Flex>
+
   <Shw::Divider @level={{2}} />
 
   <Shw::Text::H2>Display</Shw::Text::H2>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -298,16 +298,16 @@
       <SGI.Label>with <code>numeric/string</code> values (to handle special cases)</SGI.Label>
       <Hds::Layout::Flex as |HLF|>
         <HLF.Item @grow={{2}}>
-          <Shw::Placeholder @text="item #1 with grow=2" @height="40" @background="#e4c5f3" />
+          <Shw::Placeholder @text="item #1 with grow=2" @height="40" @background="transparent" />
         </HLF.Item>
         <HLF.Item @grow={{3}}>
-          <Shw::Placeholder @text="item #2 with grow=3" @height="40" @background="#e5ffd2" />
+          <Shw::Placeholder @text="item #2 with grow=3" @height="40" @background="transparent" />
         </HLF.Item>
         <HLF.Item @grow="4">
-          <Shw::Placeholder @text="item #3 with grow='4'" @height="40" @background="#d2f4ff" />
+          <Shw::Placeholder @text="item #3 with grow='4'" @height="40" @background="transparent" />
         </HLF.Item>
         <HLF.Item @grow="5">
-          <Shw::Placeholder @text="item #4 with grow='5'" @height="40" @background="#fff8d2" />
+          <Shw::Placeholder @text="item #4 with grow='5'" @height="40" @background="transparent" />
         </HLF.Item>
       </Hds::Layout::Flex>
     </SG.Item>
@@ -321,16 +321,16 @@
       <div {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
           <HLF.Item @basis="300px" @shrink={{0}}>
-            <Shw::Placeholder @text="item #1 with shrink=0" @height="40" @background="#e4c5f3" />
+            <Shw::Placeholder @text="item #1 with shrink=0" @height="40" @background="transparent" />
           </HLF.Item>
           <HLF.Item @basis="300px" @shrink={{1}}>
-            <Shw::Placeholder @text="item #2 with shrink=1" @height="40" @background="#e5ffd2" />
+            <Shw::Placeholder @text="item #2 with shrink=1" @height="40" @background="transparent" />
           </HLF.Item>
           <HLF.Item @basis="300px" @shrink={{false}}>
-            <Shw::Placeholder @text="item #3 with shrink=false" @height="40" @background="#d2f4ff" />
+            <Shw::Placeholder @text="item #3 with shrink=false" @height="40" @background="transparent" />
           </HLF.Item>
           <HLF.Item @basis="300px" @shrink={{true}}>
-            <Shw::Placeholder @text="item #4 with shrink=true" @height="40" @background="#fff8d2" />
+            <Shw::Placeholder @text="item #4 with shrink=true" @height="40" @background="transparent" />
           </HLF.Item>
         </Hds::Layout::Flex>
       </div>
@@ -340,16 +340,16 @@
       <div {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
           <HLF.Item @basis="300px" @shrink={{2}}>
-            <Shw::Placeholder @text="item #1 with shrink=2" @height="40" @background="#e4c5f3" />
+            <Shw::Placeholder @text="item #1 with shrink=2" @height="40" @background="transparent" />
           </HLF.Item>
           <HLF.Item @basis="300px" @shrink={{3}}>
-            <Shw::Placeholder @text="item #2 with shrink=3" @height="40" @background="#e5ffd2" />
+            <Shw::Placeholder @text="item #2 with shrink=3" @height="40" @background="transparent" />
           </HLF.Item>
           <HLF.Item @basis="300px" @shrink="4">
-            <Shw::Placeholder @text="item #3 with shrink='4'" @height="40" @background="#d2f4ff" />
+            <Shw::Placeholder @text="item #3 with shrink='4'" @height="40" @background="transparent" />
           </HLF.Item>
           <HLF.Item @basis="300px" @shrink="5">
-            <Shw::Placeholder @text="item #4 with shrink='5'" @height="40" @background="#fff8d2" />
+            <Shw::Placeholder @text="item #4 with shrink='5'" @height="40" @background="transparent" />
           </HLF.Item>
         </Hds::Layout::Flex>
       </div>
@@ -370,19 +370,19 @@
       <div {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
           <HLF.Item @enableCollapseBelowContentSize={{true}}>
-            <Shw::Placeholder @height="40" @background="#e4c5f3">
+            <Shw::Placeholder @height="40" @background="transparent">
               <span {{style display="block" white-space="nowrap" overflow="hidden" text-overflow="ellipsis"}}>item #1
                 with a very long text that might cause overflow issues</span>
             </Shw::Placeholder>
           </HLF.Item>
           <HLF.Item>
-            <Shw::Placeholder @text="item #2 with width=150px" @width="150px" @height="40" @background="#e5ffd2" />
+            <Shw::Placeholder @text="item #2 with width=150px" @width="150px" @height="40" @background="transparent" />
           </HLF.Item>
           <HLF.Item>
-            <Shw::Placeholder @text="item #3 with width=150px" @width="150px" @height="40" @background="#d2f4ff" />
+            <Shw::Placeholder @text="item #3 with width=150px" @width="150px" @height="40" @background="transparent" />
           </HLF.Item>
           <HLF.Item>
-            <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
+            <Shw::Placeholder @text="item #4" @height="40" @background="transparent" />
           </HLF.Item>
         </Hds::Layout::Flex>
       </div>
@@ -394,19 +394,19 @@
       <div {{style max-width="600px"}}>
         <Hds::Layout::Flex as |HLF|>
           <HLF.Item @basis="0px">
-            <Shw::Placeholder @height="40" @background="#e4c5f3">
+            <Shw::Placeholder @height="40" @background="transparent">
               <pre {{style white-space="nowrap" overflow="hidden" text-overflow="ellipsis"}}>item #1 with a very long
                 text that might cause overflow issues</pre>
             </Shw::Placeholder>
           </HLF.Item>
           <HLF.Item>
-            <Shw::Placeholder @text="item #2 with width=150px" @width="150px" @height="40" @background="#e5ffd2" />
+            <Shw::Placeholder @text="item #2 with width=150px" @width="150px" @height="40" @background="transparent" />
           </HLF.Item>
           <HLF.Item>
-            <Shw::Placeholder @text="item #3 with width=150px" @width="150px" @height="40" @background="#d2f4ff" />
+            <Shw::Placeholder @text="item #3 with width=150px" @width="150px" @height="40" @background="transparent" />
           </HLF.Item>
           <HLF.Item>
-            <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
+            <Shw::Placeholder @text="item #4" @height="40" @background="transparent" />
           </HLF.Item>
         </Hds::Layout::Flex>
       </div>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -1,0 +1,17 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{page-title "Layout::Flex Component"}}
+
+<Shw::Text::H1>Layout::Flex</Shw::Text::H1>
+
+<section data-test-percy>
+
+  {{! ADD YOUR CONTENT HERE }}
+
+  {{! This below is just an example of invocation, to get started }}
+  <Hds::Layout::Flex>This is the Hds::Layout::Flex component </Hds::Layout::Flex>
+
+</section>

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -8,20 +8,85 @@
 <Shw::Text::H1>Layout::Grid</Shw::Text::H1>
 
 <section data-test-percy>
-  <Shw::Flex @direction="column" as |SF|>
-    <SF.Item @label="TEMP - grid">
+  <Shw::Text::H2>Column min width</Shw::Text::H2>
+
+  <Shw::Text::H3>gap size 0 (default)</Shw::Text::H3>
+
+  <Shw::Grid @columns="1" @gap="1.5rem" as |SG|>
+    <SG.Item @label="No min width columns (defaults to 0)">
       <Shw::Outliner>
         <Hds::Layout::Grid>
-          <Shw::Placeholder @text="item #1" @height="40" @background="#e4c5f3" />
-          <Shw::Placeholder @text="item #2" @height="40" @background="#e5ffd2" />
-          <Shw::Placeholder @text="item #3" @height="40" @background="#d2f4ff" />
-          <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
+          <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+          <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+          <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+          <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
         </Hds::Layout::Grid>
       </Shw::Outliner>
-    </SF.Item>
-  </Shw::Flex>
+    </SG.Item>
 
-  <Shw::Divider />
+    <SG.Item @label="250px min width columns">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @columnMinWidth="250px">
+          <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+          <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+          <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+          <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+
+    <SG.Item @label="33.33% min width columns">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @columnMinWidth="33.33%">
+          <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+          <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+          <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+          <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
+  {{#each @model.GAPS as |gap|}}
+    <Shw::Text::H3>gap size {{gap}}</Shw::Text::H3>
+
+    <Shw::Grid @columns="1" @gap="1.5rem" as |SG|>
+      <SG.Item @label="No min width columns (defaults to 0)">
+        <Shw::Outliner>
+          <Hds::Layout::Grid @gap={{gap}}>
+            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </Hds::Layout::Grid>
+        </Shw::Outliner>
+      </SG.Item>
+
+      <SG.Item @label="250px min width columns">
+        <Shw::Outliner>
+          <Hds::Layout::Grid @columnMinWidth="250px" @gap={{gap}}>
+            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </Hds::Layout::Grid>
+        </Shw::Outliner>
+      </SG.Item>
+
+      <SG.Item @label="33.33% min width columns">
+        <Shw::Outliner>
+          <Hds::Layout::Grid @columnMinWidth="33.33%" @gap={{gap}}>
+            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </Hds::Layout::Grid>
+        </Shw::Outliner>
+      </SG.Item>
+    </Shw::Grid>
+  {{/each}}
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H2>Justify + Align</Shw::Text::H2>
   <Shw::Text::Body>These are the
@@ -79,11 +144,11 @@
 
   <Shw::Text::H4>Single value</Shw::Text::H4>
 
-  <Shw::Grid @columns={{@model.GAPS.length}} @gap="1.5rem" as |SG|>
+  <Shw::Grid @columns="4" @gap="2rem" as |SG|>
     {{#each @model.GAPS as |gap|}}
       <SG.Item @label="gap={{gap}}">
         <Shw::Outliner>
-          <Hds::Layout::Grid @gap={{gap}}>
+          <Hds::Layout::Grid @gap={{gap}} @columnMinWidth="50%">
             <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
             <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
             <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
@@ -96,27 +161,27 @@
 
   <Shw::Text::H4>Double value (row/column)</Shw::Text::H4>
 
-  <Shw::Flex @gap="2rem 4rem" as |SF|>
+  <Shw::Grid @columns={{2}} @gap="2rem 4rem" as |SG|>
     {{! we use only a subset of possible combinations, just for testing purposes }}
     {{#let (array (array "4" "48") (array "8" "32") (array "12" "24") (array "16" "16")) as |gapsList|}}
       {{#each gapsList as |gapsArray|}}
-        <SF.Item @label="gap=[{{gapsArray}}]">
-          <Shw::Outliner {{style width="500px"}}>
-            <Hds::Layout::Grid @gap={{gapsArray}}>
-              <Shw::Placeholder @text="item #1" @width="100px" @height="24" />
-              <Shw::Placeholder @text="item #2" @width="100px" @height="24" />
-              <Shw::Placeholder @text="item #3" @width="100px" @height="24" />
-              <Shw::Placeholder @text="item #4" @width="100px" @height="24" />
-              <Shw::Placeholder @text="item #5" @width="100px" @height="24" />
-              <Shw::Placeholder @text="item #6" @width="100px" @height="24" />
-              <Shw::Placeholder @text="item #7" @width="100px" @height="24" />
-              <Shw::Placeholder @text="item #8" @width="100px" @height="24" />
+        <SG.Item @label="gap=[{{gapsArray}}]">
+          <Shw::Outliner>
+            <Hds::Layout::Grid @gap={{gapsArray}} @columnMinWidth="50%">
+              <Shw::Placeholder @text="item #1" @width="auto" @height="24" />
+              <Shw::Placeholder @text="item #2" @width="auto" @height="24" />
+              <Shw::Placeholder @text="item #3" @width="auto" @height="24" />
+              <Shw::Placeholder @text="item #4" @width="auto" @height="24" />
+              <Shw::Placeholder @text="item #5" @width="auto" @height="24" />
+              <Shw::Placeholder @text="item #6" @width="auto" @height="24" />
+              <Shw::Placeholder @text="item #7" @width="auto" @height="24" />
+              <Shw::Placeholder @text="item #8" @width="auto" @height="24" />
             </Hds::Layout::Grid>
           </Shw::Outliner>
-        </SF.Item>
+        </SG.Item>
       {{/each}}
     {{/let}}
-  </Shw::Flex>
+  </Shw::Grid>
 
   <Shw::Divider @level={{2}} />
 
@@ -128,18 +193,18 @@
         <SF.Item @label={{if isInline "inline-grid (isInline=true)" "grid (default)"}}>
           <Hds::Text::Body @size="200" @tag="div">
             Lorem
-            <Hds::Layout::Grid @isInline={{isInline}}>
-              <Shw::Placeholder @text="#1" @width="24" @height="24" @background="#e4c5f3" />
-              <Shw::Placeholder @text="#2" @width="24" @height="24" @background="#e5ffd2" />
-              <Shw::Placeholder @text="#3" @width="24" @height="24" @background="#d2f4ff" />
-              <Shw::Placeholder @text="#4" @width="24" @height="24" @background="#fff8d2" />
+            <Hds::Layout::Grid @isInline={{isInline}} @columnMinWidth="2em">
+              <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+              <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+              <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+              <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
             </Hds::Layout::Grid>
             sit amet
-            <Hds::Layout::Grid @isInline={{isInline}}>
-              <Shw::Placeholder @text="#A" @width="24" @height="24" @background="#e4c5f3" />
-              <Shw::Placeholder @text="#B" @width="24" @height="24" @background="#e5ffd2" />
-              <Shw::Placeholder @text="#C" @width="24" @height="24" @background="#d2f4ff" />
-              <Shw::Placeholder @text="#D" @width="24" @height="24" @background="#fff8d2" />
+            <Hds::Layout::Grid @isInline={{isInline}} @columnMinWidth="2em">
+              <Shw::Placeholder @text="#A" @height="24" @background="#e4c5f3" />
+              <Shw::Placeholder @text="#B" @height="24" @background="#e5ffd2" />
+              <Shw::Placeholder @text="#C" @height="24" @background="#d2f4ff" />
+              <Shw::Placeholder @text="#D" @height="24" @background="#fff8d2" />
             </Hds::Layout::Grid>
             elit.
           </Hds::Text::Body>
@@ -147,7 +212,4 @@
       {{/each}}
     {{/let}}
   </Shw::Grid>
-
-  <Shw::Divider @level={{2}} />
-
 </section>

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -29,7 +29,7 @@
     and
     <code>align-items</code>
     CSS properties of
-    <code>flexbox</code>.</Shw::Text::Body>
+    <code>css grid</code>.</Shw::Text::Body>
 
   <Shw::Grid @columns={{@model.JUSTIFYS.length}} @gap="2rem" as |SG|>
     {{#each @model.ALIGNS as |align ac|}}
@@ -40,6 +40,7 @@
           </SG.Item>
         {{/each}}
       {{/if}}
+
       {{#each @model.JUSTIFYS as |justify jc|}}
         <SG.Item @label={{if (eq jc 0) (concat "align=" align) "​"}}>
           <Shw::Outliner {{style width="120px" height="120px"}}>

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -8,10 +8,145 @@
 <Shw::Text::H1>Layout::Grid</Shw::Text::H1>
 
 <section data-test-percy>
+  <Shw::Flex @direction="column" as |SF|>
+    <SF.Item @label="TEMP - grid">
+      <Shw::Outliner>
+        <Hds::Layout::Grid>
+          <Shw::Placeholder @text="item #1" @height="40" @background="#e4c5f3" />
+          <Shw::Placeholder @text="item #2" @height="40" @background="#e5ffd2" />
+          <Shw::Placeholder @text="item #3" @height="40" @background="#d2f4ff" />
+          <Shw::Placeholder @text="item #4" @height="40" @background="#fff8d2" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SF.Item>
+  </Shw::Flex>
 
-  {{! ADD YOUR CONTENT HERE }}
+  <Shw::Divider />
 
-  {{! This below is just an example of invocation, to get started }}
-  <Hds::Layout::Grid>This is the Hds::Layout::Grid component </Hds::Layout::Grid>
+  <Shw::Text::H2>Justify + Align</Shw::Text::H2>
+  <Shw::Text::Body>These are the
+    <code>justify-content</code>
+    and
+    <code>align-items</code>
+    CSS properties of
+    <code>flexbox</code>.</Shw::Text::Body>
+
+  <Shw::Grid @columns={{@model.JUSTIFYS.length}} @gap="2rem" as |SG|>
+    {{#each @model.ALIGNS as |align ac|}}
+      {{#if (eq ac 0)}}
+        {{#each @model.JUSTIFYS as |justify|}}
+          <SG.Item>
+            <span class="shw-label">justify={{justify}}</span>
+          </SG.Item>
+        {{/each}}
+      {{/if}}
+      {{#each @model.JUSTIFYS as |justify jc|}}
+        <SG.Item @label={{if (eq jc 0) (concat "align=" align) "​"}}>
+          <Shw::Outliner {{style width="120px" height="120px"}}>
+            <Hds::Layout::Grid @justify={{justify}} @align={{align}} {{style width="100%" height="100%"}}>
+              <Shw::Placeholder
+                @text="#A"
+                @width="auto"
+                @height="auto"
+                {{style min-width="24px" min-height="24px"}}
+                @background="#e4c5f3"
+              />
+              <Shw::Placeholder
+                @text="#B"
+                @width="auto"
+                @height="auto"
+                {{style min-width="24px" min-height="24px"}}
+                @background="#e5ffd2"
+              />
+              <Shw::Placeholder
+                @text="#C"
+                @width="auto"
+                @height="auto"
+                {{style min-width="24px" min-height="24px"}}
+                @background="#d2f4ff"
+              />
+            </Hds::Layout::Grid>
+          </Shw::Outliner>
+        </SG.Item>
+      {{/each}}
+    {{/each}}
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Gap</Shw::Text::H3>
+
+  <Shw::Text::H4>Single value</Shw::Text::H4>
+
+  <Shw::Grid @columns={{@model.GAPS.length}} @gap="1.5rem" as |SG|>
+    {{#each @model.GAPS as |gap|}}
+      <SG.Item @label="gap={{gap}}">
+        <Shw::Outliner>
+          <Hds::Layout::Grid @gap={{gap}}>
+            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </Hds::Layout::Grid>
+        </Shw::Outliner>
+      </SG.Item>
+    {{/each}}
+  </Shw::Grid>
+
+  <Shw::Text::H4>Double value (row/column)</Shw::Text::H4>
+
+  <Shw::Flex @gap="2rem 4rem" as |SF|>
+    {{! we use only a subset of possible combinations, just for testing purposes }}
+    {{#let (array (array "4" "48") (array "8" "32") (array "12" "24") (array "16" "16")) as |gapsList|}}
+      {{#each gapsList as |gapsArray|}}
+        <SF.Item @label="gap=[{{gapsArray}}]">
+          <Shw::Outliner {{style width="500px"}}>
+            <Hds::Layout::Grid @gap={{gapsArray}}>
+              <Shw::Placeholder @text="item #1" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #2" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #3" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #4" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #5" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #6" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #7" @width="100px" @height="24" />
+              <Shw::Placeholder @text="item #8" @width="100px" @height="24" />
+            </Hds::Layout::Grid>
+          </Shw::Outliner>
+        </SF.Item>
+      {{/each}}
+    {{/let}}
+  </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Display</Shw::Text::H3>
+
+  <Shw::Grid @gap="2rem" @columns={{2}} as |SF|>
+    {{#let (array false true) as |booleans|}}
+      {{#each booleans as |isInline|}}
+        <SF.Item @label={{if isInline "inline-grid (isInline=true)" "grid (default)"}}>
+          <Hds::Text::Body @size="200" @tag="div">
+            Lorem
+            <Hds::Layout::Grid @isInline={{isInline}}>
+              <Shw::Placeholder @text="#1" @width="24" @height="24" @background="#e4c5f3" />
+              <Shw::Placeholder @text="#2" @width="24" @height="24" @background="#e5ffd2" />
+              <Shw::Placeholder @text="#3" @width="24" @height="24" @background="#d2f4ff" />
+              <Shw::Placeholder @text="#4" @width="24" @height="24" @background="#fff8d2" />
+            </Hds::Layout::Grid>
+            sit amet
+            <Hds::Layout::Grid @isInline={{isInline}}>
+              <Shw::Placeholder @text="#A" @width="24" @height="24" @background="#e4c5f3" />
+              <Shw::Placeholder @text="#B" @width="24" @height="24" @background="#e5ffd2" />
+              <Shw::Placeholder @text="#C" @width="24" @height="24" @background="#d2f4ff" />
+              <Shw::Placeholder @text="#D" @width="24" @height="24" @background="#fff8d2" />
+            </Hds::Layout::Grid>
+            elit.
+          </Hds::Text::Body>
+        </SF.Item>
+      {{/each}}
+    {{/let}}
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
 
 </section>

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -88,53 +88,41 @@
 
   <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H2>Justify + Align</Shw::Text::H2>
-  <Shw::Text::Body>These are the
-    <code>justify-content</code>
-    and
+  <Shw::Text::H2>Align</Shw::Text::H2>
+  <Shw::Text::Body>This is the
     <code>align-items</code>
-    CSS properties of
+    CSS property of
     <code>css grid</code>.</Shw::Text::Body>
 
-  <Shw::Grid @columns={{@model.JUSTIFYS.length}} @gap="2rem" as |SG|>
-    {{#each @model.ALIGNS as |align ac|}}
-      {{#if (eq ac 0)}}
-        {{#each @model.JUSTIFYS as |justify|}}
-          <SG.Item>
-            <span class="shw-label">justify={{justify}}</span>
-          </SG.Item>
-        {{/each}}
-      {{/if}}
-
-      {{#each @model.JUSTIFYS as |justify jc|}}
-        <SG.Item @label={{if (eq jc 0) (concat "align=" align) "​"}}>
-          <Shw::Outliner {{style width="120px" height="120px"}}>
-            <Hds::Layout::Grid @justify={{justify}} @align={{align}} {{style width="100%" height="100%"}}>
-              <Shw::Placeholder
-                @text="#A"
-                @width="auto"
-                @height="auto"
-                {{style min-width="24px" min-height="24px"}}
-                @background="#e4c5f3"
-              />
-              <Shw::Placeholder
-                @text="#B"
-                @width="auto"
-                @height="auto"
-                {{style min-width="24px" min-height="24px"}}
-                @background="#e5ffd2"
-              />
-              <Shw::Placeholder
-                @text="#C"
-                @width="auto"
-                @height="auto"
-                {{style min-width="24px" min-height="24px"}}
-                @background="#d2f4ff"
-              />
-            </Hds::Layout::Grid>
-          </Shw::Outliner>
-        </SG.Item>
-      {{/each}}
+  <Shw::Grid @columns={{@model.ALIGNS.length}} @gap="2rem" as |SG|>
+    {{#each @model.ALIGNS as |align|}}
+      <SG.Item @label={{(concat "align=" align)}}>
+        <Shw::Outliner {{style width="120px" height="120px"}}>
+          <Hds::Layout::Grid @align={{align}} {{style width="100%" height="100%"}}>
+            <Shw::Placeholder
+              @text="#A"
+              @width="auto"
+              @height="auto"
+              {{style min-width="24px" min-height="24px"}}
+              @background="#e4c5f3"
+            />
+            <Shw::Placeholder
+              @text="#B"
+              @width="auto"
+              @height="auto"
+              {{style min-width="24px" min-height="24px"}}
+              @background="#e5ffd2"
+            />
+            <Shw::Placeholder
+              @text="#C"
+              @width="auto"
+              @height="auto"
+              {{style min-width="24px" min-height="24px"}}
+              @background="#d2f4ff"
+            />
+          </Hds::Layout::Grid>
+        </Shw::Outliner>
+      </SG.Item>
     {{/each}}
   </Shw::Grid>
 

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -43,6 +43,17 @@
         </Hds::Layout::Grid>
       </Shw::Outliner>
     </SG.Item>
+
+    <SG.Item @label="40em min width columns">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @gap="48" @columnMinWidth="40em">
+          <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+          <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+          <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+          <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
   </Shw::Grid>
 
   <Shw::Divider @level={{2}} />

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -128,9 +128,9 @@
 
   <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H3>Gap</Shw::Text::H3>
+  <Shw::Text::H2>Gap</Shw::Text::H2>
 
-  <Shw::Text::H4>Single value</Shw::Text::H4>
+  <Shw::Text::H4 @tag="h3>Single value</Shw::Text::H4>
 
   <Shw::Grid @columns="4" @gap="2rem" as |SG|>
     {{#each @model.GAPS as |gap|}}
@@ -147,7 +147,7 @@
     {{/each}}
   </Shw::Grid>
 
-  <Shw::Text::H4>Double value (row/column)</Shw::Text::H4>
+  <Shw::Text::H4 @tag="h3>Double value (row/column)</Shw::Text::H4>
 
   <Shw::Grid @columns={{2}} @gap="2rem 4rem" as |SG|>
     {{! we use only a subset of possible combinations, just for testing purposes }}
@@ -173,7 +173,7 @@
 
   <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H3>Display</Shw::Text::H3>
+  <Shw::Text::H2>Display</Shw::Text::H2>
 
   <Shw::Grid @gap="2rem" @columns={{2}} as |SF|>
     {{#let (array false true) as |booleans|}}
@@ -252,10 +252,10 @@
     <SG.Item @label="colSpan=3">
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="250px" @gap="12" as |HLG|>
-          <HLG.Item>
+          <HLG.Item @colSpan="3">
             <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
           </HLG.Item>
-          <HLG.Item @colSpan="3">
+          <HLG.Item>
             <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
           </HLG.Item>
           <HLG.Item>

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -213,3 +213,155 @@
     {{/let}}
   </Shw::Grid>
 </section>
+
+<Shw::Divider />
+
+<section data-test-percy>
+  <Shw::Text::H2>Grid::Item</Shw::Text::H2>
+
+  <Shw::Grid @columns={{1}} as |SG|>
+    <SG.Item @label="used directly or via yielded component">
+      <Shw::Outliner>
+        <Hds::Layout::Grid as |HLG|>
+          <Shw::Placeholder @text="item #1" @height="40" @background="#e4c5f3" />
+
+          <Hds::Layout::Grid::Item>
+            <Shw::Placeholder @text="item #2 within Grid::Item" @height="40" @background="#e5ffd2" />
+          </Hds::Layout::Grid::Item>
+
+          <Shw::Placeholder @text="item #3" @height="40" @background="#d2f4ff" />
+
+          <HLG.Item>
+            <Shw::Placeholder @text="item #4 within HLG.Item" @height="40" @background="#fff8d2" />
+          </HLG.Item>
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Text::H3>colSpan</Shw::Text::H3>
+
+  <Shw::Grid @columns="1" @gap="1.5rem" as |SG|>
+    <SG.Item @label="colSpan=2">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @columnMinWidth="250px" @gap="12" as |HLG|>
+          <HLG.Item @colSpan="2">
+            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </HLG.Item>
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+
+    <SG.Item @label="colSpan=3">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @columnMinWidth="250px" @gap="12" as |HLG|>
+          <HLG.Item>
+            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+          </HLG.Item>
+          <HLG.Item @colSpan="3">
+            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </HLG.Item>
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+
+    <SG.Item @label="colSpan=4">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @columnMinWidth="250px" @gap="12" as |HLG|>
+          <HLG.Item @colSpan="4">
+            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </HLG.Item>
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Text::H3>rowSpan</Shw::Text::H3>
+
+  <Shw::Grid @columns="1" @gap="1.5rem" as |SG|>
+    <SG.Item @label="rowSpan=2">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @columnMinWidth="33.33%" @gap="12" as |HLG|>
+          <HLG.Item @rowSpan="2">
+            <Shw::Placeholder @text="#1" @height="100%" @background="#e4c5f3" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </HLG.Item>
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+
+    <SG.Item @label="rowSpan=3">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @columnMinWidth="50%" @gap="12" as |HLG|>
+          <HLG.Item>
+            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+          </HLG.Item>
+          <HLG.Item @rowSpan="3">
+            <Shw::Placeholder @text="#2" @height="100%" @background="#e5ffd2" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </HLG.Item>
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Text::H3>colSpan & rowSpan</Shw::Text::H3>
+
+  <Shw::Grid @columns="1" @gap="1.5rem" as |SG|>
+    <SG.Item @label="colSpan=2, rowSpan=3">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @columnMinWidth="33.33%" @gap="12" as |HLG|>
+          <HLG.Item @colSpan="2" @rowSpan="3">
+            <Shw::Placeholder @text="#1" @height="100%" @background="#e4c5f3" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </HLG.Item>
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+</section>

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -1,0 +1,17 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+{{page-title "Layout::Grid Component"}}
+
+<Shw::Text::H1>Layout::Grid</Shw::Text::H1>
+
+<section data-test-percy>
+
+  {{! ADD YOUR CONTENT HERE }}
+
+  {{! This below is just an example of invocation, to get started }}
+  <Hds::Layout::Grid>This is the Hds::Layout::Grid component </Hds::Layout::Grid>
+
+</section>

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -14,10 +14,10 @@
     <SG.Item @label="No min width columns (min-width defaults to 0px)">
       <Shw::Outliner>
         <Hds::Layout::Grid @gap="48">
-          <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
-          <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
-          <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
-          <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          <Shw::Placeholder @text="#1" @height="40" @background="#e4c5f3" />
+          <Shw::Placeholder @text="#2" @height="40" @background="#e5ffd2" />
+          <Shw::Placeholder @text="#3" @height="40" @background="#d2f4ff" />
+          <Shw::Placeholder @text="#4" @height="40" @background="#fff8d2" />
         </Hds::Layout::Grid>
       </Shw::Outliner>
     </SG.Item>
@@ -25,10 +25,10 @@
     <SG.Item @label="250px min width columns">
       <Shw::Outliner>
         <Hds::Layout::Grid @gap="48" @columnMinWidth="250px">
-          <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
-          <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
-          <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
-          <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          <Shw::Placeholder @text="#1" @height="40" @background="#e4c5f3" />
+          <Shw::Placeholder @text="#2" @height="40" @background="#e5ffd2" />
+          <Shw::Placeholder @text="#3" @height="40" @background="#d2f4ff" />
+          <Shw::Placeholder @text="#4" @height="40" @background="#fff8d2" />
         </Hds::Layout::Grid>
       </Shw::Outliner>
     </SG.Item>
@@ -36,10 +36,10 @@
     <SG.Item @label="33.33% min width columns">
       <Shw::Outliner>
         <Hds::Layout::Grid @gap="48" @columnMinWidth="33.33%">
-          <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
-          <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
-          <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
-          <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          <Shw::Placeholder @text="#1" @height="40" @background="#e4c5f3" />
+          <Shw::Placeholder @text="#2" @height="40" @background="#e5ffd2" />
+          <Shw::Placeholder @text="#3" @height="40" @background="#d2f4ff" />
+          <Shw::Placeholder @text="#4" @height="40" @background="#fff8d2" />
         </Hds::Layout::Grid>
       </Shw::Outliner>
     </SG.Item>
@@ -47,10 +47,10 @@
     <SG.Item @label="40em min width columns">
       <Shw::Outliner>
         <Hds::Layout::Grid @gap="48" @columnMinWidth="40em">
-          <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
-          <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
-          <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
-          <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          <Shw::Placeholder @text="#1" @height="40" @background="#e4c5f3" />
+          <Shw::Placeholder @text="#2" @height="40" @background="#e5ffd2" />
+          <Shw::Placeholder @text="#3" @height="40" @background="#d2f4ff" />
+          <Shw::Placeholder @text="#4" @height="40" @background="#fff8d2" />
         </Hds::Layout::Grid>
       </Shw::Outliner>
     </SG.Item>
@@ -204,16 +204,16 @@
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="250px" @gap="12" as |HLG|>
           <HLG.Item @colSpan="2">
-            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+            <Shw::Placeholder @text="#1" @height="40" @background="#e4c5f3" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+            <Shw::Placeholder @text="#2" @height="40" @background="#e5ffd2" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+            <Shw::Placeholder @text="#3" @height="40" @background="#d2f4ff" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+            <Shw::Placeholder @text="#4" @height="40" @background="#fff8d2" />
           </HLG.Item>
         </Hds::Layout::Grid>
       </Shw::Outliner>
@@ -223,16 +223,16 @@
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="250px" @gap="12" as |HLG|>
           <HLG.Item @colSpan="3">
-            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+            <Shw::Placeholder @text="#1" @height="40" @background="#e4c5f3" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+            <Shw::Placeholder @text="#2" @height="40" @background="#e5ffd2" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+            <Shw::Placeholder @text="#3" @height="40" @background="#d2f4ff" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+            <Shw::Placeholder @text="#4" @height="40" @background="#fff8d2" />
           </HLG.Item>
         </Hds::Layout::Grid>
       </Shw::Outliner>
@@ -242,16 +242,16 @@
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="250px" @gap="12" as |HLG|>
           <HLG.Item @colSpan="4">
-            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+            <Shw::Placeholder @text="#1" @height="40" @background="#e4c5f3" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+            <Shw::Placeholder @text="#2" @height="40" @background="#e5ffd2" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+            <Shw::Placeholder @text="#3" @height="40" @background="#d2f4ff" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+            <Shw::Placeholder @text="#4" @height="40" @background="#fff8d2" />
           </HLG.Item>
         </Hds::Layout::Grid>
       </Shw::Outliner>
@@ -268,13 +268,13 @@
             <Shw::Placeholder @text="#1" @height="100%" @background="#e4c5f3" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+            <Shw::Placeholder @text="#2" @height="40" @background="#e5ffd2" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+            <Shw::Placeholder @text="#3" @height="40" @background="#d2f4ff" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+            <Shw::Placeholder @text="#4" @height="40" @background="#fff8d2" />
           </HLG.Item>
         </Hds::Layout::Grid>
       </Shw::Outliner>
@@ -284,16 +284,16 @@
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="50%" @gap="12" as |HLG|>
           <HLG.Item>
-            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
+            <Shw::Placeholder @text="#1" @height="40" @background="#e4c5f3" />
           </HLG.Item>
           <HLG.Item @rowSpan="3">
             <Shw::Placeholder @text="#2" @height="100%" @background="#e5ffd2" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+            <Shw::Placeholder @text="#3" @height="40" @background="#d2f4ff" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+            <Shw::Placeholder @text="#4" @height="40" @background="#fff8d2" />
           </HLG.Item>
         </Hds::Layout::Grid>
       </Shw::Outliner>
@@ -310,19 +310,19 @@
             <Shw::Placeholder @text="#1" @height="100%" @background="#e4c5f3" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
+            <Shw::Placeholder @text="#2" @height="40" @background="#e5ffd2" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
+            <Shw::Placeholder @text="#3" @height="40" @background="#d2f4ff" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+            <Shw::Placeholder @text="#4" @height="40" @background="#fff8d2" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#5" @height="24" @background="#f3d9c5" />
+            <Shw::Placeholder @text="#5" @height="40" @background="#f3d9c5" />
           </HLG.Item>
           <HLG.Item>
-            <Shw::Placeholder @text="#6" @height="24" @background="#fee1ec" />
+            <Shw::Placeholder @text="#6" @height="40" @background="#fee1ec" />
           </HLG.Item>
         </Hds::Layout::Grid>
       </Shw::Outliner>

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -10,12 +10,10 @@
 <section data-test-percy>
   <Shw::Text::H2>Column min width</Shw::Text::H2>
 
-  <Shw::Text::H3>gap size 0 (default)</Shw::Text::H3>
-
   <Shw::Grid @columns="1" @gap="1.5rem" as |SG|>
-    <SG.Item @label="No min width columns (defaults to 0)">
+    <SG.Item @label="No min width columns (min-width defaults to 0px)">
       <Shw::Outliner>
-        <Hds::Layout::Grid>
+        <Hds::Layout::Grid @gap="48">
           <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
           <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
           <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
@@ -26,7 +24,7 @@
 
     <SG.Item @label="250px min width columns">
       <Shw::Outliner>
-        <Hds::Layout::Grid @columnMinWidth="250px">
+        <Hds::Layout::Grid @gap="48" @columnMinWidth="250px">
           <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
           <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
           <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
@@ -37,7 +35,7 @@
 
     <SG.Item @label="33.33% min width columns">
       <Shw::Outliner>
-        <Hds::Layout::Grid @columnMinWidth="33.33%">
+        <Hds::Layout::Grid @gap="48" @columnMinWidth="33.33%">
           <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
           <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
           <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
@@ -46,45 +44,6 @@
       </Shw::Outliner>
     </SG.Item>
   </Shw::Grid>
-
-  {{#each @model.GAPS as |gap|}}
-    <Shw::Text::H3>gap size {{gap}}</Shw::Text::H3>
-
-    <Shw::Grid @columns="1" @gap="1.5rem" as |SG|>
-      <SG.Item @label="No min width columns (defaults to 0)">
-        <Shw::Outliner>
-          <Hds::Layout::Grid @gap={{gap}}>
-            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
-            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
-            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
-            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
-          </Hds::Layout::Grid>
-        </Shw::Outliner>
-      </SG.Item>
-
-      <SG.Item @label="250px min width columns">
-        <Shw::Outliner>
-          <Hds::Layout::Grid @columnMinWidth="250px" @gap={{gap}}>
-            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
-            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
-            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
-            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
-          </Hds::Layout::Grid>
-        </Shw::Outliner>
-      </SG.Item>
-
-      <SG.Item @label="33.33% min width columns">
-        <Shw::Outliner>
-          <Hds::Layout::Grid @columnMinWidth="33.33%" @gap={{gap}}>
-            <Shw::Placeholder @text="#1" @height="24" @background="#e4c5f3" />
-            <Shw::Placeholder @text="#2" @height="24" @background="#e5ffd2" />
-            <Shw::Placeholder @text="#3" @height="24" @background="#d2f4ff" />
-            <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
-          </Hds::Layout::Grid>
-        </Shw::Outliner>
-      </SG.Item>
-    </Shw::Grid>
-  {{/each}}
 
   <Shw::Divider @level={{2}} />
 
@@ -130,7 +89,7 @@
 
   <Shw::Text::H2>Gap</Shw::Text::H2>
 
-  <Shw::Text::H4 @tag="h3>Single value</Shw::Text::H4>
+  <Shw::Text::H4 @tag="h3">Single value</Shw::Text::H4>
 
   <Shw::Grid @columns="4" @gap="2rem" as |SG|>
     {{#each @model.GAPS as |gap|}}
@@ -147,7 +106,7 @@
     {{/each}}
   </Shw::Grid>
 
-  <Shw::Text::H4 @tag="h3>Double value (row/column)</Shw::Text::H4>
+  <Shw::Text::H4 @tag="h3">Double value (row/column)</Shw::Text::H4>
 
   <Shw::Grid @columns={{2}} @gap="2rem 4rem" as |SG|>
     {{! we use only a subset of possible combinations, just for testing purposes }}
@@ -230,7 +189,7 @@
   <Shw::Text::H3>colSpan</Shw::Text::H3>
 
   <Shw::Grid @columns="1" @gap="1.5rem" as |SG|>
-    <SG.Item @label="colSpan=2">
+    <SG.Item @label="1st item w/ colSpan=2">
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="250px" @gap="12" as |HLG|>
           <HLG.Item @colSpan="2">
@@ -249,7 +208,7 @@
       </Shw::Outliner>
     </SG.Item>
 
-    <SG.Item @label="colSpan=3">
+    <SG.Item @label="1st item w/ colSpan=3">
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="250px" @gap="12" as |HLG|>
           <HLG.Item @colSpan="3">
@@ -268,7 +227,7 @@
       </Shw::Outliner>
     </SG.Item>
 
-    <SG.Item @label="colSpan=4">
+    <SG.Item @label="1st item w/ colSpan=4">
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="250px" @gap="12" as |HLG|>
           <HLG.Item @colSpan="4">
@@ -291,10 +250,10 @@
   <Shw::Text::H3>rowSpan</Shw::Text::H3>
 
   <Shw::Grid @columns="1" @gap="1.5rem" as |SG|>
-    <SG.Item @label="rowSpan=2">
+    <SG.Item @label="1st item w/ rowSpan=3">
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="33.33%" @gap="12" as |HLG|>
-          <HLG.Item @rowSpan="2">
+          <HLG.Item @rowSpan="3">
             <Shw::Placeholder @text="#1" @height="100%" @background="#e4c5f3" />
           </HLG.Item>
           <HLG.Item>
@@ -310,7 +269,7 @@
       </Shw::Outliner>
     </SG.Item>
 
-    <SG.Item @label="rowSpan=3">
+    <SG.Item @label="2nd item w/ rowSpan=3">
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="50%" @gap="12" as |HLG|>
           <HLG.Item>
@@ -333,7 +292,7 @@
   <Shw::Text::H3>colSpan & rowSpan</Shw::Text::H3>
 
   <Shw::Grid @columns="1" @gap="1.5rem" as |SG|>
-    <SG.Item @label="colSpan=2, rowSpan=3">
+    <SG.Item @label="1st item w/ colSpan=2 & rowSpan=3">
       <Shw::Outliner>
         <Hds::Layout::Grid @columnMinWidth="33.33%" @gap="12" as |HLG|>
           <HLG.Item @colSpan="2" @rowSpan="3">
@@ -347,6 +306,12 @@
           </HLG.Item>
           <HLG.Item>
             <Shw::Placeholder @text="#4" @height="24" @background="#fff8d2" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#5" @height="24" @background="#f3d9c5" />
+          </HLG.Item>
+          <HLG.Item>
+            <Shw::Placeholder @text="#6" @height="24" @background="#fee1ec" />
           </HLG.Item>
         </Hds::Layout::Grid>
       </Shw::Outliner>

--- a/showcase/tests/acceptance/components/hds/layout/grid.js
+++ b/showcase/tests/acceptance/components/hds/layout/grid.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/layout/grid', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('Components/layout/grid page passes automated a11y checks', async function (assert) {
+    await visit('/components/layout/grid');
+
+    await a11yAudit();
+
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});

--- a/showcase/tests/acceptance/percy-test.js
+++ b/showcase/tests/acceptance/percy-test.js
@@ -182,6 +182,9 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/layouts/app-frame');
     await percySnapshot('AppFrame');
 
+    await visit('/layouts/flex');
+    await percySnapshot('Flex');
+
     await visit('/overrides/power-select');
     await percySnapshot('PowerSelect');
 

--- a/showcase/tests/acceptance/percy-test.js
+++ b/showcase/tests/acceptance/percy-test.js
@@ -185,6 +185,9 @@ module('Acceptance | Percy test', function (hooks) {
     await visit('/layouts/flex');
     await percySnapshot('Flex');
 
+    await visit('/layouts/grid');
+    await percySnapshot('Grid');
+
     await visit('/overrides/power-select');
     await percySnapshot('PowerSelect');
 

--- a/showcase/tests/integration/components/hds/layout/flex/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/index-test.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/layout/flex/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should render the component with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Layout::Flex id="test-layout-flex" />`);
+    assert.dom('#test-layout-flex').hasClass('hds-layout-flex');
+  });
+});

--- a/showcase/tests/integration/components/hds/layout/flex/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/index-test.js
@@ -5,11 +5,15 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | hds/layout/flex/index', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.afterEach(() => {
+    resetOnerror();
+  });
 
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
     await render(hbs`<Hds::Layout::Flex id="test-layout-flex" />`);
@@ -106,4 +110,56 @@ module('Integration | Component | hds/layout/flex/index', function (hooks) {
       .hasClass('hds-layout-flex--row-gap-4')
       .hasClass('hds-layout-flex--column-gap-48');
   });
+
+  // ASSERTIONS
+
+  test('it should throw an assertion if an incorrect value for @direction is provided', async function (assert) {
+    const errorMessage =
+      '@direction for "Hds::Layout::Flex" must be one of the following: row, column; received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Layout::Flex @direction="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+  test('it should throw an assertion if an incorrect value for @justify is provided', async function (assert) {
+    const errorMessage =
+      '@justify for "Hds::Layout::Flex" must be one of the following: start, center, end, space-between, space-around, space-evenly; received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Layout::Flex @justify="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+  test('it should throw an assertion if an incorrect value for @align is provided', async function (assert) {
+    const errorMessage =
+      '@align for "Hds::Layout::Flex" must be one of the following: start, center, end, stretch; received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Layout::Flex @align="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+  test('it should throw an assertion if an incorrect value for @gap is provided', async function (assert) {
+    const errorMessage =
+      '@gap for "Hds::Layout::Flex" must be a single value or an array of two values of one of the following: 4, 8, 12, 16, 24, 32, 48; received: 4,foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Layout::Flex @gap={{array 4 "foo"}} />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+
 });

--- a/showcase/tests/integration/components/hds/layout/flex/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/index-test.js
@@ -68,15 +68,9 @@ module('Integration | Component | hds/layout/flex/index', function (hooks) {
     await render(hbs`<Hds::Layout::Flex id="test-layout-flex" />`);
     assert
       .dom('#test-layout-flex')
-      .doesNotHaveClass(/hds-layout-flex--justify-content-/);
-    assert
-      .dom('#test-layout-flex')
-      .doesNotHaveClass(/hds-layout-flex--align-items-/);
-    assert
-      .dom('#test-layout-flex')
-      .doesNotHaveClass('.hds-layout-flex--has-wrapping');
-    assert
-      .dom('#test-layout-flex')
+      .doesNotHaveClass(/hds-layout-flex--justify-content-/)
+      .doesNotHaveClass(/hds-layout-flex--align-items-/)
+      .doesNotHaveClass('.hds-layout-flex--has-wrapping')
       .doesNotHaveClass('.hds-layout-flex--is-inline');
   });
   test('it should render the correct CSS classes if the @justify/@align/@wrap/@isInline props are declared', async function (assert) {
@@ -85,24 +79,19 @@ module('Integration | Component | hds/layout/flex/index', function (hooks) {
     );
     assert
       .dom('#test-layout-flex')
-      .hasClass('hds-layout-flex--justify-content-space-between');
-    assert
-      .dom('#test-layout-flex')
-      .hasClass('hds-layout-flex--align-items-stretch');
-    assert.dom('#test-layout-flex').hasClass('hds-layout-flex--has-wrapping');
-    assert.dom('#test-layout-flex').hasClass('hds-layout-flex--is-inline');
+      .hasClass('hds-layout-flex--justify-content-space-between')
+      .hasClass('hds-layout-flex--align-items-stretch')
+      .hasClass('hds-layout-flex--has-wrapping')
+      .hasClass('hds-layout-flex--is-inline');
   });
 
   // GAP
 
   test('it should render the element without `gap` class if no @gap is declared', async function (assert) {
     await render(hbs`<Hds::Layout::Flex id="test-layout-flex" />`);
-    assert.dom('#test-layout-flex').doesNotHaveClass(/hds-layout-flex--gap-/);
-    assert
-      .dom('#test-layout-flex')
-      .doesNotHaveClass(/hds-layout-flex--row-gap-/);
-    assert
-      .dom('#test-layout-flex')
+    assert.dom('#test-layout-flex')
+      .doesNotHaveClass(/hds-layout-flex--gap-/)
+      .doesNotHaveClass(/hds-layout-flex--row-gap-/)
       .doesNotHaveClass(/hds-layout-flex--column-gap-/);
   });
   test('it should render the correct CSS class if the @gap prop is declared as single value', async function (assert) {
@@ -113,7 +102,8 @@ module('Integration | Component | hds/layout/flex/index', function (hooks) {
     await render(
       hbs`<Hds::Layout::Flex id="test-layout-flex" @gap={{array "4" "48"}} />`
     );
-    assert.dom('#test-layout-flex').hasClass('hds-layout-flex--row-gap-4');
-    assert.dom('#test-layout-flex').hasClass('hds-layout-flex--column-gap-48');
+    assert.dom('#test-layout-flex')
+      .hasClass('hds-layout-flex--row-gap-4')
+      .hasClass('hds-layout-flex--column-gap-48');
   });
 });

--- a/showcase/tests/integration/components/hds/layout/flex/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/index-test.js
@@ -15,4 +15,105 @@ module('Integration | Component | hds/layout/flex/index', function (hooks) {
     await render(hbs`<Hds::Layout::Flex id="test-layout-flex" />`);
     assert.dom('#test-layout-flex').hasClass('hds-layout-flex');
   });
+
+  // CONTENT
+
+  test('it should render the yielded content', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex id="test-layout-flex"><pre>test</pre></Hds::Layout::Flex>`
+    );
+    assert.dom('#test-layout-flex > pre').exists().hasText('test');
+  });
+  test('it should render the `Item` yielded contextual component', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex id="test-layout-flex" as |LF|><LF.Item><pre>test</pre></LF.Item></Hds::Layout::Flex>`
+    );
+    assert
+      .dom('#test-layout-flex > .hds-layout-flex-item > pre')
+      .exists()
+      .hasText('test');
+  });
+
+  // TAG
+
+  test('it should render with a "div" element if @tag is not declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Flex id="test-layout-flex" />`);
+    assert.dom('#test-layout-flex').hasTagName('div');
+  });
+  test('it should render with the correct @tag declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex id="test-layout-flex" @tag="section" />`
+    );
+    assert.dom('#test-layout-flex').hasTagName('section');
+  });
+
+  // DIRECTION
+
+  test('it should render the element with `row` direction if no @direction is declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Flex id="test-layout-flex" />`);
+    assert.dom('#test-layout-flex').hasClass('hds-layout-flex--direction-row');
+  });
+  test('it should render the correct CSS class if the @direction prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex id="test-layout-flex" @direction="column" />`
+    );
+    assert
+      .dom('#test-layout-flex')
+      .hasClass('hds-layout-flex--direction-column');
+  });
+
+  // JUSTIFY / ALIGN / WRAP / IS-INLINE
+
+  test('it should render the element without specific classes if no @justify/@align/@wrap/@isInline are declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Flex id="test-layout-flex" />`);
+    assert
+      .dom('#test-layout-flex')
+      .doesNotHaveClass(/hds-layout-flex--justify-content-/);
+    assert
+      .dom('#test-layout-flex')
+      .doesNotHaveClass(/hds-layout-flex--align-items-/);
+    assert
+      .dom('#test-layout-flex')
+      .doesNotHaveClass('.hds-layout-flex--has-wrapping');
+    assert
+      .dom('#test-layout-flex')
+      .doesNotHaveClass('.hds-layout-flex--is-inline');
+  });
+  test('it should render the correct CSS classes if the @justify/@align/@wrap/@isInline props are declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex id="test-layout-flex" @justify="space-between" @align="stretch" @wrap={{true}} @isInline={{true}} />`
+    );
+    assert
+      .dom('#test-layout-flex')
+      .hasClass('hds-layout-flex--justify-content-space-between');
+    assert
+      .dom('#test-layout-flex')
+      .hasClass('hds-layout-flex--align-items-stretch');
+    assert.dom('#test-layout-flex').hasClass('hds-layout-flex--has-wrapping');
+    assert.dom('#test-layout-flex').hasClass('hds-layout-flex--is-inline');
+  });
+
+  // GAP
+
+  test('it should render the element without `gap` class if no @gap is declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Flex id="test-layout-flex" />`);
+    assert.dom('#test-layout-flex').doesNotHaveClass(/hds-layout-flex--gap-/);
+    assert
+      .dom('#test-layout-flex')
+      .doesNotHaveClass(/hds-layout-flex--row-gap-/);
+    assert
+      .dom('#test-layout-flex')
+      .doesNotHaveClass(/hds-layout-flex--column-gap-/);
+  });
+  test('it should render the correct CSS class if the @gap prop is declared as single value', async function (assert) {
+    await render(hbs`<Hds::Layout::Flex id="test-layout-flex" @gap="24" />`);
+    assert.dom('#test-layout-flex').hasClass('hds-layout-flex--gap-24');
+  });
+  test('it should render the correct CSS class if the @gap prop is declared as a couple of values', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex id="test-layout-flex" @gap={{array "4" "48"}} />`
+    );
+    assert.dom('#test-layout-flex').hasClass('hds-layout-flex--row-gap-4');
+    assert.dom('#test-layout-flex').hasClass('hds-layout-flex--column-gap-48');
+  });
 });

--- a/showcase/tests/integration/components/hds/layout/flex/item-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/item-test.js
@@ -54,9 +54,8 @@ module('Integration | Component | hds/layout/flex/item', function (hooks) {
     );
     assert
       .dom('#test-layout-flex-item')
-      .doesNotHaveClass(/hds-layout-flex-item--grow-/);
-    assert
-      .dom('#test-layout-flex-item')
+      .doesNotHaveAttribute('style')
+      .doesNotHaveClass(/hds-layout-flex-item--grow-/)
       .doesNotHaveClass(/hds-layout-flex-item--shrink-/);
     assert.dom('#test-layout-flex-item').doesNotHaveAttribute('style');
   });

--- a/showcase/tests/integration/components/hds/layout/flex/item-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/item-test.js
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/layout/flex/item', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should render the component with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Layout::Flex::Item id="test-layout-flex-item" />`);
+    assert.dom('#test-layout-flex-item').hasClass('hds-layout-flex-item');
+  });
+
+  // CONTENT
+
+  test('it should render the yielded content', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex::Item id="test-layout-flex-item"><pre>test</pre></Hds::Layout::Flex::Item>`
+    );
+    assert.dom('#test-layout-flex-item > pre').exists().hasText('test');
+  });
+  test('it should render as yielded contextual component', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex as |LF|><LF.Item id="test-layout-flex-item"><pre>test</pre></LF.Item></Hds::Layout::Flex>`
+    );
+    assert.dom('#test-layout-flex-item > pre').exists().hasText('test');
+  });
+
+  // TAG
+
+  test('it should render with a "div" element if @tag is not declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex as |LF|><LF.Item id="test-layout-flex-item" /></Hds::Layout::Flex>`
+    );
+    assert.dom('#test-layout-flex-item').hasTagName('div');
+  });
+  test('it should render with the correct @tag declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex as |LF|><LF.Item id="test-layout-flex-item" @tag="span" /></Hds::Layout::Flex>`
+    );
+    assert.dom('#test-layout-flex-item').hasTagName('span');
+  });
+
+  // BASIS / GROW / SHRINK
+
+  test('it should render the element without specific classes or inline styles if no @basis/@grow/@shrink are declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex as |LF|><LF.Item id="test-layout-flex-item" /></Hds::Layout::Flex>`
+    );
+    assert
+      .dom('#test-layout-flex-item')
+      .doesNotHaveClass(/hds-layout-flex-item--grow-/);
+    assert
+      .dom('#test-layout-flex-item')
+      .doesNotHaveClass(/hds-layout-flex-item--shrink-/);
+    assert.dom('#test-layout-flex-item').doesNotHaveAttribute('style');
+  });
+  test('it should render the correct CSS class if the @basis prop is declared as 0', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex as |LF|>
+        <LF.Item id="test-layout-flex-item-1" @basis={{0}} />
+      </Hds::Layout::Flex>`
+    );
+    assert
+      .dom('#test-layout-flex-item-1')
+      .doesNotHaveAttribute('style')
+      .hasClass('hds-layout-flex-item--basis-0');
+  });
+  test('it should render the correct inline styles if the @basis prop is declared as string', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex as |LF|>
+        <LF.Item id="test-layout-flex-item-1" @basis="5%" />
+        <LF.Item id="test-layout-flex-item-2" @basis="100px" />
+        <LF.Item id="test-layout-flex-item-3" @basis="auto" />
+        <LF.Item id="test-layout-flex-item-4" @basis="max-content" />
+      </Hds::Layout::Flex>`
+    );
+    assert
+      .dom('#test-layout-flex-item-1')
+      .hasAttribute('style', 'flex-basis: 5%;')
+      .hasStyle({ flexBasis: '5%' });
+    assert
+      .dom('#test-layout-flex-item-2')
+      .hasAttribute('style', 'flex-basis: 100px;')
+      .hasStyle({ flexBasis: '100px' });
+    assert
+      .dom('#test-layout-flex-item-3')
+      .hasAttribute('style', 'flex-basis: auto;')
+      .hasStyle({ flexBasis: 'auto' });
+    assert
+      .dom('#test-layout-flex-item-4')
+      .hasAttribute('style', 'flex-basis: max-content;')
+      .hasStyle({ flexBasis: 'max-content' });
+  });
+  test('it should render the correct CSS class if the @grow/@shrink props are declared as boolean or 0/1', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex as |LF|>
+        <LF.Item id="test-layout-flex-item-1" @grow={{false}} @shrink={{false}} />
+        <LF.Item id="test-layout-flex-item-2" @grow={{0}} @shrink={{0}} />
+        <LF.Item id="test-layout-flex-item-3" @grow={{true}} @shrink={{true}} />
+        <LF.Item id="test-layout-flex-item-4" @grow={{1}} @shrink={{1}} />
+      </Hds::Layout::Flex>`
+    );
+    assert
+      .dom('#test-layout-flex-item-1')
+      .doesNotHaveAttribute('style')
+      .hasClass('hds-layout-flex-item--grow-0')
+      .hasClass('hds-layout-flex-item--shrink-0');
+    assert
+      .dom('#test-layout-flex-item-2')
+      .doesNotHaveAttribute('style')
+      .hasClass('hds-layout-flex-item--grow-0')
+      .hasClass('hds-layout-flex-item--shrink-0');
+    assert
+      .dom('#test-layout-flex-item-3')
+      .doesNotHaveAttribute('style')
+      .hasClass('hds-layout-flex-item--grow-1')
+      .hasClass('hds-layout-flex-item--shrink-1');
+    assert
+      .dom('#test-layout-flex-item-4')
+      .doesNotHaveAttribute('style')
+      .hasClass('hds-layout-flex-item--grow-1')
+      .hasClass('hds-layout-flex-item--shrink-1');
+  });
+  test('it should render the correct inline styles if the @grow/@shrink props are declared as strings/numbers', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex as |LF|>
+        <LF.Item id="test-layout-flex-item-1" @grow="0" @shrink="0" />
+        <LF.Item id="test-layout-flex-item-2" @grow="1" @shrink="1" />
+        <LF.Item id="test-layout-flex-item-3" @grow={{2}} @shrink={{2}} />
+        <LF.Item id="test-layout-flex-item-4" @grow="initial" @shrink="initial" />
+      </Hds::Layout::Flex>`
+    );
+    assert
+      .dom('#test-layout-flex-item-1')
+      .hasAttribute('style', 'flex-grow: 0; flex-shrink: 0;')
+      .hasStyle({ flexGrow: '0', flexShrink: '0' });
+      assert
+      .dom('#test-layout-flex-item-2')
+      .hasAttribute('style', 'flex-grow: 1; flex-shrink: 1;')
+      .hasStyle({ flexGrow: '1', flexShrink: '1' });
+      assert
+      .dom('#test-layout-flex-item-3')
+      .hasAttribute('style', 'flex-grow: 2; flex-shrink: 2;')
+      .hasStyle({ flexGrow: '2', flexShrink: '2' });
+      assert
+      .dom('#test-layout-flex-item-4')
+      .hasAttribute('style', 'flex-grow: initial; flex-shrink: initial;')
+      // grow=0 and shrink=1 are the CSS defaults (initial)
+      .hasStyle({ flexGrow: '0', flexShrink: '1' });
+  });
+
+  // ENABLE COLLAPSE BELOW CONTENT SIZE
+
+  test('it should render the element without specific classes if no @enableCollapseBelowContentSize is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex as |LF|><LF.Item id="test-layout-flex-item" /></Hds::Layout::Flex>`
+    );
+    assert
+      .dom('#test-layout-flex-item')
+      .doesNotHaveClass(
+        '.hds-layout-flex-item--enable-collapse-below-content-size'
+      );
+  });
+  test('it should render the correct CSS class if the @enableCollapseBelowContentSize prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Flex as |LF|><LF.Item id="test-layout-flex-item" @enableCollapseBelowContentSize={{true}} /></Hds::Layout::Flex>`
+    );
+    assert
+      .dom('#test-layout-flex-item')
+      .hasClass('hds-layout-flex-item--enable-collapse-below-content-size');
+  });
+});

--- a/showcase/tests/integration/components/hds/layout/flex/item-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/item-test.js
@@ -140,15 +140,15 @@ module('Integration | Component | hds/layout/flex/item', function (hooks) {
       .dom('#test-layout-flex-item-1')
       .hasAttribute('style', 'flex-grow: 0; flex-shrink: 0;')
       .hasStyle({ flexGrow: '0', flexShrink: '0' });
-      assert
+    assert
       .dom('#test-layout-flex-item-2')
       .hasAttribute('style', 'flex-grow: 1; flex-shrink: 1;')
       .hasStyle({ flexGrow: '1', flexShrink: '1' });
-      assert
+    assert
       .dom('#test-layout-flex-item-3')
       .hasAttribute('style', 'flex-grow: 2; flex-shrink: 2;')
       .hasStyle({ flexGrow: '2', flexShrink: '2' });
-      assert
+    assert
       .dom('#test-layout-flex-item-4')
       .hasAttribute('style', 'flex-grow: initial; flex-shrink: initial;')
       // grow=0 and shrink=1 are the CSS defaults (initial)

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -40,11 +40,12 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
 
   // COLUMN MIN WIDTH
 
-  test('it should render a default min-width of 0px if @columnMinWidth is not declared', async function (assert) {
+  // Note: A fallback value of 0px is set in the CSS for the `--hds-layout-grid-column-min-width` custom property
+  test('if the @columnMinWidth prop is not declared, --hds-layout-grid-column-min-width should be unset', async function (assert) {
     await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
     assert
       .dom('#test-layout-grid')
-      .hasStyle({ '--hds-layout-grid-column-min-width': '0px' });
+      .doesNotHaveStyle('--hds-layout-grid-column-min-width');
   });
 
   test('it should render the correct min-width if the @columnMinWidth prop is declared', async function (assert) {

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/layout/grid/index', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should render the component with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
+    assert.dom('#test-layout-grid').hasClass('hds-layout-grid');
+  });
+});

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -70,13 +70,10 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
     assert.dom('#test-layout-grid').hasTagName('section');
   });
 
-  // JUSTIFY / ALIGN / IS-INLINE
+  // ALIGN / IS-INLINE
 
-  test('it should render the element without specific classes if no @justify/@align/@isInline are declared', async function (assert) {
+  test('it should render the element without specific classes if no @align/@isInline are declared', async function (assert) {
     await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
-    assert
-      .dom('#test-layout-grid')
-      .doesNotHaveClass(/hds-layout-grid--justify-content-/);
     assert
       .dom('#test-layout-grid')
       .doesNotHaveClass(/hds-layout-grid--align-items-/);
@@ -85,13 +82,10 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
       .doesNotHaveClass('.hds-layout-grid--is-inline');
   });
 
-  test('it should render the correct CSS classes if the @justify/@align/@isInline props are declared', async function (assert) {
+  test('it should render the correct CSS classes if the @align/@isInline props are declared', async function (assert) {
     await render(
-      hbs`<Hds::Layout::Grid id="test-layout-grid" @justify="space-between" @align="stretch" @wrap={{true}} @isInline={{true}} />`
+      hbs`<Hds::Layout::Grid id="test-layout-grid" @align="stretch" @wrap={{true}} @isInline={{true}} />`
     );
-    assert
-      .dom('#test-layout-grid')
-      .hasClass('hds-layout-grid--justify-content-space-between');
     assert
       .dom('#test-layout-grid')
       .hasClass('hds-layout-grid--align-items-stretch');
@@ -125,19 +119,6 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
   });
 
   // ASSERTIONS
-
-  test('it should throw an assertion if an incorrect value for @justify is provided', async function (assert) {
-    const errorMessage =
-      '@justify for "Hds::Layout::Grid" must be one of the following: start, center, end, space-between, space-around, space-evenly; received: foo';
-    assert.expect(2);
-    setupOnerror(function (error) {
-      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
-    });
-    await render(hbs`<Hds::Layout::Grid @justify="foo" />`);
-    assert.throws(function () {
-      throw new Error(errorMessage);
-    });
-  });
 
   test('it should throw an assertion if an incorrect value for @align is provided', async function (assert) {
     const errorMessage =

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -25,7 +25,6 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
     assert.dom('#test-layout-grid > pre').exists().hasText('test');
   });
 
-  // TODO: Create Item child component
   test('it should render the `Item` yielded contextual component', async function (assert) {
     await render(
       hbs`
@@ -37,6 +36,24 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
       .dom('#test-layout-grid > .hds-layout-grid-item > pre')
       .exists()
       .hasText('test');
+  });
+
+  // COLUMN MIN WIDTH
+
+  test('it should render a default min-width of 0px if @columnMinWidth is not declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
+    assert
+      .dom('#test-layout-grid')
+      .hasStyle({ '--hds-layout-grid-column-min-width': '0px' });
+  });
+
+  test('it should render the correct min-width if the @columnMinWidth prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid id="test-layout-grid" @columnMinWidth="200px" />`
+    );
+    assert
+      .dom('#test-layout-grid')
+      .hasStyle({ '--hds-layout-grid-column-min-width': '200px' });
   });
 
   // TAG

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -14,5 +14,96 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
   test('it should render the component with a CSS class that matches the component name', async function (assert) {
     await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
     assert.dom('#test-layout-grid').hasClass('hds-layout-grid');
+  });
+
+  // CONTENT
+
+  test('it should render the yielded content', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid id="test-layout-grid"><pre>test</pre></Hds::Layout::Grid>`
+    );
+    assert.dom('#test-layout-grid > pre').exists().hasText('test');
+  });
+
+  // TODO: Create Item child component
+  skip('it should render the `Item` yielded contextual component', async function (assert) {
+    await render(
+      hbs`
+        <Hds::Layout::Grid id="test-layout-grid" as |LG|>
+          <LG.Item><pre>test</pre></LG.Item>
+        </Hds::Layout::Grid>`
+    );
+    assert
+      .dom('#test-layout-grid > .hds-layout-grid-item > pre')
+      .exists()
+      .hasText('test');
+  });
+
+  // TAG
+
+  test('it should render with a "div" element if @tag is not declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
+    assert.dom('#test-layout-grid').hasTagName('div');
+  });
+
+  test('it should render with the correct @tag declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid id="test-layout-grid" @tag="section" />`
+    );
+    assert.dom('#test-layout-grid').hasTagName('section');
+  });
+
+  // JUSTIFY / ALIGN / IS-INLINE
+
+  test('it should render the element without specific classes if no @justify/@align/@isInline are declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
+    assert
+      .dom('#test-layout-grid')
+      .doesNotHaveClass(/hds-layout-grid--justify-content-/);
+    assert
+      .dom('#test-layout-grid')
+      .doesNotHaveClass(/hds-layout-grid--align-items-/);
+    assert
+      .dom('#test-layout-grid')
+      .doesNotHaveClass('.hds-layout-grid--is-inline');
+  });
+
+  test('it should render the correct CSS classes if the @justify/@align/@isInline props are declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid id="test-layout-grid" @justify="space-between" @align="stretch" @wrap={{true}} @isInline={{true}} />`
+    );
+    assert
+      .dom('#test-layout-grid')
+      .hasClass('hds-layout-grid--justify-content-space-between');
+    assert
+      .dom('#test-layout-grid')
+      .hasClass('hds-layout-grid--align-items-stretch');
+    assert.dom('#test-layout-grid').hasClass('hds-layout-grid--is-inline');
+  });
+
+  // GAP
+
+  test('it should render the element without `gap` class if no @gap is declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
+    assert.dom('#test-layout-grid').doesNotHaveClass(/hds-layout-grid--gap-/);
+    assert
+      .dom('#test-layout-grid')
+      .doesNotHaveClass(/hds-layout-grid--row-gap-/);
+    assert
+      .dom('#test-layout-grid')
+      .doesNotHaveClass(/hds-layout-grid--column-gap-/);
+  });
+
+  test('it should render the correct CSS class if the @gap prop is declared as a single value', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid id="test-layout-grid" @gap="24" />`);
+    assert.dom('#test-layout-grid').hasClass('hds-layout-grid--gap-24');
+  });
+
+  test('it should render the correct CSS class if the @gap prop is declared as two values', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid id="test-layout-grid" @gap={{array "4" "48"}} />`
+    );
+    assert.dom('#test-layout-grid').hasClass('hds-layout-grid--row-gap-4');
+    assert.dom('#test-layout-grid').hasClass('hds-layout-grid--column-gap-48');
   });
 });

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -26,7 +26,7 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
   });
 
   // TODO: Create Item child component
-  skip('it should render the `Item` yielded contextual component', async function (assert) {
+  test('it should render the `Item` yielded contextual component', async function (assert) {
     await render(
       hbs`
         <Hds::Layout::Grid id="test-layout-grid" as |LG|>

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | hds/layout/grid/index', function (hooks) {
@@ -122,5 +122,46 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
     );
     assert.dom('#test-layout-grid').hasClass('hds-layout-grid--row-gap-4');
     assert.dom('#test-layout-grid').hasClass('hds-layout-grid--column-gap-48');
+  });
+
+  // ASSERTIONS
+
+  test('it should throw an assertion if an incorrect value for @justify is provided', async function (assert) {
+    const errorMessage =
+      '@justify for "Hds::Layout::Grid" must be one of the following: start, center, end, space-between, space-around, space-evenly; received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Layout::Grid @justify="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+
+  test('it should throw an assertion if an incorrect value for @align is provided', async function (assert) {
+    const errorMessage =
+      '@align for "Hds::Layout::Grid" must be one of the following: start, center, end, stretch; received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Layout::Grid @align="foo" />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+
+  test('it should throw an assertion if an incorrect value for @gap is provided', async function (assert) {
+    const errorMessage =
+      '@gap for "Hds::Layout::Grid" must be a single value or an array of two values of one of the following: 4, 8, 12, 16, 24, 32, 48; received: 4,foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(hbs`<Hds::Layout::Grid @gap={{array 4 "foo"}} />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
   });
 });

--- a/showcase/tests/integration/components/hds/layout/grid/item-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/item-test.js
@@ -50,11 +50,12 @@ module('Integration | Component | hds/layout/grid/item', function (hooks) {
 
   // COL SPAN
 
-  test('it should render a default column span of 1 if @colSpan is not declared', async function (assert) {
-    await render(hbs`<Hds::Layout::Grid::Item id="test-layout-grid" />`);
+  // Note: A fallback value of 1 is set in the CSS for the `--hds-layout-grid-column-span` custom property
+  test('if the @colSpan prop is not declared, --hds-layout-grid-column-span should be unset', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid::Item id="test-layout-grid-item" />`);
     assert
-      .dom('#test-layout-grid')
-      .hasStyle({ '--hds-layout-grid-column-span': '1' });
+      .dom('#test-layout-grid-item')
+      .doesNotHaveStyle('--hds-layout-grid-column-span');
   });
 
   test('it should render the correct column span if the @colSpan prop is declared', async function (assert) {
@@ -68,11 +69,12 @@ module('Integration | Component | hds/layout/grid/item', function (hooks) {
 
   // ROW SPAN
 
-  test('it should render a default row span of 1 if @rowSpan is not declared', async function (assert) {
+  // Note: A fallback value of 1 is set in the CSS for the `--hds-layout-grid-row-span` custom property
+  test('if the @rowSpan prop is not declared, --hds-layout-grid-row-span should be unset', async function (assert) {
     await render(hbs`<Hds::Layout::Grid::Item id="test-layout-grid" />`);
     assert
       .dom('#test-layout-grid')
-      .hasStyle({ '--hds-layout-grid-row-span': '1' });
+      .doesNotHaveStyle('--hds-layout-grid-row-span');
   });
 
   test('it should render the correct row span if the @rowSpan prop is declared', async function (assert) {

--- a/showcase/tests/integration/components/hds/layout/grid/item-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/item-test.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hds/layout/grid/item', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should render the component with a CSS class that matches the component name', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid::Item id="test-layout-grid-item" />`);
+    assert.dom('#test-layout-grid-item').hasClass('hds-layout-grid-item');
+  });
+
+  // CONTENT
+
+  test('it should render the yielded content', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid::Item id="test-layout-grid-item"><pre>test</pre></Hds::Layout::Grid::Item>`
+    );
+    assert.dom('#test-layout-grid-item > pre').exists().hasText('test');
+  });
+
+  test('it should render as yielded contextual component', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid as |LF|><LF.Item id="test-layout-grid-item"><pre>test</pre></LF.Item></Hds::Layout::Grid>`
+    );
+    assert.dom('#test-layout-grid-item > pre').exists().hasText('test');
+  });
+
+  // TAG
+
+  test('it should render with a "div" element if @tag is not declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid as |LF|><LF.Item id="test-layout-grid-item" /></Hds::Layout::Grid>`
+    );
+    assert.dom('#test-layout-grid-item').hasTagName('div');
+  });
+
+  test('it should render with the correct @tag declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid as |LF|><LF.Item id="test-layout-grid-item" @tag="span" /></Hds::Layout::Grid>`
+    );
+    assert.dom('#test-layout-grid-item').hasTagName('span');
+  });
+
+  // COL SPAN
+
+  test('it should render a default column span of 1 if @colSpan is not declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid::Item id="test-layout-grid" />`);
+    assert
+      .dom('#test-layout-grid')
+      .hasStyle({ '--hds-layout-grid-column-span': '1' });
+  });
+
+  test('it should render the correct column span if the @colSpan prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid::Item id="test-layout-grid" @colSpan="2" />`
+    );
+    assert
+      .dom('#test-layout-grid')
+      .hasStyle({ '--hds-layout-grid-column-span': '2' });
+  });
+
+  // ROW SPAN
+
+  test('it should render a default row span of 1 if @rowSpan is not declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid::Item id="test-layout-grid" />`);
+    assert
+      .dom('#test-layout-grid')
+      .hasStyle({ '--hds-layout-grid-row-span': '1' });
+  });
+
+  test('it should render the correct row span if the @rowSpan prop is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid::Item id="test-layout-grid" @rowSpan="2" />`
+    );
+    assert
+      .dom('#test-layout-grid')
+      .hasStyle({ '--hds-layout-grid-row-span': '2' });
+  });
+});


### PR DESCRIPTION
_**STATUS:** WIP - Added first rough draft. Need to refine and add more examples. Also need to experiment more with some details of component API & layout (added some TODOs that came up within the documentation)_

---

### :pushpin: Summary

If merged, this PR adds web documentation for the `Grid` component.

👉 **Preview**: coming up...

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-4650](https://hashicorp.atlassian.net/browse/HDS-4650)
* Related PR for `Layout::Grid` component: https://github.com/hashicorp/design-system/pull/2756
* Related PR for `Layout::Flex`: https://github.com/hashicorp/design-system/pull/2751
* Project plan: [HDS Project Plan - Flex/Grid components](https://docs.google.com/document/d/1SIW_vOCEYkvK6U5XkRVSVwGyhh6hR3XY5o4RdaH2g-Q)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4650]: https://hashicorp.atlassian.net/browse/HDS-4650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ