### PR TITLE
[HDS] Match minimized-sidebar width from enterprise nav changes

### DIFF
--- a/packages/components/src/styles/components/side-nav/vars.scss
+++ b/packages/components/src/styles/components/side-nav/vars.scss
@@ -19,7 +19,7 @@
   // breakpoint
   --hds-app-desktop-breakpoint: #{map.get($hds-breakpoints, "lg")}; // this is used only to read its value via JS and set the `hds-side-nav--is-desktop` class
   // widths
-  --hds-app-sidenav-width-minimized: 48px;
+  --hds-app-sidenav-width-minimized: 16px;
   --hds-app-sidenav-width-expanded: 280px;
   --hds-app-sidenav-width-fixed: var(--hds-app-sidenav-width-expanded);
   // animation


### PR DESCRIPTION
### :pushpin: Summary
A [recent change to HCP / Cloud-UI](https://github.com/hashicorp/cloud-ui/pull/12433) introduced a new sidebar nav style, the minimized width of which is shorter than it previously was.

This PR updates the minimized sidebar width, which if unchanged causes the following misalignment on pages with sticky footers, among potentially other places:

![image](https://github.com/user-attachments/assets/05c5a2af-4653-499e-8fde-2edd2eb33f3d)

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>