### PR TITLE
HDS docs - Add missing examples for `isRequired` vs `isOptional` (HDS-5050)

### DIFF
--- a/website/docs/components/form/radio-card/partials/code/how-to-use.md
+++ b/website/docs/components/form/radio-card/partials/code/how-to-use.md
@@ -75,6 +75,56 @@ Customizable options include:
 </Hds::Form::RadioCard::Group>
 ```
 
+#### Required vs. optional
+
+Use the `@isRequired` and `@isOptional` arguments to add a visual indication next to the legend text that the field is “required” or “optional”.
+
+```handlebars
+<Hds::Form as |FORM|>
+  <FORM.Section>
+    <Hds::Form::RadioCard::Group
+      @isRequired={{true}}
+      @name="radio-card-layout-required"
+      as |G|
+    >
+      <G.Legend>Allow this source connect to the destination</G.Legend>
+      <G.RadioCard @checked={{true}} {{on "change" this.onChange}} as |R|>
+        <R.Label>Admin</R.Label>
+        <R.Description>Grants full admin capabilities for this project.</R.Description>
+      </G.RadioCard>
+      <G.RadioCard {{on "change" this.onChange}} as |R|>
+        <R.Label>Read</R.Label>
+        <R.Description>Grants full admin capabilities for this project.</R.Description>
+      </G.RadioCard>
+      <G.RadioCard {{on "change" this.onChange}} as |R|>
+        <R.Label>Write</R.Label>
+        <R.Description>Grants full admin capabilities for this project.</R.Description>
+      </G.RadioCard>
+    </Hds::Form::RadioCard::Group>
+
+    <Hds::Form::RadioCard::Group
+      @isOptional={{true}}
+      @name="radio-card-layout-optional"
+      as |G|
+    >
+      <G.Legend>Allow this source connect to the destination</G.Legend>
+      <G.RadioCard @checked={{true}} {{on "change" this.onChange}} as |R|>
+        <R.Label>Admin</R.Label>
+        <R.Description>Grants full admin capabilities for this project.</R.Description>
+      </G.RadioCard>
+      <G.RadioCard {{on "change" this.onChange}} as |R|>
+        <R.Label>Read</R.Label>
+        <R.Description>Grants full admin capabilities for this project.</R.Description>
+      </G.RadioCard>
+      <G.RadioCard {{on "change" this.onChange}} as |R|>
+        <R.Label>Write</R.Label>
+        <R.Description>Grants full admin capabilities for this project.</R.Description>
+      </G.RadioCard>
+    </Hds::Form::RadioCard::Group>
+  </FORM.Section>
+</Hds::Form>
+```
+
 ### Layout and control position
 
 To change how the cards are laid out in a group set the `@layout` argument to `vertical`. To change the position of the control elements within a card set the `@controlPosition` argument to `left`.

--- a/website/docs/components/form/super-select/partials/code/how-to-use.md
+++ b/website/docs/components/form/super-select/partials/code/how-to-use.md
@@ -303,6 +303,40 @@ For example:
 </Hds::Form::SuperSelect::Single::Field>
 ```
 
+#### Required vs. optional
+
+Use the `@isRequired` and `@isOptional` arguments to add a visual indication that the field is "required" or "optional".
+
+```handlebars
+<Hds::Form as |FORM|>
+  <FORM.Section>
+    <Hds::Form::SuperSelect::Single::Field
+      @isRequired={{true}}
+      @onChange={{fn (mut this.SELECTED_OPTION)}}
+      @selected={{this.SELECTED_OPTION}}
+      @options={{this.OPTIONS}}
+      @searchEnabled={{true}}
+      as |F|
+    >
+      <F.Label>This is the label</F.Label>
+      <F.Options>{{F.options}}</F.Options>
+    </Hds::Form::SuperSelect::Single::Field>
+
+    <Hds::Form::SuperSelect::Single::Field
+      @isOptional={{true}}
+      @onChange={{fn (mut this.SELECTED_OPTION)}}
+      @selected={{this.SELECTED_OPTION}}
+      @options={{this.OPTIONS}}
+      @searchEnabled={{true}}
+      as |F|
+    >
+      <F.Label>This is the label</F.Label>
+      <F.Options>{{F.options}}</F.Options>
+    </Hds::Form::SuperSelect::Single::Field>
+  </FORM.Section>
+</Hds::Form>
+```
+
 ### Base components
 
 The Base components are intended for rare cases where the Field components can’t be used and a custom implementation is needed. Most of the details for the Field components also apply to the Base components, but see the [Component API](#component-api) for more details.

--- a/website/docs/components/form/toggle/partials/code/how-to-use.md
+++ b/website/docs/components/form/toggle/partials/code/how-to-use.md
@@ -82,6 +82,30 @@ When helper text is added, the component automatically adds an `aria-describedby
 </Hds::Form::Toggle::Field>
 ```
 
+#### Required vs. optional
+
+Use the `@isRequired` and `@isOptional` arguments to add a visual indication next to the legend text that the field is "required" or "optional".
+
+```handlebars
+<Hds::Form as |FORM|>
+  <FORM.Section>
+    <Hds::Form::Toggle::Group @isRequired={{true}} as |G|>
+      <G.Legend>Visibility</G.Legend>
+      <G.ToggleField name="demo-private" @id="visibility-private" as |F|>
+        <F.Label>Private</F.Label>
+      </G.ToggleField>
+    </Hds::Form::Toggle::Group>
+
+    <Hds::Form::Toggle::Group @isOptional={{true}} as |G|>
+      <G.Legend>Visibility</G.Legend>
+      <G.ToggleField name="demo-private" @id="visibility-private" as |F|>
+        <F.Label>Private</F.Label>
+      </G.ToggleField>
+    </Hds::Form::Toggle::Group>
+  </FORM.Section>
+</Hds::Form>
+```
+
 #### Validation
 
 To indicate a field is invalid, provide an error message using the `Error` contextual component.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add missing examples to the documentation for `isRequired` vs. `isOptional`.

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-5050](https://hashicorp.atlassian.net/browse/HDS-5050)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>