### PR TITLE
Revert "Generate npm provenance statement"

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -63,8 +63,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           # Token setup in hashibot-hds' account
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Generate npm provenance statement
-          NPM_CONFIG_PROVENANCE: true
 
       - name: Compute new packages info
         id: packagesData

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,5 +43,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           # Token setup in hashibot-hds' account
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Generate npm provenance statement
-          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Reverts hashicorp/design-system#2960

The provenance setup seems to require more configuration. As it is, it [causes the publishing process to fail](https://github.com/hashicorp/design-system/actions/runs/15774315693/job/44465201789?pr=2962#step:8:66).