### PR TITLE
`KeyValueInput` - add support for `identityKey` in the `#each` loop

### DIFF
--- a/packages/components/src/components/hds/form/key-value-inputs/index.hbs
+++ b/packages/components/src/components/hds/form/key-value-inputs/index.hbs
@@ -66,7 +66,7 @@
     </div>
   {{/if}}
 
-  {{#each @data as |item index|}}
+  {{#each @data key=this.identityKey as |item index|}}
     <div class="hds-form-key-value-inputs__row {{if (eq index 0) 'hds-form-key-value-inputs__row--first'}}">
       {{yield
         (hash

--- a/packages/components/src/components/hds/form/key-value-inputs/index.ts
+++ b/packages/components/src/components/hds/form/key-value-inputs/index.ts
@@ -43,6 +43,7 @@ export interface HdsFormKeyValueInputsSignature {
     extraAriaDescribedBy?: string;
     isOptional?: boolean;
     isRequired?: boolean;
+    identityKey?: string;
   };
   Blocks: {
     header?: [
@@ -100,6 +101,15 @@ export default class HdsFormKeyValueInputs extends Component<HdsFormKeyValueInpu
   // different fieldsset-related elements (legend, helper text, error) with the fieldset itself
   get glueId(): string {
     return guidFor(this);
+  }
+
+  get identityKey(): string | undefined {
+    // we have to provide a way for the consumer to pass undefined because Ember tries to interpret undefined as missing an arg and therefore falls back to the default
+    if (this.args.identityKey === 'none') {
+      return undefined;
+    } else {
+      return this.args.identityKey ?? '@identity';
+    }
   }
 
   @action


### PR DESCRIPTION
### :pushpin: Summary

While looking at examples of existing implementation of Key/Value components in consumer's codebases, I have noticed that in a couple of cases the `{{#each}}` loop had an extra `key`, while other cases didn't have it.

With `key`:

- https://github.com/hashicorp/cloud-ui/blob/main/engines/vault/addon/components/form/inputs/key-value-pairs/index.hbs#L3
- https://github.com/hashicorp/cloud-ui/blob/main/engines/waypoint/addon/components/key-value-input.hbs#L14

Without `key`:

- https://github.com/hashicorp/atlas/blob/main/frontend/atlas/app/components/v2/key-value-list-input/key-value-input.hbs#L15
- https://github.com/hashicorp/vault/blob/main/ui/lib/core/addon/components/kv-object-editor.hbs#L20
- https://github.com/hashicorp/boundary-ui/blob/main/ui/admin/app/components/form/field/list-wrapper/key-value/index.hbs#L29

For context, we already have something similar in the `Table` and `AdvancedTable` components.

With this PR I want to collect feedback if it's worth to add it or not.

### :hammer_and_wrench: Detailed description

In this PR I have:
- added support for `identityKey` in the `#each` loop of the `KeyValueInput` template (same implementation as the existing one for `Table` and `AdvancedTable` loops.

**TODO** (if we decide to proceed)
- add changelog
- add ticket and PR for the documentation update
- create Jira ticket specific for this task (child of [HDS-5071](https://hashicorp.atlassian.net/browse/HDS-5071))

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-5071 (overarching task)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>