### PR TITLE
AdvancedTable - AppFrame followup

### DIFF
--- a/showcase/app/components/mock/app/index.gts
+++ b/showcase/app/components/mock/app/index.gts
@@ -5,7 +5,6 @@
 
 import Component from '@glimmer/component';
 import { hash } from '@ember/helper';
-import style from 'ember-style-modifier';
 import MockAppHeaderAppHeader from './header/app-header';
 import MockAppSidebarAppSideNav from './sidebar/app-side-nav';
 import MockAppSidebarOldSideNav from './sidebar/side-nav';
@@ -92,7 +91,7 @@ export default class MockApp extends Component<MockAppSignature> {
           {{/if}}
         {{/if}}
       </Frame.Sidebar>
-      <Frame.Main {{style overflow="auto"}}>
+      <Frame.Main>
         <div class="mock-app-layout-main-content-wrapper">
           {{yield
             (hash

--- a/showcase/app/components/mock/app/main/generic-advanced-table.gts
+++ b/showcase/app/components/mock/app/main/generic-advanced-table.gts
@@ -519,7 +519,7 @@ export default class MockAppMainGenericAdvancedTable extends Component<MockAppMa
   }
 
   <template>
-    <div class="mock-app-main-generic-advanced-table">
+    <div class="mock-app-main-generic-advanced-table-wrapper">
       <HdsAdvancedTable
         @columns={{this.demoColumns}}
         @model={{this.demoModel}}

--- a/showcase/app/styles/mock-components/app.scss
+++ b/showcase/app/styles/mock-components/app.scss
@@ -19,6 +19,7 @@
 }
 
 .mock-app-main-generic-advanced-table-wrapper {
+  // TODO remove after https://hashicorp.atlassian.net/browse/HDS-4751 is done 
   display: grid;
   height: 600px;
   overflow: auto;

--- a/showcase/app/styles/mock-components/app.scss
+++ b/showcase/app/styles/mock-components/app.scss
@@ -18,6 +18,8 @@
   margin-bottom: 12px;
 }
 
-.mock-app-main-generic-advanced-table {
+.mock-app-main-generic-advanced-table-wrapper {
+  display: grid;
   height: 600px;
+  overflow: auto;
 }

--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -8,18 +8,6 @@
 <Shw::Text::H1>AdvancedTable</Shw::Text::H1>
 <section data-test-percy>
 
-  <Shw::Text::Body>
-    <a
-      class="shw-frame__open-link"
-      href="/layouts/app-frame/frameless/demo-full-app-frame-with-advanced-table"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      See an Advanced Table in the context of a full App Frame
-      <span class="sr-only">open the frame in a new window</span>
-    </a>
-  </Shw::Text::Body>
-
   <Shw::Text::H2>Basic AdvancedTable</Shw::Text::H2>
   <Shw::Text::H3>Keyboard interaction</Shw::Text::H3>
 
@@ -1082,6 +1070,17 @@
       </B.Tr>
     </:body>
   </Hds::AdvancedTable>
+
+  <Shw::Divider />
+
+  <Shw::Text::H2>Demo</Shw::Text::H2>
+
+  <Shw::Frame
+    @id="demo-full-app-frame-with-advanced-table"
+    @src="/layouts/app-frame/frameless/demo-full-app-frame-with-advanced-table"
+    @height="780"
+    @label="Advanced Table in the context of a full App Frame"
+  />
 
   <Shw::Divider />
 

--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -8,6 +8,17 @@
 <Shw::Text::H1>AdvancedTable</Shw::Text::H1>
 <section data-test-percy>
 
+  <Shw::Text::Body>
+    <a
+      class="shw-frame__open-link"
+      href="/layouts/app-frame/frameless/demo-full-app-frame-with-advanced-table"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      See an Advanced Table in the context of a full App Frame
+      <span class="sr-only">open the frame in a new window</span>
+    </a>
+  </Shw::Text::Body>
   <Shw::Text::H2>Basic AdvancedTable</Shw::Text::H2>
   <Shw::Text::H3>Keyboard interaction</Shw::Text::H3>
 

--- a/showcase/app/templates/layouts/app-frame/index.hbs
+++ b/showcase/app/templates/layouts/app-frame/index.hbs
@@ -371,11 +371,4 @@
     @height="780"
     @label="Full AppFrame with old SideNav (without AppHeader)"
   />
-
-  <Shw::Frame
-    @id="demo-full-app-frame-with-advanced-table"
-    @src="/layouts/app-frame/frameless/demo-full-app-frame-with-advanced-table"
-    @height="780"
-    @label="Full AppFrame with AdvancedTable"
-  />
 </section>


### PR DESCRIPTION
### :pushpin: Summary

Looking at https://github.com/hashicorp/design-system/pull/2789 I noticed a couple of possible improvements.

### :hammer_and_wrench: Detailed description

In this PR I have:
- moved the `iFrame` with the AdvancedTable AppFrame demo in the “AdvancedTable” showcase page
    - reason: is more consistent with the other "demo" sections, it provide an in-page example via the iFrame, and a link to the full page via the "external link" icon in the frame
- moved the  “overflow wrapping logic” from the AppFrame main container to a local wrapper of the GenericAdvancedTable demo component
    - reason: we're not touching the `main` container, making the example more similar to what consumers would have in production

⚠️ Notice: @shleewhite this made me think if the "problem" of having a wrapper with `overflow: auto` (or `min-width: 0`) would be a problem that consumer would have too. In which case, we should consider having the `hds-advanced-table__container` as `display: grid` or something similar, so this would work out of the box instead of having to taking care of the overflow themselves. @KristinLBradley what do you think?

Preview:
- [AdvancedTable showcase page demo](https://hds-showcase-git-advanced-table-app-frame-followup-hashicorp.vercel.app/components/advanced-table#demo)
- [AppFrame standalone demo](https://hds-showcase-git-advanced-table-app-frame-followup-hashicorp.vercel.app/layouts/app-frame/frameless/demo-full-app-frame-with-advanced-table)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
