### PR TITLE
Fix sidecar in website

### DIFF
--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -106,10 +106,10 @@ export default class ShowRoute extends Route {
           }
         });
 
-        // check if there are special needs for the page layout
-        const hasCover = frontmatter?.layout?.cover ?? true;
         // TODO! probably we should also check if we have TOC data for the sidecar
-        const hasSidecar = frontmatter?.layout?.sidecar ?? true;
+        const layout = frontmatter.layout || {}; // fallback to an empty object if layout is undefined
+        const hasCover = layout.cover ?? true;
+        const hasSidecar = layout.sidecar ?? true;
         const showContentId = `show-content-${res.data.id
           .replace(/\/index$/, '')
           .replaceAll('/', '-')}`;


### PR DESCRIPTION
### :pushpin: Summary

Fix the sidecar in `website` by ensuring the `layout` object exists. While the fix doesn't demystify the root cause it does seem to fix the immediate issue. I suspect a mix of race and `frontmatter` object override.

To test the fix run `ember s --environment=production` to get prember to serve static assets. `/about/principles` is a good page to check the sidecar doesn't render.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4770](https://hashicorp.atlassian.net/browse/HDS-4770)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4770]: https://hashicorp.atlassian.net/browse/HDS-4770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ