### PR TITLE
Fix failing `changeset version`

### DIFF
--- a/.changeset/plenty-seals-cough.md
+++ b/.changeset/plenty-seals-cough.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AdvancedTable` - Improved accessibility by removing usage of `aria-expanded="mixed"` and moving the caption outside of the element with `role="grid"`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.25.9",
+    "prettier-plugin-ember-template-tag": "^2.0.5",
     "@changesets/cli": "^2.27.11",
     "@changesets/get-github-info": "^0.6.0",
     "@glint/core": "^1.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
+      prettier-plugin-ember-template-tag:
+        specifier: ^2.0.5
+        version: 2.0.5(prettier@3.5.3)
 
   packages/codemods:
     dependencies:


### PR DESCRIPTION
### :pushpin: Summary

`changeset version` currently fails when running from the root directory, complaining about missing `prettier-plugin-ember-template-tag` in `node_modules`, so I added it as a `devDependency` to get changeset working again.

Also added the missing changelog entry to resolve it in the release PR.

You can test by running `changeset` on `main` (where it will fail), and on this branch.

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
