### PR TITLE
`Modal`: replace last instance of this.isOpen with this._isOpen

### DIFF
--- a/.changeset/swift-icons-pay.md
+++ b/.changeset/swift-icons-pay.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Modal` - Fixed issue with focus trap when modal is displayed inline.

--- a/packages/components/src/components/hds/modal/index.hbs
+++ b/packages/components/src/components/hds/modal/index.hbs
@@ -9,7 +9,7 @@
   {{did-insert this.didInsert}}
   {{will-destroy this.willDestroyNode}}
   {{! @glint-expect-error - https://github.com/josemarluedke/ember-focus-trap/issues/86 }}
-  {{focus-trap isActive=this.isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=true)}}
+  {{focus-trap isActive=this._isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=true)}}
 >
   <:header>
     {{yield

--- a/packages/components/src/components/hds/modal/index.ts
+++ b/packages/components/src/components/hds/modal/index.ts
@@ -195,6 +195,8 @@ export default class HdsModal extends Component<HdsModalSignature> {
       this._element.addEventListener('close', listener);
     }
 
+    console.log('close', this._element)
+
     // Make modal dialog invisible using the native `close` method
     this._element.close();
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would replace the last instance of `this.isOpen` with `this._isOpen`. This fixes an issue where clicking anywhere on the page dismisses the inline modals and blocks you from being able to click the demo buttons to open modals.

Steps to reproduce bug:
* Open [the prod showcase modal page](https://hds-showcase.vercel.app/components/modal)
* Click anywhere on the page
* Notice that the last inline modal under the "Footer" heading disappears
* Click one of the buttons under the "Demo" heading
* Notice the modal doesn't open and another one of the inline modals under the "Footer" heading disappears

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4714](https://hashicorp.atlassian.net/browse/HDS-4714)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
