### PR TITLE
fix(components): `LinkToExternal` & make `ember-engines` optional

### DIFF
--- a/.changeset/tall-rings-act.md
+++ b/.changeset/tall-rings-act.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/design-system-components': patch
+---
+
+Introduce the `hds-resolve-link-to-component` utility to correctly resolve the LinkTo component when `@isRouteExternal` is set on `HdsBreadcrumbItem` or `HdsInteractive`. Consumers are now required to install `ember-engines` when `@isRouteExternal` is `true`.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -120,7 +120,13 @@
     "webpack": "^5.97.1"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0 || ^5.3.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || ^5.3.0",
+    "ember-engines": ">= 0.11.0"
+  },
+  "peerDependenciesMeta": {
+    "ember-engines": {
+      "optional": true
+    }
   },
   "ember": {
     "edition": "octane"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -351,6 +351,7 @@
       "./helpers/hds-format-relative.js": "./dist/_app_/helpers/hds-format-relative.js",
       "./helpers/hds-link-to-models.js": "./dist/_app_/helpers/hds-link-to-models.js",
       "./helpers/hds-link-to-query.js": "./dist/_app_/helpers/hds-link-to-query.js",
+      "./helpers/hds-resolve-link-to-component.js": "./dist/_app_/helpers/hds-resolve-link-to-component.js",
       "./instance-initializers/load-sprite.js": "./dist/_app_/instance-initializers/load-sprite.js",
       "./modifiers/hds-advanced-table-cell.js": "./dist/_app_/modifiers/hds-advanced-table-cell.js",
       "./modifiers/hds-advanced-table-cell/dom-management.js": "./dist/_app_/modifiers/hds-advanced-table-cell/dom-management.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -351,7 +351,6 @@
       "./helpers/hds-format-relative.js": "./dist/_app_/helpers/hds-format-relative.js",
       "./helpers/hds-link-to-models.js": "./dist/_app_/helpers/hds-link-to-models.js",
       "./helpers/hds-link-to-query.js": "./dist/_app_/helpers/hds-link-to-query.js",
-      "./helpers/hds-resolve-link-to-component.js": "./dist/_app_/helpers/hds-resolve-link-to-component.js",
       "./instance-initializers/load-sprite.js": "./dist/_app_/instance-initializers/load-sprite.js",
       "./modifiers/hds-advanced-table-cell.js": "./dist/_app_/modifiers/hds-advanced-table-cell.js",
       "./modifiers/hds-advanced-table-cell/dom-management.js": "./dist/_app_/modifiers/hds-advanced-table-cell/dom-management.js",

--- a/packages/components/src/components/hds/breadcrumb/item.hbs
+++ b/packages/components/src/components/hds/breadcrumb/item.hbs
@@ -13,38 +13,20 @@
       <span class="hds-breadcrumb__text">{{@text}}</span>
     </div>
   {{else}}
-    {{#if @isRouteExternal}}
-      <LinkToExternal
-        class="hds-breadcrumb__link"
-        @current-when={{@current-when}}
-        @models={{hds-link-to-models @model @models}}
-        @query={{hds-link-to-query @query}}
-        @replace={{@replace}}
-        @route={{@route}}
-      >
-        {{#if @icon}}
-          <div class="hds-breadcrumb__icon">
-            <Hds::Icon @name={{@icon}} @size="16" @stretched={{true}} />
-          </div>
-        {{/if}}
-        <span class="hds-breadcrumb__text">{{@text}}</span>
-      </LinkToExternal>
-    {{else}}
-      <LinkTo
-        class="hds-breadcrumb__link"
-        @current-when={{@current-when}}
-        @models={{hds-link-to-models @model @models}}
-        @query={{hds-link-to-query @query}}
-        @replace={{@replace}}
-        @route={{@route}}
-      >
-        {{#if @icon}}
-          <div class="hds-breadcrumb__icon">
-            <Hds::Icon @name={{@icon}} @size="16" @stretched={{true}} />
-          </div>
-        {{/if}}
-        <span class="hds-breadcrumb__text">{{@text}}</span>
-      </LinkTo>
-    {{/if}}
+    <this.linkToComponent
+      class="hds-breadcrumb__link"
+      @current-when={{@current-when}}
+      @models={{hds-link-to-models @model @models}}
+      @query={{hds-link-to-query @query}}
+      @replace={{@replace}}
+      @route={{@route}}
+    >
+      {{#if @icon}}
+        <div class="hds-breadcrumb__icon">
+          <Hds::Icon @name={{@icon}} @size="16" @stretched={{true}} />
+        </div>
+      {{/if}}
+      <span class="hds-breadcrumb__text">{{@text}}</span>
+    </this.linkToComponent>
   {{/if}}
 </li>

--- a/packages/components/src/components/hds/breadcrumb/item.ts
+++ b/packages/components/src/components/hds/breadcrumb/item.ts
@@ -9,6 +9,8 @@ import { assert } from '@ember/debug';
 
 import { hdsResolveLinkToComponent } from '../../../utils/hds-resolve-link-to-component.ts';
 
+import type Owner from '@ember/owner';
+import type { LinkTo } from '@ember/routing';
 import type { SafeString } from '@ember/template';
 import type { HdsIconSignature } from '../icon/index';
 
@@ -30,7 +32,13 @@ export interface HdsBreadcrumbItemSignature {
 }
 
 export default class HdsBreadcrumbItem extends Component<HdsBreadcrumbItemSignature> {
-  linkToComponent = hdsResolveLinkToComponent(this.args.isRouteExternal);
+  linkToComponent: LinkTo;
+
+  constructor(owner: Owner, args: HdsBreadcrumbItemSignature['Args']) {
+    super(owner, args);
+
+    this.linkToComponent = hdsResolveLinkToComponent(args.isRouteExternal);
+  }
 
   /**
    * @param maxWidth

--- a/packages/components/src/components/hds/breadcrumb/item.ts
+++ b/packages/components/src/components/hds/breadcrumb/item.ts
@@ -6,14 +6,9 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { assert } from '@ember/debug';
-import { LinkTo } from '@ember/routing';
-import {
-  dependencySatisfies,
-  importSync,
-  macroCondition,
-} from '@embroider/macros';
 
-import type Owner from '@ember/owner';
+import { hdsResolveLinkToComponent } from '../../../helpers/hds-resolve-link-to-component.ts';
+
 import type { SafeString } from '@ember/template';
 import type { HdsIconSignature } from '../icon/index';
 
@@ -35,25 +30,8 @@ export interface HdsBreadcrumbItemSignature {
 }
 
 export default class HdsBreadcrumbItem extends Component<HdsBreadcrumbItemSignature> {
-  linkToComponent = LinkTo;
+  linkToComponent = hdsResolveLinkToComponent(this.args.isRouteExternal);
 
-  constructor(owner: Owner, args: HdsBreadcrumbItemSignature['Args']) {
-    super(owner, args);
-
-    if (this.args.isRouteExternal) {
-      if (macroCondition(dependencySatisfies('ember-engines', '*'))) {
-        // @ts-expect-error: shape is unknown
-        this.linkToComponent = importSync(
-          'ember-engines/components/link-to-external-component.js'
-        ).default as LinkTo;
-      } else {
-        assert(
-          `@isRouteExternal is only available when using the "ember-engines" addon. Please install it to use this feature.`,
-          false
-        );
-      }
-    }
-  }
   /**
    * @param maxWidth
    * @type {string}

--- a/packages/components/src/components/hds/breadcrumb/item.ts
+++ b/packages/components/src/components/hds/breadcrumb/item.ts
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { assert } from '@ember/debug';
 
-import { hdsResolveLinkToComponent } from '../../../helpers/hds-resolve-link-to-component.ts';
+import { hdsResolveLinkToComponent } from '../../../utils/hds-resolve-link-to-component.ts';
 
 import type { SafeString } from '@ember/template';
 import type { HdsIconSignature } from '../icon/index';

--- a/packages/components/src/components/hds/breadcrumb/item.ts
+++ b/packages/components/src/components/hds/breadcrumb/item.ts
@@ -6,8 +6,16 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { assert } from '@ember/debug';
+import { LinkTo } from '@ember/routing';
+import {
+  dependencySatisfies,
+  importSync,
+  macroCondition,
+} from '@embroider/macros';
+
+import type Owner from '@ember/owner';
 import type { SafeString } from '@ember/template';
-import type { HdsIconSignature } from '../icon';
+import type { HdsIconSignature } from '../icon/index';
 
 export interface HdsBreadcrumbItemSignature {
   Args: {
@@ -27,6 +35,25 @@ export interface HdsBreadcrumbItemSignature {
 }
 
 export default class HdsBreadcrumbItem extends Component<HdsBreadcrumbItemSignature> {
+  linkToComponent = LinkTo;
+
+  constructor(owner: Owner, args: HdsBreadcrumbItemSignature['Args']) {
+    super(owner, args);
+
+    if (this.args.isRouteExternal) {
+      if (macroCondition(dependencySatisfies('ember-engines', '*'))) {
+        // @ts-expect-error: shape is unknown
+        this.linkToComponent = importSync(
+          'ember-engines/components/link-to-external-component.js'
+        ).default as LinkTo;
+      } else {
+        assert(
+          `@isRouteExternal is only available when using the "ember-engines" addon. Please install it to use this feature.`,
+          false
+        );
+      }
+    }
+  }
   /**
    * @param maxWidth
    * @type {string}

--- a/packages/components/src/components/hds/interactive/index.hbs
+++ b/packages/components/src/components/hds/interactive/index.hbs
@@ -2,25 +2,14 @@
 {{! IMPORTANT: we need to add "squishies" here (~) because otherwise the whitespace added by Ember becomes visible in the link (being an inline element) - See https://handlebarsjs.com/guide/expressions.html#whitespace-control }}
 {{! NOTICE: we can't support the direct use of the "href" HTML attribute via ...attributes in the <a> elements, because we need to rely on the "@href" Ember argument to differentiate between different types of generated output }}
 {{~#if @route~}}
-  {{~#if this.isRouteExternal~}}
-    <LinkToExternal
-      @current-when={{@current-when}}
-      @models={{hds-link-to-models @model @models}}
-      @query={{hds-link-to-query @query}}
-      @replace={{@replace}}
-      @route={{@route}}
-      ...attributes
-    >{{yield}}</LinkToExternal>
-  {{~else~}}
-    <LinkTo
-      @current-when={{@current-when}}
-      @models={{hds-link-to-models @model @models}}
-      @query={{hds-link-to-query @query}}
-      @replace={{@replace}}
-      @route={{@route}}
-      ...attributes
-    >{{yield}}</LinkTo>
-  {{~/if~}}
+  <this.linkToComponent
+    @current-when={{@current-when}}
+    @models={{hds-link-to-models @model @models}}
+    @query={{hds-link-to-query @query}}
+    @replace={{@replace}}
+    @route={{@route}}
+    ...attributes
+  >{{yield}}</this.linkToComponent>
 {{~else if @href~}}
   {{~#if this.isHrefExternal~}}
     <a target="_blank" rel="noopener noreferrer" ...attributes href={{@href}} {{on "keyup" this.onKeyUp}}>{{yield}}</a>

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -8,6 +8,9 @@ import { action } from '@ember/object';
 
 import { hdsResolveLinkToComponent } from '../../../utils/hds-resolve-link-to-component.ts';
 
+import type Owner from '@ember/owner';
+import type { LinkTo } from '@ember/routing';
+
 export interface HdsInteractiveSignature {
   Args: {
     href?: string;
@@ -29,7 +32,13 @@ export interface HdsInteractiveSignature {
 }
 
 export default class HdsInteractive extends Component<HdsInteractiveSignature> {
-  linkToComponent = hdsResolveLinkToComponent(this.args.isRouteExternal);
+  linkToComponent: LinkTo;
+
+  constructor(owner: Owner, args: HdsInteractiveSignature['Args']) {
+    super(owner, args);
+
+    this.linkToComponent = hdsResolveLinkToComponent(args.isRouteExternal);
+  }
 
   /**
    * Determines if a @href value is "external" (it adds target="_blank" rel="noopener noreferrer")

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
-import { hdsResolveLinkToComponent } from '../../../helpers/hds-resolve-link-to-component.ts';
+import { hdsResolveLinkToComponent } from '../../../utils/hds-resolve-link-to-component.ts';
 
 export interface HdsInteractiveSignature {
   Args: {

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -5,6 +5,15 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { assert } from '@ember/debug';
+import { LinkTo } from '@ember/routing';
+import {
+  dependencySatisfies,
+  importSync,
+  macroCondition,
+} from '@embroider/macros';
+
+import type Owner from '@ember/owner';
 
 export interface HdsInteractiveSignature {
   Args: {
@@ -27,6 +36,26 @@ export interface HdsInteractiveSignature {
 }
 
 export default class HdsInteractive extends Component<HdsInteractiveSignature> {
+  linkToComponent = LinkTo;
+
+  constructor(owner: Owner, args: HdsInteractiveSignature['Args']) {
+    super(owner, args);
+
+    if (this.args.isRouteExternal) {
+      if (macroCondition(dependencySatisfies('ember-engines', '*'))) {
+        // @ts-expect-error: shape is unknown
+        this.linkToComponent = importSync(
+          'ember-engines/components/link-to-external-component.js'
+        ).default as LinkTo;
+      } else {
+        assert(
+          `@isRouteExternal is only available when using the "ember-engines" addon. Please install it to use this feature.`,
+          false
+        );
+      }
+    }
+  }
+
   /**
    * Determines if a @href value is "external" (it adds target="_blank" rel="noopener noreferrer")
    *

--- a/packages/components/src/components/hds/interactive/index.ts
+++ b/packages/components/src/components/hds/interactive/index.ts
@@ -5,15 +5,8 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { assert } from '@ember/debug';
-import { LinkTo } from '@ember/routing';
-import {
-  dependencySatisfies,
-  importSync,
-  macroCondition,
-} from '@embroider/macros';
 
-import type Owner from '@ember/owner';
+import { hdsResolveLinkToComponent } from '../../../helpers/hds-resolve-link-to-component.ts';
 
 export interface HdsInteractiveSignature {
   Args: {
@@ -36,25 +29,7 @@ export interface HdsInteractiveSignature {
 }
 
 export default class HdsInteractive extends Component<HdsInteractiveSignature> {
-  linkToComponent = LinkTo;
-
-  constructor(owner: Owner, args: HdsInteractiveSignature['Args']) {
-    super(owner, args);
-
-    if (this.args.isRouteExternal) {
-      if (macroCondition(dependencySatisfies('ember-engines', '*'))) {
-        // @ts-expect-error: shape is unknown
-        this.linkToComponent = importSync(
-          'ember-engines/components/link-to-external-component.js'
-        ).default as LinkTo;
-      } else {
-        assert(
-          `@isRouteExternal is only available when using the "ember-engines" addon. Please install it to use this feature.`,
-          false
-        );
-      }
-    }
-  }
+  linkToComponent = hdsResolveLinkToComponent(this.args.isRouteExternal);
 
   /**
    * Determines if a @href value is "external" (it adds target="_blank" rel="noopener noreferrer")

--- a/packages/components/src/helpers/hds-resolve-link-to-component.ts
+++ b/packages/components/src/helpers/hds-resolve-link-to-component.ts
@@ -1,0 +1,33 @@
+import { LinkTo } from '@ember/routing';
+import { assert } from '@ember/debug';
+import {
+  dependencySatisfies,
+  importSync,
+  macroCondition,
+} from '@embroider/macros';
+
+/**
+ * Resolves the correct component to use for the `LinkTo` helper.
+ *
+ * @param isRouteExternal - If true, will return the `LinkToExternal` component. If `ember-engines` is not installed, an assertion will be thrown.
+ * @returns The correct component to use for the `LinkTo` helper.
+ */
+export function hdsResolveLinkToComponent(
+  isRouteExternal?: boolean
+): typeof LinkTo {
+  if (isRouteExternal) {
+    if (macroCondition(dependencySatisfies('ember-engines', '*'))) {
+      // @ts-expect-error: shape is unknown
+      return importSync(
+        'ember-engines/components/link-to-external-component.js'
+      ).default as LinkTo;
+    } else {
+      assert(
+        `@isRouteExternal is only available when using the "ember-engines" addon. Please install it to use this feature.`,
+        false
+      );
+    }
+  }
+
+  return LinkTo;
+}

--- a/packages/components/src/utils/hds-resolve-link-to-component.ts
+++ b/packages/components/src/utils/hds-resolve-link-to-component.ts
@@ -7,10 +7,10 @@ import {
 } from '@embroider/macros';
 
 /**
- * Resolves the correct component to use for the `LinkTo` helper.
+ * Resolves the correct component to use for the `LinkTo`.
  *
  * @param isRouteExternal - If true, will return the `LinkToExternal` component. If `ember-engines` is not installed, an assertion will be thrown.
- * @returns The correct component to use for the `LinkTo` helper.
+ * @returns The correct component to use for the `LinkTo`.
  */
 export function hdsResolveLinkToComponent(
   isRouteExternal?: boolean


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

Today we are referencing `<LinkToExternal/>` component and in the many cases it doesn't exists unless consumer has `ember-engines` as dependancy. In the `embroider/vite` world all components are evaluated at the build time and needs to resolve correct dependancy. If we were to run `hds` embroider/vite today it would result in an error about unresolved `LinkToExternal` component. In order to make this behaviour more controlled we are encapsulating requirements for `ember-engines` to be explicitly required only in situation when we pass `@isRouteExternal` as `true` in which case we do our check for required dependancy resigne component instance or through an error.

Shipping `ember-engines` is not an option for a couple of reasons:

* it has very interesting v1 era requirements which are impossible to satisfy in addon structure (nor should we)
* it is consumer land dependancy and we should leverage this tacktics of not locking users to  our version and letting consumer provide own copy only in situation when it's needed. I can see other optimizations in similar fashion but this is the most pressing one at the moment

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
