### PR TITLE
`Form::Field` - Helper text links focus order fix

### DIFF
--- a/.changeset/seven-eyes-whisper.md
+++ b/.changeset/seven-eyes-whisper.md
@@ -2,8 +2,8 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Accordion` - Set `aria-controls` of `Accordion::Item::Button` to `contentId` from `DisclosurePrimitve` for a11y improvements with toggled content
+`Accordion` - Set `aria-controls` of `Accordion::Item::Button` to `contentId` from `DisclosurePrimitive` for a11y improvements with toggled content
 
-`DisclosurePrimitve` - Changed DOM structure of content section and exposed `contentId` for a11y improvements with toggled content
+`DisclosurePrimitive` - Changed DOM structure of content section and exposed `contentId` for a11y improvements with toggled content
 
-`Reveal` - Set `aria-controls` of `Reveal::Toggle` to `contentId` from `DisclosurePrimitve` for a11y improvements with toggled content
+`Reveal` - Set `aria-controls` of `Reveal::Toggle` to `contentId` from `DisclosurePrimitive` for a11y improvements with toggled content

--- a/.changeset/swift-adults-share.md
+++ b/.changeset/swift-adults-share.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Primitives` - Fixed focus order a11y issue in `Form::Field` for helper text links with `@layout` of `flag`
+`Form::Field` - Fixed focus order a11y issue for helper text links with `@layout` of `flag`

--- a/.changeset/swift-adults-share.md
+++ b/.changeset/swift-adults-share.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Primitives` - Fixed focus order a11y issue in `Form::Field` for helper text links with `@layout` of `flag`

--- a/packages/components/src/components/hds/form/field/index.hbs
+++ b/packages/components/src/components/hds/form/field/index.hbs
@@ -14,7 +14,7 @@
       )
     )
   }}
-  {{#if (not-eq @layout "flag")}}
+  {{#unless (eq @layout "flag")}}
     {{yield
       (hash
         HelperText=(component
@@ -25,7 +25,7 @@
         )
       )
     }}
-  {{/if}}
+  {{/unless}}
   <div class="hds-form-field__control">
     {{! @glint-expect-error }}
     {{yield (hash Control=(component "hds/yield") id=this.id ariaDescribedBy=this.ariaDescribedBy)}}

--- a/packages/components/src/components/hds/form/field/index.hbs
+++ b/packages/components/src/components/hds/form/field/index.hbs
@@ -14,20 +14,34 @@
       )
     )
   }}
-  {{yield
-    (hash
-      HelperText=(component
-        "hds/form/helper-text"
-        controlId=this.id
-        onInsert=this.appendDescriptor
-        contextualClass="hds-form-field__helper-text"
+  {{#if (not-eq @layout "flag")}}
+    {{yield
+      (hash
+        HelperText=(component
+          "hds/form/helper-text"
+          controlId=this.id
+          onInsert=this.appendDescriptor
+          contextualClass="hds-form-field__helper-text"
+        )
       )
-    )
-  }}
+    }}
+  {{/if}}
   <div class="hds-form-field__control">
     {{! @glint-expect-error }}
     {{yield (hash Control=(component "hds/yield") id=this.id ariaDescribedBy=this.ariaDescribedBy)}}
   </div>
+  {{#if (eq @layout "flag")}}
+    {{yield
+      (hash
+        HelperText=(component
+          "hds/form/helper-text"
+          controlId=this.id
+          onInsert=this.appendDescriptor
+          contextualClass="hds-form-field__helper-text"
+        )
+      )
+    }}
+  {{/if}}
   {{yield
     (hash
       CharacterCount=(component

--- a/showcase/app/templates/components/form/masked-input.hbs
+++ b/showcase/app/templates/components/form/masked-input.hbs
@@ -330,6 +330,13 @@
         <F.HelperText>This is the helper text</F.HelperText>
       </Hds::Form::MaskedInput::Field>
     </SG.Item>
+    <SG.Item @label="Label + Helper text link">
+      <Hds::Form::MaskedInput::Field @isMultiline={{true}} @value="Lorem ipsum dolor" as |F|>
+        <F.Label>This is the label text</F.Label>
+        <F.HelperText>This is the helper text with a
+          <Hds::Link::Inline @href="#">link</Hds::Link::Inline></F.HelperText>
+      </Hds::Form::MaskedInput::Field>
+    </SG.Item>
     <SG.Item @label="Label + Helper text + Copy Button + Error">
       <Hds::Form::MaskedInput::Field
         @isMultiline={{true}}

--- a/showcase/tests/integration/components/hds/form/field/index-test.js
+++ b/showcase/tests/integration/components/hds/form/field/index-test.js
@@ -31,6 +31,38 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
     assert.dom('#test-form-field').hasClass('hds-form-field--layout-vertical');
   });
 
+  test('it should render the correct DOM order when the @layout prop has value vertical', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Field @layout="vertical" id="test-form-field" as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::Field>`,
+    );
+    let control = this.element.querySelector(
+      '#test-form-field .hds-form-field__control',
+    );
+    let helperText = this.element.querySelector(
+      '#test-form-field .hds-form-field__helper-text',
+    );
+    assert.equal(control.previousElementSibling, helperText);
+  });
+
+  test('it should render the correct DOM order when the @layout prop has value flag', async function (assert) {
+    await render(
+      hbs`<Hds::Form::Field @layout="flag" id="test-form-field" as |F|>
+        <F.Label>This is the label</F.Label>
+        <F.HelperText>This is the helper text</F.HelperText>
+      </Hds::Form::Field>`,
+    );
+    let control = this.element.querySelector(
+      '#test-form-field .hds-form-field__control',
+    );
+    let helperText = this.element.querySelector(
+      '#test-form-field .hds-form-field__helper-text',
+    );
+    assert.equal(control.nextElementSibling, helperText);
+  });
+
   // YIELDED (CONTEXTUAL) COMPONENTS
 
   test('it renders the yielded contextual components', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR would fix a a11y focus order issue present in the `Form::Field` when links are used inside `HelperText` and `@layout="flag"`.

The form components currently affected by this issue are
- `Checkbox`
- `Radio`
- `Toggle`

### :hammer_and_wrench: Detailed description

It was observed that in some of our form elements, when a link is used inside the `HelperText` the link is focused before the label of the checkbox itself. This is because the helper text element comes before the `input` in the DOM. This leads to a confusing experience for keyboard and SR users where a link with no context is announced / focused before the input it is actually associated with.

[Website example of issue](https://helios.hashicorp.design/components/form/checkbox?tab=code#extra-content-in-legend-and-helper-text-1)

The form components affected by this issue are any that use the `flag` layout of the `Form::Field`.  For the `flag` layout the link is visually after the input, so this creates a situation where the SR / focus order does not match the visual order. 

**Note:** For form components using the `vertical` layout, the link is also read before the input element, but this is the expected behavior because visually the link comes before the input, and the SR / focus order must match the visual order. 

In this PR we have updated the DOM structure for the `Form::Field` `HelperText` to place it after the `input` in the DOM when `@layout="flag"`.

### :camera_flash: Screenshots

**Example**
<img width="238" alt="Screenshot 2025-05-29 at 10 19 38 AM" src="https://github.com/user-attachments/assets/cde4e641-ba37-4713-8cab-43060b76e5d7" />

**Before**
<img width="366" alt="Screenshot 2025-05-29 at 10 20 55 AM" src="https://github.com/user-attachments/assets/babbfdf2-fee0-43b6-bd99-40cca692cb0d" />

**After**
<img width="370" alt="Screenshot 2025-05-29 at 10 21 21 AM" src="https://github.com/user-attachments/assets/4c36ea6f-44fc-4ecb-992e-296f41549f3b" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4902](https://hashicorp.atlassian.net/browse/HDS-4902)

***

### 👀 Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-4902]: https://hashicorp.atlassian.net/browse/HDS-4902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ