### PR TITLE
Update the resize column icon in the context menu

### DIFF
--- a/.changeset/stale-olives-count.md
+++ b/.changeset/stale-olives-count.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Updated the Advanced Table context menu to use `resize-column` icon.

--- a/.changeset/stale-olives-count.md
+++ b/.changeset/stale-olives-count.md
@@ -1,5 +1,0 @@
----
-"@hashicorp/design-system-components": patch
----
-
-Updated the Advanced Table context menu to use `resize-column` icon.

--- a/packages/components/src/components/hds/advanced-table/th-context-menu.ts
+++ b/packages/components/src/components/hds/advanced-table/th-context-menu.ts
@@ -51,7 +51,7 @@ export default class HdsAdvancedTableThContextMenu extends Component<HdsAdvanced
         {
           key: 'resize-column',
           label: 'Resize column',
-          icon: 'rotate-ccw',
+          icon: 'resize-column',
           action: this.resizeColumn.bind(this),
         },
         {


### PR DESCRIPTION
### :pushpin: Summary

Updates the icon in the context menu to the recently added `resize-column` icon.

### :camera_flash: Screenshots

**Before**
<img width="295" alt="Screenshot 2025-06-27 at 12 02 07 PM" src="https://github.com/user-attachments/assets/7c6eb730-15fd-48b2-b5c1-18837bd7aa53" />

**After**
<img width="284" alt="Screenshot 2025-06-27 at 12 11 14 PM" src="https://github.com/user-attachments/assets/84920c3b-36da-477a-8937-15577ad53581" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5015](https://hashicorp.atlassian.net/browse/HDS-5015)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5015]: https://hashicorp.atlassian.net/browse/HDS-5015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ