### PR TITLE
Run `changeset version` outside `changesets/action`

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -47,9 +47,7 @@ jobs:
 
       - name: Version RC Packages
         id: version
-        uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308 # v1.4.9
-        with:
-          version: pnpm version-candidate-packages
+        run: pnpm version-candidate-packages
         env:
           # Token setup in hashibot-hds' account
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
### :pushpin: Summary

Running `changeset version` in `changesets/action` results in an attempt to create a new PR, similar to Version Packages, but [fails while trying](https://github.com/hashicorp/design-system/actions/runs/13901243011/job/38893302473?pr=2714).

I suggest we run `changeset version` in the branch labeled as a `release-candidate` to overcome this issue.

Follow up on #2732

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
