### PR TITLE
Update Radio and Checkbox font weight in the Dropdown

### DIFF
--- a/.changeset/rude-rice-hang.md
+++ b/.changeset/rude-rice-hang.md
@@ -2,4 +2,5 @@
 "@hashicorp/design-system-components": patch
 ---
 
-Updated Dropdown Radio and Checkbox list items font weight to match other list items.
+`Dropdown` - Updated Radio and Checkbox list items font weight to match other
+list items.

--- a/.changeset/rude-rice-hang.md
+++ b/.changeset/rude-rice-hang.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Updated Dropdown Radio and Checkbox list items font weight to match other list items.

--- a/packages/components/src/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/checkbox.hbs
@@ -1,6 +1,6 @@
 {{!
-Copyright (c) HashiCorp, Inc.
-SPDX-License-Identifier: MPL-2.0
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
 }}
 <li class="hds-dropdown-list-item hds-dropdown-list-item--variant-checkbox">
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>

--- a/packages/components/src/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/checkbox.hbs
@@ -6,9 +6,9 @@ SPDX-License-Identifier: MPL-2.0
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>
     <Hds::Form::Checkbox::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
     {{#if @icon}}
-    <span class="hds-dropdown-list-item__icon">
-      <Hds::Icon @name={{@icon}} />
-    </span>
+      <span class="hds-dropdown-list-item__icon">
+        <Hds::Icon @name={{@icon}} />
+      </span>
     {{/if}}
     <Hds::Text::Body
       @tag="span"

--- a/packages/components/src/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/checkbox.hbs
@@ -10,10 +10,19 @@ SPDX-License-Identifier: MPL-2.0
       <Hds::Icon @name={{@icon}} />
     </span>
     {{/if}}
-    {{!-- <span class="hds-dropdown-list-item__text-content">{{yield}}</span> --}}
-    <Hds::Text::Body class="hds-dropdown-list-item__text-content" @tag="span" @size="200" @weight="medium">{{yield}}<Hds::Text::Body>
-        {{#if @count}}
-        <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
-        {{/if}}
+    <Hds::Text::Body
+      @tag="span"
+      @size="200"
+      @weight="medium"
+      class="hds-dropdown-list-item__text-content"
+    >{{yield}}</Hds::Text::Body>
+    {{#if @count}}
+      <Hds::Text::Body
+        @tag="span"
+        @size="100"
+        @weight="medium"
+        class="hds-dropdown-list-item__count"
+      >{{@count}}</Hds::Text::Body>
+    {{/if}}
   </label>
 </li>

--- a/packages/components/src/components/hds/dropdown/list-item/checkbox.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/checkbox.hbs
@@ -1,18 +1,19 @@
 {{!
-  Copyright (c) HashiCorp, Inc.
-  SPDX-License-Identifier: MPL-2.0
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
 }}
 <li class="hds-dropdown-list-item hds-dropdown-list-item--variant-checkbox">
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>
     <Hds::Form::Checkbox::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
     {{#if @icon}}
-      <span class="hds-dropdown-list-item__icon">
-        <Hds::Icon @name={{@icon}} />
-      </span>
+    <span class="hds-dropdown-list-item__icon">
+      <Hds::Icon @name={{@icon}} />
+    </span>
     {{/if}}
-    <span class="hds-dropdown-list-item__text-content">{{yield}}</span>
-    {{#if @count}}
-      <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
-    {{/if}}
+    {{!-- <span class="hds-dropdown-list-item__text-content">{{yield}}</span> --}}
+    <Hds::Text::Body class="hds-dropdown-list-item__text-content" @tag="span" @size="200" @weight="medium">{{yield}}<Hds::Text::Body>
+        {{#if @count}}
+        <span class="hds-dropdown-list-item__count hds-typography-body-100 hds-font-weight-medium">{{@count}}</span>
+        {{/if}}
   </label>
 </li>

--- a/packages/components/src/components/hds/dropdown/list-item/checkmark.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/checkmark.hbs
@@ -23,9 +23,12 @@
         <Hds::Icon @name={{@icon}} />
       </span>
     {{/if}}
-    <Hds::Text::Body @tag="span" @size="200" @weight="medium" class="hds-dropdown-list-item__interactive-text">
-      {{yield}}
-    </Hds::Text::Body>
+    <Hds::Text::Body
+      @tag="span"
+      @size="200"
+      @weight="medium"
+      class="hds-dropdown-list-item__interactive-text"
+    >{{yield}}</Hds::Text::Body>
     {{#if @count}}
       <Hds::Text::Body
         class="hds-dropdown-list-item__count"

--- a/packages/components/src/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/radio.hbs
@@ -6,9 +6,9 @@ SPDX-License-Identifier: MPL-2.0
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>
     <Hds::Form::Radio::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
     {{#if @icon}}
-    <div class="hds-dropdown-list-item__icon">
-      <Hds::Icon @name={{@icon}} />
-    </div>
+      <div class="hds-dropdown-list-item__icon">
+        <Hds::Icon @name={{@icon}} />
+      </div>
     {{/if}}
     <Hds::Text::Body
       @tag="span"

--- a/packages/components/src/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/radio.hbs
@@ -1,6 +1,6 @@
 {{!
-Copyright (c) HashiCorp, Inc.
-SPDX-License-Identifier: MPL-2.0
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
 }}
 <li class="hds-dropdown-list-item hds-dropdown-list-item--variant-radio">
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>

--- a/packages/components/src/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/radio.hbs
@@ -6,22 +6,22 @@ SPDX-License-Identifier: MPL-2.0
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>
     <Hds::Form::Radio::Base class="hds-dropdown-list-item__control" id={{this.id}} @value={{@value}} ...attributes />
     {{#if @icon}}
-      <div class="hds-dropdown-list-item__icon">
-        <Hds::Icon @name={{@icon}} />
-      </div>
+    <div class="hds-dropdown-list-item__icon">
+      <Hds::Icon @name={{@icon}} />
+    </div>
     {{/if}}
     <Hds::Text::Body
-      class="hds-dropdown-list-item__text-content"
       @tag="span"
       @size="200"
       @weight="medium"
+      class="hds-dropdown-list-item__text-content"
     >{{yield}}</Hds::Text::Body>
     {{#if @count}}
       <Hds::Text::Body
-        class="hds-dropdown-list-item__count"
         @tag="span"
         @size="100"
         @weight="medium"
+        class="hds-dropdown-list-item__count"
       >{{@count}}</Hds::Text::Body>
     {{/if}}
   </label>

--- a/packages/components/src/components/hds/dropdown/list-item/radio.hbs
+++ b/packages/components/src/components/hds/dropdown/list-item/radio.hbs
@@ -1,6 +1,6 @@
 {{!
-  Copyright (c) HashiCorp, Inc.
-  SPDX-License-Identifier: MPL-2.0
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
 }}
 <li class="hds-dropdown-list-item hds-dropdown-list-item--variant-radio">
   <label class="hds-dropdown-list-item__label hds-typography-body-200" for={{this.id}}>
@@ -10,8 +10,12 @@
         <Hds::Icon @name={{@icon}} />
       </div>
     {{/if}}
-    <span class="hds-dropdown-list-item__text-content">{{yield}}</span>
-
+    <Hds::Text::Body
+      class="hds-dropdown-list-item__text-content"
+      @tag="span"
+      @size="200"
+      @weight="medium"
+    >{{yield}}</Hds::Text::Body>
     {{#if @count}}
       <Hds::Text::Body
         class="hds-dropdown-list-item__count"

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -13,15 +13,15 @@
 
   <Shw::Grid @columns={{2}} as |SG|>
     {{#each @model.POSITIONS as |position|}}
-    <SG.Item @label={{capitalize position}}>
-      <Shw::Outliner {{style padding="6em 12em" }}>
-        <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
-          <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">Create</D.Interactive>
-          <D.Interactive @href="#">Edit</D.Interactive>
-        </Hds::Dropdown>
-      </Shw::Outliner>
-    </SG.Item>
+      <SG.Item @label={{capitalize position}}>
+        <Shw::Outliner {{style padding="6em 12em"}}>
+          <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
+            <D.ToggleButton @color="secondary" @text="Menu" />
+            <D.Interactive @href="#">Create</D.Interactive>
+            <D.Interactive @href="#">Edit</D.Interactive>
+          </Hds::Dropdown>
+        </Shw::Outliner>
+      </SG.Item>
     {{/each}}
   </Shw::Grid>
 
@@ -31,64 +31,76 @@
 
   <Shw::Grid @columns={{4}} @gap="2rem" as |SG|>
     {{#let (array false true) as |options|}}
-    {{#each options as |option|}}
-    <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
-      <SGI.Label><code>ToggleButton</code> auto</SGI.Label>
-      <div class="shw-component-dropdown-fixed-height-container">
-        <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @matchToggleWidth={{option}} as |D|>
-          <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">
-            Lorem ipsum dolor sit amet
-          </D.Interactive>
-          <D.Interactive @href="#">
-            Consectetur adipisicing elit
-          </D.Interactive>
-        </Hds::Dropdown>
-      </div>
-    </SG.Item>
-    <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
-      <SGI.Label><code>ToggleButton</code> 100%</SGI.Label>
-      <div class="shw-component-dropdown-fixed-height-container">
-        <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @matchToggleWidth={{option}} as |D|>
-          <D.ToggleButton {{style width="100%" }} @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">
-            Lorem ipsum dolor sit amet
-          </D.Interactive>
-          <D.Interactive @href="#">
-            Consectetur adipisicing elit
-          </D.Interactive>
-        </Hds::Dropdown>
-      </div>
-    </SG.Item>
-    <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
-      <SGI.Label><code>ToggleButton</code> auto + <code>@width="200px"</code></SGI.Label>
-      <div class="shw-component-dropdown-fixed-height-container">
-        <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @width="200px" @matchToggleWidth={{option}} as |D|>
-          <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">
-            Lorem ipsum dolor sit amet
-          </D.Interactive>
-          <D.Interactive @href="#">
-            Consectetur adipisicing elit
-          </D.Interactive>
-        </Hds::Dropdown>
-      </div>
-    </SG.Item>
-    <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
-      <SGI.Label><code>ToggleButton</code> auto + <code>@width="100%"</code></SGI.Label>
-      <div class="shw-component-dropdown-fixed-height-container">
-        <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @width="100%" @matchToggleWidth={{option}} as |D|>
-          <D.ToggleButton @color="secondary" @text="Menu" />
-          <D.Interactive @href="#">
-            Lorem ipsum dolor sit amet
-          </D.Interactive>
-          <D.Interactive @href="#">
-            Consectetur adipisicing elit
-          </D.Interactive>
-        </Hds::Dropdown>
-      </div>
-    </SG.Item>
-    {{/each}}
+      {{#each options as |option|}}
+        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+          <SGI.Label><code>ToggleButton</code> auto</SGI.Label>
+          <div class="shw-component-dropdown-fixed-height-container">
+            <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @matchToggleWidth={{option}} as |D|>
+              <D.ToggleButton @color="secondary" @text="Menu" />
+              <D.Interactive @href="#">
+                Lorem ipsum dolor sit amet
+              </D.Interactive>
+              <D.Interactive @href="#">
+                Consectetur adipisicing elit
+              </D.Interactive>
+            </Hds::Dropdown>
+          </div>
+        </SG.Item>
+        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+          <SGI.Label><code>ToggleButton</code> 100%</SGI.Label>
+          <div class="shw-component-dropdown-fixed-height-container">
+            <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @matchToggleWidth={{option}} as |D|>
+              <D.ToggleButton {{style width="100%"}} @color="secondary" @text="Menu" />
+              <D.Interactive @href="#">
+                Lorem ipsum dolor sit amet
+              </D.Interactive>
+              <D.Interactive @href="#">
+                Consectetur adipisicing elit
+              </D.Interactive>
+            </Hds::Dropdown>
+          </div>
+        </SG.Item>
+        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+          <SGI.Label><code>ToggleButton</code> auto + <code>@width="200px"</code></SGI.Label>
+          <div class="shw-component-dropdown-fixed-height-container">
+            <Hds::Dropdown
+              @isOpen={{true}}
+              @listPosition="bottom-left"
+              @width="200px"
+              @matchToggleWidth={{option}}
+              as |D|
+            >
+              <D.ToggleButton @color="secondary" @text="Menu" />
+              <D.Interactive @href="#">
+                Lorem ipsum dolor sit amet
+              </D.Interactive>
+              <D.Interactive @href="#">
+                Consectetur adipisicing elit
+              </D.Interactive>
+            </Hds::Dropdown>
+          </div>
+        </SG.Item>
+        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+          <SGI.Label><code>ToggleButton</code> auto + <code>@width="100%"</code></SGI.Label>
+          <div class="shw-component-dropdown-fixed-height-container">
+            <Hds::Dropdown
+              @isOpen={{true}}
+              @listPosition="bottom-left"
+              @width="100%"
+              @matchToggleWidth={{option}}
+              as |D|
+            >
+              <D.ToggleButton @color="secondary" @text="Menu" />
+              <D.Interactive @href="#">
+                Lorem ipsum dolor sit amet
+              </D.Interactive>
+              <D.Interactive @href="#">
+                Consectetur adipisicing elit
+              </D.Interactive>
+            </Hds::Dropdown>
+          </div>
+        </SG.Item>
+      {{/each}}
     {{/let}}
   </Shw::Grid>
 
@@ -133,19 +145,19 @@
 
   <Shw::Grid @columns={{3}} @gap="2rem" as |SF|>
     {{#let (array false true) as |detections|}}
-    {{#each detections as |detection|}}
-    <SF.Item @forceMinWidth={{true}} @label={{concat "enableCollisionDetection=" detection}}>
-      <Shw::Autoscrollable @verticalShift={{30}}>
-        <div class="shw-component-dropdown-collision-detection-wrapper">
-          <Hds::Dropdown @isOpen={{true}} @enableCollisionDetection={{detection}} as |D|>
-            <D.ToggleButton @color="secondary" @text="Menu" />
-            <D.Interactive @href="#">Create</D.Interactive>
-            <D.Interactive @href="#">Edit</D.Interactive>
-          </Hds::Dropdown>
-        </div>
-      </Shw::Autoscrollable>
-    </SF.Item>
-    {{/each}}
+      {{#each detections as |detection|}}
+        <SF.Item @forceMinWidth={{true}} @label={{concat "enableCollisionDetection=" detection}}>
+          <Shw::Autoscrollable @verticalShift={{30}}>
+            <div class="shw-component-dropdown-collision-detection-wrapper">
+              <Hds::Dropdown @isOpen={{true}} @enableCollisionDetection={{detection}} as |D|>
+                <D.ToggleButton @color="secondary" @text="Menu" />
+                <D.Interactive @href="#">Create</D.Interactive>
+                <D.Interactive @href="#">Edit</D.Interactive>
+              </Hds::Dropdown>
+            </div>
+          </Shw::Autoscrollable>
+        </SF.Item>
+      {{/each}}
     {{/let}}
     <SF.Item />
   </Shw::Grid>
@@ -162,7 +174,7 @@
       <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" />
     </SF.Item>
     <SF.Item @label="Primary full width">
-      <Shw::Outliner {{style width="300px" }}>
+      <Shw::Outliner {{style width="300px"}}>
         <Hds::Dropdown::Toggle::Button @isFullWidth={{true}} @text="Lorem ipsum" />
       </Shw::Outliner>
     </SF.Item>
@@ -176,7 +188,7 @@
       <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" />
     </SF.Item>
     <SF.Item @label="Secondary full width">
-      <Shw::Outliner {{style width="300px" }}>
+      <Shw::Outliner {{style width="300px"}}>
         <Hds::Dropdown::Toggle::Button @color="secondary" @isFullWidth={{true}} @text="Lorem ipsum" />
       </Shw::Outliner>
     </SF.Item>
@@ -192,7 +204,7 @@
       <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem ipsum" />
     </SF.Item>
     <SF.Item @label="Primary full width">
-      <Shw::Outliner {{style width="300px" }}>
+      <Shw::Outliner {{style width="300px"}}>
         <Hds::Dropdown::Toggle::Button @icon="hexagon" @isFullWidth={{true}} @text="Lorem ipsum" />
       </Shw::Outliner>
     </SF.Item>
@@ -205,7 +217,7 @@
       <Hds::Dropdown::Toggle::Button @color="secondary" @icon="hexagon" @text="Lorem ipsum" />
     </SF.Item>
     <SF.Item @label="Secondary full width">
-      <Shw::Outliner {{style width="300px" }}>
+      <Shw::Outliner {{style width="300px"}}>
         <Hds::Dropdown::Toggle::Button @color="secondary" @icon="hexagon" @isFullWidth={{true}} @text="Lorem ipsum" />
       </Shw::Outliner>
     </SF.Item>
@@ -221,7 +233,7 @@
       <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @count="12" />
     </SF.Item>
     <SF.Item @label="Primary full width">
-      <Shw::Outliner {{style width="300px" }}>
+      <Shw::Outliner {{style width="300px"}}>
         <Hds::Dropdown::Toggle::Button @isFullWidth={{true}} @text="Lorem ipsum" @count="12" />
       </Shw::Outliner>
     </SF.Item>
@@ -234,7 +246,7 @@
       <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" @count="12" />
     </SF.Item>
     <SF.Item @label="Secondary full width">
-      <Shw::Outliner {{style width="300px" }}>
+      <Shw::Outliner {{style width="300px"}}>
         <Hds::Dropdown::Toggle::Button @color="secondary" @isFullWidth={{true}} @text="Lorem ipsum" @count="12" />
       </Shw::Outliner>
     </SF.Item>
@@ -250,21 +262,33 @@
       <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
     </SF.Item>
     <SF.Item @label="Primary full width">
-      <Shw::Outliner {{style width="300px" }}>
+      <Shw::Outliner {{style width="300px"}}>
         <Hds::Dropdown::Toggle::Button @isFullWidth={{true}} @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
       </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Secondary small">
-      <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" @size="small" />
+      <Hds::Dropdown::Toggle::Button
+        @color="secondary"
+        @text="Lorem ipsum"
+        @badge="Badge"
+        @badgeIcon="hexagon"
+        @size="small"
+      />
     </SF.Item>
     <SF.Item @label="Secondary medium">
       <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
     </SF.Item>
     <SF.Item @label="Secondary full width">
-      <Shw::Outliner {{style width="300px" }}>
-        <Hds::Dropdown::Toggle::Button @color="secondary" @isFullWidth={{true}} @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
+      <Shw::Outliner {{style width="300px"}}>
+        <Hds::Dropdown::Toggle::Button
+          @color="secondary"
+          @isFullWidth={{true}}
+          @text="Lorem ipsum"
+          @badge="Badge"
+          @badgeIcon="hexagon"
+        />
       </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>
@@ -312,87 +336,109 @@
     {{! Notice: we use a non-standard way to showcase the states to reduce the (visual) complexity of this matrix }}
 
     {{#each @model.TOGGLE_STATES as |state|}}
-    <SG.Item>
-      <span class="shw-label">{{capitalize state}}</span>
-    </SG.Item>
+      <SG.Item>
+        <span class="shw-label">{{capitalize state}}</span>
+      </SG.Item>
     {{/each}}
     <SG.Item>
       <span class="shw-label">Open</span>
     </SG.Item>
 
     {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
-    {{#each @model.TOGGLE_STATES as |state|}}
-    <SG.Item @label="{{capitalize color}}">
-      {{#if (eq state "disabled")}}
-      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} disabled />
-      {{else}}
-      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} mock-state-value={{state}} />
-      {{/if}}
-    </SG.Item>
-    {{/each}}
-    <SG.Item @label="{{capitalize color}}">
-      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @isOpen={{true}} @color={{color}} />
-    </SG.Item>
-    {{#each @model.TOGGLE_STATES as |state|}}
-    <SG.Item @label="With icon">
-      {{#if (eq state "disabled")}}
-      <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} disabled />
-      {{else}}
-      <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} mock-state-value={{state}} />
-      {{/if}}
-    </SG.Item>
-    {{/each}}
-    <SG.Item @label="With icon">
-      <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @isOpen={{true}} @color={{color}} />
-    </SG.Item>
-    {{#each @model.TOGGLE_STATES as |state|}}
-    <SG.Item @label="With count">
-      {{#if (eq state "disabled")}}
-      <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} disabled />
-      {{else}}
-      <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} mock-state-value={{state}} />
-      {{/if}}
-    </SG.Item>
-    {{/each}}
-    <SG.Item @label="With count">
-      <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @isOpen={{true}} @color={{color}} />
-    </SG.Item>
-    {{#each @model.TOGGLE_STATES as |state|}}
-    <SG.Item @label="With badge">
-      {{#if (eq state "disabled")}}
-      <Hds::Dropdown::Toggle::Button @badge="Sit" @badgeIcon="hexagon" @text="Lorem" @color={{color}} disabled />
-      {{else}}
-      <Hds::Dropdown::Toggle::Button @badge="Sit" @badgeIcon="hexagon" @text="Lorem" @color={{color}} mock-state-value={{state}} />
-      {{/if}}
-    </SG.Item>
-    {{/each}}
-    <SG.Item @label="With badge">
-      <Hds::Dropdown::Toggle::Button @badge="Sit" @badgeIcon="hexagon" @text="Lorem" @isOpen={{true}} @color={{color}} />
-    </SG.Item>
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="{{capitalize color}}">
+          {{#if (eq state "disabled")}}
+            <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} disabled />
+          {{else}}
+            <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} mock-state-value={{state}} />
+          {{/if}}
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="{{capitalize color}}">
+        <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @isOpen={{true}} @color={{color}} />
+      </SG.Item>
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="With icon">
+          {{#if (eq state "disabled")}}
+            <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} disabled />
+          {{else}}
+            <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+          {{/if}}
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="With icon">
+        <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @isOpen={{true}} @color={{color}} />
+      </SG.Item>
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="With count">
+          {{#if (eq state "disabled")}}
+            <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} disabled />
+          {{else}}
+            <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+          {{/if}}
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="With count">
+        <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @isOpen={{true}} @color={{color}} />
+      </SG.Item>
+      {{#each @model.TOGGLE_STATES as |state|}}
+        <SG.Item @label="With badge">
+          {{#if (eq state "disabled")}}
+            <Hds::Dropdown::Toggle::Button @badge="Sit" @badgeIcon="hexagon" @text="Lorem" @color={{color}} disabled />
+          {{else}}
+            <Hds::Dropdown::Toggle::Button
+              @badge="Sit"
+              @badgeIcon="hexagon"
+              @text="Lorem"
+              @color={{color}}
+              mock-state-value={{state}}
+            />
+          {{/if}}
+        </SG.Item>
+      {{/each}}
+      <SG.Item @label="With badge">
+        <Hds::Dropdown::Toggle::Button
+          @badge="Sit"
+          @badgeIcon="hexagon"
+          @text="Lorem"
+          @isOpen={{true}}
+          @color={{color}}
+        />
+      </SG.Item>
     {{/each}}
 
     {{#each @model.TOGGLE_STATES as |state|}}
-    <SG.Item @label="Icon">
-      <Hds::Dropdown::Toggle::Icon @icon="more-horizontal" @text="overflow menu" @hasChevron={{false}} mock-state-value={{state}} />
-    </SG.Item>
+      <SG.Item @label="Icon">
+        <Hds::Dropdown::Toggle::Icon
+          @icon="more-horizontal"
+          @text="overflow menu"
+          @hasChevron={{false}}
+          mock-state-value={{state}}
+        />
+      </SG.Item>
     {{/each}}
     <SG.Item @label="Icon">
-      <Hds::Dropdown::Toggle::Icon @icon="more-horizontal" @text="overflow menu" @hasChevron={{false}} @isOpen={{true}} />
+      <Hds::Dropdown::Toggle::Icon
+        @icon="more-horizontal"
+        @text="overflow menu"
+        @hasChevron={{false}}
+        @isOpen={{true}}
+      />
     </SG.Item>
 
     {{#each @model.TOGGLE_STATES as |state|}}
-    <SG.Item @label="Icon+chevron">
-      <Hds::Dropdown::Toggle::Icon @icon="user" @text={{state}} mock-state-value={{state}} />
-    </SG.Item>
+      <SG.Item @label="Icon+chevron">
+        <Hds::Dropdown::Toggle::Icon @icon="user" @text={{state}} mock-state-value={{state}} />
+      </SG.Item>
     {{/each}}
     <SG.Item @label="Icon+chevron">
       <Hds::Dropdown::Toggle::Icon @icon="user" @text="open" @isOpen={{true}} />
     </SG.Item>
 
     {{#each @model.TOGGLE_STATES as |state|}}
-    <SG.Item @label="Avatar+chevron">
-      <Hds::Dropdown::Toggle::Icon @text={{state}} @imageSrc="/assets/images/avatar.png" mock-state-value={{state}} />
-    </SG.Item>
+      <SG.Item @label="Avatar+chevron">
+        <Hds::Dropdown::Toggle::Icon @text={{state}} @imageSrc="/assets/images/avatar.png" mock-state-value={{state}} />
+      </SG.Item>
     {{/each}}
     <SG.Item @label="Avatar+chevron">
       <Hds::Dropdown::Toggle::Icon @text="open" @isOpen={{true}} @imageSrc="/assets/images/avatar.png" />
@@ -419,10 +465,17 @@
     <SF.Item @label="Default (max width)">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Title @text="A longer title that could span multiple lines if the characters surpass a certain length" />
-          <Hds::Dropdown::ListItem::Description @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default." />
+          <Hds::Dropdown::ListItem::Title
+            @text="A longer title that could span multiple lines if the characters surpass a certain length"
+          />
+          <Hds::Dropdown::ListItem::Description
+            @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
+          />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive @route="index" @text="A longer item that could span multiple lines if the characters surpass a certain length" />
+          <Hds::Dropdown::ListItem::Interactive
+            @route="index"
+            @text="A longer item that could span multiple lines if the characters surpass a certain length"
+          />
         </ul>
       </div>
     </SF.Item>
@@ -430,10 +483,17 @@
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Title @text="A longer title that could span multiple lines if the characters surpass a certain length" />
-          <Hds::Dropdown::ListItem::Description @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default." />
+          <Hds::Dropdown::ListItem::Title
+            @text="A longer title that could span multiple lines if the characters surpass a certain length"
+          />
+          <Hds::Dropdown::ListItem::Description
+            @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
+          />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive @route="index" @text="A longer item that could span multiple lines if the characters surpass a certain length" />
+          <Hds::Dropdown::ListItem::Interactive
+            @route="index"
+            @text="A longer item that could span multiple lines if the characters surpass a certain length"
+          />
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}
@@ -614,63 +674,80 @@
   <Shw::Text::H4>States (in each color)</Shw::Text::H4>
 
   {{#each @model.ITEM_INTERACTIVE_COLORS as |color|}}
-  <Shw::Flex @direction="column" as |SF|>
-    <SF.Item @label={{capitalize color}}>
-      <Shw::Flex as |SF|>
-        <SF.Item>
-          <div class="hds-dropdown__content">
-            <ul class="hds-dropdown__list">
-              {{#each @model.ITEM_STATES as |state|}}
-              <Hds::Dropdown::ListItem::Interactive @color={{color}} mock-state-value={{state}}>
-                {{state}}
-              </Hds::Dropdown::ListItem::Interactive>
-              {{/each}}
-              <Hds::Dropdown::ListItem::Separator />
-              <Hds::Dropdown::ListItem::Interactive @color={{color}} @isLoading={{true}}>
-                Loading
-              </Hds::Dropdown::ListItem::Interactive>
-              <Hds::Dropdown::ListItem::Interactive @color={{color}} @isLoading={{true}} as |I|>
-                Loading
-                <I.Badge @text="With Badge" />
-              </Hds::Dropdown::ListItem::Interactive>
-            </ul>
-          </div>
-        </SF.Item>
-        <SF.Item>
-          <div class="hds-dropdown__content">
-            <ul class="hds-dropdown__list">
-              {{#each @model.ITEM_STATES as |state|}}
-              <Hds::Dropdown::ListItem::Interactive @icon={{if (eq color "critical" ) "trash" "settings" }} @color={{color}} mock-state-value={{state}}>
-                {{state}}
-                with icon
-              </Hds::Dropdown::ListItem::Interactive>
-              {{/each}}
-              <Hds::Dropdown::ListItem::Separator />
-              <Hds::Dropdown::ListItem::Interactive @icon={{if (eq color "critical" ) "trash" "settings" }} @color={{color}} @isLoading={{true}}>
-                loading with icon
-              </Hds::Dropdown::ListItem::Interactive>
-              <Hds::Dropdown::ListItem::Interactive @icon={{if (eq color "critical" ) "trash" "settings" }} @color={{color}} @isLoading={{true}} as |I|>
-                Loading
-                <I.Badge @text="With Badge" />
-              </Hds::Dropdown::ListItem::Interactive>
-            </ul>
-          </div>
-        </SF.Item>
-        <SF.Item>
-          <div class="hds-dropdown__content">
-            <ul class="hds-dropdown__list">
-              {{#each @model.ITEM_STATES as |state|}}
-              <Hds::Dropdown::ListItem::Interactive @icon={{if (eq color "critical" ) "trash" "settings" }} @color={{color}} mock-state-value={{state}}>
-                {{state}}
-                with a longer text string that may wrap since max-width is defined on the container
-              </Hds::Dropdown::ListItem::Interactive>
-              {{/each}}
-            </ul>
-          </div>
-        </SF.Item>
-      </Shw::Flex>
-    </SF.Item>
-  </Shw::Flex>
+    <Shw::Flex @direction="column" as |SF|>
+      <SF.Item @label={{capitalize color}}>
+        <Shw::Flex as |SF|>
+          <SF.Item>
+            <div class="hds-dropdown__content">
+              <ul class="hds-dropdown__list">
+                {{#each @model.ITEM_STATES as |state|}}
+                  <Hds::Dropdown::ListItem::Interactive @color={{color}} mock-state-value={{state}}>
+                    {{state}}
+                  </Hds::Dropdown::ListItem::Interactive>
+                {{/each}}
+                <Hds::Dropdown::ListItem::Separator />
+                <Hds::Dropdown::ListItem::Interactive @color={{color}} @isLoading={{true}}>
+                  Loading
+                </Hds::Dropdown::ListItem::Interactive>
+                <Hds::Dropdown::ListItem::Interactive @color={{color}} @isLoading={{true}} as |I|>
+                  Loading
+                  <I.Badge @text="With Badge" />
+                </Hds::Dropdown::ListItem::Interactive>
+              </ul>
+            </div>
+          </SF.Item>
+          <SF.Item>
+            <div class="hds-dropdown__content">
+              <ul class="hds-dropdown__list">
+                {{#each @model.ITEM_STATES as |state|}}
+                  <Hds::Dropdown::ListItem::Interactive
+                    @icon={{if (eq color "critical") "trash" "settings"}}
+                    @color={{color}}
+                    mock-state-value={{state}}
+                  >
+                    {{state}}
+                    with icon
+                  </Hds::Dropdown::ListItem::Interactive>
+                {{/each}}
+                <Hds::Dropdown::ListItem::Separator />
+                <Hds::Dropdown::ListItem::Interactive
+                  @icon={{if (eq color "critical") "trash" "settings"}}
+                  @color={{color}}
+                  @isLoading={{true}}
+                >
+                  loading with icon
+                </Hds::Dropdown::ListItem::Interactive>
+                <Hds::Dropdown::ListItem::Interactive
+                  @icon={{if (eq color "critical") "trash" "settings"}}
+                  @color={{color}}
+                  @isLoading={{true}}
+                  as |I|
+                >
+                  Loading
+                  <I.Badge @text="With Badge" />
+                </Hds::Dropdown::ListItem::Interactive>
+              </ul>
+            </div>
+          </SF.Item>
+          <SF.Item>
+            <div class="hds-dropdown__content">
+              <ul class="hds-dropdown__list">
+                {{#each @model.ITEM_STATES as |state|}}
+                  <Hds::Dropdown::ListItem::Interactive
+                    @icon={{if (eq color "critical") "trash" "settings"}}
+                    @color={{color}}
+                    mock-state-value={{state}}
+                  >
+                    {{state}}
+                    with a longer text string that may wrap since max-width is defined on the container
+                  </Hds::Dropdown::ListItem::Interactive>
+                {{/each}}
+              </ul>
+            </div>
+          </SF.Item>
+        </Shw::Flex>
+      </SF.Item>
+    </Shw::Flex>
   {{/each}}
 
   <Shw::Divider @level={{2}} />
@@ -719,7 +796,11 @@
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::CopyItem @copyItemTitle="Lorem ipsum dolor" @text="91ee1e8ef65b337f0e70d793f456c71d" @isTruncated={{false}} />
+          <Hds::Dropdown::ListItem::CopyItem
+            @copyItemTitle="Lorem ipsum dolor"
+            @text="91ee1e8ef65b337f0e70d793f456c71d"
+            @isTruncated={{false}}
+          />
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}
@@ -741,7 +822,10 @@
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::CopyItem @copyItemTitle="Lorem ipsum dolor" @text="91ee1e8ef65b337f0e70d793f456c71d" />
+          <Hds::Dropdown::ListItem::CopyItem
+            @copyItemTitle="Lorem ipsum dolor"
+            @text="91ee1e8ef65b337f0e70d793f456c71d"
+          />
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}
@@ -750,7 +834,11 @@
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::CopyItem @copyItemTitle="Lorem ipsum dolor" @text="91ee1e8ef65b337f0e70d793f456c71d" @isTruncated={{false}} />
+          <Hds::Dropdown::ListItem::CopyItem
+            @copyItemTitle="Lorem ipsum dolor"
+            @text="91ee1e8ef65b337f0e70d793f456c71d"
+            @isTruncated={{false}}
+          />
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}
@@ -766,7 +854,11 @@
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::CopyItem @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r" mock-state-value={{state}} mock-state-selector="button" />
+            <Hds::Dropdown::ListItem::CopyItem
+              @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r"
+              mock-state-value={{state}}
+              mock-state-selector="button"
+            />
           {{/each}}
         </ul>
       </div>
@@ -778,7 +870,12 @@
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::CopyItem @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r" @copyItemTitle="Lorem ipsumy dolor" mock-state-value={{state}} mock-state-selector="button" />
+            <Hds::Dropdown::ListItem::CopyItem
+              @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r"
+              @copyItemTitle="Lorem ipsumy dolor"
+              mock-state-value={{state}}
+              mock-state-selector="button"
+            />
           {{/each}}
         </ul>
       </div>
@@ -790,7 +887,13 @@
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::CopyItem @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r" @copyItemTitle="Lorem ipsumy dolor" @isTruncated={{false}} mock-state-value={{state}} mock-state-selector="button" />
+            <Hds::Dropdown::ListItem::CopyItem
+              @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r"
+              @copyItemTitle="Lorem ipsumy dolor"
+              @isTruncated={{false}}
+              mock-state-value={{state}}
+              mock-state-selector="button"
+            />
           {{/each}}
         </ul>
       </div>
@@ -807,9 +910,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Default">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value="disabled" disabled>
             disabled
@@ -821,9 +924,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Selected">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value="disabled" @selected={{true}} disabled>
             disabled
@@ -835,9 +938,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Icon">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}}>
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value="disabled" disabled>
             disabled
@@ -849,9 +952,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Icon, selected">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}} @selected={{true}}>
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}} @selected={{true}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value="disabled" @selected={{true}} disabled>
             disabled
@@ -863,9 +966,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Count">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -874,9 +977,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Count, selected">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -885,9 +988,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Custom content">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="128" @height="20" />
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
+              <Shw::Placeholder @text="custom content" @width="128" @height="20" />
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -896,9 +999,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Custom content, selected">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="128" @height="20" />
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
+              <Shw::Placeholder @text="custom content" @width="128" @height="20" />
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -907,10 +1010,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Badge in content">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
-            {{state}}
-            <Hds::Badge @icon="org" @text="Private" @size="small" />
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
+              {{state}}
+              <Hds::Badge @icon="org" @text="Private" @size="small" />
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -919,10 +1022,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Badge in content, selected">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
-            {{state}}
-            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
+              {{state}}
+              <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -931,11 +1034,16 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Large content">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @icon="hexagon" @selected={{true}} @count="12">
-            {{state}}
-            with a longer text string that may wrap since max-width is defined on the container
-            <Hds::Badge @text="badge" @size="small" />
-          </Hds::Dropdown::ListItem::Checkmark>
+            <Hds::Dropdown::ListItem::Checkmark
+              mock-state-value={{state}}
+              @icon="hexagon"
+              @selected={{true}}
+              @count="12"
+            >
+              {{state}}
+              with a longer text string that may wrap since max-width is defined on the container
+              <Hds::Badge @text="badge" @size="small" />
+            </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -962,9 +1070,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" disabled>
             disabled
@@ -976,9 +1084,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" disabled checked>
             disabled
@@ -990,9 +1098,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon">
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon">
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" @icon="hexagon" disabled>
             disabled
@@ -1004,9 +1112,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon" checked>
-            {{state}}
-          </Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon" checked>
+              {{state}}
+            </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" @icon="hexagon" disabled checked>
             disabled
@@ -1018,7 +1126,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">{{state}}</Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox
+              mock-state-value={{state}}
+              @count="12"
+            >{{state}}</Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1027,7 +1138,11 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">{{state}}</Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox
+              mock-state-value={{state}}
+              checked
+              @count="12"
+            >{{state}}</Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1036,9 +1151,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="122" @height="20" />
-          </Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
+            </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1047,9 +1162,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">
-            <Shw::Placeholder @text="custom content" @width="122" @height="20" />
-          </Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
+            </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1058,10 +1173,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
-            {{state}}
-            <Hds::Badge @icon="org" @text="Private" @size="small" />
-          </Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
+              {{state}}
+              <Hds::Badge @icon="org" @text="Private" @size="small" />
+            </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1070,10 +1185,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
-            {{state}}
-            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
-          </Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
+              {{state}}
+              <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+            </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1082,11 +1197,11 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12" @icon="hexagon">
-            {{state}}
-            with a longer text string that may wrap since max-width is defined on the container
-            <Hds::Badge @text="badge" @size="small" />
-          </Hds::Dropdown::ListItem::Checkbox>
+            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12" @icon="hexagon">
+              {{state}}
+              with a longer text string that may wrap since max-width is defined on the container
+              <Hds::Badge @text="badge" @size="small" />
+            </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1113,9 +1228,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
-            {{state}}
-          </Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
+              {{state}}
+            </Hds::Dropdown::ListItem::Radio>
           {{/each}}
           <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" disabled>
             disabled
@@ -1127,9 +1242,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
-            {{state}}
-          </Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
+              {{state}}
+            </Hds::Dropdown::ListItem::Radio>
           {{/each}}
           <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" checked disabled>
             disabled
@@ -1141,9 +1256,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @icon="hexagon">
-            {{state}}
-          </Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @icon="hexagon">
+              {{state}}
+            </Hds::Dropdown::ListItem::Radio>
           {{/each}}
           <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" @icon="hexagon" disabled>
             disabled
@@ -1155,9 +1270,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @icon="hexagon">
-            {{state}}
-          </Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @icon="hexagon">
+              {{state}}
+            </Hds::Dropdown::ListItem::Radio>
           {{/each}}
           <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" @icon="hexagon" checked disabled>
             disabled
@@ -1169,7 +1284,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">{{state}}</Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio
+              mock-state-value={{state}}
+              @count="12"
+            >{{state}}</Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1178,7 +1296,11 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">{{state}}</Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio
+              mock-state-value={{state}}
+              checked
+              @count="12"
+            >{{state}}</Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1187,9 +1309,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">
-            <Shw::Placeholder @text="custom content" @width="122" @height="20" />
-          </Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
+            </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1198,9 +1320,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">
-            <Shw::Placeholder @text="custom content" @width="122" @height="20" />
-          </Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">
+              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
+            </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1209,10 +1331,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
-            {{state}}
-            <Hds::Badge @icon="org" @text="Private" @size="small" />
-          </Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
+              {{state}}
+              <Hds::Badge @icon="org" @text="Private" @size="small" />
+            </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1221,10 +1343,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
-            {{state}}
-            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
-          </Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
+              {{state}}
+              <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+            </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1233,11 +1355,11 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12" @icon="hexagon">
-            {{state}}
-            with a longer text string that may wrap since max-width is defined on the container
-            <Hds::Badge @text="badge" @size="small" />
-          </Hds::Dropdown::ListItem::Radio>
+            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12" @icon="hexagon">
+              {{state}}
+              with a longer text string that may wrap since max-width is defined on the container
+              <Hds::Badge @text="badge" @size="small" />
+            </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -1,6 +1,6 @@
 {{!
-  Copyright (c) HashiCorp, Inc.
-  SPDX-License-Identifier: MPL-2.0
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
 }}
 
 {{page-title "Dropdown Component"}}
@@ -9,19 +9,33 @@
 
 <section data-test-percy>
 
+  <Shw::Text::H2>Font weight text</Shw::Text::H2>
+
+  <Shw::Grid @columns={{1}} as |SG|>
+    <SG.Item @label="Multiple list item types">
+      <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" as |D|>
+        <D.ToggleButton @color="secondary" @text="Menu" />
+        <D.Checkmark @selected={{true}}>Checkmark</D.Checkmark>
+        <D.Interactive @href="#">Interactive</D.Interactive>
+        <D.Radio name="status" @selected={{true}} @count="4">Radio</D.Radio>
+        <D.Checkbox @count="3">Checkbox</D.Checkbox>
+      </Hds::Dropdown>
+    </SG.Item>
+  </Shw::Grid>
+
   <Shw::Text::H2>Position</Shw::Text::H2>
 
   <Shw::Grid @columns={{2}} as |SG|>
     {{#each @model.POSITIONS as |position|}}
-      <SG.Item @label={{capitalize position}}>
-        <Shw::Outliner {{style padding="6em 12em"}}>
-          <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
-            <D.ToggleButton @color="secondary" @text="Menu" />
-            <D.Interactive @href="#">Create</D.Interactive>
-            <D.Interactive @href="#">Edit</D.Interactive>
-          </Hds::Dropdown>
-        </Shw::Outliner>
-      </SG.Item>
+    <SG.Item @label={{capitalize position}}>
+      <Shw::Outliner {{style padding="6em 12em" }}>
+        <Hds::Dropdown @isOpen={{true}} @listPosition={{position}} as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Interactive @href="#">Create</D.Interactive>
+          <D.Interactive @href="#">Edit</D.Interactive>
+        </Hds::Dropdown>
+      </Shw::Outliner>
+    </SG.Item>
     {{/each}}
   </Shw::Grid>
 
@@ -31,76 +45,64 @@
 
   <Shw::Grid @columns={{4}} @gap="2rem" as |SG|>
     {{#let (array false true) as |options|}}
-      {{#each options as |option|}}
-        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
-          <SGI.Label><code>ToggleButton</code> auto</SGI.Label>
-          <div class="shw-component-dropdown-fixed-height-container">
-            <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @matchToggleWidth={{option}} as |D|>
-              <D.ToggleButton @color="secondary" @text="Menu" />
-              <D.Interactive @href="#">
-                Lorem ipsum dolor sit amet
-              </D.Interactive>
-              <D.Interactive @href="#">
-                Consectetur adipisicing elit
-              </D.Interactive>
-            </Hds::Dropdown>
-          </div>
-        </SG.Item>
-        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
-          <SGI.Label><code>ToggleButton</code> 100%</SGI.Label>
-          <div class="shw-component-dropdown-fixed-height-container">
-            <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @matchToggleWidth={{option}} as |D|>
-              <D.ToggleButton {{style width="100%"}} @color="secondary" @text="Menu" />
-              <D.Interactive @href="#">
-                Lorem ipsum dolor sit amet
-              </D.Interactive>
-              <D.Interactive @href="#">
-                Consectetur adipisicing elit
-              </D.Interactive>
-            </Hds::Dropdown>
-          </div>
-        </SG.Item>
-        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
-          <SGI.Label><code>ToggleButton</code> auto + <code>@width="200px"</code></SGI.Label>
-          <div class="shw-component-dropdown-fixed-height-container">
-            <Hds::Dropdown
-              @isOpen={{true}}
-              @listPosition="bottom-left"
-              @width="200px"
-              @matchToggleWidth={{option}}
-              as |D|
-            >
-              <D.ToggleButton @color="secondary" @text="Menu" />
-              <D.Interactive @href="#">
-                Lorem ipsum dolor sit amet
-              </D.Interactive>
-              <D.Interactive @href="#">
-                Consectetur adipisicing elit
-              </D.Interactive>
-            </Hds::Dropdown>
-          </div>
-        </SG.Item>
-        <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
-          <SGI.Label><code>ToggleButton</code> auto + <code>@width="100%"</code></SGI.Label>
-          <div class="shw-component-dropdown-fixed-height-container">
-            <Hds::Dropdown
-              @isOpen={{true}}
-              @listPosition="bottom-left"
-              @width="100%"
-              @matchToggleWidth={{option}}
-              as |D|
-            >
-              <D.ToggleButton @color="secondary" @text="Menu" />
-              <D.Interactive @href="#">
-                Lorem ipsum dolor sit amet
-              </D.Interactive>
-              <D.Interactive @href="#">
-                Consectetur adipisicing elit
-              </D.Interactive>
-            </Hds::Dropdown>
-          </div>
-        </SG.Item>
-      {{/each}}
+    {{#each options as |option|}}
+    <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+      <SGI.Label><code>ToggleButton</code> auto</SGI.Label>
+      <div class="shw-component-dropdown-fixed-height-container">
+        <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @matchToggleWidth={{option}} as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Interactive @href="#">
+            Lorem ipsum dolor sit amet
+          </D.Interactive>
+          <D.Interactive @href="#">
+            Consectetur adipisicing elit
+          </D.Interactive>
+        </Hds::Dropdown>
+      </div>
+    </SG.Item>
+    <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+      <SGI.Label><code>ToggleButton</code> 100%</SGI.Label>
+      <div class="shw-component-dropdown-fixed-height-container">
+        <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @matchToggleWidth={{option}} as |D|>
+          <D.ToggleButton {{style width="100%" }} @color="secondary" @text="Menu" />
+          <D.Interactive @href="#">
+            Lorem ipsum dolor sit amet
+          </D.Interactive>
+          <D.Interactive @href="#">
+            Consectetur adipisicing elit
+          </D.Interactive>
+        </Hds::Dropdown>
+      </div>
+    </SG.Item>
+    <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+      <SGI.Label><code>ToggleButton</code> auto + <code>@width="200px"</code></SGI.Label>
+      <div class="shw-component-dropdown-fixed-height-container">
+        <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @width="200px" @matchToggleWidth={{option}} as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Interactive @href="#">
+            Lorem ipsum dolor sit amet
+          </D.Interactive>
+          <D.Interactive @href="#">
+            Consectetur adipisicing elit
+          </D.Interactive>
+        </Hds::Dropdown>
+      </div>
+    </SG.Item>
+    <SG.Item @label="matchToggleWidth={{option}}" as |SGI|>
+      <SGI.Label><code>ToggleButton</code> auto + <code>@width="100%"</code></SGI.Label>
+      <div class="shw-component-dropdown-fixed-height-container">
+        <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" @width="100%" @matchToggleWidth={{option}} as |D|>
+          <D.ToggleButton @color="secondary" @text="Menu" />
+          <D.Interactive @href="#">
+            Lorem ipsum dolor sit amet
+          </D.Interactive>
+          <D.Interactive @href="#">
+            Consectetur adipisicing elit
+          </D.Interactive>
+        </Hds::Dropdown>
+      </div>
+    </SG.Item>
+    {{/each}}
     {{/let}}
   </Shw::Grid>
 
@@ -145,19 +147,19 @@
 
   <Shw::Grid @columns={{3}} @gap="2rem" as |SF|>
     {{#let (array false true) as |detections|}}
-      {{#each detections as |detection|}}
-        <SF.Item @forceMinWidth={{true}} @label={{concat "enableCollisionDetection=" detection}}>
-          <Shw::Autoscrollable @verticalShift={{30}}>
-            <div class="shw-component-dropdown-collision-detection-wrapper">
-              <Hds::Dropdown @isOpen={{true}} @enableCollisionDetection={{detection}} as |D|>
-                <D.ToggleButton @color="secondary" @text="Menu" />
-                <D.Interactive @href="#">Create</D.Interactive>
-                <D.Interactive @href="#">Edit</D.Interactive>
-              </Hds::Dropdown>
-            </div>
-          </Shw::Autoscrollable>
-        </SF.Item>
-      {{/each}}
+    {{#each detections as |detection|}}
+    <SF.Item @forceMinWidth={{true}} @label={{concat "enableCollisionDetection=" detection}}>
+      <Shw::Autoscrollable @verticalShift={{30}}>
+        <div class="shw-component-dropdown-collision-detection-wrapper">
+          <Hds::Dropdown @isOpen={{true}} @enableCollisionDetection={{detection}} as |D|>
+            <D.ToggleButton @color="secondary" @text="Menu" />
+            <D.Interactive @href="#">Create</D.Interactive>
+            <D.Interactive @href="#">Edit</D.Interactive>
+          </Hds::Dropdown>
+        </div>
+      </Shw::Autoscrollable>
+    </SF.Item>
+    {{/each}}
     {{/let}}
     <SF.Item />
   </Shw::Grid>
@@ -174,7 +176,7 @@
       <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" />
     </SF.Item>
     <SF.Item @label="Primary full width">
-      <Shw::Outliner {{style width="300px"}}>
+      <Shw::Outliner {{style width="300px" }}>
         <Hds::Dropdown::Toggle::Button @isFullWidth={{true}} @text="Lorem ipsum" />
       </Shw::Outliner>
     </SF.Item>
@@ -188,7 +190,7 @@
       <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" />
     </SF.Item>
     <SF.Item @label="Secondary full width">
-      <Shw::Outliner {{style width="300px"}}>
+      <Shw::Outliner {{style width="300px" }}>
         <Hds::Dropdown::Toggle::Button @color="secondary" @isFullWidth={{true}} @text="Lorem ipsum" />
       </Shw::Outliner>
     </SF.Item>
@@ -204,7 +206,7 @@
       <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem ipsum" />
     </SF.Item>
     <SF.Item @label="Primary full width">
-      <Shw::Outliner {{style width="300px"}}>
+      <Shw::Outliner {{style width="300px" }}>
         <Hds::Dropdown::Toggle::Button @icon="hexagon" @isFullWidth={{true}} @text="Lorem ipsum" />
       </Shw::Outliner>
     </SF.Item>
@@ -217,7 +219,7 @@
       <Hds::Dropdown::Toggle::Button @color="secondary" @icon="hexagon" @text="Lorem ipsum" />
     </SF.Item>
     <SF.Item @label="Secondary full width">
-      <Shw::Outliner {{style width="300px"}}>
+      <Shw::Outliner {{style width="300px" }}>
         <Hds::Dropdown::Toggle::Button @color="secondary" @icon="hexagon" @isFullWidth={{true}} @text="Lorem ipsum" />
       </Shw::Outliner>
     </SF.Item>
@@ -233,7 +235,7 @@
       <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @count="12" />
     </SF.Item>
     <SF.Item @label="Primary full width">
-      <Shw::Outliner {{style width="300px"}}>
+      <Shw::Outliner {{style width="300px" }}>
         <Hds::Dropdown::Toggle::Button @isFullWidth={{true}} @text="Lorem ipsum" @count="12" />
       </Shw::Outliner>
     </SF.Item>
@@ -246,7 +248,7 @@
       <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" @count="12" />
     </SF.Item>
     <SF.Item @label="Secondary full width">
-      <Shw::Outliner {{style width="300px"}}>
+      <Shw::Outliner {{style width="300px" }}>
         <Hds::Dropdown::Toggle::Button @color="secondary" @isFullWidth={{true}} @text="Lorem ipsum" @count="12" />
       </Shw::Outliner>
     </SF.Item>
@@ -262,33 +264,21 @@
       <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
     </SF.Item>
     <SF.Item @label="Primary full width">
-      <Shw::Outliner {{style width="300px"}}>
+      <Shw::Outliner {{style width="300px" }}>
         <Hds::Dropdown::Toggle::Button @isFullWidth={{true}} @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
       </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>
   <Shw::Flex as |SF|>
     <SF.Item @label="Secondary small">
-      <Hds::Dropdown::Toggle::Button
-        @color="secondary"
-        @text="Lorem ipsum"
-        @badge="Badge"
-        @badgeIcon="hexagon"
-        @size="small"
-      />
+      <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" @size="small" />
     </SF.Item>
     <SF.Item @label="Secondary medium">
       <Hds::Dropdown::Toggle::Button @color="secondary" @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
     </SF.Item>
     <SF.Item @label="Secondary full width">
-      <Shw::Outliner {{style width="300px"}}>
-        <Hds::Dropdown::Toggle::Button
-          @color="secondary"
-          @isFullWidth={{true}}
-          @text="Lorem ipsum"
-          @badge="Badge"
-          @badgeIcon="hexagon"
-        />
+      <Shw::Outliner {{style width="300px" }}>
+        <Hds::Dropdown::Toggle::Button @color="secondary" @isFullWidth={{true}} @text="Lorem ipsum" @badge="Badge" @badgeIcon="hexagon" />
       </Shw::Outliner>
     </SF.Item>
   </Shw::Flex>
@@ -336,109 +326,87 @@
     {{! Notice: we use a non-standard way to showcase the states to reduce the (visual) complexity of this matrix }}
 
     {{#each @model.TOGGLE_STATES as |state|}}
-      <SG.Item>
-        <span class="shw-label">{{capitalize state}}</span>
-      </SG.Item>
+    <SG.Item>
+      <span class="shw-label">{{capitalize state}}</span>
+    </SG.Item>
     {{/each}}
     <SG.Item>
       <span class="shw-label">Open</span>
     </SG.Item>
 
     {{#each @model.TOGGLE_BUTTON_COLORS as |color|}}
-      {{#each @model.TOGGLE_STATES as |state|}}
-        <SG.Item @label="{{capitalize color}}">
-          {{#if (eq state "disabled")}}
-            <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} disabled />
-          {{else}}
-            <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} mock-state-value={{state}} />
-          {{/if}}
-        </SG.Item>
-      {{/each}}
-      <SG.Item @label="{{capitalize color}}">
-        <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @isOpen={{true}} @color={{color}} />
-      </SG.Item>
-      {{#each @model.TOGGLE_STATES as |state|}}
-        <SG.Item @label="With icon">
-          {{#if (eq state "disabled")}}
-            <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} disabled />
-          {{else}}
-            <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} mock-state-value={{state}} />
-          {{/if}}
-        </SG.Item>
-      {{/each}}
-      <SG.Item @label="With icon">
-        <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @isOpen={{true}} @color={{color}} />
-      </SG.Item>
-      {{#each @model.TOGGLE_STATES as |state|}}
-        <SG.Item @label="With count">
-          {{#if (eq state "disabled")}}
-            <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} disabled />
-          {{else}}
-            <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} mock-state-value={{state}} />
-          {{/if}}
-        </SG.Item>
-      {{/each}}
-      <SG.Item @label="With count">
-        <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @isOpen={{true}} @color={{color}} />
-      </SG.Item>
-      {{#each @model.TOGGLE_STATES as |state|}}
-        <SG.Item @label="With badge">
-          {{#if (eq state "disabled")}}
-            <Hds::Dropdown::Toggle::Button @badge="Sit" @badgeIcon="hexagon" @text="Lorem" @color={{color}} disabled />
-          {{else}}
-            <Hds::Dropdown::Toggle::Button
-              @badge="Sit"
-              @badgeIcon="hexagon"
-              @text="Lorem"
-              @color={{color}}
-              mock-state-value={{state}}
-            />
-          {{/if}}
-        </SG.Item>
-      {{/each}}
-      <SG.Item @label="With badge">
-        <Hds::Dropdown::Toggle::Button
-          @badge="Sit"
-          @badgeIcon="hexagon"
-          @text="Lorem"
-          @isOpen={{true}}
-          @color={{color}}
-        />
-      </SG.Item>
+    {{#each @model.TOGGLE_STATES as |state|}}
+    <SG.Item @label="{{capitalize color}}">
+      {{#if (eq state "disabled")}}
+      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} disabled />
+      {{else}}
+      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @color={{color}} mock-state-value={{state}} />
+      {{/if}}
+    </SG.Item>
+    {{/each}}
+    <SG.Item @label="{{capitalize color}}">
+      <Hds::Dropdown::Toggle::Button @text="Lorem ipsum" @isOpen={{true}} @color={{color}} />
+    </SG.Item>
+    {{#each @model.TOGGLE_STATES as |state|}}
+    <SG.Item @label="With icon">
+      {{#if (eq state "disabled")}}
+      <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} disabled />
+      {{else}}
+      <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+      {{/if}}
+    </SG.Item>
+    {{/each}}
+    <SG.Item @label="With icon">
+      <Hds::Dropdown::Toggle::Button @icon="hexagon" @text="Lorem" @isOpen={{true}} @color={{color}} />
+    </SG.Item>
+    {{#each @model.TOGGLE_STATES as |state|}}
+    <SG.Item @label="With count">
+      {{#if (eq state "disabled")}}
+      <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} disabled />
+      {{else}}
+      <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+      {{/if}}
+    </SG.Item>
+    {{/each}}
+    <SG.Item @label="With count">
+      <Hds::Dropdown::Toggle::Button @count="12" @text="Lorem" @isOpen={{true}} @color={{color}} />
+    </SG.Item>
+    {{#each @model.TOGGLE_STATES as |state|}}
+    <SG.Item @label="With badge">
+      {{#if (eq state "disabled")}}
+      <Hds::Dropdown::Toggle::Button @badge="Sit" @badgeIcon="hexagon" @text="Lorem" @color={{color}} disabled />
+      {{else}}
+      <Hds::Dropdown::Toggle::Button @badge="Sit" @badgeIcon="hexagon" @text="Lorem" @color={{color}} mock-state-value={{state}} />
+      {{/if}}
+    </SG.Item>
+    {{/each}}
+    <SG.Item @label="With badge">
+      <Hds::Dropdown::Toggle::Button @badge="Sit" @badgeIcon="hexagon" @text="Lorem" @isOpen={{true}} @color={{color}} />
+    </SG.Item>
     {{/each}}
 
     {{#each @model.TOGGLE_STATES as |state|}}
-      <SG.Item @label="Icon">
-        <Hds::Dropdown::Toggle::Icon
-          @icon="more-horizontal"
-          @text="overflow menu"
-          @hasChevron={{false}}
-          mock-state-value={{state}}
-        />
-      </SG.Item>
+    <SG.Item @label="Icon">
+      <Hds::Dropdown::Toggle::Icon @icon="more-horizontal" @text="overflow menu" @hasChevron={{false}} mock-state-value={{state}} />
+    </SG.Item>
     {{/each}}
     <SG.Item @label="Icon">
-      <Hds::Dropdown::Toggle::Icon
-        @icon="more-horizontal"
-        @text="overflow menu"
-        @hasChevron={{false}}
-        @isOpen={{true}}
-      />
+      <Hds::Dropdown::Toggle::Icon @icon="more-horizontal" @text="overflow menu" @hasChevron={{false}} @isOpen={{true}} />
     </SG.Item>
 
     {{#each @model.TOGGLE_STATES as |state|}}
-      <SG.Item @label="Icon+chevron">
-        <Hds::Dropdown::Toggle::Icon @icon="user" @text={{state}} mock-state-value={{state}} />
-      </SG.Item>
+    <SG.Item @label="Icon+chevron">
+      <Hds::Dropdown::Toggle::Icon @icon="user" @text={{state}} mock-state-value={{state}} />
+    </SG.Item>
     {{/each}}
     <SG.Item @label="Icon+chevron">
       <Hds::Dropdown::Toggle::Icon @icon="user" @text="open" @isOpen={{true}} />
     </SG.Item>
 
     {{#each @model.TOGGLE_STATES as |state|}}
-      <SG.Item @label="Avatar+chevron">
-        <Hds::Dropdown::Toggle::Icon @text={{state}} @imageSrc="/assets/images/avatar.png" mock-state-value={{state}} />
-      </SG.Item>
+    <SG.Item @label="Avatar+chevron">
+      <Hds::Dropdown::Toggle::Icon @text={{state}} @imageSrc="/assets/images/avatar.png" mock-state-value={{state}} />
+    </SG.Item>
     {{/each}}
     <SG.Item @label="Avatar+chevron">
       <Hds::Dropdown::Toggle::Icon @text="open" @isOpen={{true}} @imageSrc="/assets/images/avatar.png" />
@@ -465,17 +433,10 @@
     <SF.Item @label="Default (max width)">
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Title
-            @text="A longer title that could span multiple lines if the characters surpass a certain length"
-          />
-          <Hds::Dropdown::ListItem::Description
-            @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
-          />
+          <Hds::Dropdown::ListItem::Title @text="A longer title that could span multiple lines if the characters surpass a certain length" />
+          <Hds::Dropdown::ListItem::Description @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default." />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive
-            @route="index"
-            @text="A longer item that could span multiple lines if the characters surpass a certain length"
-          />
+          <Hds::Dropdown::ListItem::Interactive @route="index" @text="A longer item that could span multiple lines if the characters surpass a certain length" />
         </ul>
       </div>
     </SF.Item>
@@ -483,17 +444,10 @@
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::Title
-            @text="A longer title that could span multiple lines if the characters surpass a certain length"
-          />
-          <Hds::Dropdown::ListItem::Description
-            @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default."
-          />
+          <Hds::Dropdown::ListItem::Title @text="A longer title that could span multiple lines if the characters surpass a certain length" />
+          <Hds::Dropdown::ListItem::Description @text="A longer description that could span on multiple lines if the number of characters require more width than the dropdown provides by default." />
           <Hds::Dropdown::ListItem::Separator />
-          <Hds::Dropdown::ListItem::Interactive
-            @route="index"
-            @text="A longer item that could span multiple lines if the characters surpass a certain length"
-          />
+          <Hds::Dropdown::ListItem::Interactive @route="index" @text="A longer item that could span multiple lines if the characters surpass a certain length" />
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}
@@ -521,7 +475,8 @@
       <SFI.Label>With
         <code>@href</code>
         ⇒
-        <code>&lt;a&gt;</code></SFI.Label>
+        <code>&lt;a&gt;</code>
+      </SFI.Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           <Hds::Dropdown::ListItem::Interactive @href="/">
@@ -536,7 +491,8 @@
         ⇒
         <code>&lt;LinkTo&gt;</code>
         ⇒
-        <code>&lt;a&gt;</code></SFI.Label>
+        <code>&lt;a&gt;</code>
+      </SFI.Label>
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           <Hds::Dropdown::ListItem::Interactive @route="components.dropdown">
@@ -672,80 +628,63 @@
   <Shw::Text::H4>States (in each color)</Shw::Text::H4>
 
   {{#each @model.ITEM_INTERACTIVE_COLORS as |color|}}
-    <Shw::Flex @direction="column" as |SF|>
-      <SF.Item @label={{capitalize color}}>
-        <Shw::Flex as |SF|>
-          <SF.Item>
-            <div class="hds-dropdown__content">
-              <ul class="hds-dropdown__list">
-                {{#each @model.ITEM_STATES as |state|}}
-                  <Hds::Dropdown::ListItem::Interactive @color={{color}} mock-state-value={{state}}>
-                    {{state}}
-                  </Hds::Dropdown::ListItem::Interactive>
-                {{/each}}
-                <Hds::Dropdown::ListItem::Separator />
-                <Hds::Dropdown::ListItem::Interactive @color={{color}} @isLoading={{true}}>
-                  Loading
-                </Hds::Dropdown::ListItem::Interactive>
-                <Hds::Dropdown::ListItem::Interactive @color={{color}} @isLoading={{true}} as |I|>
-                  Loading
-                  <I.Badge @text="With Badge" />
-                </Hds::Dropdown::ListItem::Interactive>
-              </ul>
-            </div>
-          </SF.Item>
-          <SF.Item>
-            <div class="hds-dropdown__content">
-              <ul class="hds-dropdown__list">
-                {{#each @model.ITEM_STATES as |state|}}
-                  <Hds::Dropdown::ListItem::Interactive
-                    @icon={{if (eq color "critical") "trash" "settings"}}
-                    @color={{color}}
-                    mock-state-value={{state}}
-                  >
-                    {{state}}
-                    with icon
-                  </Hds::Dropdown::ListItem::Interactive>
-                {{/each}}
-                <Hds::Dropdown::ListItem::Separator />
-                <Hds::Dropdown::ListItem::Interactive
-                  @icon={{if (eq color "critical") "trash" "settings"}}
-                  @color={{color}}
-                  @isLoading={{true}}
-                >
-                  loading with icon
-                </Hds::Dropdown::ListItem::Interactive>
-                <Hds::Dropdown::ListItem::Interactive
-                  @icon={{if (eq color "critical") "trash" "settings"}}
-                  @color={{color}}
-                  @isLoading={{true}}
-                  as |I|
-                >
-                  Loading
-                  <I.Badge @text="With Badge" />
-                </Hds::Dropdown::ListItem::Interactive>
-              </ul>
-            </div>
-          </SF.Item>
-          <SF.Item>
-            <div class="hds-dropdown__content">
-              <ul class="hds-dropdown__list">
-                {{#each @model.ITEM_STATES as |state|}}
-                  <Hds::Dropdown::ListItem::Interactive
-                    @icon={{if (eq color "critical") "trash" "settings"}}
-                    @color={{color}}
-                    mock-state-value={{state}}
-                  >
-                    {{state}}
-                    with a longer text string that may wrap since max-width is defined on the container
-                  </Hds::Dropdown::ListItem::Interactive>
-                {{/each}}
-              </ul>
-            </div>
-          </SF.Item>
-        </Shw::Flex>
-      </SF.Item>
-    </Shw::Flex>
+  <Shw::Flex @direction="column" as |SF|>
+    <SF.Item @label={{capitalize color}}>
+      <Shw::Flex as |SF|>
+        <SF.Item>
+          <div class="hds-dropdown__content">
+            <ul class="hds-dropdown__list">
+              {{#each @model.ITEM_STATES as |state|}}
+              <Hds::Dropdown::ListItem::Interactive @color={{color}} mock-state-value={{state}}>
+                {{state}}
+              </Hds::Dropdown::ListItem::Interactive>
+              {{/each}}
+              <Hds::Dropdown::ListItem::Separator />
+              <Hds::Dropdown::ListItem::Interactive @color={{color}} @isLoading={{true}}>
+                Loading
+              </Hds::Dropdown::ListItem::Interactive>
+              <Hds::Dropdown::ListItem::Interactive @color={{color}} @isLoading={{true}} as |I|>
+                Loading
+                <I.Badge @text="With Badge" />
+              </Hds::Dropdown::ListItem::Interactive>
+            </ul>
+          </div>
+        </SF.Item>
+        <SF.Item>
+          <div class="hds-dropdown__content">
+            <ul class="hds-dropdown__list">
+              {{#each @model.ITEM_STATES as |state|}}
+              <Hds::Dropdown::ListItem::Interactive @icon={{if (eq color "critical" ) "trash" "settings" }} @color={{color}} mock-state-value={{state}}>
+                {{state}}
+                with icon
+              </Hds::Dropdown::ListItem::Interactive>
+              {{/each}}
+              <Hds::Dropdown::ListItem::Separator />
+              <Hds::Dropdown::ListItem::Interactive @icon={{if (eq color "critical" ) "trash" "settings" }} @color={{color}} @isLoading={{true}}>
+                loading with icon
+              </Hds::Dropdown::ListItem::Interactive>
+              <Hds::Dropdown::ListItem::Interactive @icon={{if (eq color "critical" ) "trash" "settings" }} @color={{color}} @isLoading={{true}} as |I|>
+                Loading
+                <I.Badge @text="With Badge" />
+              </Hds::Dropdown::ListItem::Interactive>
+            </ul>
+          </div>
+        </SF.Item>
+        <SF.Item>
+          <div class="hds-dropdown__content">
+            <ul class="hds-dropdown__list">
+              {{#each @model.ITEM_STATES as |state|}}
+              <Hds::Dropdown::ListItem::Interactive @icon={{if (eq color "critical" ) "trash" "settings" }} @color={{color}} mock-state-value={{state}}>
+                {{state}}
+                with a longer text string that may wrap since max-width is defined on the container
+              </Hds::Dropdown::ListItem::Interactive>
+              {{/each}}
+            </ul>
+          </div>
+        </SF.Item>
+      </Shw::Flex>
+    </SF.Item>
+  </Shw::Flex>
   {{/each}}
 
   <Shw::Divider @level={{2}} />
@@ -794,11 +733,7 @@
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::CopyItem
-            @copyItemTitle="Lorem ipsum dolor"
-            @text="91ee1e8ef65b337f0e70d793f456c71d"
-            @isTruncated={{false}}
-          />
+          <Hds::Dropdown::ListItem::CopyItem @copyItemTitle="Lorem ipsum dolor" @text="91ee1e8ef65b337f0e70d793f456c71d" @isTruncated={{false}} />
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}
@@ -820,10 +755,7 @@
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::CopyItem
-            @copyItemTitle="Lorem ipsum dolor"
-            @text="91ee1e8ef65b337f0e70d793f456c71d"
-          />
+          <Hds::Dropdown::ListItem::CopyItem @copyItemTitle="Lorem ipsum dolor" @text="91ee1e8ef65b337f0e70d793f456c71d" />
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}
@@ -832,11 +764,7 @@
       {{! template-lint-disable no-inline-styles }}
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
-          <Hds::Dropdown::ListItem::CopyItem
-            @copyItemTitle="Lorem ipsum dolor"
-            @text="91ee1e8ef65b337f0e70d793f456c71d"
-            @isTruncated={{false}}
-          />
+          <Hds::Dropdown::ListItem::CopyItem @copyItemTitle="Lorem ipsum dolor" @text="91ee1e8ef65b337f0e70d793f456c71d" @isTruncated={{false}} />
         </ul>
       </div>
       {{! template-lint-enable no-inline-styles }}
@@ -852,11 +780,7 @@
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::CopyItem
-              @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r"
-              mock-state-value={{state}}
-              mock-state-selector="button"
-            />
+          <Hds::Dropdown::ListItem::CopyItem @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r" mock-state-value={{state}} mock-state-selector="button" />
           {{/each}}
         </ul>
       </div>
@@ -868,12 +792,7 @@
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::CopyItem
-              @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r"
-              @copyItemTitle="Lorem ipsumy dolor"
-              mock-state-value={{state}}
-              mock-state-selector="button"
-            />
+          <Hds::Dropdown::ListItem::CopyItem @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r" @copyItemTitle="Lorem ipsumy dolor" mock-state-value={{state}} mock-state-selector="button" />
           {{/each}}
         </ul>
       </div>
@@ -885,13 +804,7 @@
       <div class="hds-dropdown__content" style="width: 250px">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::CopyItem
-              @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r"
-              @copyItemTitle="Lorem ipsumy dolor"
-              @isTruncated={{false}}
-              mock-state-value={{state}}
-              mock-state-selector="button"
-            />
+          <Hds::Dropdown::ListItem::CopyItem @text="{{state}}: fbrct1ed-fgr35h-tyng89-wed4r" @copyItemTitle="Lorem ipsumy dolor" @isTruncated={{false}} mock-state-value={{state}} mock-state-selector="button" />
           {{/each}}
         </ul>
       </div>
@@ -908,9 +821,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Default">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
-              {{state}}
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value="disabled" disabled>
             disabled
@@ -922,9 +835,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Selected">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
-              {{state}}
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkmark mock-state-value="disabled" @selected={{true}} disabled>
             disabled
@@ -936,9 +849,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Icon">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}}>
-              {{state}}
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value="disabled" disabled>
             disabled
@@ -950,9 +863,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Icon, selected">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}} @selected={{true}}>
-              {{state}}
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value={{state}} @selected={{true}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkmark @icon="hexagon" mock-state-value="disabled" @selected={{true}} disabled>
             disabled
@@ -964,9 +877,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Count">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
-              {{state}}
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -975,9 +888,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Count, selected">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
-              {{state}}
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -986,9 +899,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Custom content">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
-              <Shw::Placeholder @text="custom content" @width="128" @height="20" />
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @count="12">
+            <Shw::Placeholder @text="custom content" @width="128" @height="20" />
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -997,9 +910,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Custom content, selected">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
-              <Shw::Placeholder @text="custom content" @width="128" @height="20" />
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}} @count="12">
+            <Shw::Placeholder @text="custom content" @width="128" @height="20" />
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -1008,10 +921,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Badge in content">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
-              {{state}}
-              <Hds::Badge @icon="org" @text="Private" @size="small" />
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}}>
+            {{state}}
+            <Hds::Badge @icon="org" @text="Private" @size="small" />
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -1020,10 +933,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Badge in content, selected">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
-              {{state}}
-              <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @selected={{true}}>
+            {{state}}
+            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -1032,16 +945,11 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list" role="listbox" aria-label="Large content">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkmark
-              mock-state-value={{state}}
-              @icon="hexagon"
-              @selected={{true}}
-              @count="12"
-            >
-              {{state}}
-              with a longer text string that may wrap since max-width is defined on the container
-              <Hds::Badge @text="badge" @size="small" />
-            </Hds::Dropdown::ListItem::Checkmark>
+          <Hds::Dropdown::ListItem::Checkmark mock-state-value={{state}} @icon="hexagon" @selected={{true}} @count="12">
+            {{state}}
+            with a longer text string that may wrap since max-width is defined on the container
+            <Hds::Badge @text="badge" @size="small" />
+          </Hds::Dropdown::ListItem::Checkmark>
           {{/each}}
         </ul>
       </div>
@@ -1068,9 +976,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
-              {{state}}
-            </Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" disabled>
             disabled
@@ -1082,9 +990,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
-              {{state}}
-            </Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" disabled checked>
             disabled
@@ -1096,9 +1004,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon">
-              {{state}}
-            </Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon">
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" @icon="hexagon" disabled>
             disabled
@@ -1110,9 +1018,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon" checked>
-              {{state}}
-            </Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @icon="hexagon" checked>
+            {{state}}
+          </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
           <Hds::Dropdown::ListItem::Checkbox mock-state-value="disabled" @icon="hexagon" disabled checked>
             disabled
@@ -1124,10 +1032,7 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox
-              mock-state-value={{state}}
-              @count="12"
-            >{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">{{state}}</Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1136,11 +1041,7 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox
-              mock-state-value={{state}}
-              checked
-              @count="12"
-            >{{state}}</Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">{{state}}</Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1149,9 +1050,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">
-              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
-            </Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12">
+            <Shw::Placeholder @text="custom content" @width="122" @height="20" />
+          </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1160,9 +1061,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">
-              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
-            </Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked @count="12">
+            <Shw::Placeholder @text="custom content" @width="122" @height="20" />
+          </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1171,10 +1072,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
-              {{state}}
-              <Hds::Badge @icon="org" @text="Private" @size="small" />
-            </Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}}>
+            {{state}}
+            <Hds::Badge @icon="org" @text="Private" @size="small" />
+          </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1183,10 +1084,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
-              {{state}}
-              <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
-            </Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} checked>
+            {{state}}
+            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+          </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1195,11 +1096,11 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12" @icon="hexagon">
-              {{state}}
-              with a longer text string that may wrap since max-width is defined on the container
-              <Hds::Badge @text="badge" @size="small" />
-            </Hds::Dropdown::ListItem::Checkbox>
+          <Hds::Dropdown::ListItem::Checkbox mock-state-value={{state}} @count="12" @icon="hexagon">
+            {{state}}
+            with a longer text string that may wrap since max-width is defined on the container
+            <Hds::Badge @text="badge" @size="small" />
+          </Hds::Dropdown::ListItem::Checkbox>
           {{/each}}
         </ul>
       </div>
@@ -1226,9 +1127,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
-              {{state}}
-            </Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
+            {{state}}
+          </Hds::Dropdown::ListItem::Radio>
           {{/each}}
           <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" disabled>
             disabled
@@ -1240,9 +1141,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
-              {{state}}
-            </Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
+            {{state}}
+          </Hds::Dropdown::ListItem::Radio>
           {{/each}}
           <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" checked disabled>
             disabled
@@ -1254,9 +1155,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @icon="hexagon">
-              {{state}}
-            </Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @icon="hexagon">
+            {{state}}
+          </Hds::Dropdown::ListItem::Radio>
           {{/each}}
           <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" @icon="hexagon" disabled>
             disabled
@@ -1268,9 +1169,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @icon="hexagon">
-              {{state}}
-            </Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @icon="hexagon">
+            {{state}}
+          </Hds::Dropdown::ListItem::Radio>
           {{/each}}
           <Hds::Dropdown::ListItem::Radio mock-state-value="disabled" @icon="hexagon" checked disabled>
             disabled
@@ -1282,10 +1183,7 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio
-              mock-state-value={{state}}
-              @count="12"
-            >{{state}}</Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">{{state}}</Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1294,11 +1192,7 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio
-              mock-state-value={{state}}
-              checked
-              @count="12"
-            >{{state}}</Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">{{state}}</Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1307,9 +1201,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">
-              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
-            </Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12">
+            <Shw::Placeholder @text="custom content" @width="122" @height="20" />
+          </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1318,9 +1212,9 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">
-              <Shw::Placeholder @text="custom content" @width="122" @height="20" />
-            </Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked @count="12">
+            <Shw::Placeholder @text="custom content" @width="122" @height="20" />
+          </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1329,10 +1223,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
-              {{state}}
-              <Hds::Badge @icon="org" @text="Private" @size="small" />
-            </Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}}>
+            {{state}}
+            <Hds::Badge @icon="org" @text="Private" @size="small" />
+          </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1341,10 +1235,10 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
-              {{state}}
-              <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
-            </Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} checked>
+            {{state}}
+            <Hds::Badge @icon="globe" @text="Public" @size="small" @color="highlight" />
+          </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>
@@ -1353,11 +1247,11 @@
       <div class="hds-dropdown__content">
         <ul class="hds-dropdown__list">
           {{#each @model.ITEM_STATES as |state|}}
-            <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12" @icon="hexagon">
-              {{state}}
-              with a longer text string that may wrap since max-width is defined on the container
-              <Hds::Badge @text="badge" @size="small" />
-            </Hds::Dropdown::ListItem::Radio>
+          <Hds::Dropdown::ListItem::Radio mock-state-value={{state}} @count="12" @icon="hexagon">
+            {{state}}
+            with a longer text string that may wrap since max-width is defined on the container
+            <Hds::Badge @text="badge" @size="small" />
+          </Hds::Dropdown::ListItem::Radio>
           {{/each}}
         </ul>
       </div>

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -9,20 +9,6 @@ SPDX-License-Identifier: MPL-2.0
 
 <section data-test-percy>
 
-  <Shw::Text::H2>Font weight text</Shw::Text::H2>
-
-  <Shw::Grid @columns={{1}} as |SG|>
-    <SG.Item @label="Multiple list item types">
-      <Hds::Dropdown @isOpen={{true}} @listPosition="bottom-left" as |D|>
-        <D.ToggleButton @color="secondary" @text="Menu" />
-        <D.Checkmark @selected={{true}}>Checkmark</D.Checkmark>
-        <D.Interactive @href="#">Interactive</D.Interactive>
-        <D.Radio name="status" @selected={{true}} @count="4">Radio</D.Radio>
-        <D.Checkbox @count="3">Checkbox</D.Checkbox>
-      </Hds::Dropdown>
-    </SG.Item>
-  </Shw::Grid>
-
   <Shw::Text::H2>Position</Shw::Text::H2>
 
   <Shw::Grid @columns={{2}} as |SG|>

--- a/showcase/app/templates/components/dropdown.hbs
+++ b/showcase/app/templates/components/dropdown.hbs
@@ -1,6 +1,6 @@
 {{!
-Copyright (c) HashiCorp, Inc.
-SPDX-License-Identifier: MPL-2.0
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
 }}
 
 {{page-title "Dropdown Component"}}


### PR DESCRIPTION
### :pushpin: Summary

In testing some ways to extend the `Dropdown` to support `Advanced Table` features it was discovered that the checkbox and radio list items used a different font weight from the rest of the list items.

This PR:
- Updates the text to use `Hds::Text::Body` similarly to the other list item components
- Changes the font weight to `medium`
- Updates the `count` to use `Hds::Text::Body` in radio and checkbox to match the implementation in the checkmark.

### :camera_flash: Screenshots

#### Checkbox

Before:
<img width="224" alt="Screenshot 2025-05-05 at 1 15 55 PM" src="https://github.com/user-attachments/assets/ed24d063-8cd2-4c86-b918-7faba3c197c2" />

After:
<img width="223" alt="Screenshot 2025-05-05 at 1 34 50 PM" src="https://github.com/user-attachments/assets/18647925-d4fc-4b6c-8295-2901f66f6a5f" />

#### Radio

Before:
<img width="218" alt="Screenshot 2025-05-05 at 1 16 32 PM" src="https://github.com/user-attachments/assets/5e1f84cd-c7a4-42c9-a2df-25d7663f563b" />

After:
<img width="218" alt="Screenshot 2025-05-05 at 1 16 53 PM" src="https://github.com/user-attachments/assets/6dc8a67c-afa0-4c5a-96c9-b87fdc9833ed" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4837](https://hashicorp.atlassian.net/browse/HDS-4837)
Figma file: [Branch](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/branch/ciSw2lT4m6PVMYN3EVJ9L0/HDS-Components-v2.0?m=auto&node-id=67385-76599&t=jBxzoHX9R2GYllZe-1)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4837]: https://hashicorp.atlassian.net/browse/HDS-4837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ