### PR TITLE
`AppSideNav`, `SideNav`: fix typing issue

### DIFF
--- a/.changeset/kind-ligers-invent.md
+++ b/.changeset/kind-ligers-invent.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AppSideNav` - Fixed component types for `AppSideNav::Portal` and `AppSideNav::Portal::Target` to no longer require `@target` or `@name`.
+
+`SideNav` - Fixed component types for `SideNav::Portal` and `SideNav::Portal::Target` to no longer require `@target` or `@name`.

--- a/packages/components/src/components/hds/app-side-nav/portal/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/portal/index.ts
@@ -7,21 +7,8 @@ import TemplateOnlyComponent from '@ember/component/template-only';
 
 import type { HdsAppSideNavListSignature } from '../list/index';
 
-// TODO! understand how this should be done "correctly"
-// import type { PortalSignature } from 'ember-stargate/components/portal';
-interface PortalSignature {
-  Args: {
-    target: string;
-    renderInPlace?: boolean;
-    fallback?: 'inplace';
-  };
-  Blocks: {
-    default: [];
-  };
-}
-
 export interface HdsAppSideNavPortalSignature {
-  Args: PortalSignature['Args'] & {
+  Args: {
     ariaLabel?: string;
     targetName?: string;
   };

--- a/packages/components/src/components/hds/app-side-nav/portal/target.ts
+++ b/packages/components/src/components/hds/app-side-nav/portal/target.ts
@@ -10,24 +10,10 @@ import { action } from '@ember/object';
 import { macroCondition, isTesting } from '@embroider/macros';
 
 import type { HdsAppSideNavPortalSignature } from './index';
-
-// import { PortalTargetSignature } from 'ember-stargate/components/portal-target';
-interface PortalTargetSignature {
-  Element: HTMLDivElement;
-  Args: {
-    name: string;
-    multiple?: boolean;
-    onChange?: (count: number) => void;
-  };
-  Blocks: {
-    default: [number];
-  };
-}
-
 import type { Registry as Services } from '@ember/service';
 
 interface HdsAppSideNavPortalTargetSignature {
-  Args: PortalTargetSignature['Args'] & {
+  Args: {
     targetName?: HdsAppSideNavPortalSignature['Args']['targetName'];
   };
   Element: HTMLDivElement;

--- a/packages/components/src/components/hds/side-nav/portal/index.ts
+++ b/packages/components/src/components/hds/side-nav/portal/index.ts
@@ -7,21 +7,8 @@ import TemplateOnlyComponent from '@ember/component/template-only';
 
 import type { HdsSideNavListSignature } from '../list/index';
 
-// TODO! understand how this should be done "correctly"
-// import type { PortalSignature } from 'ember-stargate/components/portal';
-export interface PortalSignature {
-  Args: {
-    target: string;
-    renderInPlace?: boolean;
-    fallback?: 'inplace';
-  };
-  Blocks: {
-    default: [];
-  };
-}
-
 export interface HdsSideNavPortalSignature {
-  Args: PortalSignature['Args'] & {
+  Args: {
     ariaLabel?: string;
     targetName?: string;
   };

--- a/packages/components/src/components/hds/side-nav/portal/target.ts
+++ b/packages/components/src/components/hds/side-nav/portal/target.ts
@@ -11,23 +11,10 @@ import { macroCondition, isTesting } from '@embroider/macros';
 
 import type { HdsSideNavPortalSignature } from './index';
 
-// import { PortalTargetSignature } from 'ember-stargate/components/portal-target';
-export interface PortalTargetSignature {
-  Element: HTMLDivElement;
-  Args: {
-    name: string;
-    multiple?: boolean;
-    onChange?: (count: number) => void;
-  };
-  Blocks: {
-    default: [number];
-  };
-}
-
 import type { Registry as Services } from '@ember/service';
 
 export interface HdsSideNavPortalTargetSignature {
-  Args: PortalTargetSignature['Args'] & {
+  Args: {
     targetName?: HdsSideNavPortalSignature['Args']['targetName'];
   };
   Element: HTMLDivElement;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue with unused arguments being required for the AppSideNav and SideNav components.

### :hammer_and_wrench: Detailed description

Currently, the component throws type errors that `@target` is required for `Hds::AppSideNav/SideNav::Portal` and `@name` is required for `Hds::AppSideNav/SideNav::Portal::Target`.

This is because the types for Portal and Portal::Target are a union of the types from `ember-stargate` and our own args. For our components, we expose the `targetName` argument as the way consumers can change the name or target argument. 

I decided to delete the PortalSignature and PortalTarget signatures entirely because none of those args are passed to the components so if a consumer used them it wouldn't do anything.

#### Example Hds::AppSideNav::Portal

Notice `@target`, `@renderInPlace`, and `@fallback` are not forwarded to the `Portal` component.

**[handlebars](https://github.com/hashicorp/design-system/blob/f902dcd320f92ed7fc01358a9a2843a246183e4b/packages/components/src/components/hds/app-side-nav/portal/index.hbs#L6)**
![Screenshot 2025-05-27 at 4 27 04 PM](https://github.com/user-attachments/assets/84242e44-4b50-4265-9398-f57314d7d0c9)

**[types](https://github.com/hashicorp/design-system/blob/f902dcd320f92ed7fc01358a9a2843a246183e4b/packages/components/src/components/hds/app-side-nav/portal/index.ts#L12)**
![Screenshot 2025-05-27 at 4 28 25 PM](https://github.com/user-attachments/assets/2248b537-c763-4273-a467-05613df4f699)


### :link: External links

* [Cloud-ui commit where they had to add glint-expect-errors](https://github.com/hashicorp/cloud-ui/pull/12248/commits/88680ec5c14ce19b55cd221ae278cb0b3003a41e)

***

### 👀 Component checklist

- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
