### PR TITLE
Small tweaks to the changeset entries

### DIFF
--- a/.changeset/breezy-spoons-flash.md
+++ b/.changeset/breezy-spoons-flash.md
@@ -3,4 +3,5 @@
 ---
 
 `AppHeader` - Fixed import path for `hds-breakpoints`
+
 `AppSideNav` - Fixed import path for `hds-breakpoints`

--- a/.changeset/fresh-kangaroos-sing.md
+++ b/.changeset/fresh-kangaroos-sing.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`CodeBlock` - Added height toggle control which is present when a `maxHeight` is set and code content height exceeds the `maxHeight` value
+`CodeBlock` - Added height toggle control, which is present when a `maxHeight` is set and code content height exceeds the `maxHeight` value

--- a/.changeset/itchy-ravens-shout.md
+++ b/.changeset/itchy-ravens-shout.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Time` - fixed type error where the TooltipButton text could be undefined.
+`Time` - Fixed type error where the `TooltipButton` text could be undefined.

--- a/.changeset/red-rice-refuse.md
+++ b/.changeset/red-rice-refuse.md
@@ -6,6 +6,6 @@
 
 `Stepper::Nav` - Replaced custom breakpoint (`550px`) with standard `sm` (`480px`) breakpoint
 
-`AppHeader` - Removed usage of `--hds-app-desktop-breakpoint` CSS variable and relied on the `@breakpoint` argument for override of mobile behaviour
+`AppHeader` - Removed usage of `--hds-app-desktop-breakpoint` CSS variable and relied on the `@breakpoint` argument for override of mobile behavior
 
-`AppSideNav` - Removed usage of `--hds-app-desktop-breakpoint` CSS variable, added `@breakpoint` argument, and relied on it for override of mobile behaviour
+`AppSideNav` - Removed usage of `--hds-app-desktop-breakpoint` CSS variable, added `@breakpoint` argument, and relied on it for override of mobile behavior

--- a/.changeset/rotten-geese-swim.md
+++ b/.changeset/rotten-geese-swim.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`AdvancedTable` - Added `@maxHeight` argument which automatically adds a sticky header when set and sets the max height of the AdvancedTable. Also updated the container styles to constrain the Advanced Table width to the parent's width.
+`AdvancedTable` - Added `@maxHeight` argument, which sets the max height of the Advanced Table and automatically adds a sticky header to it. Also updated the container styles to constrain the Advanced Table width to the parent's width.


### PR DESCRIPTION
### :pushpin: Summary

In https://github.com/hashicorp/design-system/pull/2864 I made some changes and fixes to the changeset entries, but they're now gone (the PR is re-generated and the previous commits are lost, probably because of a forced push)

So I'm opening this PR to edit directly the source files.

@alex-ju @dchyun see comment https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3511910428/Release+Procedure?focusedCommentId=4027711557

***

### :eyes: Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>