### PR TITLE
Showcase: Remove unused route files

### DIFF
--- a/showcase/app/routes/content.js
+++ b/showcase/app/routes/content.js
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
-import Route from '@ember/routing/route';
-
-export default class ContentRoute extends Route {}

--- a/showcase/app/routes/page-components/layout/grid.js
+++ b/showcase/app/routes/page-components/layout/grid.js
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
-import Route from '@ember/routing/route';
-
-export default class PageComponentsLayoutGridRoute extends Route {}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would delete 2 old route files I found that aren't used.
* `/content` : it looks like this file came over when the showcase was initially created. There is no content for that route
* `/page-components/layout/grid`: it seems like this one was not used, `/layouts/grid` is where the grid component content actually is.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>