### PR TITLE
`SideNav` - Conditionally set `aria-labelledby`

### DIFF
--- a/.changeset/dry-buses-eat.md
+++ b/.changeset/dry-buses-eat.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SideNav` - Conditionally set `aria-labelledby` attribute for toggle button based on if `@ariaLabel` argument is provided.

--- a/packages/components/src/components/hds/side-nav/index.hbs
+++ b/packages/components/src/components/hds/side-nav/index.hbs
@@ -31,7 +31,7 @@
       {{! template-lint-enable no-invalid-interactive}}
       <Hds::SideNav::ToggleButton
         aria-label={{this.ariaLabel}}
-        aria-labelledby="hds-side-nav-header"
+        aria-labelledby={{unless this.ariaLabel "hds-side-nav-header"}}
         aria-expanded={{if this.isMinimized "false" "true"}}
         @icon={{if this.isMinimized "chevrons-right" "chevrons-left"}}
         {{on "click" this.toggleMinimizedStatus}}

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -211,6 +211,28 @@ module('Integration | Component | hds/side-nav/index', function (hooks) {
 
   // COLLAPSIBLE
 
+  test('if the @ariaLabel argument is not provided the default aria-labelledby value is set on the toggle button', async function (assert) {
+    await render(
+      hbs`<Hds::SideNav @isCollapsible={{true}} id="test-side-nav" />`
+    );
+    assert
+      .dom('.hds-side-nav__toggle-button')
+      .hasAttribute('aria-labelledby', 'hds-side-nav-header');
+    assert.dom('.hds-side-nav__toggle-button').hasNoAttribute('aria-label');
+  });
+
+  test('if the @ariaLabel argument is provided the label value is set on the toggle button', async function (assert) {
+    await render(
+      hbs`<Hds::SideNav @isCollapsible={{true}} id="test-side-nav" @ariaLabel="Test"/>`
+    );
+    assert
+      .dom('.hds-side-nav__toggle-button')
+      .hasNoAttribute('aria-labelledby');
+    assert
+      .dom('.hds-side-nav__toggle-button')
+      .hasAttribute('aria-label', 'Test');
+  });
+
   test('it responds to different events to toggle between "non-minimized" (by default) and "mimimized" states', async function (assert) {
     await render(
       hbs`<Hds::SideNav @isCollapsible={{true}} id="test-side-nav" />`


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would set the `aria-labelledby` attribute in the `SideNav` toggle button, only if the `@ariaLabel` argument is not provided.

### :hammer_and_wrench: Detailed description

Currently in the `SideNav` component's toggle button, there is a hardcoded `aria-labelledby` value of `hds-side-nav-header` present. The `@ariaLabel` argument sets the `aria-label` on the toggle button, but when this argument is set, the existing `aria-labelledby` is not removed. This leads to both `aria-label` and `aria-labelledby` being present on the toggle button. Since `aria-labelledby` overrides `aria-label` for screenreaders, the provided `aria-label` value is never announced.

To correct this behavior, the functionality has been changed so the hardcoded `aria-labelledby` is only set when the `@ariaLabel` argument is not used. 

### :camera_flash: Screenshots

**Before**

<img width="440" alt="Screenshot 2025-03-25 at 12 55 43 PM" src="https://github.com/user-attachments/assets/237703b6-e508-47b9-9f59-965c75f2b18d" />


**After**

<img width="440" alt="Screenshot 2025-03-25 at 12 54 37 PM" src="https://github.com/user-attachments/assets/58e659a2-a866-4f7c-8e3c-15ac5deabe98" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4549](https://hashicorp.atlassian.net/browse/HDS-4549)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4549]: https://hashicorp.atlassian.net/browse/HDS-4549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ