### PR TITLE
[Website] Fix multi-level component names missed by changelog script

### DIFF
--- a/website/lib/changelog/generate-component-changelog-entries.mjs
+++ b/website/lib/changelog/generate-component-changelog-entries.mjs
@@ -69,10 +69,15 @@ const extractVersion = (changelogContent, version) => {
 };
 
 const convertComponentNameFormat = (componentName) => {
+  let separator = '';
+  const multiLevelComponentNames = ['copy', 'link', 'stepper'];
+  if (multiLevelComponentNames.includes(componentName.split('-')[0])) {
+    separator = '::';
+  }
   return componentName
     .split('-')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('');
+    .join(separator);
 };
 
 const extractComponentChangelogEntries = (components, lastVersionContent) => {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue with our `generate-changelog-component-entries` script where component with multiple levels i.e. `Component::Name` are missed by the script and those components changelog enties are not added to their component pages on the website.

Affected component folders
- Copy
- Link
- Stepper

### :hammer_and_wrench: Detailed description

In the current changelog component entries script, the script associates all changelog entries with a components in a manner where all names are concatenated from the `component-name` format to `ComponentName`. This leads to an issue where a component has multiple levels such as `Link::Inline` as the script would only be looking for `LinkInline` in the changelog.

In this PR I have updated the script to catch the three component folders we have that are currently being missed due to this issue.  

### :camera_flash: Screenshots

**Before**
<img width="313" alt="Screenshot 2025-06-04 at 9 15 40 AM" src="https://github.com/user-attachments/assets/5733ed49-0e41-4c63-8f4f-6ee769280f03" />

**After**
<img width="340" alt="Screenshot 2025-06-04 at 9 15 26 AM" src="https://github.com/user-attachments/assets/f8c6b267-2435-466c-a3d5-24213ffcb4e1" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>