### PR TITLE
Small tweaks to the headings for the `AdvancedTable` showcase page

### DIFF
--- a/showcase/app/templates/components/advanced-table.hbs
+++ b/showcase/app/templates/components/advanced-table.hbs
@@ -163,7 +163,9 @@
 
   <Shw::Divider />
 
-  <Shw::Text::H2>Sticky header</Shw::Text::H2>
+  <Shw::Text::H2>Stickiness</Shw::Text::H2>
+
+  <Shw::Text::H3>Sticky header</Shw::Text::H3>
 
   <Hds::AdvancedTable
     @isSelectable={{true}}
@@ -192,7 +194,7 @@
     </:body>
   </Hds::AdvancedTable>
 
-  <Shw::Text::H2>Sticky column</Shw::Text::H2>
+  <Shw::Text::H3>Sticky column</Shw::Text::H3>
 
   <div class="shw-component-advanced-table-fixed-width-wrapper">
     <Hds::AdvancedTable
@@ -252,7 +254,7 @@
     </Hds::AdvancedTable>
   </div>
 
-  <Shw::Text::H2>Sticky header and sticky column</Shw::Text::H2>
+  <Shw::Text::H3>Sticky header and sticky column</Shw::Text::H3>
 
   <div class="shw-component-advanced-table-fixed-width-wrapper">
     <Hds::AdvancedTable


### PR DESCRIPTION
### :pushpin: Summary

@shleewhite let me know what you think of this

preview: https://hds-showcase-git-advanced-table-showcase-headi-c49fa7-hashicorp.vercel.app/components/advanced-table#stickiness

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
