### PR TITLE
 `Pagination` Docs - Fix overflow issue for rendered code examples (HDS-4687)

### DIFF
--- a/website/app/styles/pages/components/pagination.scss
+++ b/website/app/styles/pages/components/pagination.scss
@@ -11,4 +11,9 @@
       margin-top: 16px;
     }
   }
+
+  // Some Pagination examples overflow
+  .doc-code-block__code-rendered {
+    overflow: auto;
+  }
 }


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add `overflow: auto` to Pagination rendered code examples in the documentation to fix an overflow issue.

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-4687](https://hashicorp.atlassian.net/browse/HDS-4687)

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets]~~(https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
