### PR TITLE
`CodeBlock` - Make `didInsertNode` arguments optional

### DIFF
--- a/packages/components/src/components/hds/code-block/description.hbs
+++ b/packages/components/src/components/hds/code-block/description.hbs
@@ -9,7 +9,7 @@
   @size="100"
   class="hds-code-block__description"
   ...attributes
-  {{this._setUpDescription @didInsertNode}}
+  {{this._setUpDescription this.didInsertNode}}
 >
   {{yield}}
 </Hds::Text::Body>

--- a/packages/components/src/components/hds/code-block/description.ts
+++ b/packages/components/src/components/hds/code-block/description.ts
@@ -5,13 +5,14 @@
 
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import { action } from '@ember/object';
 import { modifier } from 'ember-modifier';
 import type { HdsTextBodySignature } from '../text/body';
 
 type HdsCodeBlockDescriptionElement = HdsTextBodySignature['Element'];
 export interface HdsCodeBlockDescriptionSignature {
   Args: {
-    didInsertNode: (element: HdsCodeBlockDescriptionElement) => void;
+    didInsertNode?: () => void;
   };
   Blocks: {
     default: [];
@@ -23,13 +24,19 @@ export default class HdsCodeBlockDescription extends Component<HdsCodeBlockDescr
   private _id = 'description-' + guidFor(this);
 
   private _setUpDescription = modifier(
-    (
-      element: HTMLElement,
-      [insertCallbackFunction]: [(element: HTMLElement) => void]
-    ) => {
+    (element: HTMLElement, [insertCallbackFunction]: [() => void]) => {
       if (typeof insertCallbackFunction === 'function') {
-        insertCallbackFunction(element);
+        insertCallbackFunction();
       }
     }
   );
+
+  @action
+  didInsertNode(): void {
+    const { didInsertNode } = this.args;
+
+    if (typeof didInsertNode === 'function') {
+      didInsertNode();
+    }
+  }
 }

--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -41,6 +41,10 @@ import 'prismjs/components/prism-yaml';
 import 'prismjs/components/prism-markup-templating';
 import 'prismjs/components/prism-handlebars';
 
+const TITLE_ELEMENT_SELECTOR = '.hds-code-block__title';
+const DESCRIPTION_ELEMENT_SELECTOR = '.hds-code-block__description';
+const PRECODE_ELEMENT_SELECTOR = '.hds-code-block__code';
+
 export const LANGUAGES: string[] = Object.values(HdsCodeBlockLanguageValues);
 
 export interface HdsCodeBlockSignature {
@@ -83,11 +87,13 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   private _preCodeId = 'pre-code-' + guidFor(this);
   private _preCodeElement!: HTMLPreElement;
   private _observer!: ResizeObserver;
+  private _element!: HTMLDivElement;
 
   // If a code block is hidden from view, and made visible after load, the Prism code needs to be re-run
   private _setUpCodeObserver = modifier((element: HTMLElement) => {
+    this._element = element as HTMLDivElement;
     this._preCodeElement = element.querySelector(
-      '.hds-code-block__code'
+      PRECODE_ELEMENT_SELECTOR
     ) as HTMLPreElement;
     this._observer = new ResizeObserver((entries) => {
       entries.forEach((entry) => {
@@ -176,15 +182,25 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
   }
 
   @action
-  registerTitleElement(element: HdsCodeBlockTitleSignature['Element']): void {
-    this._titleId = element.id;
+  registerTitleElement(): void {
+    // eslint-disable-next-line ember/no-runloop
+    schedule('afterRender', (): void => {
+      const titleElement = this._element.querySelector(
+        TITLE_ELEMENT_SELECTOR
+      ) as HTMLElement;
+      this._titleId = titleElement.id;
+    });
   }
 
   @action
-  registerDescriptionElement(
-    element: HdsCodeBlockDescriptionSignature['Element']
-  ): void {
-    this._descriptionId = element.id;
+  registerDescriptionElement(): void {
+    // eslint-disable-next-line ember/no-runloop
+    schedule('afterRender', (): void => {
+      const descriptionElement = this._element.querySelector(
+        DESCRIPTION_ELEMENT_SELECTOR
+      ) as HTMLElement;
+      this._descriptionId = descriptionElement.id;
+    });
   }
 
   @action

--- a/packages/components/src/components/hds/code-block/title.hbs
+++ b/packages/components/src/components/hds/code-block/title.hbs
@@ -10,7 +10,7 @@
   @weight="semibold"
   class="hds-code-block__title"
   ...attributes
-  {{this._setUpTitle @didInsertNode}}
+  {{this._setUpTitle this.didInsertNode}}
 >
   {{yield}}
 </Hds::Text::Body>

--- a/packages/components/src/components/hds/code-block/title.ts
+++ b/packages/components/src/components/hds/code-block/title.ts
@@ -4,6 +4,7 @@
  */
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import { action } from '@ember/object';
 import { modifier } from 'ember-modifier';
 import { HdsCodeBlockTitleTagValues } from './types.ts';
 import type { HdsCodeBlockTitleTags } from './types';
@@ -13,29 +14,35 @@ type HdsCodeBlockTitleElement = HdsTextBodySignature['Element'];
 export interface HdsCodeBlockTitleSignature {
   Args: {
     tag?: HdsCodeBlockTitleTags;
-    didInsertNode: (element: HdsCodeBlockTitleElement) => void;
+    didInsertNode?: () => void;
   };
   Blocks: {
     default: [];
   };
-  Element: HdsTextBodySignature['Element'];
+  Element: HdsCodeBlockTitleElement;
 }
 
 export default class HdsCodeBlockTitle extends Component<HdsCodeBlockTitleSignature> {
   private _id = 'title-' + guidFor(this);
 
   private _setUpTitle = modifier(
-    (
-      element: HTMLElement,
-      [insertCallbackFunction]: [(element: HTMLElement) => void]
-    ) => {
+    (element: HTMLElement, [insertCallbackFunction]: [() => void]) => {
       if (typeof insertCallbackFunction === 'function') {
-        insertCallbackFunction(element);
+        insertCallbackFunction();
       }
     }
   );
 
   get componentTag(): HdsCodeBlockTitleTags {
     return this.args.tag ?? HdsCodeBlockTitleTagValues.P;
+  }
+
+  @action
+  didInsertNode(): void {
+    const { didInsertNode } = this.args;
+
+    if (typeof didInsertNode === 'function') {
+      didInsertNode();
+    }
   }
 }

--- a/showcase/app/templates/components/code-block.hbs
+++ b/showcase/app/templates/components/code-block.hbs
@@ -321,7 +321,7 @@ function assertObjectsEqual (actual, expected, testName) {
       <Hds::CodeBlock
         @language="javascript"
         @maxHeight="130px"
-        @hashasLineNumbers={{true}}
+        @hasLineNumbers={{true}}
         @hasLineWrapping={{true}}
         @highlightLines="2"
         @ariaLabel="maxHeight='130px', hasLineWrapping=true, highlight line 2"


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR would make the `didInsertNode` arguments for the contextual `Title` and `Description` components optional to avoid any errors thrown in consumer repos by adding them as required arguments in #2879.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>