### PR TITLE
Website: fix instances of `display: contents;`

### DIFF
--- a/website/app/components/doc/font-helpers-list/index.hbs
+++ b/website/app/components/doc/font-helpers-list/index.hbs
@@ -5,7 +5,7 @@
 
 <ul class="doc-font-helpers-list" role="list">
   {{#each @items as |item|}}
-    {{! Add role="listitem" because the class sets display: contents; }}
+    {{! role="listitem" is needed here because the class sets `display: contents` and some browsers and assistive technologies will ignore the implied role }}
     <li class="doc-font-helpers-list__item" role="listitem">
       <div class="doc-font-helpers-list__preview {{item.previewClass}}">{{item.previewText}}</div>
       <div class="doc-font-helpers-list__content">

--- a/website/app/components/doc/font-helpers-list/index.hbs
+++ b/website/app/components/doc/font-helpers-list/index.hbs
@@ -5,7 +5,8 @@
 
 <ul class="doc-font-helpers-list" role="list">
   {{#each @items as |item|}}
-    <li class="doc-font-helpers-list__item">
+    {{! Add role="listitem" because the class sets display: contents; }}
+    <li class="doc-font-helpers-list__item" role="listitem">
       <div class="doc-font-helpers-list__preview {{item.previewClass}}">{{item.previewText}}</div>
       <div class="doc-font-helpers-list__content">
         {{#if item.copyText}}

--- a/website/app/components/doc/tokens-list/item.hbs
+++ b/website/app/components/doc/tokens-list/item.hbs
@@ -3,7 +3,8 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<li class="doc-tokens-list__item">
+{{! Add role="listitem" because the class sets display: contents; }}
+<li class="doc-tokens-list__item" role="listitem">
   <div class="doc-tokens-list__preview">
     <Doc::TokenPreview @token={{this.token}} />
   </div>

--- a/website/app/components/doc/tokens-list/item.hbs
+++ b/website/app/components/doc/tokens-list/item.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{! Add role="listitem" because the class sets display: contents; }}
+{{! role="listitem" is needed here because the class sets `display: contents` and some browsers and assistive technologies will ignore the implied role }}
 <li class="doc-tokens-list__item" role="listitem">
   <div class="doc-tokens-list__preview">
     <Doc::TokenPreview @token={{this.token}} />

--- a/website/app/styles/doc-components/algolia-search/form.scss
+++ b/website/app/styles/doc-components/algolia-search/form.scss
@@ -50,13 +50,6 @@ $doc-algolia-search-modal-search-input-height: 44px;
 .aa-InputWrapperPrefix { left: 10px; }
 .aa-InputWrapperSuffix { right: 10px; }
 
-
-// this layer is useless for us
-
-.aa-Label {
-  display: contents;
-}
-
 // buttons/containers wrapping the "search", "loading" and "clear" icons
 
 .aa-SubmitButton,


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would either remove or add an explicit `role` attribute to any element using `display: contents;`. This is because some browsers + assistive technologies will ignore the implied role for an element if it has `display: contents`. 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3803](https://hashicorp.atlassian.net/browse/HDS-3803)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3803]: https://hashicorp.atlassian.net/browse/HDS-3803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ