### PR TITLE
`AdvancedTable`: fix styling bugs with sticky column & scroll indicators

### DIFF
--- a/.changeset/popular-seahorses-love.md
+++ b/.changeset/popular-seahorses-love.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AdvancedTable` - Fixed styling issues with the sticky column and scroll indicators.

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -91,7 +91,7 @@ const getScrollIndicatorDimensions = (
     left: `${leftOffset}px`,
     right: `${verticalScrollBarWidth}px`,
     top: hasStickyHeader ? `${theadElement.offsetHeight}px` : '0px',
-    width: `${scrollWrapper.offsetHeight - verticalScrollBarWidth}px`,
+    width: `${scrollWrapper.offsetWidth - verticalScrollBarWidth}px`,
   };
 };
 

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -87,11 +87,11 @@ const getScrollIndicatorDimensions = (
 
   return {
     bottom: `${horizontalScrollBarHeight}px`,
-    height: `${scrollWrapper.clientHeight - horizontalScrollBarHeight}px`,
+    height: `${scrollWrapper.offsetHeight - horizontalScrollBarHeight}px`,
     left: `${leftOffset}px`,
     right: `${verticalScrollBarWidth}px`,
     top: hasStickyHeader ? `${theadElement.offsetHeight}px` : '0px',
-    width: `${scrollWrapper.clientWidth - verticalScrollBarWidth}px`,
+    width: `${scrollWrapper.offsetHeight - verticalScrollBarWidth}px`,
   };
 };
 
@@ -106,8 +106,7 @@ const getStickyColumnLeftOffset = (
     '.hds-advanced-table__th--is-selectable'
   ) as HTMLElement;
 
-  // otherwise, the left offset is the width of the select checkbox column + 0.5px for the border
-  return `${selectableCell?.offsetWidth + 0.5}px`;
+  return `${selectableCell?.offsetWidth}px`;
 };
 
 export interface HdsAdvancedTableSignature {

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -130,17 +130,15 @@ $hds-advanced-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px differenc
     // sticky column
 
     .hds-advanced-table__th--is-sticky-column {
+      position: sticky;
       // has a higher z-index than the sticky header content
       z-index: 7;
-
-      &:first-of-type {
-        position: sticky;
-      }
     }
 
     .hds-advanced-table__th--is-sticky-column-pinned {
       &:first-of-type {
         left: -1px;
+        // add extra left border to offset -1px and the 0.5px border from the table container being gone
         border-left: calc(#{$hds-advanced-table-border-width} + 1px) solid $hds-advanced-table-border-color;
       }
     }
@@ -152,9 +150,9 @@ $hds-advanced-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px differenc
 
     .hds-advanced-table__th--is-sticky-column.hds-advanced-table__th--is-selectable
       + .hds-advanced-table__th--is-sticky-column.hds-advanced-table__th--is-sticky-column-pinned {
-      position: sticky;
       // If there is a select column the variable gets set to the width of the select column via inline styles on the grid
       left: var(--hds-advanced-table-sticky-column-offset, 0);
+      border-left-width: $hds-advanced-table-border-width;
     }
 
     // border radius: target first and last th elements in the row
@@ -347,17 +345,15 @@ $hds-advanced-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px differenc
 
   // Sticky columns
   .hds-advanced-table__th--is-sticky-column {
+    position: sticky;
     // has a lower z-index than the sticky header
     z-index: 3;
-
-    &:first-of-type {
-      position: sticky;
-    }
   }
 
   .hds-advanced-table__th--is-sticky-column-pinned {
     &:first-of-type {
       left: -1px;
+      // add extra left border to offset -1px and the 0.5px border from the table container being gone
       border-left: calc(#{$hds-advanced-table-border-width} + 1px) solid $hds-advanced-table-border-color;
     }
   }
@@ -369,9 +365,9 @@ $hds-advanced-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px differenc
 
   .hds-advanced-table__th--is-sticky-column.hds-advanced-table__th--is-selectable
     + .hds-advanced-table__th--is-sticky-column.hds-advanced-table__th--is-sticky-column-pinned {
-    position: sticky;
     // If there is a select column the variable gets set to the width of the select column via inline styles on the grid
     left: var(--hds-advanced-table-sticky-column-offset, 0);
+    border-left-width: $hds-advanced-table-border-width;
   }
 
   // horizontal alignment


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR would fix a couple styling issues in the current Advanced Table
* scroll indicators are too short/to narrow
* sticky column has a gap when you scroll 

I tested the solution across Safari/Firefox/Chrome + on HD/SD monitors and I think it looks good but please try test it out on your setups!

**[PREVIEW](https://hds-showcase-git-hds-4768-advanced-table-styling-bugs-hashicorp.vercel.app/components/advanced-table)**

### :camera_flash: Screenshots
**Current**
![Screenshot 2025-04-14 at 2 53 45 PM](https://github.com/user-attachments/assets/c5a9cae4-4786-464e-9a8c-1cc52adc4545)

**After**
<img width="350" alt="Screenshot 2025-04-14 at 2 54 43 PM" src="https://github.com/user-attachments/assets/ab69dee0-293a-47f1-b756-5fe8bdae608b" />

**Before**
![Screenshot 2025-04-14 at 2 55 16 PM](https://github.com/user-attachments/assets/242778e3-0b73-4bdb-b672-2be230f7f63e)

**After**
<img width="283" alt="Screenshot 2025-04-14 at 2 55 36 PM" src="https://github.com/user-attachments/assets/e7f595ec-83b3-429c-83cf-dec97b933c1d" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4768](https://hashicorp.atlassian.net/browse/HDS-4768)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4768]: https://hashicorp.atlassian.net/browse/HDS-4768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ