### PR TITLE
`CodeBlock` - Add missing changelog entry for signature updates to `4.20`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -32,6 +32,12 @@
 
 ### Patch Changes
 
+`CodeBlock` - Updated signature to use `WithBoundArgs` instead of `ComponentLike` for contextual components to resolve linting issues
+
+<small class="doc-whats-new-changelog-metadata">[#2925](https://github.com/hashicorp/design-system/pull/2925)</small>
+
+<div class="doc-whats-new-changelog-separator"></div>
+
 `AppHeader` - Fixed import path for `hds-breakpoints`
 
 `AppSideNav` - Fixed import path for `hds-breakpoints`

--- a/website/docs/components/code-block/partials/version-history/version-history.md
+++ b/website/docs/components/code-block/partials/version-history/version-history.md
@@ -1,5 +1,7 @@
 ## 4.20.0
 
+Updated signature to use `WithBoundArgs` instead of `ComponentLike` for contextual components to resolve linting issues
+
 Added height toggle control, which is present when a `maxHeight` is set and code content height exceeds the `maxHeight` value
 
 Fixed issues with line numbers when line wrapping is present and when the number of lines changes dynamically; line highlighting when the Code Block is hidden from view initially such as when used inside a Tabs component; and line highlighting when hasLineNumbers is false.

--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -44,6 +44,12 @@
 
 **Patch changes**
 
+`CodeBlock` - Updated signature to use `WithBoundArgs` instead of `ComponentLike` for contextual components to resolve linting issues
+
+<small class="doc-whats-new-changelog-metadata">[#2925](https://github.com/hashicorp/design-system/pull/2925)</small>
+
+<div class="doc-whats-new-changelog-separator"></div>
+
 `AppHeader` - Fixed import path for `hds-breakpoints`
 
 `AppSideNav` - Fixed import path for `hds-breakpoints`


### PR DESCRIPTION
### :pushpin: Summary

This PR adds missing changelog entries to the `4.20` release notes for the `CodeBlock` changes made to update its signature in #2925.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>