### PR TITLE
`Stepper::Nav` - Fix alignment in mobile

### DIFF
--- a/packages/components/src/styles/components/stepper/nav.scss
+++ b/packages/components/src/styles/components/stepper/nav.scss
@@ -304,6 +304,7 @@ $progress-bar-animation-duration: 0.25s;
   }
 
   .hds-stepper-nav__step-content {
+    align-items: start;
     padding: 8px;
     border-radius: 0;
   }


### PR DESCRIPTION
### :pushpin: Summary

Follow up to the `Stepper::Nav` changes in #2909 to fix the alignment of the step title and description in mobile.

**Note:** This bug was accidentally introduced recently in #2909 so no need for a changeset 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4900](https://hashicorp.atlassian.net/browse/HDS-4900)

### 📸  Screenshots

**Before**
<img width="377" alt="Screenshot 2025-05-29 at 1 24 32 PM" src="https://github.com/user-attachments/assets/69c50127-b830-4bdf-a94d-d8b28724d509" />

**After**
<img width="381" alt="Screenshot 2025-05-29 at 1 25 34 PM" src="https://github.com/user-attachments/assets/247a25a8-8691-4308-8853-2e316e782a5c" />

***

### 👀 Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4900]: https://hashicorp.atlassian.net/browse/HDS-4900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ