### PR TITLE
[Website] Fix layout and form primitive component names missed by changelog script

### DIFF
--- a/website/lib/changelog/generate-component-changelog-entries.mjs
+++ b/website/lib/changelog/generate-component-changelog-entries.mjs
@@ -31,7 +31,16 @@ const getComponentPaths = (baseDir) => {
             components[`copy-${folder.name}`] = componentPath;
           } else if (baseDir.endsWith('/form')) {
             if (folder.name === 'primitives') {
-              const primitiveNames = ['character-count', 'error', 'field', 'fieldset', 'helper-text', 'indicator', 'label', 'legend'];
+              const primitiveNames = [
+                'character-count',
+                'error',
+                'field',
+                'fieldset',
+                'helper-text',
+                'indicator',
+                'label',
+                'legend',
+              ];
               primitiveNames.forEach((componentName) => {
                 components[`form-${componentName}`] = componentPath;
               });
@@ -83,15 +92,26 @@ const extractVersion = (changelogContent, version) => {
 };
 
 const convertComponentNameFormat = (componentName) => {
-  let separator = '';
-  const multiLevelComponentNames = ['copy', 'form', 'layout', 'link', 'stepper'];
-  if (multiLevelComponentNames.includes(componentName.split('-')[0])) {
-    separator = '::';
+  const twoLevelComponentNames = ['copy', 'form', 'layout', 'link', 'stepper'];
+  const threeLevelComponentNames = [
+    'stepper-step-indicator',
+    'stepper-task-indicator',
+  ];
+  if (twoLevelComponentNames.includes(componentName.split('-')[0])) {
+    let words = componentName
+      .split('-')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1));
+    if (threeLevelComponentNames.includes(componentName)) {
+      return words.join('::');
+    } else {
+      return words[0] + '::' + words.slice(1).join('');
+    }
+  } else {
+    return componentName
+      .split('-')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join('');
   }
-  return componentName
-    .split('-')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(separator);
 };
 
 const extractComponentChangelogEntries = (components, lastVersionContent) => {
@@ -129,7 +149,10 @@ const updateComponentVersionHistory = (componentChangelogEntries, version) => {
       const newEntries = componentChangelogEntries[componentName]
         .map((entry) => {
           // If the component is a form primitive, we want to keep the component name in the description
-          if (allComponentsPath[componentName] === './docs/components/form/primitives') {
+          if (
+            allComponentsPath[componentName] ===
+            './docs/components/form/primitives'
+          ) {
             return entry;
           } else {
             return entry.split(' - ')[1];

--- a/website/lib/changelog/generate-component-changelog-entries.mjs
+++ b/website/lib/changelog/generate-component-changelog-entries.mjs
@@ -26,9 +26,14 @@ const getComponentPaths = (baseDir) => {
         const componentPath = `${baseDir}/${folder.name}`;
         const partialsPath = `${componentPath}/partials`;
         if (fs.existsSync(partialsPath)) {
-          // we have two special cases where intermediate namespacing is used to group components:
-          // `copy` components and `link` components
-          if (baseDir.endsWith('/copy')) {
+          // we have some special cases where intermediate namespacing is used to group components:
+          if (baseDir.endsWith('/layouts')) {
+            if (folder.name === 'app-frame') {
+              components[`${folder.name}`] = componentPath;
+            } else {
+              components[`layout-${folder.name}`] = componentPath;
+            }
+          } else if (baseDir.endsWith('/copy')) {
             components[`copy-${folder.name}`] = componentPath;
           } else if (baseDir.endsWith('/link')) {
             components[`link-${folder.name}`] = componentPath;
@@ -70,7 +75,7 @@ const extractVersion = (changelogContent, version) => {
 
 const convertComponentNameFormat = (componentName) => {
   let separator = '';
-  const multiLevelComponentNames = ['copy', 'link', 'stepper'];
+  const multiLevelComponentNames = ['copy', 'link', 'stepper', 'layout'];
   if (multiLevelComponentNames.includes(componentName.split('-')[0])) {
     separator = '::';
   }


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue with our `generate-changelog-component-entries` script where the `Layout::Flex`, `Layout::Grid`, and any Form primitives components are missed by the script.

### :hammer_and_wrench: Detailed description

In the current changelog component script the `Layout::Flex`, `Layout::Grid`, and any Form primitives components are missed in getting their changelog entries added to their respective docs pages.

For the `Layout::Grid` and `Layout::Flex` this is due to them having the `Layout` prefix

For the form primitives this is due to their component docs page `form/primitives` being different from their component names (`Form::Label`, `Form::HelperText`, etc.) and that there are multiple component that map to this one page.

The script has been updated to accommodate for these use cases. 

**Note:** For the form components another effect from this change is moving forward all form components should be prefixed with `Form::` in their changelog entries in order to get caught by the script. 

### :camera_flash: Screenshots

#### Layout components

**Before**
<img width="304" alt="Screenshot 2025-06-04 at 10 13 30 AM" src="https://github.com/user-attachments/assets/56233a4d-d296-4b93-8406-0e48376a1864" />
<img width="227" alt="Screenshot 2025-06-04 at 10 13 20 AM" src="https://github.com/user-attachments/assets/df60f6c2-6263-49ed-9762-ffe96be93f26" />

**After**
<img width="304" alt="Screenshot 2025-06-04 at 10 10 34 AM" src="https://github.com/user-attachments/assets/ef07c280-eaaa-4baa-8b24-538cb7f6bd90" />
<img width="293" alt="Screenshot 2025-06-04 at 10 10 41 AM" src="https://github.com/user-attachments/assets/5aaeab9d-9692-4a56-b1dc-67b2680d40fa" />

#### Form components

**Before**
<img width="414" alt="Screenshot 2025-06-04 at 10 26 34 AM" src="https://github.com/user-attachments/assets/ddf6b0fc-e029-430d-8991-47f7367b9f6e" />
<img width="266" alt="Screenshot 2025-06-04 at 10 27 47 AM" src="https://github.com/user-attachments/assets/c23f1f09-0736-4585-bb20-82e0cb79db56" />

**After**
<img width="456" alt="Screenshot 2025-06-04 at 10 26 20 AM" src="https://github.com/user-attachments/assets/293476a4-2066-41ce-8073-2f90035a48ed" />
<img width="319" alt="Screenshot 2025-06-04 at 12 21 49 PM" src="https://github.com/user-attachments/assets/34a1815f-f66b-4ad8-a1d7-6239f4ed869e" />



### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>