### PR TITLE
Use luxon 3.x

### DIFF
--- a/.changeset/chilled-phones-give.md
+++ b/.changeset/chilled-phones-give.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+Use luxon 3.x

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -70,7 +70,7 @@
     "ember-stargate": "^0.4.3",
     "ember-style-modifier": "^4.4.0",
     "ember-truth-helpers": "^4.0.3",
-    "luxon": "^2.3.2 || ^3.4.2",
+    "luxon": "^3.4.2",
     "prismjs": "^1.30.0",
     "sass": "^1.83.0",
     "tabbable": "^6.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,7 +184,7 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.5.2)(rsvp@4.8.5))
       luxon:
-        specifier: ^2.3.2 || ^3.4.2
+        specifier: ^3.4.2
         version: 3.5.0
       prismjs:
         specifier: ^1.30.0


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

This PR drops the 2.x version of luxon from dependencies.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

I think the way it was defined consumers would always get 2.x, which has security vulnerabilities. If we do need to support 2.x, we could also make it a peerDep instead of dropping it, but I am not sure if there is a reason we need 2.x support or not.

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
