### PR TITLE
`CodeEditor` - Pass additional arguments to `onLint` and `onInput` callbacks

### DIFF
--- a/.changeset/wild-starfishes-drum.md
+++ b/.changeset/wild-starfishes-drum.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+`hds-code-editor` - Added the value and `EditorView` instance as arguments for the `onLint` callback. Added the `EditorView` instance as an argument to the `onInput` callback.
+
+`CodeEditor` - Added the value and `EditorView` instance as arguments for the `onLint` callback. Added the `EditorView` instance as an argument to the `onInput` callback.

--- a/packages/components/src/modifiers/hds-code-editor.ts
+++ b/packages/components/src/modifiers/hds-code-editor.ts
@@ -55,9 +55,9 @@ export interface HdsCodeEditorSignature {
       isLintingEnabled?: boolean;
       language?: HdsCodeEditorLanguages;
       value?: string;
-      onInput?: (newVal: string) => void;
+      onInput?: (newValue: string, editor: EditorViewType) => void;
       onBlur?: HdsCodeEditorBlurHandler;
-      onLint?: (diagnostics: DiagnosticType[]) => void;
+      onLint?: (diagnostics: DiagnosticType[], newValue: string, editor: EditorViewType) => void;
       onSetup?: (editor: EditorViewType) => unknown;
     };
   };
@@ -428,7 +428,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
           if (!update.docChanged || this.onInput === undefined) {
             return;
           }
-          this.onInput(update.state.doc.toString());
+          this.onInput(update.state.doc.toString(), update.view);
         }
       );
 

--- a/packages/components/src/modifiers/hds-code-editor/linters/json-linter.ts
+++ b/packages/components/src/modifiers/hds-code-editor/linters/json-linter.ts
@@ -109,10 +109,10 @@ export default async function jsonLinter(
     import('@codemirror/lint'),
   ]);
 
-  const jsonLinter = linter((view) => {
+  const jsonLinter = linter((editor) => {
     const diagnostics: DiagnosticType[] = [];
-    const doc = view.state.doc;
-    const tree = syntaxTree(view.state);
+    const doc = editor.state.doc;
+    const tree = syntaxTree(editor.state);
     const seenLines = new Set();
 
     tree.cursor().iterate((node) => {
@@ -141,7 +141,7 @@ export default async function jsonLinter(
       }
     });
 
-    onLint?.(diagnostics);
+    onLint?.(diagnostics, editor.state.doc.toString(), editor);
 
     return diagnostics;
   });

--- a/showcase/app/controllers/components/advanced-table.js
+++ b/showcase/app/controllers/components/advanced-table.js
@@ -9,6 +9,15 @@ import { tracked } from '@glimmer/tracking';
 import { deepTracked } from 'ember-deep-tracked';
 import { later } from '@ember/runloop';
 
+function shuffleArray(array) {
+  const shuffled = array.slice(); // make a copy to avoid mutating the original
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]; // swap
+  }
+  return shuffled;
+}
+
 // we use an array to declare the custom sorting order for the clusters' status
 const customSortingCriteriaArray = [
   'failing',
@@ -59,6 +68,11 @@ export default class ComponentsTableController extends Controller {
   @tracked multiSelectUsersCurrentPageSize_demo3 = 4;
   @deepTracked multiSelectUserData__demo4 = [...this.model.userDataDemo4];
   @tracked focusableElementsVisible = false;
+  @tracked columnOrder = ['artist', 'album', 'year'];
+
+  @action shuffleColumnOrder() {
+    this.columnOrder = shuffleArray(this.columnOrder);
+  }
 
   get clustersWithExtraData() {
     return this.model.clusters.map((record) => {

--- a/showcase/app/controllers/components/code-editor.js
+++ b/showcase/app/controllers/components/code-editor.js
@@ -164,7 +164,10 @@ SELECT 'Enjoy coding!';`,
   }
 
   @action
-  handleLint(diagnostics) {
-    console.log('Lint diagnostics:', diagnostics);
+  handleLint(diagnostics, value) {
+    console.log({
+      'Lint diagnostics': diagnostics,
+      'Lint value': value,
+    });
   }
 }

--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -36,6 +36,52 @@
     <li><strong>PageDown (fn + down)</strong>: Move to last cell in the column</li>
   </ul>
 
+  <button type="button" {{on "click" this.shuffleColumnOrder}}>Shuffle columns</button>
+
+  <Hds::AdvancedTable
+    @columnOrder={{this.columnOrder}}
+    @model={{this.model.music}}
+    @columns={{array
+      (hash key="artist" label="Artist" tooltip="More information." isSortable=true)
+      (hash key="album" label="Album" tooltip="More information." isSortable=true)
+      (hash key="year" label="Release Year" tooltip="More information." isSortable=true)
+      (hash key="other" label="Additional Actions")
+    }}
+  >
+    <:body as |B|>
+      <B.Tr as |R|>
+        {{#each R.orderedCells as |cell|}}
+          {{#if (eq cell.columnKey "artist")}}
+            <B.Th @columnKey="artist" @scope="row">
+              <Hds::Link::Inline @href="#showcase">
+                {{B.data.artist}}
+              </Hds::Link::Inline>
+            </B.Th>
+          {{else if (eq cell.columnKey "album")}}
+            <B.Td @columnKey="album">
+              <div class="shw-component-advanced-table-cell-content-div">
+                <Hds::Icon @name={{B.data.icon}} @isInline={{true}} />
+                {{B.data.album}}
+              </div>
+            </B.Td>
+          {{else if (eq cell.columnKey "year")}}
+            <B.Td @columnKey="year">
+              <Hds::Badge @text={{B.data.year}} @type={{B.data.badge-type}} @color={{B.data.badge-color.name}} />
+            </B.Td>
+          {{/if}}
+        {{/each}}
+
+        <B.Td @columnKey="other">
+          <Hds::ButtonSet>
+            <Hds::Button @text="Add" @isIconOnly={{true}} @icon="plus" @size="small" />
+            <Hds::Button @text="Edit" @isIconOnly={{true}} @icon="edit" @size="small" @color="secondary" />
+            <Hds::Button @text="Delete" @isIconOnly={{true}} @icon="trash" @size="small" @color="critical" />
+          </Hds::ButtonSet>
+        </B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::AdvancedTable>
+
   <Hds::AdvancedTable
     @model={{this.model.music}}
     @columns={{array
@@ -47,17 +93,21 @@
   >
     <:body as |B|>
       <B.Tr>
-        <B.Th @scope="row"><Hds::Link::Inline @href="#showcase">{{B.data.artist}}</Hds::Link::Inline></B.Th>
-        <B.Td>
+        <B.Th @columnKey="artist" @scope="row">
+          <Hds::Link::Inline @href="#showcase">
+            {{B.data.artist}}
+          </Hds::Link::Inline>
+        </B.Th>
+        <B.Td @columnKey="album">
           <div class="shw-component-advanced-table-cell-content-div">
             <Hds::Icon @name={{B.data.icon}} @isInline={{true}} />
             {{B.data.album}}
           </div>
         </B.Td>
-        <B.Td>
+        <B.Td @columnKey="year">
           <Hds::Badge @text={{B.data.year}} @type={{B.data.badge-type}} @color={{B.data.badge-color.name}} />
         </B.Td>
-        <B.Td>
+        <B.Td @columnKey="other">
           <Hds::ButtonSet>
             <Hds::Button @text="Add" @isIconOnly={{true}} @icon="plus" @size="small" />
             <Hds::Button @text="Edit" @isIconOnly={{true}} @icon="edit" @size="small" @color="secondary" />

--- a/showcase/tests/integration/modifiers/hds-code-editor-test.js
+++ b/showcase/tests/integration/modifiers/hds-code-editor-test.js
@@ -86,7 +86,7 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
       },
     });
 
-    assert.ok(inputSpy.calledOnceWith('Test string'));
+    assert.ok(inputSpy.calledOnceWith('Test string', this.editorView));
   });
 
   // onLint
@@ -99,13 +99,18 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
     });
 
     await setupCodeEditor(
-      hbs`<div id="code-editor-wrapper" {{hds-code-editor ariaLabel="test" isLintingEnabled=true language="json" onLint=this.handleLint onSetup=(fn (mut this.editorView)) }} />`
+      hbs`<div id="code-editor-wrapper" {{hds-code-editor ariaLabel="test" value="test" isLintingEnabled=true language="json" onLint=this.handleLint onSetup=(fn (mut this.editorView)) }} />`
     );
 
     // we know linting is complete when the error marker is rendered
     await waitFor('.cm-lint-marker-error');
 
-    assert.ok(lintSpy.calledOnce);
+    const [diagnostics, value, editor] = lintSpy.firstCall.args;
+
+    assert.strictEqual(diagnostics.length, 1);
+    assert.strictEqual(diagnostics[0].message, 'Invalid syntax');
+    assert.strictEqual(value, this.editorView.state.doc.toString());
+    assert.deepEqual(editor, this.editorView);
   });
 
   // ariaDescribedBy


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will pass additional arguments to the `onInput` and `onLint` callback functions of the `hds-code-editor` modifier (and the `Hds::CodeEditor` component that uses it under the hood).

### :hammer_and_wrench: Detailed description

Linting occurs asynchronously whereas input occurs syncrounously. Some consumers want to know the value at the time that linting has completed.

Changes:

- `onLint`: Added the new editor value at the time of linting and the editor instance as additional arguments

- `onInput`: added the editor instance as an additional argument

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4774](https://hashicorp.atlassian.net/browse/HDS-4774)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
