### PR TITLE
`Tag` - Prevent inheritance overrides for font styles

### DIFF
--- a/.changeset/empty-guests-eat.md
+++ b/.changeset/empty-guests-eat.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Tag` - Align fonts for overflow button and static text to fix issue with resize observer
+`Tag` - Updated structure to prevent inheritance overrides for font styles

--- a/.changeset/empty-guests-eat.md
+++ b/.changeset/empty-guests-eat.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Tag` - Align fonts for overflow button and static text to fix issue with resize observer

--- a/packages/components/src/components/hds/tag/index.hbs
+++ b/packages/components/src/components/hds/tag/index.hbs
@@ -46,13 +46,13 @@
   {{else}}
     {{#if this._isTextOverflow}}
       <Hds::TooltipButton class="hds-tag__text" @text={{this.text}} @placement={{this.tooltipPlacement}}>
-        <Hds::Text::Body @tag="span" @size="100" @weight="medium" @color="primary" class="hds-tag__text-container">
+        <Hds::Text::Body @tag="span" @size="100" @weight="medium" class="hds-tag__text-container">
           {{this.text}}
         </Hds::Text::Body>
       </Hds::TooltipButton>
     {{else}}
       <span class="hds-tag__text">
-        <Hds::Text::Body @tag="span" @size="100" @weight="medium" @color="primary" class="hds-tag__text-container">
+        <Hds::Text::Body @tag="span" @size="100" @weight="medium" class="hds-tag__text-container">
           {{this.text}}
         </Hds::Text::Body>
       </span>

--- a/packages/components/src/components/hds/tag/index.hbs
+++ b/packages/components/src/components/hds/tag/index.hbs
@@ -2,15 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<Hds::Text::Body
-  class={{this.classNames}}
-  @tag="span"
-  @size="100"
-  @weight="medium"
-  @color="primary"
-  {{this._setUpObserver}}
-  ...attributes
->
+<span class={{this.classNames}} {{this._setUpObserver}} ...attributes>
   {{#if this.onDismiss}}
     <button class="hds-tag__dismiss" type="button" aria-label={{this.ariaLabel}} {{on "click" this.onDismiss}}>
       <Hds::Icon class="hds-tag__dismiss-icon" @name="x" @size="16" />
@@ -30,9 +22,9 @@
         @isHrefExternal={{@isHrefExternal}}
         {{hds-tooltip this.text options=(hash placement=this.tooltipPlacement)}}
       >
-        <div class="hds-tag__text-container">
+        <Hds::Text::Body @tag="span" @size="100" @weight="medium" class="hds-tag__text-container">
           {{this.text}}
-        </div>
+        </Hds::Text::Body>
       </Hds::Interactive>
     {{else}}
       <Hds::Interactive
@@ -46,24 +38,24 @@
         @href={{@href}}
         @isHrefExternal={{@isHrefExternal}}
       >
-        <div class="hds-tag__text-container">
+        <Hds::Text::Body @tag="span" @size="100" @weight="medium" class="hds-tag__text-container">
           {{this.text}}
-        </div>
+        </Hds::Text::Body>
       </Hds::Interactive>
     {{/if}}
   {{else}}
     {{#if this._isTextOverflow}}
       <Hds::TooltipButton class="hds-tag__text" @text={{this.text}} @placement={{this.tooltipPlacement}}>
-        <div class="hds-tag__text-container">
+        <Hds::Text::Body @tag="span" @size="100" @weight="medium" @color="primary" class="hds-tag__text-container">
           {{this.text}}
-        </div>
+        </Hds::Text::Body>
       </Hds::TooltipButton>
     {{else}}
       <span class="hds-tag__text">
-        <div class="hds-tag__text-container">
+        <Hds::Text::Body @tag="span" @size="100" @weight="medium" @color="primary" class="hds-tag__text-container">
           {{this.text}}
-        </div>
+        </Hds::Text::Body>
       </span>
     {{/if}}
   {{/if}}
-</Hds::Text::Body>
+</span>

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -46,6 +46,7 @@ $hds-tag-border-radius: 50px;
   max-width: 166px; // account for excess horizontal padding of text in non-dismissible variant
   padding: 3px 10px 5px 10px;
   border-radius: inherit;
+  font: inherit;
 }
 
 .hds-tag__text-container {

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -36,7 +36,17 @@ $hds-tag-border-radius: 50px;
 .hds-tag__dismiss-icon {
   width: 12px;
   height: 12px;
+}
+
+.hds-tag__dismiss-icon,
+.hds-tag__text {
   color: var(--token-color-foreground-primary);
+}
+
+.hds-tag__dismiss,
+.hds-tag__text,
+.hds-tag__link {
+  background-color: var(--token-color-surface-interactive);
 }
 
 .hds-tag__text,
@@ -44,6 +54,7 @@ $hds-tag-border-radius: 50px;
   flex: 1 0 0;
   max-width: 166px; // account for excess horizontal padding of text in non-dismissible variant
   padding: 3px 10px 5px 10px;
+  background-color: var(--token-color-surface-interactive);
   border-radius: inherit;
 }
 
@@ -69,7 +80,6 @@ $hds-tag-border-radius: 50px;
 
 .hds-tag__dismiss,
 .hds-tag__link {
-  background-color: var(--token-color-surface-interactive);
   cursor: pointer;
 
   &:hover,

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -49,6 +49,10 @@ $hds-tag-border-radius: 50px;
   border-radius: inherit;
 }
 
+.hds-tag__text {
+  color: var(--token-color-foreground-primary);
+}
+
 .hds-tag__text-container {
   display: -webkit-box;
   overflow: hidden;

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -45,8 +45,8 @@ $hds-tag-border-radius: 50px;
   flex: 1 0 0;
   max-width: 166px; // account for excess horizontal padding of text in non-dismissible variant
   padding: 3px 10px 5px 10px;
-  border-radius: inherit;
   font: inherit;
+  border-radius: inherit;
 }
 
 .hds-tag__text-container {

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -17,7 +17,6 @@ $hds-tag-border-radius: 50px;
   align-items: stretch;
   width: fit-content;
   max-width: 100%;
-  line-height: 1rem; // 16px - override `body-100`
   vertical-align: middle;
   background-color: var(--token-color-surface-interactive);
   border: 1px solid var(--token-color-border-strong);
@@ -45,17 +44,13 @@ $hds-tag-border-radius: 50px;
   flex: 1 0 0;
   max-width: 166px; // account for excess horizontal padding of text in non-dismissible variant
   padding: 3px 10px 5px 10px;
-  font: inherit;
   border-radius: inherit;
-}
-
-.hds-tag__text {
-  color: var(--token-color-foreground-primary);
 }
 
 .hds-tag__text-container {
   display: -webkit-box;
   overflow: hidden;
+  line-height: 1rem; // 16px - override `body-100`
   word-break: break-all;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 1;

--- a/packages/components/src/styles/components/tag.scss
+++ b/packages/components/src/styles/components/tag.scss
@@ -27,6 +27,7 @@ $hds-tag-border-radius: 50px;
   flex: 0 0 auto;
   margin: 0; // reset default button margin
   padding: 6px 4px 6px 8px;
+  background-color: var(--token-color-surface-interactive);
   border: none; // reset default button border
   border-radius: inherit;
   border-top-right-radius: 0;
@@ -41,12 +42,6 @@ $hds-tag-border-radius: 50px;
 .hds-tag__dismiss-icon,
 .hds-tag__text {
   color: var(--token-color-foreground-primary);
-}
-
-.hds-tag__dismiss,
-.hds-tag__text,
-.hds-tag__link {
-  background-color: var(--token-color-surface-interactive);
 }
 
 .hds-tag__text,

--- a/showcase/app/styles/showcase-pages/tag.scss
+++ b/showcase/app/styles/showcase-pages/tag.scss
@@ -14,3 +14,12 @@ body.components-tag {
     }
   }
 }
+
+// we need to leave this out of the main selector to keep the specificity low
+
+.shw-component-tag-font-style {
+  color: #911ced;
+  font-weight: 900;
+  font-size: 18px;
+  font-family: Verdana, Geneva, Tahoma, sans-serif;
+}

--- a/showcase/app/styles/showcase-pages/tag.scss
+++ b/showcase/app/styles/showcase-pages/tag.scss
@@ -17,9 +17,13 @@ body.components-tag {
 
 // we need to leave this out of the main selector to keep the specificity low
 
-.shw-component-tag-font-style {
+.shw-component-tag-inheritance-font-style {
   color: #911ced;
   font-weight: 900;
   font-size: 18px;
   font-family: Verdana, Geneva, Tahoma, sans-serif;
+}
+
+.shw-component-tag-inheritance-background-color {
+  background-color: #a737ff;
 }

--- a/showcase/app/templates/components/tag.hbs
+++ b/showcase/app/templates/components/tag.hbs
@@ -150,22 +150,22 @@
 
   <Shw::Flex @label="Applied to parent" as |SF|>
     <SF.Item>
-      <div class="hds-typography-display-400 hds-foreground-warning-on-surface">
+      <div class="shw-component-tag-font-style">
         <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
       </div>
     </SF.Item>
     <SF.Item>
-      <div class="hds-typography-display-400 hds-foreground-warning-on-surface">
+      <div class="shw-component-tag-font-style">
         <Hds::Tag @text="My link tag" @onDismiss={{this.noop}} @route="components.tag" />
       </div>
     </SF.Item>
     <SF.Item>
-      <div class="hds-typography-display-400 hds-foreground-warning-on-surface">
+      <div class="shw-component-tag-font-style">
         <Hds::Tag @text="This is a very long text that should go on multiple lines" @onDismiss={{this.noop}} />
       </div>
     </SF.Item>
     <SF.Item>
-      <div class="hds-typography-display-400 hds-foreground-warning-on-surface">
+      <div class="shw-component-tag-font-style">
         <Hds::Tag
           @text="This is a very long text that should go on multiple lines"
           @onDismiss={{this.noop}}
@@ -177,25 +177,21 @@
 
   <Shw::Flex @label="Applied to the tag" as |SF|>
     <SF.Item>
-      <Hds::Tag
-        @text="My text tag"
-        @onDismiss={{this.noop}}
-        class="hds-typography-display-400 hds-foreground-warning-on-surface"
-      />
+      <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} class="shw-component-tag-font-style" />
     </SF.Item>
     <SF.Item>
       <Hds::Tag
         @text="My link tag"
         @onDismiss={{this.noop}}
         @route="components.tag"
-        class="hds-typography-display-400 hds-foreground-warning-on-surface"
+        class="shw-component-tag-font-style"
       />
     </SF.Item>
     <SF.Item>
       <Hds::Tag
         @text="This is a very long text that should go on multiple lines"
         @onDismiss={{this.noop}}
-        class="hds-typography-display-400 hds-foreground-warning-on-surface"
+        class="shw-component-tag-font-style"
       />
     </SF.Item>
     <SF.Item>
@@ -203,7 +199,7 @@
         @text="This is a very long text that should go on multiple lines"
         @onDismiss={{this.noop}}
         @route="components.tag"
-        class="hds-typography-display-400 hds-foreground-warning-on-surface"
+        class="shw-component-tag-font-style"
       />
     </SF.Item>
   </Shw::Flex>

--- a/showcase/app/templates/components/tag.hbs
+++ b/showcase/app/templates/components/tag.hbs
@@ -150,22 +150,22 @@
 
   <Shw::Flex @label="Applied to parent" as |SF|>
     <SF.Item>
-      <div class="shw-component-tag-font-style">
+      <div class="shw-component-tag-inheritance-font-style">
         <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
       </div>
     </SF.Item>
     <SF.Item>
-      <div class="shw-component-tag-font-style">
+      <div class="shw-component-tag-inheritance-font-style">
         <Hds::Tag @text="My link tag" @onDismiss={{this.noop}} @route="components.tag" />
       </div>
     </SF.Item>
     <SF.Item>
-      <div class="shw-component-tag-font-style">
+      <div class="shw-component-tag-inheritance-font-style">
         <Hds::Tag @text="This is a very long text that should go on multiple lines" @onDismiss={{this.noop}} />
       </div>
     </SF.Item>
     <SF.Item>
-      <div class="shw-component-tag-font-style">
+      <div class="shw-component-tag-inheritance-font-style">
         <Hds::Tag
           @text="This is a very long text that should go on multiple lines"
           @onDismiss={{this.noop}}
@@ -177,21 +177,25 @@
 
   <Shw::Flex @label="Applied to the tag" as |SF|>
     <SF.Item>
-      <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} class="shw-component-tag-font-style" />
+      <Hds::Tag
+        @text="My text tag"
+        @onDismiss={{this.noop}}
+        class="shw-component-tag-inheritance-font-style shw-component-tag-inheritance-background-color"
+      />
     </SF.Item>
     <SF.Item>
       <Hds::Tag
         @text="My link tag"
         @onDismiss={{this.noop}}
         @route="components.tag"
-        class="shw-component-tag-font-style"
+        class="shw-component-tag-inheritance-font-style shw-component-tag-inheritance-background-color"
       />
     </SF.Item>
     <SF.Item>
       <Hds::Tag
         @text="This is a very long text that should go on multiple lines"
         @onDismiss={{this.noop}}
-        class="shw-component-tag-font-style"
+        class="shw-component-tag-inheritance-font-style shw-component-tag-inheritance-background-color"
       />
     </SF.Item>
     <SF.Item>
@@ -199,7 +203,7 @@
         @text="This is a very long text that should go on multiple lines"
         @onDismiss={{this.noop}}
         @route="components.tag"
-        class="shw-component-tag-font-style"
+        class="shw-component-tag-inheritance-font-style shw-component-tag-inheritance-background-color"
       />
     </SF.Item>
   </Shw::Flex>

--- a/showcase/app/templates/components/tag.hbs
+++ b/showcase/app/templates/components/tag.hbs
@@ -65,7 +65,7 @@
 
   <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H2>Colors</Shw::Text::H2>
+  <Shw::Text::H2>Link Colors</Shw::Text::H2>
 
   {{#each @model.COLORS as |color|}}
     <Shw::Text::H3>{{capitalize color}}</Shw::Text::H3>
@@ -143,5 +143,69 @@
       </SG.Item>
     {{/each}}
   </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H2>Inheritance</Shw::Text::H2>
+
+  <Shw::Flex @label="Applied to parent" as |SF|>
+    <SF.Item>
+      <div class="hds-typography-display-400 hds-foreground-warning-on-surface">
+        <Hds::Tag @text="My text tag" @onDismiss={{this.noop}} />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <div class="hds-typography-display-400 hds-foreground-warning-on-surface">
+        <Hds::Tag @text="My link tag" @onDismiss={{this.noop}} @route="components.tag" />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <div class="hds-typography-display-400 hds-foreground-warning-on-surface">
+        <Hds::Tag @text="This is a very long text that should go on multiple lines" @onDismiss={{this.noop}} />
+      </div>
+    </SF.Item>
+    <SF.Item>
+      <div class="hds-typography-display-400 hds-foreground-warning-on-surface">
+        <Hds::Tag
+          @text="This is a very long text that should go on multiple lines"
+          @onDismiss={{this.noop}}
+          @route="components.tag"
+        />
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex @label="Applied to the tag" as |SF|>
+    <SF.Item>
+      <Hds::Tag
+        @text="My text tag"
+        @onDismiss={{this.noop}}
+        class="hds-typography-display-400 hds-foreground-warning-on-surface"
+      />
+    </SF.Item>
+    <SF.Item>
+      <Hds::Tag
+        @text="My link tag"
+        @onDismiss={{this.noop}}
+        @route="components.tag"
+        class="hds-typography-display-400 hds-foreground-warning-on-surface"
+      />
+    </SF.Item>
+    <SF.Item>
+      <Hds::Tag
+        @text="This is a very long text that should go on multiple lines"
+        @onDismiss={{this.noop}}
+        class="hds-typography-display-400 hds-foreground-warning-on-surface"
+      />
+    </SF.Item>
+    <SF.Item>
+      <Hds::Tag
+        @text="This is a very long text that should go on multiple lines"
+        @onDismiss={{this.noop}}
+        @route="components.tag"
+        class="hds-typography-display-400 hds-foreground-warning-on-surface"
+      />
+    </SF.Item>
+  </Shw::Flex>
 
 </section>


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes an issue with the `Tag` where when the text is at a specific character length, the overflow tooltip is infinitely added and removed.

### :hammer_and_wrench: Detailed description

This issue was originally observed in Atlas. Where when applying filters to the organization run page, the tooltip button that is added when a tag's text goes beyond a max width, was being infinitely added and removed causing the tag to flash back and forth.

This issue is caused by the fact that the font of the tag's text is changing from when it is not overflowing and using a `span` vs. when it is overflowing and using a `button` element from the `Hds::TooltipButton`. 

In atlas there is a different default font used for `button` elements, that does not align to the `HDS` default font. This was causing the following cycle.
1. The text is rendered for a span and the text is set to overflow
2. The overflow causes the component to update to a tooltip button
3. The tooltip button has a narrower font, which causes the overflow to be removed 

Setting `font: inherit;` insures that all fonts are standardized when both the `button` element and `span` element is used.

Steps to reproduce in Atlas
1. Run atlas locally, and  go to the `/settings/runs` page.
5. Click on "add filters"
6. Add the filter Status -> Running -> Cost estimating
7. Observe the tag issue

### External Link

- [Atlas RC Test PR](https://github.com/hashicorp/atlas/pull/22922)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
