### PR TITLE
Add `@dependabot` to `SKIP_USERS`

### DIFF
--- a/.changeset/changelog-hds.cjs.js
+++ b/.changeset/changelog-hds.cjs.js
@@ -34,6 +34,7 @@ const SKIP_USERS = [
   // bots
   'apps/dependabot',
   'apps/hashicorp-copywrite',
+  'dependabot',
   'hashibot-hds',
 ]
 


### PR DESCRIPTION
### :pushpin: Summary

We seem to be thanking @dependabot [in our changelog](https://github.com/hashicorp/design-system/pull/2747), which is nice, but we can do that privately.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
