### PR TITLE
Zamoore/advanced table/column reordering 2

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -148,6 +148,8 @@
       "./components/hds/advanced-table/th-button-sort.js": "./dist/_app_/components/hds/advanced-table/th-button-sort.js",
       "./components/hds/advanced-table/th-button-tooltip.js": "./dist/_app_/components/hds/advanced-table/th-button-tooltip.js",
       "./components/hds/advanced-table/th-context-menu.js": "./dist/_app_/components/hds/advanced-table/th-context-menu.js",
+      "./components/hds/advanced-table/th-reorder-drop-target.js": "./dist/_app_/components/hds/advanced-table/th-reorder-drop-target.js",
+      "./components/hds/advanced-table/th-reorder-handle.js": "./dist/_app_/components/hds/advanced-table/th-reorder-handle.js",
       "./components/hds/advanced-table/th-resize-handle.js": "./dist/_app_/components/hds/advanced-table/th-resize-handle.js",
       "./components/hds/advanced-table/th-selectable.js": "./dist/_app_/components/hds/advanced-table/th-selectable.js",
       "./components/hds/advanced-table/th-sort.js": "./dist/_app_/components/hds/advanced-table/th-sort.js",

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -2,6 +2,9 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
+{{! TODO: Remove this when ready }}
+{{! @glint-nocheck }}
+
 <div
   class="hds-advanced-table__container
     {{(if this.isStickyHeaderPinned 'hds-advanced-table__container--header-is-pinned')}}"
@@ -40,7 +43,7 @@
         @hasStickyColumn={{@hasStickyFirstColumn}}
         @isStickyColumnPinned={{this.isStickyColumnPinned}}
       >
-        {{#each this._tableModel.columns as |column index|}}
+        {{#each this._tableModel.orderedColumns as |column index|}}
           {{#if column.isSortable}}
             <Hds::AdvancedTable::ThSort
               @column={{column}}
@@ -48,6 +51,7 @@
               @onClickSort={{if column.key (fn this._tableModel.setSortBy column.key)}}
               @align={{column.align}}
               @tooltip={{column.tooltip}}
+              @hasReorderableColumns={{@hasReorderableColumns}}
               @hasResizableColumns={{@hasResizableColumns}}
               @isLastColumn={{eq index (sub this._tableModel.columns.length 1)}}
               @isStickyColumn={{if (and (eq index 0) @hasStickyFirstColumn) true}}
@@ -65,6 +69,7 @@
               @align={{column.align}}
               @column={{column}}
               @hasExpandAllButton={{this._tableModel.hasRowsWithChildren}}
+              @hasReorderableColumns={{@hasReorderableColumns}}
               @hasResizableColumns={{@hasResizableColumns}}
               @isExpanded={{this._tableModel.expandState}}
               @isExpandable={{column.isExpandable}}
@@ -78,6 +83,9 @@
               @tooltip={{column.tooltip}}
               @onClickToggle={{this._tableModel.toggleAll}}
               @onColumnResize={{@onColumnResize}}
+              @onReorderDragEnd={{fn (mut this._tableModel.reorderDraggedColumn) null}}
+              @onReorderDragStart={{fn (mut this._tableModel.reorderDraggedColumn)}}
+              @onReorderDrop={{this._tableModel.reorderColumn}}
               {{this._setColumnWidth column}}
             >
               {{column.label}}
@@ -110,6 +118,7 @@
                   isParentRow=T.isExpandable
                   depth=T.depth
                   displayRow=T.shouldDisplayChildRows
+                  data=T.data
                 )
                 Th=(component
                   "hds/advanced-table/th"
@@ -121,7 +130,7 @@
                   scope="row"
                   onClickToggle=T.onClickToggle
                 )
-                Td=(component "hds/advanced-table/td" align=@align)
+                Td=(component "hds/advanced-table/td" align=@align columns=this._tableModel.columns)
                 data=T.data
                 isOpen=T.isExpanded
                 rowIndex=T.rowIndex
@@ -143,6 +152,7 @@
                 selectionAriaLabelSuffix=@selectionAriaLabelSuffix
                 hasStickyColumn=@hasStickyFirstColumn
                 isStickyColumnPinned=this.isStickyColumnPinned
+                data=record
               )
               Th=(component
                 "hds/advanced-table/th"
@@ -150,7 +160,7 @@
                 isStickyColumn=@hasStickyFirstColumn
                 isStickyColumnPinned=this.isStickyColumnPinned
               )
-              Td=(component "hds/advanced-table/td" align=@align)
+              Td=(component "hds/advanced-table/td" align=@align columns=this._tableModel.columns)
               data=record
               rowIndex=index
             )

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -29,6 +29,7 @@ import type {
   HdsAdvancedTableVerticalAlignment,
   HdsAdvancedTableModel,
   HdsAdvancedTableExpandState,
+  HdsAdvancedTableColumnReorderCallback,
 } from './types.ts';
 import type HdsAdvancedTableColumnType from './models/column.ts';
 import type { HdsFormCheckboxBaseSignature } from '../form/checkbox/base.ts';
@@ -115,6 +116,7 @@ export interface HdsAdvancedTableSignature {
     align?: HdsAdvancedTableHorizontalAlignment;
     caption?: string;
     columns: HdsAdvancedTableColumn[];
+    columnOrder?: string[];
     density?: HdsAdvancedTableDensities;
     identityKey?: string;
     isSelectable?: boolean;
@@ -126,11 +128,13 @@ export interface HdsAdvancedTableSignature {
     sortedMessageText?: string;
     sortOrder?: HdsAdvancedTableThSortOrder;
     valign?: HdsAdvancedTableVerticalAlignment;
+    hasReorderableColumns?: boolean;
     hasResizableColumns?: boolean;
     hasStickyHeader?: boolean;
     hasStickyFirstColumn?: boolean;
     childrenKey?: string;
     maxHeight?: string;
+    onColumnReorder?: HdsAdvancedTableColumnReorderCallback;
     onColumnResize?: (columnKey: string, newWidth?: string) => void;
     onSelectionChange?: (
       selection: HdsAdvancedTableOnSelectionChangeSignature
@@ -205,6 +209,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     const {
       model,
       columns,
+      columnOrder,
       childrenKey,
       hasResizableColumns,
       sortBy,
@@ -216,6 +221,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     this._tableModel = new HdsAdvancedTableTableModel({
       model,
       columns,
+      columnOrder,
       childrenKey,
       hasResizableColumns,
       sortBy,

--- a/packages/components/src/components/hds/advanced-table/models/row.ts
+++ b/packages/components/src/components/hds/advanced-table/models/row.ts
@@ -7,13 +7,14 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 
-import type { HdsAdvancedTableColumn } from '../types';
+import type { HdsAdvancedTableColumn, HdsAdvancedTableCell } from '../types';
 
 interface HdsAdvancedTableRowArgs {
   [key: string]: unknown;
   columns: HdsAdvancedTableColumn[];
   id?: string;
   childrenKey?: string;
+  columnOrder?: string[];
 }
 
 export default class HdsAdvancedTableRow {
@@ -23,6 +24,8 @@ export default class HdsAdvancedTableRow {
   [key: string]: unknown;
 
   @tracked isOpen: boolean = false;
+  @tracked cells: HdsAdvancedTableCell[] = [];
+  @tracked columnOrder: string[] = [];
 
   children: HdsAdvancedTableRow[] = [];
   childrenKey: string;
@@ -35,7 +38,33 @@ export default class HdsAdvancedTableRow {
     return this.isOpen && this.hasChildren;
   }
 
+  get orderedCells(): HdsAdvancedTableCell[] {
+    return this.columnOrder.reduce((acc, key) => {
+      const cell = this.cells.find((cell) => cell.columnKey === key);
+
+      if (cell) {
+        acc.push(cell);
+      }
+
+      return acc;
+    }, [] as HdsAdvancedTableCell[]);
+  }
+
   constructor(args: HdsAdvancedTableRowArgs) {
+    const { columns } = args;
+
+    this.cells = columns.map((column) => {
+      const cell = args[column.key ?? ''];
+
+      return {
+        columnKey: column.key ?? '',
+        content: cell,
+      };
+    });
+
+    this.columnOrder =
+      args.columnOrder ?? this.cells.map((cell) => cell.columnKey);
+
     // set row data
     Object.assign(this, args);
 
@@ -48,6 +77,15 @@ export default class HdsAdvancedTableRow {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         (child) => new HdsAdvancedTableRow(child)
       );
+    }
+  }
+
+  @action
+  updateColumnOrder(columnOrder: string[]) {
+    this.columnOrder = columnOrder;
+
+    for (const child of this.children) {
+      child.updateColumnOrder(columnOrder);
     }
   }
 

--- a/packages/components/src/components/hds/advanced-table/th-reorder-drop-target.hbs
+++ b/packages/components/src/components/hds/advanced-table/th-reorder-drop-target.hbs
@@ -1,0 +1,12 @@
+<div
+  class={{this.classNames}}
+  aria-hidden="true"
+  role="presentation"
+  {{style height=(if @tableHeight (concat (sub @tableHeight 3.5) "px"))}}
+  {{this._registerElement}}
+  {{on "dragover" this.handleDragOver}}
+  {{on "dragenter" this.handleDragEnter}}
+  {{on "dragleave" this.handleDragLeave}}
+  {{on "drop" this.handleDrop}}
+  ...attributes
+/>

--- a/packages/components/src/components/hds/advanced-table/th-reorder-drop-target.ts
+++ b/packages/components/src/components/hds/advanced-table/th-reorder-drop-target.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { modifier } from 'ember-modifier';
+
+import type HdsAdvancedTableColumn from './models/column.ts';
+
+export interface HdsAdvancedTableThReorderDropTargetSignature {
+  Args: {
+    column: HdsAdvancedTableColumn;
+    tableHeight?: number;
+    onReorderDrop?: (
+      column: HdsAdvancedTableColumn,
+      side: 'left' | 'right'
+    ) => void;
+  };
+  Blocks: {
+    default?: [];
+  };
+  Element: HTMLDivElement;
+}
+
+export default class HdsAdvancedTableThReorderDropTarget extends Component<HdsAdvancedTableThReorderDropTargetSignature> {
+  @tracked private _dragSide: 'left' | 'right' | null = null;
+  @tracked private _isDraggingOver = false;
+  @tracked private _dragCount = 0;
+
+  private _element!: HdsAdvancedTableThReorderDropTargetSignature['Element'];
+
+  get classNames(): string {
+    const { column } = this.args;
+
+    const classes = ['hds-advanced-table__th-reorder-drop-target'];
+
+    if (column.isFirst) {
+      classes.push('hds-advanced-table__th-reorder-drop-target--is-first');
+    } else if (column.isLast) {
+      classes.push('hds-advanced-table__th-reorder-drop-target--is-last');
+    }
+
+    if (column.isBeingDragged) {
+      classes.push(
+        'hds-advanced-table__th-reorder-drop-target--is-being-dragged'
+      );
+    } else if (this._isDraggingOver && this._dragSide !== null) {
+      classes.push(
+        ...[
+          'hds-advanced-table__th-reorder-drop-target--is-dragging-over',
+          `hds-advanced-table__th-reorder-drop-target--is-dragging-over--${this._dragSide}`,
+        ]
+      );
+    }
+
+    return classes.join(' ');
+  }
+
+  private _registerElement = modifier(
+    (element: HdsAdvancedTableThReorderDropTargetSignature['Element']) => {
+      this._element = element;
+    }
+  );
+
+  private _resetDragState(): void {
+    this._dragCount = 0;
+    this._isDraggingOver = false;
+    this._dragSide = null;
+  }
+
+  // determines whether the drag event is occurring on the left or right side of the element
+  private _getDragSide(event: DragEvent): 'left' | 'right' {
+    const rect = this._element.getBoundingClientRect();
+    const mouseX = event.clientX;
+    const elementMiddleX = rect.left + rect.width / 2;
+
+    return mouseX < elementMiddleX ? 'left' : 'right';
+  }
+
+  @action
+  handleDragOver(event: DragEvent): void {
+    event.preventDefault();
+
+    const { column } = this.args;
+    const { reorderDraggedColumn } = column.table;
+
+    if (column.isBeingDragged || reorderDraggedColumn === null) {
+      return;
+    }
+
+    const { next, previous } = reorderDraggedColumn.siblings;
+    const dragSide = this._getDragSide(event);
+
+    if (
+      (column === previous && dragSide === 'left') ||
+      (column === next && dragSide === 'right') ||
+      (column !== previous && column !== next)
+    ) {
+      this._dragSide = dragSide;
+    }
+  }
+
+  @action
+  handleDragEnter(event: DragEvent): void {
+    event.preventDefault();
+
+    this._dragCount = this._dragCount + 1;
+
+    if (this._dragCount === 1) {
+      this._isDraggingOver = true;
+    }
+  }
+
+  @action
+  handleDragLeave(event: DragEvent): void {
+    event.preventDefault();
+
+    this._dragCount = this._dragCount - 1;
+
+    // ensure count doesn't go negative and reset isDraggingOver when appropriate
+    if (this._dragCount <= 0) {
+      this._resetDragState();
+    }
+  }
+
+  @action
+  handleDrop(event: DragEvent): void {
+    event.preventDefault();
+
+    const { column, onReorderDrop } = this.args;
+    const { _dragSide } = this;
+
+    // reset drag state completely when an item is dropped
+    this._resetDragState();
+
+    if (
+      column === undefined ||
+      _dragSide === null ||
+      typeof onReorderDrop !== 'function'
+    ) {
+      return;
+    }
+
+    onReorderDrop(column, _dragSide);
+  }
+}

--- a/packages/components/src/components/hds/advanced-table/th-reorder-handle.hbs
+++ b/packages/components/src/components/hds/advanced-table/th-reorder-handle.hbs
@@ -1,0 +1,8 @@
+{{! template-lint-disable no-pointer-down-event-binding }}
+<div
+  draggable="true"
+  class={{this.classNames}}
+  {{on "dragstart" this.handleDragStart}}
+  {{on "dragend" this.handleDragEnd}}
+  ...attributes
+/>

--- a/packages/components/src/components/hds/advanced-table/th-reorder-handle.ts
+++ b/packages/components/src/components/hds/advanced-table/th-reorder-handle.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+
+import type HdsAdvancedTableColumn from './models/column.ts';
+import { action } from '@ember/object';
+
+export interface HdsAdvancedTableThReorderHandleSignature {
+  Args: {
+    column: HdsAdvancedTableColumn;
+    columnWidth: number;
+    tableHeight?: number;
+    onReorderDragStart: (column: HdsAdvancedTableColumn) => void;
+    onReorderDragEnd?: () => void;
+  };
+  Blocks: {
+    default?: [];
+  };
+  Element: HTMLDivElement;
+}
+
+function constructDragPreview(width: number, height?: number): HTMLDivElement {
+  const dragPreviewElement = document.createElement('div');
+
+  dragPreviewElement.className = 'hds-advanced-table__th-reorder-drag-preview';
+
+  dragPreviewElement.style.width = `${width}px`;
+
+  if (height) {
+    dragPreviewElement.style.height = `${height}px`;
+  }
+
+  document.body.appendChild(dragPreviewElement);
+
+  return dragPreviewElement;
+}
+
+export default class HdsAdvancedTableThReorderHandle extends Component<HdsAdvancedTableThReorderHandleSignature> {
+  get classNames(): string {
+    const classes = ['hds-advanced-table__th-reorder-handle'];
+
+    return classes.join(' ');
+  }
+
+  @action
+  handleDragStart(event: DragEvent): void {
+    const { column, columnWidth, tableHeight, onReorderDragStart } = this.args;
+
+    if (column.key === undefined || typeof onReorderDragStart !== 'function') {
+      return;
+    }
+
+    event.dataTransfer?.setData('text/plain', column.key);
+
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+    }
+
+    const dragPreview = constructDragPreview(columnWidth, tableHeight);
+
+    document.body.appendChild(dragPreview);
+
+    event.dataTransfer?.setDragImage(dragPreview, columnWidth / 2, 10);
+
+    setTimeout(() => document.body.removeChild(dragPreview), 0);
+
+    onReorderDragStart(column);
+  }
+
+  @action
+  handleDragEnd(): void {
+    const { column, onReorderDragEnd } = this.args;
+
+    column.isBeingDragged = false;
+
+    if (typeof onReorderDragEnd === 'function') {
+      onReorderDragEnd();
+    }
+  }
+}

--- a/packages/components/src/components/hds/advanced-table/th.hbs
+++ b/packages/components/src/components/hds/advanced-table/th.hbs
@@ -77,6 +77,16 @@
         />
       {{/if}}
 
+      {{#if @hasReorderableColumns}}
+        <Hds::AdvancedTable::ThReorderHandle
+          @column={{@column}}
+          @columnWidth={{this._element.clientWidth}}
+          @tableHeight={{@tableHeight}}
+          @onReorderDragStart={{this.handleDragStart}}
+          @onReorderDragEnd={{@onReorderDragEnd}}
+        />
+      {{/if}}
+
       {{#if (and @hasResizableColumns (not @isLastColumn))}}
         <Hds::AdvancedTable::ThResizeHandle
           @column={{@column}}
@@ -89,4 +99,12 @@
       {{/if}}
     {{/if}}
   </Hds::Layout::Flex>
+
+  {{#if @column.table.hasColumnBeingDragged}}
+    <Hds::AdvancedTable::ThReorderDropTarget
+      @column={{@column}}
+      @tableHeight={{@tableHeight}}
+      @onReorderDrop={{@onReorderDrop}}
+    />
+  {{/if}}
 </div>

--- a/packages/components/src/components/hds/advanced-table/tr.hbs
+++ b/packages/components/src/components/hds/advanced-table/tr.hbs
@@ -21,5 +21,5 @@
     />
   {{/if}}
 
-  {{yield}}
+  {{yield (hash orderedCells=@data.orderedCells)}}
 </div>

--- a/packages/components/src/components/hds/advanced-table/tr.ts
+++ b/packages/components/src/components/hds/advanced-table/tr.ts
@@ -14,6 +14,7 @@ import type {
 import type { HdsFormCheckboxBaseSignature } from '../form/checkbox/base.ts';
 import type { HdsAdvancedTableSignature } from './index.ts';
 import type { HdsAdvancedTableThSelectableSignature } from './th-selectable.ts';
+import type HdsAdvancedTableRow from './models/row.ts';
 
 export interface BaseHdsAdvancedTableTrSignature {
   Args: {
@@ -22,6 +23,7 @@ export interface BaseHdsAdvancedTableTrSignature {
     isSelectable?: boolean;
     isSelected?: false;
     isParentRow?: boolean;
+    data?: HdsAdvancedTableRow;
     selectionAriaLabelSuffix?: string;
     selectionKey?: string;
     selectionScope?: HdsAdvancedTableScope;
@@ -42,7 +44,11 @@ export interface BaseHdsAdvancedTableTrSignature {
     isStickyColumnPinned?: boolean;
   };
   Blocks: {
-    default?: [];
+    default?: [
+      {
+        orderedCells?: HdsAdvancedTableRow['cells'];
+      },
+    ];
   };
   Element: HTMLDivElement;
 }

--- a/packages/components/src/components/hds/advanced-table/types.ts
+++ b/packages/components/src/components/hds/advanced-table/types.ts
@@ -113,3 +113,17 @@ export interface HdsAdvancedTableOnSelectionChangeSignature {
 }
 
 export type HdsAdvancedTableModel = Array<Record<string, unknown>>;
+
+export type HdsAdvancedTableColumnResizeCallback = (
+  columnKey: string,
+  newWidth?: string
+) => void;
+
+export type HdsAdvancedTableColumnReorderCallback = (
+  columnOrder: string[]
+) => void;
+
+export interface HdsAdvancedTableCell {
+  columnKey: string;
+  content: unknown;
+}

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -23,6 +23,7 @@ $hds-advanced-table-cell-padding-medium: 14px 16px 13px 16px; // the 1px differe
 $hds-advanced-table-cell-padding-short: 6px 16px 5px 16px; // the 1px difference is to account for the bottom border
 $hds-advanced-table-cell-padding-tall: 22px 16px 21px 16px; // the 1px difference is to account for the bottom border
 $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown triggers in the header cell
+$hds-advanced-table-drag-preview-background-color: rgba(204, 227, 254, 30%);
 
 // ADVANCED TABLE
 
@@ -111,6 +112,72 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
         z-index: 1;
         isolation: isolate;
       }
+    }
+
+    .hds-advanced-table__th-reorder-drop-target {
+      position: absolute;
+      top: 0;
+      right: 0;
+      left: 0;
+      z-index: 1;
+    }
+
+    // is being dragged
+    .hds-advanced-table__th-reorder-drop-target--is-being-dragged {
+      background-color: var(--token-color-surface-strong);
+    }
+
+    // is dragging over
+    .hds-advanced-table__th-reorder-drop-target--is-dragging-over {
+      position: absolute;
+      top: 0;
+      right: 0;
+      left: 0;
+      z-index: 1;
+
+      &::after {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 4px;
+        background-color: var(--token-color-palette-blue-300);
+        content: "";
+      }
+    }
+
+    // dragging over left
+    .hds-advanced-table__th-reorder-drop-target--is-dragging-over--left::after {
+      left: 0;
+      transform: translateX(-3px);
+    }
+
+    // dragging over left and is first
+    .hds-advanced-table__th-reorder-drop-target--is-dragging-over--left.hds-advanced-table__th-reorder-drop-target--is-first::after {
+      transform: translateX(0);
+    }
+
+    // dragging over right
+    .hds-advanced-table__th-reorder-drop-target--is-dragging-over--right::after {
+      right: 0;
+      transform: translateX(3px);
+    }
+
+    // dragging over right and is last
+    .hds-advanced-table__th-reorder-drop-target--is-dragging-over--right.hds-advanced-table__th-reorder-drop-target--is-last::after {
+      transform: translateX(0);
+    }
+
+    .hds-advanced-table__th-reorder-handle {
+      position: absolute;
+      top: 0;
+      left: 50%;
+      z-index: 2;
+      width: 24px;
+      height: 24px;
+      background-color: var(--token-color-surface-primary);
+      border: 1px solid $hds-advanced-table-border-color;
+      border-radius: var(--token-border-radius-x-small);
+      transform: translateX(-50%);
     }
 
     .hds-advanced-table__th-resize-handle {
@@ -582,4 +649,13 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
   height: 8px;
   // the rgb value is equivalent to neutral/600, need to use rgba for the right opacity
   background: linear-gradient(to bottom, rgba(59, 61, 69, 0%) 0%, rgba(59, 61, 69, 8%) 100%);
+}
+
+.hds-advanced-table__th-reorder-drag-preview {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+  background-color: $hds-advanced-table-drag-preview-background-color;
+  border: 5px solid var(--token-color-focus-action-external);
+  border-radius: var(--token-border-radius-medium);
 }


### PR DESCRIPTION
In-progress; Do not review/merge.

### :pushpin: Summary

If merged, this PR will add support for column reordering to the AdvancedTable component.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4588](https://hashicorp.atlassian.net/browse/HDS-4588)
Figma file: [if it applies]

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-4588]: https://hashicorp.atlassian.net/browse/HDS-4588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ