### PR TITLE
Add Figma changelog entry for interactive variants and component-level tokens

### DIFF
--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -8,7 +8,6 @@
 
 Unpublished all local variables for component-level tokens.
 
-
 ## April 2nd, 2025
 
 `StepperList` and `StepperNav` - Components added.

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -2,11 +2,12 @@
 
 ## April 24th, 2025
 
-`Button`, `StandaloneLink`, `Breadcrumb`, `Table Primitives`
+`Button`, `StandaloneLink`, `Breadcrumb`, `Table Primitives` - Removed interactive component variants
 
-- Removed interactive component variants
+`AdvancedTable` - Restored a missing row variant, added multi-selection to the sticky column [Template]
 
 Unpublished all local variables for component-level tokens.
+
 
 ## April 2nd, 2025
 

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -4,8 +4,6 @@
 
 `Button`, `StandaloneLink`, `Breadcrumb`, `Table Primitives` - Removed interactive component variants
 
-`AdvancedTable` - Restored a missing row variant, added multi-selection to the sticky column [Template]
-
 Unpublished all local variables for component-level tokens.
 
 ## April 2nd, 2025

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -6,7 +6,7 @@
 
 - Removed interactive component variants
 
-Unpublished local styles for `navigation`, `side-nav`, `app-footer`, and `app-side-nav`.
+Unpublished all local variables for component-level tokens.
 
 ## April 2nd, 2025
 

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -1,5 +1,13 @@
 # [HDS Components UI Kit v2.0](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?m=auto&node-id=2-7&t=HYGTIoXBy2YkVWDP-1)
 
+## April 24th, 2025
+
+`Button`, `StandaloneLink`, `Breadcrumb`, `Table Primitives`
+
+- Removed interactive component variants
+
+Unpublished local styles for `navigation`, `side-nav`, `app-footer`, and `app-side-nav`.
+
 ## April 2nd, 2025
 
 `StepperList` and `StepperNav` - Components added.

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -18,7 +18,7 @@
 
 - Removed interactive component variants
 
-Unpublished local styles for `navigation`, `side-nav`, `app-footer`, and `app-side-nav`.
+Unpublished all local variables for component-level tokens.
 
 ### April 2nd, 2025
 

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -16,8 +16,6 @@
 
 `Button`, `StandaloneLink`, `Breadcrumb`, `Table Primitives` - Removed interactive component variants
 
-`AdvancedTable` - Restored a missing row variant, added multi-selection to the sticky column [Template]
-
 Unpublished all local variables for component-level tokens.
 
 ### April 2nd, 2025

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -12,6 +12,14 @@
 </p>
 
 
+### April 24th, 2025
+
+`Button`, `StandaloneLink`, `Breadcrumb`, `Table Primitives`
+
+- Removed interactive component variants
+
+Unpublished local styles for `navigation`, `side-nav`, `app-footer`, and `app-side-nav`.
+
 ### April 2nd, 2025
 
 `StepperList` and `StepperNav` - Components added.
@@ -127,12 +135,6 @@ _Adding support for a `Tooltip` and updates to the `Sort Button` result in a bre
 ### November 3rd, 2023
 
 `Breadcrumb` - Updated the number of `breadcrumb / _items` to the component.
-
-### October 23rd, 2023
-
-`Button` - Updated icon only button variants to be square to match the ToggleIcon.
-
-`Dropdown / ToggleIcon` - Fixed the small variant so that it’s the correct size (28px height) to match the other small Buttons and ToggleButton.
 
 
 ---

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -14,9 +14,9 @@
 
 ### April 24th, 2025
 
-`Button`, `StandaloneLink`, `Breadcrumb`, `Table Primitives`
+`Button`, `StandaloneLink`, `Breadcrumb`, `Table Primitives` - Removed interactive component variants
 
-- Removed interactive component variants
+`AdvancedTable` - Restored a missing row variant, added multi-selection to the sticky column [Template]
 
 Unpublished all local variables for component-level tokens.
 


### PR DESCRIPTION
### :pushpin: Summary

Adds a changelog entry for unpublishing component-level tokens and removing interactive variants from components.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
