### PR TITLE
`hds-code-editor` - Attach `EditorView` instance to modified element

### DIFF
--- a/.changeset/tall-numbers-exercise.md
+++ b/.changeset/tall-numbers-exercise.md
@@ -2,6 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`hds-code-editor` - Attaches EditorView instance to the modified element on instantiation
+`hds-code-editor` - Attached `EditorView` instance to the modified element on instantiation
 
-`CodeEditor` - Attaches EditorView instance to the editor element (`.hds-code-editor__editor`) within the Code Editor component
+`CodeEditor` - Attached `EditorView` instance to the editor element (`.hds-code-editor__editor`)

--- a/.changeset/tall-numbers-exercise.md
+++ b/.changeset/tall-numbers-exercise.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`hds-code-editor` - Attaches EditorView instance to the modified element on instantiation
+
+`CodeEditor` - Attaches EditorView instance to the editor element (`.hds-code-editor__editor`) within the Code Editor component

--- a/packages/components/src/modifiers/hds-code-editor.ts
+++ b/packages/components/src/modifiers/hds-code-editor.ts
@@ -32,6 +32,8 @@ import type {
 import type { Diagnostic as DiagnosticType } from '@codemirror/lint';
 import type Owner from '@ember/owner';
 
+type HTMLElementWithEditor = HTMLElement & { editor: EditorViewType };
+
 type HdsCodeEditorBlurHandler = (
   editor: EditorViewType,
   event: FocusEvent
@@ -156,7 +158,7 @@ const LANGUAGES: Record<
 
 export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignature> {
   editor!: EditorViewType;
-  element!: HTMLElement;
+  element!: HTMLElementWithEditor;
 
   onBlur: HdsCodeEditorSignature['Args']['Named']['onBlur'];
   onInput: HdsCodeEditorSignature['Args']['Named']['onInput'];
@@ -181,7 +183,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
   }
 
   modify(
-    element: HTMLElement,
+    element: HTMLElementWithEditor,
     positional: PositionalArgs<HdsCodeEditorSignature>,
     named: NamedArgs<HdsCodeEditorSignature>
   ): void {
@@ -220,7 +222,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
   }
 
   private _setupEditorBlurHandler(
-    element: HTMLElement,
+    element: HTMLElementWithEditor,
     onBlur: HdsCodeEditorBlurHandler
   ) {
     const inputElement = element.querySelector('.cm-content');
@@ -473,7 +475,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
   private _createEditorTask = task(
     { drop: true },
     async (
-      element: HTMLElement,
+      element: HTMLElementWithEditor,
       {
         cspNonce,
         language,
@@ -551,7 +553,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
   private _setupTask = task(
     { drop: true },
     async (
-      element: HTMLElement,
+      element: HTMLElementWithEditor,
       _positional: PositionalArgs<HdsCodeEditorSignature>,
       named: NamedArgs<HdsCodeEditorSignature>
     ) => {
@@ -594,7 +596,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
       }
 
       this.editor = editor;
-      (element as HTMLElement & { editor: EditorViewType }).editor = editor;
+      element.editor = editor;
 
       if (onBlur !== undefined) {
         this._setupEditorBlurHandler(element, onBlur);

--- a/packages/components/src/modifiers/hds-code-editor.ts
+++ b/packages/components/src/modifiers/hds-code-editor.ts
@@ -594,6 +594,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
       }
 
       this.editor = editor;
+      (element as HTMLElement & { editor: EditorViewType }).editor = editor;
 
       if (onBlur !== undefined) {
         this._setupEditorBlurHandler(element, onBlur);

--- a/showcase/tests/integration/modifiers/hds-code-editor-test.js
+++ b/showcase/tests/integration/modifiers/hds-code-editor-test.js
@@ -30,6 +30,12 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
     assert
       .dom('#code-editor-wrapper .cm-editor')
       .exists('code editor is rendered');
+
+    assert.strictEqual(
+      document.getElementById('code-editor-wrapper').editor.constructor.name,
+      'EditorView',
+      'it attaches an EditorView instance to the element'
+    );
   });
 
   // value


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will attach the CodeMirror `EditorView` instance to the element modified by the `hds-code-editor` modifier.

### :hammer_and_wrench: Detailed description

#### Why?

Needed for supporting editor interactions in the acceptance tests of our downstream consumers

#### How?

When the editor is instantiated by the modifier, we attach the instance to the modified DOM Element.

### :link: External links

Jira ticket: [HDS-4677](https://hashicorp.atlassian.net/browse/HDS-4677)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4677]: https://hashicorp.atlassian.net/browse/HDS-4677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ