### PR TITLE
Remove Figma v1.0 banner

### DIFF
--- a/website/docs/getting-started/for-designers.md
+++ b/website/docs/getting-started/for-designers.md
@@ -14,14 +14,6 @@ The Design Systems Team maintains and publishes Figma libraries which contain fo
 
 ## Enabling Helios libraries
 
-!!! Insight
-
-The Design Systems Team has been hard at work updating many of our core Figma libraries, including [Components v2.0](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?m=auto&t=Rk02iW7PpBI5vhtJ-6), [Foundations v2.0](https://www.figma.com/design/uX4OEaJQdWfzULADchjAeN/HDS-Foundations-v2.0?m=auto&t=Rk02iW7PpBI5vhtJ-6), and [Patterns v2.0](https://www.figma.com/design/5Pv32j4QiOOD8lkFTD1dxC/HDS-Patterns-v2.0?m=auto&t=Rk02iW7PpBI5vhtJ-6). We're piloting these libraries with a select group of designers before fully replacing the v1.0 libraries, which will then be unpublished and archived.
-
-- [HDS Product Components v1.0 [Deprecated]](https://www.figma.com/design/noyY6dUMDYjmySpHcMjhkN/HDS-Components?m=auto&node-id=2-7&t=xoUUaynJ7hvhFDde-1)
-- [HDS Product Foundations v1.0 [Deprecated]](https://www.figma.com/design/oQsMzMMnynfPWpMEt91OpH/HDS-Foundations?m=auto&node-id=2916-4&t=ZajrnSJGabmjkb2n-1)
-!!!
-
 1. Open the Library modal via one of the following methods:
 
       - Click the `Assets` panel in the left sidebar, then click the `book` icon to open the modal.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR removes the banner about Figma v2.0 libraries being piloted and Figma v1.0 libraries being deprecated from the Getting Started for Designers page.

**👉🏻 Preview:** https://hds-website-git-hl-remove-v1figma-banner-hashicorp.vercel.app/getting-started/for-designers

### :camera_flash: Screenshots

**Before**
<img width="883" alt="Screenshot 2025-06-13 at 10 17 18 AM" src="https://github.com/user-attachments/assets/269a34f6-b5a0-48f9-b936-f75001eeba8b" />

**After**
<img width="890" alt="Screenshot 2025-06-13 at 10 19 07 AM" src="https://github.com/user-attachments/assets/701f12f1-b19b-4bbb-a497-94daaa2bb549" />

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.