### PR TITLE
`Modal`: fix issue with click outside to dismiss

### DIFF
--- a/.changeset/khaki-swans-type.md
+++ b/.changeset/khaki-swans-type.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Modal` - Fixed issue where conditionall disabling ability to dismiss the `Modal` breaks click outside to dismiss.

--- a/.changeset/khaki-swans-type.md
+++ b/.changeset/khaki-swans-type.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Modal` - Fixed issue where conditionall disabling ability to dismiss the `Modal` breaks click outside to dismiss.
+`Modal` - Fixed issue where conditionally disabling ability to dismiss the `Modal` breaks click outside to dismiss.

--- a/packages/components/src/components/hds/modal/index.hbs
+++ b/packages/components/src/components/hds/modal/index.hbs
@@ -9,7 +9,7 @@
   {{did-insert this.didInsert}}
   {{will-destroy this.willDestroyNode}}
   {{! @glint-expect-error - https://github.com/josemarluedke/ember-focus-trap/issues/86 }}
-  {{focus-trap isActive=this._isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=false)}}
+  {{focus-trap isActive=this._isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss)}}
 >
   <:header>
     {{yield

--- a/packages/components/src/components/hds/modal/index.hbs
+++ b/packages/components/src/components/hds/modal/index.hbs
@@ -9,7 +9,7 @@
   {{did-insert this.didInsert}}
   {{will-destroy this.willDestroyNode}}
   {{! @glint-expect-error - https://github.com/josemarluedke/ember-focus-trap/issues/86 }}
-  {{focus-trap isActive=this._isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=true)}}
+  {{focus-trap isActive=this._isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=false)}}
 >
   <:header>
     {{yield

--- a/packages/components/src/components/hds/modal/index.ts
+++ b/packages/components/src/components/hds/modal/index.ts
@@ -154,28 +154,28 @@ export default class HdsModal extends Component<HdsModalSignature> {
     } else {
       this._isOpen = false;
 
-    // Reset page `overflow` property
-    if (this._body) {
-      this._body.style.removeProperty('overflow');
-      if (this._bodyInitialOverflowValue === '') {
-        if (this._body.style.length === 0) {
-          this._body.removeAttribute('style');
+      // Reset page `overflow` property
+      if (this._body) {
+        this._body.style.removeProperty('overflow');
+        if (this._bodyInitialOverflowValue === '') {
+          if (this._body.style.length === 0) {
+            this._body.removeAttribute('style');
+          }
+        } else {
+          this._body.style.setProperty(
+            'overflow',
+            this._bodyInitialOverflowValue
+          );
         }
-      } else {
-        this._body.style.setProperty(
-          'overflow',
-          this._bodyInitialOverflowValue
-        );
       }
-    }
 
-    // Return focus to a specific element (if provided)
-    if (this.args.returnFocusTo) {
-      const initiator = document.getElementById(this.args.returnFocusTo);
-      if (initiator) {
-        initiator.focus();
+      // Return focus to a specific element (if provided)
+      if (this.args.returnFocusTo) {
+        const initiator = document.getElementById(this.args.returnFocusTo);
+        if (initiator) {
+          initiator.focus();
+        }
       }
-    }
     }
   }
 

--- a/packages/components/src/components/hds/modal/index.ts
+++ b/packages/components/src/components/hds/modal/index.ts
@@ -233,7 +233,6 @@ export default class HdsModal extends Component<HdsModalSignature> {
   async onDismiss(): Promise<void> {
     // allow ember test helpers to be aware of when the `close` event fires
     // when using `click` or other helpers from '@ember/test-helpers'
-    // Notice: this code will get stripped out in production builds (DEBUG evaluates to `true` in dev/test builds, but `false` in prod builds)
     if (this._element.open) {
       const token = waiter.beginAsync();
       const listener = () => {

--- a/packages/components/src/components/hds/modal/index.ts
+++ b/packages/components/src/components/hds/modal/index.ts
@@ -153,6 +153,29 @@ export default class HdsModal extends Component<HdsModalSignature> {
       }
     } else {
       this._isOpen = false;
+
+          // Reset page `overflow` property
+    if (this._body) {
+      this._body.style.removeProperty('overflow');
+      if (this._bodyInitialOverflowValue === '') {
+        if (this._body.style.length === 0) {
+          this._body.removeAttribute('style');
+        }
+      } else {
+        this._body.style.setProperty(
+          'overflow',
+          this._bodyInitialOverflowValue
+        );
+      }
+    }
+
+    // Return focus to a specific element (if provided)
+    if (this.args.returnFocusTo) {
+      const initiator = document.getElementById(this.args.returnFocusTo);
+      if (initiator) {
+        initiator.focus();
+      }
+    }
     }
   }
 
@@ -222,28 +245,5 @@ export default class HdsModal extends Component<HdsModalSignature> {
 
     // Make modal dialog invisible using the native `close` method
     this._element.close();
-
-    // Reset page `overflow` property
-    if (this._body) {
-      this._body.style.removeProperty('overflow');
-      if (this._bodyInitialOverflowValue === '') {
-        if (this._body.style.length === 0) {
-          this._body.removeAttribute('style');
-        }
-      } else {
-        this._body.style.setProperty(
-          'overflow',
-          this._bodyInitialOverflowValue
-        );
-      }
-    }
-
-    // Return focus to a specific element (if provided)
-    if (this.args.returnFocusTo) {
-      const initiator = document.getElementById(this.args.returnFocusTo);
-      if (initiator) {
-        initiator.focus();
-      }
-    }
   }
 }

--- a/packages/components/src/components/hds/modal/index.ts
+++ b/packages/components/src/components/hds/modal/index.ts
@@ -154,7 +154,7 @@ export default class HdsModal extends Component<HdsModalSignature> {
     } else {
       this._isOpen = false;
 
-          // Reset page `overflow` property
+    // Reset page `overflow` property
     if (this._body) {
       this._body.style.removeProperty('overflow');
       if (this._bodyInitialOverflowValue === '') {

--- a/packages/components/src/components/hds/modal/index.ts
+++ b/packages/components/src/components/hds/modal/index.ts
@@ -68,20 +68,6 @@ export default class HdsModal extends Component<HdsModalSignature> {
   constructor(owner: Owner, args: HdsModalSignature['Args']) {
     super(owner, args);
 
-    this._clickHandler = (event: MouseEvent) => {
-      // check if the click is outside the modal and the modal is open
-      if (!this._element.contains(event.target as Node) && this._isOpen) {
-        if (!this.isDismissDisabled) {
-          void this.onDismiss();
-        }
-      }
-    };
-
-    document.addEventListener('click', this._clickHandler, {
-      capture: true,
-      passive: false,
-    });
-
     registerDestructor(this, (): void => {
       document.removeEventListener('click', this._clickHandler);
     });
@@ -199,6 +185,20 @@ export default class HdsModal extends Component<HdsModalSignature> {
     if (!this._element.open) {
       this.open();
     }
+
+    this._clickHandler = (event: MouseEvent) => {
+      // check if the click is outside the modal and the modal is open
+      if (!this._element.contains(event.target as Node) && this._isOpen) {
+        if (!this.isDismissDisabled) {
+          void this.onDismiss();
+        }
+      }
+    };
+
+    document.addEventListener('click', this._clickHandler, {
+      capture: true,
+      passive: false,
+    });
   }
 
   @action

--- a/showcase/tests/integration/components/hds/modal/index-test.js
+++ b/showcase/tests/integration/components/hds/modal/index-test.js
@@ -169,6 +169,27 @@ module('Integration | Component | hds/modal/index', function (hooks) {
     assert.dom('#test-modal').isNotVisible();
   });
 
+  test('it should appropriately dismiss the modal when clicking outside the modal', async function (assert) {
+    this.set('isDismissDisabled', true);
+    await render(
+      hbs`<Hds::Modal @isDismissDisabled={{this.isDismissDisabled}} id="test-modal" as |M|>
+            <M.Header>Title</M.Header>
+            <M.Footer as |F|>
+              <Hds::Button id="cancel-button" type="button" @text="Cancel" @color="secondary" {{on "click" F.close}} />
+            </M.Footer>
+          </Hds::Modal>`
+    );
+
+    await click('.hds-modal__overlay');
+    assert.dom('#test-modal').isVisible();
+
+    // now let's check that the state is reset and it can be closed
+    this.set('isDismissDisabled', false);
+    await rerender();
+    await click('.hds-modal__overlay');
+    assert.dom('#test-modal').isNotVisible();
+  });
+
   // ACCESSIBILITY
 
   test('it uses the title as name for the dialog', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR would update Modal to not use `ember-focus-trap` to dismiss the Modal on click outside and instead use our own click event.

It also fixes an issue where the scroll bar would get added back if try to close the modal when `isDismissDisabled=true`.

### :hammer_and_wrench: Detailed description

This is necessary because the `ember-focus-trap`'s `clickOutSideDeactivates` only ever runs once. If a consumer conditionally disables the ability to dismiss the modal, the user may not be able to click outside to deactivate it.

Steps to reproduce:
1. Navigate to: https://hds-showcase.vercel.app/components/modal#demo
2. Click "Open non-dismissable modal"
3. Click outside the modal after it opens, notice it doesn't close and you are able to scroll the page behind the modal.
4. Click "reset isDismissDisabled"
5. Click outside the modal, notice it doesnt close.
6. Click "confirm"/"Cancel"/"close", notice the modal does close. 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3972](https://hashicorp.atlassian.net/browse/HDS-3972)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3972]: https://hashicorp.atlassian.net/browse/HDS-3972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ