### PR TITLE
Showcase / Some updates

### DIFF
--- a/showcase/app/templates/components/form/checkbox.hbs
+++ b/showcase/app/templates/components/form/checkbox.hbs
@@ -128,6 +128,25 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Grid @columns="3" as |SG|>
+    <SG.Item @label="Disabled">
+      <Hds::Form::Checkbox::Field disabled as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::Checkbox::Field>
+    </SG.Item>
+    <SG.Item @label="Disabled / Checked">
+      <Hds::Form::Checkbox::Field disabled checked="checked" as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::Checkbox::Field>
+    </SG.Item>
+  </Shw::Grid>
+
   <Shw::Divider />
 
   <Shw::Text::H2>"Group" of controls</Shw::Text::H2>
@@ -227,6 +246,8 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Horizontal layout</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
@@ -312,6 +333,8 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Required and optional</Shw::Text::H3>
 
   <Shw::Flex as |SF|>
@@ -340,6 +363,31 @@
         </G.CheckboxField>
         <G.CheckboxField indeterminate={{true}} as |F|>
           <F.Label>Label of control #3</F.Label>
+        </G.CheckboxField>
+      </Hds::Form::Checkbox::Group>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Disabled">
+      <Hds::Form::Checkbox::Group @name="control-disabled" as |G|>
+        <G.Legend>Legend of the group</G.Legend>
+        <G.HelperText>Helper text for the entire group</G.HelperText>
+        <G.CheckboxField disabled={{true}} as |F|>
+          <F.Label>Label of control #1</F.Label>
+          <F.HelperText>Helper text for control #1</F.HelperText>
+        </G.CheckboxField>
+        <G.CheckboxField disabled={{true}} checked="checked" as |F|>
+          <F.Label>Label of control #2</F.Label>
+          <F.HelperText>Helper text for control #2</F.HelperText>
+        </G.CheckboxField>
+        <G.CheckboxField disabled={{true}} indeterminate={{true}} as |F|>
+          <F.Label>Label of control #3</F.Label>
+          <F.HelperText>Helper text for control #3</F.HelperText>
         </G.CheckboxField>
       </Hds::Form::Checkbox::Group>
     </SF.Item>

--- a/showcase/app/templates/components/form/checkbox.hbs
+++ b/showcase/app/templates/components/form/checkbox.hbs
@@ -96,8 +96,13 @@
         <F.HelperText>This is the helper text</F.HelperText>
       </Hds::Form::Checkbox::Field>
     </SG.Item>
-    {{! left empty on purpose }}
-    <SG.Item />
+    <SG.Item @label="Label + Helper text with link">
+      <Hds::Form::Checkbox::Field checked="checked" as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text
+          <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+      </Hds::Form::Checkbox::Field>
+    </SG.Item>
     <SG.Item @label="Label + Error">
       <Hds::Form::Checkbox::Field as |F|>
         <F.Label>This is the label</F.Label>

--- a/showcase/app/templates/components/form/file-input.hbs
+++ b/showcase/app/templates/components/form/file-input.hbs
@@ -56,8 +56,13 @@
           <F.HelperText>This is the helper text</F.HelperText>
         </Hds::Form::FileInput::Field>
       </SG.Item>
-      {{! left empty on purpose }}
-      <SG.Item />
+      <SG.Item @label="Label + Helper text with link">
+        <Hds::Form::FileInput::Field @value="Lorem ipsum dolor" as |F|>
+          <F.Label>This is the label text</F.Label>
+          <F.HelperText>This is the helper text
+            <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+        </Hds::Form::FileInput::Field>
+      </SG.Item>
       <SG.Item @label="Label + Error">
         <Hds::Form::FileInput::Field @value="Lorem ipsum dolor" @isInvalid={{true}} as |F|>
           <F.Label>This is the label</F.Label>

--- a/showcase/app/templates/components/form/file-input.hbs
+++ b/showcase/app/templates/components/form/file-input.hbs
@@ -22,7 +22,7 @@
       </SF.Item>
     </Shw::Flex>
 
-    <Shw::Text::H2>States</Shw::Text::H2>
+    <Shw::Text::H3>States</Shw::Text::H3>
 
     <Shw::Flex @gap="2rem" as |SF|>
       {{#each @model.STATES as |state|}}
@@ -88,4 +88,16 @@
       </SG.Item>
     </Shw::Grid>
   </div>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Grid @columns="3" @gap="2rem" as |SG|>
+    <SG.Item @label="Disabled">
+      <Hds::Form::FileInput::Field @value="Lorem ipsum dolor" disabled={{true}} as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::FileInput::Field>
+    </SG.Item>
+  </Shw::Grid>
+
 </section>

--- a/showcase/app/templates/components/form/masked-input.hbs
+++ b/showcase/app/templates/components/form/masked-input.hbs
@@ -280,8 +280,8 @@
     <SG.Item @label="Label + Helper text with link">
       <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" as |F|>
         <F.Label>This is the label text</F.Label>
-          <F.HelperText>This is the helper text
-            <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+        <F.HelperText>This is the helper text
+          <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
       </Hds::Form::MaskedInput::Field>
     </SG.Item>
     <SG.Item @label="Label + Helper text + Copy Button + Error">

--- a/showcase/app/templates/components/form/masked-input.hbs
+++ b/showcase/app/templates/components/form/masked-input.hbs
@@ -115,7 +115,7 @@
 
   <Shw::Text::H4>Single line</Shw::Text::H4>
 
-  {{#let (array "base" "invalid" "readonly") as |variants|}}
+  {{#let (array "base" "invalid" "readonly" "disabled") as |variants|}}
     {{#each variants as |variant|}}
       <Shw::Grid @columns={{3}} as |SG|>
         {{#each @model.STATES as |state|}}
@@ -143,7 +143,7 @@
 
   <Shw::Text::H4>Multiline</Shw::Text::H4>
 
-  {{#let (array "base" "invalid" "readonly") as |variants|}}
+  {{#let (array "base" "invalid" "readonly" "disabled") as |variants|}}
     {{#each variants as |variant|}}
       <Shw::Grid @columns={{3}} as |SG|>
         {{#each @model.STATES as |state|}}
@@ -498,6 +498,40 @@
     </SG.Item>
     <SG.Item @label="Label + Optional">
       <Hds::Form::MaskedInput::Field @isMultiline={{true}} @value="Lorem ipsum dolor" @isOptional={{true}} as |F|>
+        <F.Label>This is the label text</F.Label>
+      </Hds::Form::MaskedInput::Field>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level="2" />
+
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Text::H4>Single line</Shw::Text::H4>
+
+  <Shw::Grid @columns={{3}} as |SG|>
+    <SG.Item @label="Readonly Optional">
+      <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" readonly={{true}} as |F|>
+        <F.Label>This is the label text</F.Label>
+      </Hds::Form::MaskedInput::Field>
+    </SG.Item>
+    <SG.Item @label="Disabled">
+      <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" disabled={{true}} as |F|>
+        <F.Label>This is the label text</F.Label>
+      </Hds::Form::MaskedInput::Field>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Text::H4>Multiline</Shw::Text::H4>
+
+  <Shw::Grid @columns={{3}} as |SG|>
+    <SG.Item @label="Readonly">
+      <Hds::Form::MaskedInput::Field @isMultiline={{true}} @value="Lorem ipsum dolor" readonly={{true}} as |F|>
+        <F.Label>This is the label text</F.Label>
+      </Hds::Form::MaskedInput::Field>
+    </SG.Item>
+    <SG.Item @label="Disabled">
+      <Hds::Form::MaskedInput::Field @isMultiline={{true}} @value="Lorem ipsum dolor" disabled={{true}} as |F|>
         <F.Label>This is the label text</F.Label>
       </Hds::Form::MaskedInput::Field>
     </SG.Item>

--- a/showcase/app/templates/components/form/masked-input.hbs
+++ b/showcase/app/templates/components/form/masked-input.hbs
@@ -277,6 +277,13 @@
         <F.HelperText>This is the helper text</F.HelperText>
       </Hds::Form::MaskedInput::Field>
     </SG.Item>
+    <SG.Item @label="Label + Helper text with link">
+      <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" as |F|>
+        <F.Label>This is the label text</F.Label>
+          <F.HelperText>This is the helper text
+            <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+      </Hds::Form::MaskedInput::Field>
+    </SG.Item>
     <SG.Item @label="Label + Helper text + Copy Button + Error">
       <Hds::Form::MaskedInput::Field @value="Lorem ipsum dolor" @isInvalid={{true}} @hasCopyButton={{true}} as |F|>
         <F.Label>This is the label</F.Label>

--- a/showcase/app/templates/components/form/radio.hbs
+++ b/showcase/app/templates/components/form/radio.hbs
@@ -83,8 +83,13 @@
         <F.HelperText>This is the helper text</F.HelperText>
       </Hds::Form::Radio::Field>
     </SG.Item>
-    {{! left empty on purpose }}
-    <SG.Item />
+    <SG.Item @label="Label + Helper text with link">
+      <Hds::Form::Radio::Field checked="checked" as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text
+          <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+      </Hds::Form::Radio::Field>
+    </SG.Item>
     <SG.Item @label="Label + Error">
       <Hds::Form::Radio::Field as |F|>
         <F.Label>This is the label</F.Label>

--- a/showcase/app/templates/components/form/radio.hbs
+++ b/showcase/app/templates/components/form/radio.hbs
@@ -115,6 +115,25 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Grid @columns="3" as |SG|>
+    <SG.Item @label="Disabled">
+      <Hds::Form::Radio::Field disabled as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::Radio::Field>
+    </SG.Item>
+    <SG.Item @label="Disabled / Checked">
+      <Hds::Form::Radio::Field disabled checked="checked" as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::Radio::Field>
+    </SG.Item>
+  </Shw::Grid>
+
   <Shw::Divider />
 
   <Shw::Text::H2>"Group" of controls</Shw::Text::H2>
@@ -214,6 +233,8 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Horizontal layout</Shw::Text::H3>
 
   <Shw::Flex @direction="column" as |SF|>
@@ -299,6 +320,8 @@
     </SF.Item>
   </Shw::Flex>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Required and optional</Shw::Text::H3>
 
   <Shw::Flex as |SF|>
@@ -331,6 +354,33 @@
       </Hds::Form::Radio::Group>
     </SF.Item>
   </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Flex as |SF|>
+    <SF.Item @label="Disabled">
+      <Hds::Form::Radio::Group @name="control-disabled" as |G|>
+        <G.Legend>Legend of the group</G.Legend>
+        <G.HelperText>Helper text for the entire group</G.HelperText>
+        <G.RadioField disabled={{true}} as |F|>
+          <F.Label>Label of control #1</F.Label>
+          <F.HelperText>Helper text for control #1</F.HelperText>
+        </G.RadioField>
+        <G.RadioField disabled={{true}} checked="checked" as |F|>
+          <F.Label>Label of control #2</F.Label>
+          <F.HelperText>Helper text for control #2</F.HelperText>
+        </G.RadioField>
+        <G.RadioField disabled={{true}} indeterminate={{true}} as |F|>
+          <F.Label>Label of control #3</F.Label>
+          <F.HelperText>Helper text for control #3</F.HelperText>
+        </G.RadioField>
+      </Hds::Form::Radio::Group>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>Special cases</Shw::Text::H3>
 

--- a/showcase/app/templates/components/form/select.hbs
+++ b/showcase/app/templates/components/form/select.hbs
@@ -238,8 +238,8 @@
 
   <Shw::Text::H3>Required and optional</Shw::Text::H3>
 
-  <Shw::Flex as |SF|>
-    <SF.Item @label="With legend + Required">
+  <Shw::Grid @columns="3" as |SG|>
+    <SG.Item @label="With legend + Required">
       <Hds::Form::Select::Field @isRequired={{true}} as |F|>
         <F.Label>Lorem ipsum dolor</F.Label>
         <F.Options>
@@ -247,8 +247,8 @@
           <option>Sine qua non est</option>
         </F.Options>
       </Hds::Form::Select::Field>
-    </SF.Item>
-    <SF.Item @label="With legend + Optional">
+    </SG.Item>
+    <SG.Item @label="With legend + Optional">
       <Hds::Form::Select::Field @isOptional={{true}} as |F|>
         <F.Label>Lorem ipsum dolor</F.Label>
         <F.Options>
@@ -256,8 +256,44 @@
           <option>Sine qua non est</option>
         </F.Options>
       </Hds::Form::Select::Field>
-    </SF.Item>
-  </Shw::Flex>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Grid @columns="3" as |SG|>
+    <SG.Item @label="Disabled">
+      <Hds::Form::Select::Field disabled={{true}} as |F|>
+        <F.Label>Lorem ipsum dolor</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Options>
+          <option>Lorem ipsum dolor</option>
+          <option>Sine qua non est</option>
+        </F.Options>
+      </Hds::Form::Select::Field>
+    </SG.Item>
+    <SG.Item @label="Disabled / Multiple">
+      <Hds::Form::Select::Field disabled={{true}} aria-label="multiple groups selected" multiple size="8" as |F|>
+        <F.Label>Lorem ipsum dolor</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        <F.Options>
+          <optgroup label="Most common">
+            <option value="Kubernetes">Kubernetes</option>
+            <option value="AWS">AWS</option>
+            <option value="Azure" disabled>Azure</option>
+          </optgroup>
+          <optgroup label="Others">
+            <option value="Alibaba" selected>Alibaba</option>
+            <option value="CloudWise" selected>CloudWise</option>
+            <option value="SWA">SWA</option>
+            <option value="Other">Other</option>
+          </optgroup>
+        </F.Options>
+      </Hds::Form::Select::Field>
+    </SG.Item>
+  </Shw::Grid>
 
   <Shw::Divider @level={{2}} />
 

--- a/showcase/app/templates/components/form/select.hbs
+++ b/showcase/app/templates/components/form/select.hbs
@@ -184,8 +184,17 @@
             </F.Options>
           </Hds::Form::Select::Field>
         </SG.Item>
-        {{! left empty on purpose }}
-        <SG.Item />
+        <SG.Item @label="Label + Helper text with link">
+          <Hds::Form::Select::Field multiple={{if (eq type "multiple") true null}} as |F|>
+            <F.Label>This is the label</F.Label>
+            <F.HelperText>This is the helper text
+              <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+            <F.Options>
+              <option selected>Lorem ipsum dolor</option>
+              <option>Sine qua non est</option>
+            </F.Options>
+          </Hds::Form::Select::Field>
+        </SG.Item>
         <SG.Item @label="Label + Error">
           <Hds::Form::Select::Field multiple={{if (eq type "multiple") true null}} @isInvalid={{true}} as |F|>
             <F.Label>This is the label</F.Label>

--- a/showcase/app/templates/components/form/super-select.hbs
+++ b/showcase/app/templates/components/form/super-select.hbs
@@ -377,8 +377,19 @@
         {{F.options}}
       </Hds::Form::SuperSelect::Single::Field>
     </SG.Item>
-    {{! left empty on purpose }}
-    <SG.Item />
+    <SG.Item @label="Label + Helper text with link">
+      <Hds::Form::SuperSelect::Single::Field
+        @onChange={{fn (mut @model.SELECTED_OPTION)}}
+        @options={{@model.OPTIONS}}
+        @selected={{@model.SELECTED_OPTION}}
+        as |F|
+      >
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text
+          <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+        {{F.options}}
+      </Hds::Form::SuperSelect::Single::Field>
+    </SG.Item>
     <SG.Item @label="Label + Error">
       <Hds::Form::SuperSelect::Single::Field
         @onChange={{fn (mut @model.SELECTED_OPTION)}}
@@ -906,8 +917,19 @@
         {{F.options}}
       </Hds::Form::SuperSelect::Multiple::Field>
     </SG.Item>
-    {{! left empty on purpose }}
-    <SG.Item />
+    <SG.Item @label="Label + Helper text with link">
+      <Hds::Form::SuperSelect::Multiple::Field
+        @onChange={{fn (mut @model.SELECTED_OPTIONS)}}
+        @options={{@model.OPTIONS}}
+        @selected={{@model.SELECTED_OPTIONS}}
+        as |F|
+      >
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text
+          <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+        {{F.options}}
+      </Hds::Form::SuperSelect::Multiple::Field>
+    </SG.Item>
     <SG.Item @label="Label + Error">
       <Hds::Form::SuperSelect::Multiple::Field
         @onChange={{fn (mut @model.SELECTED_OPTIONS)}}

--- a/showcase/app/templates/components/form/super-select.hbs
+++ b/showcase/app/templates/components/form/super-select.hbs
@@ -436,6 +436,8 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Required and optional</Shw::Text::H3>
 
   <Shw::Grid @columns={{3}} as |SG|>
@@ -464,6 +466,28 @@
       </Hds::Form::SuperSelect::Single::Field>
     </SG.Item>
   </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Grid @columns={{3}} as |SG|>
+    <SG.Item @label="Disabled">
+      <Hds::Form::SuperSelect::Single::Field
+        @onChange={{fn (mut @model.SELECTED_OPTION)}}
+        @options={{@model.OPTIONS}}
+        @selected={{@model.SELECTED_OPTION}}
+        @disabled={{true}}
+        as |F|
+      >
+        <F.Label>Lorem ipsum dolor</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        {{F.options}}
+      </Hds::Form::SuperSelect::Single::Field>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>Complex content</Shw::Text::H3>
 
@@ -976,6 +1000,8 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Required and optional</Shw::Text::H3>
 
   <Shw::Grid @columns={{3}} as |SG|>
@@ -1004,6 +1030,28 @@
       </Hds::Form::SuperSelect::Multiple::Field>
     </SG.Item>
   </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Grid @columns={{3}} as |SG|>
+    <SG.Item @label="Disabled">
+      <Hds::Form::SuperSelect::Multiple::Field
+        @onChange={{fn (mut @model.SELECTED_OPTIONS)}}
+        @options={{@model.OPTIONS}}
+        @selected={{@model.SELECTED_OPTIONS}}
+        @disabled={{true}}
+        as |F|
+      >
+        <F.Label>Lorem ipsum dolor</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+        {{F.options}}
+      </Hds::Form::SuperSelect::Multiple::Field>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
 
   <Shw::Text::H3>Complex content</Shw::Text::H3>
 

--- a/showcase/app/templates/components/form/text-input.hbs
+++ b/showcase/app/templates/components/form/text-input.hbs
@@ -356,6 +356,25 @@
 
   <Shw::Divider @level={{2}} />
 
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Grid @columns={{3}} as |SG|>
+    <SG.Item @label="Readonly">
+      <Hds::Form::TextInput::Field @value="Lorem ipsum dolor" readonly={{true}} as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::TextInput::Field>
+    </SG.Item>
+    <SG.Item @label="Disabled">
+      <Hds::Form::TextInput::Field @value="Lorem ipsum dolor" disabled={{true}} as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::TextInput::Field>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Containers</Shw::Text::H3>
 
   <Shw::Grid @columns={{3}} as |SG|>

--- a/showcase/app/templates/components/form/text-input.hbs
+++ b/showcase/app/templates/components/form/text-input.hbs
@@ -260,8 +260,13 @@
         <F.HelperText>This is the helper text</F.HelperText>
       </Hds::Form::TextInput::Field>
     </SG.Item>
-    {{! left empty on purpose }}
-    <SG.Item />
+    <SG.Item @label="Label + Helper text with link">
+      <Hds::Form::TextInput::Field @value="Lorem ipsum dolor" as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text
+          <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+      </Hds::Form::TextInput::Field>
+    </SG.Item>
     <SG.Item @label="Label + Error">
       <Hds::Form::TextInput::Field @value="Lorem ipsum dolor" @isInvalid={{true}} as |F|>
         <F.Label>This is the label</F.Label>

--- a/showcase/app/templates/components/form/textarea.hbs
+++ b/showcase/app/templates/components/form/textarea.hbs
@@ -251,6 +251,25 @@
 
   <Shw::Divider @level={{2}} />
 
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Grid @columns={{3}} as |SG|>
+    <SG.Item @label="Readonly">
+      <Hds::Form::Textarea::Field @value="Lorem ipsum dolor" readonly={{true}} as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::Textarea::Field>
+    </SG.Item>
+    <SG.Item @label="Disabled">
+      <Hds::Form::Textarea::Field @value="Lorem ipsum dolor" disabled={{true}} as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::Textarea::Field>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Containers</Shw::Text::H3>
 
   <Shw::Grid @columns={{3}} as |SG|>

--- a/showcase/app/templates/components/form/textarea.hbs
+++ b/showcase/app/templates/components/form/textarea.hbs
@@ -144,8 +144,13 @@
         <F.HelperText>This is the helper text</F.HelperText>
       </Hds::Form::Textarea::Field>
     </SG.Item>
-    {{! left empty on purpose }}
-    <SG.Item />
+    <SG.Item @label="Label + Helper text with link">
+      <Hds::Form::Textarea::Field @value="Ut enim ad minim veniam, quis nostrud exercitation ullamco" as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text
+          <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+      </Hds::Form::Textarea::Field>
+    </SG.Item>
     <SG.Item @label="Label + Error">
       <Hds::Form::Textarea::Field
         @value="Ut enim ad minim veniam, quis nostrud exercitation ullamco"

--- a/showcase/app/templates/components/form/toggle.hbs
+++ b/showcase/app/templates/components/form/toggle.hbs
@@ -111,6 +111,19 @@
     </SG.Item>
   </Shw::Grid>
 
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>States</Shw::Text::H3>
+
+  <Shw::Grid @columns="3" as |SG|>
+    <SG.Item @label="Disabled / Checked">
+      <Hds::Form::Toggle::Field checked="checked" disabled={{true}} as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::Toggle::Field>
+    </SG.Item>
+  </Shw::Grid>
+
   <Shw::Divider />
 
   <Shw::Text::H2>"Group" of controls</Shw::Text::H2>

--- a/showcase/app/templates/components/form/toggle.hbs
+++ b/showcase/app/templates/components/form/toggle.hbs
@@ -79,8 +79,13 @@
         <F.HelperText>This is the helper text</F.HelperText>
       </Hds::Form::Toggle::Field>
     </SG.Item>
-    {{! left empty on purpose }}
-    <SG.Item />
+    <SG.Item @label="Label + Helper text with link">
+      <Hds::Form::Toggle::Field checked="checked" as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text
+          <Hds::Link::Inline @route="index">with a link</Hds::Link::Inline></F.HelperText>
+      </Hds::Form::Toggle::Field>
+    </SG.Item>
     <SG.Item @label="Label + Error">
       <Hds::Form::Toggle::Field as |F|>
         <F.Label>This is the label</F.Label>


### PR DESCRIPTION
### :pushpin: Summary

Small PR that adds a few extra use cases for the `Hds::Form` components in the showcase 
 - where the help text has a link in it
 - where the field control is disabled/readonly

Context: https://github.com/hashicorp/vault/pull/30771#discussion_r2112532607

***

### 👀 Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
