### PR TITLE
Set spacing between step and panel in `Hds::Stepper::Nav`

### DIFF
--- a/packages/components/src/styles/components/stepper/nav.scss
+++ b/packages/components/src/styles/components/stepper/nav.scss
@@ -104,6 +104,12 @@ $progress-bar-animation-duration: 0.25s;
   color: var(--token-color-foreground-faint);
 }
 
+// STEPPER > NAV > PANEL
+
+.hds-stepper-nav__panel {
+  margin-top: 24px;
+}
+
 // STATUSES
 
 // Complete & Active


### PR DESCRIPTION
### :pushpin: Summary

This PR would set a margin between the Step and Panel of `24px` in the `Hds::Stepper::Nav`

### :hammer_and_wrench: Detailed description

Currently there is [guidance](https://helios.hashicorp.design/components/stepper/nav#spacing) for consumers to set a spacing of 24px between the stepper and the step panel content in the `Hds::Stepper::Nav`. The component itself does not set any spacing between the steps and panels currently. 

Handling this spacing inside the component would ensure that anytime the stepper is used in a non-standalone fashion there is a proper spacing between the steps and panels. In adoption testing, it was found that this could ease adoption, as the majority of instances do not set any spacing between the panel and steps via their step content blocks. 

In many cases adding in the margin would require wrapping the content in the `<:body>` with the div that sets the margin itself. 
```
<Hds::Stepper::Nav
  @currentStep={{this.currentStep}}
  @steps={{this.steps}}
  @onStepChange={{this.onStepChange}}
>
  <:body>
    <div class="has-margin-top-md">
      {{!-- Step content --}}
    </div>
  </:body>
</Hds::Stepper::Nav>
```

### :camera_flash: Screenshots

**Current Example implementation**
![Screenshot 2025-04-18 at 12 32 03 PM](https://github.com/user-attachments/assets/64f30a01-48f0-4af1-9f0f-48a22c0a0eb1)

**After**
![Screenshot 2025-04-18 at 12 35 59 PM](https://github.com/user-attachments/assets/450e3709-3d5c-49d2-9de4-e0ad3843cd7b)

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
