### PR TITLE
`AppSideNav`: fix scrolling issue and being able to focus hidden links issue

### DIFF
--- a/.changeset/honest-experts-battle.md
+++ b/.changeset/honest-experts-battle.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`AppSideNav` - fixed bug where scrolling was blocked when the `AppSideNav` was expanded on desktop views. Also fixed bug where able to focus links that are visually hidden.
+`AppSideNav` - Fixed bug where scrolling was blocked when the `AppSideNav` was expanded on desktop views. Also fixed bug which allowed user to focus links that were visually hidden.

--- a/.changeset/honest-experts-battle.md
+++ b/.changeset/honest-experts-battle.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`AppSideNav` - fixed bug where scrolling was blocked when the `AppSideNav` was expanded on desktop views.
+`AppSideNav` - fixed bug where scrolling was blocked when the `AppSideNav` was expanded on desktop views. Also fixed bug where able to focus links that are visually hidden.

--- a/.changeset/honest-experts-battle.md
+++ b/.changeset/honest-experts-battle.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AppSideNav` - fixed bug where scrolling was blocked when the `AppSideNav` was expanded on desktop views.

--- a/packages/components/src/components/hds/app-side-nav/index.hbs
+++ b/packages/components/src/components/hds/app-side-nav/index.hbs
@@ -27,7 +27,7 @@
       />
     {{/if}}
 
-    <div class="hds-app-side-nav__wrapper-body hds-app-side-nav--hide-when-minimized">
+    <div class="hds-app-side-nav__wrapper-body" {{did-insert this.didInsertNavWrapperBody}}>
       {{~yield~}}
     </div>
   </div>

--- a/packages/components/src/components/hds/app-side-nav/index.hbs
+++ b/packages/components/src/components/hds/app-side-nav/index.hbs
@@ -10,7 +10,7 @@
   {{on "transitionend" (fn this.setTransition "end")}}
   {{! @glint-expect-error - https://github.com/josemarluedke/ember-focus-trap/issues/86 }}
   {{focus-trap isActive=this.shouldTrapFocus}}
-  {{did-insert this.didInsert}}
+  {{this._setUpBodyElement}}
 >
   <h2 class="sr-only" id="hds-app-side-nav-header">Application local navigation</h2>
 
@@ -27,7 +27,7 @@
       />
     {{/if}}
 
-    <div class="hds-app-side-nav__wrapper-body" {{did-insert this.didInsertNavWrapperBody}}>
+    <div class="hds-app-side-nav__wrapper-body" {{this._setUpNavWrapperBody}}>
       {{~yield~}}
     </div>
   </div>

--- a/packages/components/src/components/hds/app-side-nav/index.hbs
+++ b/packages/components/src/components/hds/app-side-nav/index.hbs
@@ -27,7 +27,7 @@
       />
     {{/if}}
 
-    <div class="hds-app-side-nav__wrapper-body hds-app-side-nav-hide-when-minimized">
+    <div class="hds-app-side-nav__wrapper-body hds-app-side-nav--hide-when-minimized">
       {{~yield~}}
     </div>
   </div>

--- a/packages/components/src/components/hds/app-side-nav/index.hbs
+++ b/packages/components/src/components/hds/app-side-nav/index.hbs
@@ -27,7 +27,7 @@
       />
     {{/if}}
 
-    <div class="hds-app-side-nav__wrapper-body">
+    <div class="hds-app-side-nav__wrapper-body hds-app-side-nav-hide-when-minimized">
       {{~yield~}}
     </div>
   </div>

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -188,7 +188,7 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   @action
   didInsert(element: HTMLElement): void {
     this._containersToHide = element.querySelectorAll(
-      '.hds-app-side-nav-hide-when-minimized'
+      '.hds-app-side-nav--hide-when-minimized'
     );
     this._body = document.body;
     // Store the initial `overflow` value of `<body>` so we can reset to it

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -175,10 +175,12 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
       onToggleMinimizedStatus(this._isMinimized);
     }
 
-    if (this._isMinimized) {
-      this.unlockBodyScroll();
-    } else {
-      this.lockBodyScroll();
+    if (!this._isDesktop) {
+      if (this._isMinimized) {
+        this.unlockBodyScroll();
+      } else {
+        this.lockBodyScroll();
+      }
     }
   }
 
@@ -214,6 +216,11 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
     this._isMinimized = !this._isDesktop;
 
     this.synchronizeInert();
+
+    if (this._isDesktop) {
+      // make sure scrolling is enabled if the user resizes the window from mobile to desktop
+      this.unlockBodyScroll();
+    }
 
     const { onDesktopViewportChange } = this.args;
 

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -34,7 +34,7 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   private _body!: HTMLElement;
   private _bodyInitialOverflowValue = '';
   private _desktopMQ: MediaQueryList;
-  private _containersToHide!: NodeListOf<Element>;
+  private _navWrapperBody!: HTMLElement;
 
   // we use the `lg` breakpoint for `desktop` viewports, but consumers can override its value
   private _desktopMQVal = this.args.breakpoint ?? hdsBreakpoints['lg'].px;
@@ -123,13 +123,11 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   }
 
   synchronizeInert(): void {
-    this._containersToHide?.forEach((element): void => {
-      if (this._isMinimized) {
-        element.setAttribute('inert', '');
-      } else {
-        element.removeAttribute('inert');
-      }
-    });
+    if (this._isMinimized) {
+      this._navWrapperBody?.setAttribute('inert', '');
+    } else {
+      this._navWrapperBody?.removeAttribute('inert');
+    }
   }
 
   lockBodyScroll(): void {
@@ -186,14 +184,16 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
   }
 
   @action
-  didInsert(element: HTMLElement): void {
-    this._containersToHide = element.querySelectorAll(
-      '.hds-app-side-nav--hide-when-minimized'
-    );
+  didInsert(): void {
     this._body = document.body;
     // Store the initial `overflow` value of `<body>` so we can reset to it
     this._bodyInitialOverflowValue =
       this._body.style.getPropertyValue('overflow');
+  }
+
+  @action
+  didInsertNavWrapperBody(element: HTMLElement): void {
+    this._navWrapperBody = element;
   }
 
   @action

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -161,6 +161,7 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
     if (event.key === 'Escape' && !this._isMinimized && !this._isDesktop) {
       this._isMinimized = true;
       this.synchronizeInert();
+      this.unlockBodyScroll();
     }
   }
 

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -8,6 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { registerDestructor } from '@ember/destroyable';
 import type Owner from '@ember/owner';
+import { modifier } from 'ember-modifier';
 
 import { hdsBreakpoints } from '@hashicorp/design-system-components/utils/hds-breakpoints';
 
@@ -48,6 +49,17 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
       this.removeEventListeners();
     });
   }
+
+  private _setUpBodyElement = modifier(() => {
+    this._body = document.body;
+    // Store the initial `overflow` value of `<body>` so we can reset to it
+    this._bodyInitialOverflowValue =
+      this._body.style.getPropertyValue('overflow');
+  });
+
+  private _setUpNavWrapperBody = modifier((element: HTMLElement) => {
+    this._navWrapperBody = element;
+  });
 
   addEventListeners(): void {
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -181,19 +193,6 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
         this.lockBodyScroll();
       }
     }
-  }
-
-  @action
-  didInsert(): void {
-    this._body = document.body;
-    // Store the initial `overflow` value of `<body>` so we can reset to it
-    this._bodyInitialOverflowValue =
-      this._body.style.getPropertyValue('overflow');
-  }
-
-  @action
-  didInsertNavWrapperBody(element: HTMLElement): void {
-    this._navWrapperBody = element;
   }
 
   @action

--- a/packages/components/src/components/hds/app-side-nav/portal/target.hbs
+++ b/packages/components/src/components/hds/app-side-nav/portal/target.hbs
@@ -8,7 +8,7 @@
     @multiple={{true}}
     @onChange={{this.panelsChanged}}
     @name={{if @targetName @targetName "hds-app-side-nav-portal-target"}}
-    class="hds-app-side-nav__content-panels hds-app-side-nav-hide-when-minimized"
+    class="hds-app-side-nav__content-panels hds-app-side-nav--hide-when-minimized"
     {{did-update this.didUpdateSubnav this._numSubnavs}}
   />
 </div>

--- a/packages/components/src/components/hds/app-side-nav/portal/target.hbs
+++ b/packages/components/src/components/hds/app-side-nav/portal/target.hbs
@@ -8,7 +8,7 @@
     @multiple={{true}}
     @onChange={{this.panelsChanged}}
     @name={{if @targetName @targetName "hds-app-side-nav-portal-target"}}
-    class="hds-app-side-nav__content-panels hds-app-side-nav--hide-when-minimized"
+    class="hds-app-side-nav__content-panels"
     {{did-update this.didUpdateSubnav this._numSubnavs}}
   />
 </div>

--- a/packages/components/src/styles/components/app-side-nav/main.scss
+++ b/packages/components/src/styles/components/app-side-nav/main.scss
@@ -102,12 +102,7 @@
   overflow-y: auto;
 }
 
-// "HIDE-WHEN-MINIMIZED" SPECIAL CLASS
-// this is a special class that is used to control which elements of the sidenav need to be:
-// - hidden (immediately) when the sidenav is "minimized"
-// - shown (transitioning their opacity) when the sidenav is "expanded"
-
-.hds-app-side-nav--hide-when-minimized {
+.hds-app-side-nav__wrapper-body {
   .hds-app-side-nav--is-minimized & {
     visibility: hidden !important; // we need `!important` here to override the inline style applied to the single panels
     opacity: 0;

--- a/packages/components/src/styles/components/app-side-nav/main.scss
+++ b/packages/components/src/styles/components/app-side-nav/main.scss
@@ -107,7 +107,7 @@
 // - hidden (immediately) when the sidenav is "minimized"
 // - shown (transitioning their opacity) when the sidenav is "expanded"
 
-.hds-app-side-nav-hide-when-minimized {
+.hds-app-side-nav--hide-when-minimized {
   .hds-app-side-nav--is-minimized & {
     visibility: hidden !important; // we need `!important` here to override the inline style applied to the single panels
     opacity: 0;

--- a/showcase/tests/integration/components/hds/app-side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/index-test.js
@@ -156,7 +156,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   test('it collapses when the ESC key is pressed on narrow viewports', async function (assert) {
     await render(hbs`<Hds::AppSideNav id='test-app-side-nav' @breakpoint='10000px'>
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav-hide-when-minimized' />
+  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav>`);
     assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');
     await click('.hds-app-side-nav__toggle-button');
@@ -166,7 +166,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
 
     await triggerKeyEvent('#test-app-side-nav', 'keydown', 'Escape');
     assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');
-    assert.dom('.hds-app-side-nav-hide-when-minimized').hasAttribute('inert');
+    assert.dom('.hds-app-side-nav--hide-when-minimized').hasAttribute('inert');
   });
 
   // COLLAPSIBLE
@@ -191,7 +191,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   test('the "non-minimized" and "minimized" states have impact on its internal properties', async function (assert) {
     await render(hbs`<Hds::AppSideNav @isCollapsible={{true}} id='test-app-side-nav'>
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav-hide-when-minimized' />
+  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav>`);
     assert
       .dom('#test-app-side-nav')
@@ -203,7 +203,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       .dom('.hds-app-side-nav__toggle-button .hds-icon')
       .hasClass('hds-icon-chevrons-left');
     assert
-      .dom('.hds-app-side-nav-hide-when-minimized')
+      .dom('.hds-app-side-nav--hide-when-minimized')
       .doesNotHaveAttribute('inert');
     assert.dom('#test-app-side-nav-body').doesNotHaveAttribute('inert');
     assert.dom('body', document).doesNotHaveStyle('overflow');
@@ -217,7 +217,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     assert
       .dom('.hds-app-side-nav__toggle-button .hds-icon')
       .hasClass('hds-icon-chevrons-right');
-    assert.dom('.hds-app-side-nav-hide-when-minimized').hasAttribute('inert');
+    assert.dom('.hds-app-side-nav--hide-when-minimized').hasAttribute('inert');
     assert.dom('#test-app-side-nav-body').doesNotHaveAttribute('inert');
     assert.dom('body', document).doesNotHaveStyle('overflow');
   });
@@ -235,7 +235,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav-hide-when-minimized' />
+  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav>`);
 
     assert.strictEqual(calls.length, 1, 'called with initial viewport');
@@ -247,7 +247,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       'resizing to mobile triggers a false event'
     );
 
-    assert.dom('.hds-app-side-nav-hide-when-minimized').hasAttribute('inert');
+    assert.dom('.hds-app-side-nav--hide-when-minimized').hasAttribute('inert');
   });
 
   test('when collapsed and the viewport changes from mobile to desktop, it automatically expands and is no longer inert', async function (assert) {
@@ -263,11 +263,11 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav-hide-when-minimized' />
+  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav>`);
 
     await click('.hds-app-side-nav__toggle-button');
-    assert.dom('.hds-app-side-nav-hide-when-minimized').hasAttribute('inert');
+    assert.dom('.hds-app-side-nav--hide-when-minimized').hasAttribute('inert');
 
     await this.changeBrowserSize(false);
     assert.deepEqual(
@@ -275,7 +275,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       [false],
       'resizing to mobile triggers a false event'
     );
-    assert.dom('.hds-app-side-nav-hide-when-minimized').hasAttribute('inert');
+    assert.dom('.hds-app-side-nav--hide-when-minimized').hasAttribute('inert');
 
     await this.changeBrowserSize(true);
     assert.deepEqual(
@@ -284,7 +284,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       'resizing to desktop triggers a true event'
     );
     assert
-      .dom('.hds-app-side-nav-hide-when-minimized')
+      .dom('.hds-app-side-nav--hide-when-minimized')
       .doesNotHaveAttribute('inert');
     assert.dom('body', document).doesNotHaveStyle('overflow');
   });
@@ -302,7 +302,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav-hide-when-minimized' />
+  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav>`);
     await this.changeBrowserSize(false);
     assert.deepEqual(
@@ -334,7 +334,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav-hide-when-minimized' />
+  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav><button id='button-2'>Click</button>`);
 
     await click('.hds-app-side-nav__toggle-button');

--- a/showcase/tests/integration/components/hds/app-side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/index-test.js
@@ -314,7 +314,6 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     await render(hbs`<Hds::AppSideNav
     id='test-app-side-nav'
   @isCollapsible={{true}}
-  @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
   <button id='button-inside'>Click</button>
 </Hds::AppSideNav><button id='button-outside'>Click</button>`);

--- a/showcase/tests/integration/components/hds/app-side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/index-test.js
@@ -324,7 +324,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
   <span id='test-app-side-nav-body' />
-</Hds::AppSideNav><button id='button-2'>Click</button>`);
+</Hds::AppSideNav><button id='button-outside'>Click</button>`);
 
     await click('.hds-app-side-nav__toggle-button');
     assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');

--- a/showcase/tests/integration/components/hds/app-side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/index-test.js
@@ -156,7 +156,6 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   test('it collapses when the ESC key is pressed on narrow viewports', async function (assert) {
     await render(hbs`<Hds::AppSideNav id='test-app-side-nav' @breakpoint='10000px'>
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav>`);
     assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');
     await click('.hds-app-side-nav__toggle-button');
@@ -166,7 +165,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
 
     await triggerKeyEvent('#test-app-side-nav', 'keydown', 'Escape');
     assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');
-    assert.dom('.hds-app-side-nav--hide-when-minimized').hasAttribute('inert');
+    assert.dom('.hds-app-side-nav__wrapper-body').hasAttribute('inert');
   });
 
   // COLLAPSIBLE
@@ -191,7 +190,6 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   test('the "non-minimized" and "minimized" states have impact on its internal properties', async function (assert) {
     await render(hbs`<Hds::AppSideNav @isCollapsible={{true}} id='test-app-side-nav'>
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav>`);
     assert
       .dom('#test-app-side-nav')
@@ -202,9 +200,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     assert
       .dom('.hds-app-side-nav__toggle-button .hds-icon')
       .hasClass('hds-icon-chevrons-left');
-    assert
-      .dom('.hds-app-side-nav--hide-when-minimized')
-      .doesNotHaveAttribute('inert');
+    assert.dom('.hds-app-side-nav__wrapper-body').doesNotHaveAttribute('inert');
     assert.dom('#test-app-side-nav-body').doesNotHaveAttribute('inert');
     assert.dom('body', document).doesNotHaveStyle('overflow');
 
@@ -217,8 +213,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     assert
       .dom('.hds-app-side-nav__toggle-button .hds-icon')
       .hasClass('hds-icon-chevrons-right');
-    assert.dom('.hds-app-side-nav--hide-when-minimized').hasAttribute('inert');
-    assert.dom('#test-app-side-nav-body').doesNotHaveAttribute('inert');
+    assert.dom('.hds-app-side-nav__wrapper-body').hasAttribute('inert');
     assert.dom('body', document).doesNotHaveStyle('overflow');
   });
 
@@ -235,7 +230,6 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav>`);
 
     assert.strictEqual(calls.length, 1, 'called with initial viewport');
@@ -247,7 +241,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       'resizing to mobile triggers a false event'
     );
 
-    assert.dom('.hds-app-side-nav--hide-when-minimized').hasAttribute('inert');
+    assert.dom('.hds-app-side-nav__wrapper-body').hasAttribute('inert');
   });
 
   test('when collapsed and the viewport changes from mobile to desktop, it automatically expands and is no longer inert', async function (assert) {
@@ -263,11 +257,10 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav>`);
 
     await click('.hds-app-side-nav__toggle-button');
-    assert.dom('.hds-app-side-nav--hide-when-minimized').hasAttribute('inert');
+    assert.dom('.hds-app-side-nav__wrapper-body').hasAttribute('inert');
 
     await this.changeBrowserSize(false);
     assert.deepEqual(
@@ -275,7 +268,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       [false],
       'resizing to mobile triggers a false event'
     );
-    assert.dom('.hds-app-side-nav--hide-when-minimized').hasAttribute('inert');
+    assert.dom('.hds-app-side-nav__wrapper-body').hasAttribute('inert');
 
     await this.changeBrowserSize(true);
     assert.deepEqual(
@@ -283,9 +276,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       [true],
       'resizing to desktop triggers a true event'
     );
-    assert
-      .dom('.hds-app-side-nav--hide-when-minimized')
-      .doesNotHaveAttribute('inert');
+    assert.dom('.hds-app-side-nav__wrapper-body').doesNotHaveAttribute('inert');
     assert.dom('body', document).doesNotHaveStyle('overflow');
   });
 
@@ -302,7 +293,6 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav>`);
     await this.changeBrowserSize(false);
     assert.deepEqual(
@@ -334,7 +324,6 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
   <span id='test-app-side-nav-body' />
-  <span class='hds-app-side-nav--hide-when-minimized' />
 </Hds::AppSideNav><button id='button-2'>Click</button>`);
 
     await click('.hds-app-side-nav__toggle-button');

--- a/showcase/tests/integration/components/hds/app-side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/index-test.js
@@ -304,17 +304,18 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   <span id='test-app-side-nav-body' />
   <span class='hds-app-side-nav-hide-when-minimized' />
 </Hds::AppSideNav>`);
-
-    assert.dom('body', document).hasStyle({
-      overflow: 'hidden',
-    });
-
     await this.changeBrowserSize(false);
     assert.deepEqual(
       calls[1],
       [false],
       'resizing to mobile triggers a false event'
     );
+
+    await click('.hds-app-side-nav__toggle-button');
+
+    assert.dom('body', document).hasStyle({
+      overflow: 'hidden',
+    });
 
     await this.changeBrowserSize(true);
     assert.deepEqual(

--- a/showcase/tests/integration/components/hds/app-side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/index-test.js
@@ -154,9 +154,8 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   });
 
   test('it collapses when the ESC key is pressed on narrow viewports', async function (assert) {
-    await render(hbs`<Hds::AppSideNav id='test-app-side-nav' @breakpoint='10000px'>
-  <span id='test-app-side-nav-body' />
-</Hds::AppSideNav>`);
+    await render(hbs`<Hds::AppSideNav id='test-app-side-nav' @breakpoint='10000px'
+/>`);
     assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');
     await click('.hds-app-side-nav__toggle-button');
     assert
@@ -228,9 +227,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     await render(hbs`<Hds::AppSideNav
   @isCollapsible={{true}}
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
->
-  <span id='test-app-side-nav-body' />
-</Hds::AppSideNav>`);
+/>`);
 
     assert.strictEqual(calls.length, 1, 'called with initial viewport');
 
@@ -255,9 +252,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     await render(hbs`<Hds::AppSideNav
   @isCollapsible={{true}}
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
->
-  <span id='test-app-side-nav-body' />
-</Hds::AppSideNav>`);
+/>`);
 
     await click('.hds-app-side-nav__toggle-button');
     assert.dom('.hds-app-side-nav__wrapper-body').hasAttribute('inert');
@@ -291,9 +286,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     await render(hbs`<Hds::AppSideNav
   @isCollapsible={{true}}
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
->
-  <span id='test-app-side-nav-body' />
-</Hds::AppSideNav>`);
+/>`);
     await this.changeBrowserSize(false);
     assert.deepEqual(
       calls[1],
@@ -323,7 +316,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
   @isCollapsible={{true}}
   @onDesktopViewportChange={{this.onDesktopViewportChange}}
 >
-  <span id='test-app-side-nav-body' />
+  <button id='button-inside'>Click</button>
 </Hds::AppSideNav><button id='button-outside'>Click</button>`);
 
     await click('.hds-app-side-nav__toggle-button');
@@ -331,7 +324,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     assert.dom('.hds-app-side-nav__toggle-button').isFocused();
 
     await tab();
-    assert.dom('#button-2').isFocused();
+    assert.dom('#button-outside').isFocused();
   });
 
   // CALLBACKS

--- a/showcase/tests/integration/components/hds/app-side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/index-test.js
@@ -11,6 +11,7 @@ import {
   resetOnerror,
   settled,
   triggerKeyEvent,
+  tab,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -137,13 +138,19 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       hbs`<Hds::AppSideNav id='test-app-side-nav' @breakpoint='10000px' />`
     );
     assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');
+    assert.dom('body', document).doesNotHaveStyle('overflow');
 
     await click('.hds-app-side-nav__toggle-button');
     assert
       .dom('#test-app-side-nav')
       .hasClass('hds-app-side-nav--is-not-minimized');
+    assert.dom('body', document).hasStyle({
+      overflow: 'hidden',
+    });
+
     await click('.hds-app-side-nav__toggle-button');
     assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');
+    assert.dom('body', document).doesNotHaveStyle('overflow');
   });
 
   test('it collapses when the ESC key is pressed on narrow viewports', async function (assert) {
@@ -199,6 +206,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       .dom('.hds-app-side-nav-hide-when-minimized')
       .doesNotHaveAttribute('inert');
     assert.dom('#test-app-side-nav-body').doesNotHaveAttribute('inert');
+    assert.dom('body', document).doesNotHaveStyle('overflow');
 
     await click('.hds-app-side-nav__toggle-button');
 
@@ -211,6 +219,7 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
       .hasClass('hds-icon-chevrons-right');
     assert.dom('.hds-app-side-nav-hide-when-minimized').hasAttribute('inert');
     assert.dom('#test-app-side-nav-body').doesNotHaveAttribute('inert');
+    assert.dom('body', document).doesNotHaveStyle('overflow');
   });
 
   test('when the viewport changes from desktop to mobile, it automatically collapses and becomes inert', async function (assert) {
@@ -277,6 +286,62 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     assert
       .dom('.hds-app-side-nav-hide-when-minimized')
       .doesNotHaveAttribute('inert');
+    assert.dom('body', document).doesNotHaveStyle('overflow');
+  });
+
+  test('when collapsed and the viewport changes from mobile to desktop and is expanded, scrolling is enabled', async function (assert) {
+    this.mockMedia();
+
+    let calls = [];
+    this.setProperties({
+      onDesktopViewportChange: (...args) => calls.push(args),
+    });
+
+    await render(hbs`<Hds::AppSideNav
+  @isCollapsible={{true}}
+  @onDesktopViewportChange={{this.onDesktopViewportChange}}
+>
+  <span id='test-app-side-nav-body' />
+  <span class='hds-app-side-nav-hide-when-minimized' />
+</Hds::AppSideNav>`);
+
+    assert.dom('body', document).hasStyle({
+      overflow: 'hidden',
+    });
+
+    await this.changeBrowserSize(false);
+    assert.deepEqual(
+      calls[1],
+      [false],
+      'resizing to mobile triggers a false event'
+    );
+
+    await this.changeBrowserSize(true);
+    assert.deepEqual(
+      calls[2],
+      [true],
+      'resizing to desktop triggers a true event'
+    );
+
+    assert.dom('body', document).doesNotHaveStyle('overflow');
+  });
+
+  test('when collapsed, the content in the AppSideNav is not focusable', async function (assert) {
+    await render(hbs`<Hds::AppSideNav
+    id='test-app-side-nav'
+  @isCollapsible={{true}}
+  @onDesktopViewportChange={{this.onDesktopViewportChange}}
+>
+  <span id='test-app-side-nav-body' />
+  <span class='hds-app-side-nav-hide-when-minimized' />
+</Hds::AppSideNav><button id='button-2'>Click</button>`);
+
+    await click('.hds-app-side-nav__toggle-button');
+    assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');
+    assert.dom('.hds-app-side-nav__toggle-button').isFocused();
+
+    await tab();
+    assert.dom('#button-2').isFocused();
   });
 
   // CALLBACKS

--- a/showcase/tests/integration/components/hds/modal/index-test.js
+++ b/showcase/tests/integration/components/hds/modal/index-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
   click,
@@ -231,8 +231,7 @@ module('Integration | Component | hds/modal/index', function (hooks) {
     assert.dom('#test-button').isFocused();
   });
 
-  // not sure how to reach the `body` element, it says "body is not a valid root element"
-  skip('it returns focus to the `body` element, if the one that initiated the open event not anymore in the DOM', async function (assert) {
+  test('it returns focus to the `body` element, if the one that initiated the open event not anymore in the DOM', async function (assert) {
     await render(
       hbs`<Hds::Dropdown as |D|>
             <D.ToggleButton id="test-toggle" @text="open modal" />
@@ -249,7 +248,7 @@ module('Integration | Component | hds/modal/index', function (hooks) {
     await click('#test-interactive');
     assert.true(this.showModal);
     await click('button.hds-modal__dismiss');
-    assert.dom('body', 'body').isFocused();
+    assert.dom('body', document).isFocused();
   });
 
   test('it returns focus to a specific element if provided via`@returnFocusTo`', async function (assert) {

--- a/website/docs/components/app-side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/app-side-nav/partials/code/how-to-use.md
@@ -201,7 +201,7 @@ Each one of these states has CSS class names associated, and they’re used by t
 
 The App Side Nav component **automatically**:
 
-- fades in/out the the content in the navigation
+- fades in/out the content in the navigation
 - swaps the toggle button icon from “menu” to “close” and moves it from one position to another
 
 More specifically, the animation is:

--- a/website/docs/components/app-side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/app-side-nav/partials/code/how-to-use.md
@@ -201,17 +201,15 @@ Each one of these states has CSS class names associated, and they’re used by t
 
 The App Side Nav component **automatically**:
 
-- fades in/out the “actions” block in the header and the content injected in the body via “portals”.
+- fades in/out the the content in the navigation
 - swaps the toggle button icon from “menu” to “close” and moves it from one position to another
 
-Any other content in the App Side Nav needs to be **explicitly handled** by the consumers (in this way they have full control of the content they add, and they can customize the transition as they want/need).
-
-One possible way to do it is to use the **`hds-app-side-nav--hide-when-minimized` class**. This is a special class that can be applied to a DOM element so that it **automatically** fades in/out when the App Side Nav changes its “minimization” state.
-
-More specifically:
+More specifically, the animation is:
 
 - `minimized → maximized` transition: the content appears with a fade-in effect, when the width animation is already completed (the width is maximized)
 - `maximized → minimized` transition: the content disappears at once with no transition, before the width animation starts
+
+Any other content in the App Side Nav needs to be **explicitly handled** by the consumers (in this way they have full control of the content they add, and they can customize the transition as they want/need).
 
 #### Advanced customization
 

--- a/website/docs/components/app-side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/app-side-nav/partials/code/how-to-use.md
@@ -206,14 +206,12 @@ The App Side Nav component **automatically**:
 
 Any other content in the App Side Nav needs to be **explicitly handled** by the consumers (in this way they have full control of the content they add, and they can customize the transition as they want/need).
 
-One possible way to do it is to use the **`hds-app-side-nav-hide-when-minimized` class**. This is a special class that can be applied to a DOM element so that it **automatically** fades in/out when the App Side Nav changes its “minimization” state.
+One possible way to do it is to use the **`hds-app-side-nav--hide-when-minimized` class**. This is a special class that can be applied to a DOM element so that it **automatically** fades in/out when the App Side Nav changes its “minimization” state.
 
 More specifically:
 
 - `minimized → maximized` transition: the content appears with a fade-in effect, when the width animation is already completed (the width is maximized)
 - `maximized → minimized` transition: the content disappears at once with no transition, before the width animation starts
-
-Another option is to use the **`isMinimized` parameter**, which is useful in those cases where the content is so custom/specialized that it can’t just be faded in/out but needs to have a different kind of transition (eg. remain visible but change layout or respond to the width of the container). This value is passed down by the `<:header/body/footer>` named blocks as parameters, and can be used to build custom logic on the consumers’ side.
 
 #### Advanced customization
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would do some cleanup of the AppSideNav component
* only lock scrolling if the user is on mobile (when on desktop, scrolling shouldnt be prevented because the user can still interact with the rest of the page)
* reset ability to scroll when close the AppSideNav with the escape key
* prevent the user from tabbing to the body of the AppSideNav when it is minimized


There are also updates to tests to check for the correct behavior  (+ 1 bonus fix for a Modal test):
* add test to check the user cannot tab to the content when the AppSideNav is minimized
* add checks to existing tests that `overflow: hidden` is set appropriately
* add test that when a user resizes from mobile -> desktop, ability to scroll is returned
* re-enable test for Modal because I figured out how to target the `body` element in tests

**🧪 Tested in Atlas:**
* [Slack thread with context](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1745609577404549)
* [deployment](https://atlas-inspirational-prairie-334208.prod.previews.hashicorp.services/app/hashicorp_v2/projects/prj-7tgHyPpDmBebEkYN0)

### :link: External links

Jira ticket: [HDS-4827](https://hashicorp.atlassian.net/browse/HDS-4827)
Jira ticket: [HDS-4858](https://hashicorp.atlassian.net/browse/HDS-4858)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4827]: https://hashicorp.atlassian.net/browse/HDS-4827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-4858]: https://hashicorp.atlassian.net/browse/HDS-4858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ