### PR TITLE
`Layout::Grid` - Add `columnWidth` property (HDS-5013)

### DIFF
--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -14,7 +14,7 @@
   // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as a fallback value within calc()
   // https://drafts.csswg.org/css-values/#calc-type-checking
   grid-template-columns: repeat(
-    auto-fit,
+    var(--hds-layout-grid-column-fill-type, auto-fit),
     minmax(calc(var(--hds-layout-grid-column-min-width, 0px) - var(--hds-layout-grid-column-gap, 0px)), 1fr)
   );
 
@@ -22,6 +22,12 @@
   // For the gap size variants, we override the value of the gap custom properties to set the desired sizes.
   // These variables can be used by the consumers as an escape hatch if they need to set non-standard gap values (but adds a bit of friction to it)
   gap: var(--hds-layout-grid-row-gap, 0) var(--hds-layout-grid-column-gap, 0);
+}
+
+// columnWidth
+// We set the fill type to "auto-fill" if a columnWidth value is passed in to trigger a "fixed" column layout vs. a fluid layout.
+.hds-layout-grid--has-column-width {
+  --hds-layout-grid-column-fill-type: auto-fill;
 }
 
 // align

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -33,7 +33,18 @@
       </Shw::Outliner>
     </SG.Item>
 
-    <SG.Item @label="33.33% min width columns">
+    <SG.Item @label="30em min width columns">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @gap="24" @columnMinWidth="30em">
+          <Shw::Placeholder @text="#1" @height="40" />
+          <Shw::Placeholder @text="#2" @height="40" />
+          <Shw::Placeholder @text="#3" @height="40" />
+          <Shw::Placeholder @text="#4" @height="40" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+
+    <SG.Item @label="33.33% min width columns w/ 4 items">
       <Shw::Outliner>
         <Hds::Layout::Grid @gap="24" @columnMinWidth="33.33%">
           <Shw::Placeholder @text="#1" @height="40" />
@@ -44,13 +55,53 @@
       </Shw::Outliner>
     </SG.Item>
 
-    <SG.Item @label="30em min width columns">
+    <SG.Item @label="33.33% min width columns w/ 2 items">
       <Shw::Outliner>
-        <Hds::Layout::Grid @gap="24" @columnMinWidth="30em">
+        <Hds::Layout::Grid @gap="24" @columnMinWidth="33.33%">
+          <Shw::Placeholder @text="#1" @height="40" />
+          <Shw::Placeholder @text="#2" @height="40" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+
+    <SG.Item @label="33.33% min width columns w/ 1 item">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @gap="24" @columnMinWidth="33.33%">
+          <Shw::Placeholder @text="#1" @height="40" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H2>Column width</Shw::Text::H2>
+
+  <Shw::Grid @columns="1" @gap="1.5rem" class="shw-layout-grid-example-tint-flex-items" as |SG|>
+    <SG.Item @label="33.33% width columns">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @gap="24" @columnWidth="33.33%">
           <Shw::Placeholder @text="#1" @height="40" />
           <Shw::Placeholder @text="#2" @height="40" />
           <Shw::Placeholder @text="#3" @height="40" />
           <Shw::Placeholder @text="#4" @height="40" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+
+    <SG.Item @label="33.33% width columns w/ 2 items">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @gap="24" @columnWidth="33.33%">
+          <Shw::Placeholder @text="#1" @height="40" />
+          <Shw::Placeholder @text="#2" @height="40" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+
+    <SG.Item @label="33.33% width columns w/ 1 item">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @gap="24" @columnWidth="33.33%">
+          <Shw::Placeholder @text="#1" @height="40" />
         </Hds::Layout::Grid>
       </Shw::Outliner>
     </SG.Item>
@@ -294,17 +345,17 @@
   <Shw::Text::H2>Examples</Shw::Text::H2>
 
   <Shw::Grid @columns="1" @gap="2rem" as |SG|>
-    <SG.Item @label="3 column layout Card layout">
-      <Hds::Layout::Grid @columnMinWidth="33.33%" @gap="32">
+    <SG.Item @label="3 column layout Card layout using columnWidth=33.33%">
+      <Hds::Layout::Grid @columnWidth="33.33%" @gap="32">
         <Hds::Card::Container @level="mid" @hasBorder={{true}} {{style padding="24px"}}>
-          <Hds::Layout::Grid @columnMinWidth="100%" @gap="16">
+          <Hds::Layout::Grid @columnWidth="100%" @gap="16">
             <Hds::Layout::Flex @align="center" @gap="8">
               <Hds::IconTile @icon="cloud" @size="small" />
               <Hds::Text::Display @tag="h2" @size="300">
                 Active resources
               </Hds::Text::Display>
             </Hds::Layout::Flex>
-            <Hds::Layout::Grid @columnMinWidth="100%" @gap="8" as |LG|>
+            <Hds::Layout::Grid @columnWidth="100%" @gap="8" as |LG|>
               <LG.Item>
                 <Hds::Badge @text="5 active resources" @color="success" @icon="check-circle" @size="medium" />
               </LG.Item>

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -38,7 +38,9 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
       .hasText('test');
   });
 
-  // COLUMN MIN WIDTH
+  // OPTIONS
+
+  // ColumnMinWidth
 
   // Note: A fallback value of 0px is set in the CSS for the `--hds-layout-grid-column-min-width` custom property
   test('if the @columnMinWidth prop is not declared, --hds-layout-grid-column-min-width should be unset', async function (assert) {
@@ -57,7 +59,25 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
       .hasStyle({ '--hds-layout-grid-column-min-width': '200px' });
   });
 
-  // TAG
+  // ColumnWidth
+
+  test('it should not have the hds-layout-grid--has-column-width class if @columnWidth is not declared', async function (assert) {
+    await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
+    assert
+      .dom('#test-layout-grid')
+      .doesNotHaveClass('hds-layout-grid--has-column-width');
+  });
+
+  test('it should have the hds-layout-grid--has-column-width class if @columnWidth is declared', async function (assert) {
+    await render(
+      hbs`<Hds::Layout::Grid id="test-layout-grid" @columnWidth="200px" />`,
+    );
+    assert
+      .dom('#test-layout-grid')
+      .hasClass('hds-layout-grid--has-column-width');
+  });
+
+  // Tag
 
   test('it should render with a "div" element if @tag is not declared', async function (assert) {
     await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
@@ -71,7 +91,7 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
     assert.dom('#test-layout-grid').hasTagName('section');
   });
 
-  // ALIGN
+  // Align
 
   test('it should render the element without specific classes if @align is not declared', async function (assert) {
     await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
@@ -89,7 +109,7 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
       .hasClass('hds-layout-grid--align-items-stretch');
   });
 
-  // GAP
+  // Gap
 
   test('it should render the element without `gap` class if no @gap is declared', async function (assert) {
     await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
@@ -141,6 +161,21 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
     });
     await render(hbs`<Hds::Layout::Grid @gap={{array 4 "foo"}} />`);
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+
+  test('it should throw an assertion if both @columnMinWidth and @columnWidth are declared', async function (assert) {
+    const errorMessage =
+      '@columnMinWidth and @columnWidth for "Hds::Layout::Grid" cannot be used together';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(
+      hbs`<Hds::Layout::Grid id="test-layout-grid" @columnMinWidth="200px" @columnWidth="300px" />`,
+    );
     assert.throws(function () {
       throw new Error(errorMessage);
     });


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a `@columnWidth` option to the `Hds::Layout::Grid` component which is mutually exclusive to the existing `@columnMinWidth` property and changes the column layout behavior from more fluid to fixed in addition to setting column widths.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-5013](https://hashicorp.atlassian.net/browse/HDS-5013)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>