### PR TITLE
Remove `@hashicorp/flight-icons` from `website`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -883,9 +883,6 @@ importers:
       '@hashicorp/design-system-tokens':
         specifier: workspace:*
         version: link:../packages/tokens
-      '@hashicorp/flight-icons':
-        specifier: ^3.9.0
-        version: 3.9.0
       algoliasearch:
         specifier: ^4.24.0
         version: 4.24.0

--- a/website/package.json
+++ b/website/package.json
@@ -52,7 +52,6 @@
     "@glimmer/tracking": "^1.1.2",
     "@hashicorp/design-system-components": "workspace:*",
     "@hashicorp/design-system-tokens": "workspace:*",
-    "@hashicorp/flight-icons": "^3.9.0",
     "algoliasearch": "^4.24.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-funnel": "^3.0.8",


### PR DESCRIPTION
### :pushpin: Summary

Following [our own guidance](https://helios.hashicorp.design/getting-started/for-engineers), we don't need to import this dependency directly, as it is available via `@hashicorp/design-system-components`.

Declaring a version results [CI failing `changesets version`](https://github.com/hashicorp/design-system/actions/runs/14168687546/job/39687457736)
Declaring it as `workspace:*` results in [flight icons sync failing](https://github.com/hashicorp/design-system/pull/2782)

[HDS-4716](https://hashicorp.atlassian.net/browse/HDS-4716)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4716]: https://hashicorp.atlassian.net/browse/HDS-4716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ