### PR TITLE
[Website] Changelog component docs script format enhancements

### DIFF
--- a/packages/components/.prettierignore
+++ b/packages/components/.prettierignore
@@ -7,3 +7,6 @@
 
 # misc
 /coverage/
+
+# docs
+/CHANGELOG.md

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,6 +949,9 @@ importers:
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
+      glob:
+        specifier: ^11.0.3
+        version: 11.0.3
       globals:
         specifier: ^16.1.0
         version: 16.1.0
@@ -2790,6 +2793,14 @@ packages:
   '@inquirer/figures@1.0.9':
     resolution: {integrity: sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==}
     engines: {node: '>=18'}
+
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -7035,6 +7046,10 @@ packages:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
@@ -7227,6 +7242,11 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   glob@5.0.15:
@@ -8065,6 +8085,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+    engines: {node: 20 || >=22}
+
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -8566,6 +8590,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.1.0:
+    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -8896,6 +8924,10 @@ packages:
   mini-svg-data-uri@1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
+
+  minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -9429,6 +9461,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -14091,6 +14127,12 @@ snapshots:
   '@humanwhocodes/retry@0.4.2': {}
 
   '@inquirer/figures@1.0.9': {}
+
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -20343,6 +20385,11 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   forever-agent@0.6.1: {}
 
   form-data@2.3.3:
@@ -20583,6 +20630,15 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+
+  glob@11.0.3:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.0.3
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
 
   glob@5.0.15:
     dependencies:
@@ -21520,6 +21576,10 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.1.1:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
   jest-changed-files@29.7.0:
     dependencies:
       execa: 5.1.1
@@ -22230,6 +22290,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.1.0: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -22765,6 +22827,10 @@ snapshots:
       webpack: 5.99.9
 
   mini-svg-data-uri@1.4.4: {}
+
+  minimatch@10.0.3:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
 
   minimatch@3.1.2:
     dependencies:
@@ -23309,6 +23375,11 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.1.0
       minipass: 7.1.2
 
   path-to-regexp@0.1.12: {}

--- a/website/lib/changelog/generate-component-changelog-entries.mjs
+++ b/website/lib/changelog/generate-component-changelog-entries.mjs
@@ -55,7 +55,7 @@ const extractVersion = (changelogContent, version) => {
   return match ? match[0] : null;
 };
 
-const extractComponentChangelogEntries = (components, lastVersionContent) => {
+const extractComponentChangelogEntries = (lastVersionContent) => {
   const componentChangelogEntries = {};
 
   // Regular expression to match and capture a block of text delimited by two HTML comments used as START/END markers:
@@ -265,7 +265,6 @@ const currentVersionContent = extractVersion(changelogContent, version);
 
 // Extracts changelog entries for each components
 const componentChangelogEntries = extractComponentChangelogEntries(
-  allComponentPaths,
   currentVersionContent,
 );
 

--- a/website/lib/changelog/generate-component-changelog-entries.mjs
+++ b/website/lib/changelog/generate-component-changelog-entries.mjs
@@ -95,28 +95,13 @@ const updateComponentVersionHistory = (componentChangelogEntries, version) => {
       );
     }
 
-    // for each entry, remove the component name and keep only the description (assuming the "`ComponentName` - Description" format)
-    const newEntries = componentChangelogEntries[componentName]
-      .map((entry) => {
-        // If the component is a form primitive, we want to keep the component name in the description
-        if (
-          allComponentPaths[componentName] ===
-            './docs/components/form/primitives' ||
-          allComponentPaths[componentName] === './docs/components/form/layout'
-        ) {
-          return entry;
-        } else {
-          return entry.split(' - ')[1];
-        }
-      })
-      .join('\n\n');
     // prevent duplicate sections if the script is called multiple times
     if (!versionHistoryContent.includes(`## ${version}`)) {
       // for each entry, remove the component name and keep only the description (assuming the "`ComponentName` - Description" format)
       const newEntries = componentChangelogEntries[componentName]
         .map((entry) => {
-          // If the component is a form primitive, we want to keep the component name in the description
-          if (componentName === 'components/form/primitives') {
+          // If the component is a form primitive or layout, we want to keep the component name in the description
+          if (componentName === 'components/form/primitives' || componentName === 'components/form/layout') {
             return entry;
           } else {
             return entry.split(' - ')[1];
@@ -131,7 +116,7 @@ const updateComponentVersionHistory = (componentChangelogEntries, version) => {
 
 const updateComponentFrontMatter = (componentChangelogEntries, version) => {
   Object.keys(componentChangelogEntries).forEach((componentName) => {
-    const indexPath = `${allComponentPaths[componentName]}/index.md`;
+    const indexPath = `${componentName}/index.md`;
 
     if (fs.existsSync(indexPath)) {
       // Fetch the index markdown file

--- a/website/lib/changelog/generate-component-changelog-entries.mjs
+++ b/website/lib/changelog/generate-component-changelog-entries.mjs
@@ -140,7 +140,7 @@ const updateComponentVersionHistory = (componentChangelogEntries, version) => {
 
 const updateComponentFrontMatter = (componentChangelogEntries, version) => {
   Object.keys(componentChangelogEntries).forEach((componentPath) => {
-    const indexPath = `${componentPath}/index.md`;
+    const indexPath = `./docs/${componentPath}/index.md`;
 
     if (fs.existsSync(indexPath)) {
       // Fetch the index markdown file
@@ -176,7 +176,7 @@ const updateComponentFrontMatter = (componentChangelogEntries, version) => {
 
 const cleanComponentFrontMatter = (componentPaths, version) => {
   componentPaths.forEach((componentPath) => {
-    const indexPath = `${componentPath}/index.md`;
+    const indexPath = `./docs/${componentPath}/index.md`;
 
     if (fs.existsSync(indexPath)) {
       // Fetch the index markdown file

--- a/website/lib/changelog/generate-component-changelog-entries.mjs
+++ b/website/lib/changelog/generate-component-changelog-entries.mjs
@@ -174,9 +174,9 @@ const updateComponentFrontMatter = (componentChangelogEntries, version) => {
   });
 };
 
-const cleanComponentFrontMatter = (components, version) => {
-  Object.keys(components).forEach((componentPath) => {
-    const indexPath = `${components[componentPath]}/index.md`;
+const cleanComponentFrontMatter = (componentPaths, version) => {
+  componentPaths.forEach((componentPath) => {
+    const indexPath = `${componentPath}/index.md`;
 
     if (fs.existsSync(indexPath)) {
       // Fetch the index markdown file

--- a/website/lib/changelog/generate-component-changelog-entries.mjs
+++ b/website/lib/changelog/generate-component-changelog-entries.mjs
@@ -58,9 +58,9 @@ const extractVersion = (changelogContent, version) => {
 const extractComponentChangelogEntries = (components, lastVersionContent) => {
   const componentChangelogEntries = {};
 
-  components.forEach((componentName) => {
+  components.forEach((componentPath) => {
     const regex = new RegExp(
-      `^(<!-- START ${componentName})((.|\n)*?)(<!-- END -->)$`,
+      `^(<!-- START ${componentPath})((.|\n)*?)(<!-- END -->)$`,
       'gm',
     );
     const matches = lastVersionContent.match(regex);
@@ -69,12 +69,12 @@ const extractComponentChangelogEntries = (components, lastVersionContent) => {
       matches.forEach((match) => {
         // Remove the start and end comments to get the changelog entry
         const cleanMatch = match
-          .replace(`<!-- START ${componentName} -->`, '')
+          .replace(`<!-- START ${componentPath} -->`, '')
           .replace(`<!-- END -->`, '')
           .trim();
         cleanedMatches.push(cleanMatch);
       });
-      componentChangelogEntries[componentName] = cleanedMatches;
+      componentChangelogEntries[componentPath] = cleanedMatches;
     }
   });
 
@@ -95,13 +95,13 @@ const checkUnknownComponentChangelogEntries = (
   const matches = lastVersionContent.match(baseRegex);
   if (matches) {
     matches.forEach((match) => {
-      let componentNameFound = false;
-      Object.keys(componentChangelogEntries).forEach((componentName) => {
-        if (match.includes(`<!-- START ${componentName} -->`)) {
-          componentNameFound = true;
+      let componentPathFound = false;
+      Object.keys(componentChangelogEntries).forEach((componentPath) => {
+        if (match.includes(`<!-- START ${componentPath} -->`)) {
+          componentPathFound = true;
         }
       });
-      if (!componentNameFound) {
+      if (!componentPathFound) {
         console.warn(
           `No path found for changelog entry: ${match.substring(match.indexOf('<!-- START') + 11, match.indexOf(' -->'))}`,
         );
@@ -111,15 +111,15 @@ const checkUnknownComponentChangelogEntries = (
 };
 
 const updateComponentVersionHistory = (componentChangelogEntries, version) => {
-  Object.keys(componentChangelogEntries).forEach((componentName) => {
-    const versionHistoryPath = `./docs/${componentName}/partials/version-history/version-history.md`;
+  Object.keys(componentChangelogEntries).forEach((componentPath) => {
+    const versionHistoryPath = `./docs/${componentPath}/partials/version-history/version-history.md`;
     let versionHistoryContent = '';
 
     if (fs.existsSync(versionHistoryPath)) {
       versionHistoryContent = fs.readFileSync(versionHistoryPath, 'utf8');
     } else {
       fs.mkdirSync(
-        `./docs/${componentName}/partials/version-history/version-history`,
+        `./docs/${componentPath}/partials/version-history`,
         { recursive: true },
       );
     }
@@ -127,12 +127,12 @@ const updateComponentVersionHistory = (componentChangelogEntries, version) => {
     // prevent duplicate sections if the script is called multiple times
     if (!versionHistoryContent.includes(`## ${version}`)) {
       // for each entry, remove the component name and keep only the description (assuming the "`ComponentName` - Description" format)
-      const newEntries = componentChangelogEntries[componentName]
+      const newEntries = componentChangelogEntries[componentPath]
         .map((entry) => {
           // If the component is a form primitive or layout, we want to keep the component name in the description
           if (
-            componentName === 'components/form/primitives' ||
-            componentName === 'components/form/layout'
+            componentPath === 'components/form/primitives' ||
+            componentPath === 'components/form/layout'
           ) {
             return entry;
           } else {
@@ -147,8 +147,8 @@ const updateComponentVersionHistory = (componentChangelogEntries, version) => {
 };
 
 const updateComponentFrontMatter = (componentChangelogEntries, version) => {
-  Object.keys(componentChangelogEntries).forEach((componentName) => {
-    const indexPath = `${componentName}/index.md`;
+  Object.keys(componentChangelogEntries).forEach((componentPath) => {
+    const indexPath = `${componentPath}/index.md`;
 
     if (fs.existsSync(indexPath)) {
       // Fetch the index markdown file
@@ -183,8 +183,8 @@ const updateComponentFrontMatter = (componentChangelogEntries, version) => {
 };
 
 const cleanComponentFrontMatter = (components, version) => {
-  Object.keys(components).forEach((componentName) => {
-    const indexPath = `${components[componentName]}/index.md`;
+  Object.keys(components).forEach((componentPath) => {
+    const indexPath = `${components[componentPath]}/index.md`;
 
     if (fs.existsSync(indexPath)) {
       // Fetch the index markdown file

--- a/website/lib/changelog/generate-component-changelog-entries.mjs
+++ b/website/lib/changelog/generate-component-changelog-entries.mjs
@@ -282,6 +282,6 @@ if (isNotPatchVersion(version)) {
 // Update front matter for each updated component
 updateComponentFrontMatter(componentChangelogEntries, version);
 
-// // Clean the changelog entries for components
+// Clean the changelog entries for components
 cleanChangelogContent('./docs/whats-new/release-notes/partials/components.md');
 cleanChangelogContent('../packages/components/CHANGELOG.md');

--- a/website/package.json
+++ b/website/package.json
@@ -112,6 +112,7 @@
     "eslint-plugin-n": "^17.18.0",
     "eslint-plugin-qunit": "^8.1.2",
     "fs-extra": "^11.3.0",
+    "glob": "^11.0.3",
     "globals": "^16.1.0",
     "gray-matter": "^4.0.3",
     "jsonapi-serializer": "^3.6.9",


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the script that generate component changelog entries to a new format, which would support the following enhancements in writing changelog entries.

- Support for multi-line changes for one component
- Remove the requirement that component names in the changelog match exactly to what the script expects

### :hammer_and_wrench: Detailed description

#### New format
In the new format, changelog component entries must contain comments above and below each component entry that tell the script which portions to use in the appropriate component changelog files. 
```
<!-- START components/name -->
`ComponentName` - Change description
<!-- END -->
```
The path used inside the comments directs the script to what website docs file to attach the entry. That path must match exactly. For example a change to the `LinkStandalone` would use the path `components/links/standalone`.

When the script is ran, these comments will be removed following parsing.

### Testing

> [!NOTE]
> The testing commit has now been removed, but changes were previously approved. 

There is a temporary commit included in this PR that allows testing of the script locally. To test this change do the following:

1. Cd into `./website`
2. Run `pnpm generate-component-changelog-entries`
3. Review that the appropriate component changelog files have been updated, and the comments have been removed from the `CHANGELOG.md` and website release notes page. 
4. Do not commit any changes made

### :camera_flash: Screenshots

#### Changeset file format

**Before**
```
`ComponentName` - This is a list of changes. Change one. Change two.
```

**After**
```
<!-- START components/name -->
`ComponentName` - This is a list of changes
- Change one
- Change two
<!-- END -->
```

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4951](https://hashicorp.atlassian.net/browse/HDS-4951)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-4951]: https://hashicorp.atlassian.net/browse/HDS-4951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ