### PR TITLE
Code Editor - Support custom keybinding

### DIFF
--- a/.changeset/four-avocados-smoke.md
+++ b/.changeset/four-avocados-smoke.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`hds-code-editor` modifier - Add `extraKeys` argument which supports custom keybinding
+
+`CodeEditor` - Add `@extraKeys` argument which supports custom keybinding

--- a/packages/components/src/components/hds/code-editor/index.hbs
+++ b/packages/components/src/components/hds/code-editor/index.hbs
@@ -55,6 +55,7 @@
       ariaDescribedBy=this.ariaDescribedBy
       ariaLabel=@ariaLabel
       ariaLabelledBy=this.ariaLabelledBy
+      extraKeys=@extraKeys
       hasLineWrapping=@hasLineWrapping
       language=@language
       value=@value

--- a/showcase/tests/integration/modifiers/hds-code-editor-test.js
+++ b/showcase/tests/integration/modifiers/hds-code-editor-test.js
@@ -139,6 +139,30 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
     assert.ok(document.querySelector('style[nonce="test-nonce"]'));
   });
 
+  // extraKeys
+  test('setting extraKeys should add the provided keybindings to the editor', async function (assert) {
+    const saveSpy = sinon.spy(() => console.log('Save!'));
+
+    this.set('extraKeys', {
+      'Shift-Enter': saveSpy,
+    });
+
+    await setupCodeEditor(
+      hbs`<div id="code-editor-wrapper" {{hds-code-editor ariaLabel="test" extraKeys=this.extraKeys}} />`
+    );
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      code: 'Enter',
+      shiftKey: true,
+      bubbles: true,
+    });
+
+    document.querySelector('.cm-content').dispatchEvent(event);
+
+    assert.ok(saveSpy.calledOnce);
+  });
+
   // ASSERTIONS
 
   test('it should throw an assertion if both ariaLabel and ariaLabelledBy are ommitted', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds support for custom keybinding through the `extraKeys` argument.

### :hammer_and_wrench: Detailed description

Many of our consumers code editors have custom keybinding through the `extraKeys` argument, which was a setting in CodeMirror 5

```
{{code-mirror
  screenReaderLabel="Namespace definition"
  theme="hashi"
  mode="javascript"
  content=this.definitionString
  onUpdate=this.updateNamespaceDefinition
  autofocus=false
  extraKeys=(hash Cmd-Enter=this.save) <- here
}}
```

This duplicates that same API but with our CodeMirror 6 implementation.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4672](https://hashicorp.atlassian.net/browse/HDS-4672)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4672]: https://hashicorp.atlassian.net/browse/HDS-4672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ