### PR TITLE
[DEMO] Dropdown re-render popover disassociation

### DIFF
--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -8,6 +8,50 @@
 <Shw::Text::H1>Dropdown</Shw::Text::H1>
 
 <section data-test-percy>
+  <Shw::Text::H2>Popover disassociated on toggle re-render</Shw::Text::H2>
+
+  <Shw::Grid @columns={{2}} as |SG|>
+    <SG.Item @label="with ToggleButton">
+      <Shw::Outliner {{style padding="6em 12em"}}>
+        <Hds::Button
+          @size="small"
+          @text="Force re-render"
+          @color="critical"
+          {{style margin="0 0 1em"}}
+          {{on "click" (fn (mut this.rerenderOne) true)}}
+        />
+        <Hds::Dropdown as |D|>
+          {{#if this.rerenderOne}}
+            <D.ToggleButton @color="secondary" @text="Replacement" />
+          {{else}}
+            <D.ToggleButton @color="primary" @text="Original" />
+          {{/if}}
+          <D.Interactive @href="#">Create</D.Interactive>
+          <D.Interactive @href="#">Edit</D.Interactive>
+        </Hds::Dropdown>
+      </Shw::Outliner>
+    </SG.Item>
+    <SG.Item @label="with ToggleIcon">
+      <Shw::Outliner {{style padding="6em 12em"}}>
+        <Hds::Button
+          @size="small"
+          @text="Force re-render"
+          @color="critical"
+          {{style margin="0 0 1em"}}
+          {{on "click" (fn (mut this.rerenderTwo) true)}}
+        />
+        <Hds::Dropdown as |D|>
+          {{#if this.rerenderTwo}}
+            <D.ToggleIcon @icon="frown" @text="Replacement" />
+          {{else}}
+            <D.ToggleIcon @icon="smile" @text="Original" />
+          {{/if}}
+          <D.Interactive @href="#">Create</D.Interactive>
+          <D.Interactive @href="#">Edit</D.Interactive>
+        </Hds::Dropdown>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
 
   <Shw::Text::H2>Position</Shw::Text::H2>
 


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

### :hammer_and_wrench: Detailed description

When the dropdown toggle or dropdown toggle icon is replaced in a re-render, the popoverElement and the toggleElement become disassociated, resulting in a dropdown that cannot be opened.

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
