### PR TITLE
`CodeBlock` - `@onCopy`

### DIFF
--- a/.changeset/rotten-suits-impress.md
+++ b/.changeset/rotten-suits-impress.md
@@ -1,5 +1,4 @@
 ---
 "@hashicorp/design-system-components": patch
 ---
-
 `AdvancedTable` - Updated the icons used in `th-button-expand` component to match designs.

--- a/.changeset/rotten-suits-impress.md
+++ b/.changeset/rotten-suits-impress.md
@@ -1,4 +1,5 @@
 ---
 "@hashicorp/design-system-components": patch
 ---
+
 `AdvancedTable` - Updated the icons used in `th-button-expand` component to match designs.

--- a/.changeset/smooth-nails-tell.md
+++ b/.changeset/smooth-nails-tell.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`CodeBlock` - Added `onCopy` argument which accepts a callback function that will be invoked when the "copy" action succeeds.

--- a/packages/components/src/components/hds/code-block/copy-button.hbs
+++ b/packages/components/src/components/hds/code-block/copy-button.hbs
@@ -9,5 +9,6 @@
   @isIconOnly={{true}}
   @size="small"
   @targetToCopy={{@targetToCopy}}
+  @onSuccess={{@onCopy}}
   ...attributes
 />

--- a/packages/components/src/components/hds/code-block/copy-button.ts
+++ b/packages/components/src/components/hds/code-block/copy-button.ts
@@ -11,6 +11,7 @@ export interface HdsCodeBlockCopyButtonSignature {
   Args: {
     targetToCopy?: HdsCopyButtonSignature['Args']['targetToCopy'];
     text?: HdsCopyButtonSignature['Args']['text'];
+    onCopy?: HdsCopyButtonSignature['Args']['onSuccess'];
   };
   Blocks: {
     default: [];

--- a/packages/components/src/components/hds/code-block/index.hbs
+++ b/packages/components/src/components/hds/code-block/index.hbs
@@ -26,6 +26,7 @@
         @targetToCopy="#{{this._preCodeId}}"
         aria-describedby={{this._preCodeId}}
         @text={{this.copyButtonText}}
+        @onCopy={{@onCopy}}
       />
     {{/if}}
   </div>

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -54,6 +54,7 @@ export interface HdsCodeBlockSignature {
     maxHeight?: string;
     value: string;
     copyButtonText?: HdsCopyButtonSignature['Args']['text'];
+    onCopy?: HdsCopyButtonSignature['Args']['onSuccess'];
   };
   Blocks: {
     default: [

--- a/showcase/tests/integration/components/hds/code-block/index-test.js
+++ b/showcase/tests/integration/components/hds/code-block/index-test.js
@@ -10,8 +10,10 @@ import {
   settled,
   resetOnerror,
   setupOnerror,
+  click,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
 
 module('Integration | Component | hds/code-block/index', function (hooks) {
   setupRenderingTest(hooks);
@@ -153,6 +155,23 @@ module('Integration | Component | hds/code-block/index', function (hooks) {
     `);
 
     assert.dom('.hds-code-block__copy-button').exists().hasAria('label', 'Foo');
+  });
+
+  test('it calls the onCopy action when the Copy button is clicked', async function (assert) {
+    sinon.stub(window.navigator.clipboard, 'writeText').resolves();
+
+    const copySpy = sinon.spy();
+
+    this.set('onCopy', copySpy);
+
+    await render(hbs`
+      <Hds::CodeBlock @value="test" @hasCopyButton={{true}} @onCopy={{this.onCopy}} />
+    `);
+
+    await click('.hds-code-block__copy-button');
+    assert.ok(copySpy.calledOnce, 'onCopy action was called');
+
+    sinon.restore();
   });
 
   // hasLineNumbers

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -41,6 +41,9 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
   <C.Property @name="maxHeight" @type="string" @default="auto">
     Accepts any valid CSS unit. If the `CodeBlock` content exceeds the maximum height a vertical scrollbar is enabled. This value applies to the code content only and does not include the header element (title and/or description).
   </C.Property>
+  <C.Property @name="onCopy" @type="function">
+    Callback function invoked (if provided) when the "copy" action succeeds.
+  </C.Property>
 </Doc::ComponentApi>
 
 ### Contextual components

--- a/website/docs/components/code-block/partials/code/how-to-use.md
+++ b/website/docs/components/code-block/partials/code/how-to-use.md
@@ -81,7 +81,7 @@ func main() {
 
 ### Copy button
 
-Set `hasCopyButton` to `true` to display a button for users to copy `CodeBlock` content to their computer clipboard. Use `copyButtonText` to provide a meaningful and unique label for the copy button.
+Set `hasCopyButton` to `true` to display a button for users to copy `CodeBlock` content to their computer clipboard. Use `copyButtonText` to provide a meaningful and unique label for the copy button. Set `onCopy` to a callback function that is invoked when the "copy" action succeeds.
 
 ```handlebars
 <Hds::CodeBlock


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds adds support for an `@onCopy` callback function to the `Hds::CodeBlock` component that is called when the copy action succeeds.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4741](https://hashicorp.atlassian.net/browse/HDS-4741)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4741]: https://hashicorp.atlassian.net/browse/HDS-4741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ