### PR TITLE
[HDS-4345] - Fix double loading of flight icons in engines

### DIFF
--- a/packages/components/src/instance-initializers/load-sprite.ts
+++ b/packages/components/src/instance-initializers/load-sprite.ts
@@ -4,17 +4,27 @@
  */
 
 import config from 'ember-get-config';
-import type ApplicationInstance from '@ember/application/instance';
+import ApplicationInstance from '@ember/application/instance';
+import EngineInstance from '@ember/engine/instance';
+
+type AppInstanceWithSpriteFlag = ApplicationInstance & {
+  __flightIconsSpriteLoaded?: boolean;
+};
+
+type EngineInstanceWithSpriteFlag = EngineInstance & {
+  __flightIconsSpriteLoaded?: boolean;
+};
 
 export async function initialize(
-  appInstance: ApplicationInstance & {
-    __flightIconsSpriteLoaded?: boolean;
-  }
+  instance: AppInstanceWithSpriteFlag | EngineInstanceWithSpriteFlag
 ) {
+  const parentApp = getRootAppInstance(instance);
+
   if (
     config?.emberFlightIcons?.lazyEmbed &&
     // we use this flag to avoid loading the sprite multiple times
-    appInstance.__flightIconsSpriteLoaded !== true
+    parentApp.__flightIconsSpriteLoaded !== true &&
+    instance.__flightIconsSpriteLoaded !== true
   ) {
     const { default: svgSprite } = await import(
       // @ts-expect-error: missing types
@@ -32,8 +42,36 @@ export async function initialize(
     }
 
     // set the flag to avoid loading the sprite multiple times
-    appInstance.__flightIconsSpriteLoaded = true;
+    parentApp.__flightIconsSpriteLoaded = true;
   }
+}
+
+/**
+ * Searches up the hierarchy to get the parent app instance from an engine
+ * @param instance The instance passed to initialize, either an app or engine
+ * @returns The parent app instance
+ */
+function getRootAppInstance(
+  instance: AppInstanceWithSpriteFlag | EngineInstance
+): AppInstanceWithSpriteFlag {
+  if (instance instanceof ApplicationInstance) {
+    return instance as AppInstanceWithSpriteFlag;
+  }
+
+  let current = instance;
+
+  const symbols = Object.getOwnPropertySymbols(current);
+  const ENGINE_PARENT = symbols.find(
+    (s) => s.toString() === 'Symbol(ENGINE_PARENT)'
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  while (ENGINE_PARENT && (current as any)[ENGINE_PARENT]) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    current = (current as any)[ENGINE_PARENT];
+  }
+
+  return current as AppInstanceWithSpriteFlag;
 }
 
 export default {

--- a/packages/components/src/instance-initializers/load-sprite.ts
+++ b/packages/components/src/instance-initializers/load-sprite.ts
@@ -4,28 +4,9 @@
  */
 
 import config from 'ember-get-config';
-import ApplicationInstance from '@ember/application/instance';
-import EngineInstance from '@ember/engine/instance';
 
-type AppInstanceWithSpriteFlag = ApplicationInstance & {
-  __flightIconsSpriteLoaded?: boolean;
-};
-
-type EngineInstanceWithSpriteFlag = EngineInstance & {
-  __flightIconsSpriteLoaded?: boolean;
-};
-
-export async function initialize(
-  instance: AppInstanceWithSpriteFlag | EngineInstanceWithSpriteFlag
-) {
-  const parentApp = getRootAppInstance(instance);
-
-  if (
-    config?.emberFlightIcons?.lazyEmbed &&
-    // we use this flag to avoid loading the sprite multiple times
-    parentApp.__flightIconsSpriteLoaded !== true &&
-    instance.__flightIconsSpriteLoaded !== true
-  ) {
+export async function initialize() {
+  if (config?.emberFlightIcons?.lazyEmbed) {
     const { default: svgSprite } = await import(
       // @ts-expect-error: missing types
       '@hashicorp/flight-icons/svg-sprite/svg-sprite-module'
@@ -34,44 +15,19 @@ export async function initialize(
     // in test environments we can inject the sprite directly into the ember testing container
     // to avoid issues with tools like Percy that only consider content inside that element
     if (config.environment === 'test') {
-      window.document
-        ?.getElementById('ember-testing')
-        ?.insertAdjacentHTML('afterbegin', svgSprite);
+      const container = window.document?.getElementById('ember-testing');
+
+      if (container && !container.querySelector('.flight-sprite-container')) {
+        container.insertAdjacentHTML('afterbegin', svgSprite);
+      }
     } else {
-      window.document?.body?.insertAdjacentHTML('beforeend', svgSprite);
+      const container = window.document?.body;
+
+      if (container && !container.querySelector('.flight-sprite-container')) {
+        container.insertAdjacentHTML('beforeend', svgSprite);
+      }
     }
-
-    // set the flag to avoid loading the sprite multiple times
-    parentApp.__flightIconsSpriteLoaded = true;
   }
-}
-
-/**
- * Searches up the hierarchy to get the parent app instance from an engine
- * @param instance The instance passed to initialize, either an app or engine
- * @returns The parent app instance
- */
-function getRootAppInstance(
-  instance: AppInstanceWithSpriteFlag | EngineInstanceWithSpriteFlag
-): AppInstanceWithSpriteFlag | EngineInstanceWithSpriteFlag {
-  if (instance instanceof ApplicationInstance) {
-    return instance as AppInstanceWithSpriteFlag;
-  }
-
-  let current = instance;
-
-  const symbols = Object.getOwnPropertySymbols(current);
-  const ENGINE_PARENT = symbols.find(
-    (s) => s.toString() === 'Symbol(ENGINE_PARENT)'
-  );
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  while (ENGINE_PARENT && (current as any)[ENGINE_PARENT]) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    current = (current as any)[ENGINE_PARENT];
-  }
-
-  return current;
 }
 
 export default {

--- a/packages/components/src/instance-initializers/load-sprite.ts
+++ b/packages/components/src/instance-initializers/load-sprite.ts
@@ -52,8 +52,8 @@ export async function initialize(
  * @returns The parent app instance
  */
 function getRootAppInstance(
-  instance: AppInstanceWithSpriteFlag | EngineInstance
-): AppInstanceWithSpriteFlag {
+  instance: AppInstanceWithSpriteFlag | EngineInstanceWithSpriteFlag
+): AppInstanceWithSpriteFlag | EngineInstanceWithSpriteFlag {
   if (instance instanceof ApplicationInstance) {
     return instance as AppInstanceWithSpriteFlag;
   }
@@ -71,7 +71,7 @@ function getRootAppInstance(
     current = (current as any)[ENGINE_PARENT];
   }
 
-  return current as AppInstanceWithSpriteFlag;
+  return current;
 }
 
 export default {


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes an issue where flight icons would be loaded every time an engine was accessed.


### :hammer_and_wrench: Detailed description

This required updating the `load-sprite` instance initializer to check if the parent app had the icons loaded yet or not.

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4345](https://hashicorp.atlassian.net/browse/HDS-4345)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4345]: https://hashicorp.atlassian.net/browse/HDS-4345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ