### PR TITLE
`Web docs` - Remove mention of filled badge in tables

### DIFF
--- a/website/docs/components/badge/partials/guidelines/guidelines.md
+++ b/website/docs/components/badge/partials/guidelines/guidelines.md
@@ -61,8 +61,6 @@ Use filled Badges when displaying many on a single page or for subtle callouts.
 <Hds::Badge @color="critical" @text="Critical filled" />
 
 For example:
-
-- when listing statuses in a table
 - for successful or passive actions
 
 ### Inverted

--- a/website/docs/components/badge/partials/guidelines/guidelines.md
+++ b/website/docs/components/badge/partials/guidelines/guidelines.md
@@ -61,6 +61,7 @@ Use filled Badges when displaying many on a single page or for subtle callouts.
 <Hds::Badge @color="critical" @text="Critical filled" />
 
 For example:
+
 - for successful or passive actions
 
 ### Inverted


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will remove the reference of a fill badge in a table. 

### :hammer_and_wrench: Detailed description

We are removing this reference because of A11Y requirements of color contrast. Not all filled in badges will work with striping, while outlining will.

### :link: External links

Jira ticket: [HDS-5075](https://hashicorp.atlassian.net/browse/HDS-5075)

***
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

[HDS-5075]: https://hashicorp.atlassian.net/browse/HDS-5075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ