### PR TITLE
CardContainer: fix component name in template registry

### DIFF
--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -426,8 +426,8 @@ export default interface HdsComponentsRegistry {
   'hds/button-set': typeof HdsButtonSetComponent;
 
   // Card
-  'Hds::Card': typeof HdsCardContainerComponent;
-  'hds/card': typeof HdsCardContainerComponent;
+  'Hds::Card::Container': typeof HdsCardContainerComponent;
+  'hds/card/container': typeof HdsCardContainerComponent;
 
   // Code Block
   'Hds::CodeBlock': typeof HdsCodeBlockComponent;

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -426,6 +426,9 @@ export default interface HdsComponentsRegistry {
   'hds/button-set': typeof HdsButtonSetComponent;
 
   // Card
+  // NOTE: this will be removed in 5.0.0, use 'Hds::Card::Container' instead
+  'Hds::Card': typeof HdsCardContainerComponent;
+  'hds/card': typeof HdsCardContainerComponent;
   'Hds::Card::Container': typeof HdsCardContainerComponent;
   'hds/card/container': typeof HdsCardContainerComponent;
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the name for the Card Container component in the template registry. 

I noticed that there is a discrepancy where in template registry, we export `hds/card` and `Hds::Card`, but in [our docs](https://helios.hashicorp.design/components/card?tab=code) and in [the showcase template](https://github.com/hashicorp/design-system/blob/c605a1805d64943a6ce916611fbce3f2b740af32/showcase/app/templates/components/card.hbs#L19), we exclusively refer to it as `Hds::Card::Container`.

Changing this would be **a breaking change** because it would change the name of a component externally. Options for moving forward:
1. Wait to fix this until the 5.0 release and add glint ignores to the Card template file to supress current errors. 
2. Just rename it `Hds::Card` and update the showcase/website to match
3. Export it as both names as a fix for now, circle back to remove the incorrect name in the 5.0 release _(Lee's preference)_

I found this while I was upgrading the routes files to typescript ([example test failure](https://github.com/hashicorp/design-system/actions/runs/16124069042/job/45496690922))
<img width="937" alt="Screenshot 2025-07-07 at 2 17 33 PM" src="https://github.com/user-attachments/assets/810646a4-f74e-4fd1-a079-4cab210ccfd1" />


***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>