### PR TITLE
`AdvancedTable` - add `@maxHeight` argument and fix the container styles

### DIFF
--- a/.changeset/rotten-geese-swim.md
+++ b/.changeset/rotten-geese-swim.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AdvancedTable` - Added `@maxHeight` argument which automatically adds a sticky header when set and sets the max height of the AdvancedTable. Also updated the container styles to constrain the Advanced Table width to the parent's width.

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -21,6 +21,7 @@
     {{style
       grid-template-columns=this.gridTemplateColumns
       --hds-advanced-table-sticky-column-offset=this.stickyColumnOffset
+      max-height=@maxHeight
     }}
     {{this._setUpScrollWrapper}}
   >

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -132,6 +132,7 @@ export interface HdsAdvancedTableSignature {
     hasStickyHeader?: boolean;
     hasStickyFirstColumn?: boolean;
     childrenKey?: string;
+    maxHeight?: string;
   };
   Blocks: {
     body?: [
@@ -311,6 +312,19 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     return density;
   }
 
+  get hasStickyHeader(): boolean {
+    if (this.args.maxHeight && this.args.hasStickyHeader !== false) {
+      return true;
+    } else if (this.args.hasStickyHeader && !this.args.maxHeight) {
+      assert(
+        'Must set @maxHeight to use @hasStickyHeader.',
+        false
+      );
+    }
+
+    return false
+  }
+
   get valign(): HdsAdvancedTableVerticalAlignment {
     const { valign = DEFAULT_VALIGN } = this.args;
 
@@ -371,7 +385,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
   get theadClassNames(): string {
     const classes = ['hds-advanced-table__thead'];
 
-    if (this.args.hasStickyHeader) {
+    if (this.hasStickyHeader) {
       classes.push('hds-advanced-table__thead--sticky');
     }
 
@@ -411,12 +425,12 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
 
       // sticky header
       if (element.scrollTop > 0) {
-        if (this.args.hasStickyHeader) {
+        if (this.hasStickyHeader) {
           this.isStickyHeaderPinned = true;
         }
         this.showScrollIndicatorTop = true;
       } else {
-        if (this.args.hasStickyHeader) {
+        if (this.hasStickyHeader) {
           this.isStickyHeaderPinned = false;
         }
         this.showScrollIndicatorTop = false;
@@ -440,7 +454,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
       this.scrollIndicatorDimensions = getScrollIndicatorDimensions(
         element,
         this._theadElement,
-        hasStickyHeader,
+        this.hasStickyHeader,
         hasStickyFirstColumn
       );
 
@@ -453,7 +467,6 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     };
 
     const {
-      hasStickyHeader = false,
       hasStickyFirstColumn = false,
       isSelectable = false,
     } = this.args;

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -316,13 +316,10 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     if (this.args.maxHeight && this.args.hasStickyHeader !== false) {
       return true;
     } else if (this.args.hasStickyHeader && !this.args.maxHeight) {
-      assert(
-        'Must set @maxHeight to use @hasStickyHeader.',
-        false
-      );
+      assert('Must set @maxHeight to use @hasStickyHeader.', false);
     }
 
-    return false
+    return false;
   }
 
   get valign(): HdsAdvancedTableVerticalAlignment {
@@ -466,10 +463,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
       }
     };
 
-    const {
-      hasStickyFirstColumn = false,
-      isSelectable = false,
-    } = this.args;
+    const { hasStickyFirstColumn = false, isSelectable = false } = this.args;
 
     this._resizeObserver = new ResizeObserver((entries) => {
       entries.forEach(() => {

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -25,6 +25,8 @@ $hds-advanced-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px differenc
 
 .hds-advanced-table__container {
   position: relative;
+  display: grid;
+  align-items: start;
   width: 100%;
   height: 100%;
   // add overflow hidden and border radius so scroll shadows appear rounded in the corners

--- a/showcase/app/components/mock/app/main/generic-advanced-table.gts
+++ b/showcase/app/components/mock/app/main/generic-advanced-table.gts
@@ -519,95 +519,93 @@ export default class MockAppMainGenericAdvancedTable extends Component<MockAppMa
   }
 
   <template>
-    <div class="mock-app-main-generic-advanced-table-wrapper">
-      <HdsAdvancedTable
-        @columns={{this.demoColumns}}
-        @model={{this.demoModel}}
-        @hasStickyHeader={{true}}
-        @isSelectable={{true}}
-        @isStriped={{true}}
-        @onSelectionChange={{this.onSelectionChange}}
-        @hasStickyFirstColumn={{true}}
-      >
-        <:body as |B|>
-          {{! @glint-expect-error }}
-          <B.Tr @selectionKey={{get B.data "name"}}>
-            <B.Th>
-              <HdsLinkInline @href="www.google.com">
-                {{! @glint-expect-error }}
-                {{get B.data "name"}}
-              </HdsLinkInline>
-            </B.Th>
-            <B.Td>
-              <HdsLinkInline @href="www.google.com">
-                {{! @glint-expect-error }}
-                {{get B.data "project-name"}}
-              </HdsLinkInline>
-            </B.Td>
-            <B.Td>
-              <HdsLinkInline @href="www.google.com">
-                {{! @glint-expect-error }}
-                {{get B.data "current-run-id"}}
-              </HdsLinkInline>
-            </B.Td>
-            <B.Td>
-              <HdsBadge
-                @type="outlined"
-                {{! @glint-expect-error }}
-                @text={{get B.data "run-status"}}
-                {{! @glint-expect-error }}
-                @color={{get B.data "run-status-color"}}
-              />
-            </B.Td>
-            <B.Td>
+    <HdsAdvancedTable
+      @columns={{this.demoColumns}}
+      @model={{this.demoModel}}
+      @maxHeight="600px"
+      @isSelectable={{true}}
+      @isStriped={{true}}
+      @onSelectionChange={{this.onSelectionChange}}
+      @hasStickyFirstColumn={{true}}
+    >
+      <:body as |B|>
+        {{! @glint-expect-error }}
+        <B.Tr @selectionKey={{get B.data "name"}}>
+          <B.Th>
+            <HdsLinkInline @href="www.google.com">
               {{! @glint-expect-error }}
-              {{get B.data "current-run-applied"}}
-            </B.Td>
-            <B.Td>
+              {{get B.data "name"}}
+            </HdsLinkInline>
+          </B.Th>
+          <B.Td>
+            <HdsLinkInline @href="www.google.com">
               {{! @glint-expect-error }}
-              {{get B.data "vcs-repo"}}
-            </B.Td>
-            <B.Td>
-              <HdsLinkInline @href="www.google.com">
-                {{! @glint-expect-error }}
-                {{get B.data "module-count"}}
-              </HdsLinkInline>
-            </B.Td>
-            <B.Td>
+              {{get B.data "project-name"}}
+            </HdsLinkInline>
+          </B.Td>
+          <B.Td>
+            <HdsLinkInline @href="www.google.com">
               {{! @glint-expect-error }}
-              {{get B.data "modules"}}
-            </B.Td>
-            <B.Td>
-              <HdsLinkInline @href="www.google.com">
-                {{! @glint-expect-error }}
-                {{get B.data "provider-count"}}
-              </HdsLinkInline>
-            </B.Td>
-            <B.Td>
+              {{get B.data "current-run-id"}}
+            </HdsLinkInline>
+          </B.Td>
+          <B.Td>
+            <HdsBadge
+              @type="outlined"
               {{! @glint-expect-error }}
-              {{get B.data "providers"}}
-            </B.Td>
-            <B.Td>
+              @text={{get B.data "run-status"}}
               {{! @glint-expect-error }}
-              {{get B.data "terraform-version"}}
-            </B.Td>
-            <B.Td>
-              <HdsLinkInline @href="www.google.com">
-                {{! @glint-expect-error }}
-                {{get B.data "state-terraform-version"}}
-              </HdsLinkInline>
-            </B.Td>
-            <B.Td>
+              @color={{get B.data "run-status-color"}}
+            />
+          </B.Td>
+          <B.Td>
+            {{! @glint-expect-error }}
+            {{get B.data "current-run-applied"}}
+          </B.Td>
+          <B.Td>
+            {{! @glint-expect-error }}
+            {{get B.data "vcs-repo"}}
+          </B.Td>
+          <B.Td>
+            <HdsLinkInline @href="www.google.com">
               {{! @glint-expect-error }}
-              {{get B.data "created"}}
-            </B.Td>
-            <B.Td>
+              {{get B.data "module-count"}}
+            </HdsLinkInline>
+          </B.Td>
+          <B.Td>
+            {{! @glint-expect-error }}
+            {{get B.data "modules"}}
+          </B.Td>
+          <B.Td>
+            <HdsLinkInline @href="www.google.com">
               {{! @glint-expect-error }}
-              {{get B.data "updated"}}
-            </B.Td>
-          </B.Tr>
-        </:body>
-      </HdsAdvancedTable>
-    </div>
+              {{get B.data "provider-count"}}
+            </HdsLinkInline>
+          </B.Td>
+          <B.Td>
+            {{! @glint-expect-error }}
+            {{get B.data "providers"}}
+          </B.Td>
+          <B.Td>
+            {{! @glint-expect-error }}
+            {{get B.data "terraform-version"}}
+          </B.Td>
+          <B.Td>
+            <HdsLinkInline @href="www.google.com">
+              {{! @glint-expect-error }}
+              {{get B.data "state-terraform-version"}}
+            </HdsLinkInline>
+          </B.Td>
+          <B.Td>
+            {{! @glint-expect-error }}
+            {{get B.data "created"}}
+          </B.Td>
+          <B.Td>
+            {{! @glint-expect-error }}
+            {{get B.data "updated"}}
+          </B.Td>
+        </B.Tr>
+      </:body>
+    </HdsAdvancedTable>
   </template>
 }

--- a/showcase/app/styles/mock-components/app.scss
+++ b/showcase/app/styles/mock-components/app.scss
@@ -42,10 +42,3 @@
   gap: 12px;
   margin-bottom: 12px;
 }
-
-.mock-app-main-generic-advanced-table-wrapper {
-  // TODO remove after https://hashicorp.atlassian.net/browse/HDS-4751 is done
-  display: grid;
-  height: 600px;
-  overflow: auto;
-}

--- a/showcase/app/styles/showcase-pages/advanced-table.scss
+++ b/showcase/app/styles/showcase-pages/advanced-table.scss
@@ -22,16 +22,12 @@ body.components-advanced-table {
     .shw-component-advanced-table-cell-content-div {
       display: flex;
       align-items: center;
-  
+
       .hds-icon {
         flex: none;
         margin-right: 5px;
       }
     }
-
-  .shw-component-advanced-table-fixed-height-wrapper {
-    height: 400px;
-  }
 
   .shw-component-advanced-table-fixed-width-wrapper {
     width: 400px;

--- a/showcase/app/styles/showcase-pages/advanced-table.scss
+++ b/showcase/app/styles/showcase-pages/advanced-table.scss
@@ -33,11 +33,6 @@ body.components-advanced-table {
     width: 400px;
   }
 
-  .shw-component-advanced-table-fixed-dimensions-wrapper {
-    width: 400px;
-    height: 400px;
-  }
-
   .shw-component-advanced-table-with-pagination-demo-wrapper {
     .hds-table + .hds-pagination {
       margin-top: 16px;

--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -124,10 +124,12 @@
   <Shw::Divider />
 
   <Shw::Text::H2>Horizontal scrolling indicators</Shw::Text::H2>
-  <div class="shw-component-advanced-table-fixed-dimensions-wrapper">
+  <div class="shw-component-advanced-table-fixed-width-wrapper">
     <Hds::AdvancedTable
       @model={{this.model.music}}
       @isStriped={{true}}
+      @maxHeight="400px"
+      @hasStickyHeader={{false}}
       @columns={{array
         (hash key="artist" label="Artist" tooltip="More information." isSortable=true)
         (hash key="album" label="Album" tooltip="More information." isSortable=true)
@@ -163,47 +165,47 @@
 
   <Shw::Text::H2>Sticky header</Shw::Text::H2>
 
-  <div class="shw-component-advanced-table-fixed-height-wrapper">
-    <Hds::AdvancedTable
-      @isSelectable={{true}}
-      @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
-      @model={{this.model.userData}}
-      @columns={{array
-        (hash key="id" label="ID" width="auto")
-        (hash key="name" label="Name")
-        (hash key="email" label="Email")
-        (hash key="role" label="Role")
-      }}
-      @maxHeight="400px"
-      @isStriped={{true}}
-    >
-      <:body as |B|>
-        <B.Tr
-          @selectionKey={{B.data.id}}
-          @isSelected={{B.data.isSelected}}
-          @selectionAriaLabelSuffix="row #{{B.data.id}}"
-        >
-          <B.Td>{{B.data.id}}</B.Td>
-          <B.Td>{{B.data.name}}</B.Td>
-          <B.Td>{{B.data.email}}</B.Td>
-          <B.Td>{{B.data.role}}</B.Td>
-        </B.Tr>
-      </:body>
-    </Hds::AdvancedTable>
-  </div>
+  <Hds::AdvancedTable
+    @isSelectable={{true}}
+    @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
+    @model={{this.model.userData}}
+    @columns={{array
+      (hash key="id" label="ID" width="auto")
+      (hash key="name" label="Name")
+      (hash key="email" label="Email")
+      (hash key="role" label="Role")
+    }}
+    @maxHeight="400px"
+    @isStriped={{true}}
+  >
+    <:body as |B|>
+      <B.Tr
+        @selectionKey={{B.data.id}}
+        @isSelected={{B.data.isSelected}}
+        @selectionAriaLabelSuffix="row #{{B.data.id}}"
+      >
+        <B.Td>{{B.data.id}}</B.Td>
+        <B.Td>{{B.data.name}}</B.Td>
+        <B.Td>{{B.data.email}}</B.Td>
+        <B.Td>{{B.data.role}}</B.Td>
+      </B.Tr>
+    </:body>
+  </Hds::AdvancedTable>
 
   <Shw::Text::H2>Sticky column</Shw::Text::H2>
 
-  <div class="shw-component-advanced-table-fixed-dimensions-wrapper">
+  <div class="shw-component-advanced-table-fixed-width-wrapper">
     <Hds::AdvancedTable
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
       @model={{this.model.userData}}
+      @maxHeight="400px"
+      @hasStickyHeader={{false}}
       @columns={{array
         (hash key="id" label="ID" width="auto")
-        (hash key="name" label="Name")
-        (hash key="email" label="Email")
-        (hash key="role" label="Role")
+        (hash key="name" label="Name" width="max-content")
+        (hash key="email" label="Email" width="max-content")
+        (hash key="role" label="Role" width="max-content")
       }}
       @hasStickyFirstColumn={{true}}
       @isStriped={{true}}
@@ -225,17 +227,19 @@
 
   <Shw::Text::H3>Sticky column not selectable</Shw::Text::H3>
 
-  <div class="shw-component-advanced-table-fixed-dimensions-wrapper">
+  <div class="shw-component-advanced-table-fixed-width-wrapper">
     <Hds::AdvancedTable
       @model={{this.model.userData}}
       @columns={{array
         (hash key="id" label="ID" width="auto")
-        (hash key="name" label="Name")
-        (hash key="email" label="Email")
-        (hash key="role" label="Role")
+        (hash key="name" label="Name" width="max-content")
+        (hash key="email" label="Email" width="max-content")
+        (hash key="role" label="Role" width="max-content")
       }}
       @hasStickyFirstColumn={{true}}
       @isStriped={{true}}
+      @maxHeight="400px"
+      @hasStickyHeader={{false}}
     >
       <:body as |B|>
         <B.Tr>
@@ -257,9 +261,9 @@
       @model={{this.model.userData}}
       @columns={{array
         (hash key="id" label="ID" width="auto")
-        (hash key="name" label="Name")
-        (hash key="email" label="Email")
-        (hash key="role" label="Role")
+        (hash key="name" label="Name" width="max-content")
+        (hash key="email" label="Email" width="max-content")
+        (hash key="role" label="Role" width="max-content")
       }}
       @maxHeight="400px"
       @hasStickyFirstColumn={{true}}

--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -174,7 +174,7 @@
         (hash key="email" label="Email")
         (hash key="role" label="Role")
       }}
-      @hasStickyHeader={{true}}
+      @maxHeight="400px"
       @isStriped={{true}}
     >
       <:body as |B|>
@@ -250,7 +250,7 @@
 
   <Shw::Text::H2>Sticky header and sticky column</Shw::Text::H2>
 
-  <div class="shw-component-advanced-table-fixed-dimensions-wrapper">
+  <div class="shw-component-advanced-table-fixed-width-wrapper">
     <Hds::AdvancedTable
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
@@ -261,7 +261,7 @@
         (hash key="email" label="Email")
         (hash key="role" label="Role")
       }}
-      @hasStickyHeader={{true}}
+      @maxHeight="400px"
       @hasStickyFirstColumn={{true}}
       @isStriped={{true}}
     >

--- a/showcase/tests/integration/components/hds/advanced-table/index-test.js
+++ b/showcase/tests/integration/components/hds/advanced-table/index-test.js
@@ -325,11 +325,12 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
     setSortableTableData(this);
 
     await render(
-      hbs`<div id='short-advanced-table-wrapper' style="height: 75px; overflow-y: scroll;"><Hds::AdvancedTable
+      hbs`<Hds::AdvancedTable
   id='data-test-advanced-table'
   @model={{this.model}}
   @columns={{this.columns}}
   @hasStickyHeader={{true}}
+  @maxHeight='75px'
 >
 <:body as |B|>
     <B.Tr>
@@ -338,12 +339,71 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
       <B.Td>{{B.data.year}}</B.Td>
     </B.Tr>
   </:body>
-</Hds::AdvancedTable></div>`
+</Hds::AdvancedTable>`
     );
 
     assert
       .dom('#data-test-advanced-table .hds-advanced-table__thead')
       .hasClass('hds-advanced-table__thead--sticky');
+  });
+
+  test('it should render the appropriate CSS and add a sticky header when set @maxHeight', async function (assert) {
+    setSortableTableData(this);
+
+    await render(
+      hbs`<Hds::AdvancedTable
+  id='data-test-advanced-table'
+  @model={{this.model}}
+  @columns={{this.columns}}
+  @maxHeight='75px'
+>
+<:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::AdvancedTable>`
+    );
+
+    assert
+      .dom('#data-test-advanced-table .hds-advanced-table__thead')
+      .hasClass('hds-advanced-table__thead--sticky');
+
+    assert
+      .dom('#data-test-advanced-table .hds-advanced-table')
+      .hasStyle({ maxHeight: '75px' });
+  });
+
+  test('it should render the appropriate CSS when set @maxHeight and @hasStickyHeader is set to false', async function (assert) {
+    setSortableTableData(this);
+
+    await render(
+      hbs`<Hds::AdvancedTable
+  id='data-test-advanced-table'
+  @model={{this.model}}
+  @columns={{this.columns}}
+  @hasStickyHeader={{false}}
+  @maxHeight='75px'
+>
+<:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::AdvancedTable>`
+    );
+
+    assert
+      .dom('#data-test-advanced-table .hds-advanced-table__thead')
+      .doesNotHaveClass('hds-advanced-table__thead--sticky');
+
+    assert
+      .dom('#data-test-advanced-table .hds-advanced-table')
+      .hasStyle({ maxHeight: '75px' });
   });
 
   test('it should render with a CSS class appropriate for the @hasStickyFirstColumn argument', async function (assert) {
@@ -528,6 +588,38 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
         </B.Tr>
       </:body>
     </Hds::AdvancedTable>`);
+
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+
+  test('it throws an assertion if it has `@hasStickyHeader` and does not have @maxHeight', async function (assert) {
+    const errorMessage = 'Must set @maxHeight to use @hasStickyHeader.';
+
+    setSortableTableData(this);
+
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+
+    await render(
+      hbs`<Hds::AdvancedTable
+  id='data-test-advanced-table'
+  @model={{this.model}}
+  @columns={{this.columns}}
+  @hasStickyHeader={{true}}
+>
+<:body as |B|>
+    <B.Tr>
+      <B.Td>{{B.data.artist}}</B.Td>
+      <B.Td>{{B.data.album}}</B.Td>
+      <B.Td>{{B.data.year}}</B.Td>
+    </B.Tr>
+  </:body>
+</Hds::AdvancedTable>`
+    );
 
     assert.throws(function () {
       throw new Error(errorMessage);


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would: 
* add a `maxHeight` argument. If it is set, `hasStickyHeader` is automatically set to true.
* add a check that if `hasStickyHeader` is true, the consumer has to set  `@maxHeight`
* update the showcase

**[Showcase preview](https://hds-showcase-git-hds-4751-advanced-table-height-hashicorp.vercel.app/components/advanced-table)**

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4751](https://hashicorp.atlassian.net/browse/HDS-4751)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4751]: https://hashicorp.atlassian.net/browse/HDS-4751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ