### PR TITLE
`Card` - docs for tag arg (HDS-4688)

### DIFF
--- a/website/app/styles/app.scss
+++ b/website/app/styles/app.scss
@@ -35,6 +35,7 @@
 @use "pages/components/app-footer" as components-app-footer;
 @use "pages/components/application-state" as components-application-state;
 @use "pages/components/button" as components-button;
+@use "pages/components/card" as components-card;
 @use "pages/components/code-block" as components-code-block;
 @use "pages/components/code-editor" as components-code-editor;
 @use "pages/components/copy-snippet" as components-copy-snippet;

--- a/website/app/styles/pages/components/card.scss
+++ b/website/app/styles/pages/components/card.scss
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// COMPONENTS > CARD
+
+#show-content-components-card {
+  .doc-card-list-demo {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  .doc-card-list-demo__item {
+    margin: 0; // styles are being inherited from doc-markdown list styles
+    padding: 24px;
+  }
+}

--- a/website/docs/components/card/partials/accessibility/accessibility.md
+++ b/website/docs/components/card/partials/accessibility/accessibility.md
@@ -2,7 +2,9 @@
 
 <Doc::Badge @type="warning">Conditionally conformant</Doc::Badge>
 
-By default, the card container component has `@overflow="hidden"` applied to it. This means you may need to handle cases where text is truncated, to make it accessible for keyboard-only users.
+By default, the Card container component has `@overflow="hidden"` applied to it. This means you may need to handle cases where text is truncated, to make it accessible for keyboard-only users.
+
+If the Card `tag` argument is set to `li`, it must be contained within either a `ul` or `ol` parent element in order for the HTML markup to be valid.
 
 Additionally, if the component is altered to be an interactive element, and also contains interactive elements like links or buttons, it can cause a conformance failure for having nested interactive elements.
 

--- a/website/docs/components/card/partials/code/component-api.md
+++ b/website/docs/components/card/partials/code/component-api.md
@@ -21,6 +21,9 @@
   <C.Property @name="overflow" @type="enum" @values={{array "visible" "hidden" }} @default="visible">
     Controls the "overflow" property for the component.
   </C.Property>
+  <C.Property @name="tag" @type="enum" @values={{array "div" "li"}} @default="div">
+    The HTML tag that wraps the `Card` content.
+  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/components/card/partials/code/how-to-use.md
+++ b/website/docs/components/card/partials/code/how-to-use.md
@@ -22,7 +22,7 @@ Alternatively, you could use the Card Containers in a CSS `flex` or `grid` conta
 
 To specify which HTML tag to use to render the component, use the `@tag` argument. The default tag is a `div` but you can optionally render the Card as an `li` to be used within a list.
 
-Note: If you choose to use the `Card` as a list item, you are responsible for the related styling.
+Note: If you choose to use the `Card` as a list item, you must wrap it either in a `ul` or `ol` tag for the markup to be valid. Also note that you are responsible for the related styling for the list and list items.
 
 ```handlebars
 <ul class="doc-card-list-demo">

--- a/website/docs/components/card/partials/code/how-to-use.md
+++ b/website/docs/components/card/partials/code/how-to-use.md
@@ -18,6 +18,28 @@ To style the Cards, you can add an external element that wraps the Card, with a 
 
 Alternatively, you could use the Card Containers in a CSS `flex` or `grid` container.
 
+### HTML tag
+
+To specify which HTML tag to use to render the component, use the `@tag` argument. The default tag is a `div` but you can optionally render the Card as an `li` to be used within a list.
+
+Note: If you choose to use the `Card` as a list item, you are responsible for the related styling.
+
+```handlebars
+<ul class="doc-card-list-demo">
+  <Hds::Card::Container @tag="li" @hasBorder={{true}} class="doc-card-list-demo__item">
+    Card item 1
+  </Hds::Card::Container>
+
+  <Hds::Card::Container @tag="li" @hasBorder={{true}} class="doc-card-list-demo__item">
+    Card item 2
+  </Hds::Card::Container>
+
+  <Hds::Card::Container @tag="li" @hasBorder={{true}} class="doc-card-list-demo__item">
+    Card item 3
+  </Hds::Card::Container>
+</ul>
+```
+
 ### Interactive states
 
 At the moment, we do not recommend using the Card component as an interactive element, although we may add this feature in the future. Despite this, some products have implemented designs that provide visual feedback to the user interacting with a Card by changing the elevation style (on `:hover` or `:active`).


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds documentation for the `Card` `tag` argument to the web site.

#### Preview:
* Example code: https://hds-website-git-hds-4688-card-tag-arg-docs-hashicorp.vercel.app/components/card?tab=code#html-tag
* API docs: https://hds-website-git-hds-4688-card-tag-arg-docs-hashicorp.vercel.app/components/card?tab=code#component-api
* Accessibility: https://hds-website-git-hds-4688-card-tag-arg-docs-hashicorp.vercel.app/components/card?tab=accessibility

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* PR for adding tag arg to Card: https://github.com/hashicorp/design-system/pull/2787
* Jira ticket: [HDS-4688](https://hashicorp.atlassian.net/browse/HDS-4688)

***

### 👀 Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4688]: https://hashicorp.atlassian.net/browse/HDS-4688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ