### PR TITLE
`Layout::Flex` & `Layout::Grid` -  Prevent inheritance of gap values when nested (HDS-5067)

### DIFF
--- a/.changeset/violet-jars-love.md
+++ b/.changeset/violet-jars-love.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`LayoutFlex` - Fixed issue in which `gap` value was improperly inherited by nested `Flex` components, Added "0" as a supported `gap` value.
+
+`LayoutGrid` - Fixed issue in which `gap` & `columnMinWidth` values were improperly inherited by nested `Grid` components, Added "0" as a supported `gap` value.

--- a/.changeset/violet-jars-love.md
+++ b/.changeset/violet-jars-love.md
@@ -2,6 +2,6 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`LayoutFlex` - Fixed issue in which `gap` value was improperly inherited by nested `Flex` components, Added "0" as a supported `gap` value.
+`Layout::Flex` - Fixed issue in which `gap` value was improperly inherited by nested `Flex` components, added "0" as a supported `gap` value.
 
-`LayoutGrid` - Fixed issue in which `gap` & `columnMinWidth` values were improperly inherited by nested `Grid` components, Added "0" as a supported `gap` value.
+`Layout::Grid` - Fixed issue in which `gap` & `columnMinWidth` values were improperly inherited by nested `Grid` components, added "0" as a supported `gap` value.

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -124,7 +124,7 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
     }
   }
 
-  get classNames() {
+  get classNames(): string {
     const classes = ['hds-layout-flex'];
 
     // add a class based on the @direction argument

--- a/packages/components/src/components/hds/layout/flex/index.ts
+++ b/packages/components/src/components/hds/layout/flex/index.ts
@@ -30,6 +30,7 @@ export const DEFAULT_DIRECTION = HdsLayoutFlexDirectionValues.Row;
 export const DIRECTIONS: string[] = Object.values(HdsLayoutFlexDirectionValues);
 export const JUSTIFYS: string[] = Object.values(HdsLayoutFlexJustifyValues);
 export const ALIGNS: string[] = Object.values(HdsLayoutFlexAlignValues);
+export const DEFAULT_GAP = HdsLayoutFlexGapValues.Zero;
 export const GAPS: string[] = Object.values(HdsLayoutFlexGapValues);
 
 export interface HdsLayoutFlexSignature {
@@ -104,7 +105,7 @@ export default class HdsLayoutFlex extends Component<HdsLayoutFlexSignature> {
     | [HdsLayoutFlexGaps]
     | [HdsLayoutFlexGaps, HdsLayoutFlexGaps]
     | undefined {
-    const { gap } = this.args;
+    const { gap = DEFAULT_GAP } = this.args;
 
     if (gap) {
       assert(

--- a/packages/components/src/components/hds/layout/flex/types.ts
+++ b/packages/components/src/components/hds/layout/flex/types.ts
@@ -31,6 +31,7 @@ export enum HdsLayoutFlexAlignValues {
 export type HdsLayoutFlexAligns = `${HdsLayoutFlexAlignValues}`;
 
 export enum HdsLayoutFlexGapValues {
+  'Zero' = '0',
   'Four' = '4',
   'Eight' = '8',
   'Twelve' = '12',

--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -19,6 +19,7 @@ import type {
 } from './types.ts';
 
 export const ALIGNS: string[] = Object.values(HdsLayoutGridAlignValues);
+export const DEFAULT_GAP = HdsLayoutGridGapValues.Zero;
 export const GAPS: string[] = Object.values(HdsLayoutGridGapValues);
 
 export interface HdsLayoutGridSignature {
@@ -63,7 +64,7 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
     | [HdsLayoutGridGaps]
     | [HdsLayoutGridGaps, HdsLayoutGridGaps]
     | undefined {
-    const { gap } = this.args;
+    const { gap = DEFAULT_GAP } = this.args;
 
     if (gap) {
       assert(

--- a/packages/components/src/components/hds/layout/grid/types.ts
+++ b/packages/components/src/components/hds/layout/grid/types.ts
@@ -13,6 +13,7 @@ export enum HdsLayoutGridAlignValues {
 export type HdsLayoutGridAligns = `${HdsLayoutGridAlignValues}`;
 
 export enum HdsLayoutGridGapValues {
+  'Zero' = '0',
   'Four' = '4',
   'Eight' = '8',
   'Twelve' = '12',

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -8,12 +8,16 @@
 //
 
 .hds-layout-flex {
+  // default gap values
+  --hds-layout-flex-row-gap: 0;
+  --hds-layout-flex-column-gap: 0;
+
   display: flex;
 
   // Note: The gap style is defined here to avoid setting it repeatedly for the gap size variants defined below.
   // For the gap size variants, we override the value of the gap custom properties to set the desired sizes.
   // These variables can be used by the consumers as an escape hatch if they need to set non-standard gap values (but adds a bit of friction to it)
-  gap: var(--hds-layout-flex-row-gap, 0) var(--hds-layout-flex-column-gap, 0);
+  gap: var(--hds-layout-flex-row-gap) var(--hds-layout-flex-column-gap);
 }
 
 // inline
@@ -88,6 +92,11 @@
 
 // gap
 
+// row
+.hds-layout-flex--row-gap-0 {
+  --hds-layout-flex-row-gap: 0px;
+}
+
 .hds-layout-flex--row-gap-4 {
   --hds-layout-flex-row-gap: 4px;
 }
@@ -114,6 +123,11 @@
 
 .hds-layout-flex--row-gap-48 {
   --hds-layout-flex-row-gap: 48px;
+}
+
+// column
+.hds-layout-flex--column-gap-0 {
+  --hds-layout-flex-column-gap: 0px;
 }
 
 .hds-layout-flex--column-gap-4 {

--- a/packages/components/src/styles/components/layout/flex.scss
+++ b/packages/components/src/styles/components/layout/flex.scss
@@ -8,10 +8,6 @@
 //
 
 .hds-layout-flex {
-  // default gap values
-  --hds-layout-flex-row-gap: 0;
-  --hds-layout-flex-column-gap: 0;
-
   display: flex;
 
   // Note: The gap style is defined here to avoid setting it repeatedly for the gap size variants defined below.

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -8,12 +8,8 @@
 //
 
 .hds-layout-grid {
-  // default values
-  --hds-layout-grid-row-gap: 0;
-
   // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as a default value within calc()
   // https://drafts.csswg.org/css-values/#calc-type-checking
-  --hds-layout-grid-column-gap: 0px;
   --hds-layout-grid-column-min-width: 0px;
 
   display: grid;

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -10,6 +10,7 @@
 .hds-layout-grid {
   // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as a default value within calc()
   // https://drafts.csswg.org/css-values/#calc-type-checking
+  // We initialize the variable here to prevent inheritance issues in nested grids
   --hds-layout-grid-column-min-width: 0px;
 
   display: grid;

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -8,20 +8,26 @@
 //
 
 .hds-layout-grid {
-  display: grid;
-  // The column gap value is subtracted from the column-min-width to prevent overflow & simplify API for consumers
+  // default values
+  --hds-layout-grid-row-gap: 0;
 
-  // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as a fallback value within calc()
+  // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as a default value within calc()
   // https://drafts.csswg.org/css-values/#calc-type-checking
+  --hds-layout-grid-column-gap: 0px;
+  --hds-layout-grid-column-min-width: 0px;
+
+  display: grid;
+
+  // The column gap value is subtracted from the column-min-width to prevent overflow & simplify API for consumers
   grid-template-columns: repeat(
     var(--hds-layout-grid-column-fill-type, auto-fit),
-    minmax(calc(var(--hds-layout-grid-column-min-width, 0px) - var(--hds-layout-grid-column-gap, 0px)), 1fr)
+    minmax(calc(var(--hds-layout-grid-column-min-width) - var(--hds-layout-grid-column-gap)), 1fr)
   );
 
   // Note: The gap style is defined here to avoid setting it repeatedly for the gap size variants defined below.
   // For the gap size variants, we override the value of the gap custom properties to set the desired sizes.
   // These variables can be used by the consumers as an escape hatch if they need to set non-standard gap values (but adds a bit of friction to it)
-  gap: var(--hds-layout-grid-row-gap, 0) var(--hds-layout-grid-column-gap, 0);
+  gap: var(--hds-layout-grid-row-gap) var(--hds-layout-grid-column-gap);
 }
 
 // align
@@ -45,6 +51,11 @@
 // gap
 
 // We set the values of the gap custom properties overriding the default value of 0
+
+// row
+.hds-layout-grid--row-gap-0 {
+  --hds-layout-grid-row-gap: 0px;
+}
 
 .hds-layout-grid--row-gap-4 {
   --hds-layout-grid-row-gap: 4px;
@@ -72,6 +83,11 @@
 
 .hds-layout-grid--row-gap-48 {
   --hds-layout-grid-row-gap: 48px;
+}
+
+// column
+.hds-layout-grid--column-gap-0 {
+  --hds-layout-grid-column-gap: 0px;
 }
 
 .hds-layout-grid--column-gap-4 {

--- a/showcase/app/styles/showcase-pages/layout/flex.scss
+++ b/showcase/app/styles/showcase-pages/layout/flex.scss
@@ -5,6 +5,17 @@
 
 // LAYOUTS > FLEX
 
+@mixin shw-tint-placeholders {
+  > .shw-placeholder {
+    &:nth-child(6n+1) { background-color: #e4c5f3; }
+    &:nth-child(6n+2) { background-color: #e5ffd2; }
+    &:nth-child(6n+3) { background-color: #d2f4ff; }
+    &:nth-child(6n+4) { background-color: #fff8d2; }
+    &:nth-child(6n+5) { background-color: #f3d9c5; }
+    &:nth-child(6n+6) { background-color: #fee1ec; }
+  }
+}
+
 body.layouts-flex {
   .shw-layout-flex-example-outline-flex-container {
     .hds-layout-flex {
@@ -24,21 +35,7 @@ body.layouts-flex {
 
   .shw-layout-flex-example-tint-flex-items {
     .hds-layout-flex {
-        > * {
-        &:nth-child(6n+1) { background-color: #e4c5f3; }
-        &:nth-child(6n+2) { background-color: #e5ffd2; }
-        &:nth-child(6n+3) { background-color: #d2f4ff; }
-        &:nth-child(6n+4) { background-color: #fff8d2; }
-        &:nth-child(6n+5) { background-color: #f3d9c5; }
-        &:nth-child(6n+6) { background-color: #fee1ec; }
-      }
-
-      // We add an outline to make nested Flex items more visible
-      &:has(.hds-layout-flex),
-      &:has(.hds-layout-flex) > *,
-      .hds-layout-flex > * {
-        outline: 1px dotted var(--shw-color-gray-200);
-      }
+      @include shw-tint-placeholders();
     }
   }
 
@@ -46,6 +43,15 @@ body.layouts-flex {
     width: 50px;
     height: 50px;
     border-radius: 8px;
+  }
+
+  .shw-layout-flex-example-nested-layouts {
+    .hds-layout-flex,
+    .hds-layout-grid {
+      @include shw-tint-placeholders();
+
+      outline: 1px dotted var(--shw-color-gray-400);
+    }
   }
 
   .shw-layout-flex-example-gap-override {

--- a/showcase/app/styles/showcase-pages/layout/flex.scss
+++ b/showcase/app/styles/showcase-pages/layout/flex.scss
@@ -5,15 +5,13 @@
 
 // LAYOUTS > FLEX
 
-@mixin shw-tint-placeholders {
-  > .shw-placeholder {
-    &:nth-child(6n+1) { background-color: #e4c5f3; }
-    &:nth-child(6n+2) { background-color: #e5ffd2; }
-    &:nth-child(6n+3) { background-color: #d2f4ff; }
-    &:nth-child(6n+4) { background-color: #fff8d2; }
-    &:nth-child(6n+5) { background-color: #f3d9c5; }
-    &:nth-child(6n+6) { background-color: #fee1ec; }
-  }
+@mixin shw-tint-children {
+  &:nth-child(6n+1) { background-color: #e4c5f3; }
+  &:nth-child(6n+2) { background-color: #e5ffd2; }
+  &:nth-child(6n+3) { background-color: #d2f4ff; }
+  &:nth-child(6n+4) { background-color: #fff8d2; }
+  &:nth-child(6n+5) { background-color: #f3d9c5; }
+  &:nth-child(6n+6) { background-color: #fee1ec; }
 }
 
 body.layouts-flex {
@@ -34,8 +32,8 @@ body.layouts-flex {
   }
 
   .shw-layout-flex-example-tint-flex-items {
-    .hds-layout-flex {
-      @include shw-tint-placeholders();
+    .hds-layout-flex > * {
+      @include shw-tint-children();
     }
   }
 
@@ -48,7 +46,9 @@ body.layouts-flex {
   .shw-layout-flex-example-nested-layouts {
     .hds-layout-flex,
     .hds-layout-grid {
-      @include shw-tint-placeholders();
+      .shw-placeholder {
+        @include shw-tint-children();
+      }
 
       outline: 1px dotted var(--shw-color-gray-400);
     }

--- a/showcase/app/styles/showcase-pages/layout/flex.scss
+++ b/showcase/app/styles/showcase-pages/layout/flex.scss
@@ -23,13 +23,22 @@ body.layouts-flex {
   }
 
   .shw-layout-flex-example-tint-flex-items {
-    .hds-layout-flex > * {
-      &:nth-child(6n+1) { background-color: #e4c5f3; }
-      &:nth-child(6n+2) { background-color: #e5ffd2; }
-      &:nth-child(6n+3) { background-color: #d2f4ff; }
-      &:nth-child(6n+4) { background-color: #fff8d2; }
-      &:nth-child(6n+5) { background-color: #f3d9c5; }
-      &:nth-child(6n+6) { background-color: #fee1ec; }
+    .hds-layout-flex {
+        > * {
+        &:nth-child(6n+1) { background-color: #e4c5f3; }
+        &:nth-child(6n+2) { background-color: #e5ffd2; }
+        &:nth-child(6n+3) { background-color: #d2f4ff; }
+        &:nth-child(6n+4) { background-color: #fff8d2; }
+        &:nth-child(6n+5) { background-color: #f3d9c5; }
+        &:nth-child(6n+6) { background-color: #fee1ec; }
+      }
+
+      // We add an outline to make nested Flex items more visible
+      &:has(.hds-layout-flex),
+      &:has(.hds-layout-flex) > *,
+      .hds-layout-flex > * {
+        outline: 1px dotted var(--shw-color-gray-200);
+      }
     }
   }
 

--- a/showcase/app/styles/showcase-pages/layout/grid.scss
+++ b/showcase/app/styles/showcase-pages/layout/grid.scss
@@ -13,13 +13,22 @@ body.layouts-grid {
   }
 
   .shw-layout-grid-example-tint-flex-items {
-    .hds-layout-grid > * {
-      &:nth-child(6n+1) { background-color: #e4c5f3; }
-      &:nth-child(6n+2) { background-color: #e5ffd2; }
-      &:nth-child(6n+3) { background-color: #d2f4ff; }
-      &:nth-child(6n+4) { background-color: #fff8d2; }
-      &:nth-child(6n+5) { background-color: #f3d9c5; }
-      &:nth-child(6n+6) { background-color: #fee1ec; }
+    .hds-layout-grid {
+      > * {
+        &:nth-child(6n+1) { background-color: #e4c5f3; }
+        &:nth-child(6n+2) { background-color: #e5ffd2; }
+        &:nth-child(6n+3) { background-color: #d2f4ff; }
+        &:nth-child(6n+4) { background-color: #fff8d2; }
+        &:nth-child(6n+5) { background-color: #f3d9c5; }
+        &:nth-child(6n+6) { background-color: #fee1ec; }
+      }
+
+      // We add an outline to make nested Grid items more visible
+      &:has(.hds-layout-grid),
+      &:has(.hds-layout-grid) > *,
+      .hds-layout-grid > * {
+        outline: 1px dotted var(--shw-color-gray-200);
+      }
     }
   }
 }

--- a/showcase/app/styles/showcase-pages/layout/grid.scss
+++ b/showcase/app/styles/showcase-pages/layout/grid.scss
@@ -5,6 +5,8 @@
 
 // LAYOUT > GRID
 
+@use "./flex" as flex;
+
 body.layouts-grid {
   .shw-layouts-grid-plain-list {
     margin: 0;
@@ -13,22 +15,17 @@ body.layouts-grid {
   }
 
   .shw-layout-grid-example-tint-flex-items {
-    .hds-layout-grid {
-      > * {
-        &:nth-child(6n+1) { background-color: #e4c5f3; }
-        &:nth-child(6n+2) { background-color: #e5ffd2; }
-        &:nth-child(6n+3) { background-color: #d2f4ff; }
-        &:nth-child(6n+4) { background-color: #fff8d2; }
-        &:nth-child(6n+5) { background-color: #f3d9c5; }
-        &:nth-child(6n+6) { background-color: #fee1ec; }
-      }
+    .hds-layout-grid  {
+      @include flex.shw-tint-placeholders();
+    }
+  }
 
-      // We add an outline to make nested Grid items more visible
-      &:has(.hds-layout-grid),
-      &:has(.hds-layout-grid) > *,
-      .hds-layout-grid > * {
-        outline: 1px dotted var(--shw-color-gray-200);
-      }
+  .shw-layout-grid-example-nested-layouts {
+    .hds-layout-grid,
+    .hds-layout-flex {
+      @include flex.shw-tint-placeholders();
+
+      outline: 1px dotted var(--shw-color-gray-400);
     }
   }
 }

--- a/showcase/app/styles/showcase-pages/layout/grid.scss
+++ b/showcase/app/styles/showcase-pages/layout/grid.scss
@@ -15,15 +15,17 @@ body.layouts-grid {
   }
 
   .shw-layout-grid-example-tint-flex-items {
-    .hds-layout-grid  {
-      @include flex.shw-tint-placeholders();
+    .hds-layout-grid > * {
+      @include flex.shw-tint-children();
     }
   }
 
   .shw-layout-grid-example-nested-layouts {
     .hds-layout-grid,
     .hds-layout-flex {
-      @include flex.shw-tint-placeholders();
+      .shw-placeholder {
+        @include flex.shw-tint-children();
+      }
 
       outline: 1px dotted var(--shw-color-gray-400);
     }

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -132,7 +132,7 @@
     <Shw::Grid @columns="4" @gap="1rem 2rem" as |SG|>
       {{#each @model.GAPS as |gap|}}
         <SG.Item
-          @label="gap={{gap}} {{if (eq gap '0') ' (default)'}}"
+          @label="gap={{if (eq gap '0') '0 (default)' gap}}"
           class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
         >
           <Hds::Layout::Flex @direction={{direction}} @gap={{gap}}>

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -170,35 +170,83 @@
     {{/let}}
   </Shw::Flex>
 
-  <Shw::Text::H4 @tag="h3">Nested Flex</Shw::Text::H4>
+  <br />
+  <br />
 
-  <Shw::Grid @columns={{2}} @gap="2rem 4rem" class="shw-layout-flex-example-tint-flex-items" as |SG|>
-    <SG.Item @label="Parent w/ gap=16, nested Flex w/ default 0 gap">
-      <Hds::Layout::Flex @gap="16" @wrap={{true}}>
-        <Hds::Layout::Flex @direction="column" @wrap={{true}}>
-          <Shw::Placeholder @text="nested item #1" @width="100px" @height="24" />
-          <Shw::Placeholder @text="nested item #2" @width="100px" @height="24" />
-          <Shw::Placeholder @text="nested item #3" @width="100px" @height="24" />
-          <Shw::Placeholder @text="nested item #4" @width="100px" @height="24" />
-        </Hds::Layout::Flex>
+  <Shw::Text::H4 @tag="h3">Nested layouts</Shw::Text::H4>
 
-        <Shw::Placeholder @text="item #2" @width="100px" @height="24" />
+  <Shw::Flex @gap="2rem" @direction="column" class="shw-layout-flex-example-nested-layouts" as |SF|>
+    <SF.Item @label="Parent Flex w/ @gap=16, nested Flex without/ @gap (defaults to 0)">
+      <Hds::Layout::Flex @gap="16" @align="center" as |LF|>
+        <Shw::Placeholder @text="item #1" @height="48" />
+        <Shw::Placeholder @text="item #2" @height="48" />
+        <LF.Item @basis="25%" @grow="0" @shrink="0">
+          <Hds::Layout::Flex>
+            <Shw::Placeholder @text="item #3A" @height="24" />
+            <Shw::Placeholder @text="item #3B" @height="24" />
+            <Shw::Placeholder @text="item #3C" @height="24" />
+          </Hds::Layout::Flex>
+        </LF.Item>
+        <Shw::Placeholder @text="item #4" @height="48" />
       </Hds::Layout::Flex>
-    </SG.Item>
-
-    <SG.Item @label="Parent w/ default 0 gap, nested Flex w/ gap=16">
-      <Hds::Layout::Flex @wrap={{true}}>
-        <Hds::Layout::Flex @gap="16" @direction="column" @wrap={{true}}>
-          <Shw::Placeholder @text="nested item #1" @width="100px" @height="24" />
-          <Shw::Placeholder @text="nested item #2" @width="100px" @height="24" />
-          <Shw::Placeholder @text="nested item #3" @width="100px" @height="24" />
-          <Shw::Placeholder @text="nested item #4" @width="100px" @height="24" />
-        </Hds::Layout::Flex>
-
-        <Shw::Placeholder @text="item #2" @width="100px" @height="24" />
+    </SF.Item>
+    <SF.Item @label="Parent Flex w/ @gap=16, nested Flex wo/ @gap=0 (explicit)">
+      <Hds::Layout::Flex @gap="16" @align="center" as |LF|>
+        <Shw::Placeholder @text="item #1" @height="48" />
+        <Shw::Placeholder @text="item #2" @height="48" />
+        <LF.Item @basis="25%" @grow="0" @shrink="0">
+          <Hds::Layout::Flex @gap="0">
+            <Shw::Placeholder @text="item #3A" @height="24" />
+            <Shw::Placeholder @text="item #3B" @height="24" />
+            <Shw::Placeholder @text="item #3C" @height="24" />
+          </Hds::Layout::Flex>
+        </LF.Item>
+        <Shw::Placeholder @text="item #4" @height="48" />
       </Hds::Layout::Flex>
-    </SG.Item>
-  </Shw::Grid>
+    </SF.Item>
+    <SF.Item @label="Parent Flex w/ @gap=48, nested Flex w/ @gap=16">
+      <Hds::Layout::Flex @gap="48" @align="center" as |LF|>
+        <Shw::Placeholder @text="item #1" @height="48" />
+        <Shw::Placeholder @text="item #2" @height="48" />
+        <LF.Item @basis="25%" @grow="0" @shrink="0">
+          <Hds::Layout::Flex @gap="16">
+            <Shw::Placeholder @text="item #3A" @height="24" />
+            <Shw::Placeholder @text="item #3B" @height="24" />
+            <Shw::Placeholder @text="item #3C" @height="24" />
+          </Hds::Layout::Flex>
+        </LF.Item>
+        <Shw::Placeholder @text="item #4" @height="48" />
+      </Hds::Layout::Flex>
+    </SF.Item>
+    <SF.Item @label="Parent Flex w/ @gap=48, nested Grid w/ @gap=16">
+      <Hds::Layout::Flex @gap="48" @align="center" as |LF|>
+        <Shw::Placeholder @text="item #1" @height="48" />
+        <Shw::Placeholder @text="item #2" @height="48" />
+        <LF.Item @basis="25%" @grow="0" @shrink="0">
+          <Hds::Layout::Grid @gap="16">
+            <Shw::Placeholder @text="item #3A" @height="24" />
+            <Shw::Placeholder @text="item #3B" @height="24" />
+            <Shw::Placeholder @text="item #3C" @height="24" />
+          </Hds::Layout::Grid>
+        </LF.Item>
+        <Shw::Placeholder @text="item #4" @height="48" />
+      </Hds::Layout::Flex>
+    </SF.Item>
+    <SF.Item @label="Parent Grid w/ @gap=48, nested Flex w/ @gap=16">
+      <Hds::Layout::Grid @gap="48" @align="center" as |LG|>
+        <Shw::Placeholder @text="item #1" @height="48" />
+        <Shw::Placeholder @text="item #2" @height="48" />
+        <LG.Item @basis="25%" @grow="0" @shrink="0">
+          <Hds::Layout::Flex @gap="16">
+            <Shw::Placeholder @text="item #3A" @height="24" />
+            <Shw::Placeholder @text="item #3B" @height="24" />
+            <Shw::Placeholder @text="item #3C" @height="24" />
+          </Hds::Layout::Flex>
+        </LG.Item>
+        <Shw::Placeholder @text="item #4" @height="48" />
+      </Hds::Layout::Grid>
+    </SF.Item>
+  </Shw::Flex>
 
   <br />
   <br />

--- a/showcase/app/templates/layouts/flex.hbs
+++ b/showcase/app/templates/layouts/flex.hbs
@@ -129,10 +129,10 @@
   <Shw::Text::H4 @tag="h3">Single value</Shw::Text::H4>
 
   {{#each @model.DIRECTIONS as |direction|}}
-    <Shw::Grid @columns={{@model.GAPS.length}} @gap="2rem" as |SG|>
+    <Shw::Grid @columns="4" @gap="1rem 2rem" as |SG|>
       {{#each @model.GAPS as |gap|}}
         <SG.Item
-          @label="gap={{gap}}"
+          @label="gap={{gap}} {{if (eq gap '0') ' (default)'}}"
           class="shw-layout-flex-example-outline-flex-container shw-layout-flex-example-tint-flex-items"
         >
           <Hds::Layout::Flex @direction={{direction}} @gap={{gap}}>
@@ -169,6 +169,36 @@
       {{/each}}
     {{/let}}
   </Shw::Flex>
+
+  <Shw::Text::H4 @tag="h3">Nested Flex</Shw::Text::H4>
+
+  <Shw::Grid @columns={{2}} @gap="2rem 4rem" class="shw-layout-flex-example-tint-flex-items" as |SG|>
+    <SG.Item @label="Parent w/ gap=16, nested Flex w/ default 0 gap">
+      <Hds::Layout::Flex @gap="16" @wrap={{true}}>
+        <Hds::Layout::Flex @direction="column" @wrap={{true}}>
+          <Shw::Placeholder @text="nested item #1" @width="100px" @height="24" />
+          <Shw::Placeholder @text="nested item #2" @width="100px" @height="24" />
+          <Shw::Placeholder @text="nested item #3" @width="100px" @height="24" />
+          <Shw::Placeholder @text="nested item #4" @width="100px" @height="24" />
+        </Hds::Layout::Flex>
+
+        <Shw::Placeholder @text="item #2" @width="100px" @height="24" />
+      </Hds::Layout::Flex>
+    </SG.Item>
+
+    <SG.Item @label="Parent w/ default 0 gap, nested Flex w/ gap=16">
+      <Hds::Layout::Flex @wrap={{true}}>
+        <Hds::Layout::Flex @gap="16" @direction="column" @wrap={{true}}>
+          <Shw::Placeholder @text="nested item #1" @width="100px" @height="24" />
+          <Shw::Placeholder @text="nested item #2" @width="100px" @height="24" />
+          <Shw::Placeholder @text="nested item #3" @width="100px" @height="24" />
+          <Shw::Placeholder @text="nested item #4" @width="100px" @height="24" />
+        </Hds::Layout::Flex>
+
+        <Shw::Placeholder @text="item #2" @width="100px" @height="24" />
+      </Hds::Layout::Flex>
+    </SG.Item>
+  </Shw::Grid>
 
   <br />
   <br />

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -175,35 +175,84 @@
     {{/let}}
   </Shw::Grid>
 
-  <Shw::Text::H4 @tag="h3">Nested Grids</Shw::Text::H4>
+  <br />
+  <br />
 
-  <Shw::Grid @columns={{2}} @gap="2rem 4rem" class="shw-layout-grid-example-tint-flex-items" as |SG|>
-    <SG.Item @label="Parent w/ gap=16, nested Grid w/ default 0 gap">
-      <Hds::Layout::Grid @gap="16" @columnMinWidth="50%">
-        <Hds::Layout::Grid @columnMinWidth="50%">
-          <Shw::Placeholder @text="nested item #1" @width="auto" @height="24" />
-          <Shw::Placeholder @text="nested item #2" @width="auto" @height="24" />
-          <Shw::Placeholder @text="nested item #3" @width="auto" @height="24" />
-          <Shw::Placeholder @text="nested item #4" @width="auto" @height="24" />
-        </Hds::Layout::Grid>
+  <Shw::Text::H4 @tag="h3">Nested layouts</Shw::Text::H4>
 
-        <Shw::Placeholder @text="item #2" @width="auto" @height="24" />
+  <Shw::Flex @gap="2rem" @direction="column" class="shw-layout-grid-example-nested-layouts" as |SF|>
+    <SF.Item @label="Parent Grid w/ @gap=16, nested Grid wo/ @gap (defaults to 0)">
+      <Hds::Layout::Grid @gap="16" @align="center" as |LG|>
+        <Shw::Placeholder @text="item #1" @height="48" />
+        <Shw::Placeholder @text="item #2" @height="48" />
+        <LG.Item>
+          <Hds::Layout::Grid>
+            <Shw::Placeholder @text="item #3A" @height="24" />
+            <Shw::Placeholder @text="item #3B" @height="24" />
+            <Shw::Placeholder @text="item #3C" @height="24" />
+          </Hds::Layout::Grid>
+        </LG.Item>
+        <Shw::Placeholder @text="item #4" @height="48" />
       </Hds::Layout::Grid>
-    </SG.Item>
-
-    <SG.Item @label="Parent w/ default 0 gap, nested Grid w/ gap=16">
-      <Hds::Layout::Grid @columnMinWidth="50%">
-        <Hds::Layout::Grid @gap="16" @columnMinWidth="50%">
-          <Shw::Placeholder @text="nested item #1" @width="auto" @height="24" />
-          <Shw::Placeholder @text="nested item #2" @width="auto" @height="24" />
-          <Shw::Placeholder @text="nested item #3" @width="auto" @height="24" />
-          <Shw::Placeholder @text="nested item #4" @width="auto" @height="24" />
-        </Hds::Layout::Grid>
-
-        <Shw::Placeholder @text="item #2" @width="auto" @height="24" />
+    </SF.Item>
+    <SF.Item @label="Parent Grid w/ @gap=16, nested Grid w/ @gap=0 (explicit)">
+      <Hds::Layout::Grid @gap="16" @align="center" as |LG|>
+        <Shw::Placeholder @text="item #1" @height="48" />
+        <Shw::Placeholder @text="item #2" @height="48" />
+        <LG.Item @columnWidth="25%">
+          <Hds::Layout::Grid @gap="0">
+            <Shw::Placeholder @text="item #3A" @height="24" />
+            <Shw::Placeholder @text="item #3B" @height="24" />
+            <Shw::Placeholder @text="item #3C" @height="24" />
+          </Hds::Layout::Grid>
+        </LG.Item>
+        <Shw::Placeholder @text="item #4" @height="48" />
       </Hds::Layout::Grid>
-    </SG.Item>
-  </Shw::Grid>
+    </SF.Item>
+    <SF.Item @label="Parent Grid w/ @gap=48, nested Grid w/ @gap=16">
+      <Hds::Layout::Grid @gap="48" @align="center" as |LG|>
+        <Shw::Placeholder @text="item #1" @height="48" />
+        <Shw::Placeholder @text="item #2" @height="48" />
+        <LG.Item @columnWidth="25%">
+          <Hds::Layout::Grid @gap="16">
+            <Shw::Placeholder @text="item #3A" @height="24" />
+            <Shw::Placeholder @text="item #3B" @height="24" />
+            <Shw::Placeholder @text="item #3C" @height="24" />
+          </Hds::Layout::Grid>
+        </LG.Item>
+        <Shw::Placeholder @text="item #4" @height="48" />
+      </Hds::Layout::Grid>
+    </SF.Item>
+    <SF.Item @label="Parent Grid w/ @gap=48, nested Flex w/ @gap=16">
+      <Hds::Layout::Grid @gap="48" @align="center" as |LG|>
+        <Shw::Placeholder @text="item #1" @height="48" />
+        <Shw::Placeholder @text="item #2" @height="48" />
+        <LG.Item @columnWidth="25%">
+          <Hds::Layout::Flex @gap="16">
+            <Shw::Placeholder @text="item #3A" @height="24" />
+            <Shw::Placeholder @text="item #3B" @height="24" />
+            <Shw::Placeholder @text="item #3C" @height="24" />
+          </Hds::Layout::Flex>
+        </LG.Item>
+        <Shw::Placeholder @text="item #4" @height="48" />
+      </Hds::Layout::Grid>
+    </SF.Item>
+    <SF.Item @label="Parent Flex w/ @gap=48, nested Grid w/ @gap=16">
+      <Hds::Layout::Flex @gap="48" @align="center" as |LF|>
+        <Shw::Placeholder @text="item #1" @height="48" />
+        <Shw::Placeholder @text="item #2" @height="48" />
+        <LF.Item @basis="25%" @grow="0" @shrink="0">
+          <Hds::Layout::Grid @gap="16">
+            <Shw::Placeholder @text="item #3A" @height="24" />
+            <Shw::Placeholder @text="item #3B" @height="24" />
+            <Shw::Placeholder @text="item #3C" @height="24" />
+          </Hds::Layout::Grid>
+        </LF.Item>
+        <Shw::Placeholder @text="item #4" @height="48" />
+      </Hds::Layout::Flex>
+    </SF.Item>
+  </Shw::Flex>
+
 </section>
 
 <Shw::Divider />

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -138,7 +138,7 @@
 
   <Shw::Grid @columns="4" @gap="2rem" class="shw-layout-grid-example-tint-flex-items" as |SG|>
     {{#each @model.GAPS as |gap|}}
-      <SG.Item @label="gap={{gap}} {{if (eq gap '0') ' (default)'}}">
+      <SG.Item @label="gap={{if (eq gap '0') '0 (default)' gap}}">
         <Shw::Outliner>
           <Hds::Layout::Grid @gap={{gap}} @columnMinWidth="50%">
             <Shw::Placeholder @text="#1" @height="24" />

--- a/showcase/app/templates/layouts/grid.hbs
+++ b/showcase/app/templates/layouts/grid.hbs
@@ -138,7 +138,7 @@
 
   <Shw::Grid @columns="4" @gap="2rem" class="shw-layout-grid-example-tint-flex-items" as |SG|>
     {{#each @model.GAPS as |gap|}}
-      <SG.Item @label="gap={{gap}}">
+      <SG.Item @label="gap={{gap}} {{if (eq gap '0') ' (default)'}}">
         <Shw::Outliner>
           <Hds::Layout::Grid @gap={{gap}} @columnMinWidth="50%">
             <Shw::Placeholder @text="#1" @height="24" />
@@ -173,6 +173,36 @@
         </SG.Item>
       {{/each}}
     {{/let}}
+  </Shw::Grid>
+
+  <Shw::Text::H4 @tag="h3">Nested Grids</Shw::Text::H4>
+
+  <Shw::Grid @columns={{2}} @gap="2rem 4rem" class="shw-layout-grid-example-tint-flex-items" as |SG|>
+    <SG.Item @label="Parent w/ gap=16, nested Grid w/ default 0 gap">
+      <Hds::Layout::Grid @gap="16" @columnMinWidth="50%">
+        <Hds::Layout::Grid @columnMinWidth="50%">
+          <Shw::Placeholder @text="nested item #1" @width="auto" @height="24" />
+          <Shw::Placeholder @text="nested item #2" @width="auto" @height="24" />
+          <Shw::Placeholder @text="nested item #3" @width="auto" @height="24" />
+          <Shw::Placeholder @text="nested item #4" @width="auto" @height="24" />
+        </Hds::Layout::Grid>
+
+        <Shw::Placeholder @text="item #2" @width="auto" @height="24" />
+      </Hds::Layout::Grid>
+    </SG.Item>
+
+    <SG.Item @label="Parent w/ default 0 gap, nested Grid w/ gap=16">
+      <Hds::Layout::Grid @columnMinWidth="50%">
+        <Hds::Layout::Grid @gap="16" @columnMinWidth="50%">
+          <Shw::Placeholder @text="nested item #1" @width="auto" @height="24" />
+          <Shw::Placeholder @text="nested item #2" @width="auto" @height="24" />
+          <Shw::Placeholder @text="nested item #3" @width="auto" @height="24" />
+          <Shw::Placeholder @text="nested item #4" @width="auto" @height="24" />
+        </Hds::Layout::Grid>
+
+        <Shw::Placeholder @text="item #2" @width="auto" @height="24" />
+      </Hds::Layout::Grid>
+    </SG.Item>
   </Shw::Grid>
 </section>
 

--- a/showcase/tests/integration/components/hds/layout/flex/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/index-test.js
@@ -155,7 +155,7 @@ module('Integration | Component | hds/layout/flex/index', function (hooks) {
   });
   test('it should throw an assertion if an incorrect value for @gap is provided', async function (assert) {
     const errorMessage =
-      '@gap for "Hds::Layout::Flex" must be a single value or an array of two values of one of the following: 4, 8, 12, 16, 24, 32, 48; received: 4,foo';
+      '@gap for "Hds::Layout::Flex" must be a single value or an array of two values of one of the following: 0, 4, 8, 12, 16, 24, 32, 48; received: 4,foo';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);

--- a/showcase/tests/integration/components/hds/layout/flex/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/flex/index-test.js
@@ -91,12 +91,12 @@ module('Integration | Component | hds/layout/flex/index', function (hooks) {
 
   // GAP
 
-  test('it should render the element without `gap` class if no @gap is declared', async function (assert) {
+  test('it should render the element with the default `gap` class if no @gap is declared', async function (assert) {
     await render(hbs`<Hds::Layout::Flex id="test-layout-flex" />`);
     assert
       .dom('#test-layout-flex')
-      .doesNotHaveClass(/hds-layout-flex--row-gap-/)
-      .doesNotHaveClass(/hds-layout-flex--column-gap-/);
+      .hasClass('hds-layout-flex--row-gap-0')
+      .hasClass('hds-layout-flex--column-gap-0');
   });
   test('it should render the correct CSS classes if the @gap prop is declared as single value', async function (assert) {
     await render(hbs`<Hds::Layout::Flex id="test-layout-flex" @gap="24" />`);

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -108,15 +108,10 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
 
   // GAP
 
-  test('it should render the element without `gap` class if no @gap is declared', async function (assert) {
+  test('it should render the element with the default `gap` class if no @gap is declared', async function (assert) {
     await render(hbs`<Hds::Layout::Grid id="test-layout-grid" />`);
-    assert.dom('#test-layout-grid').doesNotHaveClass(/hds-layout-grid--gap-/);
-    assert
-      .dom('#test-layout-grid')
-      .doesNotHaveClass(/hds-layout-grid--row-gap-/);
-    assert
-      .dom('#test-layout-grid')
-      .doesNotHaveClass(/hds-layout-grid--column-gap-/);
+    assert.dom('#test-layout-grid').hasClass('hds-layout-grid--row-gap-0');
+    assert.dom('#test-layout-grid').hasClass('hds-layout-grid--column-gap-0');
   });
 
   test('it should render the correct CSS classes if the @gap prop is declared as a single value', async function (assert) {

--- a/showcase/tests/integration/components/hds/layout/grid/index-test.js
+++ b/showcase/tests/integration/components/hds/layout/grid/index-test.js
@@ -152,7 +152,7 @@ module('Integration | Component | hds/layout/grid/index', function (hooks) {
 
   test('it should throw an assertion if an incorrect value for @gap is provided', async function (assert) {
     const errorMessage =
-      '@gap for "Hds::Layout::Grid" must be a single value or an array of two values of one of the following: 4, 8, 12, 16, 24, 32, 48; received: 4,foo';
+      '@gap for "Hds::Layout::Grid" must be a single value or an array of two values of one of the following: 0, 4, 8, 12, 16, 24, 32, 48; received: 4,foo';
     assert.expect(2);
     setupOnerror(function (error) {
       assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes a bug in which `gap` values of nested `Flex` & `Grid` components were being inherited and adds "0" as a supported `gap` value. Also fixes improper inheritance of `Grid` `columnMinWidth` value.

- **Flex Showcase**: https://hds-showcase-git-kristin-hds-5067-fix-layout-g-490374-hashicorp.vercel.app/layouts/flex#gap
- **Grid Showcase**: https://hds-showcase-git-kristin-hds-5067-fix-layout-g-490374-hashicorp.vercel.app/layouts/grid#gap

**Documentation updates PR**: https://github.com/hashicorp/design-system/pull/2998

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-5067](https://hashicorp.atlassian.net/browse/HDS-5067)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5067]: https://hashicorp.atlassian.net/browse/HDS-5067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ