### PR TITLE
Update `setupRenderingTest` import path

### DIFF
--- a/showcase/blueprints/hds-component-test/files/tests/integration/components/hds/__name__/index-test.js
+++ b/showcase/blueprints/hds-component-test/files/tests/integration/components/hds/__name__/index-test.js
@@ -4,11 +4,13 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | hds/<%= dasherizedModuleName %>/index', function (hooks) {
+module(
+  'Integration | Component | hds/<%= dasherizedModuleName %>/index',
+  function (hooks) {
     setupRenderingTest(hooks);
 
     test('it should render the component with a CSS class that matches the component name', async function (assert) {

--- a/showcase/tests/integration/components/hds/accordion/index-test.js
+++ b/showcase/tests/integration/components/hds/accordion/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/advanced-table/index-test.js
+++ b/showcase/tests/integration/components/hds/advanced-table/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, click, focus, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';

--- a/showcase/tests/integration/components/hds/advanced-table/td-test.js
+++ b/showcase/tests/integration/components/hds/advanced-table/td-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/advanced-table/th-sort-test.js
+++ b/showcase/tests/integration/components/hds/advanced-table/th-sort-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, click, focus, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/advanced-table/th-test.js
+++ b/showcase/tests/integration/components/hds/advanced-table/th-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, focus, click, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/advanced-table/tr-test.js
+++ b/showcase/tests/integration/components/hds/advanced-table/tr-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, click, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/alert/index-test.js
+++ b/showcase/tests/integration/components/hds/alert/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-footer/copyright-test.js
+++ b/showcase/tests/integration/components/hds/app-footer/copyright-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-footer/index-test.js
+++ b/showcase/tests/integration/components/hds/app-footer/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-footer/item-test.js
+++ b/showcase/tests/integration/components/hds/app-footer/item-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-footer/legal-links-test.js
+++ b/showcase/tests/integration/components/hds/app-footer/legal-links-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-footer/link-test.js
+++ b/showcase/tests/integration/components/hds/app-footer/link-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-footer/status-link-test.js
+++ b/showcase/tests/integration/components/hds/app-footer/status-link-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-frame/index-test.js
+++ b/showcase/tests/integration/components/hds/app-frame/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-header/home-link-test.js
+++ b/showcase/tests/integration/components/hds/app-header/home-link-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-header/index-test.js
+++ b/showcase/tests/integration/components/hds/app-header/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, click, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   render,
   click,

--- a/showcase/tests/integration/components/hds/app-side-nav/list/back-link-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/list/back-link-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-side-nav/list/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/list/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-side-nav/list/item-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/list/item-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-side-nav/list/link-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/list/link-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/app-side-nav/portal/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/portal/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, waitUntil } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/badge-count/index-test.js
+++ b/showcase/tests/integration/components/hds/badge-count/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/badge/index-test.js
+++ b/showcase/tests/integration/components/hds/badge/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/breadcrumb/index-test.js
+++ b/showcase/tests/integration/components/hds/breadcrumb/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/breadcrumb/item-test.js
+++ b/showcase/tests/integration/components/hds/breadcrumb/item-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/breadcrumb/truncation-test.js
+++ b/showcase/tests/integration/components/hds/breadcrumb/truncation-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/button-set/index-test.js
+++ b/showcase/tests/integration/components/hds/button-set/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/button/index-test.js
+++ b/showcase/tests/integration/components/hds/button/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/card/container-test.js
+++ b/showcase/tests/integration/components/hds/card/container-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/code-block/index-test.js
+++ b/showcase/tests/integration/components/hds/code-block/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   render,
   settled,

--- a/showcase/tests/integration/components/hds/code-editor/description-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/description-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';

--- a/showcase/tests/integration/components/hds/code-editor/full-screen-button-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/full-screen-button-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';

--- a/showcase/tests/integration/components/hds/code-editor/index-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';

--- a/showcase/tests/integration/components/hds/code-editor/title-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/title-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';

--- a/showcase/tests/integration/components/hds/copy/button/index-test.js
+++ b/showcase/tests/integration/components/hds/copy/button/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';

--- a/showcase/tests/integration/components/hds/copy/snippet/index-test.js
+++ b/showcase/tests/integration/components/hds/copy/snippet/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';

--- a/showcase/tests/integration/components/hds/dialog-primitive/body-test.js
+++ b/showcase/tests/integration/components/hds/dialog-primitive/body-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dialog-primitive/description-test.js
+++ b/showcase/tests/integration/components/hds/dialog-primitive/description-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dialog-primitive/footer-test.js
+++ b/showcase/tests/integration/components/hds/dialog-primitive/footer-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, resetOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dialog-primitive/header-test.js
+++ b/showcase/tests/integration/components/hds/dialog-primitive/header-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, resetOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dialog-primitive/overlay-test.js
+++ b/showcase/tests/integration/components/hds/dialog-primitive/overlay-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dialog-primitive/wrapper-test.js
+++ b/showcase/tests/integration/components/hds/dialog-primitive/wrapper-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/disclosure-primitive/index-test.js
+++ b/showcase/tests/integration/components/hds/disclosure-primitive/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, resetOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dismiss-button/index-test.js
+++ b/showcase/tests/integration/components/hds/dismiss-button/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/index-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/checkbox-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/checkmark-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/list-item/copy-item-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/copy-item-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/list-item/description-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/description-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/list-item/generic-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/generic-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/list-item/interactive-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/interactive-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/list-item/radio-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/radio-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/list-item/separator-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/separator-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/list-item/title-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/list-item/title-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/toggle/button-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/toggle/button-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/dropdown/toggle/icon-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/toggle/icon-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, skip, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   render,
   resetOnerror,

--- a/showcase/tests/integration/components/hds/flyout/index-test.js
+++ b/showcase/tests/integration/components/hds/flyout/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, skip, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   click,
   render,

--- a/showcase/tests/integration/components/hds/form/character-count/index-test.js
+++ b/showcase/tests/integration/components/hds/form/character-count/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, typeIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/checkbox/base-test.js
+++ b/showcase/tests/integration/components/hds/form/checkbox/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/checkbox/field-test.js
+++ b/showcase/tests/integration/components/hds/form/checkbox/field-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/checkbox/group-test.js
+++ b/showcase/tests/integration/components/hds/form/checkbox/group-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/error/index-test.js
+++ b/showcase/tests/integration/components/hds/form/error/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/field/index-test.js
+++ b/showcase/tests/integration/components/hds/form/field/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/fieldset/index-test.js
+++ b/showcase/tests/integration/components/hds/form/fieldset/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/file-input/base-test.js
+++ b/showcase/tests/integration/components/hds/form/file-input/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/file-input/field-test.js
+++ b/showcase/tests/integration/components/hds/form/file-input/field-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/helper-text/index-test.js
+++ b/showcase/tests/integration/components/hds/form/helper-text/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/label/index-test.js
+++ b/showcase/tests/integration/components/hds/form/label/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/legend/index-test.js
+++ b/showcase/tests/integration/components/hds/form/legend/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/masked-input/base-test.js
+++ b/showcase/tests/integration/components/hds/form/masked-input/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/masked-input/field-test.js
+++ b/showcase/tests/integration/components/hds/form/masked-input/field-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, resetOnerror, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/radio-card/group-test.js
+++ b/showcase/tests/integration/components/hds/form/radio-card/group-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/radio-card/index-test.js
+++ b/showcase/tests/integration/components/hds/form/radio-card/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/radio/base-test.js
+++ b/showcase/tests/integration/components/hds/form/radio/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/radio/field-test.js
+++ b/showcase/tests/integration/components/hds/form/radio/field-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/radio/group-test.js
+++ b/showcase/tests/integration/components/hds/form/radio/group-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/select/base-test.js
+++ b/showcase/tests/integration/components/hds/form/select/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/select/field-test.js
+++ b/showcase/tests/integration/components/hds/form/select/field-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/super-select/multiple/base-test.js
+++ b/showcase/tests/integration/components/hds/form/super-select/multiple/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { selectChoose } from 'ember-power-select/test-support';

--- a/showcase/tests/integration/components/hds/form/super-select/multiple/field-test.js
+++ b/showcase/tests/integration/components/hds/form/super-select/multiple/field-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/super-select/single/base-test.js
+++ b/showcase/tests/integration/components/hds/form/super-select/single/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/super-select/single/field-test.js
+++ b/showcase/tests/integration/components/hds/form/super-select/single/field-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/text-input/base-test.js
+++ b/showcase/tests/integration/components/hds/form/text-input/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/text-input/field-test.js
+++ b/showcase/tests/integration/components/hds/form/text-input/field-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, resetOnerror, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/textarea/base-test.js
+++ b/showcase/tests/integration/components/hds/form/textarea/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/textarea/field-test.js
+++ b/showcase/tests/integration/components/hds/form/textarea/field-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/toggle/base-test.js
+++ b/showcase/tests/integration/components/hds/form/toggle/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/toggle/field-test.js
+++ b/showcase/tests/integration/components/hds/form/toggle/field-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/toggle/group-test.js
+++ b/showcase/tests/integration/components/hds/form/toggle/group-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/form/visibility-toggle/index-test.js
+++ b/showcase/tests/integration/components/hds/form/visibility-toggle/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/icon-tile/index-test.js
+++ b/showcase/tests/integration/components/hds/icon-tile/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/icon/index-test.js
+++ b/showcase/tests/integration/components/hds/icon/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/interactive/index-test.js
+++ b/showcase/tests/integration/components/hds/interactive/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/layout/flex/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/layout/flex/item-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/item-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/layout/grid/item-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/item-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/link/inline-test.js
+++ b/showcase/tests/integration/components/hds/link/inline-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/link/standalone-test.js
+++ b/showcase/tests/integration/components/hds/link/standalone-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/menu-primitive/index-test.js
+++ b/showcase/tests/integration/components/hds/menu-primitive/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   click,
   triggerEvent,

--- a/showcase/tests/integration/components/hds/modal/index-test.js
+++ b/showcase/tests/integration/components/hds/modal/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   click,
   render,

--- a/showcase/tests/integration/components/hds/page-header/index-test.js
+++ b/showcase/tests/integration/components/hds/page-header/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/pagination/compact-test.js
+++ b/showcase/tests/integration/components/hds/pagination/compact-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/pagination/info-test.js
+++ b/showcase/tests/integration/components/hds/pagination/info-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/pagination/nav/arrow-test.js
+++ b/showcase/tests/integration/components/hds/pagination/nav/arrow-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/pagination/nav/ellipsis-test.js
+++ b/showcase/tests/integration/components/hds/pagination/nav/ellipsis-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/pagination/nav/number-test.js
+++ b/showcase/tests/integration/components/hds/pagination/nav/number-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/pagination/numbered-test.js
+++ b/showcase/tests/integration/components/hds/pagination/numbered-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   click,
   select,

--- a/showcase/tests/integration/components/hds/pagination/size-selector-test.js
+++ b/showcase/tests/integration/components/hds/pagination/size-selector-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   select,
   render,

--- a/showcase/tests/integration/components/hds/popover-primitive/index-test.js
+++ b/showcase/tests/integration/components/hds/popover-primitive/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test, skip } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, click, focus, blur, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/reveal/index-test.js
+++ b/showcase/tests/integration/components/hds/reveal/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/rich-tooltip/bubble-test.js
+++ b/showcase/tests/integration/components/hds/rich-tooltip/bubble-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test, skip } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { modifier } from 'ember-modifier';

--- a/showcase/tests/integration/components/hds/rich-tooltip/index-test.js
+++ b/showcase/tests/integration/components/hds/rich-tooltip/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, click, focus, blur } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/rich-tooltip/toggle-test.js
+++ b/showcase/tests/integration/components/hds/rich-tooltip/toggle-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/segmented-group/index-test.js
+++ b/showcase/tests/integration/components/hds/segmented-group/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/separator/index-test.js
+++ b/showcase/tests/integration/components/hds/separator/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/side-nav/base-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/base-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/side-nav/header/home-link-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/header/home-link-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/side-nav/header/icon-button-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/header/icon-button-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/side-nav/header/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/header/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   render,
   click,

--- a/showcase/tests/integration/components/hds/side-nav/list/back-link-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/list/back-link-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/side-nav/list/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/list/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/side-nav/list/item-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/list/item-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/side-nav/list/link-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/list/link-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/side-nav/portal/index-test.js
+++ b/showcase/tests/integration/components/hds/side-nav/portal/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, waitUntil } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/stepper/list-step-test.js
+++ b/showcase/tests/integration/components/hds/stepper/list-step-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/stepper/list-test.js
+++ b/showcase/tests/integration/components/hds/stepper/list-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/stepper/nav-panel-test.js
+++ b/showcase/tests/integration/components/hds/stepper/nav-panel-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/stepper/nav-step-test.js
+++ b/showcase/tests/integration/components/hds/stepper/nav-step-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/stepper/nav-test.js
+++ b/showcase/tests/integration/components/hds/stepper/nav-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   render,
   click,

--- a/showcase/tests/integration/components/hds/stepper/step-indicator-test.js
+++ b/showcase/tests/integration/components/hds/stepper/step-indicator-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/stepper/task-indicator-test.js
+++ b/showcase/tests/integration/components/hds/stepper/task-indicator-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/table/index-test.js
+++ b/showcase/tests/integration/components/hds/table/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, click, focus } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';

--- a/showcase/tests/integration/components/hds/table/td-test.js
+++ b/showcase/tests/integration/components/hds/table/td-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/table/th-sort-test.js
+++ b/showcase/tests/integration/components/hds/table/th-sort-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, click, focus } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/table/th-test.js
+++ b/showcase/tests/integration/components/hds/table/th-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, focus } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/table/tr-test.js
+++ b/showcase/tests/integration/components/hds/table/tr-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, click, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/tabs/index-test.js
+++ b/showcase/tests/integration/components/hds/tabs/index-test.js
@@ -9,7 +9,7 @@ import {
   skip,
   // only
 } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   click,
   focus,

--- a/showcase/tests/integration/components/hds/tag/index-test.js
+++ b/showcase/tests/integration/components/hds/tag/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   render,
   resetOnerror,

--- a/showcase/tests/integration/components/hds/text/body-test.js
+++ b/showcase/tests/integration/components/hds/text/body-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/text/code-test.js
+++ b/showcase/tests/integration/components/hds/text/code-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/text/display-test.js
+++ b/showcase/tests/integration/components/hds/text/display-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/text/index-test.js
+++ b/showcase/tests/integration/components/hds/text/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/time/index-test.js
+++ b/showcase/tests/integration/components/hds/time/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import {

--- a/showcase/tests/integration/components/hds/toast/index-test.js
+++ b/showcase/tests/integration/components/hds/toast/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/components/hds/tooltip/tooltip-button-test.js
+++ b/showcase/tests/integration/components/hds/tooltip/tooltip-button-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   focus,
   render,

--- a/showcase/tests/integration/components/hds/tooltip/tooltip-modifier-test.js
+++ b/showcase/tests/integration/components/hds/tooltip/tooltip-modifier-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { focus, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/helpers/hds-format-date-test.js
+++ b/showcase/tests/integration/helpers/hds-format-date-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { hdsFormatDate } from '@hashicorp/design-system-components/helpers/hds-format-date';
 
 module(

--- a/showcase/tests/integration/helpers/hds-format-relative-test.js
+++ b/showcase/tests/integration/helpers/hds-format-relative-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { hdsFormatRelative } from '@hashicorp/design-system-components/helpers/hds-format-relative';
 
 module(

--- a/showcase/tests/integration/modifiers/hds-advanced-table-cell.js
+++ b/showcase/tests/integration/modifiers/hds-advanced-table-cell.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   render,
   focus,

--- a/showcase/tests/integration/modifiers/hds-anchored-position-test.js
+++ b/showcase/tests/integration/modifiers/hds-anchored-position-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/showcase/tests/integration/modifiers/hds-clipboard-test.js
+++ b/showcase/tests/integration/modifiers/hds-clipboard-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test, skip } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   click,
   render,

--- a/showcase/tests/integration/modifiers/hds-code-editor-test.js
+++ b/showcase/tests/integration/modifiers/hds-code-editor-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   render,
   waitFor,

--- a/showcase/tests/integration/modifiers/hds-register-event-test.js
+++ b/showcase/tests/integration/modifiers/hds-register-event-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { click, render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/website/tests/integration/modifiers/doc-track-event-test.js
+++ b/website/tests/integration/modifiers/doc-track-event-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'showcase/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { click, focus } from '@ember/test-helpers';

--- a/website/tests/integration/modifiers/doc-track-event-test.js
+++ b/website/tests/integration/modifiers/doc-track-event-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'showcase/tests/helpers';
+import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { click, focus } from '@ember/test-helpers';


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will update the import path for `setupRenderingTest`

from

`import { setupRenderingTest } from 'ember-qunit';`

to

`import { setupRenderingTest } from 'showcase/tests/helpers';`

which runs the `setupRenderingTest` method from `ember-qunit` under the hood.

Doing so allows us to run setup code prior to each test in test helpers. This work is needed ahead of the `ember-intl` integration.

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
