### PR TITLE
CodeBlock - Fix line wrapping and highlighting rendering

### DIFF
--- a/.changeset/selfish-apes-breathe.md
+++ b/.changeset/selfish-apes-breathe.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`CodeBlock` - Fixed issues with line numbers when line wrapping is present and when the number of lines changes dynamically. Also fixed line highlighting when Code Block is hidden from view initially such as when used inside a Tabs component.
+`CodeBlock` - Fixed issues with line numbers when line wrapping is present and when the number of lines changes dynamically; line highlighting when the Code Block is hidden from view initially such as when used inside a Tabs component; and line highlighting when hasLineNumbers is false.

--- a/.changeset/selfish-apes-breathe.md
+++ b/.changeset/selfish-apes-breathe.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`CodeBlock` - Fixed issues with line numbers when line wrapping is present, and line highlighting when hidden from view initially such as inside a tabs component

--- a/.changeset/selfish-apes-breathe.md
+++ b/.changeset/selfish-apes-breathe.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`CodeBlock` - Fixed issues with line numbers when line wrapping is present, and line highlighting when hidden from view initially such as inside a tabs component
+`CodeBlock` - Fixed issues with line numbers when line wrapping is present and when the number of lines changes dynamically. Also fixed line highlighting when Code Block is hidden from view initially such as when used inside a Tabs component.

--- a/packages/components/src/components/hds/code-block/index.hbs
+++ b/packages/components/src/components/hds/code-block/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<div class={{this.classNames}} ...attributes {{this._setUpObserver}}>
+<div class={{this.classNames}} ...attributes {{this._setUpCodeObserver}}>
   <div class="hds-code-block__header">
     {{~yield (hash Title=(component "hds/code-block/title"))~}}
     {{~yield (hash Description=(component "hds/code-block/description"))~}}

--- a/packages/components/src/components/hds/code-block/index.hbs
+++ b/packages/components/src/components/hds/code-block/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<div class={{this.classNames}} ...attributes>
+<div class={{this.classNames}} ...attributes {{this._setUpObserver}}>
   <div class="hds-code-block__header">
     {{~yield (hash Title=(component "hds/code-block/title"))~}}
     {{~yield (hash Description=(component "hds/code-block/description"))~}}
@@ -17,7 +17,7 @@
       data-start={{@lineNumberStart}}
       id={{this._preCodeId}}
       tabindex="0"
-    ><code {{did-insert this.setPrismCode}} {{did-update this.setPrismCode this.code @language}}>
+    ><code {{this._setUpCodeBlockCode}}>
         {{~this._prismCode~}}
       </code></pre>
 

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -81,7 +81,9 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
 
   // If a code block is hidden from view, and made visible after load, the Prism code needs to be re-run
   private _setUpObserver = modifier((element: HTMLElement) => {
-    this._preCodeElement = element.querySelector('.hds-code-block__code') as HTMLPreElement;
+    this._preCodeElement = element.querySelector(
+      '.hds-code-block__code'
+    ) as HTMLPreElement;
     this._observer = new ResizeObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.contentBoxSize) {
@@ -98,6 +100,7 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   });
 
   private _setUpCodeBlockCode = modifier((element: HTMLElement) => {
+    this._isExpanded = false; // reset expanded state on updates
     this.setPrismCode(element);
     return () => {};
   });
@@ -169,6 +172,14 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
         } else {
           // eslint-disable-next-line @typescript-eslint/no-base-to-string
           this._prismCode = htmlSafe(Prism.util.encode(code).toString());
+        }
+
+        // Existing line numbers must be removed in order to be updated correctly
+        if (element.querySelector('.line-numbers-rows')) {
+          const lineNumbers = element.querySelector(
+            '.line-numbers-rows'
+          ) as HTMLElement;
+          element.removeChild(lineNumbers);
         }
 
         // Force prism-line-numbers plugin initialization, required for Prism.highlight usage

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -100,7 +100,9 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   });
 
   private _setUpCodeBlockCode = modifier((element: HTMLElement) => {
-    this._isExpanded = false; // reset expanded state on updates
+    if (this.showFooter) {
+      this._isExpanded = false; // reset expanded state on updates
+    }
     this.setPrismCode(element);
     return () => {};
   });
@@ -175,10 +177,10 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
         }
 
         // Existing line numbers must be removed in order to be updated correctly
-        if (element.querySelector('.line-numbers-rows')) {
-          const lineNumbers = element.querySelector(
-            '.line-numbers-rows'
-          ) as HTMLElement;
+        const lineNumbers = element.querySelector(
+          '.line-numbers-rows'
+        ) as HTMLElement;
+        if (lineNumbers) {
           element.removeChild(lineNumbers);
         }
 

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -10,6 +10,7 @@ import { assert } from '@ember/debug';
 import { next, schedule } from '@ember/runloop';
 import { htmlSafe } from '@ember/template';
 import { guidFor } from '@ember/object/internals';
+import { modifier } from 'ember-modifier';
 
 import Prism from 'prismjs';
 
@@ -75,6 +76,31 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
 
   // Generates a unique ID for the code content
   private _preCodeId = 'pre-code-' + guidFor(this);
+  private _preCodeElement!: HTMLPreElement;
+  private _observer!: IntersectionObserver;
+
+  // If a code block is hidden from view, and made visible after load, the Prism code needs to be re-run
+  private _setUpObserver = modifier((element: HTMLElement) => {
+    const codeBlock = element.querySelector('code') as HTMLElement;
+    this._observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          this.setPrismCode(codeBlock);
+        }
+      });
+    });
+    this._observer.observe(element);
+
+    return () => {
+      this._observer.disconnect();
+    };
+  });
+
+  private _setUpCodeBlockCode = modifier((element: HTMLElement) => {
+    this._preCodeElement = element.querySelector('pre') as HTMLPreElement;
+    this.setPrismCode(element);
+    return () => {};
+  });
 
   // code text content for the CodeBlock
   get code(): string {
@@ -152,24 +178,26 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
           element,
         });
 
-        // Get the actual height & the content height of the preCodeElement
         // eslint-disable-next-line ember/no-runloop
         schedule('afterRender', (): void => {
-          const preCodeElement = document.getElementById(this._preCodeId);
-          this._codeContentHeight = preCodeElement?.scrollHeight ?? 0;
-          this._codeContainerHeight = preCodeElement?.clientHeight ?? 0;
-        });
+          // Get the actual height & the content height of the preCodeElement
+          this._codeContentHeight = this._preCodeElement?.scrollHeight ?? 0;
+          this._codeContainerHeight = this._preCodeElement?.clientHeight ?? 0;
 
-        // Force prism-line-highlight plugin initialization
-        // Context: https://github.com/hashicorp/design-system/pull/1749#discussion_r1374288785
-        if (this.args.highlightLines) {
-          // we need to delay re-evaluating the context for prism-line-highlight for as much as possible, and `afterRender` is the 'latest' we can use in the component lifecycle
-          // eslint-disable-next-line ember/no-runloop
-          schedule('afterRender', (): void => {
+          // we need to re-trigger the line numbers generation as late as possible to account for any line wrapping styles that are applied
+          if (this.args.hasLineWrapping && Prism?.plugins?.['lineNumbers']) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+            Prism.plugins['lineNumbers'].highlight(this._preCodeElement);
+          }
+
+          // Force prism-line-highlight plugin initialization
+          // Context: https://github.com/hashicorp/design-system/pull/1749#discussion_r1374288785
+          if (this.args.highlightLines) {
+            // we need to delay re-evaluating the context for prism-line-highlight for as much as possible, and `afterRender` is the 'latest' we can use in the component lifecycle
             // we piggy-back on the plugin's `resize` event listener to trigger a new call of the `highlightLines` function: https://github.com/PrismJS/prism/blob/master/plugins/line-highlight/prism-line-highlight.js#L337
             if (window) window.dispatchEvent(new Event('resize'));
-          });
-        }
+          }
+        });
       });
     }
   }

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -80,7 +80,7 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   private _observer!: ResizeObserver;
 
   // If a code block is hidden from view, and made visible after load, the Prism code needs to be re-run
-  private _setUpObserver = modifier((element: HTMLElement) => {
+  private _setUpCodeObserver = modifier((element: HTMLElement) => {
     this._preCodeElement = element.querySelector(
       '.hds-code-block__code'
     ) as HTMLPreElement;

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -77,15 +77,15 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   // Generates a unique ID for the code content
   private _preCodeId = 'pre-code-' + guidFor(this);
   private _preCodeElement!: HTMLPreElement;
-  private _observer!: IntersectionObserver;
+  private _observer!: ResizeObserver;
 
   // If a code block is hidden from view, and made visible after load, the Prism code needs to be re-run
   private _setUpObserver = modifier((element: HTMLElement) => {
     this._preCodeElement = element.querySelector('pre') as HTMLPreElement;
     const codeBlock = element.querySelector('code') as HTMLElement;
-    this._observer = new IntersectionObserver((entries) => {
+    this._observer = new ResizeObserver((entries) => {
       entries.forEach((entry) => {
-        if (entry.isIntersecting) {
+        if (entry.contentBoxSize) {
           this.setPrismCode(codeBlock);
         }
       });

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -81,6 +81,7 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
 
   // If a code block is hidden from view, and made visible after load, the Prism code needs to be re-run
   private _setUpObserver = modifier((element: HTMLElement) => {
+    this._preCodeElement = element.querySelector('pre') as HTMLPreElement;
     const codeBlock = element.querySelector('code') as HTMLElement;
     this._observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
@@ -97,7 +98,6 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   });
 
   private _setUpCodeBlockCode = modifier((element: HTMLElement) => {
-    this._preCodeElement = element.querySelector('pre') as HTMLPreElement;
     this.setPrismCode(element);
     return () => {};
   });
@@ -187,7 +187,7 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
           // we need to re-trigger the line numbers generation as late as possible to account for any line wrapping styles that are applied
           if (this.args.hasLineWrapping && Prism?.plugins?.['lineNumbers']) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            Prism.plugins['lineNumbers'].highlight(this._preCodeElement);
+            Prism.plugins['lineNumbers'].resize(this._preCodeElement);
           }
 
           // Force prism-line-highlight plugin initialization

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -100,9 +100,7 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   });
 
   private _setUpCodeBlockCode = modifier((element: HTMLElement) => {
-    if (this.showFooter) {
-      this._isExpanded = false; // reset expanded state on updates
-    }
+    this._isExpanded = false; // reset expanded state on updates
     this.setPrismCode(element);
     return () => {};
   });

--- a/packages/components/src/styles/components/code-block/index.scss
+++ b/packages/components/src/styles/components/code-block/index.scss
@@ -147,6 +147,7 @@ $hds-code-block-code-footer-height: 48px;
   }
 
   code {
+    position: relative;
     display: inline-block;
     padding-right: $hds-code-block-code-padding;
   }
@@ -220,6 +221,13 @@ $hds-code-block-code-footer-height: 48px;
       position: relative;
       // reserve space for line numbers
       padding-left: calc(#{$hds-code-block-line-numbers-width} + #{$hds-code-block-code-padding});
+
+      // When line numbers are enabled, line highlighing is calculated based on the pre element instead of the code element
+      // To ensure the offset is correct, we need to set the position of the code element to static
+      // Source: https://github.com/PrismJS/prism/blob/v2/src/plugins/line-highlight/prism-line-highlight.ts#L92
+      code {
+        position: static;
+      }
     }
 
     .hds-code-block__overlay-footer {
@@ -250,15 +258,17 @@ $hds-code-block-code-footer-height: 48px;
         }
       }
     }
+
+    .line-highlight {
+      left: 0;
+    }
   }
 
   // Highlighted Lines
   .line-highlight {
     position: absolute;
     right: 0;
-    left: 0;
-    // Note: position seems off by a few px although not sure why
-    margin-top: -3px;
+    left: -$hds-code-block-code-padding;
     background-color: var(--hds-code-block-color-line-highlight);
     border: solid var(--hds-code-block-color-line-highlight-border);
     border-width: 1px 0 1px 4px;

--- a/showcase/app/controllers/components/code-block.js
+++ b/showcase/app/controllers/components/code-block.js
@@ -31,6 +31,25 @@ export default class CodeBlockController extends Controller {
   @tracked isModalActive = false;
   @tracked declaration = 'let';
   @tracked input = '';
+  @tracked value_demo1 = this.value_start_demo1;
+
+  value_start_demo1 = `package main
+import 'fmt'
+func main() {
+  res = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam'
+  fm.Println(res)
+}`;
+
+  value_new_demo1 = `package main
+import 'fmt'
+func main() {
+  res = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam'
+  fm.Println(res)
+}
+func main2() {
+  res = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam'
+  fm.Println(res)
+}`;
 
   constructor() {
     super(...arguments);
@@ -75,5 +94,14 @@ export default class CodeBlockController extends Controller {
   @action
   deactivateModal() {
     this.isModalActive = false;
+  }
+
+  @action
+  onUpdateClickDemo1() {
+    if (this.value_demo1 === this.value_start_demo1) {
+      this.value_demo1 = this.value_new_demo1;
+    } else {
+      this.value_demo1 = this.value_start_demo1;
+    }
   }
 }

--- a/showcase/app/styles/showcase-pages/code-block.scss
+++ b/showcase/app/styles/showcase-pages/code-block.scss
@@ -13,4 +13,8 @@ body.components-code-block {
       left: 0;
     }
   }
+
+  .shw-component-code-block-demo-btn {
+    margin-top: 12px;
+  }
 }

--- a/showcase/app/styles/showcase-pages/code-block.scss
+++ b/showcase/app/styles/showcase-pages/code-block.scss
@@ -13,8 +13,4 @@ body.components-code-block {
       left: 0;
     }
   }
-
-  .shw-component-code-block-demo-btn {
-    margin-top: 12px;
-  }
 }

--- a/showcase/app/templates/components/code-block.hbs
+++ b/showcase/app/templates/components/code-block.hbs
@@ -721,5 +721,15 @@ func main() {
         </Hds::Modal>
       {{/if}}
     </SF.Item>
+    <SF.Item @label="Dynamic updates">
+      <Hds::CodeBlock @language="go" @highlightLines="2, 4" @maxHeight="180px" @value={{this.value_demo1}} />
+      <Hds::Button
+        type="button"
+        @text="Update"
+        @isInline={{true}}
+        class="shw-component-code-block-demo-btn"
+        {{on "click" this.onUpdateClickDemo1}}
+      />
+    </SF.Item>
   </Shw::Flex>
 </section>

--- a/showcase/app/templates/components/code-block.hbs
+++ b/showcase/app/templates/components/code-block.hbs
@@ -659,6 +659,7 @@ console.log(`I am ${codeLang} code`);"
             @language="go"
             @highlightLines="2, 4"
             @hasLineWrapping={{true}}
+            @maxHeight="130px"
             @value="package main
 import 'fmt'
 func main() {

--- a/showcase/app/templates/components/code-block.hbs
+++ b/showcase/app/templates/components/code-block.hbs
@@ -727,7 +727,7 @@ func main() {
         type="button"
         @text="Update"
         @isInline={{true}}
-        class="shw-component-code-block-demo-btn"
+        {{style marginTop="12px"}}
         {{on "click" this.onUpdateClickDemo1}}
       />
     </SF.Item>


### PR DESCRIPTION
### :pushpin: Summary

[Preview](https://hds-showcase-git-dchyun-code-block-tabs-render-fix-hashicorp.vercel.app/components/code-block#demo)

If merged, this PR would fix rendering issues in the `CodeBlock` with the line wrapping and line highlighting. The primary issues found and resolved are.

- Line numbers are not displayed correctly when line wrapping is enabled
- Line numbers are not displayed correctly when the number of lines is updated dynamically
- Line numbers and line highlighting are not displayed correctly when line wrapping is enabled, and the code block is hidden from view initially (ex: inside a tab)
- Line highlighting is not displayed correctly when line numbers are not present

The `CodeBlock` was also converted from using `did-insert` and `did-update` to custom modifiers.

### :hammer_and_wrench: Detailed description

Originally in #2826 there were several issues observed in the `CodeBlock`. It was observed that when the code block was [used inside the tabs](https://hds-showcase.vercel.app/components/code-block#demo) the line numbers and line highlighting of the code blocks inside tabs initially hidden were not rendering correctly.

After additional investigation several issues with the Prism.js library were contributing to this problem.

#### Line numbers issues when line wrapping is enabled
First, line numbers are not being rendered correctly in the following situation

- `hasLineWrapping` is `true`
- no lines are highlighted
- there is only one `CodeBlock` on the page

The reason this issue has not been caught before is that when line highlighting is true, we trigger a `resize` event on the window to re-trigger Prism.js's line highlighting rendering. When there are other code blocks on a page that have line highlighting, this event was being listened to by code blocks without line highlighting as well. It would then re-trigger a Prism update, which would fix the line number issues.

If a page has no other code blocks with line highlighting to trigger this `resize` event, then the issues with the line numbers are not fixed.

#### Line number and highlight issues inside tabs

When the code block is initially hidden, such as being inside an inactive tab, the line numbers and highlighting are not rendered correctly when it is made visible, if `hasLineWrapping` is `true`.

When the code block is hidden on load, the `resize` event to re-trigger the prism.js updates does not correctly apply the styles to the hidden content. To solve this issue, we are now re-triggering Prism.js when the code block becomes visible using an `IntersectionObserver`.

#### Line highlighting with no line numbers

When [line highlighting is set](https://hds-showcase.vercel.app/components/code-block#highlight-lines) but `hasLineNumbers` is `false` the highlights start one line earlier than they should. This is due to Prism js calculating the line numbers based on the `pre` element when line numbers are present, but calculating it based on the `code` element when they are not ([source code link](https://github.com/PrismJS/prism/blob/v2/src/plugins/line-highlight/prism-line-highlight.ts#L92)).

### :camera_flash: Screenshots

#### Line number & wrapping issues

Note: This was only possible to show locally by only displaying one code block on the showcase page

**Before**
<img width="420" alt="Screenshot 2025-05-05 at 6 50 51 PM" src="https://github.com/user-attachments/assets/c50cdbc1-626a-4d9e-855c-a088b72783c5" />

**After**
<img width="420" alt="Screenshot 2025-05-05 at 6 50 22 PM" src="https://github.com/user-attachments/assets/48343d7d-a98f-4df4-b19a-793017ec4069" />

### Tabs issue

**Before**
<img width="435" alt="Screenshot 2025-05-06 at 8 20 11 AM" src="https://github.com/user-attachments/assets/0d2f7e8f-4c11-4e1a-b373-b0c51d6a99a8" />

**After**
<img width="421" alt="Screenshot 2025-05-06 at 8 27 27 AM" src="https://github.com/user-attachments/assets/b49f693b-d054-4aa9-921d-64e03d25800d" />

#### Line highlighting with no line numbers

**Before**
<img width="497" alt="Screenshot 2025-05-16 at 11 00 29 AM" src="https://github.com/user-attachments/assets/da3c31f3-66d5-4562-bd39-157e587e2741" />

**After**
<img width="516" alt="Screenshot 2025-05-16 at 11 00 38 AM" src="https://github.com/user-attachments/assets/1ed963bf-36f5-4315-a5fb-d7acf98a153f" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4875](https://hashicorp.atlassian.net/browse/HDS-4875)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4875]: https://hashicorp.atlassian.net/browse/HDS-4875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ