### PR TITLE
`RadioCard` - Fix hover styles shown when disabled

### DIFF
--- a/.changeset/curly-dogs-greet.md
+++ b/.changeset/curly-dogs-greet.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/form/radio-card -->
+`Form::RadioCard` - Fixed styling bug where hover styles were visible when disabled
+<!-- END -->

--- a/packages/components/src/styles/components/form/radio-card.scss
+++ b/packages/components/src/styles/components/form/radio-card.scss
@@ -76,6 +76,7 @@
     }
   }
 
+  // note: using full class name so it overrides the :hover styles
   &.hds-form-radio-card--disabled {
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);

--- a/packages/components/src/styles/components/form/radio-card.scss
+++ b/packages/components/src/styles/components/form/radio-card.scss
@@ -76,8 +76,7 @@
     }
   }
 
-  &--disabled,
-  &.mock-disabled {
+  &.hds-form-radio-card--disabled {
     background-color: var(--token-color-surface-interactive-disabled);
     border-color: var(--token-color-border-primary);
     box-shadow: none;

--- a/packages/components/src/styles/components/form/radio-card.scss
+++ b/packages/components/src/styles/components/form/radio-card.scss
@@ -61,8 +61,7 @@
     box-shadow: 0 0 0 3px var(--token-color-focus-action-external);
   }
 
-  &--checked,
-  &.mock-checked {
+  &.hds-form-radio-card--checked {
     border-color: var(--token-color-palette-blue-300);
 
     .hds-form-radio-card__control-wrapper {
@@ -90,6 +89,11 @@
 
     .hds-form-radio-card__content {
       opacity: 0.5;
+    }
+
+    &:hover,
+    &.mock-hover {
+      border-color: var(--token-color-border-primary);
     }
   }
 }

--- a/showcase/app/templates/page-components/form/radio-card.hbs
+++ b/showcase/app/templates/page-components/form/radio-card.hbs
@@ -15,7 +15,7 @@
 
   <Shw::Grid @columns={{4}} as |SG|>
     {{#each @model.STATES as |state|}}
-      <SG.Item @label={{capitalize state}} mock-state-value={{state}} mock-state-selector="label">
+      <SG.Item @label={{capitalize state}} mock-state-value={{unless (eq state "disabled") state}} mock-state-selector="label">
         <Hds::Form::RadioCard @disabled={{eq state "disabled"}} as |R|>
           <R.Icon @name="hexagon" />
           <R.Label>Label</R.Label>
@@ -24,7 +24,7 @@
       </SG.Item>
     {{/each}}
     {{#each @model.STATES as |state|}}
-      <SG.Item @label="{{capitalize state}} selected" mock-state-value={{state}} mock-state-selector="label">
+      <SG.Item @label="{{capitalize state}} selected" mock-state-value={{unless (eq state "disabled") state}} mock-state-selector="label">
         <Hds::Form::RadioCard @checked={{true}} @disabled={{eq state "disabled"}} as |R|>
           <R.Icon @name="hexagon" />
           <R.Label>Label</R.Label>

--- a/showcase/app/templates/page-components/form/radio-card.hbs
+++ b/showcase/app/templates/page-components/form/radio-card.hbs
@@ -15,7 +15,11 @@
 
   <Shw::Grid @columns={{4}} as |SG|>
     {{#each @model.STATES as |state|}}
-      <SG.Item @label={{capitalize state}} mock-state-value={{unless (eq state "disabled") state}} mock-state-selector="label">
+      <SG.Item
+        @label={{capitalize state}}
+        mock-state-value={{unless (eq state "disabled") state}}
+        mock-state-selector="label"
+      >
         <Hds::Form::RadioCard @disabled={{eq state "disabled"}} as |R|>
           <R.Icon @name="hexagon" />
           <R.Label>Label</R.Label>
@@ -24,7 +28,11 @@
       </SG.Item>
     {{/each}}
     {{#each @model.STATES as |state|}}
-      <SG.Item @label="{{capitalize state}} selected" mock-state-value={{unless (eq state "disabled") state}} mock-state-selector="label">
+      <SG.Item
+        @label="{{capitalize state}} selected"
+        mock-state-value={{unless (eq state "disabled") state}}
+        mock-state-selector="label"
+      >
         <Hds::Form::RadioCard @checked={{true}} @disabled={{eq state "disabled"}} as |R|>
           <R.Icon @name="hexagon" />
           <R.Label>Label</R.Label>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue in the `RadioCard` where hover state styles were visible when `@disabed` was `true`.

### :hammer_and_wrench: Detailed description

It was [observed in atlas](https://hashicorp.slack.com/archives/C7KTUHNUS/p1751998251683399) that `RadioCard` components were still having hover styles applied even when disabled. This same observation was **not** observed in the showcase. 

When `:hover` is applied to a disabled card, the selector for the hover styles `.hds-form-radio-card:hover` takes precedence over the selector for the disabled styles `.hds-form-radio-card--disabled`.

In the showcase the styles are trigged by the `mock-` class with the selector `.hds-form-radio-card.mock-disabled`. This takes precedence over the hover selector. This is what is causing the mismatch between the showcase and the atlas example.

To solve this issue I have increased the specificity of the selectors for the disabled state. The showcase has also been updated to no longer use the `mock-` selector for the disabled state, since the `@disabled` argument is available. 

### :camera_flash: Screenshots

**Before**

https://github.com/user-attachments/assets/b23a454f-b96c-4b52-ad73-e272fc95102d

**After**

https://github.com/user-attachments/assets/2f853bb1-468f-4a81-8bcd-bfc3cbb8c936

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5084](https://hashicorp.atlassian.net/browse/HDS-5084)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5084]: https://hashicorp.atlassian.net/browse/HDS-5084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ