### PR TITLE
Update the `@tag` entry in the Component API documentation for the `Text` component

### DIFF
--- a/website/docs/components/text/partials/code/component-api.md
+++ b/website/docs/components/text/partials/code/component-api.md
@@ -8,8 +8,8 @@ The `Text` component is used through these specialized variants: `Hds::Text::Dis
   <C.Property @name="size" @type="string" @values={{array "500" "400" "300" "200" "100" }} @default="200">
     The size of the `Display` text style.
   </C.Property>
-  <C.Property @name="tag" @type="string" @default="span">
-    HTML tag to be used to render the text element.
+  <C.Property @name="tag" @type="HTMLElementTagName" @default="span">
+    A valid HTML tag name to be used to render the text element.
   </C.Property>
   <C.Property @name="weight" @type="string" @values={{array "medium" "semibold" "bold" }}>
     The font weight of the text. If no `@weight` argument is provided, the component will inherit its weight from the parent container/context.<br><br>


### PR DESCRIPTION
### :pushpin: Summary

Tiny PR for a small update to the `@tag` entry in the Component API documentation for the `Text` component (context: https://github.com/hashicorp/design-system/pull/2772#discussion_r2001344691)

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
