### PR TITLE
Website: Fix failing AdvancedTable page acceptance tests

### DIFF
--- a/website/docs/components/table/advanced-table/partials/code/how-to-use.md
+++ b/website/docs/components/table/advanced-table/partials/code/how-to-use.md
@@ -396,6 +396,7 @@ For situations where the default number of rows visible may be high, it can be d
       (hash key="role" label="Role" isSortable=true)
     }}
     @hasStickyHeader={{true}}
+    @maxHeight="500px"
   >
     <:body as |B|>
       <B.Tr>


### PR DESCRIPTION
### :pushpin: Summary

Currently, website tests are failing in main because the website has an AdvancedTable with a sticky header that doesn't have a maxHeight set - which Is throwing an assertion. This would resolve the test failure, but leave the full docs change to happen closer to the release.

**[Preview](https://hds-website-git-fix-advanced-table-website-tests-hashicorp.vercel.app/components/table/advanced-table?tab=code#vertical-scrolling)**

**[Current test failure](https://github.com/hashicorp/design-system/actions/runs/15028028313/job/42233573323)**

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
