### PR TITLE
Add missing `flex` and `grid` exports

### DIFF
--- a/.changeset/thick-mice-bow.md
+++ b/.changeset/thick-mice-bow.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Layout::Flex` - Added missing export of component/subcomponent
+
+`Layout::Grid` - Added missing export of component/subcomponent

--- a/packages/components/src/components.ts
+++ b/packages/components/src/components.ts
@@ -330,6 +330,14 @@ export { default as HdsAppFrameMain } from './components/hds/app-frame/parts/mai
 export { default as HdsAppFrameModals } from './components/hds/app-frame/parts/modals.ts';
 export { default as HdsAppFrameSidebar } from './components/hds/app-frame/parts/sidebar.ts';
 
+// Layout > Flex
+export { default as HdsLayoutFlex } from './components/hds/layout/flex/index.ts';
+export { default as HdsLayoutFlexItem } from './components/hds/layout/flex/item.ts';
+
+// Layout > Grid
+export { default as HdsLayoutGrid } from './components/hds/layout/grid/index.ts';
+export { default as HdsLayoutGridItem } from './components/hds/layout/grid/item.ts';
+
 // -----------------------------------------------------------
 // ### UTILITIES
 // -----------------------------------------------------------


### PR DESCRIPTION
### :pushpin: Summary

Small PR to add the missing re-exports of the `Flex` and `Grid` components so they can be used in TypeScript.

Context: https://hashicorp.slack.com/archives/C7KTUHNUS/p1747424098651969

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-4876

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
