### PR TITLE
Advanced Table: enable acceptance tests, resolve a11y violations

### DIFF
--- a/.changeset/blue-suits-hide.md
+++ b/.changeset/blue-suits-hide.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`AdvancedTable` - improved accessibility by removing usage of `aria-expanded="mixed"` and moving the caption outside of the element with `role="grid"`.
+`AdvancedTable` - Improved accessibility by removing usage of `aria-expanded="mixed"` and moving the caption outside of the element with `role="grid"`.

--- a/.changeset/blue-suits-hide.md
+++ b/.changeset/blue-suits-hide.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AdvancedTable` - improved accessibility

--- a/.changeset/blue-suits-hide.md
+++ b/.changeset/blue-suits-hide.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`AdvancedTable` - improved accessibility
+`AdvancedTable` - improved accessibility by removing usage of `aria-expanded="mixed"` and moving the caption outside of the element with `role="grid"`.

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -7,6 +7,13 @@
     {{(if this.isStickyHeaderPinned 'hds-advanced-table__container--header-is-pinned')}}"
   ...attributes
 >
+  {{! Caption }}
+  <div id={{this._captionId}} class="sr-only hds-advanced-table__caption" aria-live="polite">
+    {{@caption}}
+    {{this.sortedMessageText}}
+  </div>
+
+  {{! Grid }}
   <div
     class={{this.classNames}}
     role="grid"
@@ -17,12 +24,6 @@
     }}
     {{this._setUpScrollWrapper}}
   >
-    {{! Caption }}
-    <div id={{this._captionId}} class="sr-only hds-advanced-table__caption" aria-live="polite">
-      {{@caption}}
-      {{this.sortedMessageText}}
-    </div>
-
     {{! Header }}
     <div class={{this.theadClassNames}} role="rowgroup" {{this._setUpThead}}>
       <Hds::AdvancedTable::Tr

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -66,8 +66,6 @@ export default class HdsAdvancedTableTableModel {
   get expandState(): HdsAdvancedTableExpandState {
     if (this.allRowsAreOpen) {
       return true;
-    } else if (this.rows.some((row) => row.isOpen)) {
-      return 'mixed';
     } else {
       return false;
     }

--- a/packages/components/src/components/hds/advanced-table/th-button-expand.ts
+++ b/packages/components/src/components/hds/advanced-table/th-button-expand.ts
@@ -16,7 +16,7 @@ export interface HdsAdvancedTableThButtonExpandSignature {
   Args: {
     labelId?: string;
     isExpanded?: HdsAdvancedTableExpandState;
-    onToggle?: (newValue?: HdsAdvancedTableExpandState) => void;
+    onToggle?: () => void;
     isExpandAll?: boolean;
   };
   Element: HTMLButtonElement;
@@ -37,8 +37,6 @@ export default class HdsAdvancedTableThButtonExpand extends Component<HdsAdvance
       return this.args.isExpandAll
         ? HdsAdvancedTableThExpandIconValues.UnfoldClose
         : HdsAdvancedTableThExpandIconValues.ChevronUp;
-    } else if (this.isExpanded === 'mixed' && this.args.isExpandAll) {
-      return HdsAdvancedTableThExpandIconValues.UnfoldOpen;
     } else {
       return this.args.isExpandAll
         ? HdsAdvancedTableThExpandIconValues.UnfoldOpen
@@ -59,10 +57,6 @@ export default class HdsAdvancedTableThButtonExpand extends Component<HdsAdvance
     // add a class based on the isExpanded state
     if (this.args.isExpanded === true) {
       classes.push(`hds-advanced-table__th-button--is-expanded`);
-    }
-
-    if (this.args.isExpanded === 'mixed') {
-      classes.push(`hds-advanced-table__th-button--is-mixed`);
     }
 
     return classes.join(' ');

--- a/packages/components/src/components/hds/advanced-table/types.ts
+++ b/packages/components/src/components/hds/advanced-table/types.ts
@@ -72,7 +72,7 @@ export type HdsAdvancedTableSelectableRow = {
   selectionKey: string;
 };
 
-export type HdsAdvancedTableExpandState = boolean | 'mixed';
+export type HdsAdvancedTableExpandState = boolean;
 
 interface BaseHdsAdvancedTableColumn {
   align?: HdsAdvancedTableHorizontalAlignment;

--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -1094,8 +1094,12 @@
   <Shw::Flex @direction="column" @label="Nested rows" as |SF|>
     <SF.Item @grow={{true}}>
 
-      <div class="hds-advanced-table hds-advanced-table--density-medium" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__tbody">
+      <div
+        class="hds-advanced-table hds-advanced-table--density-medium"
+        {{style gridTemplateColumns="repeat(4, 1fr)"}}
+        role="grid"
+      >
+        <div class="hds-advanced-table__tbody" role="rowgroup">
           <Hds::AdvancedTable::Tr @depth={{0}}>
             <Hds::AdvancedTable::Th @depth={{0}} @isExpandable={{true}}>
               Depth 0
@@ -1145,8 +1149,12 @@
 
   <Shw::Flex @direction="column" @label="Nested rows with multiline" as |SF|>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table hds-advanced-table--density-medium" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__tbody">
+      <div
+        class="hds-advanced-table hds-advanced-table--density-medium"
+        role="grid"
+        {{style gridTemplateColumns="repeat(4, 1fr)"}}
+      >
+        <div class="hds-advanced-table__tbody" role="rowgroup">
           <Hds::AdvancedTable::Tr @depth={{0}}>
             <Hds::AdvancedTable::Th @depth={{0}} @isExpandable={{true}}>
               Depth 0 - This is a very long text that should go on two lines
@@ -1200,9 +1208,9 @@
     {{#each @model.STATES as |state|}}
       <SF.Item @grow={{true}}>
 
-        <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(3, 1fr)"}}>
-          <div class="hds-advanced-table__thead">
-            <div class="hds-advanced-table__tr">
+        <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(3, 1fr)"}}>
+          <div class="hds-advanced-table__thead" role="rowgroup">
+            <div class="hds-advanced-table__tr" role="row">
               <Hds::AdvancedTable::ThSort
                 mock-state-value={{state}}
                 mock-state-selector="button"
@@ -1225,9 +1233,9 @@
 
   <Shw::Flex @label="Alignment" as |SF|>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(6, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(6, 1fr)"}}>
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::ThSort>Left</Hds::AdvancedTable::ThSort>
             <Hds::AdvancedTable::ThSort @tooltip="Here is more information">Left</Hds::AdvancedTable::ThSort>
             <Hds::AdvancedTable::ThSort @align="center">Center</Hds::AdvancedTable::ThSort>
@@ -1248,9 +1256,9 @@
 
   <Shw::Flex @direction="column" @label="Multi-line" as |SF|>
     <SF.Item {{style width="600px"}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(2, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(2, 1fr)"}}>
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::ThSort>
               This is a very long text that should go on two lines
             </Hds::AdvancedTable::ThSort>
@@ -1269,9 +1277,9 @@
 
   <Shw::Flex @label="Interactive states" as |SF|>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             {{#each @model.STATES as |state|}}
               <Hds::AdvancedTable::Th
                 @tooltip="Here is more information"
@@ -1289,9 +1297,9 @@
 
   <Shw::Flex @label="Expandable" as |SF|>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             {{#each @model.STATES as |state|}}
               <Hds::AdvancedTable::Th
                 mock-state-value={{state}}
@@ -1307,34 +1315,15 @@
       </div>
     </SF.Item>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             {{#each @model.STATES as |state|}}
               <Hds::AdvancedTable::Th
                 mock-state-value={{state}}
                 mock-state-selector="button"
                 @isExpandable={{true}}
                 @isExpanded={{true}}
-                @hasExpandAllButton={{true}}
-              >
-                {{capitalize state}}
-              </Hds::AdvancedTable::Th>
-            {{/each}}
-          </div>
-        </div>
-      </div>
-    </SF.Item>
-    <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
-            {{#each @model.STATES as |state|}}
-              <Hds::AdvancedTable::Th
-                mock-state-value={{state}}
-                mock-state-selector="button"
-                @isExpandable={{true}}
-                @isExpanded="mixed"
                 @hasExpandAllButton={{true}}
               >
                 {{capitalize state}}
@@ -1348,9 +1337,9 @@
 
   <Shw::Flex @label="Expandable with tooltip" as |SF|>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             {{#each @model.STATES as |state|}}
               <Hds::AdvancedTable::Th
                 @tooltip="Here is more information"
@@ -1367,9 +1356,9 @@
       </div>
     </SF.Item>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             {{#each @model.STATES as |state|}}
               <Hds::AdvancedTable::Th
                 @tooltip="Here is more information"
@@ -1386,33 +1375,13 @@
         </div>
       </div>
     </SF.Item>
-    <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
-            {{#each @model.STATES as |state|}}
-              <Hds::AdvancedTable::Th
-                @tooltip="Here is more information"
-                mock-state-value={{state}}
-                mock-state-selector="button"
-                @isExpandable={{true}}
-                @isExpanded="mixed"
-                @hasExpandAllButton={{true}}
-              >
-                {{capitalize state}}
-              </Hds::AdvancedTable::Th>
-            {{/each}}
-          </div>
-        </div>
-      </div>
-    </SF.Item>
   </Shw::Flex>
 
   <Shw::Flex @label="Alignment" as |SF|>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(6, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(6, 1fr)"}}>
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th @tooltip="Here is more information">Left</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
@@ -1427,9 +1396,9 @@
 
   <Shw::Flex @label="Display" as |SF|>
     <SF.Item @label="Th with visually hidden text" @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Lorem</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Ipsum</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Dolor</Hds::AdvancedTable::Th>
@@ -1442,9 +1411,9 @@
 
   <Shw::Flex @label="Sticky header" as |SF|>
     <SF.Item @label="Default" @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead hds-advanced-table__thead--sticky">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
+        <div class="hds-advanced-table__thead hds-advanced-table__thead--sticky" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Lorem</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Ipsum</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Dolor</Hds::AdvancedTable::Th>
@@ -1454,9 +1423,12 @@
       </div>
     </SF.Item>
     <SF.Item @label="Pinned" @grow={{true}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead hds-advanced-table__thead--sticky hds-advanced-table__thead--is-pinned">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
+        <div
+          class="hds-advanced-table__thead hds-advanced-table__thead--sticky hds-advanced-table__thead--is-pinned"
+          role="rowgroup"
+        >
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Lorem</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Ipsum</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Dolor</Hds::AdvancedTable::Th>
@@ -1469,9 +1441,9 @@
 
   <Shw::Flex @direction="column" @label="Multi-line" as |SF|>
     <SF.Item {{style width="600px"}}>
-      <div class="hds-advanced-table" {{style gridTemplateColumns="repeat(2, 1fr)"}}>
-        <div class="hds-advanced-table__thead hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(2, 1fr)"}}>
+        <div class="hds-advanced-table__thead hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>
               This is a very long text that should go on two lines
             </Hds::AdvancedTable::Th>
@@ -1494,9 +1466,13 @@
         {{#each booleans as |bool2|}}
           <SF.Item @label="{{if bool1 'Selected' 'Deselected'}} {{if bool2 ' with sort'}}">
 
-            <div class="hds-advanced-table hds-advanced-table--density-medium" {{style gridTemplateColumns="auto 1fr"}}>
-              <div class="hds-advanced-table__thead">
-                <div class="hds-advanced-table__tr">
+            <div
+              class="hds-advanced-table hds-advanced-table--density-medium"
+              role="grid"
+              {{style gridTemplateColumns="auto 1fr"}}
+            >
+              <div class="hds-advanced-table__thead" role="rowgroup">
+                <div class="hds-advanced-table__tr" role="row">
                   <Hds::AdvancedTable::ThSelectable
                     @selectionScope="col"
                     @isSelected={{bool1}}
@@ -1505,8 +1481,8 @@
                   <Hds::AdvancedTable::Th>Lorem</Hds::AdvancedTable::Th>
                 </div>
               </div>
-              <div class="hds-advanced-table__tbody">
-                <div class="hds-advanced-table__tr">
+              <div class="hds-advanced-table__tbody" role="rowgroup">
+                <div class="hds-advanced-table__tr" role="row">
                   <Hds::AdvancedTable::ThSelectable @selectionScope="row" @isSelected={{bool1}} />
                   <Hds::AdvancedTable::Td>Ipsum</Hds::AdvancedTable::Td>
                 </div>
@@ -1514,9 +1490,13 @@
             </div>
             <br />
 
-            <div class="hds-advanced-table hds-advanced-table--density-medium" {{style gridTemplateColumns="auto 1fr"}}>
-              <div class="hds-advanced-table__thead">
-                <div class="hds-advanced-table__tr">
+            <div
+              class="hds-advanced-table hds-advanced-table--density-medium"
+              role="grid"
+              {{style gridTemplateColumns="auto 1fr"}}
+            >
+              <div class="hds-advanced-table__thead" role="rowgroup">
+                <div class="hds-advanced-table__tr" role="row">
                   <Hds::AdvancedTable::ThSelectable
                     @selectionScope="col"
                     @isSelected={{bool1}}
@@ -1527,8 +1507,8 @@
                   <Hds::AdvancedTable::Th>Lorem</Hds::AdvancedTable::Th>
                 </div>
               </div>
-              <div class="hds-advanced-table__tbody">
-                <div class="hds-advanced-table__tr">
+              <div class="hds-advanced-table__tbody" role="rowgroup">
+                <div class="hds-advanced-table__tr" role="row">
                   <Hds::AdvancedTable::ThSelectable
                     @selectionScope="row"
                     @isSelected={{bool1}}
@@ -1547,9 +1527,13 @@
       {{#each booleans as |bool|}}
         <SF.Item @label="Indeterminate {{if bool ' with sort'}}">
 
-          <div class="hds-advanced-table hds-advanced-table--density-medium" {{style gridTemplateColumns="auto 1fr"}}>
-            <div class="hds-advanced-table__thead">
-              <div class="hds-advanced-table__tr">
+          <div
+            class="hds-advanced-table hds-advanced-table--density-medium"
+            role="grid"
+            {{style gridTemplateColumns="auto 1fr"}}
+          >
+            <div class="hds-advanced-table__thead" role="rowgroup">
+              <div class="hds-advanced-table__tr" role="row">
                 <Hds::AdvancedTable::ThSelectable
                   @selectionScope="col"
                   @isSelected={{true}}
@@ -1559,8 +1543,8 @@
                 <Hds::AdvancedTable::Th>Lorem</Hds::AdvancedTable::Th>
               </div>
             </div>
-            <div class="hds-advanced-table__tbody">
-              <div class="hds-advanced-table__tr">
+            <div class="hds-advanced-table__tbody" role="rowgroup">
+              <div class="hds-advanced-table__tr" role="row">
                 <Hds::AdvancedTable::ThSelectable
                   @selectionScope="row"
                   @isSelected={{false}}
@@ -1572,9 +1556,13 @@
           </div>
           <br />
 
-          <div class="hds-advanced-table hds-advanced-table--density-medium" {{style gridTemplateColumns="auto 1fr"}}>
-            <div class="hds-advanced-table__thead">
-              <div class="hds-advanced-table__tr">
+          <div
+            class="hds-advanced-table hds-advanced-table--density-medium"
+            role="grid"
+            {{style gridTemplateColumns="auto 1fr"}}
+          >
+            <div class="hds-advanced-table__thead" role="rowgroup">
+              <div class="hds-advanced-table__tr" role="row">
                 <Hds::AdvancedTable::ThSelectable
                   @selectionScope="col"
                   @isSelected={{true}}
@@ -1586,8 +1574,8 @@
                 <Hds::AdvancedTable::Th>Lorem</Hds::AdvancedTable::Th>
               </div>
             </div>
-            <div class="hds-advanced-table__tbody">
-              <div class="hds-advanced-table__tr">
+            <div class="hds-advanced-table__tbody" role="rowgroup">
+              <div class="hds-advanced-table__tr" role="row">
                 <Hds::AdvancedTable::ThSelectable
                   @selectionScope="row"
                   @isSelected={{false}}
@@ -1610,9 +1598,13 @@
 
   <Shw::Flex @label="Horizontal alignment" as |SF|>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table hds-advanced-table--density-medium" {{style gridTemplateColumns="repeat(4, 1fr)"}}>
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+      <div
+        class="hds-advanced-table hds-advanced-table--density-medium"
+        role="grid"
+        {{style gridTemplateColumns="repeat(4, 1fr)"}}
+      >
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>
               Entity
             </Hds::AdvancedTable::Th>
@@ -1627,14 +1619,14 @@
             </Hds::AdvancedTable::Th>
           </div>
         </div>
-        <div class="hds-advanced-table__tbody">
-          <div class="hds-advanced-table__tr">
+        <div class="hds-advanced-table__tbody" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Text</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Td @align="left">Text is left aligned</Hds::AdvancedTable::Td>
             <Hds::AdvancedTable::Td @align="center">Text is center aligned</Hds::AdvancedTable::Td>
             <Hds::AdvancedTable::Td @align="right">Text is right aligned</Hds::AdvancedTable::Td>
           </div>
-          <div class="hds-advanced-table__tr">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Icon</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Td @align="left"><Hds::Icon @name="film" @isInline={{true}} /></Hds::AdvancedTable::Td>
             <Hds::AdvancedTable::Td @align="center"><Hds::Icon
@@ -1646,7 +1638,7 @@
                 @isInline={{true}}
               /></Hds::AdvancedTable::Td>
           </div>
-          <div class="hds-advanced-table__tr">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Icon + Inline text</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Td @align="left"><Hds::Icon @name="film" @isInline={{true}} />
               <span>Text in a <code>&lt;span&gt;</code></span></Hds::AdvancedTable::Td>
@@ -1655,13 +1647,13 @@
             <Hds::AdvancedTable::Td @align="right"><Hds::Icon @name="film" @isInline={{true}} />
               <span>Text in a <code>&lt;span&gt;</code></span></Hds::AdvancedTable::Td>
           </div>
-          <div class="hds-advanced-table__tr">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Badge</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Td @align="left"><Hds::Badge @text="Badge" /></Hds::AdvancedTable::Td>
             <Hds::AdvancedTable::Td @align="center"><Hds::Badge @text="Badge" /></Hds::AdvancedTable::Td>
             <Hds::AdvancedTable::Td @align="right"><Hds::Badge @text="Badge" /></Hds::AdvancedTable::Td>
           </div>
-          <div class="hds-advanced-table__tr">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Button (with inline container)</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Td @align="left">
               <div {{style display="inline-block"}}>
@@ -1679,7 +1671,7 @@
               </div>
             </Hds::AdvancedTable::Td>
           </div>
-          <div class="hds-advanced-table__tr">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Dropdown (with <code>@isInline</code>)</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Td @align="left">
               <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
@@ -1700,7 +1692,7 @@
               </Hds::Dropdown>
             </Hds::AdvancedTable::Td>
           </div>
-          <div class="hds-advanced-table__tr">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Tooltip(Button)</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Td @align="left">
               <Hds::TooltipButton @text="Hello!">
@@ -1727,10 +1719,11 @@
     <SF.Item @grow={{true}}>
       <div
         class="hds-advanced-table hds-advanced-table--density-medium hds-advanced-table--valign-top"
+        role="grid"
         {{style gridTemplateColumns="repeat(8, 1fr)"}}
       >
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Spacer</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Text</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Icon</Hds::AdvancedTable::Th>
@@ -1741,8 +1734,8 @@
             <Hds::AdvancedTable::Th>Tooltip(Button)</Hds::AdvancedTable::Th>
           </div>
         </div>
-        <div class="hds-advanced-table__tbody">
-          <div class="hds-advanced-table__tr">
+        <div class="hds-advanced-table__tbody" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Top (default)<Shw::Placeholder @height="50" /></Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Td>Text is top aligned</Hds::AdvancedTable::Td>
             <Hds::AdvancedTable::Td><Hds::Icon @name="film" @isInline={{true}} /></Hds::AdvancedTable::Td>
@@ -1773,10 +1766,11 @@
     <SF.Item @grow={{true}}>
       <div
         class="hds-advanced-table hds-advanced-table--density-medium hds-advanced-table--valign-middle"
+        role="grid"
         {{style gridTemplateColumns="repeat(8, 1fr)"}}
       >
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Spacer</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Text</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Icon</Hds::AdvancedTable::Th>
@@ -1787,8 +1781,8 @@
             <Hds::AdvancedTable::Th>Tooltip(Button)</Hds::AdvancedTable::Th>
           </div>
         </div>
-        <div class="hds-advanced-table__tbody">
-          <div class="hds-advanced-table__tr">
+        <div class="hds-advanced-table__tbody" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th><Shw::Placeholder @height="25" />Middle<Shw::Placeholder
                 @height="25"
               /></Hds::AdvancedTable::Th>
@@ -1821,10 +1815,11 @@
     <SF.Item @grow={{true}}>
       <div
         class="hds-advanced-table hds-advanced-table--density-medium hds-advanced-table--valign-baseline"
+        role="grid"
         {{style gridTemplateColumns="repeat(8, 1fr)"}}
       >
-        <div class="hds-advanced-table__thead">
-          <div class="hds-advanced-table__tr">
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Spacer</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Text</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Icon</Hds::AdvancedTable::Th>
@@ -1835,8 +1830,8 @@
             <Hds::AdvancedTable::Th>Tooltip(Button)</Hds::AdvancedTable::Th>
           </div>
         </div>
-        <div class="hds-advanced-table__tbody">
-          <div class="hds-advanced-table__tr">
+        <div class="hds-advanced-table__tbody" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th><Shw::Placeholder @height="25" />Baseline<Shw::Placeholder
                 @height="25"
               /></Hds::AdvancedTable::Th>
@@ -1914,9 +1909,6 @@
           <SF.Item>
             <Hds::AdvancedTable::ThButtonExpand @isExpanded={{true}} mock-state-value={{state}} />
           </SF.Item>
-          <SF.Item>
-            <Hds::AdvancedTable::ThButtonExpand @isExpanded="mixed" mock-state-value={{state}} />
-          </SF.Item>
         </Shw::Flex>
       </SG.Item>
     {{/each}}
@@ -1931,9 +1923,6 @@
           </SF.Item>
           <SF.Item>
             <Hds::AdvancedTable::ThButtonExpand @isExpanded={{true}} mock-state-value={{state}} @isExpandAll={{true}} />
-          </SF.Item>
-          <SF.Item>
-            <Hds::AdvancedTable::ThButtonExpand @isExpanded="mixed" mock-state-value={{state}} @isExpandAll={{true}} />
           </SF.Item>
         </Shw::Flex>
       </SG.Item>

--- a/showcase/tests/acceptance/components/hds/advanced-table-test.js
+++ b/showcase/tests/acceptance/components/hds/advanced-table-test.js
@@ -13,7 +13,6 @@ module('Acceptance | components/advanced-table', function (hooks) {
 
   test('Components/advanced-table page passes automated a11y checks', async function (assert) {
     await visit('/components/advanced-table');
-
     await a11yAudit();
 
     assert.ok(true, 'a11y automation audit passed');

--- a/showcase/tests/acceptance/components/hds/advanced-table.js
+++ b/showcase/tests/acceptance/components/hds/advanced-table.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'dummy/tests/helpers';
+import { setupApplicationTest } from 'showcase/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | components/advanced-table', function (hooks) {

--- a/showcase/tests/integration/components/hds/advanced-table/index-test.js
+++ b/showcase/tests/integration/components/hds/advanced-table/index-test.js
@@ -1106,7 +1106,7 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
         '#data-test-nested-advanced-table .hds-advanced-table__tbody .hds-advanced-table__tr.hds-advanced-table__tr--hidden'
       )
       .exists({ count: 2 });
-    assert.dom(expandAllButton).hasAria('expanded', 'mixed');
+    assert.dom(expandAllButton).hasAria('expanded', 'false');
 
     await click(expandAllButton);
 
@@ -1144,7 +1144,7 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
       await click(rowToggles[i]);
 
       if (i < rowToggles.length - 1) {
-        assert.dom(expandAllButton).hasAria('expanded', 'mixed');
+        assert.dom(expandAllButton).hasAria('expanded', 'false');
       }
     }
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would:
* actually enable the Advanced Table showcase acceptance tests
* move the caption outside of the element with `role="grid"`
* remove usage of `aria-expanded="mixed"` in the component, showcase page, and tests
* fix a11y errors on the showcase page by adding appropriate roles to mock elements wrapping actual components


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4758](https://hashicorp.atlassian.net/browse/HDS-4758)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4758]: https://hashicorp.atlassian.net/browse/HDS-4758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ