### PR TITLE
DialogPrimitive documentation updates

### DIFF
--- a/website/docs/utilities/dialog-primitive/index.md
+++ b/website/docs/utilities/dialog-primitive/index.md
@@ -20,7 +20,6 @@ navigation:
 ---
 
 <section data-tab="Guidelines">
-  @include "partials/guidelines/overview.md"
   @include "partials/guidelines/guidelines.md"
 </section>
 

--- a/website/docs/utilities/dialog-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/dialog-primitive/partials/code/how-to-use.md
@@ -1,3 +1,11 @@
+The DialogPrimitive contains the building blocks used to construct dialog-based components and consists of:
+
+- `DialogPrimitive::Wrapper` is the structure that contains and arranges all other dialog primitives.
+- `DialogPrimitive::Header` contains the title, dismiss button, and optionally a visually supportive icon and tagline.
+- `DialogPrimitive::Description` contains optional descriptive information about the dialog.
+- `DialogPrimitive::Body` is a generic container that houses the main content or message of the dialog.
+- `DialogPrimitive::Footer` contains buttons to act on the content in the body container or link to additional resources.
+
 The DialogPrimitive Wrapper is built on the HTML `<dialog>` element, and therefore supports the same [JavaScript API](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog).
 
 ## How to use this component

--- a/website/docs/utilities/dialog-primitive/partials/guidelines/guidelines.md
+++ b/website/docs/utilities/dialog-primitive/partials/guidelines/guidelines.md
@@ -37,6 +37,6 @@ The DialogPrimitive sub-components are not intended to be used independently of 
 
 A common example of a non-modal dialog is a SplitWindow, Panel, or Drawer. This type of component allows the user to interact with both the main page content and the content within the dialog.
 
-![Example of a non-modal example](/assets/components/dialog-primitives/dialog-primitive-non-modal-example.png)
+![](/assets/components/dialog-primitives/dialog-primitive-non-modal-example.png)
 
 _If you discover other use cases, [contact the Design Systems Team](/about/support) for assistance._

--- a/website/docs/utilities/dialog-primitive/partials/guidelines/guidelines.md
+++ b/website/docs/utilities/dialog-primitive/partials/guidelines/guidelines.md
@@ -1,23 +1,42 @@
-## Usage
+## What is a “dialog”
 
-The DialogPrimitive sub-components are not intended to be used independently of each other or in isolation. If you are looking to create your own dialog-based component, use the `DialogPrimitive::Wrapper` as your foundation.
+A dialog is both a [semantic HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) and a UX pattern in which a “conversation” occurs between the user and the system.
 
-A common example of this is a non-modal dialog such as a SplitWindow or Panel, which allows the user to interact with both the main page content and the content within the dialog.
+### Dialog types
+
+There are two types of dialogs:
+
+- **Modal**: A modal dialog is an interruptive experience that demands the user’s attention and renders the rest of the page inert. It is often coupled with an overlay to obscure the page underneath and requires user action to proceed. The [Modal component](/components/modal) is an example of this.
+
+- **Non-modal**: A non-modal dialog minimizes interruption by allowing the user to continue interacting with the rest of the page. It does not always require user action and is often dismissed on its own. The [Toast component](/components/toast) is an example of this.
+
+### Conversation types
+
+Conversations between the user and the system can be:
+
+- **One-way**: A conversation in which the system communicates directly to the user. One-way conversations are commonly initiated when the system’s state changes, e.g., by notifying the user of a successful background process. Non-modal dialogs are best used for one-way conversations.
+
+- **Two-way**: A conversation between the system and the user. It is commonly initiated by a user action, e.g., interacting with a button, and often requires user engagement. Modal dialogs are best for two-way conversations.
+
+## What a “dialog” isn’t
+
+### Form errors and alerts
+
+When a form is submitted with errors, it’s common to show an alert before the form. This kind of experience is not considered a dialog because, although the system communicates the error to the user (conversational), alerts do not overlay the UI or interrupt the user’s workflow.
+
+### Tooltip or Rich Tooltip
+
+While the Tooltip and Rich Tooltip overlay the UI and block content underneath, they display static informational content and are not seen as a conversation between the system and user.
+
+## Creating custom dialogs
 
 !!! Info
 
-If you discover a use case outside of this example, [contact the Design Systems Team](/about/support) for assistance.
+The DialogPrimitive sub-components are not intended to be used independently of each other or in isolation. If looking to create a dialog-based component, use the `DialogPrimitive::Wrapper` as the foundation.
 !!!
+
+A common example of a non-modal dialog is a SplitWindow, Panel, or Drawer. This type of component allows the user to interact with both the main page content and the content within the dialog.
 
 ![Example of a non-modal example](/assets/components/dialog-primitives/dialog-primitive-non-modal-example.png)
 
-### Use within HDS components
-
-Examples of how to use the DialogPrimitive components can be found in the HDS [Modal](/components/modal) and [Flyout](/components/flyout) components which are composed using the DialogPrimitive. They are both types of dialogs, but have different use cases depending on the context and type of information they convey.
-
-### What is a “dialog”
-
-The term “dialog” has somewhat of a loaded meaning and, depending on the context, can be either an ambiguous high-level term or have a specific semantic meaning. For example:
-
-- Broadly, the term dialog can refer to the interaction between a user and an application or machine that encourages a bidirectional exchange of information between the two.
-- Specifically, a dialog can refer to a semantic `<dialog>` element in HTML. This element can be further broken down into modal and non-modal dialogs, more details of which can be found in the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog).
+_If you discover a use case outside of this example, [contact the Design Systems Team](/about/support) for assistance._

--- a/website/docs/utilities/dialog-primitive/partials/guidelines/guidelines.md
+++ b/website/docs/utilities/dialog-primitive/partials/guidelines/guidelines.md
@@ -18,13 +18,13 @@ Conversations between the user and the system can be:
 
 - **Two-way**: A conversation between the system and the user. It is commonly initiated by a user action, e.g., interacting with a button, and often requires user engagement. Modal dialogs are best for two-way conversations.
 
-## What a “dialog” isn’t
+### What a “dialog” isn’t
 
-### Form errors and alerts
+#### Form errors and alerts
 
 When a form is submitted with errors, it’s common to show an alert before the form. This kind of experience is not considered a dialog because, although the system communicates the error to the user (conversational), alerts do not overlay the UI or interrupt the user’s workflow.
 
-### Tooltip or Rich Tooltip
+#### Tooltip or Rich Tooltip
 
 While the Tooltip and Rich Tooltip overlay the UI and block content underneath, they display static informational content and are not seen as a conversation between the system and user.
 
@@ -39,4 +39,4 @@ A common example of a non-modal dialog is a SplitWindow, Panel, or Drawer. This 
 
 ![Example of a non-modal example](/assets/components/dialog-primitives/dialog-primitive-non-modal-example.png)
 
-_If you discover a use case outside of this example, [contact the Design Systems Team](/about/support) for assistance._
+_If you discover other use cases, [contact the Design Systems Team](/about/support) for assistance._

--- a/website/docs/utilities/dialog-primitive/partials/guidelines/overview.md
+++ b/website/docs/utilities/dialog-primitive/partials/guidelines/overview.md
@@ -1,7 +1,0 @@
-The DialogPrimitive contains the building blocks used to construct dialog-based components and consists of:
-
-- `DialogPrimitive::Wrapper` is the structure that contains and arranges all other dialog primitives.
-- `DialogPrimitive::Header` contains the title, dismiss button, and optionally a visually supportive icon and tagline.
-- `DialogPrimitive::Description` contains optional descriptive information about the dialog.
-- `DialogPrimitive::Body` is a generic container that houses the main content or message of the dialog.
-- `DialogPrimitive::Footer` contains buttons to act on the content in the body container or link to additional resources.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR makes changes to the DialogPrimitive guidelines to clarify what a dialog is. 

**👉🏻 Preview link:**  https://hds-website-git-hds-3554-dialog-documentation-hashicorp.vercel.app/utilities/dialog-primitive

### :hammer_and_wrench: Detailed description

- Moved the overview content to the Code tab, which is a more appropriate place for content geared towards engineers
- Changed the heading "Usage" to "Creating custom dialogs" to be more descriptive of the content in the section
- Moved @majedelass's dialog documentation updates out of Google

### :camera_flash: Screenshots

**Before:**
<img width="942" alt="Screenshot 2025-05-23 at 10 14 21 AM" src="https://github.com/user-attachments/assets/1fe26aff-3613-46a0-a813-333f765446fb" />

**After:**
<img width="863" alt="Screenshot 2025-05-23 at 10 14 42 AM" src="https://github.com/user-attachments/assets/119f0f98-86ef-4659-bdda-e1b81d4ebcf9" />
<img width="868" alt="Screenshot 2025-05-23 at 10 14 54 AM" src="https://github.com/user-attachments/assets/84795add-5451-4ac9-871a-f9cfb3584666" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3554](https://hashicorp.atlassian.net/browse/HDS-3554)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-3554]: https://hashicorp.atlassian.net/browse/HDS-3554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ