### PR TITLE
Fix incomplete string escaping in `docs-scraper`

### DIFF
--- a/website/docs-scraper/parts/remarkSanitizeDocComponentApi.mjs
+++ b/website/docs-scraper/parts/remarkSanitizeDocComponentApi.mjs
@@ -15,12 +15,12 @@ export const remarkSanitizeDocComponentApi = () => (tree) => {
       node.value = node.value
         .replace(
           /`(.*?)`/gim,
-          (_match, p1) => `${p1.replace('<', '&#60;').replace('>', '&#62;')}`,
+          (_match, p1) => `${p1.replace(/</g, '&#60;').replace(/>/g, '&#62;')}`,
         )
         .replace(
           /@name="(.*?)"/gim,
           (_match, p1) =>
-            `@name="${p1.replace('<', '&#60;').replace('>', '&#62;')}"`,
+            `@name="${p1.replace(/</g, '&#60;').replace(/>/g, '&#62;')}"`,
         );
     }
   });


### PR DESCRIPTION
### :pushpin: Summary

Fix incomplete string escaping in `docs-scraper` to address vulnerability raised by [code scanning](https://github.com/hashicorp/design-system/security/code-scanning)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
