### PR TITLE
`Stepper::Nav` Safari text alignment fix for interactive steps

### DIFF
--- a/.changeset/spicy-buses-design.md
+++ b/.changeset/spicy-buses-design.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Stepper::Nav` - Fixed issue in Safari with text alignment on interactive steps

--- a/packages/components/src/styles/components/stepper/nav.scss
+++ b/packages/components/src/styles/components/stepper/nav.scss
@@ -72,6 +72,7 @@ $progress-bar-animation-duration: 0.25s;
   position: relative;
   display: flex;
   flex-direction: column;
+  align-items: center;
   width: 100%;
   padding: 0;
   background-color: transparent;

--- a/packages/components/src/styles/components/stepper/nav.scss
+++ b/packages/components/src/styles/components/stepper/nav.scss
@@ -72,6 +72,7 @@ $progress-bar-animation-duration: 0.25s;
   position: relative;
   display: flex;
   flex-direction: column;
+  // important: in Safari the text alignment of `button` elements is set to `align-items: flex-start` by default, so we need to make sure the content is centered 
   align-items: center;
   width: 100%;
   padding: 0;

--- a/packages/components/src/styles/components/stepper/nav.scss
+++ b/packages/components/src/styles/components/stepper/nav.scss
@@ -72,7 +72,7 @@ $progress-bar-animation-duration: 0.25s;
   position: relative;
   display: flex;
   flex-direction: column;
-  // important: in Safari the text alignment of `button` elements is set to `align-items: flex-start` by default, so we need to make sure the content is centered 
+  // important: in Safari the text alignment of `button` elements is set to `align-items: flex-start` by default, so we need to make sure the content is centered
   align-items: center;
   width: 100%;
   padding: 0;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes an issue with the `Stepper::Nav` for text alignment of interactive steps in Safari.

### :hammer_and_wrench: Detailed description

If was observed in the `Stepper::Nav`: in Safari the text alignment of the step title and description was left aligned instead of center aligned. 

This is due to Safari setting `align-items: flex-start;` on all `button` elements by default. 

<img width="295" alt="Screenshot 2025-05-28 at 8 29 24 AM" src="https://github.com/user-attachments/assets/9562799b-6a32-47d8-903c-e0430d268a03" />


This PR would update the styles to fix this issue in Safari, and insure the text is center aligned.

### :camera_flash: Screenshots

**Before**
<img width="372" alt="Screenshot 2025-05-28 at 9 02 08 AM" src="https://github.com/user-attachments/assets/77891991-a7dd-4f62-b314-c7746472d0b1" />

**After**
<img width="371" alt="Screenshot 2025-05-28 at 9 02 00 AM" src="https://github.com/user-attachments/assets/59907fb9-4b17-4bef-8ec8-306dcea24e47" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4900](https://hashicorp.atlassian.net/browse/HDS-4900)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4900]: https://hashicorp.atlassian.net/browse/HDS-4900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ