### PR TITLE
`CodeBlock` - Update signature to use `WithBoundArgs`

### DIFF
--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -15,13 +15,16 @@ import { modifier } from 'ember-modifier';
 import Prism from 'prismjs';
 
 import type { SafeString } from '@ember/template';
-import type { ComponentLike } from '@glint/template';
+import type { WithBoundArgs } from '@glint/template';
 
 import type { HdsCodeBlockTitleSignature } from './title';
 import type { HdsCodeBlockDescriptionSignature } from './description';
 import { HdsCodeBlockLanguageValues } from './types.ts';
 import type { HdsCodeBlockLanguages } from './types.ts';
 import type { HdsCopyButtonSignature } from '../copy/button/index.ts';
+
+import HdsCodeBlockTitleComponent from './title.ts';
+import HdsCodeBlockDescriptionComponent from './description.ts';
 
 import 'prismjs/plugins/line-numbers/prism-line-numbers';
 import 'prismjs/plugins/line-highlight/prism-line-highlight';
@@ -63,8 +66,14 @@ export interface HdsCodeBlockSignature {
   Blocks: {
     default: [
       {
-        Title?: ComponentLike<HdsCodeBlockTitleSignature>;
-        Description?: ComponentLike<HdsCodeBlockDescriptionSignature>;
+        Title?: WithBoundArgs<
+          typeof HdsCodeBlockTitleComponent,
+          'didInsertNode'
+        >;
+        Description?: WithBoundArgs<
+          typeof HdsCodeBlockDescriptionComponent,
+          'didInsertNode'
+        >;
       },
     ];
   };


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR would update the `CodeBlock` signature to use `WithBoundArgs` instead of `ComponentLike`. This is to avoid any errors thrown in consumer repos by having required arguments in the `Title` and `Description` contextual components, which came from #2879.

These issues were originally caught in the release `4.20` smoke testing. 

- [Cloud UI smoke test](https://github.com/hashicorp/cloud-ui/pull/12342)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>