### PR TITLE
fix: import paths that are missing `/index`

### DIFF
--- a/showcase/app/routes/components/accordion.js
+++ b/showcase/app/routes/components/accordion.js
@@ -5,8 +5,8 @@
 
 import Route from '@ember/routing/route';
 
-import { SIZES } from '@hashicorp/design-system-components/components/hds/accordion/item';
-import { TYPES } from '@hashicorp/design-system-components/components/hds/accordion/item';
+import { SIZES } from '@hashicorp/design-system-components/components/hds/accordion/item/index';
+import { TYPES } from '@hashicorp/design-system-components/components/hds/accordion/item/index';
 
 export default class ComponentsAccordionRoute extends Route {
   model() {

--- a/showcase/app/routes/components/advanced-table.js
+++ b/showcase/app/routes/components/advanced-table.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { DENSITIES } from '@hashicorp/design-system-components/components/hds/table';
+import { DENSITIES } from '@hashicorp/design-system-components/components/hds/table/index';
 
 const STATES = ['default', 'hover', 'active', 'focus'];
 

--- a/showcase/app/routes/components/alert.js
+++ b/showcase/app/routes/components/alert.js
@@ -8,7 +8,7 @@ import Route from '@ember/routing/route';
 import {
   TYPES,
   COLORS,
-} from '@hashicorp/design-system-components/components/hds/alert';
+} from '@hashicorp/design-system-components/components/hds/alert/index';
 
 export default class ComponentsAlertRoute extends Route {
   model() {

--- a/showcase/app/routes/components/application-state.js
+++ b/showcase/app/routes/components/application-state.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 
-import { ALIGNS } from '@hashicorp/design-system-components/components/hds/application-state';
+import { ALIGNS } from '@hashicorp/design-system-components/components/hds/application-state/index';
 
 export default class ComponentsApplicationStateRoute extends Route {
   model() {

--- a/showcase/app/routes/components/badge-count.js
+++ b/showcase/app/routes/components/badge-count.js
@@ -9,7 +9,7 @@ import {
   SIZES as BADGE_COUNT_SIZES,
   TYPES as BADGE_COUNT_TYPES,
   COLORS as BADGE_COUNT_COLORS,
-} from '@hashicorp/design-system-components/components/hds/badge-count';
+} from '@hashicorp/design-system-components/components/hds/badge-count/index';
 
 export default class ComponentsBadgeCountRoute extends Route {
   model() {

--- a/showcase/app/routes/components/badge.js
+++ b/showcase/app/routes/components/badge.js
@@ -9,7 +9,7 @@ import {
   SIZES as BADGE_SIZES,
   TYPES as BADGE_TYPES,
   COLORS as BADGE_COLORS,
-} from '@hashicorp/design-system-components/components/hds/badge';
+} from '@hashicorp/design-system-components/components/hds/badge/index';
 
 export default class ComponentsBadgeRoute extends Route {
   model() {

--- a/showcase/app/routes/components/button.js
+++ b/showcase/app/routes/components/button.js
@@ -8,7 +8,7 @@ import Route from '@ember/routing/route';
 import {
   SIZES,
   COLORS,
-} from '@hashicorp/design-system-components/components/hds/button';
+} from '@hashicorp/design-system-components/components/hds/button/index';
 export default class ComponentsButtonRoute extends Route {
   model() {
     // these are used only for presentation purpose in the showcase

--- a/showcase/app/routes/components/code-block.js
+++ b/showcase/app/routes/components/code-block.js
@@ -7,7 +7,7 @@ import Route from '@ember/routing/route';
 import {
   SUCCESS_ICON,
   ERROR_ICON,
-} from '@hashicorp/design-system-components/components/hds/copy/button';
+} from '@hashicorp/design-system-components/components/hds/copy/button/index';
 
 export default class ComponentsCodeBlockRoute extends Route {
   model() {

--- a/showcase/app/routes/components/copy/button.js
+++ b/showcase/app/routes/components/copy/button.js
@@ -8,7 +8,7 @@ import {
   SIZES,
   SUCCESS_ICON,
   ERROR_ICON,
-} from '@hashicorp/design-system-components/components/hds/copy/button';
+} from '@hashicorp/design-system-components/components/hds/copy/button/index';
 
 export default class ComponentsCopyButtonRoute extends Route {
   model() {

--- a/showcase/app/routes/components/copy/snippet.js
+++ b/showcase/app/routes/components/copy/snippet.js
@@ -8,7 +8,7 @@ import {
   COLORS,
   SUCCESS_ICON,
   ERROR_ICON,
-} from '@hashicorp/design-system-components/components/hds/copy/snippet';
+} from '@hashicorp/design-system-components/components/hds/copy/snippet/index';
 
 export default class ComponentsCopySnippetRoute extends Route {
   model() {

--- a/showcase/app/routes/components/flyout.js
+++ b/showcase/app/routes/components/flyout.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 
-import { SIZES } from '@hashicorp/design-system-components/components/hds/flyout';
+import { SIZES } from '@hashicorp/design-system-components/components/hds/flyout/index';
 
 export default class ComponentsFlyoutRoute extends Route {
   model() {

--- a/showcase/app/routes/components/icon-tile.js
+++ b/showcase/app/routes/components/icon-tile.js
@@ -9,7 +9,7 @@ import {
   SIZES,
   COLORS,
   PRODUCTS,
-} from '@hashicorp/design-system-components/components/hds/icon-tile';
+} from '@hashicorp/design-system-components/components/hds/icon-tile/index';
 
 export default class ComponentsIconTileRoute extends Route {
   model() {

--- a/showcase/app/routes/components/modal.js
+++ b/showcase/app/routes/components/modal.js
@@ -8,7 +8,7 @@ import Route from '@ember/routing/route';
 import {
   COLORS,
   SIZES,
-} from '@hashicorp/design-system-components/components/hds/modal';
+} from '@hashicorp/design-system-components/components/hds/modal/index';
 
 export default class ComponentsModalRoute extends Route {
   model() {

--- a/showcase/app/routes/components/table.js
+++ b/showcase/app/routes/components/table.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { DENSITIES } from '@hashicorp/design-system-components/components/hds/table';
+import { DENSITIES } from '@hashicorp/design-system-components/components/hds/table/index';
 
 // basic function that clones an array of objects (not deep)
 const clone = (arr) => {

--- a/showcase/app/routes/components/tabs.js
+++ b/showcase/app/routes/components/tabs.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 
-import { SIZES } from '@hashicorp/design-system-components/components/hds/tabs';
+import { SIZES } from '@hashicorp/design-system-components/components/hds/tabs/index';
 
 export default class ComponentsTabsRoute extends Route {
   model() {

--- a/showcase/app/routes/components/tag.js
+++ b/showcase/app/routes/components/tag.js
@@ -4,8 +4,8 @@
  */
 
 import Route from '@ember/routing/route';
-import { COLORS } from '@hashicorp/design-system-components/components/hds/tag';
-import { TOOLTIP_PLACEMENTS } from '@hashicorp/design-system-components/components/hds/tag';
+import { COLORS } from '@hashicorp/design-system-components/components/hds/tag/index';
+import { TOOLTIP_PLACEMENTS } from '@hashicorp/design-system-components/components/hds/tag/index';
 
 export default class ComponentsTagRoute extends Route {
   model() {

--- a/showcase/app/routes/components/toast.js
+++ b/showcase/app/routes/components/toast.js
@@ -6,7 +6,7 @@
 import Route from '@ember/routing/route';
 
 // the "Toast" is built on top of the "Alert" so it shares the same colors
-import { COLORS } from '@hashicorp/design-system-components/components/hds/alert';
+import { COLORS } from '@hashicorp/design-system-components/components/hds/alert/index';
 
 export default class ComponentsToastRoute extends Route {
   model() {

--- a/showcase/app/routes/components/tooltip.js
+++ b/showcase/app/routes/components/tooltip.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 
-import { PLACEMENTS } from '@hashicorp/design-system-components/components/hds/tooltip-button';
+import { PLACEMENTS } from '@hashicorp/design-system-components/components/hds/tooltip-button/index';
 
 export default class ComponentsTooltipRoute extends Route {
   model() {

--- a/showcase/app/routes/layouts/flex.js
+++ b/showcase/app/routes/layouts/flex.js
@@ -10,7 +10,7 @@ import {
   JUSTIFYS,
   ALIGNS,
   GAPS,
-} from '@hashicorp/design-system-components/components/hds/layout/flex';
+} from '@hashicorp/design-system-components/components/hds/layout/flex/index';
 
 export default class LayoutsFlexRoute extends Route {
   model() {

--- a/showcase/app/routes/layouts/grid.js
+++ b/showcase/app/routes/layouts/grid.js
@@ -8,7 +8,7 @@ import Route from '@ember/routing/route';
 import {
   ALIGNS,
   GAPS,
-} from '@hashicorp/design-system-components/components/hds/layout/grid';
+} from '@hashicorp/design-system-components/components/hds/layout/grid/index';
 
 export default class LayoutsGridRoute extends Route {
   model() {

--- a/showcase/tests/integration/components/hds/form/character-count/index-test.js
+++ b/showcase/tests/integration/components/hds/form/character-count/index-test.js
@@ -135,10 +135,10 @@ module(
         hbs`
         <input type="hidden" value={{this.value}} id="input-2" {{on "input" this.update}} />
         <Hds::Form::CharacterCount @value={{this.value}} @minLength={{20}} @maxLength={{40}} @controlId="input-2" id="test-form-character-count" as |CC|>
-          maxLength {{CC.maxLength}} 
-          minLength {{CC.minLength}} 
-          remaining {{CC.remaining}} 
-          shortfall {{CC.shortfall}} 
+          maxLength {{CC.maxLength}}
+          minLength {{CC.minLength}}
+          remaining {{CC.remaining}}
+          shortfall {{CC.shortfall}}
           currentLength {{CC.currentLength}}
         </Hds::Form::CharacterCount>`,
       );

--- a/showcase/tests/unit/components/hds/pagination/numbered-test.js
+++ b/showcase/tests/unit/components/hds/pagination/numbered-test.js
@@ -5,7 +5,7 @@
 
 // prettier-ignore
 import { module, test } from 'qunit';
-import { elliptize } from '@hashicorp/design-system-components/components/hds/pagination/numbered';
+import { elliptize } from '@hashicorp/design-system-components/components/hds/pagination/numbered/index';
 
 const A10 = Array.from(Array(10), (x, i) => i + 1);
 const A11 = Array.from(Array(11), (x, i) => i + 1);


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

* while testing vite build I came across a few incorrect import paths, `/index` should always be present. This most likely will come back till we move to vite completely

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
