### PR TITLE
Fix `Hds::Form::Label` argument `for` with boolean values

### DIFF
--- a/.changeset/nine-fans-cough.md
+++ b/.changeset/nine-fans-cough.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Form::Label` - Forced the `for` HTML attribute to be converted to a string

--- a/packages/components/src/components/hds/form/label/index.hbs
+++ b/packages/components/src/components/hds/form/label/index.hbs
@@ -2,7 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-<label class={{this.classNames}} for={{@controlId}} id={{this.id}} ...attributes>
+<label class={{this.classNames}} for="{{@controlId}}" id={{this.id}} ...attributes>
   {{yield}}
   <Hds::Form::Indicator @isRequired={{@isRequired}} @isOptional={{@isOptional}} />
 </label>

--- a/showcase/app/templates/components/form/radio.hbs
+++ b/showcase/app/templates/components/form/radio.hbs
@@ -327,4 +327,21 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Text::H3>Special cases</Shw::Text::H3>
+
+  <Shw::Flex as |SF|>
+    <SF.Item as |SFI|>
+      <SFI.Label>With <code>true/false</code> as boolean values</SFI.Label>
+      <Hds::Form::Radio::Group @name="control-booleans" as |G|>
+        {{#let (array true false) as |bools|}}
+          {{#each bools as |bool|}}
+            <G.RadioField @id={{bool}} @value={{bool}} as |F|>
+              <F.Label>{{bool}}</F.Label>
+            </G.RadioField>
+          {{/each}}
+        {{/let}}
+      </Hds::Form::Radio::Group>
+    </SF.Item>
+  </Shw::Flex>
+
 </section>

--- a/showcase/tests/integration/components/hds/form/label/index-test.js
+++ b/showcase/tests/integration/components/hds/form/label/index-test.js
@@ -66,6 +66,16 @@ module('Integration | Component | hds/form/label/index', function (hooks) {
     assert.dom('#test-form-label').hasAttribute('for', 'my-control-id');
   });
 
+  test('it renders a label with the "for" attribute even if the @controlId argument is a boolean', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Label @controlId={{true}} id="test-form-label-true">True</Hds::Form::Label>
+        <Hds::Form::Label @controlId={{false}} id="test-form-label-false">False</Hds::Form::Label>
+      `
+    );
+    assert.dom('#test-form-label-true').hasAttribute('for', 'true');
+    assert.dom('#test-form-label-false').hasAttribute('for', 'false');
+  });
+
   // ID
 
   test('it renders a label with the correct "id" attribute if the @controlId argument is provided', async function (assert) {

--- a/showcase/tests/integration/components/hds/form/radio/group-test.js
+++ b/showcase/tests/integration/components/hds/form/radio/group-test.js
@@ -141,6 +141,31 @@ module('Integration | Component | hds/form/radio/group', function (hooks) {
       );
   });
 
+  test('it automatically provides all the ID relations between the elements when dynamically rendered using boolean values', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Radio::Group as |G|>
+            <G.RadioField @value={{true}} @id={{true}} as |F|>
+              <F.Label>This is the label for the 'true' value</F.Label>
+            </G.RadioField>
+            <G.RadioField @value={{false}} @id={{false}} as |F|>
+              <F.Label>This is the label for the 'false' value</F.Label>
+            </G.RadioField>
+          </Hds::Form::Radio::Group>`
+    );
+
+    const inputs = this.element.querySelectorAll('input[type="radio"]');
+    const labels = this.element.querySelectorAll('label');
+
+    // the `true` value should be used for the `id` (input) and `for` (label) attributes
+    assert.dom(inputs[0]).hasAttribute('id', 'true');
+    assert.dom(labels[0]).hasAttribute('for', 'true');
+
+    // the `false` value should not be used, but the `id` (input) attribute should be generated and the `for` (label) attribute should match it
+    const generatedId = inputs[1].id;
+    assert.true(generatedId.startsWith('ember'));
+    assert.dom(labels[1]).hasAttribute('for', generatedId);
+  });
+
   // NAME
 
   test('it renders the defined name on all controls within a group', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

While working on https://github.com/hashicorp/vault/pull/30555 I discovered a strange "bug" in the `Hds::Form::Label`: essentially in the case of a radio group (an `Hds::Form::Field`) where the possible values are booleans `true`/`false` and the values are used also as `ID` for the elements, the `for` HTML attribute behaves differently than the `id` HTML attribute:
- `for={{true}}` in the template → renders as `for` attribute, without value
- `for={{false}}` in the template → it does not render the `for` attribute
- `id={{true}}` in the template → renders as `id="true"` attribute
- `id={{false}}` in the template → renders as `id="false"` attribute

This means that, while for the `false` case the association between the `id` of the `input` and the `for` of the label is maintained, because the ID is generated as `guidFor()` by the `getElementId()` function, in the `true` case this association is broken, because the `getElementId()` function sees that an ID is provided (`element.args.id` evaluates to `true`), and so it passes this argument to the `id` of the input, which is converted to a string, and passed to the `for` of the label, which is not converted to a string but simply omitted.

<img width="594" alt="screenshot_4956" src="https://github.com/user-attachments/assets/2d1358d0-52b6-4539-ac8f-b4cd30e305db" />


To fix this discrepancy, I have just wrapped in double quotes the `for` assignment in the handlebars template of the `Form::Label` component.

### :hammer_and_wrench: Detailed description

In this PR I have:
- forced `for` attribute in `Hds::Form::Label` to be a string
- added special use case for `Hds::Form::Radio::Group` with boolean values to showcase
- added integration test for
    - `Hds::Form::Label` for use case when `@controlId` is a boolean
    - `Hds::Form::Radio::Group` for use case when RadioField `@id` is a boolean

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
