### PR TITLE
Website - Remove “localized” when associated with “string/message”

### DIFF
--- a/website/docs/components/accordion/partials/code/component-api.md
+++ b/website/docs/components/accordion/partials/code/component-api.md
@@ -48,7 +48,7 @@ The `Accordion::Item` component, yielded as contextual component.
     </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="ariaLabel" @type="string" @default="&quot;Toggle display&quot;">
-    Accepts a localized string. The `ariaLabel` value is applied to the HTML button which controls visibility of the content block content.
+    Accepts a string. The `ariaLabel` value is applied to the HTML button which controls visibility of the content block content.
   </C.Property>
   <C.Property @name="isOpen" @default="false" @type="boolean">
     Toggles the visibility of the content. To display content on page load, set the value to `true`.

--- a/website/docs/components/alert/partials/guidelines/guidelines.md
+++ b/website/docs/components/alert/partials/guidelines/guidelines.md
@@ -143,7 +143,7 @@ Order multiple Alerts by their importance and impact on the user, starting from 
 
 ## Placing Alerts
 
-`Inline` and `compact` Alerts can have more meaning if they are placed within the element that is responsible for the Alert. This can help when it’s necessary to have more than one Alert on the page and is relevant for pages that aggregate content like dashboards, or where a specific localized message is necessary.
+`Inline` and `compact` Alerts can have more meaning if they are placed within the element that is responsible for the Alert. This can help when it’s necessary to have more than one Alert on the page and is relevant for pages that aggregate content like dashboards, or where a specific message is necessary.
 
 ![Example of multiple Alerts placed to different parts of the UI](/assets/components/alert/combining-contextualized-alerts.png)
 

--- a/website/docs/components/app-footer/partials/code/component-api.md
+++ b/website/docs/components/app-footer/partials/code/component-api.md
@@ -27,7 +27,7 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
     Set the overall theme used by the component and its children.
   </C.Property>
   <C.Property @name="ariaLabel" @type="string" @default="&quot;Footer items&quot;">
-    Accepts a localized string. The `ariaLabel` value is applied to the list of `AppFooter` content.
+    Accepts a string. The `ariaLabel` value is applied to the list of `AppFooter` content.
   </C.Property>
   <C.Property @name="copyrightYear" @type="string" @default="currentYear">
     Pass a custom year value for the `Copyright` instead of the default current year value.
@@ -97,7 +97,7 @@ The `AppFooter::LegalLinks` component, yielded as contextual component.
     Override the default href value with a custom url value.
   </C.Property>
   <C.Property @name="ariaLabel" @type="string" @default="&quot;Legal links&quot;">
-    Accepts a localized string. The `ariaLabel` value is applied to the nested list of included legal links.
+    Accepts a string. The `ariaLabel` value is applied to the nested list of included legal links.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).

--- a/website/docs/components/breadcrumb/partials/code/component-api.md
+++ b/website/docs/components/breadcrumb/partials/code/component-api.md
@@ -13,7 +13,7 @@ The Breadcrumb component is composed of three different parts, each with their o
     This controls if the Breadcrumb Items can wrap if they don’t fit within the container.
   </C.Property>
   <C.Property @name="ariaLabel" @type="string" @default="&quot;breadcrumbs&quot;">
-    Accepts a localized string.
+    Accepts a string.
   </C.Property>
   <C.Property @name="didInsert" @type="function">
     This hook method is called when the component is inserted in the DOM. Internally we use the `did-insert` modifier from `@ember/render-modifiers`.
@@ -50,7 +50,7 @@ The Breadcrumb component is composed of three different parts, each with their o
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="ariaLabel" @type="string" @default="show more">
-    Set on the truncation toggle button. Accepts a localized string.
+    Set on the truncation toggle button. Accepts a string.
   </C.Property>
   <C.Property @name="yield">
     Elements passed as children are yielded to the content of the [MenuPrimitive](/utilities/menu-primitive) component (used to show/hide the yielded Breadcrumb Items via a "toggle" button).

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -12,13 +12,13 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
     `ContentBlock::Description` yielded as contextual component (see below).
   </C.Property>
   <C.Property @name="ariaLabel" @type="string">
-    Accepts a localized string. The `ariaLabel` value is applied to the code block pre element.
+    Accepts a string. The `ariaLabel` value is applied to the code block pre element.
   </C.Property>
   <C.Property @name="ariaLabelledBy" @type="string">
-    Accepts a localized string. The `ariaLabelledBy` value is applied to the code block pre element.
+    Accepts a string. The `ariaLabelledBy` value is applied to the code block pre element.
   </C.Property>
   <C.Property @name="ariaDescribedBy" @type="string">
-    Accepts a localized string. The `ariaDescribedBy` value is applied to the code block pre element.
+    Accepts a string. The `ariaDescribedBy` value is applied to the code block pre element.
   </C.Property>
   <C.Property @name="value" @type="string" @required={{true}}>
     The text/code content for the `CodeBlock`. The component encodes this argument before displaying it.

--- a/website/docs/components/code-editor/partials/code/component-api.md
+++ b/website/docs/components/code-editor/partials/code/component-api.md
@@ -15,13 +15,13 @@ This component uses [CodeMirror 6](https://codemirror.net/) under the hood.
     `ContentBlock::Generic` yielded as contextual component (see below).
   </C.Property>
   <C.Property @name="ariaLabel" @type="string">
-    Accepts a localized string. The `ariaLabel` value is applied to the code editor input element.
+    Accepts a string. The `ariaLabel` value is applied to the code editor input element.
   </C.Property>
   <C.Property @name="ariaLabelledBy" @type="string">
-    Accepts a localized string. The `ariaLabelledBy` value is applied to the code editor input element.
+    Accepts a string. The `ariaLabelledBy` value is applied to the code editor input element.
   </C.Property>
   <C.Property @name="ariaDescribedBy" @type="string">
-    Accepts a localized string. The `ariaDescribedBy` value is applied to the code editor input element.
+    Accepts a string. The `ariaDescribedBy` value is applied to the code editor input element.
   </C.Property>
   <C.Property @name="hasCopyButton" @type="boolean" @default="false">
     Used to control whether a copy button for copying the code/text content will be displayed.

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -23,7 +23,7 @@ These Pagination sub-elements may be used directly if you need to cover a very s
 
 <Doc::ComponentApi as |C|>
 <C.Property @name="ariaLabel" @type="string" @default="Pagination">
-    Accepts a localized string.
+    Accepts a string.
 </C.Property>
 <C.Property @name="totalItems" @required={{true}} @type="number">
 Pass the total number of items to be paginated. If no value is defined an error will be thrown.
@@ -70,7 +70,7 @@ This component supports use of [`...attributes`](https://guides.emberjs.com/rele
 
 <Doc::ComponentApi as |C|>
 <C.Property @name="ariaLabel" @type="string" @default="Pagination">
-    Accepts a localized string.
+    Accepts a string.
 </C.Property>
 <C.Property @name="showLabels" @type="boolean" @default="true">
 Used to control the visibility of the "prev/next" text labels.

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -50,7 +50,7 @@ This is the full-fledged component (responsive and animated).
     </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="ariaLabel" @type="string" @deprecated={{true}}>
-    Accepts a localized string; the fallback is set to `Open menu` if the menu is closed, and `Close menu` if the menu is open.<br /><br />Note: The purpose of this argument has been replaced by an `aria-labelledby` attribute referencing the "hds-side-nav-header" `h2` combined with the use of `aria-expanded` on the Toggle button tab.
+    Accepts a string; the fallback is set to `Open menu` if the menu is closed, and `Close menu` if the menu is open.<br /><br />Note: The purpose of this argument has been replaced by an `aria-labelledby` attribute referencing the "hds-side-nav-header" `h2` combined with the use of `aria-expanded` on the Toggle button tab.
   </C.Property>
   <C.Property @name="onToggleMinimizedStatus" @type="function">
     Callback function invoked when the `SideNav` is collapsed or expanded. The function receives a boolean argument stating if the `SideNav` is minimized or not.

--- a/website/docs/components/table/advanced-table/partials/code/how-to-use.md
+++ b/website/docs/components/table/advanced-table/partials/code/how-to-use.md
@@ -687,7 +687,7 @@ _Notice: only non-sortable headers can be visually hidden._
 
 #### Internationalized column headers, overflow menu dropdown
 
-Here’s an Advanced Table implementation that uses an array hash with localized strings for the column headers. It indicates which columns should be sortable, and adds an overflow menu.
+Here’s an Advanced Table implementation that uses an array hash with strings for the column headers. It indicates which columns should be sortable, and adds an overflow menu.
 
 ```handlebars{data-execute=false}
 <Hds::AdvancedTable

--- a/website/docs/components/table/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/table/partials/code/how-to-use.md
@@ -848,7 +848,7 @@ _Notice: only non-sortable headers can be visually hidden._
 
 #### Internationalized column headers, overflow menu dropdown
 
-Here’s a Table implementation that uses an array hash with localized strings for the column headers, indicates which columns should be sortable, and adds an overflow menu.
+Here’s a Table implementation that uses an array hash with strings for the column headers, indicates which columns should be sortable, and adds an overflow menu.
 
 ```handlebars{data-execute=false}
 <Hds::Table

--- a/website/docs/components/tag/partials/code/component-api.md
+++ b/website/docs/components/tag/partials/code/component-api.md
@@ -10,7 +10,7 @@
     The text of the Tag; or link text when the `@route` or `@href` are set. If no text value is defined an error will be thrown.
   </C.Property>
   <C.Property @name="ariaLabel" @type="string">
-    Accepts a localized string; the fallback is set to `Dismiss`. Note that the total value of the `aria-label` attribute is `@ariaLabel` + `@text`.
+    Accepts a string; the fallback is set to `Dismiss`. Note that the total value of the `aria-label` attribute is `@ariaLabel` + `@text`.
   </C.Property>
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.

--- a/website/docs/utilities/dismiss-button/partials/code/component-api.md
+++ b/website/docs/utilities/dismiss-button/partials/code/component-api.md
@@ -4,7 +4,7 @@
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="ariaLabel" @type="string" @default="dismiss">
-    Accepts a localized string.
+    Accepts a string.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).


### PR DESCRIPTION
### :pushpin: Summary

As [agreed](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1749065917588059), it's unnecessary to add "localized" to the "string" term in the documentation, our components work with any kind of strings, not just localized ones.

### :hammer_and_wrench: Detailed description

Removed `localized` whenever is associated to a string or message.

***

### :eyes: Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>