### PR TITLE
`AdvancedTable`: use correct icons in th-button-expand

### DIFF
--- a/.changeset/rotten-suits-impress.md
+++ b/.changeset/rotten-suits-impress.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AdvancedTable` - Updated the icons used in `th-button-expand` component to match designs.

--- a/packages/components/src/components/hds/advanced-table/th-button-expand.ts
+++ b/packages/components/src/components/hds/advanced-table/th-button-expand.ts
@@ -37,13 +37,13 @@ export default class HdsAdvancedTableThButtonExpand extends Component<HdsAdvance
     if (this.isExpanded === true) {
       return this.args.isExpandAll
         ? HdsAdvancedTableThExpandIconValues.UnfoldClose
-        : HdsAdvancedTableThExpandIconValues.ChevronDown;
+        : HdsAdvancedTableThExpandIconValues.ChevronUp;
     } else if (this.isExpanded === 'mixed' && this.args.isExpandAll) {
       return HdsAdvancedTableThExpandIconValues.UnfoldOpen;
     } else {
       return this.args.isExpandAll
         ? HdsAdvancedTableThExpandIconValues.UnfoldOpen
-        : HdsAdvancedTableThExpandIconValues.ChevronRight;
+        : HdsAdvancedTableThExpandIconValues.ChevronDown;
     }
   }
 

--- a/packages/components/src/components/hds/advanced-table/types.ts
+++ b/packages/components/src/components/hds/advanced-table/types.ts
@@ -28,7 +28,7 @@ export enum HdsAdvancedTableScopeValues {
 export type HdsAdvancedTableScope = `${HdsAdvancedTableScopeValues}`;
 
 export enum HdsAdvancedTableThExpandIconValues {
-  ChevronRight = 'chevron-right',
+  ChevronUp = 'chevron-up',
   ChevronDown = 'chevron-down',
   UnfoldOpen = 'unfold-open',
   UnfoldClose = 'unfold-close',

--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -1191,7 +1191,12 @@
         <div class="hds-advanced-table__thead">
           <div class="hds-advanced-table__tr">
             {{#each @model.STATES as |state|}}
-              <Hds::AdvancedTable::Th mock-state-value={{state}} mock-state-selector="button" @isExpandable={{true}}>
+              <Hds::AdvancedTable::Th
+                mock-state-value={{state}}
+                mock-state-selector="button"
+                @isExpandable={{true}}
+                @hasExpandAllButton={{true}}
+              >
                 {{capitalize state}}
               </Hds::AdvancedTable::Th>
             {{/each}}
@@ -1209,6 +1214,7 @@
                 mock-state-selector="button"
                 @isExpandable={{true}}
                 @isExpanded={{true}}
+                @hasExpandAllButton={{true}}
               >
                 {{capitalize state}}
               </Hds::AdvancedTable::Th>
@@ -1227,6 +1233,7 @@
                 mock-state-selector="button"
                 @isExpandable={{true}}
                 @isExpanded="mixed"
+                @hasExpandAllButton={{true}}
               >
                 {{capitalize state}}
               </Hds::AdvancedTable::Th>
@@ -1248,6 +1255,7 @@
                 mock-state-value={{state}}
                 mock-state-selector="button"
                 @isExpandable={{true}}
+                @hasExpandAllButton={{true}}
               >
                 {{capitalize state}}
               </Hds::AdvancedTable::Th>
@@ -1267,6 +1275,7 @@
                 mock-state-selector="button"
                 @isExpandable={{true}}
                 @isExpanded={{true}}
+                @hasExpandAllButton={{true}}
               >
                 {{capitalize state}}
               </Hds::AdvancedTable::Th>
@@ -1286,6 +1295,7 @@
                 mock-state-selector="button"
                 @isExpandable={{true}}
                 @isExpanded="mixed"
+                @hasExpandAllButton={{true}}
               >
                 {{capitalize state}}
               </Hds::AdvancedTable::Th>
@@ -1804,6 +1814,24 @@
           </SF.Item>
           <SF.Item>
             <Hds::AdvancedTable::ThButtonExpand @isExpanded="mixed" mock-state-value={{state}} />
+          </SF.Item>
+        </Shw::Flex>
+      </SG.Item>
+    {{/each}}
+  </Shw::Grid>
+
+  <Shw::Grid @label="Expand all interactive states + Expand state" @columns={{4}} as |SG|>
+    {{#each @model.STATES as |state|}}
+      <SG.Item @label={{capitalize state}}>
+        <Shw::Flex @direction="row" as |SF|>
+          <SF.Item>
+            <Hds::AdvancedTable::ThButtonExpand mock-state-value={{state}} @isExpandAll={{true}} />
+          </SF.Item>
+          <SF.Item>
+            <Hds::AdvancedTable::ThButtonExpand @isExpanded={{true}} mock-state-value={{state}} @isExpandAll={{true}} />
+          </SF.Item>
+          <SF.Item>
+            <Hds::AdvancedTable::ThButtonExpand @isExpanded="mixed" mock-state-value={{state}} @isExpandAll={{true}} />
           </SF.Item>
         </Shw::Flex>
       </SG.Item>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update `th-button-expand` to use icons that match what is in Figma. This PR also fixes a couple out of date examples of `th` cells and `th-button-expand` towards the bottom of the showcase page.

### :camera_flash: Screenshots

**Expected from design**
<img width="627" alt="Screenshot 2025-03-18 at 3 50 02 PM" src="https://github.com/user-attachments/assets/854d6268-5df2-47d7-a0c7-8e459fe85f80" />

**Current**

<img width="1131" alt="Screenshot 2025-03-18 at 4 26 36 PM" src="https://github.com/user-attachments/assets/c3e1e440-cc9c-4d17-8663-31a973ae5b63" />

**After**

<img width="1142" alt="Screenshot 2025-03-18 at 3 55 01 PM" src="https://github.com/user-attachments/assets/515ddcfc-2d2a-4a51-8468-be79e4b5097d" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4673](https://hashicorp.atlassian.net/browse/HDS-4673)
Figma file: https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?m=auto&node-id=72039-3972&t=80TE8WBi8bf9PGcm-1

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4673]: https://hashicorp.atlassian.net/browse/HDS-4673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ