### PR TITLE
`CodeEditor` - Website improvements

### DIFF
--- a/website/docs/components/code-editor/partials/accessibility/accessibility.md
+++ b/website/docs/components/code-editor/partials/accessibility/accessibility.md
@@ -4,7 +4,7 @@
 
 When used without linting enabled, there should not be any WCAG conformance issues with this component.
 
-When linting is enabled, inline error indicator icons are not focusable. However, the errors are also displayed in a toggleable drawer beneath the code editor, providing an accessible alternative.
+When linting is enabled, the inline error indicator icons are not focusable. However, the errors are also displayed in a drawer beneath the code editor as an accessible alternative. The drawer is opened by pressing `cmd/ctrl + shift + m` while focused in the editor.
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/code-editor/partials/accessibility/accessibility.md
+++ b/website/docs/components/code-editor/partials/accessibility/accessibility.md
@@ -1,8 +1,10 @@
 ## Conformance rating
 
-<Doc::Badge @type="success">Conformant</Doc::Badge>
+<Doc::Badge @type="warning">Conditionally conformant</Doc::Badge>
 
-When used as recommended, there should not be any WCAG conformance issues with this component.
+When used without linting enabled, there should not be any WCAG conformance issues with this component.
+
+When linting is enabled, inline error indicator icons are not focusable. However, the errors are also displayed in a toggleable drawer beneath the code editor, providing an accessible alternative.
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/code-editor/partials/code/how-to-use.md
+++ b/website/docs/components/code-editor/partials/code/how-to-use.md
@@ -70,7 +70,7 @@ The `language` argument sets the syntax highlighting used. We support the follow
 ```
 ### Linting
 
-Set `isLintingEnabled to `true` to enable linting within the editor. Linting is only available when `language` is set to `json`.
+Set `isLintingEnabled` to `true` to enable linting within the editor. Linting is only available when `language` is set to `json`.
 
 ```handlebars
 <Hds::CodeEditor


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR changes the accessibility statement for the `CodeEditor`. When linting is enabled, the editor has some accessibility problems as described. Otherwise, the component remains accessible,

### :camera_flash: Screenshots

![Screenshot 2025-03-27 at 4 32 34 PM](https://github.com/user-attachments/assets/ee19b76b-119b-40dd-995e-394fa2290778)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4713](https://hashicorp.atlassian.net/browse/HDS-4713)


[HDS-4713]: https://hashicorp.atlassian.net/browse/HDS-4713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ