### PR TITLE
replace deprecated imports

### DIFF
--- a/packages/components/src/components/hds/app-side-nav/portal/target.ts
+++ b/packages/components/src/components/hds/app-side-nav/portal/target.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { macroCondition, isTesting } from '@embroider/macros';

--- a/packages/components/src/components/hds/side-nav/portal/target.ts
+++ b/packages/components/src/components/hds/side-nav/portal/target.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { macroCondition, isTesting } from '@embroider/macros';

--- a/packages/components/src/components/hds/time/index.ts
+++ b/packages/components/src/components/hds/time/index.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { typeOf } from '@ember/utils';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import type { DisplayType } from '../../../services/hds-time-types.ts';
 

--- a/packages/components/src/components/hds/time/range.ts
+++ b/packages/components/src/components/hds/time/range.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type TimeService from '../../../services/hds-time';
 
 export interface HdsTimeRangeSignature {

--- a/showcase/app/controllers/application.js
+++ b/showcase/app/controllers/application.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class ApplicationController extends Controller {

--- a/showcase/app/controllers/components.js
+++ b/showcase/app/controllers/components.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { scheduleOnce } from '@ember/runloop';
 
 function replaceMockStates() {

--- a/showcase/app/controllers/components/code-block.js
+++ b/showcase/app/controllers/components/code-block.js
@@ -6,7 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { scheduleOnce } from '@ember/runloop';
 
 function replaceMockCopyStatus() {

--- a/showcase/app/controllers/components/copy/button.js
+++ b/showcase/app/controllers/components/copy/button.js
@@ -6,7 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { scheduleOnce } from '@ember/runloop';
 
 function replaceMockCopyStatus() {

--- a/showcase/app/controllers/components/copy/snippet.js
+++ b/showcase/app/controllers/components/copy/snippet.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { scheduleOnce } from '@ember/runloop';
 
 function replaceMockCopyStatus() {

--- a/showcase/app/controllers/components/pagination.js
+++ b/showcase/app/controllers/components/pagination.js
@@ -6,7 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 // uncomment this to override the `atob/btoa` functions for debugging
 // const atob = (s) => s;

--- a/showcase/app/controllers/components/tabs.js
+++ b/showcase/app/controllers/components/tabs.js
@@ -6,7 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const getRandomInteger = (max = 125) => Math.floor(Math.random() * max);
 export default class TabsController extends Controller {

--- a/showcase/app/controllers/components/time.js
+++ b/showcase/app/controllers/components/time.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TimeController extends Controller {
   @service hdsTime;

--- a/showcase/app/controllers/utilities.js
+++ b/showcase/app/controllers/utilities.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { scheduleOnce } from '@ember/runloop';
 
 function replaceMockStates() {

--- a/website/app/components/doc/page/banner.js
+++ b/website/app/components/doc/page/banner.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const COOKIE_NAME = 'hide-banner';
 

--- a/website/app/components/doc/page/header/algolia-search/index.js
+++ b/website/app/components/doc/page/header/algolia-search/index.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { autocomplete } from '@algolia/autocomplete-js';
 

--- a/website/app/components/doc/page/sidebar.js
+++ b/website/app/components/doc/page/sidebar.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const DEBOUNCE_MS = 250;
 

--- a/website/app/components/doc/scroll-to-top/index.js
+++ b/website/app/components/doc/scroll-to-top/index.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class DocScrollToTopComponent extends Component {

--- a/website/app/controllers/application.js
+++ b/website/app/controllers/application.js
@@ -7,7 +7,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { scheduleOnce } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { next, later, cancel } from '@ember/runloop';
 import { defaultValidator } from 'ember-a11y-refocus';
 

--- a/website/app/controllers/show.js
+++ b/website/app/controllers/show.js
@@ -4,7 +4,7 @@ import { set, action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { schedule } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { showdownConfig } from '../shared/showdown-config';
 

--- a/website/app/modifiers/doc-track-event.js
+++ b/website/app/modifiers/doc-track-event.js
@@ -5,7 +5,7 @@
 
 import Modifier from 'ember-modifier';
 import { registerDestructor } from '@ember/destroyable';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { assert } from '@ember/debug';
 
 export default class DocTrackEvent extends Modifier {

--- a/website/app/routes/show.js
+++ b/website/app/routes/show.js
@@ -7,7 +7,7 @@ import {
   isNotFoundResponse,
 } from 'ember-fetch/errors';
 import config from 'ember-get-config';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { reject } from 'rsvp';
 

--- a/website/app/services/event-tracking.js
+++ b/website/app/services/event-tracking.js
@@ -4,7 +4,7 @@
  */
 
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class EventService extends Service {

--- a/website/app/services/head-data.js
+++ b/website/app/services/head-data.js
@@ -5,7 +5,7 @@
 
 import HeadDataService from 'ember-meta/services/head-data';
 import config from 'ember-get-config';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CustomHeadDataService extends HeadDataService {
   @service router;

--- a/website/docs/components/pagination/index.js
+++ b/website/docs/components/pagination/index.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const getCursorParts = (cursor, records) => {
   const token = atob(cursor);

--- a/website/docs/components/tabs/index.js
+++ b/website/docs/components/tabs/index.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Index extends Component {
   @service router;

--- a/website/docs/foundations/tokens/index.js
+++ b/website/docs/foundations/tokens/index.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import TOKENS_RAW from '@hashicorp/design-system-tokens/dist/docs/products/tokens.json';
 

--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { AVAILABLE_NAMES } from '@hashicorp/design-system-components/components/hds/icon/index';
 
 import catalog from '@hashicorp/flight-icons/catalog.json';


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will replace all instances of deprecated import statements with the recommended fix.

### :hammer_and_wrench: Detailed description

The import statement:
```js
import { inject as service } from '@ember/service'
```
is deprecated and should be replaced with:
```js
import { service } from '@ember/service'
```

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

n/a

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

n/a

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>