### PR TITLE
 `Textarea` - Fix charcount margin (HDS-4680)

### DIFF
--- a/.changeset/tiny-radios-suffer.md
+++ b/.changeset/tiny-radios-suffer.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Textarea` - Fix issue with bottom margin on charcount so that a top margin is instead added to the error message, if one exists, following it

--- a/packages/components/src/styles/components/form/field.scss
+++ b/packages/components/src/styles/components/form/field.scss
@@ -44,8 +44,9 @@
     }
   }
 
-  .hds-form-field__character-count {
-    margin-bottom: 8px;
+  // Add spacing between the character count and the error message if one exists
+  .hds-form-field__character-count + .hds-form-error {
+    margin-top: 8px;
   }
 }
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR refactors the `Form::Textarea` styles to add a top-margin to error messages following the charcount instead of always adding a bottom margin to the charcount itself.

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-4680](https://hashicorp.atlassian.net/browse/HDS-4680)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4680]: https://hashicorp.atlassian.net/browse/HDS-4680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ