### PR TITLE
Add missing component paths to changelog script

### DIFF
--- a/website/lib/changelog/generate-component-changelog-entries.mjs
+++ b/website/lib/changelog/generate-component-changelog-entries.mjs
@@ -195,14 +195,20 @@ const componentPaths = getComponentPaths('./docs/components');
 const copyComponentPaths = getComponentPaths('./docs/components/copy');
 const formComponentPaths = getComponentPaths('./docs/components/form');
 const linkComponentPaths = getComponentPaths('./docs/components/link');
+const stepperComponentPaths = getComponentPaths('./docs/components/stepper');
 const tableComponentPaths = getComponentPaths('./docs/components/table');
+const layoutComponentPaths = getComponentPaths('./docs/layouts');
+const overrideComponentPaths = getComponentPaths('./docs/overrides');
 const utilityComponentPaths = getComponentPaths('./docs/utilities');
 const allComponentsPath = {
   ...componentPaths,
   ...copyComponentPaths,
   ...formComponentPaths,
   ...linkComponentPaths,
+  ...stepperComponentPaths,
   ...tableComponentPaths,
+  ...layoutComponentPaths,
+  ...overrideComponentPaths,
   ...utilityComponentPaths,
 };
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add missing component paths to the `generate-changelog-markdown-file` script file.

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
