### PR TITLE
`CodeBlock` - aria argument and screen-reader improvements

### DIFF
--- a/.changeset/strong-bananas-drum.md
+++ b/.changeset/strong-bananas-drum.md
@@ -3,3 +3,5 @@
 ---
 
 `CodeBlock` - Added arguments `@ariaLabel`, `@ariaLabelledBy`, and `@ariaDescribedBy`. Added screen-reader only copy for highlighted lines.
+
+`hds-clipboard` - Prevent screen-reader only text (text with the `sr-only` class) from being copied to the clipboard.

--- a/.changeset/strong-bananas-drum.md
+++ b/.changeset/strong-bananas-drum.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`CodeBlock` - Added arguments `@ariaLabel`, `@ariaLabelledBy`, and `@ariaDescribedBy`. Added screen-reader only copy for highlighted lines.

--- a/packages/components/src/components/hds/code-block/description.hbs
+++ b/packages/components/src/components/hds/code-block/description.hbs
@@ -3,6 +3,13 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<Hds::Text::Body @tag="p" @size="100" class="hds-code-block__description" ...attributes>
+<Hds::Text::Body
+  id={{this._id}}
+  @tag="p"
+  @size="100"
+  class="hds-code-block__description"
+  ...attributes
+  {{this._setUpDescription @didInsertNode}}
+>
   {{yield}}
 </Hds::Text::Body>

--- a/packages/components/src/components/hds/code-block/description.ts
+++ b/packages/components/src/components/hds/code-block/description.ts
@@ -3,17 +3,33 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import templateOnlyComponent from '@ember/component/template-only';
+import Component from '@glimmer/component';
+import { guidFor } from '@ember/object/internals';
+import { modifier } from 'ember-modifier';
 import type { HdsTextBodySignature } from '../text/body';
 
+type HdsCodeBlockDescriptionElement = HdsTextBodySignature['Element'];
 export interface HdsCodeBlockDescriptionSignature {
+  Args: {
+    didInsertNode: (element: HdsCodeBlockDescriptionElement) => void;
+  };
   Blocks: {
     default: [];
   };
-  Element: HdsTextBodySignature['Element'];
+  Element: HdsCodeBlockDescriptionElement;
 }
 
-const HdsCodeBlockDescription =
-  templateOnlyComponent<HdsCodeBlockDescriptionSignature>();
+export default class HdsCodeBlockDescription extends Component<HdsCodeBlockDescriptionSignature> {
+  private _id = 'description-' + guidFor(this);
 
-export default HdsCodeBlockDescription;
+  private _setUpDescription = modifier(
+    (
+      element: HTMLElement,
+      [insertCallbackFunction]: [(element: HTMLElement) => void]
+    ) => {
+      if (typeof insertCallbackFunction === 'function') {
+        insertCallbackFunction(element);
+      }
+    }
+  );
+}

--- a/packages/components/src/components/hds/code-block/index.hbs
+++ b/packages/components/src/components/hds/code-block/index.hbs
@@ -5,8 +5,10 @@
 
 <div class={{this.classNames}} ...attributes {{this._setUpCodeObserver}}>
   <div class="hds-code-block__header">
-    {{~yield (hash Title=(component "hds/code-block/title"))~}}
-    {{~yield (hash Description=(component "hds/code-block/description"))~}}
+    {{~yield (hash Title=(component "hds/code-block/title" didInsertNode=this.registerTitleElement))~}}
+    {{~yield
+      (hash Description=(component "hds/code-block/description" didInsertNode=this.registerDescriptionElement))
+    ~}}
   </div>
   <div class="hds-code-block__body">
     {{! content within pre tag is whitespace-sensitive; do not add new lines! }}
@@ -16,6 +18,9 @@
       data-line={{@highlightLines}}
       data-start={{@lineNumberStart}}
       id={{this._preCodeId}}
+      aria-label={{@ariaLabel}}
+      aria-labelledby={{this.ariaLabelledBy}}
+      aria-describedby={{this.ariaDescribedBy}}
       tabindex="0"
     ><code {{this._setUpCodeBlockCode}}>
         {{~this._prismCode~}}

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -261,6 +261,8 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
     this._isExpanded = !this._isExpanded;
   }
 
+  // Logic for determining where line highlighting starts and ends taken from Prism.js plugin source code
+  // Context: https://github.com/PrismJS/prism/blob/19f8de66b0f3a79aedbbf096081a4060fc0e80af/src/plugins/line-highlight/prism-line-highlight.ts#L82
   private _addHighlightSrOnlyText(code: string): SafeString {
     const NEW_LINE_EXP = /\n(?!$)/g;
     const lines = code.split(NEW_LINE_EXP);

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -45,6 +45,9 @@ export const LANGUAGES: string[] = Object.values(HdsCodeBlockLanguageValues);
 
 export interface HdsCodeBlockSignature {
   Args: {
+    ariaLabel?: string;
+    ariaLabelledBy?: string;
+    ariaDescribedBy?: string;
     hasCopyButton?: boolean;
     hasLineNumbers?: boolean;
     hasLineWrapping?: boolean;
@@ -73,6 +76,8 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   @tracked private _isExpanded: boolean = false;
   @tracked private _codeContentHeight: number = 0;
   @tracked private _codeContainerHeight: number = 0;
+  @tracked private _titleId: string | undefined;
+  @tracked private _descriptionId: string | undefined;
 
   // Generates a unique ID for the code content
   private _preCodeId = 'pre-code-' + guidFor(this);
@@ -104,6 +109,18 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
     this.setPrismCode(element);
     return () => {};
   });
+
+  get ariaLabelledBy(): string | undefined {
+    if (this.args.ariaLabel !== undefined) {
+      return;
+    }
+
+    return this.args.ariaLabelledBy ?? this._titleId;
+  }
+
+  get ariaDescribedBy(): string | undefined {
+    return this.args.ariaDescribedBy ?? this._descriptionId;
+  }
 
   // code text content for the CodeBlock
   get code(): string {
@@ -156,6 +173,18 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
 
   get copyButtonText(): HdsCopyButtonSignature['Args']['text'] {
     return this.args.copyButtonText ? this.args.copyButtonText : 'Copy';
+  }
+
+  @action
+  registerTitleElement(element: HdsCodeBlockTitleSignature['Element']): void {
+    this._titleId = element.id;
+  }
+
+  @action
+  registerDescriptionElement(
+    element: HdsCodeBlockDescriptionSignature['Element']
+  ): void {
+    this._descriptionId = element.id;
   }
 
   @action

--- a/packages/components/src/components/hds/code-block/title.hbs
+++ b/packages/components/src/components/hds/code-block/title.hbs
@@ -3,6 +3,14 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<Hds::Text::Body @size="200" @tag={{this.componentTag}} @weight="semibold" class="hds-code-block__title" ...attributes>
+<Hds::Text::Body
+  id={{this._id}}
+  @size="200"
+  @tag={{this.componentTag}}
+  @weight="semibold"
+  class="hds-code-block__title"
+  ...attributes
+  {{this._setUpTitle @didInsertNode}}
+>
   {{yield}}
 </Hds::Text::Body>

--- a/packages/components/src/components/hds/code-block/title.ts
+++ b/packages/components/src/components/hds/code-block/title.ts
@@ -3,13 +3,17 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 import Component from '@glimmer/component';
+import { guidFor } from '@ember/object/internals';
+import { modifier } from 'ember-modifier';
 import { HdsCodeBlockTitleTagValues } from './types.ts';
 import type { HdsCodeBlockTitleTags } from './types';
 import type { HdsTextBodySignature } from '../text/body';
 
+type HdsCodeBlockTitleElement = HdsTextBodySignature['Element'];
 export interface HdsCodeBlockTitleSignature {
   Args: {
     tag?: HdsCodeBlockTitleTags;
+    didInsertNode: (element: HdsCodeBlockTitleElement) => void;
   };
   Blocks: {
     default: [];
@@ -18,6 +22,19 @@ export interface HdsCodeBlockTitleSignature {
 }
 
 export default class HdsCodeBlockTitle extends Component<HdsCodeBlockTitleSignature> {
+  private _id = 'title-' + guidFor(this);
+
+  private _setUpTitle = modifier(
+    (
+      element: HTMLElement,
+      [insertCallbackFunction]: [(element: HTMLElement) => void]
+    ) => {
+      if (typeof insertCallbackFunction === 'function') {
+        insertCallbackFunction(element);
+      }
+    }
+  );
+
   get componentTag(): HdsCodeBlockTitleTags {
     return this.args.tag ?? HdsCodeBlockTitleTagValues.P;
   }

--- a/packages/components/src/modifiers/hds-clipboard.ts
+++ b/packages/components/src/modifiers/hds-clipboard.ts
@@ -88,7 +88,7 @@ export const getTextToCopyFromTargetElement = (
       textToCopy = targetElement.value;
     } else {
       // Hide any screen reader only text from the innerText calculation
-      let srOnlyTexts = targetElement.querySelectorAll('.sr-only');
+      const srOnlyTexts = targetElement.querySelectorAll('.sr-only');
       srOnlyTexts.forEach((el: Element) => {
         el.setAttribute('style', 'display: none;');
       });

--- a/packages/components/src/modifiers/hds-clipboard.ts
+++ b/packages/components/src/modifiers/hds-clipboard.ts
@@ -87,8 +87,19 @@ export const getTextToCopyFromTargetElement = (
     ) {
       textToCopy = targetElement.value;
     } else {
+      // Hide any screen reader only text from the innerText calculation
+      let srOnlyTexts = targetElement.querySelectorAll('.sr-only');
+      srOnlyTexts.forEach((el: Element) => {
+        el.setAttribute('style', 'display: none;');
+      });
+
       // simplest approach
       textToCopy = targetElement.innerText;
+
+      // Restore visibility of screen reader only text
+      srOnlyTexts.forEach((el: Element) => {
+        el.removeAttribute('style');
+      });
 
       // approach based on text selection (left for backup just in case)
       // var selection = window.getSelection();

--- a/showcase/app/templates/components/code-block.hbs
+++ b/showcase/app/templates/components/code-block.hbs
@@ -12,11 +12,12 @@
 
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
     <SG.Item @label="one line">
-      <Hds::CodeBlock @language="javascript" @value="console.log('I am JavaScript code');" />
+      <Hds::CodeBlock @language="javascript" @ariaLabel="one line" @value="console.log('I am JavaScript code');" />
     </SG.Item>
     <SG.Item @label="multi-line">
       <Hds::CodeBlock
         @language="javascript"
+        @ariaLabel="multi-line"
         @value="let codeLang='JavaScript';
 console.log(`I am ${codeLang} code`);"
       />
@@ -29,6 +30,7 @@ console.log(`I am ${codeLang} code`);"
     <SG.Item @label="new lines in Handlebars" @forceMinWidth={{true}}>
       <Hds::CodeBlock
         @language="javascript"
+        @ariaLabel="new lines in Handlebars"
         @value="let codeLang='JavaScript';
 console.log(`I am ${codeLang} code`);"
       />
@@ -38,7 +40,11 @@ console.log(`I am ${codeLang} code`);"
         <code>\n</code>
         escape sequence in JavaScript
       </SGI.Label>
-      <Hds::CodeBlock @language="javascript" @value={{this.textWithNewline}} />
+      <Hds::CodeBlock
+        @language="javascript"
+        @ariaLabel="new lines with escape sequence in JavaScript"
+        @value={{this.textWithNewline}}
+      />
     </SG.Item>
     <SG.Item @forceMinWidth={{true}} as |SGI|>
       <SGI.Label><code>\n</code>
@@ -46,6 +52,7 @@ console.log(`I am ${codeLang} code`);"
       </SGI.Label>
       <Hds::CodeBlock
         @language="javascript"
+        @ariaLabel="\n in Handlebars (not interpreted as newline)"
         @value="let codeLang='JavaScript';\nconsole.log(`I am ${codeLang} code`);"
       />
     </SG.Item>
@@ -57,6 +64,7 @@ console.log(`I am ${codeLang} code`);"
         @language="javascript"
         @maxHeight="105px"
         @lineNumberStart={{5}}
+        @ariaLabel="Line numbering start changed to 5"
         @value="function convertObjectToArray (obj) {
   let arr = Object
     .keys(obj) // return object's keys as an array
@@ -92,7 +100,12 @@ function assertObjectsEqual (actual, expected, testName) {
       </Hds::CodeBlock>
     </SG.Item>
     <SG.Item @label="description">
-      <Hds::CodeBlock @value="console.log('I am JavaScript code');" @language="javascript" as |CB|>
+      <Hds::CodeBlock
+        @value="console.log('I am JavaScript code');"
+        @language="javascript"
+        @ariaLabel="description"
+        as |CB|
+      >
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
     </SG.Item>
@@ -156,6 +169,7 @@ function assertObjectsEqual (actual, expected, testName) {
       <Hds::CodeBlock
         @isStandalone={{false}}
         @language="javascript"
+        @ariaLabel="isStandalone=false"
         @value="let codeLang='JavaScript';
 console.log(`I am ${codeLang} code`);"
       />
@@ -181,6 +195,7 @@ console.log(`I am ${codeLang} code`);"
     <SG.Item @label="hasLineWrapping=false (default)" @forceMinWidth={{true}}>
       <Hds::CodeBlock
         @language="javascript"
+        @ariaLabel="hasLineWrapping=false (default)"
         @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';
 console.log(codeLand);"
       />
@@ -189,12 +204,14 @@ console.log(codeLand);"
       <Hds::CodeBlock
         @language="javascript"
         @hasLineWrapping={{true}}
+        @ariaLabel="hasLineWrapping=true"
         @value="let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';"
       />
     </SG.Item>
     <SG.Item @label="hasLineWrapping=true with long string" @forceMinWidth={{true}}>
       <Hds::CodeBlock
         @hasLineWrapping={{true}}
+        @ariaLabel="hasLineWrapping=true with long string"
         @value="hcp-domain-verification=6ea52e476fc6232d974c31453dcd884a68df6cf374892a50a897c87d11125b67"
       />
     </SG.Item>
@@ -209,6 +226,7 @@ console.log(codeLand);"
       <Hds::CodeBlock
         @language="javascript"
         @hasLineNumbers={{false}}
+        @ariaLabel="hasLineNumbers=false"
         @value="let codeLang='JavaScript';
     console.log(`I am ${codeLang} code`);"
       />
@@ -237,6 +255,7 @@ console.log(`I am ${codeLang} code`);"
       <Hds::CodeBlock
         @language="javascript"
         @maxHeight="130px"
+        @ariaLabel="maxHeight='130px'"
         @value="function convertObjectToArray (obj) {
   let arr = Object
     .keys(obj) // return object's keys as an array
@@ -305,6 +324,7 @@ function assertObjectsEqual (actual, expected, testName) {
         @hashasLineNumbers={{true}}
         @hasLineWrapping={{true}}
         @highlightLines="2"
+        @ariaLabel="maxHeight='130px', hasLineWrapping=true, highlight line 2"
         @value="function convertObjectToArray (obj) {
   let codeLang='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam';
   let arr = Object
@@ -335,6 +355,7 @@ function assertObjectsEqual (actual, expected, testName) {
         @language="javascript"
         @maxHeight="130px"
         @hasLineNumbers={{false}}
+        @ariaLabel="maxHeight='130px, hasLineNumbers=false"
         @value="function convertObjectToArray (obj) {
   let arr = Object
     .keys(obj) // return object's keys as an array
@@ -359,7 +380,12 @@ function assertObjectsEqual (actual, expected, testName) {
     </SG.Item>
 
     <SG.Item @label="maxHeight='130px' with short content that does not overflow" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="javascript" @maxHeight="130px" @value="convertObjectToArray(obj);" />
+      <Hds::CodeBlock
+        @language="javascript"
+        @maxHeight="130px"
+        @ariaLabel="maxHeight='130px' with short content that does not overflow"
+        @value="convertObjectToArray(obj);"
+      />
     </SG.Item>
   </Shw::Grid>
 
@@ -369,7 +395,12 @@ function assertObjectsEqual (actual, expected, testName) {
 
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
     <SG.Item @label="hasCopyButton=true" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="shell-session" @hasCopyButton={{true}} @value="$ brew tap hashicorp/tap" />
+      <Hds::CodeBlock
+        @language="shell-session"
+        @hasCopyButton={{true}}
+        @ariaLabel="hasCopyButton=true"
+        @value="$ brew tap hashicorp/tap"
+      />
     </SG.Item>
     <SG.Item @label="hasCopyButton=true, maxHeight='130px', title and description" @forceMinWidth={{true}}>
       {{! template-lint-disable no-whitespace-for-layout }}
@@ -416,6 +447,7 @@ function assertObjectsEqual (actual, expected, testName) {
         @language="javascript"
         @hasLineNumbers={{false}}
         @highlightLines="2, 4"
+        @ariaLabel="Highlight lines 2 & 4, hasLineNumbers=false"
         @value="import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
@@ -435,6 +467,7 @@ loadInitializers(App, config.modulePrefix);"
       <Hds::CodeBlock
         @language="javascript"
         @highlightLines="6-10"
+        @ariaLabel="Highlight lines 6-10"
         @value="import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
@@ -458,6 +491,7 @@ loadInitializers(App, config.modulePrefix);"
   <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
     <SG.Item @label="no language (default)" @forceMinWidth={{true}}>
       <Hds::CodeBlock
+        @ariaLabel="no language (default)"
         @value="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU
 GPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3
 Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA
@@ -468,12 +502,17 @@ NrRFi9wrf+M7Q=="
     </SG.Item>
 
     <SG.Item @label="bash" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="bash" @value="aws ec2 --region us-west-1 accept-vpc-peering-connection" />
+      <Hds::CodeBlock
+        @language="bash"
+        @ariaLabel="bash"
+        @value="aws ec2 --region us-west-1 accept-vpc-peering-connection"
+      />
     </SG.Item>
 
     <SG.Item @label="Go" @forceMinWidth={{true}}>
       <Hds::CodeBlock
         @language="go"
+        @ariaLabel="Go"
         @value="package main
 import 'fmt'
 func main() {
@@ -486,6 +525,7 @@ func main() {
       {{! template-lint-disable no-whitespace-for-layout }}
       <Hds::CodeBlock
         @language="hcl"
+        @ariaLabel="HashiCorp Configuration Language"
         @value='variable "hvn_id" {
   description = "The ID of the HCP HVN."
   type        = string
@@ -499,6 +539,7 @@ func main() {
       {{! template-lint-disable no-whitespace-for-layout }}
       <Hds::CodeBlock
         @language="json"
+        @ariaLabel="JSON"
         @value='{
   "result": [
     {
@@ -523,6 +564,7 @@ func main() {
       {{! template-lint-disable no-whitespace-for-layout }}
       <Hds::CodeBlock
         @language="log"
+        @ariaLabel="log"
         @value='web_1            | USE_L10N =3D True
 web_1            | USE_THOUSAND_SEPARATOR =3D False
 web_1            | USE_TZ =3D True
@@ -564,12 +606,13 @@ web_1            | [13/Jun/2019 02:54:33] "GET /api/v1/rides/ HTTP/1.1" 500 9049
     </SG.Item>
 
     <SG.Item @label="Shell" @forceMinWidth={{true}}>
-      <Hds::CodeBlock @language="shell-session" @value="$ brew tap hashicorp/tap" />
+      <Hds::CodeBlock @language="shell-session" @ariaLabel="Shell" @value="$ brew tap hashicorp/tap" />
     </SG.Item>
 
     <SG.Item @label="YAML" @forceMinWidth={{true}}>
       <Hds::CodeBlock
         @language="yaml"
+        @ariaLabel="YAML"
         @value="---
 result:
 - expressions:
@@ -585,6 +628,7 @@ result:
     <SG.Item @label="Ruby" @forceMinWidth={{true}}>
       <Hds::CodeBlock
         @language="ruby"
+        @ariaLabel="Ruby"
         @value='Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/noble64"
 end'
@@ -595,6 +639,7 @@ end'
       {{! template-lint-disable no-whitespace-for-layout }}
       <Hds::CodeBlock
         @language="foo"
+        @ariaLabel="Invalid language (foo)"
         @value='variable "hvn_id" {
   description = "The ID of the HCP HVN."
   type        = string
@@ -650,6 +695,7 @@ end'
           <Hds::CodeBlock
             @language="javascript"
             @highlightLines="2"
+            @ariaLabel="JavaScript within tabs"
             @value="let codeLang='JavaScript';
 console.log(`I am ${codeLang} code`);"
           />
@@ -660,6 +706,7 @@ console.log(`I am ${codeLang} code`);"
             @highlightLines="2, 4"
             @hasLineWrapping={{true}}
             @maxHeight="130px"
+            @ariaLabel="Go within tabs"
             @value="package main
 import 'fmt'
 func main() {
@@ -669,7 +716,7 @@ func main() {
           />
         </T.Panel>
         <T.Panel>
-          <Hds::CodeBlock @language="shell-session" @value="$ brew tap hashicorp/tap" />
+          <Hds::CodeBlock @language="shell-session" @ariaLabel="Shell within tabs" @value="$ brew tap hashicorp/tap" />
         </T.Panel>
       </Hds::Tabs>
 
@@ -682,6 +729,7 @@ func main() {
             @hasCopyButton={{true}}
             @language="go"
             @highlightLines="2, 4"
+            @ariaLabel="Within a dropdown"
             @value="package main
 import 'fmt'
 func main() {
@@ -705,6 +753,7 @@ func main() {
               @hasCopyButton={{true}}
               @language="go"
               @highlightLines="2, 4"
+              @ariaLabel="Within a modal"
               @value="package main
 import 'fmt'
 func main() {

--- a/showcase/app/templates/components/code-block.hbs
+++ b/showcase/app/templates/components/code-block.hbs
@@ -482,6 +482,26 @@ export default class App extends Application {
 loadInitializers(App, config.modulePrefix);"
       />
     </SG.Item>
+    <SG.Item @label="Highlight lines 7-11, lineNumberStart 2" @forceMinWidth={{true}}>
+      <Hds::CodeBlock
+        @language="javascript"
+        @highlightLines="7-11"
+        @lineNumberStart={{2}}
+        @ariaLabel="Highlight lines 7-11, lineNumberStart 2"
+        @value="import Application from '@ember/application';
+import Resolver from 'ember-resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from 'dummy/config/environment';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);"
+      />
+    </SG.Item>
   </Shw::Grid>
 
   <Shw::Divider @level="2" />

--- a/showcase/tests/integration/components/hds/code-block/index-test.js
+++ b/showcase/tests/integration/components/hds/code-block/index-test.js
@@ -66,7 +66,15 @@ module('Integration | Component | hds/code-block/index', function (hooks) {
         <CB.Description>Description</CB.Description>
       </Hds::CodeBlock>
     `);
+    let titleId = document
+      .querySelector('.hds-code-block__title')
+      .getAttribute('id');
+    assert.dom('.hds-code-block__code').hasAria('labelledby', titleId);
     assert.dom('.hds-code-block__title').hasText('Title');
+    let descriptionId = document
+      .querySelector('.hds-code-block__description')
+      .getAttribute('id');
+    assert.dom('.hds-code-block__code').hasAria('describedby', descriptionId);
     assert.dom('.hds-code-block__description').hasText('Description');
   });
 
@@ -89,6 +97,36 @@ module('Integration | Component | hds/code-block/index', function (hooks) {
   });
 
   // OPTIONS
+
+  // ariaLabel
+  test('it sets the aria-label property to the value provided', async function (assert) {
+    await render(hbs`
+      <Hds::CodeBlock @value="console.log('Hello world');" @ariaLabel="test" id="test-code-block" />
+    `);
+    assert.dom('.hds-code-block__code').hasAria('label', 'test');
+  });
+
+  // ariaLabelledBy
+  test('it sets the aria-labelledby property to the value provided', async function (assert) {
+    await render(hbs`
+      <Hds::CodeBlock @value="console.log('Hello world');" @ariaLabelledBy="test-id" id="test-code-block" />
+    `);
+    assert.dom('.hds-code-block__code').hasAria('labelledby', 'test-id');
+  });
+  test('it does not set the aria-labelledby property to the value provided if an ariaLabel argument is set', async function (assert) {
+    await render(hbs`
+      <Hds::CodeBlock @value="console.log('Hello world');" @ariaLabel="test" @ariaLabelledBy="test-id" id="test-code-block" />
+    `);
+    assert.dom('.hds-code-block__code').doesNotHaveAria('labelledby');
+  });
+
+  // ariaDescribedBy
+  test('it sets the aria-describedby property to the value provided', async function (assert) {
+    await render(hbs`
+      <Hds::CodeBlock @value="console.log('Hello world');" @ariaDescribedBy="test-id" id="test-code-block" />
+    `);
+    assert.dom('.hds-code-block__code').hasAria('describedby', 'test-id');
+  });
 
   // isStandalone
   test('it has rounded corners by default', async function (assert) {

--- a/showcase/tests/integration/modifiers/hds-clipboard-test.js
+++ b/showcase/tests/integration/modifiers/hds-clipboard-test.js
@@ -181,6 +181,15 @@ module(
       this.target = find('#test-target');
       assert.deepEqual(getTextToCopyFromTargetElement(this.target), 'Lorem ');
     });
+
+    test('returns the innerText of DOM element passed as `target` argument without including sr only text', async function (assert) {
+      await render(hbs`<p id="test-target">
+        <span>Lorem ipsum</span>
+        <span class="sr-only">Text not to copy</span>
+      </p>`);
+      this.target = find('#test-target');
+      assert.deepEqual(getTextToCopyFromTargetElement(this.target), 'Lorem ipsum');
+    });
   },
 );
 

--- a/showcase/tests/integration/modifiers/hds-clipboard-test.js
+++ b/showcase/tests/integration/modifiers/hds-clipboard-test.js
@@ -188,7 +188,10 @@ module(
         <span class="sr-only">Text not to copy</span>
       </p>`);
       this.target = find('#test-target');
-      assert.deepEqual(getTextToCopyFromTargetElement(this.target), 'Lorem ipsum');
+      assert.deepEqual(
+        getTextToCopyFromTargetElement(this.target),
+        'Lorem ipsum',
+      );
     });
   },
 );


### PR DESCRIPTION
### :pushpin: Summary

[PREVIEW](https://hds-showcase-git-dchyun-code-block-a11y-improvements-hashicorp.vercel.app/components/code-block)

If merged, this PR would improve the accessibility of the `CodeBlock` by implementing the following features

- New arguments for `@ariaLabel`, `@ariaLabelledBy`, and `@ariaDescribedBy`
- Attaching the title and description, if present, to the code block element via `aria-labelledby` and `aria-describedby`
- Adding screen-reader only text to indicate line highlighting

It would also update the `hds-clipboard` modifier to support not copying `sr-only` text.

### :hammer_and_wrench: Detailed description

#### Accessible names

The `@ariaLabel`, `@ariaLabelledBy`, and `@ariaDescribedBy` arguments have been added to the `CodeBlock` to align its approach to the `CodeEditor`. 

Also, the setting of these aria attributes has been aligned to the `CodeEditor` in the following ways.

- If a title is present, `aria-labelledby` will be set to the ID of the title element
- If a description is present, `aria-describedby`, will be set to the ID of the description element
- If a custom value is set on the `@ariaLabel` argument, and a title is present, the title id will not be set in `aria-labelledby`

The docs (#2896) will be updated to match the `CodeEditor` and say that `@ariaLabel` or `@ariaLabelledby` must be used if a title is not present. Existing implementation of the `CodeBlock` should be updated to add these arguments, but this will not cause breaking changes for anyone. 

#### Line highlighting for screen readers

Currently, there is no indication to screen reader users when line highlighting is used. Due to the fact that line numbers are also inaccessible to the screen reader (which can not be fixed since line numbers come from Prism), we can not add sr only text such as "Line 2 and 4 highlighed"

Instead the approach taken is to edit the code generated by prism to add `sr-only` text before and after line highlight starts indicating when highlighting starts, and when it ends. To prevent the `sr-only` text from being copied to the clipboard with the `CopyButton`, the `hds-clipboard` modifier has been updated to ignore `sr-only` text

The logic for determining where to add the sr only text mirrors the Prism plugin's code for determining highlights.

### :camera_flash: Screenshots

#### Aria attributes for title and description

**Before**
<img width="494" alt="Screenshot 2025-05-15 at 3 43 39 PM" src="https://github.com/user-attachments/assets/1e86ccd2-5f04-4f64-b8df-246b1f756351" />

**After**
<img width="438" alt="Screenshot 2025-05-15 at 3 44 09 PM" src="https://github.com/user-attachments/assets/e7259201-35d2-46b4-addd-7511875a9e7e" />

#### Line highlighting screen-reader only copy

<img width="938" alt="Screenshot 2025-05-15 at 3 47 33 PM" src="https://github.com/user-attachments/assets/a771cfc5-1733-479c-9d00-772d5b65e602" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3349](https://hashicorp.atlassian.net/browse/HDS-3349)

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3349]: https://hashicorp.atlassian.net/browse/HDS-3349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ