### PR TITLE
Resolve `flight-icons` misalignment in `website`

### DIFF
--- a/packages/components/src/components/hds/icon/index.ts
+++ b/packages/components/src/components/hds/icon/index.ts
@@ -13,6 +13,7 @@ import type { IconName } from '@hashicorp/flight-icons/svg';
 import type Owner from '@ember/owner';
 
 export const AVAILABLE_COLORS: string[] = Object.values(HdsIconColorValues);
+export const AVAILABLE_NAMES = iconNames;
 
 export interface HdsIconSignature {
   Args: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -884,8 +884,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/tokens
       '@hashicorp/flight-icons':
-        specifier: ^3.9.0
-        version: 3.9.0
+        specifier: workspace:*
+        version: link:../packages/flight-icons
       algoliasearch:
         specifier: ^4.24.0
         version: 4.24.0

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
+import { AVAILABLE_NAMES } from '@hashicorp/design-system-components/components/hds/icon/index';
 
 import catalog from '@hashicorp/flight-icons/catalog.json';
 
@@ -17,8 +18,9 @@ export default class Index extends Component {
   @service eventTracking;
   @service router;
 
-  allIcons = catalog.assets.map(
-    ({ iconName, fileName, size, description, category }) => {
+  allIcons = catalog.assets
+    .filter(({ iconName }) => AVAILABLE_NAMES.includes(iconName))
+    .map(({ iconName, fileName, size, description, category }) => {
       category = category.toLowerCase(); // category names in json begin with uppercase letter
 
       return {
@@ -29,8 +31,7 @@ export default class Index extends Component {
         category: `${category}`,
         searchable: `${iconName}, ${description}, ${category}`,
       };
-    }
-  );
+    });
 
   get searchQuery() {
     return this.router.currentRoute.queryParams['searchQuery'];

--- a/website/package.json
+++ b/website/package.json
@@ -52,7 +52,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@hashicorp/design-system-components": "workspace:*",
     "@hashicorp/design-system-tokens": "workspace:*",
-    "@hashicorp/flight-icons": "^3.9.0",
+    "@hashicorp/flight-icons": "workspace:*",
     "algoliasearch": "^4.24.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-funnel": "^3.0.8",


### PR DESCRIPTION
### :pushpin: Summary

Reverting some of the changes introduced in #2782 and fixing the icon name misalignment issue.

🛠️ Detailed description

Using `flight-icons` from `workspace` in `website` comes with the pitfall of `@hashicorp/design-system-components` resolving into a fixed version (hence the `Hds::Icon` failing to recognize the recently added icons) while the `catalog.json` used for the icon library in `website` is up to date and contains unreleased icons (as it resolves locally via workspace).

To resolve this misalignment I expose the available icon names through the `Hds::Icon` component so we can check their availability before trying to render them in website.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4716](https://hashicorp.atlassian.net/browse/HDS-4716)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4716]: https://hashicorp.atlassian.net/browse/HDS-4716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ