### PR TITLE
`Web Docs` Banner Audit: Required Actions and Tip

### DIFF
--- a/website/docs/components/card/partials/code/how-to-use.md
+++ b/website/docs/components/card/partials/code/how-to-use.md
@@ -1,9 +1,8 @@
-!!! Info
+!!! Warning
 
-**Just a container**
+**Consumer responsibility**
 
 The layout of the Card itself, and its content, is left to the consumer of the component. The `Hds::Card::Container` is nothing more than a block container—a `<div>`—that provides styling for the `elevation`, `border`, and `background`. Sizing of the card, internal padding, and content alignment are all the consumer’s responsibility.
-
 !!!
 
 ## How to use this component

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -368,7 +368,9 @@ For single selection within a form or larger filter pattern use `ListItem::Radio
 
 ### ListItem::Generic
 
-!!! Info
+!!! Warning
+
+**Consumer responsibility**
 
 When using the “generic” ListItem, the product team is responsible for implementing the layout and accessibility.
 !!!

--- a/website/docs/components/form/checkbox/partials/code/how-to-use.md
+++ b/website/docs/components/form/checkbox/partials/code/how-to-use.md
@@ -325,6 +325,8 @@ The Base element is intended for rare cases where the Field or Group components 
 
 !!! Warning
 
+**Consumer responsibility**
+
 `Form::Checkbox::Base` does not come with built-in accessibility functionality. It is the responsibility of the product team to ensure the implementation is conformant.
 !!!
 

--- a/website/docs/components/form/primitives/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/primitives/partials/guidelines/guidelines.md
@@ -11,7 +11,9 @@
 
 ### Form::CharacterCount
 
-!!! Info
+!!! Warning
+
+**Consumer responsibility**
 
 The character count is not coupled with the invalid state of the field. Instead, it is the responsibility of the consumer to implement validation at the application-level.
 !!!

--- a/website/docs/components/form/radio-card/partials/code/how-to-use.md
+++ b/website/docs/components/form/radio-card/partials/code/how-to-use.md
@@ -8,6 +8,8 @@
 
 !!! Warning
 
+**Consumer responsibility**
+
 The `<Hds::Form::RadioCard::Group>` component does not provide the logic for handling the mutually exclusive nature of radio controls (when a Radio Card is checked, any other Radio Cards with the same name that were previously checked become unchecked). You can implement this yourself in an `\{{on "change" this.onChange}}` function or manage the `checked` state of Radio Cards by updating the underlying data.
 !!!
 

--- a/website/docs/components/form/radio/partials/code/how-to-use.md
+++ b/website/docs/components/form/radio/partials/code/how-to-use.md
@@ -186,6 +186,8 @@ The Base and Field components are intended for rare cases where the Group compon
 
 !!! Warning
 
+**Consumer responsibility**
+
 `Form::Checkbox::Base` does not come with built-in accessibility functionality. It is the responsibility of the product team to ensure the implementation is conformant.
 !!!
 

--- a/website/docs/components/form/select/partials/code/how-to-use.md
+++ b/website/docs/components/form/select/partials/code/how-to-use.md
@@ -242,6 +242,8 @@ The Base component is intended for rare cases where the Field component can’t 
 
 !!! Warning
 
+**Consumer responsibility**
+
 `Form::Select::Base` does not come with built-in accessibility functionality. It is the responsibility of the product team to ensure the implementation is conformant.
 !!!
 

--- a/website/docs/components/form/super-select/partials/code/how-to-use.md
+++ b/website/docs/components/form/super-select/partials/code/how-to-use.md
@@ -6,12 +6,13 @@ It’s primarily a wrapper for [ember-power-select](https://ember-power-select.c
 
 !!! Warning
 
+**Consumer responsibility**
+
 ember-power-select 8.0, and by extension the Super Select component, requires the following line in your `application.hbs`. [Read more about migrating from 7.0 to 8.0](https://ember-power-select.com/docs/migrate-7-0-to-8-0).
 
 ```markup
 <BasicDropdownWormhole />
 ```
-
 !!!
 
 We provide two main components with similar APIs: `Form::SuperSelect::Single` and `Form::SuperSelect::Multiple`.

--- a/website/docs/components/form/textarea/partials/code/how-to-use.md
+++ b/website/docs/components/form/textarea/partials/code/how-to-use.md
@@ -233,6 +233,8 @@ The Base component is intended for rare cases where the Field component can’t 
 
 !!! Warning
 
+**Consumer responsibility**
+
 `Form::Textarea::Base` does not come with built-in accessibility functionality. It is the responsibility of the product team to ensure the implementation is conformant.
 !!!
 

--- a/website/docs/components/page-header/partials/guidelines/guidelines.md
+++ b/website/docs/components/page-header/partials/guidelines/guidelines.md
@@ -222,10 +222,11 @@ Size only pertains to the Figma component and accounts for smaller viewports by 
 
 ### Responsiveness
 
-!!! Info
+!!! Warning 
+
+**Consumer responsibility**
 
 Additional responsive characteristics are the responsibility of the consumer and dependent on the layout and spacing methods defined at the application level.
-
 !!!
 
 The Page Header component in Figma supports two sizes; `large` which accounts for the majority of desktop sizes and large tablets, and `small` which accounts for smaller tablet and mobile devices. The core difference between each variant is the vertical stacking of elements.

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -139,6 +139,8 @@ When the routing parameters are provided, the "navigation controls" are rendered
 
 !!! Warning
 
+**Consumer responsibility**
+
 When a pagination component is controlled externally, as described above, at least one routing argument (`@route`, `@model`, or `@models`) **must** be provided.
 !!!
 

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -139,7 +139,7 @@ When the routing parameters are provided, the "navigation controls" are rendered
 
 !!! Warning
 
-**Consumer responsibility**
+**Code alert**
 
 When a pagination component is controlled externally, as described above, at least one routing argument (`@route`, `@model`, or `@models`) **must** be provided.
 !!!

--- a/website/docs/components/rich-tooltip/partials/code/how-to-use.md
+++ b/website/docs/components/rich-tooltip/partials/code/how-to-use.md
@@ -214,6 +214,13 @@ By default, the size of the tooltip automatically adapts to the size of its cont
 
 There may be special use cases in which the standard text or icon-based toggle doesn't work in a specific context or design. For this reason, custom content can be yielded to the `Toggle` element, but this should be considered an option of last resort, because it could result in a non-accessible implementation.
 
+!!! Warning
+
+**Consumer responsibility**
+
+When used in this way, it's up to the consumer to make sure the implementation is compliant with the [accessibility requirements](/components/rich-tooltip?tab=accessibility).
+!!!
+
 ```handlebars
 <Hds::RichTooltip as |RT|>
   <RT.Toggle>
@@ -225,13 +232,6 @@ There may be special use cases in which the standard text or icon-based toggle d
   </RT.Bubble>
 </Hds::RichTooltip>
 ```
-
-!!! Warning
-
-**Consumer responsibility**
-
-When used in this way, it's up to the consumer to make sure the implementation is compliant with the [accessibility requirements](/components/rich-tooltip?tab=accessibility).
-!!!
 
 ### Advanced options
 

--- a/website/docs/components/rich-tooltip/partials/code/how-to-use.md
+++ b/website/docs/components/rich-tooltip/partials/code/how-to-use.md
@@ -228,10 +228,9 @@ There may be special use cases in which the standard text or icon-based toggle d
 
 !!! Warning
 
-**Important**
+**Consumer responsibility**
 
 When used in this way, it's up to the consumer to make sure the implementation is compliant with the [accessibility requirements](/components/rich-tooltip?tab=accessibility).
-
 !!!
 
 ### Advanced options

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -136,11 +136,12 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
 
 !!! Warning
 
+**Deprecation notice**
+
 The `SideNav::Header::IconButton` subcomponent is now deprecated. Use the `Hds::Button` component with the `isIconOnly` variant instead.
 
 * [Example usage of an Icon-only Button](/components/side-nav?tab=code#actions) within the Side Nav `:actions` block.
 * [Icon-only Button documentation](/components/button?tab=code#icon-only-button)
-
 !!!
 
 The `SideNav::Header::IconButton` component.

--- a/website/docs/components/side-nav/partials/code/how-to-use.md
+++ b/website/docs/components/side-nav/partials/code/how-to-use.md
@@ -1,7 +1,8 @@
 !!! Warning
 
-The `Hds::SideNav` component is now deprecated. Use the [`Hds::AppSideNav`](/components/app-side-nav) component instead.
+**Deprecation notice**
 
+The `Hds::SideNav` component is now deprecated. Use the [`Hds::AppSideNav`](/components/app-side-nav) component instead.
 !!!
 
 This section provides in-depth instructions on how consumers can use the **full-featured `Hds::SideNav`** component to build a "standard" sidebar navigation with responsive behavior, animations/transitions, support for portals, etc.

--- a/website/docs/components/side-nav/partials/guidelines/overview.md
+++ b/website/docs/components/side-nav/partials/guidelines/overview.md
@@ -1,7 +1,8 @@
 !!! Warning
 
-The `Hds::SideNav` component is now deprecated. Use the [`Hds::AppSideNav`](/components/app-side-nav) component instead.
+**Deprecation notice**
 
+The `Hds::SideNav` component is now deprecated. Use the [`Hds::AppSideNav`](/components/app-side-nav) component instead.
 !!!
 
 The Side Nav provides users with access to contextual navigation within areas of the application and generally includes subpages and nested pages within projects and organizations.

--- a/website/docs/foundations/breakpoints/partials/guidelines/guidelines.md
+++ b/website/docs/foundations/breakpoints/partials/guidelines/guidelines.md
@@ -22,8 +22,9 @@ The provided breakpoints serve as a cohesive _starting_ point for design, which 
 
 !!! insight
 
-If a custom value already exists that is relatively close to an established breakpoint, we recommend migrating it to the nearest standard breakpoint. This creates a consistent and predictable experience for the user as they work within (and across) the HashiCorp product suite.
+**Migration tip** 
 
+If a custom value already exists that is relatively close to an established breakpoint, we recommend migrating it to the nearest standard breakpoint. This creates a consistent and predictable experience for the user as they work within (and across) the HashiCorp product suite.
 !!!
 
 ## Designing with purpose

--- a/website/docs/foundations/elevation/partials/code/how-to-use.md
+++ b/website/docs/foundations/elevation/partials/code/how-to-use.md
@@ -2,7 +2,9 @@
 
 You can apply an `elevation` or `surface` effect to an element via **design tokens** or **CSS helper classes**.
 
-!!! Info
+!!! Warning
+
+**Consumer responsibility**
 
 Note that `border-radius` is not included with this token and needs to be set according to the specs of the UI element.
 !!!

--- a/website/docs/foundations/focus-ring/partials/code/how-to-use.md
+++ b/website/docs/foundations/focus-ring/partials/code/how-to-use.md
@@ -3,7 +3,9 @@
 
 We recommend applying the “focus-ring” style to an element using the **design token** provided as a custom CSS property.
 
-!!! Info 
+!!! Warning 
+
+**Consumer responsibility**
 
 Note that `border-radius` is not included with this token and needs to be set according to the specs of the UI element. Consider using `inherit`.
 !!!

--- a/website/docs/getting-started/for-engineers.md
+++ b/website/docs/getting-started/for-engineers.md
@@ -69,12 +69,11 @@ app.import('node_modules/@hashicorp/design-system-components/dist/styles/@hashic
 
 !!! Warning
 
-##### Ensure a box-sizing reset is present
+**Consumer responsibility**
 
 Our component library assumes that a box-sizing reset is applied globally in your application. To ensure components render properly, include the following reset:
 
 `*, *::before, *::after { box-sizing: border-box; }`
-
 !!!
 
 ## Icons

--- a/website/docs/overrides/power-select/partials/code/how-to-use.md
+++ b/website/docs/overrides/power-select/partials/code/how-to-use.md
@@ -1,7 +1,8 @@
 !!! Warning
 
-The PowerSelect style overrides are deprecated and will be removed in a future major release. We recommend migrating PowerSelect instances to [SuperSelect](/components/form/super-select).
+**Deprecation notice**
 
+The PowerSelect style overrides are deprecated and will be removed in a future major release. We recommend migrating PowerSelect instances to [SuperSelect](/components/form/super-select).
 !!!
 
 [PowerSelect](https://ember-power-select.com) is a popular Ember add-on aiming to overcome some limitations of the `<select>` tag. We only provide style overrides for this add-on to keep it in line with other form components.

--- a/website/docs/utilities/menu-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/menu-primitive/partials/code/how-to-use.md
@@ -1,7 +1,8 @@
 !!! Warning
 
-The `MenuPrimitive` component is deprecated and will be removed in a future major release. It has been replaced internally with the [`PopoverPrimitive`](/utilities/popover-primitive).
+**Deprecation notice**
 
+The `MenuPrimitive` component is deprecated and will be removed in a future major release. It has been replaced internally with the [`PopoverPrimitive`](/utilities/popover-primitive).
 !!!
 
 ## How to use this component

--- a/website/docs/utilities/popover-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/popover-primitive/partials/code/how-to-use.md
@@ -68,8 +68,9 @@ Alternatively, the toggle behavior can be enabled via "click" events:
 
 !!! Warning
 
-Important: if you don't apply either `@enableSoftEvents` or `@enableClickEvents` the popover will not become visible with any kind of interaction (unless it's rendered already opened via the special `@isOpen` argument).
+**Consumer responsibility**
 
+Important: if you don't apply either `@enableSoftEvents` or `@enableClickEvents` the popover will not become visible with any kind of interaction (unless it's rendered already opened via the special `@isOpen` argument).
 !!!
 
 ### Content positioning


### PR DESCRIPTION
### :pushpin: Summary

This PR includes updates to banners based on the banner audit work, specifically focusing on the banners in the Migration Tip, Consumer Responsibility, and Deprecation Notices categories. The goal is to align banners in these categories to the latest writing guidelines, which defines:

- Title: Migration tip, Banner type: Insight
- Title: Consumer responsibility, Banner type: Warning
- Title: Deprecation notice, Banner type: Warning

To review, cross-reference with the categories from the audit in [Figma](https://github.com/hashicorp/design-system/pull/link) and the new banner guidelines in [Confluence](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3344269975/Markdown+Best+Practices?atlOrigin=eyJpIjoiNWMwMzU3NDBjN2ZhNGU0NjkyYWM1ZmI5ZmRmNDUzYmUiLCJwIjoiYyJ9).

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5020](https://hashicorp.atlassian.net/browse/HDS-5020)

[HDS-5020]: https://hashicorp.atlassian.net/browse/HDS-5020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ