### PR TITLE
`Web Docs` Banner Audit: Figma differences and tip

### DIFF
--- a/website/docs/components/accordion/partials/guidelines/guidelines.md
+++ b/website/docs/components/accordion/partials/guidelines/guidelines.md
@@ -131,6 +131,8 @@ This example depicts the `isStatic` property being used to prevent interaction w
 
 !!! Info
 
+**Differences between Figma and code**
+
 The content type property is only relevant within Figma and doesn’t exist as a property in the code.
 !!!
 
@@ -145,6 +147,8 @@ Content type supports any generic content, local components, or Helios component
 ## Nesting Accordions
 
 !!! Info
+
+**Differences between Figma and code**
 
 Nesting Accordions is only supported [in code](/components/accordion?tab=code#complex-html-content), as Figma does not support nesting an instance inside itself. 
 

--- a/website/docs/components/app-footer/partials/guidelines/guidelines.md
+++ b/website/docs/components/app-footer/partials/guidelines/guidelines.md
@@ -68,7 +68,9 @@ The App Footer supports both `Light` and `Dark` theme options. The dark theme ca
 
 ## Responsiveness
 
-!!! Warning 
+!!! Info 
+
+**Differences between Figma and code**
 
 Due to limitations in Figma, the component may not be a direct translation to what is rendered in the browser. The Ember component should be the source of truth for proper wrapping.
 !!!

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -1,7 +1,8 @@
 !!! Info
 
-Due to differences in text rendering between Figma and web browsers, the `Button` Ember component uses `font-weight` 400 vs. the Figma component which uses `font-weight` 500.
+**Differences between Figma and code**
 
+Due to differences in text rendering between Figma and web browsers, the `Button` Ember component uses `font-weight` 400 vs. the Figma component which uses `font-weight` 500.
 !!!
 
 ## How to use this component

--- a/website/docs/components/code-block/partials/guidelines/guidelines.md
+++ b/website/docs/components/code-block/partials/guidelines/guidelines.md
@@ -60,7 +60,9 @@ If a user needs to copy only a portion of the Code Block, the relevant portion c
 
 ## Line numbers
 
-!!! Info
+!!! Insight
+
+**Figma tip**
 
 In the Figma component, the code examples have the appropriate number of lines by default but must be manually hidden or shown to match the length of custom snippets.
 !!!
@@ -82,6 +84,8 @@ Interacting with it again collapses the Code Block back to its set `maxHeight`.
 ## Line highlighting
 
 !!! Info
+
+**Differences between Figma and code**
 
 In the Ember component, lines can be highlighted by passing a single line number, multiple line numbers, or a range of lines. For more examples, refer to the [How to use](/?tab=code#highlightlines) documentation.
 

--- a/website/docs/components/dropdown/partials/guidelines/guidelines.md
+++ b/website/docs/components/dropdown/partials/guidelines/guidelines.md
@@ -178,6 +178,8 @@ Use icons consistently. Doing so keeps the text aligned so the eye can scan the 
 
 !!! Info
 
+**Differences between Figma and code**
+
 The Figma component will not fully reflect the Badge wrapping behavior expected in the Ember component due to current known limitations in Figma’s auto layout settings.
 !!!
 

--- a/website/docs/components/flyout/partials/guidelines/guidelines.md
+++ b/website/docs/components/flyout/partials/guidelines/guidelines.md
@@ -212,7 +212,9 @@ Multiple dismissal options are available that can be customized in production wi
 
 ## Positioning and responsive sizing
 
-!!! Info
+!!! Insight
+
+**Figma tip**
 
 In Figma, the Flyout should be paired with the [Overlay](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?node-id=67216-32335&t=gWdKy44MzTP4cTRo-1) component which obscures the main page content the Flyout sits on top of. Using the Flyout without the overlay is currently not supported and helps to communicate visually the `inert` nature of the main page.
 

--- a/website/docs/components/form/file-input/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/file-input/partials/guidelines/guidelines.md
@@ -12,6 +12,8 @@ Because the File Input is based on the native HTML input, the content and visual
 
 !!! Info
 
+**Differences between Figma and code**
+
 Due to limitations in Figma, truncation will occur at the end of the text, while in the browser, truncation occurs in the middle. 
 
 ![visual difference in truncation between figma and browser](/assets/components/form/file-input/file-input-truncation.png)

--- a/website/docs/components/link/inline/partials/guidelines/guidelines.md
+++ b/website/docs/components/link/inline/partials/guidelines/guidelines.md
@@ -41,7 +41,9 @@ Don’t mix `primary` and `secondary` links within a block of text or adjacent b
 
 ## Icon position
 
-!!! Info
+!!! Insight
+
+**Figma tip**
 
 There is no straight-forward method to add an icon within a block of text in Figma. Some strategies to consider are:
 

--- a/website/docs/components/link/standalone/partials/code/how-to-use.md
+++ b/website/docs/components/link/standalone/partials/code/how-to-use.md
@@ -5,8 +5,9 @@ The Standalone Link handles the generation of:
 
 !!! Info
 
-Due to differences in text rendering between Figma and web browsers, the `Link::Standalone` Ember component uses `font-weight` 400 vs. the Figma component which uses `font-weight` 500.
+**Differences between Figma and code**
 
+Due to differences in text rendering between Figma and web browsers, the `Link::Standalone` Ember component uses `font-weight` 400 vs. the Figma component which uses `font-weight` 500.
 !!!
 
 ## How to use this component

--- a/website/docs/components/modal/partials/guidelines/guidelines.md
+++ b/website/docs/components/modal/partials/guidelines/guidelines.md
@@ -42,6 +42,8 @@ Common examples include:
 
 !!! Info
 
+**Differences between Figma and code**
+
 In Figma, the `critical` Modal color is coupled with the `critical` Button color. However, in code, the Modal footer `yields` components passed to it and can accept any Button type or color. We recommend matching the `critical` colors for both the Modal and Button components to better communicate the severity of a destructive action.
 !!!
 

--- a/website/docs/components/segmented-group/partials/guidelines/guidelines.md
+++ b/website/docs/components/segmented-group/partials/guidelines/guidelines.md
@@ -2,6 +2,8 @@
 
 !!! Info
 
+**Differences between Figma and code**
+
 How these components are published and assembled is fundamentally different between the Figma and Ember components.
 
 - In Figma, we publish multiple primitive `Segment` components (`Segmented Button`, `Segmented Dropdown`, and `Segmented Input`) that are intended to be assembled in an auto layout container. A pre-assembled `Base` component is also made available for more simple instances.

--- a/website/docs/components/table/advanced-table/partials/guidelines/guidelines.md
+++ b/website/docs/components/table/advanced-table/partials/guidelines/guidelines.md
@@ -41,8 +41,9 @@ Column width is determined by manually resizing the header column and cells with
 
 !!! Info
 
-The column placement property is only relevant within Figma and doesn’t exist as a property in code.
+**Differences between Figma and code**
 
+The column placement property is only relevant within Figma and doesn’t exist as a property in code.
 !!!
 
 Column placement determines the visual styling based on where the column is placed relative to other columns in the Advanced Table.
@@ -218,8 +219,9 @@ Striping enhances readability by alternating row colors, making it easier to sca
 
 !!! Info
 
-The row placement property is only relevant within Figma and doesn’t exist as a property within the code.
+**Differences between Figma and code**
 
+The row placement property is only relevant within Figma and doesn’t exist as a property within the code.
 !!!
 
 Row placement determines the visual styling based on where the row is placed relative to other rows within the Advanced Table. Only cells with a column placement that is either start or end use the row placement property; column position middle does not use this property.

--- a/website/docs/components/table/table/partials/guidelines/guidelines.md
+++ b/website/docs/components/table/table/partials/guidelines/guidelines.md
@@ -142,8 +142,6 @@ When using striping in a Table, the first tinted row will be the second row of t
 
 ### Placement
 
-**Differences between Figma and code**
-
 !!! Info
 
 **Differences between Figma and code**

--- a/website/docs/components/table/table/partials/guidelines/guidelines.md
+++ b/website/docs/components/table/table/partials/guidelines/guidelines.md
@@ -45,6 +45,8 @@ Columns use as much room as they need to use to fit their content unless a speci
 
 !!! Info
 
+**Differences between Figma and code**
+
 The column placement property is only relevant in Figma and doesn’t exist as a property in code.
 !!!
 
@@ -140,7 +142,11 @@ When using striping in a Table, the first tinted row will be the second row of t
 
 ### Placement
 
+**Differences between Figma and code**
+
 !!! Info
+
+**Differences between Figma and code**
 
 The row placement property is only relevant in Figma and doesn’t exist as a property in code.
 !!!

--- a/website/docs/components/tag/partials/guidelines/guidelines.md
+++ b/website/docs/components/tag/partials/guidelines/guidelines.md
@@ -48,8 +48,9 @@ When content within the tag is not user-generated, it should be concise and cons
 
 !!! Info
 
-Tooltip placement can only be customized in the Ember component. For simplicity, the Figma component only includes top placement.
+**Differences between Figma and code**
 
+Tooltip placement can only be customized in the Ember component. For simplicity, the Figma component only includes top placement.
 !!!
 
 Tags can display about 20 characters maximum before the text becomes automatically truncated. When truncated, the full text will display in a [Tooltip](/components/tooltip) that appears when the user hovers or focuses the Tag. This Tooltip displays above the Tag by default; however, the placement can be customized.

--- a/website/docs/components/tooltip/partials/guidelines/guidelines.md
+++ b/website/docs/components/tooltip/partials/guidelines/guidelines.md
@@ -73,6 +73,8 @@ If more complex content is necessary to convey the information, consider other d
 
 !!! Info
 
+**Differences between Figma and code**
+
 Text wrapping can be achieved using the property `isMultiline` in Figma.
 !!!
 

--- a/website/docs/getting-started/for-designers.md
+++ b/website/docs/getting-started/for-designers.md
@@ -77,6 +77,8 @@ To use icons within your project, first ensure the [Icons library](https://www.f
 
 !!! Insight
 
+**Figma tip**
+
 In Helios, icons are technically components. This means you can swap instances, sizes, and colors quickly within Figma’s design panel in the right sidebar.
 !!!
 
@@ -142,9 +144,9 @@ Helios components are built to be layout-agnostic, meaning laying out components
 
 Unless specifically mentioned in the documentation, the implemented component will fill the parent container. For designers, it’s helpful to use [auto layout](https://help.figma.com/hc/en-us/articles/5731482952599-Using-auto-layout#:~:text=You%20can%20add%20auto%20layout%20to%20a%20selected%20frame%2C%20component,and%20select%20Add%20Auto%20layout) wherever possible. Auto layout closely mimics [CSS Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) and other browser layout mechanisms. Setting a Helios component to `fill container` within an auto layout frame typically replicates the experience of a development environment.
 
-!!! Warning
+!!! Insight
 
-**Fixed width components**
+**Figma tip**
 
 Setting a component to a fixed width in Figma is the same as setting a `width` value on a component or element in code. Setting a fixed width generally goes against fluid and responsive best practices and should be avoided in Figma. Instead, use auto layout wherever possible.
 !!!


### PR DESCRIPTION
### :pushpin: Summary

This PR includes updates to banners based on the banner audit work, specifically focusing on the banners in the Figma categories. The goal is to align banners in these categories to the latest writing guidelines, which defines two Figma-related categories:

- Title: Differences between Figma and code, Banner type: Informational
- Title: Figma tips, Banner type: Insight

To review, cross-reference with the categories from the audit in [Figma](https://github.com/hashicorp/design-system/pull/link) and the new banner guidelines in [Confluence](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3344269975/Markdown+Best+Practices?atlOrigin=eyJpIjoiNWMwMzU3NDBjN2ZhNGU0NjkyYWM1ZmI5ZmRmNDUzYmUiLCJwIjoiYyJ9).

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5020](https://hashicorp.atlassian.net/browse/HDS-5020)

[HDS-5020]: https://hashicorp.atlassian.net/browse/HDS-5020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ