### PR TITLE
Web docs - Update form examples to use `Form` layout components (HDS-4999)

### DIFF
--- a/website/docs/components/accordion/partials/code/how-to-use.md
+++ b/website/docs/components/accordion/partials/code/how-to-use.md
@@ -101,12 +101,17 @@ With a link in the toggle block and a form in the content.
         </div>
       </:toggle>
       <:content>
-        <p>
-          <Hds::Form::TextInput::Field @type="email" as |F|>
-            <F.Label>Email</F.Label>
-          </Hds::Form::TextInput::Field>
-        </p>
-        <Hds::Button @text="Submit" />
+        <Hds::Form as |FORM|>
+          <FORM.Section>
+            <Hds::Form::TextInput::Field @type="email" as |F|>
+              <F.Label>Email</F.Label>
+            </Hds::Form::TextInput::Field>
+          </FORM.Section>
+
+          <FORM.Footer>
+            <Hds::Button @text="Submit" />
+          </FORM.Footer>
+        </Hds::Form>
       </:content>
     </A.Item>
   </Hds::Accordion>

--- a/website/docs/components/form/checkbox/partials/code/how-to-use.md
+++ b/website/docs/components/form/checkbox/partials/code/how-to-use.md
@@ -110,23 +110,25 @@ When helper text is added, the component automatically adds an `aria-describedby
 Use the `@isRequired` and `@isOptional` arguments to add a visual indication that the field is “required” or “optional”.
 
 ```handlebars
-<Hds::Form::Checkbox::Group @isRequired={{true}} @layout="horizontal" @name="demo-methods" as |G|>
-  <G.Legend>Methods</G.Legend>
-  <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
-  <G.CheckboxField checked as |F|><F.Label>POST</F.Label></G.CheckboxField>
-  <G.CheckboxField checked as |F|><F.Label>GET</F.Label></G.CheckboxField>
-  <G.CheckboxField checked as |F|><F.Label>PUT</F.Label></G.CheckboxField>
-</Hds::Form::Checkbox::Group>
-```
+<Hds::Form as |FORM|>
+  <FORM.Section>
+    <Hds::Form::Checkbox::Group @isRequired={{true}} @layout="horizontal" @name="demo-methods" as |G|>
+      <G.Legend>Methods</G.Legend>
+      <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
+      <G.CheckboxField checked as |F|><F.Label>POST</F.Label></G.CheckboxField>
+      <G.CheckboxField checked as |F|><F.Label>GET</F.Label></G.CheckboxField>
+      <G.CheckboxField checked as |F|><F.Label>PUT</F.Label></G.CheckboxField>
+    </Hds::Form::Checkbox::Group>
 
-```handlebars
-<Hds::Form::Checkbox::Group @isOptional={{true}} @layout="horizontal" @name="demo-methods" as |G|>
-  <G.Legend>Methods</G.Legend>
-  <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
-  <G.CheckboxField checked as |F|><F.Label>POST</F.Label></G.CheckboxField>
-  <G.CheckboxField checked as |F|><F.Label>GET</F.Label></G.CheckboxField>
-  <G.CheckboxField checked as |F|><F.Label>PUT</F.Label></G.CheckboxField>
-</Hds::Form::Checkbox::Group>
+    <Hds::Form::Checkbox::Group @isOptional={{true}} @layout="horizontal" @name="demo-methods" as |G|>
+      <G.Legend>Methods</G.Legend>
+      <G.HelperText>All methods are applied by default unless specified.</G.HelperText>
+      <G.CheckboxField checked as |F|><F.Label>POST</F.Label></G.CheckboxField>
+      <G.CheckboxField checked as |F|><F.Label>GET</F.Label></G.CheckboxField>
+      <G.CheckboxField checked as |F|><F.Label>PUT</F.Label></G.CheckboxField>
+    </Hds::Form::Checkbox::Group>
+  </FORM.Section>
+</Hds::Form>
 ```
 
 #### Validation

--- a/website/docs/components/form/file-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/file-input/partials/code/how-to-use.md
@@ -52,15 +52,19 @@ The `Label` and `HelperText` contextual components used in the Field component y
 Use the `@isRequired` and `@isOptional` arguments to add a visual indication that the field is "required" or "optional".
 
 ```handlebars
-<Hds::Form::FileInput::Field @isRequired={{true}} name="demo-profile-photo" as |F|>
-  <F.Label>Upload a file</F.Label>
-  <F.HelperText>File size should be a maximum of 2 MB.</F.HelperText>
-</Hds::Form::FileInput::Field>
-<br />
-<Hds::Form::FileInput::Field @isOptional={{true}} name="demo-profile-photo" as |F|>
-  <F.Label>Upload a file</F.Label>
-  <F.HelperText>File size should be a maximum of 2 MB.</F.HelperText>
-</Hds::Form::FileInput::Field>
+<Hds::Form as |FORM|>
+  <FORM.Section>
+    <Hds::Form::FileInput::Field @isRequired={{true}} name="demo-profile-photo" as |F|>
+      <F.Label>Upload a file</F.Label>
+      <F.HelperText>File size should be a maximum of 2 MB.</F.HelperText>
+    </Hds::Form::FileInput::Field>
+
+    <Hds::Form::FileInput::Field @isOptional={{true}} name="demo-profile-photo" as |F|>
+      <F.Label>Upload a file</F.Label>
+      <F.HelperText>File size should be a maximum of 2 MB.</F.HelperText>
+    </Hds::Form::FileInput::Field>
+  </FORM.Section>
+</Hds::Form>
 ```
 
 #### Validation

--- a/website/docs/components/form/masked-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/masked-input/partials/code/how-to-use.md
@@ -135,15 +135,19 @@ The `Label` and `HelperText` contextual components used in the Field component y
 Use the `@isRequired` and `@isOptional` arguments to add a visual indication that the field is "required" or "optional".
 
 ```handlebars
-<Hds::Form::MaskedInput::Field @isRequired={{true}} name="demo-team-token" as |F|>
-  <F.Label>Terraform Cloud team token</F.Label>
-  <F.HelperText>The token must include permissions to manage workspaces and projects.</F.HelperText>
-</Hds::Form::MaskedInput::Field>
-<br />
-<Hds::Form::MaskedInput::Field @isOptional={{true}} name="demo-team-token" as |F|>
-  <F.Label>Terraform Cloud team token</F.Label>
-  <F.HelperText>The token must include permissions to manage workspaces and projects.</F.HelperText>
-</Hds::Form::MaskedInput::Field>
+<Hds::Form as |FORM|>
+  <FORM.Section>
+    <Hds::Form::MaskedInput::Field @isRequired={{true}} name="demo-team-token" as |F|>
+      <F.Label>Terraform Cloud team token</F.Label>
+      <F.HelperText>The token must include permissions to manage workspaces and projects.</F.HelperText>
+    </Hds::Form::MaskedInput::Field>
+
+    <Hds::Form::MaskedInput::Field @isOptional={{true}} name="demo-team-token" as |F|>
+      <F.Label>Terraform Cloud team token</F.Label>
+      <F.HelperText>The token must include permissions to manage workspaces and projects.</F.HelperText>
+    </Hds::Form::MaskedInput::Field>
+  </FORM.Section>
+</Hds::Form>
 ```
 
 #### Character count

--- a/website/docs/components/form/radio/partials/code/how-to-use.md
+++ b/website/docs/components/form/radio/partials/code/how-to-use.md
@@ -108,21 +108,25 @@ When helper text is added, the component automatically adds an `aria-describedby
 Use the `@isRequired` and `@isOptional` arguments to add a visual indication that the field is “required” or “optional”.
 
 ```handlebars
-<Hds::Form::Radio::Group @isRequired={{true}} @layout="horizontal" @name="method-demo2" as |G|>
-  <G.Legend>Method</G.Legend>
-  <G.HelperText>Choose which HTTP method to use for the communication channel.</G.HelperText>
-  <G.RadioField as |F|><F.Label>POST</F.Label></G.RadioField>
-  <G.RadioField as |F|><F.Label>GET</F.Label></G.RadioField>
-  <G.RadioField as |F|><F.Label>PUT</F.Label></G.RadioField>
-</Hds::Form::Radio::Group>
-<br />
-<Hds::Form::Radio::Group @isOptional={{true}} @layout="horizontal" @name="method-demo3" as |G|>
-  <G.Legend>Method</G.Legend>
-  <G.HelperText>Choose which HTTP method to use for the communication channel.</G.HelperText>
-  <G.RadioField as |F|><F.Label>POST</F.Label></G.RadioField>
-  <G.RadioField as |F|><F.Label>GET</F.Label></G.RadioField>
-  <G.RadioField as |F|><F.Label>PUT</F.Label></G.RadioField>
-</Hds::Form::Radio::Group>
+<Hds::Form as |FORM|>
+  <FORM.Section>
+    <Hds::Form::Radio::Group @isRequired={{true}} @layout="horizontal" @name="method-demo2" as |G|>
+      <G.Legend>Method</G.Legend>
+      <G.HelperText>Choose which HTTP method to use for the communication channel.</G.HelperText>
+      <G.RadioField as |F|><F.Label>POST</F.Label></G.RadioField>
+      <G.RadioField as |F|><F.Label>GET</F.Label></G.RadioField>
+      <G.RadioField as |F|><F.Label>PUT</F.Label></G.RadioField>
+    </Hds::Form::Radio::Group>
+
+    <Hds::Form::Radio::Group @isOptional={{true}} @layout="horizontal" @name="method-demo3" as |G|>
+      <G.Legend>Method</G.Legend>
+      <G.HelperText>Choose which HTTP method to use for the communication channel.</G.HelperText>
+      <G.RadioField as |F|><F.Label>POST</F.Label></G.RadioField>
+      <G.RadioField as |F|><F.Label>GET</F.Label></G.RadioField>
+      <G.RadioField as |F|><F.Label>PUT</F.Label></G.RadioField>
+    </Hds::Form::Radio::Group>
+  </FORM.Section>
+</Hds::Form>
 ```
 
 #### Validation

--- a/website/docs/components/form/select/partials/code/how-to-use.md
+++ b/website/docs/components/form/select/partials/code/how-to-use.md
@@ -103,25 +103,29 @@ For example:
 Use the `@isRequired` and `@isOptional` arguments to add a visual indication that the field is "required" or "optional".
 
 ```handlebars
-<Hds::Form::Select::Field @isRequired={{true}} name="demo-target-infrastructure" as |F|>
-  <F.Label>Target infrastructure</F.Label>
-  <F.HelperText>The target infrastructure is where you want to deploy your apps.</F.HelperText>
-  <F.Options>
-    <option value=""></option>
-    <option value="Kubernetes">Kubernetes</option>
-    <option value="Other">Other</option>
-  </F.Options>
-</Hds::Form::Select::Field>
-<br />
-<Hds::Form::Select::Field @isOptional={{true}} name="demo-target-infrastructure" as |F|>
-  <F.Label>Target infrastructure</F.Label>
-  <F.HelperText>The target infrastructure is where you want to deploy your apps.</F.HelperText>
-  <F.Options>
-    <option value=""></option>
-    <option value="Kubernetes">Kubernetes</option>
-    <option value="Other">Other</option>
-  </F.Options>
-</Hds::Form::Select::Field>
+<Hds::Form as |FORM|>
+  <FORM.Section>
+    <Hds::Form::Select::Field @isRequired={{true}} name="demo-target-infrastructure" as |F|>
+      <F.Label>Target infrastructure</F.Label>
+      <F.HelperText>The target infrastructure is where you want to deploy your apps.</F.HelperText>
+      <F.Options>
+        <option value=""></option>
+        <option value="Kubernetes">Kubernetes</option>
+        <option value="Other">Other</option>
+      </F.Options>
+    </Hds::Form::Select::Field>
+
+    <Hds::Form::Select::Field @isOptional={{true}} name="demo-target-infrastructure" as |F|>
+      <F.Label>Target infrastructure</F.Label>
+      <F.HelperText>The target infrastructure is where you want to deploy your apps.</F.HelperText>
+      <F.Options>
+        <option value=""></option>
+        <option value="Kubernetes">Kubernetes</option>
+        <option value="Other">Other</option>
+      </F.Options>
+    </Hds::Form::Select::Field>
+  </FORM.Section>
+</Hds::Form>
 ```
 
 #### Validation

--- a/website/docs/components/form/text-input/partials/code/how-to-use.md
+++ b/website/docs/components/form/text-input/partials/code/how-to-use.md
@@ -84,15 +84,19 @@ The `Label` and `HelperText` contextual components used in the Field component y
 Use the `@isRequired` and `@isOptional` arguments to add a visual indication that the field is "required" or "optional".
 
 ```handlebars
-<Hds::Form::TextInput::Field @isRequired={{true}} name="demo-aws-account-id" as |F|>
-  <F.Label>AWS Account ID</F.Label>
-  <F.HelperText>Copy this ID to your AWS Resource Access Manager to initiate the resource share.</F.HelperText>
-</Hds::Form::TextInput::Field>
-<br />
-<Hds::Form::TextInput::Field @isOptional={{true}} name="demo-aws-account-id" as |F|>
-  <F.Label>AWS Account ID</F.Label>
-  <F.HelperText>Copy this ID to your AWS Resource Access Manager to initiate the resource share.</F.HelperText>
-</Hds::Form::TextInput::Field>
+<Hds::Form as |FORM|>
+  <FORM.Section>
+    <Hds::Form::TextInput::Field @isRequired={{true}} name="demo-aws-account-id" as |F|>
+      <F.Label>AWS Account ID</F.Label>
+      <F.HelperText>Copy this ID to your AWS Resource Access Manager to initiate the resource share.</F.HelperText>
+    </Hds::Form::TextInput::Field>
+
+    <Hds::Form::TextInput::Field @isOptional={{true}} name="demo-aws-account-id" as |F|>
+      <F.Label>AWS Account ID</F.Label>
+      <F.HelperText>Copy this ID to your AWS Resource Access Manager to initiate the resource share.</F.HelperText>
+    </Hds::Form::TextInput::Field>
+  </FORM.Section>
+</Hds::Form>
 ```
 
 #### Character count

--- a/website/docs/components/form/textarea/partials/code/how-to-use.md
+++ b/website/docs/components/form/textarea/partials/code/how-to-use.md
@@ -65,15 +65,19 @@ The `Label` and `HelperText` contextual components used in the Field component y
 Use the `@isRequired` and `@isOptional` arguments to add a visual indication that the field is "required" or "optional".
 
 ```handlebars
-<Hds::Form::Textarea::Field @isRequired={{true}} name="demo-description" as |F|>
-  <F.Label>Short description</F.Label>
-  <F.HelperText>Add a short description about the workspace you are creating.</F.HelperText>
-</Hds::Form::Textarea::Field>
-<br />
-<Hds::Form::Textarea::Field @isOptional={{true}} name="demo-description" as |F|>
-  <F.Label>Short description</F.Label>
-  <F.HelperText>Add a short description about the workspace you are creating.</F.HelperText>
-</Hds::Form::Textarea::Field>
+<Hds::Form as |FORM|>
+  <FORM.Section>
+    <Hds::Form::Textarea::Field @isRequired={{true}} name="demo-description" as |F|>
+      <F.Label>Short description</F.Label>
+      <F.HelperText>Add a short description about the workspace you are creating.</F.HelperText>
+    </Hds::Form::Textarea::Field>
+
+    <Hds::Form::Textarea::Field @isOptional={{true}} name="demo-description" as |F|>
+      <F.Label>Short description</F.Label>
+      <F.HelperText>Add a short description about the workspace you are creating.</F.HelperText>
+    </Hds::Form::Textarea::Field>
+  </FORM.Section>
+</Hds::Form>
 ```
 
 #### Character count

--- a/website/docs/components/modal/partials/code/how-to-use.md
+++ b/website/docs/components/modal/partials/code/how-to-use.md
@@ -71,17 +71,23 @@ When the Modal dialog contains information that might be lost on close, use a co
       Why do you want to leave the beta?
     </M.Header>
     <M.Body>
-      <form id="leaving-beta-form" {{on "submit" (fn this.submitForm)}}>
-        <Hds::Form::Select::Field autofocus @width="100%" as |F|>
-          <F.Label>Select the primary reason</F.Label>
-          <F.Options>
-            <option></option>
-          </F.Options>
-        </Hds::Form::Select::Field>
-        <Hds::Form::Textarea::Field @isOptional={{true}} as |F|>
-          <F.Label>Your feedback</F.Label>
-        </Hds::Form::Textarea::Field>
-      </form>
+      <Hds::Form
+        id="leaving-beta-form"
+        {{on "submit" (fn this.submitForm)}}
+        as |FORM|
+      >
+        <FORM.Section>
+          <Hds::Form::Select::Field autofocus @width="100%" as |F|>
+            <F.Label>Select the primary reason</F.Label>
+            <F.Options>
+              <option></option>
+            </F.Options>
+          </Hds::Form::Select::Field>
+          <Hds::Form::Textarea::Field @isOptional={{true}} as |F|>
+            <F.Label>Your feedback</F.Label>
+          </Hds::Form::Textarea::Field>
+        </FORM.Section>
+      </Hds::Form>
     </M.Body>
     <M.Footer as |F|>
       <Hds::ButtonSet>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will update form example code within the Helios web documentation to make use of the `Form` layout components for laying out the form fields & content.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-4999](https://hashicorp.atlassian.net/browse/HDS-4999)

***

### :eyes: Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-4999]: https://hashicorp.atlassian.net/browse/HDS-4999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ